### PR TITLE
Fix ResourceWarning with fits.writeto and pathlib object

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -928,6 +928,9 @@ astropy.io.fits
 
 - Fix duplication issue when setting a keyword ending with space. [#10482]
 
+- Fix ResourceWarning with ``fits.writeto`` and ``pathlib.Path`` object.
+  [#10599]
+
 astropy.io.misc
 ^^^^^^^^^^^^^^^
 

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -38,7 +38,7 @@ def fitsopen(name, mode='readonly', memmap=None, save_backup=False,
 
     Parameters
     ----------
-    name : file path, file object, file-like object or pathlib.Path object
+    name : str, file-like or `pathlib.Path`
         File to be opened.
 
     mode : str, optional
@@ -888,7 +888,7 @@ class HDUList(list, _Verify):
 
         Parameters
         ----------
-        fileobj : file path, file object or file-like object
+        fileobj : str, file-like or `pathlib.Path`
             File to write to.  If a file object, must be opened in a
             writeable mode.
 

--- a/astropy/io/fits/tests/test_convenience.py
+++ b/astropy/io/fits/tests/test_convenience.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see PYFITS.rst
 
 import os
+import pathlib
 import warnings
 
 import pytest
@@ -276,3 +277,12 @@ class TestConvenience(FitsTestCase):
 
         with fits.open(testfile, checksum=True) as hdus:
             assert len(hdus) == 5
+
+    def test_pathlib(self):
+        testfile = pathlib.Path(self.temp('test.fits'))
+        data = np.arange(10)
+        hdulist = fits.HDUList([fits.PrimaryHDU(data)])
+        hdulist.writeto(testfile)
+
+        with fits.open(testfile) as hdul:
+            np.testing.assert_array_equal(hdul[0].data, data)

--- a/astropy/io/fits/util.py
+++ b/astropy/io/fits/util.py
@@ -6,6 +6,7 @@ import io
 import mmap
 import operator
 import os
+import pathlib
 import platform
 import signal
 import sys
@@ -433,7 +434,7 @@ def fileobj_closed(f):
     they are file-like objects with no sense of a 'closed' state.
     """
 
-    if isinstance(f, str):
+    if isinstance(f, (str, pathlib.Path)):
         return True
 
     if hasattr(f, 'closed'):


### PR DESCRIPTION
Fix #10594

Note: the `ResourceWarning` is hidden by the filter in `setup.cfg`.