### PR TITLE
Don't ignore blank-valued attributes with the c-based parser.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -306,6 +306,9 @@ astropy.io.misc
 astropy.io.votable
 ^^^^^^^^^^^^^^^^^^
 
+- No longer ignore attributes whose values were specified as empty
+  strings. [#10583]
+
 astropy.modeling
 ^^^^^^^^^^^^^^^^
 
@@ -893,7 +896,7 @@ astropy.coordinates
 - Fixed an error where ``SkyCoord.apply_space_motion`` would return incorrect
   results when no distance is set and proper motion is high. [#10296]
 
-- Make the parsing of angles thread-safe so that ``Angle`` can be used in 
+- Make the parsing of angles thread-safe so that ``Angle`` can be used in
   Python multithreading. [#10556]
 
 astropy.cosmology

--- a/astropy/io/votable/tests/data/regression.bin.tabledata.truth.1.1.xml
+++ b/astropy/io/votable/tests/data/regression.bin.tabledata.truth.1.1.xml
@@ -29,7 +29,7 @@
   <PARAM ID="empty_value" arraysize="*" datatype="char" name="empty_value" unit="foo" value="">
    <VALUES>
     <OPTION name="empty_value" value=""/>
-    <OPTION name="full_value" value="90prime"/>
+    <OPTION value="90prime"/>
    </VALUES>
   </PARAM>
   <LINK href="http://www.foo.com/"/>

--- a/astropy/io/votable/tests/data/regression.bin.tabledata.truth.1.1.xml
+++ b/astropy/io/votable/tests/data/regression.bin.tabledata.truth.1.1.xml
@@ -26,7 +26,12 @@
    This is a resource description
   </DESCRIPTION>
   <PARAM ID="awesome" arraysize="*" datatype="float" name="INPUT" unit="deg" value="0 0"/>
-  <PARAM ID="empty_value" arraysize="*" datatype="char" name="empty_value" unit="foo" value=""/>
+  <PARAM ID="empty_value" arraysize="*" datatype="char" name="empty_value" unit="foo" value="">
+   <VALUES>
+    <OPTION name="empty_value" value=""/>
+    <OPTION name="full_value" value="90prime"/>
+   </VALUES>
+  </PARAM>
   <LINK href="http://www.foo.com/"/>
   <TABLE ID="main_table" nrows="5">
    <DESCRIPTION>

--- a/astropy/io/votable/tests/data/regression.bin.tabledata.truth.1.3.xml
+++ b/astropy/io/votable/tests/data/regression.bin.tabledata.truth.1.3.xml
@@ -25,7 +25,12 @@
    This is a resource description
   </DESCRIPTION>
   <PARAM ID="awesome" arraysize="*" datatype="float" name="INPUT" unit="deg" value="0 0"/>
-  <PARAM ID="empty_value" arraysize="*" datatype="char" name="empty_value" unit="foo" value=""/>
+  <PARAM ID="empty_value" arraysize="*" datatype="char" name="empty_value" unit="foo" value="">
+   <VALUES>
+    <OPTION name="empty_value" value=""/>
+    <OPTION name="full_value" value="90prime"/>
+   </VALUES>
+  </PARAM>
   <LINK href="http://www.foo.com/"/>
   <TABLE ID="main_table" nrows="5">
    <DESCRIPTION>

--- a/astropy/io/votable/tests/data/regression.bin.tabledata.truth.1.3.xml
+++ b/astropy/io/votable/tests/data/regression.bin.tabledata.truth.1.3.xml
@@ -28,7 +28,7 @@
   <PARAM ID="empty_value" arraysize="*" datatype="char" name="empty_value" unit="foo" value="">
    <VALUES>
     <OPTION name="empty_value" value=""/>
-    <OPTION name="full_value" value="90prime"/>
+    <OPTION value="90prime"/>
    </VALUES>
   </PARAM>
   <LINK href="http://www.foo.com/"/>

--- a/astropy/io/votable/tests/data/regression.xml
+++ b/astropy/io/votable/tests/data/regression.xml
@@ -18,7 +18,12 @@ The VOTable format is an XML standard for the interchange of data represented as
   This is a resource description
 </DESCRIPTION>
 <PARAM ID="awesome" datatype="float" name="INPUT" value="0.000000,0.000000" arraysize="*" unit="deg"></PARAM>
-<PARAM ID="empty_value" name="empty_value" arraysize="*" datatype="char" value="" unit="foo"/>
+<PARAM ID="empty_value" arraysize="*" datatype="char" name="empty_value" unit="foo" value="">
+  <VALUES>
+    <OPTION name="empty_value" value=""/>
+    <OPTION name="full_value" value="90prime"/>
+  </VALUES>
+</PARAM>
 <LINK href="http://www.foo.com/" gref="DECPRECATED">
   <DESCRIPTION>Really, this link is totally bogus.</DESCRIPTION>
 </LINK>

--- a/astropy/io/votable/tests/data/regression.xml
+++ b/astropy/io/votable/tests/data/regression.xml
@@ -21,7 +21,7 @@ The VOTable format is an XML standard for the interchange of data represented as
 <PARAM ID="empty_value" arraysize="*" datatype="char" name="empty_value" unit="foo" value="">
   <VALUES>
     <OPTION name="empty_value" value=""/>
-    <OPTION name="full_value" value="90prime"/>
+    <OPTION value="90prime"/>
   </VALUES>
 </PARAM>
 <LINK href="http://www.foo.com/" gref="DECPRECATED">

--- a/astropy/io/votable/tests/data/validation.txt
+++ b/astropy/io/votable/tests/data/validation.txt
@@ -1,4 +1,4 @@
-Validation report for /tmp/astropy-test-D69Wr6/lib.linux-x86_64-2.7/astropy/io/votable/tests/data/regression.xml
+Validation report for regression.xml
 
 11: W01: Array uses commas rather than whitespace
 <PARAM datatype="float" name="wrong_arraysize" value="0.000000,0.00...
@@ -18,216 +18,216 @@ Validation report for /tmp/astropy-test-D69Wr6/lib.linux-x86_64-2.7/astropy/io/v
 ^
 
 21: W50: Invalid unit string 'foo'
-<PARAM ID="empty_value" name="empty_value" arraysize="*" datatype="...
+<PARAM ID="empty_value" arraysize="*" datatype="char" name="empty_v...
 ^
 
-22: W11: The gref attribute on LINK is deprecated in VOTable 1.1
+27: W11: The gref attribute on LINK is deprecated in VOTable 1.1
 <LINK href="http://www.foo.com/" gref="DECPRECATED">
 ^
 
-23: W10: Unknown tag 'DESCRIPTION'.  Ignoring
+28: W10: Unknown tag 'DESCRIPTION'.  Ignoring
   <DESCRIPTION>Really, this link is totally bogus.</DESCRIPTION>
   ^
 
-29: W26: 'INFO' inside 'TABLE' added in VOTable 1.2
+34: W26: 'INFO' inside 'TABLE' added in VOTable 1.2
 <INFO name="Error" ID="ErrorInfo" value="One might expect to find s...
 ^
 
-33: W01: Array uses commas rather than whitespace
+38: W01: Array uses commas rather than whitespace
 <PARAM datatype="float" name="INPUT2" value="0.000000,0.000000" arr...
 ^
 
-36: W09: ID attribute not capitalized
+41: W09: ID attribute not capitalized
 <FIELD id="string_test" name="string test" datatype="char" arraysiz...
 ^
 
-39: W13: 'unicodeString' is not a valid VOTable datatype, should be
+44: W13: 'unicodeString' is not a valid VOTable datatype, should be
   'unicodeChar'
 <FIELD ID="fixed_unicode_test" name="unicode test" datatype="unicod...
 ^
 
-41: W13: 'string' is not a valid VOTable datatype, should be 'char'
+46: W13: 'string' is not a valid VOTable datatype, should be 'char'
 <FIELD ID="string_array_test" name="string array test" datatype="st...
 ^
 
-44: W51: Value '-32769' is out of range for a 16-bit integer field
+49: W51: Value '-32769' is out of range for a 16-bit integer field
   <VALUES null="-32769"/>
   ^
 
-52: W10: Unknown tag 'IGNORE_ME'.  Ignoring
+57: W10: Unknown tag 'IGNORE_ME'.  Ignoring
   <IGNORE_ME/>
   ^
 
-92: W17: GROUP element contains more than one DESCRIPTION element
+97: W17: GROUP element contains more than one DESCRIPTION element
     This should warn of a second description.
 ^
 
-99: W01: Array uses commas rather than whitespace
+104: W01: Array uses commas rather than whitespace
   <PARAM datatype="float" name="INPUT3" value="0.000000,0.000000" a...
   ^
 
-37: W32: Duplicate ID 'string_test' renamed to 'string_test_2' to
+42: W32: Duplicate ID 'string_test' renamed to 'string_test_2' to
   ensure uniqueness
 <FIELD ID="string_test" name="fixed string test" datatype="char" ar...
 ^
 
-107: W46: char value is too long for specified length of 10
+112: W46: char value is too long for specified length of 10
   <TD>Fixed string long test</TD> <!-- Should truncate -->
       ^
 
-109: W46: unicodeChar value is too long for specified length of 10
+114: W46: unicodeChar value is too long for specified length of 10
   <TD>Ceçi n'est pas un pipe</TD>
       ^
 
-110: W46: char value is too long for specified length of 4
+115: W46: char value is too long for specified length of 4
   <TD>ab cd</TD>
       ^
 
-129: E02: Incorrect number of elements in array. Expected multiple of
+134: E02: Incorrect number of elements in array. Expected multiple of
   4, got 1
   <TD/>
   ^
 
-129: W49: Empty cell illegal for integer fields.
+134: W49: Empty cell illegal for integer fields.
   <TD/>
   ^
 
-137: W46: char value is too long for specified length of 10
+142: W46: char value is too long for specified length of 10
   <TD>0123456789A</TD>
       ^
 
-140: W46: char value is too long for specified length of 4
+145: W46: char value is too long for specified length of 4
   <TD>0123456789A</TD>
       ^
 
-141: W51: Value '256' is out of range for a 8-bit unsigned integer
+146: W51: Value '256' is out of range for a 8-bit unsigned integer
   field
   <TD>256</TD> <!-- should overflow to 0 -->
       ^
 
-142: W51: Value '65536' is out of range for a 16-bit integer field
+147: W51: Value '65536' is out of range for a 16-bit integer field
   <TD>65536</TD> <!-- should overflow to 0-->
       ^
 
-144: W49: Empty cell illegal for integer fields.
+149: W49: Empty cell illegal for integer fields.
   <TD></TD>
   ^
 
-147: W01: Array uses commas rather than whitespace
+152: W01: Array uses commas rather than whitespace
   <TD>42 32, 12 32</TD>
       ^
 
-163: E02: Incorrect number of elements in array. Expected multiple of
+168: E02: Incorrect number of elements in array. Expected multiple of
   16, got 0
   <TD/>
   ^
 
-163: W49: Empty cell illegal for integer fields.
+168: W49: Empty cell illegal for integer fields.
   <TD/>
   ^
 
-163: W49: Empty cell illegal for integer fields.
+168: W49: Empty cell illegal for integer fields.
   <TD/>
   ^
 
-163: W49: Empty cell illegal for integer fields.
+168: W49: Empty cell illegal for integer fields.
   <TD/>
   ^
 
-163: W49: Empty cell illegal for integer fields.
+168: W49: Empty cell illegal for integer fields.
   <TD/>
   ^
 
-163: W49: Empty cell illegal for integer fields.
+168: W49: Empty cell illegal for integer fields.
   <TD/>
   ^
 
-163: W49: Empty cell illegal for integer fields.
+168: W49: Empty cell illegal for integer fields.
   <TD/>
   ^
 
-163: W49: Empty cell illegal for integer fields.
+168: W49: Empty cell illegal for integer fields.
   <TD/>
   ^
 
-163: W49: Empty cell illegal for integer fields. (suppressing further
+168: W49: Empty cell illegal for integer fields. (suppressing further
   warnings of this type...)
   <TD/>
   ^
 
-169: W46: unicodeChar value is too long for specified length of 10
+174: W46: unicodeChar value is too long for specified length of 10
   <TD>0123456789A</TD>
       ^
 
-171: W51: Value '-23' is out of range for a 8-bit unsigned integer
+176: W51: Value '-23' is out of range for a 8-bit unsigned integer
   field
   <TD>-23</TD> <!-- negative, should wrap around to positive -->
       ^
 
-193: E02: Incorrect number of elements in array. Expected multiple of
+198: E02: Incorrect number of elements in array. Expected multiple of
   16, got 0
   <TD/>
   ^
 
-202: W51: Value '65535' is out of range for a 16-bit integer field
+207: W51: Value '65535' is out of range for a 16-bit integer field
   <TD>0xffff</TD> <!-- hex - negative value -->
       ^
 
-207: W01: Array uses commas rather than whitespace
+212: W01: Array uses commas rather than whitespace
   <TD>NaN, 23</TD>
       ^
 
-209: E02: Incorrect number of elements in array. Expected multiple of
+214: E02: Incorrect number of elements in array. Expected multiple of
   6, got 0
   <TD/>
   ^
 
-217: E02: Incorrect number of elements in array. Expected multiple of
+222: E02: Incorrect number of elements in array. Expected multiple of
   4, got 1
   <TD/>
   ^
 
-223: E02: Incorrect number of elements in array. Expected multiple of
+228: E02: Incorrect number of elements in array. Expected multiple of
   16, got 0
   <TD/>
   ^
 
-231: W51: Value '256' is out of range for a 8-bit unsigned integer
+236: W51: Value '256' is out of range for a 8-bit unsigned integer
   field
   <TD>0x100</TD> <!-- hex, overflow -->
       ^
 
-232: W51: Value '65536' is out of range for a 16-bit integer field
+237: W51: Value '65536' is out of range for a 16-bit integer field
   <TD>0x10000</TD> <!-- hex, overflow -->
       ^
 
-237: W01: Array uses commas rather than whitespace
+242: W01: Array uses commas rather than whitespace
   <TD>31, -1</TD>
       ^
 
-239: E02: Incorrect number of elements in array. Expected multiple of
+244: E02: Incorrect number of elements in array. Expected multiple of
   6, got 0
   <TD/>
   ^
 
-247: E02: Incorrect number of elements in array. Expected multiple of
+252: E02: Incorrect number of elements in array. Expected multiple of
   4, got 1
   <TD/>
   ^
 
-249: E02: Incorrect number of elements in array. Expected multiple of
+254: E02: Incorrect number of elements in array. Expected multiple of
   4, got 1 (suppressing further warnings of this type...)
   <TD/>
   ^
 
-267: W46: char value is too long for specified length of 10
+272: W46: char value is too long for specified length of 10
   <TD>Fixed string long test</TD> <!-- Should truncate -->
       ^
 
-269: W46: unicodeChar value is too long for specified length of 10
+274: W46: unicodeChar value is too long for specified length of 10
   <TD>Ceçi n'est pas un pipe</TD>
       ^
 
-270: W46: char value is too long for specified length of 4
+275: W46: char value is too long for specified length of 4
   <TD>ab cd</TD>
       ^

--- a/astropy/utils/xml/src/iterparse.c
+++ b/astropy/utils/xml/src/iterparse.c
@@ -22,6 +22,7 @@
  *     library.
  ******************************************************************************/
 
+#include <stdio.h>
 #include <Python.h>
 #include "structmember.h"
 
@@ -384,25 +385,24 @@ startElement(IterParser *self, const XML_Char *name, const XML_Char **atts)
                 goto fail;
             }
             do {
-                if (*(*(att_ptr + 1)) != 0) {
-                    key = PyUnicode_FromString(*att_ptr);
-                    if (key == NULL) {
-                        goto fail;
-                    }
-                    val = PyUnicode_FromString(*(att_ptr + 1));
-                    if (val == NULL) {
-                        Py_DECREF(key);
-                        goto fail;
-                    }
-                    if (PyDict_SetItem(pyatts, key, val)) {
-                        Py_DECREF(key);
-                        Py_DECREF(val);
-                        goto fail;
-                    }
+                key = PyUnicode_FromString(*att_ptr);
+                if (key == NULL) {
+                    goto fail;
+                }
+                val = PyUnicode_FromString(*(att_ptr + 1));
+                if (val == NULL) {
+                    Py_DECREF(key);
+                    goto fail;
+                }
+                if (PyDict_SetItem(pyatts, key, val)) {
                     Py_DECREF(key);
                     Py_DECREF(val);
-                    key = val = NULL;
+                    goto fail;
                 }
+                Py_DECREF(key);
+                Py_DECREF(val);
+                key = val = NULL;
+
                 att_ptr += 2;
             } while (*att_ptr);
         } else {


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to address the failure to parse VOTables that have `OPTION` elements with attribute `value=""`.  More generally, all blank-valued attributes will no longer be ignored.

The previous behavior differed between the "fast" C-based parser and the slower Python-based parser.  The fast parser was ignoring blank-valued attributes, treating them the same as if the attribute were not present.  The slow parser was passing the empty string values of those attributes through to the `tree.py` code that handles the VOTable elements.  The slow parser was correct, so this PR updates the fast parser to do the same thing.

In most cases the difference didn't matter, but in cases like issue #10572, treating a blank value as unspecified caused the parser to think that `OPTION` had no `value`.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #10572 

