### PR TITLE
Linear1D and Planar2D should be able to fit as model sets

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -884,6 +884,7 @@ astropy.wcs
 Bug fixes
 ---------
 
+
 astropy.config
 ^^^^^^^^^^^^^^
 
@@ -989,6 +990,8 @@ astropy.modeling
 - Removed a limitation of fitting of data with units with compound models
   without units when the expression involves operators other than addition
   and subtraction. [#10415]
+
+- Fixed a problem with fitting ``Linear1D`` and ``Planar2D`` in model sets. [#10623]
 
 astropy.nddata
 ^^^^^^^^^^^^^^

--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -403,14 +403,12 @@ class LinearLSQFitter(metaclass=_FitterMeta):
             if hasattr(model_copy, 'domain'):
                 x = self._map_domain_window(model_copy, x)
             if has_fixed:
-                lhs = self._deriv_with_constraints(model_copy,
-                                                   fitparam_indices,
-                                                   x=x)
-                fixderivs = self._deriv_with_constraints(model_copy,
-                                                         fixparam_indices,
-                                                         x=x)
+                lhs = np.asarray(self._deriv_with_constraints(model_copy,
+                                                              fitparam_indices,
+                                                              x=x))
+                fixderivs = self._deriv_with_constraints(model_copy, fixparam_indices, x=x)
             else:
-                lhs = model_copy.fit_deriv(x, *model_copy.parameters)
+                lhs = np.asarray(model_copy.fit_deriv(x, *model_copy.parameters))
             sum_of_implicit_terms = model_copy.sum_of_implicit_terms(x)
             rhs = y
         else:
@@ -421,12 +419,13 @@ class LinearLSQFitter(metaclass=_FitterMeta):
                 x, y = self._map_domain_window(model_copy, x, y)
 
             if has_fixed:
-                lhs = self._deriv_with_constraints(model_copy,
-                                                   fitparam_indices, x=x, y=y)
+                lhs = np.asarray(self._deriv_with_constraints(model_copy,
+                                                              fitparam_indices, x=x, y=y))
                 fixderivs = self._deriv_with_constraints(model_copy,
-                                                         fixparam_indices, x=x, y=y)
+                                                         fixparam_indices,
+                                                         x=x, y=y)
             else:
-                lhs = model_copy.fit_deriv(x, y, *model_copy.parameters)
+                lhs = np.asanyarray(model_copy.fit_deriv(x, y, *model_copy.parameters))
             sum_of_implicit_terms = model_copy.sum_of_implicit_terms(x, y)
 
             if len(model_copy) > 1:
@@ -458,7 +457,7 @@ class LinearLSQFitter(metaclass=_FitterMeta):
         # when constructing their Vandermonde matrix, which can lead to obscure
         # failures below. Ultimately, np.linalg.lstsq can't handle >2D matrices,
         # so just raise a slightly more informative error when this happens:
-        if lhs.ndim > 2:
+        if np.asanyarray(lhs).ndim > 2:
             raise ValueError('{} gives unsupported >2D derivative matrix for '
                              'this x/y'.format(type(model_copy).__name__))
 
@@ -494,9 +493,6 @@ class LinearLSQFitter(metaclass=_FitterMeta):
             else:
                 lhs *= weights[:, np.newaxis]
                 rhs = rhs * weights
-
-        if rcond is None:
-            rcond = len(x) * np.finfo(x.dtype).eps
 
         scl = (lhs * lhs).sum(0)
         lhs /= scl
@@ -551,7 +547,8 @@ class LinearLSQFitter(metaclass=_FitterMeta):
 
         # TODO: Only Polynomial models currently have an _order attribute;
         # maybe change this to read isinstance(model, PolynomialBase)
-        if hasattr(model_copy, '_order') and rank != model_copy._order:
+        if hasattr(model_copy, '_order') and len(model_copy) == 1 \
+            and not has_fixed and rank != model_copy._order:
             warnings.warn("The fit may be poorly conditioned\n",
                           AstropyUserWarning)
 

--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -823,7 +823,6 @@ class Linear1D(Fittable1DModel):
 
         .. math:: f(x) = a x + b
     """
-
     slope = Parameter(default=1)
     intercept = Parameter(default=0)
     linear = True
@@ -835,7 +834,7 @@ class Linear1D(Fittable1DModel):
         return slope * x + intercept
 
     @staticmethod
-    def fit_deriv(x, slope, intercept):
+    def fit_deriv(x, *params):
         """One dimensional Line model derivative with respect to parameters"""
 
         d_slope = x
@@ -893,7 +892,7 @@ class Planar2D(Fittable2DModel):
         return slope_x * x + slope_y * y + intercept
 
     @staticmethod
-    def fit_deriv(x, y, slope_x, slope_y, intercept):
+    def fit_deriv(x, y, *params):
         """Two dimensional Plane model derivative with respect to parameters"""
 
         d_slope_x = x

--- a/astropy/modeling/tests/test_constraints.py
+++ b/astropy/modeling/tests/test_constraints.py
@@ -234,9 +234,7 @@ class TestLinearConstraints:
         self.p1.c0.fixed = True
         self.p1.c1.fixed = True
         pfit = fitting.LinearLSQFitter()
-        with pytest.warns(AstropyUserWarning,
-                          match=r'The fit may be poorly conditioned'):
-            model = pfit(self.p1, self.x, self.y)
+        model = pfit(self.p1, self.x, self.y)
         assert_allclose(self.y, model(self.x))
 
 # Test constraints as parameter properties

--- a/astropy/modeling/tests/test_fitters.py
+++ b/astropy/modeling/tests/test_fitters.py
@@ -53,16 +53,17 @@ class TestPolynomial2D:
         def poly2(x, y):
             return 1 + 2 * x + 3 * x ** 2 + 4 * y + 5 * y ** 2 + 6 * x * y
         self.z = poly2(self.x, self.y)
-        self.fitter = LinearLSQFitter()
 
     def test_poly2D_fitting(self):
+        fitter = LinearLSQFitter()
         v = self.model.fit_deriv(x=self.x, y=self.y)
         p = linalg.lstsq(v, self.z.flatten(), rcond=-1)[0]
-        new_model = self.fitter(self.model, self.x, self.y, self.z)
+        new_model = fitter(self.model, self.x, self.y, self.z)
         assert_allclose(new_model.parameters, p)
 
     def test_eval(self):
-        new_model = self.fitter(self.model, self.x, self.y, self.z)
+        fitter = LinearLSQFitter()
+        new_model = fitter(self.model, self.x, self.y, self.z)
         assert_allclose(new_model(self.x, self.y), self.z)
 
     @pytest.mark.skipif('not HAS_SCIPY')
@@ -255,9 +256,7 @@ class TestLinearLSQFitter:
             z = z_expected + np.random.normal(0, 0.01, size=z_expected.shape)
 
         fitter = LinearLSQFitter()
-        with pytest.warns(AstropyUserWarning,
-                          match=r'The fit may be poorly conditioned'):
-            fitted_model = fitter(init_model, x, y, z)
+        fitted_model = fitter(init_model, x, y, z)
         assert_allclose(fitted_model(x, y, model_set_axis=False), z_expected,
                         rtol=1e-1)
 
@@ -272,9 +271,7 @@ class TestLinearLSQFitter:
         y = 2 + x + 0.5*x*x
 
         fitter = LinearLSQFitter()
-        with pytest.warns(AstropyUserWarning,
-                          match=r'The fit may be poorly conditioned'):
-            fitted_model = fitter(init_model, x, y)
+        fitted_model = fitter(init_model, x, y)
         assert_allclose(fitted_model.parameters, [2., 1., 0.5], atol=1e-14)
 
     def test_linear_fit_model_set_fixed_parameter(self):
@@ -288,9 +285,7 @@ class TestLinearLSQFitter:
         yy = np.array([2 + x + 0.5*x*x, -2*x])
 
         fitter = LinearLSQFitter()
-        with pytest.warns(AstropyUserWarning,
-                          match=r'The fit may be poorly conditioned'):
-            fitted_model = fitter(init_model, x, yy)
+        fitted_model = fitter(init_model, x, yy)
 
         assert_allclose(fitted_model.c0, [2., 0.], atol=1e-14)
         assert_allclose(fitted_model.c1, [1., -2.], atol=1e-14)
@@ -308,9 +303,7 @@ class TestLinearLSQFitter:
         zz = np.array([1+x-0.5*y+0.1*x*x, 2*x+y-0.2*y*y])
 
         fitter = LinearLSQFitter()
-        with pytest.warns(AstropyUserWarning,
-                          match=r'The fit may be poorly conditioned'):
-            fitted_model = fitter(init_model, x, y, zz)
+        fitted_model = fitter(init_model, x, y, zz)
 
         assert_allclose(fitted_model(x, y, model_set_axis=False), zz,
                         atol=1e-14)

--- a/astropy/modeling/tests/test_model_sets.py
+++ b/astropy/modeling/tests/test_model_sets.py
@@ -1,14 +1,15 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
-This module tests model set evaluation for some common use cases.
+This module tests model set evaluation and fitting for some common use cases.
 """
 # pylint: disable=invalid-name
 import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 
-from astropy.modeling.models import (Polynomial1D, Polynomial2D,
-                                     Chebyshev2D)
+from astropy.modeling.models import (Polynomial1D, Polynomial2D, Legendre1D, Legendre2D,
+                                     Chebyshev2D, Chebyshev1D, Hermite1D, Hermite2D,
+                                     Linear1D, Planar2D)
 from astropy.modeling.fitting import LinearLSQFitter
 from astropy.modeling.core import Model
 from astropy.modeling.parameters import Parameter
@@ -37,24 +38,24 @@ class TParModel(Model):
         return x*coeff + e
 
 
-def test_model_axis_1():
+@pytest.mark.parametrize('model_class', [Polynomial1D, Chebyshev1D, Legendre1D, Hermite1D])
+def test_model1d_axis_1(model_class):
     """
     Test that a model initialized with model_set_axis=1
     can be evaluated with model_set_axis=False.
     """
-    model_axis = 1
     n_models = 2
-    p1 = Polynomial1D(1, n_models=n_models, model_set_axis=model_axis)
-    p1.c0 = [2, 3]
-    p1.c1 = [1, 2]
-    t1 = Polynomial1D(1, c0=2, c1=1)
-    t2 = Polynomial1D(1, c0=3, c1=2)
+    model_axis = 1
+
+    c0 = [[2, 3]]
+    c1 = [[1, 2]]
+    t1 = model_class(1, c0=2, c1=1)
+    t2 = model_class(1, c0=3, c1=2)
+
+    p1 = model_class(1, c0=c0, c1=c1, n_models=n_models, model_set_axis=model_axis)
 
     with pytest.raises(ValueError):
         p1(x)
-
-    with pytest.raises(ValueError):
-        p1(xx)
 
     y = p1(x, model_set_axis=False)
     assert y.shape[model_axis] == n_models
@@ -72,16 +73,17 @@ def test_model_axis_1():
     assert_allclose(y[:, 1, :, :], t2(xxx))
 
 
-def test_model_axis_2():
+@pytest.mark.parametrize('model_class', [Polynomial1D, Chebyshev1D, Legendre1D, Hermite1D])
+def test_model1d_axis_2(model_class):
     """
     Test that a model initialized with model_set_axis=2
     can be evaluated with model_set_axis=False.
     """
-    p1 = Polynomial1D(1, c0=[[[1, 2, 3]]], c1=[[[10, 20, 30]]],
-                      n_models=3, model_set_axis=2)
-    t1 = Polynomial1D(1, c0=1, c1=10)
-    t2 = Polynomial1D(1, c0=2, c1=20)
-    t3 = Polynomial1D(1, c0=3, c1=30)
+    p1 = model_class(1, c0=[[[1, 2, 3]]], c1=[[[10, 20, 30]]],
+                     n_models=3, model_set_axis=2)
+    t1 = model_class(1, c0=1, c1=10)
+    t2 = model_class(1, c0=2, c1=20)
+    t3 = model_class(1, c0=3, c1=30)
 
     with pytest.raises(ValueError):
         p1(x)
@@ -95,38 +97,18 @@ def test_model_axis_2():
     assert_allclose(y[:, :, 1].flatten(), t2(x))
     assert_allclose(y[:, :, 2].flatten(), t3(x))
 
-    p2 = Polynomial2D(1, c0_0=[[[0, 1, 2]]], c0_1=[[[3, 4, 5]]],
-                      c1_0=[[[5, 6, 7]]], n_models=3, model_set_axis=2)
-    t1 = Polynomial2D(1, c0_0=0, c0_1=3, c1_0=5)
-    t2 = Polynomial2D(1, c0_0=1, c0_1=4, c1_0=6)
-    t3 = Polynomial2D(1, c0_0=2, c0_1=5, c1_0=7)
 
-    assert p2.c0_0.shape == (1, 1, 3)
-    y = p2(x, x, model_set_axis=False)
-    assert y.shape == (1, 4, 3)
-    # These are columns along the 2nd axis.
-    assert_allclose(y[:, :, 0].flatten(), t1(x, x))
-    assert_allclose(y[:, :, 1].flatten(), t2(x, x))
-    assert_allclose(y[:, :, 2].flatten(), t3(x, x))
-
-    cheb = Chebyshev2D(1, 1, c0_0=[[[0, 1, 2]]], c0_1=[[[3, 4, 5]]],
-                      c1_0=[[[5, 6, 7]]], c1_1=[[[1,1,1]]],
-                      n_models=3, model_set_axis=2)
-    assert cheb.c0_0.shape == (1, 1, 3)
-    y = cheb(x, x, model_set_axis=False)
-    assert y.shape == (1, 4, 3)
-
-
-def test_axis_0():
+@pytest.mark.parametrize('model_class', [Polynomial1D, Chebyshev1D, Legendre1D, Hermite1D])
+def test_model1d_axis_0(model_class):
     """
     Test that a model initialized with model_set_axis=0
     can be evaluated with model_set_axis=False.
     """
-    p1 = Polynomial1D(1, n_models=2, model_set_axis=0)
+    p1 = model_class(1, n_models=2, model_set_axis=0)
     p1.c0 = [2, 3]
     p1.c1 = [1, 2]
-    t1 = Polynomial1D(1, c0=2, c1=1)
-    t2 = Polynomial1D(1, c0=3, c1=2)
+    t1 = model_class(1, c0=2, c1=1)
+    t2 = model_class(1, c0=3, c1=2)
 
     with pytest.raises(ValueError):
         p1(x)
@@ -149,6 +131,27 @@ def test_axis_0():
     assert_allclose(y[0], t1(xxx))
     assert_allclose(y[1], t2(xxx))
     assert len(y) == 2
+
+
+@pytest.mark.parametrize('model_class', [Chebyshev2D, Legendre2D, Hermite2D])
+def test_model2d_axis_2(model_class):
+    """
+    Test that a model initialized with model_set_axis=2
+    can be evaluated with model_set_axis=False.
+    """
+    p2 = model_class(1, 1, c0_0=[[[0, 1, 2]]], c0_1=[[[3, 4, 5]]],
+                     c1_0=[[[5, 6, 7]]], c1_1=[[[1,1,1]]], n_models=3, model_set_axis=2)
+    t1 = model_class(1, 1, c0_0=0, c0_1=3, c1_0=5, c1_1=1)
+    t2 = model_class(1, 1, c0_0=1, c0_1=4, c1_0=6, c1_1=1)
+    t3 = model_class(1, 1, c0_0=2, c0_1=5, c1_0=7, c1_1=1)
+
+    assert p2.c0_0.shape == (1, 1, 3)
+    y = p2(x, x, model_set_axis=False)
+    assert y.shape == (1, 4, 3)
+    # These are columns along the 2nd axis.
+    assert_allclose(y[:, :, 0].flatten(), t1(x, x))
+    assert_allclose(y[:, :, 1].flatten(), t2(x, x))
+    assert_allclose(y[:, :, 2].flatten(), t3(x, x))
 
 
 def test_negative_axis():
@@ -204,11 +207,43 @@ def test_shapes():
     assert t.e.shape == (2,)
 
 
-def test_linearlsqfitter():
+def test_eval():
+    """ Tests evaluation of Linear1D and Planar2D with different model_set_axis."""
+    model = Linear1D(slope=[1, 2], intercept=[3, 4], n_models=2)
+    p = Polynomial1D(1, c0=[3, 4], c1=[1, 2], n_models=2)
+
+    assert_allclose(model(xx), p(xx))
+    assert_allclose(model(x, model_set_axis=False), p(x, model_set_axis=False))
+
+    with pytest.raises(ValueError):
+        model(x)
+
+    model = Linear1D(slope=[[1, 2]], intercept=[[3, 4]], n_models=2, model_set_axis=1)
+    p = Polynomial1D(1, c0=[[3, 4]], c1=[[1, 2]], n_models=2, model_set_axis=1)
+
+    assert_allclose(model(xx.T), p(xx.T))
+    assert_allclose(model(x, model_set_axis=False), p(x, model_set_axis=False))
+    with pytest.raises(ValueError):
+        model(xx)
+
+    model = Planar2D(slope_x=[1, 2], slope_y=[1, 2], intercept=[3, 4], n_models=2)
+    y = model(xx, xx)
+
+    assert y.shape == (2, 4)
+
+    with pytest.raises(ValueError):
+        model(x)
+
+
+# Test fitting
+
+
+@pytest.mark.parametrize('model_class', [Polynomial1D, Chebyshev1D, Legendre1D, Hermite1D])
+def test_linearlsqfitter(model_class):
     """
     Issue #7159
     """
-    p = Polynomial1D(1, n_models=2, model_set_axis=1)
+    p = model_class(1, n_models=2, model_set_axis=1)
 
     # Generate data for fitting 2 models and re-stack them along the last axis:
     y = np.array([2*x+1, x+4])
@@ -217,13 +252,15 @@ def test_linearlsqfitter():
     f = LinearLSQFitter()
     # This seems to fit the model_set correctly:
     fit = f(p, x, y)
-
     model_y = fit(x, model_set_axis=False)
 
-    m1 = Polynomial1D(1, c0=fit.c0[0][0], c1=fit.c1[0][0])
-    m2 = Polynomial1D(1, c0=fit.c0[0][1], c1=fit.c1[0][1])
+    m1 = model_class(1, c0=fit.c0[0][0], c1=fit.c1[0][0], domain=fit.domain)
+    m2 = model_class(1, c0=fit.c0[0][1], c1=fit.c1[0][1], domain=fit.domain)
     assert_allclose(model_y[:, 0], m1(x))
     assert_allclose(model_y[:, 1], m2(x))
+
+    p = model_class(1, n_models=2, model_set_axis=0)
+    fit = f(p, x, y.T)
 
 
 def test_model_set_axis_outputs():
@@ -253,6 +290,22 @@ def test_model_set_axis_outputs():
     assert_allclose(y0[:, 1], y1[1])
     with pytest.raises(ValueError):
         model_set(x)
+
+
+def test_fitting_shapes():
+    """ Test fitting model sets of Linear1D and Planar2D."""
+    fitter = LinearLSQFitter()
+
+    model = Linear1D(slope=[1, 2], intercept=[3, 4], n_models=2)
+    y = model(xx)
+    fit_model = fitter(model, x, y)
+
+    model = Linear1D(slope=[[1, 2]], intercept=[[3, 4]], n_models=2, model_set_axis=1)
+    fit_model = fitter(model, x, y.T)
+
+    model = Planar2D(slope_x=[1, 2], slope_y=[1, 2], intercept=[3, 4], n_models=2)
+    y = model(xx, xx)
+    fit_model = fitter(model, x, x, y)
 
 
 def test_compound_model_sets():

--- a/docs/modeling/models.rst
+++ b/docs/modeling/models.rst
@@ -521,6 +521,41 @@ the set of equations to find the exact solution. Nonlinear models, which require
 an iterative algorithm, cannot be currently fit using model sets. Model sets of nonlinear
 models can only be evaluated.
 
+When fitting model sets it is important that data arrays are passed to the fitter
+in the correct shape. The shape depends on the ``model_set_axis`` attribute of the
+model to be fit. The rule is that the index of the dependent variable that corresponds
+to a model set should be along the ``model_set_axis`` dimension. For example, for a
+1D model set with 3 models with ``model_set_axis == 1`` the shape of ``y`` should be (x, 3)::
+
+    >>> import numpy as np
+    >>> from astropy.modeling.models import Polynomial1D
+    >>> from astropy.modeling.fitting import LinearLSQFitter
+    >>> fitter = LinearLSQFitter()
+    >>> x = np.arange(4)
+    >>> y = np.array([2*x+1, x+4, x]).T
+    >>> print(y)
+    [[1 4 0]
+     [3 5 1]
+     [5 6 2]
+     [7 7 3]]
+    >>> print(y.shape)
+    (4, 3)
+    >>> m = Polynomial1D(1, n_models=3, model_set_axis=1)
+    >>> mfit = fitter(m, x, y)
+
+For 2D models with 3 models and ``model_set_axis = 0`` the shape of ``z`` should be (3, x, y)::
+
+    >>> import numpy as np
+    >>> from astropy.modeling.models import Polynomial2D
+    >>> from astropy.modeling.fitting import LinearLSQFitter
+    >>> fitter = LinearLSQFitter()
+    >>> x = np.arange(8).reshape(2, 4)
+    >>> y = x
+    >>> z = np.asarray([2 * x + 1, x + 4, x + 3])
+    >>> print(z.shape)
+    (3, 2, 4)
+    >>> m = Polynomial2D(1, n_models=3, model_set_axis=0)
+    >>> mfit = fitter(m, x, y, z)
 
 .. _modeling-asdf:
 
@@ -529,7 +564,7 @@ Model Serialization (Writing a Model to a File)
 
 Models are serializable using the `ASDF`_
 format. This can be useful in many contexts, one of which is the implementation of a
-`Generalized World Coordinate System (GWCS)`_. 
+`Generalized World Coordinate System (GWCS)`_.
 
 Serializing a model to disk is possible by assigning the object to ``AsdfFile.tree``:
 
@@ -559,6 +594,6 @@ To read the file and create the model:
         -----
          23.7
 
-Compound models can also be serialized. Please note that some model attributes (e.g ``meta``, 
+Compound models can also be serialized. Please note that some model attributes (e.g ``meta``,
 ``tied`` parameter constraints used in fitting), as well as model sets are not yet serializable.
 For more information on serialization of models, see :ref:`asdf_dev`.


### PR DESCRIPTION
`Linear1D` and `Planar2D` should be able to fit as model sets with `LinearLSQ` fitter which this PR enables.
While fixing the problem I noticed a larger (design) issue with the way the fitter calls the derivative of a model. Currently the call is
```
model.fit_deriv(x, *model.parameters)
```
This works fine with single models. However, the signature of this method for non-linear models lists all parameters as keyword parameters. When a model set is fit the list `*model.parameters` becomes longer than the list of parameters in the signature. 
When fitting.py is refactored the call to `fit_deriv` needs to be changed to solve this problem.

