### PR TITLE
Fix performance and bugs for Table init from lists with masks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1034,6 +1034,11 @@ astropy.table
 - Fixed a bug in table argsort when called with ``reverse=True`` for an
   indexed table. [#10103]
 
+- Fixed a performance regression introduced in #9048 when initializing a table
+  from Python lists. Also fixed incorrect behavior (for data types other than
+  float) when those lists contain ``np.ma.masked`` elements to indicate masked
+  data. [#10636]
+
 - Avoid modifying ``.meta`` when serializing columns to FITS. [#10485]
 
 - Avoid crash when reading a FITS table that contains mixin info and PyYAML

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -25,7 +25,7 @@ from astropy.io.registry import UnifiedReadWriteMethod
 from . import groups
 from .pprint import TableFormatter
 from .column import (BaseColumn, Column, MaskedColumn, _auto_names, FalseArray,
-                     col_copy)
+                     col_copy, _convert_sequence_data_to_array)
 from .row import Row
 from .np_utils import fix_column_name
 from .info import TableInfo
@@ -999,6 +999,7 @@ class Table:
         masked_col_cls = (self.ColumnClass
                           if issubclass(self.ColumnClass, self.MaskedColumn)
                           else self.MaskedColumn)
+
         try:
             data0_is_mixin = self._is_mixin_for_table(data[0])
         except Exception:
@@ -1055,32 +1056,16 @@ class Table:
             col_cls = masked_col_cls
 
         elif not hasattr(data, 'dtype'):
-            # If value doesn't have a dtype then convert to a masked numpy array.
-            # Then check if there were any masked elements.  This logic is handling
-            # normal lists like [1, 2] but also odd-ball cases like a list of masked
-            # arrays (see #8977).  Use np.ma.array() to do the heavy lifting.
-            try:
-                np_data = np.ma.array(data, dtype=dtype)
-            except Exception:
-                # Conversion failed for some reason, e.g. [2, 1*u.m] gives TypeError in Quantity
-                np_data = np.ma.array(data, dtype=object)
-
-            if np_data.ndim > 0 and len(np_data) == 0:
-                # Implies input was an empty list (e.g. initializing an empty table
-                # with pre-declared names and dtypes but no data).  Here we need to
-                # fall through to initializing with the original data=[].
-                col_cls = self.ColumnClass
-            else:
-                if np_data.mask is np.ma.nomask:
-                    data = np_data.data
-                    col_cls = self.ColumnClass
-                else:
-                    data = np_data
-                    col_cls = masked_col_cls
-                copy = False
+            # `data` is none of the above, convert to numpy array or MaskedArray
+            # assuming only that it is a scalar or sequence or N-d nested
+            # sequence. This function is relatively intricate and tries to
+            # maintain performance for common cases while handling things like
+            # list input with embedded np.ma.masked entries.
+            data = _convert_sequence_data_to_array(data, dtype)
+            copy = False  # Already made a copy above
+            col_cls = masked_col_cls if isinstance(data, np.ma.MaskedArray) else self.ColumnClass
 
         else:
-            # `data` is none of the above, so just go for it and try init'ing Column
             col_cls = self.ColumnClass
 
         try:

--- a/astropy/table/tests/test_masked.py
+++ b/astropy/table/tests/test_masked.py
@@ -182,6 +182,64 @@ class TestMaskedColumnInit(SetupData):
 class TestTableInit(SetupData):
     """Initializing a table"""
 
+    @pytest.mark.parametrize('type_str', ('?', 'b', 'i2', 'f4', 'c8', 'S', 'U', 'O'))
+    @pytest.mark.parametrize('shape', ((4,), (2, 2)))
+    def test_init_from_sequence_data_numeric_typed(self, type_str, shape):
+        """Test init from list or list of lists with dtype specified, optionally
+        including an np.ma.masked element.
+        """
+        # Make data of correct dtype and shape, then turn into a list,
+        # then use that to init Table with spec'd type_str.
+        data = [0, 1, 2, 3]
+        np_data = np.array(data, dtype=type_str).reshape(shape)
+        np_data_list = np_data.tolist()
+        t = Table([np_data_list], dtype=[type_str])
+        col = t['col0']
+        assert col.dtype == np_data.dtype
+        assert np.all(col == np_data)
+        assert type(col) is Column
+
+        # Introduce np.ma.masked in the list input and confirm dtype still OK.
+        if len(shape) == 1:
+            np_data_list[-1] = np.ma.masked
+        else:
+            np_data_list[-1][-1] = np.ma.masked
+        last_idx = tuple(-1 for _ in shape)
+        t = Table([np_data_list], dtype=[type_str])
+        col = t['col0']
+        assert col.dtype == np_data.dtype
+        assert np.all(col == np_data)
+        assert col.mask[last_idx]
+        assert type(col) is MaskedColumn
+
+    @pytest.mark.parametrize('type_str', ('?', 'b', 'i2', 'f4', 'c8', 'S', 'U', 'O'))
+    @pytest.mark.parametrize('shape', ((4,), (2, 2)))
+    def test_init_from_sequence_data_numeric_untyped(self, type_str, shape):
+        """Test init from list or list of lists with dtype NOT specified,
+        optionally including an np.ma.masked element.
+        """
+        data = [0, 1, 2, 3]
+        np_data = np.array(data, dtype=type_str).reshape(shape)
+        np_data_list = np_data.tolist()
+        t = Table([np_data_list])
+        # Grab the dtype that numpy assigns for the Python list inputs
+        dtype_expected = t['col0'].dtype
+
+        # Introduce np.ma.masked in the list input and confirm dtype still OK.
+        if len(shape) == 1:
+            np_data_list[-1] = np.ma.masked
+        else:
+            np_data_list[-1][-1] = np.ma.masked
+        last_idx = tuple(-1 for _ in shape)
+        t = Table([np_data_list])
+        col = t['col0']
+
+        # Confirm dtype is same as for untype list input w/ no mask
+        assert col.dtype == dtype_expected
+        assert np.all(col == np_data)
+        assert col.mask[last_idx]
+        assert type(col) is MaskedColumn
+
     def test_initialization_with_all_columns(self):
         t1 = Table([self.a, self.b, self.c, self.d, self.ca, self.sc])
         assert t1.colnames == ['a', 'b', 'c', 'd', 'ca', 'sc']
@@ -190,27 +248,7 @@ class TestTableInit(SetupData):
         lofd = [{k: row[k] for k in t1.colnames} for row in t1]
         t2 = Table(lofd)
         for k in t1.colnames:
-            assert np.all(t1[k] == t2[k]) in (True, np.ma.masked)
-            assert np.all(getattr(t1[k], 'mask', False)
-                          == getattr(t2[k], 'mask', False))
-
-    # Filter warnings since these are set to lead to exceptions,
-    # which changes behaviour in Table._convert_data_to_col
-    # (causing conversion of columns with masked elements to object dtype).
-    @pytest.mark.filterwarnings('ignore:.*converting a masked element.*')
-    def test_initialization_with_all_columns2(self):
-        t1 = Table([self.a, self.b, self.c, self.d, self.ca, self.sc])
-        assert t1.colnames == ['a', 'b', 'c', 'd', 'ca', 'sc']
-        # Check we get the same result by passing in as list of dict.
-        # (Regression test for error uncovered by scintillometry package.)
-        lofd = [{k: row[k] for k in t1.colnames} for row in t1]
-        t2 = Table(lofd)
-        for k in t1.colnames:
-            # TODO: the final dtype should not depend on the presence of
-            # masked elements, but unfortunately np.ma.MaskedArray does take
-            # it into account.
-            if k not in ('b', 'd'):
-                assert t1[k].dtype == t2[k].dtype
+            assert t1[k].dtype == t2[k].dtype
             assert np.all(t1[k] == t2[k]) in (True, np.ma.masked)
             assert np.all(getattr(t1[k], 'mask', False)
                           == getattr(t2[k], 'mask', False))

--- a/docs/table/masking.rst
+++ b/docs/table/masking.rst
@@ -42,22 +42,9 @@ Table Creation
 
 A masked table can be created in several ways:
 
-**Create a new table object and specify masked=True** ::
-
-  >>> from astropy.table import Table, Column, MaskedColumn
-  >>> Table([(1, 2), (3, 4)], names=('a', 'b'), masked=True, dtype=('i4', 'i8'))
-  <Table masked=True length=2>
-    a     b
-  int32 int64
-  ----- -----
-      1     3
-      2     4
-
-Notice the table attributes ``mask`` and ``fill_value`` that are
-available for a masked table.
-
 **Create a table with one or more columns as a MaskedColumn object**
 
+  >>> from astropy.table import Table, Column, MaskedColumn
   >>> a = MaskedColumn([1, 2], name='a', mask=[False, True], dtype='i4')
   >>> b = Column([3, 4], name='b', dtype='i8')
   >>> Table([a, b])
@@ -79,10 +66,28 @@ Notice that masked entries in the table output are shown as ``--``.
 
 **Create a table with one or more columns as a ``numpy`` MaskedArray**
 
-  >>> from numpy import ma  # masked array package
-  >>> a = ma.array([1, 2])
+  >>> import numpy as np
+  >>> a = np.ma.array([1, 2])
   >>> b = [3, 4]
   >>> t = Table([a, b], names=('a', 'b'))
+
+**Create a table from list data containing `numpy.ma.masked`**
+
+You can use the `numpy.ma.masked` constant to indicate masked or invalid data::
+
+  >>> a = [1.0, np.ma.masked]
+  >>> b = [np.ma.masked, 'val']
+  >>> Table([a, b], names=('a', 'b'))
+  <Table length=2>
+    a     b
+  float64 str3
+  ------- ----
+      1.0   --
+      --  val
+
+Initializing from lists with embedded `numpy.ma.masked` elements is considerably
+slower than using `numpy.ma.array` or |MaskedColumn| directly, so if performance
+is a concern you should use the latter methods if possible.
 
 **Add a MaskedColumn object to an existing table**
 
@@ -90,20 +95,29 @@ Notice that masked entries in the table output are shown as ``--``.
   >>> b = MaskedColumn([3, 4], mask=[True, False])
   >>> t['b'] = b
 
-Prior to ``astropy`` 4.0, adding the first |MaskedColumn| resulted in
-converting the entire table to be masked, which meant converting every existing
-|Column| to |MaskedColumn|. An informational warning was issued::
-
-  INFO: Upgrading Table to masked Table. Use Table.filled() to convert to unmasked table. [astropy.table.table]
-
-In ``astropy`` 4.0 and later, existing columns are not changed.
-
 **Add a new row to an existing table and specify a mask argument**
 
   >>> a = Column([1, 2], name='a')
   >>> b = Column([3, 4], name='b')
   >>> t = Table([a, b])
   >>> t.add_row([3, 6], mask=[True, False])
+
+**Create a new table object and specify masked=True**
+
+If ``masked=True`` is provided when creating the table then every column will
+be created as a |MaskedColumn|, and new columns will always be added as a
+a |MaskedColumn|.
+
+  >>> Table([(1, 2), (3, 4)], names=('a', 'b'), masked=True, dtype=('i4', 'i8'))
+  <Table masked=True length=2>
+    a     b
+  int32 int64
+  ----- -----
+      1     3
+      2     4
+
+Notice the table attributes ``mask`` and ``fill_value`` that are
+available for a masked table.
 
 **Convert an existing table to a masked table**
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to address a serious performance regression introduced by #9048 when initializing a table from Python list data. See #10548 for discussion.

Along the way I discovered that a number of things were just plain broken related to using `MaskedArray` as the universal converter from list data to np array data:
- `MaskedArray` looks for `np.ma.masked` in 1-d inputs but not N-d inputs, leading to inconsistent / wrong outputs. Only in the 1-d case is it slow, but in the N-d case it can give the wrong result.
- For `int` + `np.ma.masked` input, it converts to float.
- For `str`, it replaces `np.ma.masked` with `0.0` with no warning and gives a weird str item length.

This PR makes a new function `_convert_sequence_data_to_array` that does all the work for any input that is not already a mixin or ndarray subclass. That function is fairly extensively commented so best to just read it to see the strategy.

### Performance changes

This is captured in a couple of jupyter notebooks. These also show some of the inconsistent behavior of np.array and np.ma.MaskedArray:

- [table-list-init-performance-4.0.1.ipynb](https://gist.github.com/taldcroft/c55edc7f98d068d5fc94ea09cbf77c70)
- [table-list-init-performance-10636.ipynb](https://gist.github.com/taldcroft/2fa546ecb13ebe4a7ebc33ffa5dbb016)

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #10548
