### PR TITLE
Remove trailing references to astropy's own ErfaWarning

### DIFF
--- a/astropy/coordinates/tests/test_regression.py
+++ b/astropy/coordinates/tests/test_regression.py
@@ -10,6 +10,7 @@ import io
 import copy
 import pytest
 import numpy as np
+from erfa import ErfaWarning
 
 from astropy import units as u
 from astropy.coordinates import (
@@ -22,7 +23,6 @@ from astropy.coordinates import (
     CylindricalRepresentation, CylindricalDifferential,
     CartesianDifferential)
 from astropy.coordinates.sites import get_builtin_sites
-from astropy.utils.exceptions import ErfaWarning
 from astropy.time import Time
 from astropy.utils import iers
 from astropy.table import Table

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -12,6 +12,7 @@ from copy import deepcopy
 import pytest
 import numpy as np
 import numpy.testing as npt
+from erfa import ErfaWarning
 
 from astropy import units as u
 from astropy.tests.helper import assert_quantity_allclose as assert_allclose
@@ -25,7 +26,6 @@ from astropy.coordinates import Latitude, EarthLocation
 from astropy.coordinates.transformations import FunctionTransform
 from astropy.time import Time
 from astropy.utils import minversion, isiterable
-from astropy.utils.exceptions import ErfaWarning
 from astropy.units import allclose as quantity_allclose
 from astropy.io import fits
 from astropy.wcs import WCS

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -11,8 +11,9 @@ import numpy as np
 import pytest
 from numpy.testing import assert_allclose
 import erfa
+from erfa import ErfaWarning
 
-from astropy.utils.exceptions import AstropyDeprecationWarning, ErfaWarning
+from astropy.utils.exceptions import AstropyDeprecationWarning
 from astropy.utils import isiterable, iers
 from astropy.time import (Time, TimeDelta, ScaleValueError, STANDARD_TIME_SCALES,
                           TimeString, TimezoneInfo, TIME_FORMATS)

--- a/astropy/time/tests/test_precision.py
+++ b/astropy/time/tests/test_precision.py
@@ -13,13 +13,13 @@ from hypothesis.strategies import (composite, datetimes, floats, integers,
 
 import numpy as np
 import erfa
+from erfa import ErfaError, ErfaWarning
 
 import astropy.units as u
 from astropy.tests.helper import assert_quantity_allclose
 from astropy.time import STANDARD_TIME_SCALES, Time, TimeDelta
 from astropy.time.utils import day_frac, two_sum
 from astropy.utils import iers
-from astropy.utils.exceptions import ErfaError, ErfaWarning
 
 
 allclose_jd = functools.partial(np.allclose, rtol=np.finfo(float).eps, atol=0)

--- a/astropy/visualization/tests/test_time.py
+++ b/astropy/visualization/tests/test_time.py
@@ -6,10 +6,10 @@ import pytest
 pytest.importorskip('matplotlib')  # noqa
 
 import matplotlib.pyplot as plt
+from erfa import ErfaWarning
 
 from astropy.time import Time
 from astropy.visualization.time import time_support
-from astropy.utils.exceptions import ErfaWarning
 from astropy.utils.compat.context import nullcontext
 
 # Since some of the examples below use times/dates in the future, we use the


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->


<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

Since moving to a standalone pyerfa package, some references to ErfaWarning from astropy.utils.exceptions remained.

This removes them, hopefully fixes #10648 
