### PR TITLE
Remove LooseVersion

### DIFF
--- a/astropy/io/misc/asdf/tags/transform/tests/test_transform.py
+++ b/astropy/io/misc/asdf/tags/transform/tests/test_transform.py
@@ -2,8 +2,8 @@
 # -*- coding: utf-8 -*-
 
 import warnings
-from distutils.version import LooseVersion
 
+from packaging.version import Version
 import pytest
 import numpy as np
 
@@ -138,7 +138,7 @@ def test_inverse_transforms(tmpdir):
 def test_single_model(tmpdir, model):
     with warnings.catch_warnings():
         # Some schema files are missing from asdf<=2.6.0 which causes warnings
-        if LooseVersion(asdf.__version__) <= '2.6.0':
+        if Version(asdf.__version__) <= Version('2.6.0'):
             warnings.filterwarnings('ignore', 'Unable to locate schema file')
         tree = {'single_model': model}
         helpers.assert_roundtrip_tree(tree, tmpdir)
@@ -186,7 +186,7 @@ def test_generic_projections(tmpdir):
         }
         with warnings.catch_warnings():
             # Some schema files are missing from asdf<=2.4.2 which causes warnings
-            if LooseVersion(asdf.__version__) <= '2.5.1':
+            if Version(asdf.__version__) <= Version('2.5.1'):
                 warnings.filterwarnings('ignore', 'Unable to locate schema file')
             helpers.assert_roundtrip_tree(tree, tmpdir)
 
@@ -302,7 +302,7 @@ def test_fix_inputs(tmpdir):
 
     with warnings.catch_warnings():
         # Some schema files are missing from asdf<=2.4.2 which causes warnings
-        if LooseVersion(asdf.__version__) <= '2.5.1':
+        if Version(asdf.__version__) <= Version('2.5.1'):
             warnings.filterwarnings('ignore', 'Unable to locate schema file')
 
         model = astmodels.Pix2Sky_TAN() | astmodels.Rotation2D()

--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -9,7 +9,6 @@ import types
 import pickle
 import warnings
 import functools
-from distutils.version import LooseVersion
 
 import pytest
 
@@ -285,7 +284,7 @@ def treat_deprecations_as_exceptions():
     except ImportError:
         pass
     else:
-        if LooseVersion(matplotlib.__version__) < '3':
+        if matplotlib.__version__[0] < '3':
             warnings.filterwarnings('ignore', category=DeprecationWarning,
                                     module='numpy.lib.type_check')
 

--- a/astropy/utils/introspection.py
+++ b/astropy/utils/introspection.py
@@ -9,7 +9,6 @@ import os
 import sys
 import types
 import importlib
-from distutils.version import LooseVersion
 
 __all__ = ['resolve_name', 'minversion', 'find_current_module',
            'isinstancemethod']
