### PR TITLE
MNT: Replace distutils with setuptools in wcs extension test

### DIFF
--- a/astropy/wcs/tests/extension/setup.py
+++ b/astropy/wcs/tests/extension/setup.py
@@ -4,10 +4,6 @@ import os
 import sys
 
 if __name__ == '__main__':
-    astropy_path = sys.argv[-1]
-    sys.argv = sys.argv[:-1]
-    sys.path.insert(0, astropy_path)
-
     from setuptools import setup, Extension
 
     import numpy as np

--- a/astropy/wcs/tests/extension/setup.py
+++ b/astropy/wcs/tests/extension/setup.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-
 import os
 import sys
 
@@ -9,9 +8,10 @@ if __name__ == '__main__':
     sys.argv = sys.argv[:-1]
     sys.path.insert(0, astropy_path)
 
-    from astropy import wcs
+    from setuptools import setup, Extension
+
     import numpy as np
-    from distutils.core import setup, Extension
+    from astropy import wcs
 
     if sys.platform == 'win32':
         # These are written into wcsconfig.h, but that file is not


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<details>
  <summary>This has been resolved.</summary>

This will fail. Not sure how to fix.

```
____________________________ test_wcsapi_extension _____________________________
[gw0] linux -- Python 3.6.11 /root/project/.tox/py36-test/bin/python

tmpdir = local('/tmp/pytest-of-root/pytest-0/popen-gw0/test_wcsapi_extension0')

    def test_wcsapi_extension(tmpdir):
        # ...

        code = """
        import sys
        import wcsapi_test
        sys.exit(wcsapi_test.test())
        """
    
        code = code.strip().replace('\n', '; ')
    
        # Import and run the extension
>       subprocess.check_call([sys.executable, '-c', code], env=env)

../../.tox/py36-test/lib/python3.6/site-packages/astropy/wcs/tests/extension/test_extension.py:78: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

popenargs = (['/root/project/.tox/py36-test/bin/python', '-c', 'import sys;     import wcsapi_test;     sys.exit(wcsapi_test.test())'],)
kwargs = {'env': {'CI': 'true', 'HOME': '/root', 'LANG': 'en_US.UTF-8', 'LANGUAGE': 'en_US.UTF-8', ...}}
retcode = 1
cmd = ['/root/project/.tox/py36-test/bin/python', '-c', 'import sys;     import wcsapi_test;     sys.exit(wcsapi_test.test())']

    def check_call(*popenargs, **kwargs):
        # ...
        retcode = call(*popenargs, **kwargs)
        if retcode:
            cmd = kwargs.get("args")
            if cmd is None:
                cmd = popenargs[0]
>           raise CalledProcessError(retcode, cmd)
E           subprocess.CalledProcessError: Command '['/root/project/.tox/py36-test/bin/python', '-c', 'import sys;     import wcsapi_test;     sys.exit(wcsapi_test.test())']' returned non-zero exit status 1.

/opt/python/cp36-cp36m/lib/python3.6/subprocess.py:311: CalledProcessError
----------------------------- Captured stderr call -----------------------------
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ModuleNotFoundError: No module named 'wcsapi_test'
```

</details>

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

This is a direct follow-up of #10571 .