### PR TITLE
Remove flawed transform serialization test

### DIFF
--- a/astropy/io/misc/asdf/tags/transform/tests/test_transform.py
+++ b/astropy/io/misc/asdf/tags/transform/tests/test_transform.py
@@ -314,20 +314,6 @@ def test_fix_inputs(tmpdir):
         helpers.assert_roundtrip_tree(tree, tmpdir)
 
 
-def test_fix_inputs_type():
-    with pytest.raises(TypeError):
-        tree = {
-        'compound': fix_inputs(3, {'x': 45})
-        }
-        helpers.assert_roundtrip_tree(tree, tmpdir)
-
-    with pytest.raises(AttributeError):
-        tree = {
-        'compound': astmodels.Pix2Sky_TAN() & {'x': 45}
-        }
-        helpers.assert_roundtrip_tree(tree, tmpdir)
-
-
 comp_model = custom_and_analytical_inverse()
 
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

@pllim pointed out that this test is using the `tmpdir` fixture but `tmpdir` is not included in the test method signature.  I thought the `pytest.raises` was covering up the bug, but it turns out the test doesn't even get to the that line -- the error is being raised by the call to `fix_inputs`.

It doesn't appear possible to create a model that would fail ASDF schema validation, so I think we should remove this test.  I'll need @perrygreenfield or @nden to confirm.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->