### PR TITLE
Fix tests on MacOS X with Matplotlib 3.3

### DIFF
--- a/astropy/conftest.py
+++ b/astropy/conftest.py
@@ -32,9 +32,6 @@ enable_deprecations_as_exceptions(
     # installed. This can be removed once pyopenssl 1.7.20+ is released.
     modules_to_ignore_on_import=['requests'])
 
-if HAS_MATPLOTLIB:
-    matplotlib.use('Agg')
-
 matplotlibrc_cache = {}
 
 
@@ -60,6 +57,7 @@ def pytest_configure(config):
             warnings.simplefilter('ignore')
             matplotlibrc_cache.update(matplotlib.rcParams)
             matplotlib.rcdefaults()
+            matplotlib.use('Agg')
 
     # Make sure we use temporary directories for the config and cache
     # so that the tests are insensitive to local configuration. Note that this


### PR DESCRIPTION
The MacOS X cron job was failing (which I totally missed) and this was also breaking the wheel building. I've now fixed the failure, which was due to https://github.com/matplotlib/matplotlib/pull/17764 which made it so that when resetting the rcParams to default, we were changing the backend to MacOS X and this now has an effect (which is correct).

<s>I've switched MacOS X back to being a non-cron job temporarily to check if it works.</s> - worked!