### PR TITLE
Fixes for commentary cards

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -957,6 +957,9 @@ astropy.io.fits
 - Fix ResourceWarning with ``fits.writeto`` and ``pathlib.Path`` object.
   [#10599]
 
+- Fix repr for commentary cards and strip spaces for commentary keywords.
+  [#10640]
+
 astropy.io.misc
 ^^^^^^^^^^^^^^^
 

--- a/astropy/io/fits/header.py
+++ b/astropy/io/fits/header.py
@@ -2233,7 +2233,7 @@ class _HeaderCommentaryCards(_CardAccessor):
             yield self._header[(self._keyword, idx)]
 
     def __repr__(self):
-        return '\n'.join(self)
+        return '\n'.join(str(x) for x in self)
 
     def __getitem__(self, idx):
         if isinstance(idx, slice):

--- a/astropy/io/fits/header.py
+++ b/astropy/io/fits/header.py
@@ -161,7 +161,7 @@ class Header:
             return
 
         if isinstance(value, tuple):
-            if not (0 < len(value) <= 2):
+            if len(value) > 2:
                 raise ValueError(
                     'A Header item may be set with either a scalar value, '
                     'a 1-tuple containing a scalar value, or a 2-tuple '

--- a/astropy/io/fits/header.py
+++ b/astropy/io/fits/header.py
@@ -136,16 +136,20 @@ class Header:
         elif self._haswildcard(key):
             return self.__class__([copy.copy(self._cards[idx])
                                    for idx in self._wildcardmatch(key)])
-        elif (isinstance(key, str) and
-              key.upper() in Card._commentary_keywords):
-            key = key.upper()
-            # Special case for commentary cards
-            return _HeaderCommentaryCards(self, key)
+        elif isinstance(key, str):
+            key = key.strip()
+            if key.upper() in Card._commentary_keywords:
+                key = key.upper()
+                # Special case for commentary cards
+                return _HeaderCommentaryCards(self, key)
+
         if isinstance(key, tuple):
             keyword = key[0]
         else:
             keyword = key
+
         card = self._cards[self._cardindex(key)]
+
         if card.field_specifier is not None and keyword == card.rawkeyword:
             # This is RVKC; if only the top-level keyword was specified return
             # the raw value, not the parsed out float value

--- a/astropy/io/fits/tests/test_header.py
+++ b/astropy/io/fits/tests/test_header.py
@@ -209,6 +209,11 @@ class TestHeaderFunctions(FitsTestCase):
         assert header.cards[1].value == 0
         assert header[''] == [0, 1, 2, 3, '', '', 4]
 
+        header[''] = 5
+        header[' '] = 6
+        assert header[''] == [0, 1, 2, 3, '', '', 4, 5, 6]
+        assert header[' '] == [0, 1, 2, 3, '', '', 4, 5, 6]
+
     def test_update(self):
         class FakeHeader(list):
             def keys(self):

--- a/astropy/io/fits/tests/test_header.py
+++ b/astropy/io/fits/tests/test_header.py
@@ -175,7 +175,7 @@ class TestHeaderFunctions(FitsTestCase):
         assert len(w) == 1
         assert c.image == _pad('HIERARCH abc+ =                    9')
 
-    def test_add_commentary(self):
+    def test_add_history(self):
         header = fits.Header([('A', 'B', 'C'), ('HISTORY', 1),
                               ('HISTORY', 2), ('HISTORY', 3), ('', '', ''),
                               ('', '', '')])
@@ -184,12 +184,14 @@ class TestHeaderFunctions(FitsTestCase):
         assert len(header) == 6
         assert header.cards[4].value == 4
         assert header['HISTORY'] == [1, 2, 3, 4]
+        assert repr(header['HISTORY']) == '1\n2\n3\n4'
 
         header.add_history(0, after='A')
         assert len(header) == 6
         assert header.cards[1].value == 0
         assert header['HISTORY'] == [0, 1, 2, 3, 4]
 
+    def test_add_blank(self):
         header = fits.Header([('A', 'B', 'C'), ('', 1), ('', 2), ('', 3),
                               ('', '', ''), ('', '', '')])
         header.add_blank(4)
@@ -200,6 +202,7 @@ class TestHeaderFunctions(FitsTestCase):
         assert len(header) == 7
         assert header.cards[6].value == 4
         assert header[''] == [1, 2, 3, '', '', 4]
+        assert repr(header['']) == '1\n2\n3\n\n\n4'
 
         header.add_blank(0, after='A')
         assert len(header) == 8


### PR DESCRIPTION
Fix #10496 :
- Strip spaces in keyword before checking for commentary keyword
- Fix repr for commentary cards 