### PR TITLE
MNT: Deprecate unused keywords in utils/data.py

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -282,6 +282,12 @@ astropy.utils
   have been moved to their own module, ``astropy.utils.shapes``. They remain
   importable from ``astropy.utils``. [#10337]
 
+- ``check_hashes`` keyword in ``check_download_cache`` is deprecated and will
+  be removed in a future release. [#10628]
+
+- ``hexdigest`` keyword in ``import_file_to_cache`` is deprecated and will
+  be removed in a future release. [#10628]
+
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -25,6 +25,7 @@ from warnings import warn
 
 import astropy.config.paths
 from astropy import config as _config
+from astropy.utils.decorators import deprecated_renamed_argument
 from astropy.utils.exceptions import AstropyWarning
 from astropy.utils.introspection import find_current_module, resolve_name
 
@@ -1602,8 +1603,13 @@ class CacheDamaged(ValueError):
         self.bad_files = bad_files if bad_files is not None else []
 
 
+@deprecated_renamed_argument('check_hashes', None, '4.2')
 def check_download_cache(check_hashes=False, pkgname='astropy'):
     """Do a consistency check on the cache.
+
+    .. note::
+
+        This function will not return anything in a future release.
 
     Because the cache is shared by all versions of astropy in all virtualenvs
     run by your user, possibly concurrently, it could accumulate problems.
@@ -1623,9 +1629,6 @@ def check_download_cache(check_hashes=False, pkgname='astropy'):
 
     Parameters
     ----------
-    check_hashes : boolean, optional
-        Deprecated; does nothing.
-
     pkgname : `str`, optional
         The package name to use to locate the download cache. i.e. for
         ``pkgname='astropy'`` the default cache location is
@@ -1746,6 +1749,7 @@ def _rmtree(path, replace=None):
                     raise
 
 
+@deprecated_renamed_argument('hexdigest', None, '4.2')
 def import_file_to_cache(url_key, filename,
                          hexdigest=None,
                          remove_original=False,
@@ -1773,8 +1777,6 @@ def import_file_to_cache(url_key, filename,
         location.
     filename : str
         The file whose contents you want to import.
-    hexdigest : ignored
-        Deprecated, has no effect.
     remove_original : bool
         Whether to remove the original file (``filename``) once import is
         complete.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request follows up on #10437 to really deprecate unused keywords. We decided not to issue warning when they are refactored to be no-op keywords in #10437 because that PR is being backported to LTS.

With this patch:
```python
>>> from astropy.utils.data import check_download_cache
>>> check_download_cache(check_hashes=True)
WARNING: AstropyDeprecationWarning: "check_hashes" was deprecated in
version 4.2 and will be removed in a future version.  [warnings]
```
```python
>>> from astropy.utils.data import import_file_to_cache
>>> import_file_to_cache('https://example.com/', 'README.md', hexdigest='abcdef')
WARNING: AstropyDeprecationWarning: "hexdigest" was deprecated in
version 4.2 and will be removed in a future version.  [warnings]
'/path/to/.astropy/cache/download/url/.../contents'
```

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

cc @aarchiba 