### PR TITLE
Improve stability for mpmath KBN algorithm in poisson_confidence_interval

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -985,7 +985,12 @@ astropy.stats
 
 - Fixed bug with ``funcs.poisson_conf_interval`` where an integer for N
   with ``interval='kraft-burrows-nousek'`` would throw an error with
-  mpmath backend [#10427]
+  mpmath backend. [#10427]
+
+- Fixed bug in ``funcs.poisson_conf_interval`` with
+  ``interval='kraft-burrows-nousek'`` where certain combinations of source
+  and background count numbers led to ``ValueError`` due to the choice of 
+  starting value for numerical optimization. [#10618]
 
 
 astropy.table

--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -1210,12 +1210,17 @@ def _mpmath_kraft_burrows_nousek(N, B, CL):
         eqn7(S_min) here.
         '''
         y_S_max = eqn7(S_max, N, B)
-        if eqn7(0, N, B) >= y_S_max:
+        # If B > N, then N-B, the "most probable" values is < 0
+        # and thus s_min is certainly 0.
+        # Note: For small N, s_max is also close to 0 and root finding
+        # might find the wrong root, thus it is important to handle this
+        # case here and return the analytical answer (s_min = 0).
+        if (B > N) or (eqn7(0, N, B) >= y_S_max):
             return 0.
         else:
             def eqn7ysmax(x):
                 return eqn7(x, N, B) - y_S_max
-            return findroot(eqn7ysmax, [0., max(N - B, 1)], solver='ridder',
+            return findroot(eqn7ysmax, [0., N - B], solver='ridder',
                             tol=tol)
 
     def func(s):

--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -1215,7 +1215,7 @@ def _mpmath_kraft_burrows_nousek(N, B, CL):
         # Note: For small N, s_max is also close to 0 and root finding
         # might find the wrong root, thus it is important to handle this
         # case here and return the analytical answer (s_min = 0).
-        if (B > N) or (eqn7(0, N, B) >= y_S_max):
+        if (B >= N) or (eqn7(0, N, B) >= y_S_max):
             return 0.
         else:
             def eqn7ysmax(x):

--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -641,6 +641,10 @@ def poisson_conf_interval(n, interval='root-n', sigma=1, background=0,
     This function has an optional dependency: Either `Scipy
     <https://www.scipy.org/>`_ or `mpmath <http://mpmath.org/>`_  need
     to be available (Scipy works only for N < 100).
+    This code is very intense numerically, which makes it much slower than
+    the other methods, in particular for large count numbers (above 1000
+    even with ``mpmath``). Fortunately, some of the other methods or a
+    Gaussian approximation usually work well in this regime.
 
     Examples
     --------

--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -1153,9 +1153,11 @@ def _scipy_kraft_burrows_nousek(N, B, CL):
 
 def _mpmath_kraft_burrows_nousek(N, B, CL):
     '''Upper limit on a poisson count rate
+
     The implementation is based on Kraft, Burrows and Nousek in
     `ApJ 374, 344 (1991) <http://adsabs.harvard.edu/abs/1991ApJ...374..344K>`_.
     The XMM-Newton upper limit server used the same formalism.
+
     Parameters
     ----------
     N : int or np.int32/np.int64
@@ -1165,9 +1167,11 @@ def _mpmath_kraft_burrows_nousek(N, B, CL):
         from a large background area).
     CL : float or np.float32/np.float64
        Confidence level (number between 0 and 1)
+
     Returns
     -------
     S : source count limit
+
     Notes
     -----
     Requires the `mpmath <http://mpmath.org/>`_ library.  See

--- a/astropy/stats/tests/test_funcs.py
+++ b/astropy/stats/tests/test_funcs.py
@@ -627,8 +627,10 @@ def test_scipy_poisson_limit():
 
 @pytest.mark.skipif('not HAS_MPMATH')
 def test_mpmath_poisson_limit():
-    assert_allclose(funcs._mpmath_kraft_burrows_nousek(6., 2., .9),
-                    (0.81, 8.99), rtol=5e-3)
+    assert_allclose(funcs._mpmath_kraft_burrows_nousek(1., .1, .99),
+                    (0.00, 6.54), rtol=5e-3)
+    assert_allclose(funcs._mpmath_kraft_burrows_nousek(5., 0., .9),
+                    (1.17, 13.32), rtol=5e-3)
     assert_allclose(funcs._mpmath_kraft_burrows_nousek(5., 2.5, .99),
                     (0, 10.67), rtol=1e-3)
     assert_allclose(funcs._mpmath_kraft_burrows_nousek(np.int32(6), 2., .9),
@@ -649,6 +651,10 @@ def test_mpmath_poisson_limit():
     assert_allclose(funcs.poisson_conf_interval(
         n=160, background=154.543,
         confidence_level=.95, interval='kraft-burrows-nousek')[:, 0], (0, 30.30454909))
+    # For this one we do not have the "true" answer from the publication,
+    # but we want to make sure that it at least runs without error
+    # see https://github.com/astropy/astropy/issues/9596
+    out = funcs._mpmath_kraft_burrows_nousek(1000., 900., .9)
 
 
 @pytest.mark.skipif('not HAS_SCIPY')

--- a/astropy/stats/tests/test_funcs.py
+++ b/astropy/stats/tests/test_funcs.py
@@ -629,7 +629,7 @@ def test_scipy_poisson_limit():
 def test_mpmath_poisson_limit():
     assert_allclose(funcs._mpmath_kraft_burrows_nousek(1., .1, .99),
                     (0.00, 6.54), rtol=5e-3)
-    assert_allclose(funcs._mpmath_kraft_burrows_nousek(5., 0., .9),
+    assert_allclose(funcs._mpmath_kraft_burrows_nousek(5., 0., .99),
                     (1.17, 13.32), rtol=5e-3)
     assert_allclose(funcs._mpmath_kraft_burrows_nousek(5., 2.5, .99),
                     (0, 10.67), rtol=1e-3)

--- a/astropy/stats/tests/test_funcs.py
+++ b/astropy/stats/tests/test_funcs.py
@@ -629,6 +629,8 @@ def test_scipy_poisson_limit():
 def test_mpmath_poisson_limit():
     assert_allclose(funcs._mpmath_kraft_burrows_nousek(1., .1, .99),
                     (0.00, 6.54), rtol=5e-3)
+    assert_allclose(funcs._mpmath_kraft_burrows_nousek(1., .5, .95),
+                    (0.00, 4.36), rtol=5e-3)
     assert_allclose(funcs._mpmath_kraft_burrows_nousek(5., 0., .99),
                     (1.17, 13.32), rtol=5e-3)
     assert_allclose(funcs._mpmath_kraft_burrows_nousek(5., 2.5, .99),


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description

The KBN implementation in astropy differs from the suggestion in the KBN
paper in an important way. The paper suggests to integrate, starting
from the most likely value, into both directions. That is conceptually
easy, save, and could be fast. However, it is a pain to implement because
you have to worry about the integration step size, what do do when you
overstep, which parameter (lower or upper bound) needs to be moved next
etc.
So, instead, the astropy implementation reformulates this a root-finding
problem. That has the advantage that out of-the-box root finding algorithms
can be used to take care of steps and tolerance checking, but it opens up a 
of numerical problems that creep in, in particular when the background is 0.
    
So, this PR reworks the algorithm to use safer interval-based root-finding
algorithms. The PR may slow down the code, but it makes it work for all case
I tested (see added tests).
I tried the following grid (but decided not to put all that in the tests
because it runs over a minute):
    
    ```
    import numpy as np
    s = np.array([0., 1, 2, 3, 5, 10, 49, 50, 99, 100, 500, 999, 1000.])
    b = np.array([0, .1, 1, 2, 3, 4.9, 5, 5.1, 10, 49, 50, 99, 100, 500, 999, 99
    cl = np.array([.9, .95, .99])
    
    for i in s:
        for j in b:
            for c in cl:
                try:
                    _mpmath_kraft_burrows_nousek(i, j, c)
                except:
                    print(i, j, c)
    ```
    
fixes #9596

