### PR TITLE
Add a grow parameter to sigma_clip et al.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -195,7 +195,7 @@ astropy.stats
 
 - Added a ``grow`` parameter to ``SigmaClip``, ``sigma_clip`` and
   ``sigma_clipped_stats``, to allow expanding the masking of each deviant
-  value to its neighbours within a specified radius. [#?]
+  value to its neighbours within a specified radius. [#10613]
 
 
 astropy.table

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -193,6 +193,11 @@ astropy.samp
 astropy.stats
 ^^^^^^^^^^^^^
 
+- Added a ``grow`` parameter to ``SigmaClip``, ``sigma_clip`` and
+  ``sigma_clipped_stats``, to allow expanding the masking of each deviant
+  value to its neighbours within a specified radius. [#?]
+
+
 astropy.table
 ^^^^^^^^^^^^^
 

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -418,7 +418,8 @@ class SigmaClip:
         if masked:
             # create an output masked array
             if copy:
-                filtered_data = np.ma.MaskedArray(data, ~np.isfinite(filtered_data),
+                filtered_data = np.ma.MaskedArray(data,
+                                                  ~np.isfinite(filtered_data),
                                                   copy=True)
             else:
                 # ignore RuntimeWarnings for comparisons with NaN data values

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -168,7 +168,7 @@ class SigmaClip:
     grow : float or `False`, optional
         Radius within which to mask the neighbouring pixels of those that
         fall outwith the clipping limits (only applied along ``axis``, if
-        specified). A value of 1 will mask the nearest pixels in a cross
+        specified). As an example, for a 2D image a value of 1 will mask the nearest pixels in a cross
         pattern around each deviant pixel, while 1.5 will also reject the
         nearest diagonal neighbours and so on.
 
@@ -629,7 +629,7 @@ def sigma_clip(data, sigma=3, sigma_lower=None, sigma_upper=None, maxiters=5,
     grow : float or `False`, optional
         Radius within which to mask the neighbouring pixels of those that
         fall outwith the clipping limits (only applied along ``axis``, if
-        specified). A value of 1 will mask the nearest pixels in a cross
+        specified). As an example, for a 2D image a value of 1 will mask the nearest pixels in a cross
         pattern around each deviant pixel, while 1.5 will also reject the
         nearest diagonal neighbours and so on.
 
@@ -787,7 +787,7 @@ def sigma_clipped_stats(data, mask=None, mask_value=None, sigma=3.0,
     grow : float or `False`, optional
         Radius within which to mask the neighbouring pixels of those that
         fall outwith the clipping limits (only applied along ``axis``, if
-        specified). A value of 1 will mask the nearest pixels in a cross
+        specified). As an example, for a 2D image a value of 1 will mask the nearest pixels in a cross
         pattern around each deviant pixel, while 1.5 will also reject the
         nearest diagonal neighbours and so on.
 

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -143,13 +143,6 @@ class SigmaClip:
         achieved prior to ``maxiters`` iterations, the clipping
         iterations will stop.  The default is 5.
 
-    grow : float or `False`, optional
-        Radius within which to mask the neighbouring pixels of those that
-        fall outwith the clipping limits (only applied along `axis`, if
-        specified). A value of 1 will mask the nearest pixels in a cross
-        pattern around each deviant pixel, while 1.5 will also reject the
-        nearest diagonal neighbours and so on.
-
     cenfunc : {'median', 'mean'} or callable, optional
         The statistic or callable function/object used to compute the
         center value for the clipping.  If set to ``'median'`` or
@@ -171,6 +164,13 @@ class SigmaClip:
         be callable that can ignore NaNs (e.g., `numpy.nanstd`) and has
         an ``axis`` keyword to return an array with axis dimension(s)
         removed.  The default is ``'std'``.
+
+    grow : float or `False`, optional
+        Radius within which to mask the neighbouring pixels of those that
+        fall outwith the clipping limits (only applied along `axis`, if
+        specified). A value of 1 will mask the nearest pixels in a cross
+        pattern around each deviant pixel, while 1.5 will also reject the
+        nearest diagonal neighbours and so on.
 
     See Also
     --------
@@ -214,15 +214,15 @@ class SigmaClip:
     """
 
     def __init__(self, sigma=3., sigma_lower=None, sigma_upper=None,
-                 maxiters=5, grow=False, cenfunc='median', stdfunc='std'):
+                 maxiters=5, cenfunc='median', stdfunc='std', grow=False):
 
         self.sigma = sigma
         self.sigma_lower = sigma_lower or sigma
         self.sigma_upper = sigma_upper or sigma
         self.maxiters = maxiters or np.inf
-        self.grow = grow
         self.cenfunc = self._parse_cenfunc(cenfunc)
         self.stdfunc = self._parse_stdfunc(stdfunc)
+        self.grow = grow
 
         # This just checks that SciPy is available, to avoid failing later
         # than necessary if __call__ needs it:
@@ -232,14 +232,14 @@ class SigmaClip:
 
     def __repr__(self):
         return ('SigmaClip(sigma={}, sigma_lower={}, sigma_upper={}, '
-                'maxiters={}, grow={}, cenfunc={}, stdfunc={})'
+                'maxiters={}, cenfunc={}, stdfunc={}, grow={})'
                 .format(self.sigma, self.sigma_lower, self.sigma_upper,
-                        self.maxiters, self.grow, self.cenfunc, self.stdfunc))
+                        self.maxiters, self.cenfunc, self.stdfunc, self.grow))
 
     def __str__(self):
         lines = ['<' + self.__class__.__name__ + '>']
-        attrs = ['sigma', 'sigma_lower', 'sigma_upper', 'maxiters', 'grow',
-                 'cenfunc', 'stdfunc']
+        attrs = ['sigma', 'sigma_lower', 'sigma_upper', 'maxiters', 'cenfunc',
+                 'stdfunc', 'grow']
         for attr in attrs:
             lines.append('    {}: {}'.format(attr, getattr(self, attr)))
         return '\n'.join(lines)
@@ -520,8 +520,8 @@ class SigmaClip:
 
 
 def sigma_clip(data, sigma=3, sigma_lower=None, sigma_upper=None, maxiters=5,
-               grow=False, cenfunc='median', stdfunc='std', axis=None,
-               masked=True, return_bounds=False, copy=True):
+               cenfunc='median', stdfunc='std', axis=None, masked=True,
+               return_bounds=False, copy=True, grow=False):
     """
     Perform sigma-clipping on the provided data.
 
@@ -582,13 +582,6 @@ def sigma_clip(data, sigma=3, sigma_lower=None, sigma_upper=None, maxiters=5,
         achieved prior to ``maxiters`` iterations, the clipping
         iterations will stop.  The default is 5.
 
-    grow : float or `False`, optional
-        Radius within which to mask the neighbouring pixels of those that
-        fall outwith the clipping limits (only applied along `axis`, if
-        specified). A value of 1 will mask the nearest pixels in a cross
-        pattern around each deviant pixel, while 1.5 will also reject the
-        nearest diagonal neighbours and so on.
-
     cenfunc : {'median', 'mean'} or callable, optional
         The statistic or callable function/object used to compute the
         center value for the clipping.  If set to ``'median'`` or
@@ -632,6 +625,13 @@ def sigma_clip(data, sigma=3, sigma_lower=None, sigma_upper=None, maxiters=5,
         contain the same array as the input ``data`` (if ``data`` is a
         `~numpy.ndarray` or `~numpy.ma.MaskedArray`).  The default is
         `True`.
+
+    grow : float or `False`, optional
+        Radius within which to mask the neighbouring pixels of those that
+        fall outwith the clipping limits (only applied along `axis`, if
+        specified). A value of 1 will mask the nearest pixels in a cross
+        pattern around each deviant pixel, while 1.5 will also reject the
+        nearest diagonal neighbours and so on.
 
     Returns
     -------
@@ -700,7 +700,7 @@ def sigma_clip(data, sigma=3, sigma_lower=None, sigma_upper=None, maxiters=5,
 
     sigclip = SigmaClip(sigma=sigma, sigma_lower=sigma_lower,
                         sigma_upper=sigma_upper, maxiters=maxiters,
-                        grow=grow, cenfunc=cenfunc, stdfunc=stdfunc)
+                        cenfunc=cenfunc, stdfunc=stdfunc, grow=grow)
 
     return sigclip(data, axis=axis, masked=masked,
                    return_bounds=return_bounds, copy=copy)
@@ -708,8 +708,8 @@ def sigma_clip(data, sigma=3, sigma_lower=None, sigma_upper=None, maxiters=5,
 
 def sigma_clipped_stats(data, mask=None, mask_value=None, sigma=3.0,
                         sigma_lower=None, sigma_upper=None, maxiters=5,
-                        grow=False, cenfunc='median', stdfunc='std',
-                        std_ddof=0, axis=None):
+                        cenfunc='median', stdfunc='std', std_ddof=0,
+                        axis=None, grow=False):
     """
     Calculate sigma-clipped statistics on the provided data.
 
@@ -751,13 +751,6 @@ def sigma_clipped_stats(data, mask=None, mask_value=None, sigma=3.0,
         achieved prior to ``maxiters`` iterations, the clipping
         iterations will stop.  The default is 5.
 
-    grow : float or `False`, optional
-        Radius within which to mask the neighbouring pixels of those that
-        fall outwith the clipping limits (only applied along `axis`, if
-        specified). A value of 1 will mask the nearest pixels in a cross
-        pattern around each deviant pixel, while 1.5 will also reject the
-        nearest diagonal neighbours and so on.
-
     cenfunc : {'median', 'mean'} or callable, optional
         The statistic or callable function/object used to compute the
         center value for the clipping.  If set to ``'median'`` or
@@ -791,6 +784,13 @@ def sigma_clipped_stats(data, mask=None, mask_value=None, sigma=3.0,
         then the flattened data will be used.  ``axis`` is passed
         to the ``cenfunc`` and ``stdfunc``.  The default is `None`.
 
+    grow : float or `False`, optional
+        Radius within which to mask the neighbouring pixels of those that
+        fall outwith the clipping limits (only applied along `axis`, if
+        specified). A value of 1 will mask the nearest pixels in a cross
+        pattern around each deviant pixel, while 1.5 will also reject the
+        nearest diagonal neighbours and so on.
+
     Returns
     -------
     mean, median, stddev : float
@@ -812,7 +812,7 @@ def sigma_clipped_stats(data, mask=None, mask_value=None, sigma=3.0,
 
     sigclip = SigmaClip(sigma=sigma, sigma_lower=sigma_lower,
                         sigma_upper=sigma_upper, maxiters=maxiters,
-                        grow=grow, cenfunc=cenfunc, stdfunc=stdfunc)
+                        cenfunc=cenfunc, stdfunc=stdfunc, grow=grow)
     data_clipped = sigclip(data, axis=axis, masked=False, return_bounds=False,
                            copy=False)
 

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -229,7 +229,6 @@ class SigmaClip:
         if self.grow:
             from scipy.ndimage import binary_dilation
 
-
     def __repr__(self):
         return ('SigmaClip(sigma={}, sigma_lower={}, sigma_upper={}, '
                 'maxiters={}, cenfunc={}, stdfunc={}, grow={})'

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -384,8 +384,8 @@ class SigmaClip:
                     # indices outside the growth radius, so masked points won't
                     # "grow" in that dimension:
                     if n not in axis:
-                        dim[dim!=cenidx] = size
-            kernel = sum(((idx-cenidx)**2 for idx in indices)) <= self.grow**2
+                        dim[dim != cenidx] = size
+            kernel = sum(((idx - cenidx)**2 for idx in indices)) <= self.grow**2
             del indices
 
         nchanged = 1

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -4,8 +4,6 @@ import warnings
 
 import numpy as np
 
-from scipy.ndimage import binary_dilation
-
 from astropy.utils import isiterable
 from astropy.utils.exceptions import AstropyUserWarning
 
@@ -226,6 +224,12 @@ class SigmaClip:
         self.cenfunc = self._parse_cenfunc(cenfunc)
         self.stdfunc = self._parse_stdfunc(stdfunc)
 
+        # This just checks that SciPy is available, to avoid failing later
+        # than necessary if __call__ needs it:
+        if self.grow:
+            from scipy.ndimage import binary_dilation
+
+
     def __repr__(self):
         return ('SigmaClip(sigma={}, sigma_lower={}, sigma_upper={}, '
                 'maxiters={}, grow={}, cenfunc={}, stdfunc={})'
@@ -368,6 +372,8 @@ class SigmaClip:
                            for dim, size in enumerate(filtered_data.shape))
 
         if self.grow:
+            from scipy.ndimage import binary_dilation
+
             # Construct a growth kernel from the specified radius in pixels
             # (consider caching this for re-use by subsequent calls?):
             cenidx = int(self.grow)

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -167,7 +167,7 @@ class SigmaClip:
 
     grow : float or `False`, optional
         Radius within which to mask the neighbouring pixels of those that
-        fall outwith the clipping limits (only applied along `axis`, if
+        fall outwith the clipping limits (only applied along ``axis``, if
         specified). A value of 1 will mask the nearest pixels in a cross
         pattern around each deviant pixel, while 1.5 will also reject the
         nearest diagonal neighbours and so on.
@@ -628,7 +628,7 @@ def sigma_clip(data, sigma=3, sigma_lower=None, sigma_upper=None, maxiters=5,
 
     grow : float or `False`, optional
         Radius within which to mask the neighbouring pixels of those that
-        fall outwith the clipping limits (only applied along `axis`, if
+        fall outwith the clipping limits (only applied along ``axis``, if
         specified). A value of 1 will mask the nearest pixels in a cross
         pattern around each deviant pixel, while 1.5 will also reject the
         nearest diagonal neighbours and so on.
@@ -786,7 +786,7 @@ def sigma_clipped_stats(data, mask=None, mask_value=None, sigma=3.0,
 
     grow : float or `False`, optional
         Radius within which to mask the neighbouring pixels of those that
-        fall outwith the clipping limits (only applied along `axis`, if
+        fall outwith the clipping limits (only applied along ``axis``, if
         specified). A value of 1 will mask the nearest pixels in a cross
         pattern around each deviant pixel, while 1.5 will also reject the
         nearest diagonal neighbours and so on.

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -168,9 +168,9 @@ class SigmaClip:
     grow : float or `False`, optional
         Radius within which to mask the neighbouring pixels of those that
         fall outwith the clipping limits (only applied along ``axis``, if
-        specified). As an example, for a 2D image a value of 1 will mask the nearest pixels in a cross
-        pattern around each deviant pixel, while 1.5 will also reject the
-        nearest diagonal neighbours and so on.
+        specified). As an example, for a 2D image a value of 1 will mask the
+        nearest pixels in a cross pattern around each deviant pixel, while
+        1.5 will also reject the nearest diagonal neighbours and so on.
 
     See Also
     --------
@@ -629,9 +629,9 @@ def sigma_clip(data, sigma=3, sigma_lower=None, sigma_upper=None, maxiters=5,
     grow : float or `False`, optional
         Radius within which to mask the neighbouring pixels of those that
         fall outwith the clipping limits (only applied along ``axis``, if
-        specified). As an example, for a 2D image a value of 1 will mask the nearest pixels in a cross
-        pattern around each deviant pixel, while 1.5 will also reject the
-        nearest diagonal neighbours and so on.
+        specified). As an example, for a 2D image a value of 1 will mask the
+        nearest pixels in a cross pattern around each deviant pixel, while
+        1.5 will also reject the nearest diagonal neighbours and so on.
 
     Returns
     -------
@@ -787,9 +787,9 @@ def sigma_clipped_stats(data, mask=None, mask_value=None, sigma=3.0,
     grow : float or `False`, optional
         Radius within which to mask the neighbouring pixels of those that
         fall outwith the clipping limits (only applied along ``axis``, if
-        specified). As an example, for a 2D image a value of 1 will mask the nearest pixels in a cross
-        pattern around each deviant pixel, while 1.5 will also reject the
-        nearest diagonal neighbours and so on.
+        specified). As an example, for a 2D image a value of 1 will mask the
+        nearest pixels in a cross pattern around each deviant pixel, while
+        1.5 will also reject the nearest diagonal neighbours and so on.
 
     Returns
     -------

--- a/astropy/stats/tests/test_sigma_clipping.py
+++ b/astropy/stats/tests/test_sigma_clipping.py
@@ -376,7 +376,6 @@ def test_sigma_clip_grow():
 
     assert np.array_equal(np.where(filtered_data.mask)[0], expected)
 
-
     # Test block growth in 2 of 3 dimensions (as in a 2D model set):
     data = data.reshape(4,5,5)
     filtered_data = sigma_clip(data, sigma=2.1, maxiters=1, grow=1.5,
@@ -391,7 +390,6 @@ def test_sigma_clip_grow():
     )
 
     assert np.array_equal(np.where(filtered_data.mask), expected)
-
 
     # Test ~spherical growth (of a single very-deviant point) in 3D data:
     data[1,2,2] = 100.

--- a/astropy/stats/tests/test_sigma_clipping.py
+++ b/astropy/stats/tests/test_sigma_clipping.py
@@ -270,22 +270,20 @@ def test_sigma_clip_axis_tuple_3D():
 
 def test_sigmaclip_repr():
 
-    import re
-
     sigclip = SigmaClip()
-    sigclip_repr = ('SigmaClip[(]sigma=3[.]0, sigma_lower=3[.]0, '
-                    'sigma_upper=3[.]0, maxiters=5, '
-                    'cenfunc=<function _nanmedian at 0x[a-f0-9]+>, '
-                    'stdfunc=<function _nanstd at 0x[a-f0-9]+>, '
-                    'grow=False[)]$')
+    median_str = str(sigclip._parse_cenfunc('median'))
+    std_str = str(sigclip._parse_stdfunc('std'))
+
+    sigclip_repr = ('SigmaClip(sigma=3.0, sigma_lower=3.0, sigma_upper=3.0,'
+                    ' maxiters=5, cenfunc={}, stdfunc={}, '
+                    'grow=False)'.format(median_str, std_str))
     sigclip_str = ('<SigmaClip>\n    sigma: 3.0\n    sigma_lower: 3.0\n'
                    '    sigma_upper: 3.0\n    maxiters: 5\n'
-                   '    cenfunc: <function _nanmedian at 0x[a-f0-9]+>\n'
-                   '    stdfunc: <function _nanstd at 0x[a-f0-9]+>\n'
-                   '    grow: False$')
+                   '    cenfunc: {}\n    stdfunc: {}\n'
+                   '    grow: False'.format(median_str, std_str))
 
-    assert re.match(sigclip_repr, repr(sigclip)) is not None
-    assert re.match(sigclip_str, str(sigclip)) is not None
+    assert repr(sigclip) == sigclip_repr
+    assert str(sigclip) == sigclip_str
 
 
 def test_sigma_clippped_stats_unit():

--- a/astropy/stats/tests/test_sigma_clipping.py
+++ b/astropy/stats/tests/test_sigma_clipping.py
@@ -384,9 +384,9 @@ def test_sigma_clip_grow():
     assert np.array_equal(np.where(filtered_data.mask)[0], expected)
 
     # Test block growth in 2 of 3 dimensions (as in a 2D model set):
-    data = data.reshape(4,5,5)
+    data = data.reshape(4, 5, 5)
     filtered_data = sigma_clip(data, sigma=2.1, maxiters=1, grow=1.5,
-                               axis=(1,2))
+                               axis=(1, 2))
     expected = np.array(
         [[0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
           2, 2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3],
@@ -399,7 +399,7 @@ def test_sigma_clip_grow():
     assert np.array_equal(np.where(filtered_data.mask), expected)
 
     # Test ~spherical growth (of a single very-deviant point) in 3D data:
-    data[1,2,2] = 100.
+    data[1, 2, 2] = 100.
     filtered_data = sigma_clip(data, sigma=3., maxiters=1, grow=2.)
 
     expected = np.array(

--- a/astropy/stats/tests/test_sigma_clipping.py
+++ b/astropy/stats/tests/test_sigma_clipping.py
@@ -346,6 +346,7 @@ def test_sigma_clip_masked_data_values():
     assert np.shares_memory(result.data, data)
 
 
+@pytest.mark.skipif('not HAS_SCIPY')
 def test_sigma_clip_grow():
     """
     Test sigma_clip with growth of masking to include the neighbours within a

--- a/astropy/stats/tests/test_sigma_clipping.py
+++ b/astropy/stats/tests/test_sigma_clipping.py
@@ -271,9 +271,10 @@ def test_sigma_clip_axis_tuple_3D():
 def test_sigmaclip_repr():
     sigclip = SigmaClip()
     sigclip_repr = ('SigmaClip(sigma=3.0, sigma_lower=3.0, sigma_upper=3.0,'
-                    ' maxiters=5, cenfunc=')
+                    ' maxiters=5, grow=False, cenfunc=')
     sigclip_str = ('<SigmaClip>\n    sigma: 3.0\n    sigma_lower: 3.0\n'
-                   '    sigma_upper: 3.0\n    maxiters: 5\n    cenfunc: ')
+                   '    sigma_upper: 3.0\n    maxiters: 5\n    grow: False\n'
+                   '    cenfunc: ')
 
     assert repr(sigclip).startswith(sigclip_repr)
     assert str(sigclip).startswith(sigclip_str)

--- a/astropy/stats/tests/test_sigma_clipping.py
+++ b/astropy/stats/tests/test_sigma_clipping.py
@@ -269,15 +269,23 @@ def test_sigma_clip_axis_tuple_3D():
 
 
 def test_sigmaclip_repr():
-    sigclip = SigmaClip()
-    sigclip_repr = ('SigmaClip(sigma=3.0, sigma_lower=3.0, sigma_upper=3.0,'
-                    ' maxiters=5, grow=False, cenfunc=')
-    sigclip_str = ('<SigmaClip>\n    sigma: 3.0\n    sigma_lower: 3.0\n'
-                   '    sigma_upper: 3.0\n    maxiters: 5\n    grow: False\n'
-                   '    cenfunc: ')
 
-    assert repr(sigclip).startswith(sigclip_repr)
-    assert str(sigclip).startswith(sigclip_str)
+    import re
+
+    sigclip = SigmaClip()
+    sigclip_repr = ('SigmaClip[(]sigma=3[.]0, sigma_lower=3[.]0, '
+                    'sigma_upper=3[.]0, maxiters=5, '
+                    'cenfunc=<function _nanmedian at 0x[a-f0-9]+>, '
+                    'stdfunc=<function _nanstd at 0x[a-f0-9]+>, '
+                    'grow=False[)]$')
+    sigclip_str = ('<SigmaClip>\n    sigma: 3.0\n    sigma_lower: 3.0\n'
+                   '    sigma_upper: 3.0\n    maxiters: 5\n'
+                   '    cenfunc: <function _nanmedian at 0x[a-f0-9]+>\n'
+                   '    stdfunc: <function _nanstd at 0x[a-f0-9]+>\n'
+                   '    grow: False$')
+
+    assert re.match(sigclip_repr, repr(sigclip)) is not None
+    assert re.match(sigclip_str, str(sigclip)) is not None
 
 
 def test_sigma_clippped_stats_unit():


### PR DESCRIPTION
### Description
Adds a `grow` parameter to `SigmaClip`, `sigma_clip` & `sigma_clipped_stats`, to expand the masking of each deviant value to its neighbours within a specified pixel radius. This is a common feature of bad pixel rejection algorithms, notably in IRAF, and will also be useful for `FittingWithOutlierRejection` in `modeling`.

This will need merging with my PR #10610 from yesterday.

I've used `grow=False` as the default value, which seems clear to me, but `0.` would also work (and is fairly clear) if people prefer a fixed type (but that's not the case elsewhere).

This could _perhaps_ be optimized slightly by caching the growth kernel calculated in `SigmaClip.__call__` -- but since it depends on the dimensionality of the input data and the value of `axis`, it would need storing in a dict by `axis` value or something. I would think the gain would be very marginal for the array sizes we typically deal with in astronomy and existing uses without `grow` will be unaffected either way, so I'm inclined to consider this "premature optimization" until demonstrated otherwise.