### PR TITLE
MNT: Temporarily ignore setuptools warning about distutils

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -109,6 +109,7 @@ xfail_strict = true
 qt_no_exception_capture = 1
 filterwarnings =
     error
+    ignore:Distutils was imported before Setuptools
     ignore:unclosed file:ResourceWarning
     ignore:unclosed <socket:ResourceWarning
     ignore:unclosed <ssl.SSLSocket:ResourceWarning


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

Hopefully #10571 or its replacement will undo this later. This is a temporarily bandaid to allow CI to be green again until we find a proper solution.