### PR TITLE
Fix extract_array with integer input array and NaN fill value

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1074,6 +1074,9 @@ Other Changes and Additions
 - Updated the bundled CFITSIO library to 3.480. See
   ``cextern/cfitsio/docs/changes.txt`` for additional information. [#10256]
 
+- ``extract_array`` raises a ``ValueError`` if the data type of the
+  input array is inconsistent with the ``fill_value``. [#10602]
+
 
 4.0.1 (2020-03-27)
 ==================

--- a/astropy/nddata/tests/test_utils.py
+++ b/astropy/nddata/tests/test_utils.py
@@ -8,7 +8,7 @@ from astropy.tests.helper import assert_quantity_allclose
 from astropy.nddata import (extract_array, add_array, subpixel_indices,
                             overlap_slices, NoOverlapError,
                             PartialOverlapError, Cutout2D)
-
+from astropy.utils import minversion
 from astropy.wcs import WCS, Sip
 from astropy.wcs.utils import proj_plane_pixel_area
 from astropy.coordinates import SkyCoord
@@ -274,7 +274,7 @@ def test_extract_array_return_pos():
     The result will differ by mode. All test here are done in 1d because it's
     easier to construct correct test cases.
     '''
-    large_test_array = np.arange(5)
+    large_test_array = np.arange(5).astype(float)
     for i in np.arange(-1, 6):
         extracted, new_pos = extract_array(large_test_array, 3, i,
                                            mode='partial',
@@ -290,6 +290,14 @@ def test_extract_array_return_pos():
         extracted, new_pos = extract_array(large_test_array, (3,), (i,),
                                            mode='trim', return_position=True)
         assert new_pos == (expected, )
+
+
+def test_extract_array_nan_fillvalue():
+    if minversion(np, '1.20'):
+        with pytest.raises(ValueError) as err:
+            extract_array(np.ones((10, 10), dtype=int), (5, 5), (1, 1),
+                          fill_value=np.nan)
+        assert 'fill_value cannot be set to np.nan if' in err.value.args[0]
 
 
 def test_add_array_odd_shape():

--- a/astropy/nddata/tests/test_utils.py
+++ b/astropy/nddata/tests/test_utils.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+from packaging.version import Version
 import pytest
 import numpy as np
 from numpy.testing import assert_allclose, assert_array_equal
@@ -8,7 +9,6 @@ from astropy.tests.helper import assert_quantity_allclose
 from astropy.nddata import (extract_array, add_array, subpixel_indices,
                             overlap_slices, NoOverlapError,
                             PartialOverlapError, Cutout2D)
-from astropy.utils import minversion
 from astropy.wcs import WCS, Sip
 from astropy.wcs.utils import proj_plane_pixel_area
 from astropy.coordinates import SkyCoord
@@ -293,7 +293,7 @@ def test_extract_array_return_pos():
 
 
 def test_extract_array_nan_fillvalue():
-    if minversion(np, '1.20'):
+    if Version(np.__version__) >= Version('1.20'):
         msg = 'fill_value cannot be set to np.nan if the input array has'
         with pytest.raises(ValueError, match=msg):
             extract_array(np.ones((10, 10), dtype=int), (5, 5), (1, 1),

--- a/astropy/nddata/tests/test_utils.py
+++ b/astropy/nddata/tests/test_utils.py
@@ -274,7 +274,7 @@ def test_extract_array_return_pos():
     The result will differ by mode. All test here are done in 1d because it's
     easier to construct correct test cases.
     '''
-    large_test_array = np.arange(5).astype(float)
+    large_test_array = np.arange(5, dtype=float)
     for i in np.arange(-1, 6):
         extracted, new_pos = extract_array(large_test_array, 3, i,
                                            mode='partial',
@@ -294,10 +294,10 @@ def test_extract_array_return_pos():
 
 def test_extract_array_nan_fillvalue():
     if minversion(np, '1.20'):
-        with pytest.raises(ValueError) as err:
+        msg = 'fill_value cannot be set to np.nan if the input array has'
+        with pytest.raises(ValueError, match=msg):
             extract_array(np.ones((10, 10), dtype=int), (5, 5), (1, 1),
                           fill_value=np.nan)
-        assert 'fill_value cannot be set to np.nan if' in err.value.args[0]
 
 
 def test_add_array_odd_shape():

--- a/astropy/nddata/utils.py
+++ b/astropy/nddata/utils.py
@@ -244,8 +244,8 @@ def extract_array(array_large, shape, position, mode='partial',
 
     # Extracting on the edges is presumably a rare case, so treat special here
     if (extracted_array.shape != shape) and (mode == 'partial'):
+        extracted_array = np.zeros(shape, dtype=array_large.dtype)
         try:
-            extracted_array = np.zeros(shape, dtype=array_large.dtype)
             extracted_array[:] = fill_value
         except ValueError:
             raise ValueError('fill_value cannot be set to np.nan if the '

--- a/astropy/nddata/utils.py
+++ b/astropy/nddata/utils.py
@@ -248,10 +248,12 @@ def extract_array(array_large, shape, position, mode='partial',
         try:
             extracted_array[:] = fill_value
         except ValueError:
-            raise ValueError('fill_value cannot be set to np.nan if the '
-                             'input array has integer type. Please '
-                             'change either the input array dtype or the '
-                             'fill_value.') from None
+            raise ValueError('fill_value is inconsistent with the data type '
+                             'of the input array (e.g., fill_value cannot be '
+                             'set to np.nan if the input array has integer '
+                             'type). Please change either the input array '
+                             'dtype or the fill_value.') from None
+
         extracted_array[small_slices] = array_large[large_slices]
         if return_position:
             new_position = [i + s.start for i, s in zip(new_position,

--- a/astropy/nddata/utils.py
+++ b/astropy/nddata/utils.py
@@ -194,8 +194,10 @@ def extract_array(array_large, shape, position, mode='partial',
     fill_value : number, optional
         If ``mode='partial'``, the value to fill pixels in the extracted
         small array that do not overlap with the input ``array_large``.
-        ``fill_value`` must have the same ``dtype`` as the
-        ``array_large`` array.
+        ``fill_value`` will be changed to have the same ``dtype`` as the
+        ``array_large`` array, with one exception. If ``array_large``
+        has integer type and ``fill_value`` is ``np.nan``, then a
+        `ValueError` will be raised.
     return_position : bool, optional
         If `True`, return the coordinates of ``position`` in the
         coordinate system of the returned array.
@@ -242,8 +244,14 @@ def extract_array(array_large, shape, position, mode='partial',
 
     # Extracting on the edges is presumably a rare case, so treat special here
     if (extracted_array.shape != shape) and (mode == 'partial'):
-        extracted_array = np.zeros(shape, dtype=array_large.dtype)
-        extracted_array[:] = fill_value
+        try:
+            extracted_array = np.zeros(shape, dtype=array_large.dtype)
+            extracted_array[:] = fill_value
+        except ValueError:
+            raise ValueError('fill_value cannot be set to np.nan if the '
+                             'input array has integer type. Please '
+                             'change either the input array dtype or the '
+                             'fill_value.') from None
         extracted_array[small_slices] = array_large[large_slices]
         if return_position:
             new_position = [i + s.start for i, s in zip(new_position,

--- a/astropy/nddata/utils.py
+++ b/astropy/nddata/utils.py
@@ -247,12 +247,13 @@ def extract_array(array_large, shape, position, mode='partial',
         extracted_array = np.zeros(shape, dtype=array_large.dtype)
         try:
             extracted_array[:] = fill_value
-        except ValueError:
-            raise ValueError('fill_value is inconsistent with the data type '
-                             'of the input array (e.g., fill_value cannot be '
-                             'set to np.nan if the input array has integer '
-                             'type). Please change either the input array '
-                             'dtype or the fill_value.') from None
+        except ValueError as exc:
+            exc.args += ('fill_value is inconsistent with the data type of '
+                         'the input array (e.g., fill_value cannot be set to '
+                         'np.nan if the input array has integer type). Please '
+                         'change either the input array dtype or the '
+                         'fill_value.',)
+            raise exc
 
         extracted_array[small_slices] = array_large[large_slices]
         if return_position:


### PR DESCRIPTION
`numpy 1.20dev` now raises `ValueError: cannot convert float NaN to integer` when attempting to assign to `np.nan` in an integer array.  In this PR, I've updated the `extract_array` function to change the `dtype` of the output array to float if the fill value is used and its value is `np.nan`.  That preserves the current behavior with `numpy <= 1.19`.

https://github.com/astropy/astropy/pull/10601 simply fixes an `astropy` test.  This PR fixes the root issue (I noticed this in `photutils`).

Fix #10600.