@@ -123,6 +122,10 @@ def minversion(module, version, inclusive=True, version_path='__version__'):
     >>> minversion(astropy, '0.4.4')
     True
     """
+    # import LooseVersion here to avoid conflicts between setuptools and
+    # distutils. See https://github.com/astropy/astropy/pull/10571
+    from distutils.version import LooseVersion
+
     if isinstance(module, types.ModuleType):
         module_name = module.__name__
     elif isinstance(module, str):

--- a/astropy/utils/introspection.py
+++ b/astropy/utils/introspection.py
@@ -152,6 +152,11 @@ def minversion(module, version, inclusive=True, version_path='__version__'):
     if m:
         version = m.group(0)
 
+    # have_version can have the same issue as version, so also regex it
+    m = re.match(expr, have_version)
+    if m:
+        have_version = m.group(0)
+
     if inclusive:
         return LooseVersion(have_version) >= LooseVersion(version)
     else:

--- a/astropy/visualization/scripts/fits2bitmap.py
+++ b/astropy/visualization/scripts/fits2bitmap.py
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import os
-from distutils.version import LooseVersion
 
 from astropy.visualization.mpl_normalize import simple_norm
 from astropy import log
@@ -100,7 +99,7 @@ def fits2bitmap(filename, ext=0, out_fn=None, stretch='linear',
     # workaround for matplotlib 2.0.0 bug where png images are inverted
     # (mpl-#7656)
     if (out_format.lower() == 'png' and
-            LooseVersion(matplotlib.__version__) == LooseVersion('2.0.0')):
+            matplotlib.__version__[:5] == '2.0.0'):
         image = image[::-1]
 
     try:

--- a/astropy/visualization/tests/test_norm.py
+++ b/astropy/visualization/tests/test_norm.py
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from distutils.version import LooseVersion
-
+from packaging.version import Version
 import pytest
 import numpy as np
 from numpy import ma
@@ -16,7 +15,7 @@ try:
     import matplotlib    # pylint: disable=W0611
     from matplotlib import pyplot as plt
     HAS_MATPLOTLIB = True
-    MATPLOTLIB_LT_32 = LooseVersion(matplotlib.__version__) < '3.2'
+    MATPLOTLIB_LT_32 = Version(matplotlib.__version__) < Version('3.2')
 except ImportError:
     HAS_MATPLOTLIB = False
 

--- a/astropy/visualization/wcsaxes/tests/test_misc.py
+++ b/astropy/visualization/wcsaxes/tests/test_misc.py
@@ -1,8 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import os
-from distutils.version import LooseVersion
 
+from packaging.version import Version
 import pytest
 import numpy as np
 import matplotlib
@@ -20,8 +20,8 @@ from astropy.visualization.wcsaxes.frame import (
 from astropy.visualization.wcsaxes.utils import get_coord_meta
 from astropy.visualization.wcsaxes.transforms import CurvedTransform
 
-MATPLOTLIB_LT_21 = LooseVersion(matplotlib.__version__) < LooseVersion("2.1")
-MATPLOTLIB_LT_22 = LooseVersion(matplotlib.__version__) < LooseVersion("2.2")
+MATPLOTLIB_LT_21 = Version(matplotlib.__version__) < Version("2.1")
+MATPLOTLIB_LT_22 = Version(matplotlib.__version__) < Version("2.2")
 TEX_UNAVAILABLE = not matplotlib.checkdep_usetex(True)
 
 DATA = os.path.abspath(os.path.join(os.path.dirname(__file__), 'data'))

--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -3,8 +3,8 @@
 import io
 import os
 from datetime import datetime
-from distutils.version import LooseVersion
 
+from packaging.version import Version
 import pytest
 import numpy as np
 from numpy.testing import (
@@ -22,12 +22,12 @@ from astropy.io import fits
 from astropy.coordinates import SkyCoord
 
 
-_WCSLIB_VER = LooseVersion(_wcs.__version__)
+_WCSLIB_VER = Version(_wcs.__version__)
 
 
 # NOTE: User can choose to use system wcslib instead of bundled.
 def _check_v71_dateref_warnings(w, nmax=None):
-    if _WCSLIB_VER >= '7.1' and _WCSLIB_VER < '7.3' and w:
+    if _WCSLIB_VER >= Version('7.1') and _WCSLIB_VER < Version('7.3') and w:
         if nmax is None:
             assert w
         else:
@@ -208,7 +208,7 @@ def test_dict_init():
         'CDELT1': -0.1,
         'CDELT2': 0.1
     }
-    if _WCSLIB_VER >= '7.1':
+    if _WCSLIB_VER >= Version('7.1'):
         hdr['DATEREF'] = '1858-11-17'
 
     w = wcs.WCS(hdr)
@@ -345,12 +345,12 @@ def test_to_header_string():
         "LATPOLE =                 90.0 / [deg] Native latitude of celestial pole        ",
     )
 
-    if _WCSLIB_VER >= '7.3':
+    if _WCSLIB_VER >= Version('7.3'):
         hdrstr += (
             "MJDREF  =                  0.0 / [d] MJD of fiducial time                       ",
         )
 
-    elif _WCSLIB_VER >= '7.1':
+    elif _WCSLIB_VER >= Version('7.1'):
         hdrstr += (
             "DATEREF = '1858-11-17'         / ISO-8601 fiducial time                         ",
             "MJDREFI =                  0.0 / [d] MJD of fiducial time, integer part         ",
@@ -372,10 +372,10 @@ def test_to_header_string():
 
 
 def test_to_fits():
-    nrec = 11 if _WCSLIB_VER >= '7.1' else 8
-    if _WCSLIB_VER < '7.1':
+    nrec = 11 if _WCSLIB_VER >= Version('7.1') else 8
+    if _WCSLIB_VER < Version('7.1'):
         nrec = 8
-    elif _WCSLIB_VER < '7.3':
+    elif _WCSLIB_VER < Version('7.3'):
         nrec = 11
     else:
         nrec = 9
@@ -1390,7 +1390,7 @@ def test_cunit():
 
 class TestWcsWithTime:
     def setup(self):
-        if _WCSLIB_VER >= '7.1':
+        if _WCSLIB_VER >= Version('7.1'):
             fname = get_pkg_data_filename('data/header_with_time_wcslib71.fits')
         else:
             fname = get_pkg_data_filename('data/header_with_time.fits')

--- a/astropy/wcs/tests/test_wcsprm.py
+++ b/astropy/wcs/tests/test_wcsprm.py
@@ -5,8 +5,8 @@
 import gc
 import locale
 import re
-from distutils.version import LooseVersion
 
+from packaging.version import Version
 import pytest
 import numpy as np
 from numpy.testing import assert_array_equal, assert_array_almost_equal
@@ -410,9 +410,9 @@ def test_fix():
         'celfix': 'No change',
         'obsfix': 'No change'}
     version = wcs._wcs.__version__
-    if LooseVersion(version) <= '5':
+    if Version(version) <= Version('5'):
         del fix_ref['obsfix']
-    if LooseVersion(version) >= '7.1':
+    if Version(version) >= Version('7.1'):
         w.dateref = '1858-11-17'
     assert w.fix() == fix_ref
 
@@ -429,14 +429,14 @@ def test_fix2():
         'unitfix': 'No change',
         'celfix': 'No change'}
     version = wcs._wcs.__version__
-    if LooseVersion(version) <= "5":
+    if Version(version) <= Version("5"):
         del fix_ref['obsfix']
         fix_ref['datfix'] = "Changed '31/12/99' to '1999-12-31'"
 
-    if LooseVersion(version) >= '7.3':
+    if Version(version) >= Version('7.3'):
         fix_ref['datfix'] = "Set DATEREF to '1858-11-17' from MJDREF.\n" + fix_ref['datfix']
 
-    elif LooseVersion(version) >= '7.1':
+    elif Version(version) >= Version('7.1'):
         fix_ref['datfix'] = "Set DATE-REF to '1858-11-17' from MJD-REF.\n" + fix_ref['datfix']
 
     assert w.fix() == fix_ref
@@ -458,13 +458,13 @@ def test_fix3():
     }
 
     version = wcs._wcs.__version__
-    if LooseVersion(version) <= "5":
+    if Version(version) <= Version("5"):
         del fix_ref['obsfix']
         fix_ref['datfix'] = "Invalid parameter value: invalid date '31/12/F9'"
 
-    if LooseVersion(version) >= '7.3':
+    if Version(version) >= Version('7.3'):
         fix_ref['datfix'] = "Set DATEREF to '1858-11-17' from MJDREF.\n" + fix_ref['datfix']
-    elif LooseVersion(version) >= '7.1':
+    elif Version(version) >= Version('7.1'):
         fix_ref['datfix'] = "Set DATE-REF to '1858-11-17' from MJD-REF.\n" + fix_ref['datfix']
 
     assert w.fix() == fix_ref
@@ -1121,9 +1121,9 @@ def test_datebeg():
         'unitfix': 'No change',
         'celfix': 'No change'}
 
-    if LooseVersion(wcs._wcs.__version__) >= '7.3':
+    if Version(wcs._wcs.__version__) >= Version('7.3'):
         fix_ref['datfix'] = "Set DATEREF to '1858-11-17' from MJDREF.\n" + fix_ref['datfix']
-    elif LooseVersion(wcs._wcs.__version__) >= '7.1':
+    elif Version(wcs._wcs.__version__) >= Version('7.1'):
         fix_ref['datfix'] = "Set DATE-REF to '1858-11-17' from MJD-REF.\n" + fix_ref['datfix']
 
     assert w.fix() == fix_ref
@@ -1165,7 +1165,7 @@ def test_num_keys(key):
 def test_array_keys(key):
     w = _wcs.Wcsprm()
     attr = getattr(w, key)
-    if key == 'mjdref' and LooseVersion(_wcs.__version__) >= '7.1':
+    if key == 'mjdref' and Version(_wcs.__version__) >= Version('7.1'):
         assert np.allclose(attr, [0, 0])
     else:
         assert np.all(np.isnan(attr))

--- a/astropy/wcs/wcsapi/tests/test_fitswcs.py
+++ b/astropy/wcs/wcsapi/tests/test_fitswcs.py
@@ -3,8 +3,8 @@
 # a mix-in)
 
 import warnings
-from distutils.version import LooseVersion
 
+from packaging.version import Version
 import numpy as np
 import pytest
 from numpy.testing import assert_equal, assert_allclose
@@ -531,7 +531,7 @@ OBSGEO-B= -70
 OBSGEO-H= 2530
 """
 
