### PR TITLE
Galactocentric frame defaults registry

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,7 @@ astropy.coordinates
   Depending on needed precision and the obstime array in question, speed ups
   reach factors of 10x to >100x. [#10647]
 
+- ``galactocentric_frame_defaults`` can now also be used as a registry, with user-defined parameter values and metadata. [#10624]
 
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^

--- a/astropy/__init__.py
+++ b/astropy/__init__.py
@@ -170,25 +170,7 @@ class base_constants_version(ScienceState):
         if 'astropy.constants' in sys.modules:
             raise RuntimeError('astropy.constants is already imported')
 
-        class _Context:
-            def __init__(self, parent, value):
-                self._value = value
-                self._parent = parent
-
-            def __enter__(self):
-                pass
-
-            def __exit__(self, type, value, tb):
-                self._parent._value = self._value
-
-            def __repr__(self):
-                return ('<ScienceState {}: {!r}>'
-                        .format(self._parent.__name__, self._parent._value))
-
-        ctx = _Context(cls, cls._value)
-        value = cls.validate(value)
-        cls._value = value
-        return ctx
+        return super().set(cls, value)
 
 
 class physical_constants(base_constants_version):

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -1419,6 +1419,26 @@ def test_galactocentric_defaults(reset_galactocentric_defaults):
         else:
             assert getattr(galcen_40, k) == getattr(galcen_latest, k)
 
+    # test validate Galactocentric
+    with galactocentric_frame_defaults.set('latest'):
+        params = galactocentric_frame_defaults.validate(galcen_latest)
+        references = galcen_latest.frame_attribute_references
+        state = dict(parameters=params, references=references)
+
+        assert galactocentric_frame_defaults.parameters == params
+        assert galactocentric_frame_defaults.references == references
+        assert galactocentric_frame_defaults._state == state
+
+    # Test not one of accepted parameter types
+    with pytest.raises(ValueError):
+        galactocentric_frame_defaults.validate(ValueError)
+
+    # test parameters property
+    assert (
+        galactocentric_frame_defaults.parameters
+        == galactocentric_frame_defaults.parameters
+    )
+
 
 def test_galactocentric_references(reset_galactocentric_defaults):
     # references in the "scientific paper"-sense

--- a/astropy/utils/tests/test_state.py
+++ b/astropy/utils/tests/test_state.py
@@ -1,0 +1,25 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+from astropy.utils.state import ScienceState
+
+
+def test_ScienceState_and_Context():
+    """
+    Tests a ScienceState and spawned contexts.
+    """
+
+    class MyState(ScienceState):
+        _value = "A"
+        _state = dict(foo="bar")
+
+    state = {"foo": "bar"}
+
+    # test created ScienceState
+    assert MyState.get() == "A"
+    assert MyState.validate("B") == "B"
+    assert MyState._state == state
+
+    # test setting
+    with MyState.set("B"):
+        assert MyState.get() == "B"
+    assert MyState.get() == "A"  # test returning

--- a/docs/coordinates/galactocentric.rst
+++ b/docs/coordinates/galactocentric.rst
@@ -171,7 +171,13 @@ up-to-date list of valid names, see the docstring of
 like ``'pre-v4.0'``, which sets the default parameter values to their original
 definition (i.e. pre-astropy-v4.0) values, and ``'v4.0'``, which sets the
 default parameter values to a more modern set of measurements as updated in
-Astropy version 4.0.
+Astropy version 4.0. Also, custom sets of measurements can be registered to
+`~astropy.coordinates.galactocentric_frame_defaults` and used like the
+built-in options.
+
+`~astropy.coordinates.galactocentric_frame_defaults` also tracks the
+references (i.e. scientific papers that define the parameter values) for all
+parameter values, as well as any further specified metadata information.
 
 As with other `~astropy.utils.state.ScienceState` subclasses, the
 `~astropy.coordinates.galactocentric_frame_defaults` class can be used to
@@ -222,6 +228,21 @@ attributes that are explicitly specified::
     ...     print(Galactocentric(galcen_distance=8.0*u.kpc)) # doctest: +FLOAT_CMP
     <Galactocentric Frame (galcen_coord=<ICRS Coordinate: (ra, dec) in deg
         (266.4051, -28.936175)>, galcen_distance=8.0 kpc, galcen_v_sun=(11.1, 232.24, 7.25) km / s, z_sun=27.0 pc, roll=0.0 deg)>
+
+
+Additional parameter sets may be registered, for instance to use the Dehnen & Binney (1998) measurements of the solar motion. We can also add metadata, such as the 1-sigma errors::
+
+    >>> state = galactocentric_frame_defaults.get_from_registry("v4.0")
+    >>> state["parameters"]["galcen_v_sun"] = (10.00, 225.25, 7.17) * (u.km / u.s)
+    >>> state["references"]["galcen_v_sun"] = "http://www.adsabs.harvard.edu/full/1998MNRAS.298..387D"
+    >>> state["error"] = {"galcen_v_sun": (0.36, 0.62, 0.38) * (u.km / u.s)}
+    >>> galactocentric_frame_defaults.register(name="DB1998", **state)
+
+Just as in the previous examples, the new parameter set can be get / set::
+
+    >>> state = galactocentric_frame_defaults.get_from_registry("DB1998")
+    >>> print(state["error"]["galcen_v_sun"])  # doctest: +FLOAT_CMP
+    [0.36 0.62 0.38] km / s
 
 ..
   EXAMPLE END

--- a/docs/credits.rst
+++ b/docs/credits.rst
@@ -267,6 +267,7 @@ Core Package Contributors
 * Nabil Freij
 * Nadia Dencheva
 * Nathanial Hendler
+* Nathaniel Starkman
 * Neal McBurnett
 * Neil Crighton
 * Neil Parley


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
`galactocentric_frame_defaults` allows for a user-defined set of parameters to be manually set. This PR extends that capability to a registry system such that parameter sets may be named and get/set just like the built-in option (pre-v4.0, v4.0).

```python
import astropy.units as u
from astropy.coordinates import galactocentric_frame_defaults

galactocentric_frame_defaults.register(
    name="test",
    value={"galcen_coord": ICRS(ra=266.0 * u.degree, dec=-29 * u.degree),
                "galcen_distance": 8.1 * u.kpc,
                "galcen_v_sun": r.CartesianDifferential([12.9, 245.6, 7.8] * u.km / u.s),
                "z_sun": 21.0 * u.pc,
                 "roll": 0 * u.deg},
    references=None
)

with galactocentric_frame_defaults.set("test"):
    params = galactocentric_frame_defaults.get()
```

Additional metadata, such as the value standard deviations,  is supported by the ``_state`` dictionary attribute, whose items are also exposed to the user by key access on the main class.

```python
galactocentric_frame_defaults._registry["test"]["stdv"] = {
    "galcen_coord": {"ra": 1 * u.deg, "dec": 1 * u.deg},
    "galcen_distance": 0.1 * u.kpc,
    "galcen_v_sun": {"x": 2 * u.km / u.s, "y": 1 * u.km / u.s, "z": 1* u.km / u.s},
    "z_sun": 1 * u.pc,
    "roll": 0 * u.deg,
}

galactocentric_frame_defaults.set("test")

test_stdv = galactocentric_frame_defaults["stdv"]

```

If metadata is added to one parameter set, for consistency it should be added to all. Though the built-in options are read-only for "value" and "references", they permit additional fields, such as the standard deviation.

```python
galactocentric_frame_defaults._registry["v4.0"]["stdv"] = {
    "galcen_coord": {"ra": 1 * u.deg, "dec": 1 * u.deg},
    "galcen_distance": 0.1 * u.kpc,
    "galcen_v_sun": {"x": 2 * u.km / u.s, "y": 1 * u.km / u.s, "z": 1* u.km / u.s},
    "z_sun": 1 * u.pc,
    "roll": 0 * u.deg,
}

galactocentric_frame_defaults.set("v4.0")

stdv = galactocentric_frame_defaults["stdv"]

```

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->
