### PR TITLE
Add a stopping criterion to FittingWithOutlierRemoval

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -42,7 +42,11 @@ astropy.modeling
 ^^^^^^^^^^^^^^^^
 
 - Added NFW profile and tests to modeling package [#10505]
+
 - Added missing logic for evaluate to compound models [#10002]
+
+- Stop iteration in ``FittingWithOutlierRemoval`` before reaching ``niter`` if
+  the masked points are no longer changing. [#?]
 
 astropy.nddata
 ^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -48,6 +48,10 @@ astropy.modeling
 - Stop iteration in ``FittingWithOutlierRemoval`` before reaching ``niter`` if
   the masked points are no longer changing. [#10642]
 
+- Keep a (shallow) copy of ``fit_info`` from the last iteration of the wrapped
+  fitter in ``FittingWithOutlierRemoval`` and also record the actual number of
+  iterations performed in it. [#10642]
+
 astropy.nddata
 ^^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -46,7 +46,7 @@ astropy.modeling
 - Added missing logic for evaluate to compound models [#10002]
 
 - Stop iteration in ``FittingWithOutlierRemoval`` before reaching ``niter`` if
-  the masked points are no longer changing. [#?]
+  the masked points are no longer changing. [#10642]
 
 astropy.nddata
 ^^^^^^^^^^^^^^

--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -585,10 +585,10 @@ class FittingWithOutlierRemoval:
     Attributes
     ----------
     fit_info : dict
-        The `fit_info` (if any) from the last iteration of the wrapped `fitter`
-        during the most recent fit. An entry is also added with the keyword
-        `niter` that records the actual number of fitting iterations performed
-        (as opposed to the user-specified maximum).
+        The ``fit_info`` (if any) from the last iteration of the wrapped
+        ``fitter`` during the most recent fit. An entry is also added with the
+        keyword ``niter`` that records the actual number of fitting iterations
+        performed (as opposed to the user-specified maximum).
     """
 
     def __init__(self, fitter, outlier_func, niter=3, **outlier_kwargs):


### PR DESCRIPTION
### Description

Currently `FittingWithOutlierRemoval` keeps iterating until `niter` is reached, even when the set of masked points has stopped changing between iterations, rather than [detecting convergence like `stats.SigmaClip`](https://github.com/astropy/astropy/blob/03a99e9ef071541834cb204fcc3429f41bb47867/astropy/stats/sigma_clipping.py#L374) and stopping. This is a basic thing that I should have fixed last time I worked on it...

This mini PR stops iteration when the number of masked points is no longer changing (which, with the current cumulative method of masking, implies that the points are the same ones).

When the equivalent change was made in `SigmaClip`, [the parameter there was renamed from `iters` to `maxiters`](https://github.com/astropy/astropy/commit/662cd2fa41b6657f1b385720b5c6793f044d4107#diff-9a14850376ba3cb948038a9ac71a2bf6). At Gemini we found that a bit disruptive for just a small improvement in clarity, to be honest, so I'm not necessarily advocating changing it here, but am pointing it out for completeness.

With the current API, there isn't really any new test to be added here -- all results should be identical to the previous ones and `__call__` returns a fitted model and mask, which don't provide any way for a test to check what the _actual_ number of iterations was. However, this change does cause the existing `TestWeightedFittingWithOutlierRemoval` to perform 2 iterations instead of the previous 3 and that test still passes unmodified, validating the new behaviour.

We could also add the actual number of iterations as an attribute of `self`, then it could be obtained from the fitter instance immediately after calling it, if that's useful for whatever reason (not that it has any bearing on the results). That would allow a new test to confirm that the actual number of iterations is less than `niter` but still produces the same results, FWIW. What do you think? What would we call the attribute in that case (`niter_actual`?). Thanks.
