### PR TITLE
Include 3-d list for full coverage of list init code

### DIFF
--- a/astropy/table/tests/test_masked.py
+++ b/astropy/table/tests/test_masked.py
@@ -183,14 +183,14 @@ class TestTableInit(SetupData):
     """Initializing a table"""
 
     @pytest.mark.parametrize('type_str', ('?', 'b', 'i2', 'f4', 'c8', 'S', 'U', 'O'))
-    @pytest.mark.parametrize('shape', ((4,), (2, 2)))
+    @pytest.mark.parametrize('shape', ((8,), (4, 2), (2, 2, 2)))
     def test_init_from_sequence_data_numeric_typed(self, type_str, shape):
         """Test init from list or list of lists with dtype specified, optionally
         including an np.ma.masked element.
         """
         # Make data of correct dtype and shape, then turn into a list,
         # then use that to init Table with spec'd type_str.
-        data = [0, 1, 2, 3]
+        data = list(range(8))
         np_data = np.array(data, dtype=type_str).reshape(shape)
         np_data_list = np_data.tolist()
         t = Table([np_data_list], dtype=[type_str])
@@ -202,8 +202,10 @@ class TestTableInit(SetupData):
         # Introduce np.ma.masked in the list input and confirm dtype still OK.
         if len(shape) == 1:
             np_data_list[-1] = np.ma.masked
-        else:
+        elif len(shape) == 2:
             np_data_list[-1][-1] = np.ma.masked
+        else:
+            np_data_list[-1][-1][-1] = np.ma.masked
         last_idx = tuple(-1 for _ in shape)
         t = Table([np_data_list], dtype=[type_str])
         col = t['col0']
@@ -213,12 +215,12 @@ class TestTableInit(SetupData):
         assert type(col) is MaskedColumn
 
     @pytest.mark.parametrize('type_str', ('?', 'b', 'i2', 'f4', 'c8', 'S', 'U', 'O'))
-    @pytest.mark.parametrize('shape', ((4,), (2, 2)))
+    @pytest.mark.parametrize('shape', ((8,), (4, 2), (2, 2, 2)))
     def test_init_from_sequence_data_numeric_untyped(self, type_str, shape):
         """Test init from list or list of lists with dtype NOT specified,
         optionally including an np.ma.masked element.
         """
-        data = [0, 1, 2, 3]
+        data = list(range(8))
         np_data = np.array(data, dtype=type_str).reshape(shape)
         np_data_list = np_data.tolist()
         t = Table([np_data_list])
@@ -228,8 +230,10 @@ class TestTableInit(SetupData):
         # Introduce np.ma.masked in the list input and confirm dtype still OK.
         if len(shape) == 1:
             np_data_list[-1] = np.ma.masked
-        else:
+        elif len(shape) == 2:
             np_data_list[-1][-1] = np.ma.masked
+        else:
+            np_data_list[-1][-1][-1] = np.ma.masked
         last_idx = tuple(-1 for _ in shape)
         t = Table([np_data_list])
         col = t['col0']


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This is a follow-up to #10636 since I noticed the inline code coverage comment that [one line of the code](https://github.com/astropy/astropy/pull/10636/files#diff-30ea8400f76ea2c3dfd24787113276f6R248) there was not tested. Indeed that was correct and this PR adds a 3-d list that will now test that line.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