-if LooseVersion(wcsver) >= '7.1':
+if Version(wcsver) >= Version('7.1'):
     HEADER_TIME_1D += "DATEREF = '1995-10-12T14:24:00'\n"
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,6 +57,7 @@ test =
     coverage
     skyfield>=1.20
     sgp4>=2.3
+    packaging
 all =
     scipy>=0.18
     dask[array]

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,7 +57,6 @@ test =
     coverage
     skyfield>=1.20
     sgp4>=2.3
-    packaging
 all =
     scipy>=0.18
     dask[array]


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description

This addresses part of #10578 by removing `distutils.version.LooseVersion`.  

- In the tests, `packaging` is added as a dependency and `packaging.version.Version` is used instead of `LooseVersion`. It does not seem problematic to me to add this as a test dependency.
- In a couple of places ([here](https://github.com/astropy/astropy/pull/10590/files#diff-cb06e7e54ea6c0cc5013e1e85f3cda5bR102) and [here](https://github.com/astropy/astropy/pull/10590/files#diff-5a4193c12a96fa7bfa06b29a41e95120R287)) the version test was simple to replace.
- [x] One place I'm not sure how to handle: https://github.com/astropy/astropy/blob/master/astropy/utils/introspection.py#L153 . Writing a bit of code to do the check ourselves would be straightforward and avoid `LooseVersion`; alternatively, we could just move the import of `LooseVersion` inside of the function, which should remove the setuptools warnings.
