### PR TITLE
fix fitting test

### DIFF
--- a/astropy/modeling/tests/test_models_quantities.py
+++ b/astropy/modeling/tests/test_models_quantities.py
@@ -162,7 +162,7 @@ POWERLAW_MODELS = [
  'bounding_box': False},
 {'class': SmoothlyBrokenPowerLaw1D,
  'parameters': {'amplitude': 5 * u.kg, 'x_break': 10 * u.cm, 'alpha_1': 1, 'alpha_2': -1, 'delta': 1},
- 'evaluation': [(1 * u.m, 15.125 * u.kg), (1 * u.cm, 15.125 * u.kg)],
+ 'evaluation': [(1 * u.cm, 15.125 * u.kg), (1 * u.m, 15.125 * u.kg)],
  'bounding_box': False},
 {'class': ExponentialCutoffPowerLaw1D,
  'parameters': {'amplitude': 5 * u.kg, 'x_0': 10 * u.cm, 'alpha': 1, 'x_cutoff': 1 * u.m},
@@ -322,7 +322,6 @@ def test_models_bounding_box(model):
 @pytest.mark.filterwarnings(r'ignore:The fit may be unsuccessful.*')
 @pytest.mark.parametrize('model', MODELS)
 def test_models_fitting(model):
-
     m = model['class'](**model['parameters'])
     if len(model['evaluation'][0]) == 2:
         x = np.linspace(1, 3, 100) * model['evaluation'][0][0].unit


### PR DESCRIPTION
This fixes a problem with setting up the values for the test discovered in #10552.

#10552 also revealed a more general issue  with validators in models (not addressed here) -  parameter validators are not run on fitted parameters because the values are assigned using `model.parameters=fitted parameters` and do not use the parameter setters. Example is the fitting test of `SmoothlyBrokenPowerLaw` in test_models_quantities where the data has such values that the amplitude is 0. Although an amplitude of 0. is not a valid value, it is not caught by the validator.

@cshanahan1 