### PR TITLE
Fix PyInstaller cron job/tox env

### DIFF
--- a/.pyinstaller/run_astropy_tests.py
+++ b/.pyinstaller/run_astropy_tests.py
@@ -20,7 +20,7 @@ for root, dirnames, _ in os.walk(os.path.join(ROOT, 'astropy')):
         final_dir = os.path.relpath(os.path.join(root.replace('astropy', 'astropy_tests'), dirname), ROOT)
         # We only copy over 'tests' directories, but not astropy/tests (only
         # astropy/tests/tests) since that is not just a directory with tests.
-        if dirname == 'tests' and root != 'astropy':
+        if dirname == 'tests' and not root.endswith('astropy'):
             shutil.copytree(os.path.join(root, dirname), final_dir, dirs_exist_ok=True)
         else:
             # Create empty __init__.py files so that 'astropy_tests' still

--- a/tox.ini
+++ b/tox.ini
@@ -160,6 +160,10 @@ deps =
     # so for now we pin to the latest working commit.
     git+https://github.com/pyinstaller/pyinstaller.git@c111ec5c#egg=PyInstaller
     pytest-mpl
+    # PyInstaller is not yet compatible with Matplotlib 3.3 so we pin
+    # Matplotlib to an older version for now - see the following issue
+    # for more details: https://github.com/pyinstaller/pyinstaller/issues/5004
+    matplotlib<3.3
 extras = test
 commands =
     pyinstaller --onefile run_astropy_tests.py \


### PR DESCRIPTION
This pins Matplotlib in the pyinstaller job until PyInstaller is compatible with Matplotlib 3.3

<s> ⚠️ contains temporary commit to ensure CI passes, don't merge until this is removed! ⚠️ </s> - passed!