### PR TITLE
Enable Travis notifications to slack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,13 @@ cache:
   - ccache
   - .hypothesis
 
+notifications:
+  slack:
+    on_success: never
+    on_failure: always
+    secure: gLrQgrHNqHs0lOPsfvjlh0v8k56mJifPNpht0BX55YV0n1u5alKCrKOVcKTFNFY0gOldhwFNFq4oy3o5EaZkDx+CO71qiwwJr7ex7zT70EjHzWxEG8l2Bww9J3xVzhGgQw6tMq57HHiuOoJ07TJPvVxL+E/WZmkxRAdlzUhcab4=
+    if: type = cron
+
 os:
     - linux
 


### PR DESCRIPTION
This will post any cron failures to slack (for now the ci-issues channel)

For the record, to set this up I added the Travis integration to slack then followed their instructions for what to add to the Travis file. I added a few [options](https://docs.travis-ci.com/user/notifications/#default-notification-settings) to control the notifications.