### PR TITLE
Move bar out of SI, since it is not recommended to use it.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -119,8 +119,6 @@ astropy.units
 - Added the ``spat`` unit of solid angle that represents the full sphere.
   [#10726]
 
-- The ``bar`` unit is no longer wrongly considered an SI unit. [#10586]
-
 astropy.utils
 ^^^^^^^^^^^^^
 
@@ -221,6 +219,10 @@ astropy.uncertainty
 
 astropy.units
 ^^^^^^^^^^^^^
+
+- The ``bar`` unit is no longer wrongly considered an SI unit, meaning that
+  SI decompositions like ``(u.kg*u.s**-2* u.sr**-1 * u.nm**-1).si`` will
+  no longer include it. [#10586]
 
 astropy.utils
 ^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -112,11 +112,14 @@ astropy.uncertainty
 
 astropy.units
 ^^^^^^^^^^^^^
+
 - ``Quantity.to`` has gained a ``copy`` option to allow copies to be avoided
   when the units do not change. [#10517]
 
 - Added the ``spat`` unit of solid angle that represents the full sphere.
   [#10726]
+
+- The ``bar`` unit is no longer wrongly considered an SI unit. [#10586]
 
 astropy.utils
 ^^^^^^^^^^^^^

--- a/astropy/units/astrophys.py
+++ b/astropy/units/astrophys.py
@@ -100,6 +100,12 @@ def_unit(['Ry', 'rydberg'],
          "constant",
          format={'latex': r'R_{\infty}', 'unicode': 'R∞'})
 
+##########################################################################
+# PRESSURE
+
+def_unit(['bar'], 1e5 * si.Pa, namespace=_ns,
+         prefixes=[(['m'], ['milli'], 1.e-3)],
+         doc="bar: pressure")
 
 ###########################################################################
 # ILLUMINATION

--- a/astropy/units/si.py
+++ b/astropy/units/si.py
@@ -158,9 +158,6 @@ def_unit(['eV', 'electronvolt'], _si.e.value * J, namespace=_ns, prefixes=True,
 
 def_unit(['Pa', 'Pascal', 'pascal'], J * m ** -3, namespace=_ns, prefixes=True,
          doc="Pascal: pressure")
-def_unit(['bar'], 1e5 * Pa, namespace=_ns,
-         prefixes=[(['m'], ['milli'], 1.e-3)],
-         doc="bar: pressure")
 
 
 ###########################################################################
@@ -212,7 +209,7 @@ def_unit(['lx', 'lux'], lm * m ** -2, namespace=_ns, prefixes=True,
 ###########################################################################
 # RADIOACTIVITY
 
-def_unit(['Bq', 'becquerel'], Hz, namespace=_ns, prefixes=False,
+def_unit(['Bq', 'becquerel'], 1 / s, namespace=_ns, prefixes=False,
          doc="becquerel: unit of radioactivity")
 def_unit(['Ci', 'curie'], Bq * 3.7e10, namespace=_ns, prefixes=False,
          doc="curie: unit of radioactivity")

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -373,6 +373,20 @@ def test_compose_si_to_cgs(unit):
         assert cgs[0] == unit.cgs
 
 
+def test_to_si():
+    """Check units that are not official derived units.
+
+    Should not appear on its own or as part of a composite unit.
+    """
+    # TODO: extend to all units not listed in Tables 1--6 of
+    # https://physics.nist.gov/cuu/Units/units.html
+    # See gh-10585.
+    # This was always the case
+    assert u.bar.si is not u.bar
+    # But this used to fail.
+    assert u.bar not in (u.kg/(u.s**2*u.sr*u.nm)).si._bases
+
+
 def test_to_cgs():
     assert u.Pa.to_system(u.cgs)[1]._bases[0] is u.Ba
     assert u.Pa.to_system(u.cgs)[1]._scale == 10.0


### PR DESCRIPTION
Partially addresses #10585 

I mile-stoned it for 4.2 since there are more units in `units.si` that really do not belong, but which also do not make sense in `astrophys` - so, this could become a larger overhaul. Also, it is not really a bug in that the result is not strictly "wrong", just not recommended.