### PR TITLE
ENH: New astropy.utils.data.conf.allow_internet to replace remote_timeout=0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -144,6 +144,8 @@ astropy.utils
 
 - ``get_free_space_in_dir`` now takes a new ``unit`` keyword and
   ``check_free_space_in_dir`` takes ``size`` defined as ``Quantity``. [#10627]
+- New ``astropy.utils.data.conf.allow_internet`` configuration item to
+  control downloading data from the Internet. [#10632]
 
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
@@ -281,6 +283,10 @@ astropy.utils
   ``check_broadcast``, ``unbroadcast``, and ``IncompatibleShapeError`` --
   have been moved to their own module, ``astropy.utils.shapes``. They remain
   importable from ``astropy.utils``. [#10337]
+
+- Setting ``astropy.utils.data.conf.remote_timeout`` to zero no longer prevents
+  downloading data from the Internet. Use
+  ``astropy.utils.data.conf.allow_internet = False`` instead. [#10632]
 
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -145,7 +145,9 @@ astropy.utils
 - ``get_free_space_in_dir`` now takes a new ``unit`` keyword and
   ``check_free_space_in_dir`` takes ``size`` defined as ``Quantity``. [#10627]
 - New ``astropy.utils.data.conf.allow_internet`` configuration item to
-  control downloading data from the Internet. [#10632]
+  control downloading data from the Internet. Setting ``allow_internet=False``
+  is the same as ``remote_timeout=0``. Using ``remote_timeout=0`` to control
+  internet access will stop working in a future release. [#10632]
 
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
@@ -283,10 +285,6 @@ astropy.utils
   ``check_broadcast``, ``unbroadcast``, and ``IncompatibleShapeError`` --
   have been moved to their own module, ``astropy.utils.shapes``. They remain
   importable from ``astropy.utils``. [#10337]
-
-- Setting ``astropy.utils.data.conf.remote_timeout`` to zero no longer prevents
-  downloading data from the Internet. Use
-  ``astropy.utils.data.conf.allow_internet = False`` instead. [#10632]
 
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -69,7 +69,9 @@ class Conf(_config.ConfigNamespace):
         'This only provides the default value when not set by https_headers.')
     remote_timeout = _config.ConfigItem(
         10.,
-        'Time to wait for remote data queries (in seconds).',
+        'Time to wait for remote data queries (in seconds). Set this to zero '
+        'to prevent any attempt to download anything (this will stop working '
+        'in a future release, use allow_internet=False instead).',
         aliases=['astropy.coordinates.name_resolve.name_resolve_timeout'])
     allow_internet = _config.ConfigItem(
         True,
@@ -993,6 +995,13 @@ def _download_file_from_source(source_url, show_progress=True, timeout=None,
                                remote_url=None, cache=False, pkgname='astropy',
                                http_headers=None, ftp_tls=None):
     from astropy.utils.console import ProgressBarOrSpinner
+
+    if timeout == 0:
+        raise urllib.error.URLError(
+            f"URL {remote_url} was supposed to be downloaded but timeout was set to 0; "
+            f"if this is unexpected check the astropy.cfg file for the option "
+            f"remote_timeout. If this is intentional, this will stop working "
+            f"in a future release. Use astropy.utils.data.conf.allow_internet=False instead.")
 
     if not conf.allow_internet:
         raise urllib.error.URLError(

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -2051,14 +2051,15 @@ def test_update_of_open_files_windows(temp_cache, valid_urls, monkeypatch):
     assert get_file_contents(download_file(u, cache=True, sources=[])) == c
 
 
-def test_zero_remote_timeout(temp_cache, valid_urls):
+def test_no_allow_internet(temp_cache, valid_urls):
     u, c = next(valid_urls)
-    with pytest.raises(urllib.error.URLError):
-        download_file(u, timeout=0)
-    assert not is_url_in_cache(u)
-    with pytest.raises(urllib.error.URLError):
-        # This will trigger the remote data error if it's allowed to touch the internet
-        download_file(TESTURL, timeout=0)
+    with conf.set_temp('allow_internet', False):
+        with pytest.raises(urllib.error.URLError):
+            download_file(u)
+        assert not is_url_in_cache(u)
+        with pytest.raises(urllib.error.URLError):
+            # This will trigger the remote data error if it's allowed to touch the internet
+            download_file(TESTURL)
 
 
 def test_clear_download_cache_not_too_aggressive(temp_cache, valid_urls):

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -2051,6 +2051,16 @@ def test_update_of_open_files_windows(temp_cache, valid_urls, monkeypatch):
     assert get_file_contents(download_file(u, cache=True, sources=[])) == c
 
 
+def test_zero_remote_timeout(temp_cache, valid_urls):
+    u, c = next(valid_urls)
+    with pytest.raises(urllib.error.URLError):
+        download_file(u, timeout=0)
+    assert not is_url_in_cache(u)
+    with pytest.raises(urllib.error.URLError):
+        # This will trigger the remote data error if it's allowed to touch the internet
+        download_file(TESTURL, timeout=0)
+
+
 def test_no_allow_internet(temp_cache, valid_urls):
     u, c = next(valid_urls)
     with conf.set_temp('allow_internet', False):

--- a/docs/utils/data.rst
+++ b/docs/utils/data.rst
@@ -257,7 +257,7 @@ therefore recommend the following guidelines:
    not suddenly notice an out-of-date table all at once and frantically attempt
    to download it.
 
- * Optionally, in this file, set ``astropy.utils.data.conf.remote_timeout = 0`` to
+ * Optionally, in this file, set ``astropy.utils.data.conf.allow_internet = False`` to
    prevent any attempt to download any file from the worker nodes; if you do this,
    you will need to override this setting in your script that does the actual
    downloading.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to replace the usage of `astropy.utils.data.conf.remote_timeout=0` to disable internet. Discussion of using a separate config item to control internet access happened in #10437 (`remote_timeout=0` behavior was implemented there) but we agreed not to introduce new feature into that PR because it was milestoned as LTS bugfix backport.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

@aarchiba , for some reason, I cannot add you to "Reviewers" but would very much like a review from you too. Thank you!