### PR TITLE
Fix SigmaClip output data values for masked=True, copy=True, axis is not None

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -978,7 +978,7 @@ astropy.stats
 - Fixed an API regression where ``SigmaClip.__call__`` would convert masked
   elements to ``nan`` and upcast the dtype to ``float64`` in its output
   ``MaskedArray`` when using the ``axis`` parameter along with the defaults
-  ``masked=True`` and ``copy=True``. [?]
+  ``masked=True`` and ``copy=True``. [#10610]
 
 - Fixed an issue where fully masked ``MaskedArray`` input to
   ``sigma_clipped_stats`` gave incorrect results. [#10099]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -975,10 +975,15 @@ astropy.samp
 astropy.stats
 ^^^^^^^^^^^^^
 
+- Fixed an API regression where ``SigmaClip.__call__`` would convert masked
+  elements to ``nan`` and upcast the dtype to ``float64`` in its output
+  ``MaskedArray`` when using the ``axis`` parameter along with the defaults
+  ``masked=True`` and ``copy=True``. [?]
+
 - Fixed an issue where fully masked ``MaskedArray`` input to
   ``sigma_clipped_stats`` gave incorrect results. [#10099]
 
-- Fixed an issued where ``sigma_clip`` and ``SigmaClip.__call__``
+- Fixed an issue where ``sigma_clip`` and ``SigmaClip.__call__``
   would return a masked array instead of a ``ndarray`` when
   ``masked=False`` and the input was a full-masked ``MaskedArray``.
   [#10099]

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -378,7 +378,9 @@ class SigmaClip:
         if masked:
             # create an output masked array
             if copy:
-                filtered_data = np.ma.masked_invalid(filtered_data)
+                filtered_data = np.ma.masked_invalid(filtered_data, copy=False)
+                filtered_data = np.ma.MaskedArray(data, filtered_data.mask,
+                                                  copy=True)
             else:
                 # ignore RuntimeWarnings for comparisons with NaN data values
                 with np.errstate(invalid='ignore'):

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -378,8 +378,7 @@ class SigmaClip:
         if masked:
             # create an output masked array
             if copy:
-                filtered_data = np.ma.masked_invalid(filtered_data, copy=False)
-                filtered_data = np.ma.MaskedArray(data, filtered_data.mask,
+                filtered_data = np.ma.MaskedArray(data, ~np.isfinite(filtered_data),
                                                   copy=True)
             else:
                 # ignore RuntimeWarnings for comparisons with NaN data values

--- a/astropy/stats/tests/test_sigma_clipping.py
+++ b/astropy/stats/tests/test_sigma_clipping.py
@@ -302,3 +302,44 @@ def test_sigma_clippped_stats_all_masked():
     mask = arr < 20
     result = sigma_clipped_stats(arr, mask=mask)
     assert result == (np.ma.masked, np.ma.masked, np.ma.masked)
+
+
+def test_sigma_clip_masked_data_values():
+    """
+    Test that the data values & type returned by sigma_clip are the same as
+    its input when using masked=True (rather than being upcast to float64 &
+    containing NaNs as in issue #10605) and also that the input data get
+    copied or referenced as appropriate.
+    """
+
+    data = np.array([-2, 5, -5, -6, 20, 14, 1])
+
+    result = sigma_clip(data, sigma=1.5, maxiters=3, axis=None, masked=True,
+                        copy=True)
+
+    assert result.dtype == data.dtype
+    assert np.all(result.data == data)
+    assert not np.shares_memory(result.data, data)
+
+    result = sigma_clip(data, sigma=1.5, maxiters=3, axis=None, masked=True,
+                        copy=False)
+
+    assert result.dtype == data.dtype
+    assert np.all(result.data == data)
+    assert np.shares_memory(result.data, data)
+    # (The fact that the arrays share memory probably also means they're the
+    # same, but doesn't strictly prove it, eg. one could be reversed.)
+
+    result = sigma_clip(data, sigma=1.5, maxiters=3, axis=0, masked=True,
+                        copy=True)
+
+    assert result.dtype == data.dtype
+    assert np.all(result.data == data)
+    assert not np.shares_memory(result.data, data)
+
+    result = sigma_clip(data, sigma=1.5, maxiters=3, axis=0, masked=True,
+                        copy=False)
+
+    assert result.dtype == data.dtype
+    assert np.all(result.data == data)
+    assert np.shares_memory(result.data, data)

--- a/astropy/stats/tests/test_sigma_clipping.py
+++ b/astropy/stats/tests/test_sigma_clipping.py
@@ -318,14 +318,14 @@ def test_sigma_clip_masked_data_values():
                         copy=True)
 
     assert result.dtype == data.dtype
-    assert np.all(result.data == data)
+    assert_equal(result.data, data)
     assert not np.shares_memory(result.data, data)
 
     result = sigma_clip(data, sigma=1.5, maxiters=3, axis=None, masked=True,
                         copy=False)
 
     assert result.dtype == data.dtype
-    assert np.all(result.data == data)
+    assert_equal(result.data, data)
     assert np.shares_memory(result.data, data)
     # (The fact that the arrays share memory probably also means they're the
     # same, but doesn't strictly prove it, eg. one could be reversed.)
@@ -334,12 +334,12 @@ def test_sigma_clip_masked_data_values():
                         copy=True)
 
     assert result.dtype == data.dtype
-    assert np.all(result.data == data)
+    assert_equal(result.data, data)
     assert not np.shares_memory(result.data, data)
 
     result = sigma_clip(data, sigma=1.5, maxiters=3, axis=0, masked=True,
                         copy=False)
 
     assert result.dtype == data.dtype
-    assert np.all(result.data == data)
+    assert_equal(result.data, data)
     assert np.shares_memory(result.data, data)


### PR DESCRIPTION
### Description

This fixes #10605 by re-copying the input data into the final `MaskedArray` at the end of `_sigmaclip_withaxis`. It adds a regression test to confirm that the output data (as opposed to mask) are the same as the input for `masked=True` with different `axis` and `copy` arguments and also that the input array gets copied or referenced as appropriate.

I've made one change WRT what I proposed in #10605, which is to add `copy=False` at L381 to avoid an additional copy operation. Does that look good? Thanks.