### PR TITLE
 Prevent comparisons between Time and TimeDelta from succeeding.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -166,6 +166,9 @@ astropy.tests
 astropy.time
 ^^^^^^^^^^^^
 
+- ``Time`` can no longer be initialized with subclasses such as ``TimeDelta``,
+  thus allowing one to count on getting a ``Time`` instance. [#10652]
+
 astropy.timeseries
 ^^^^^^^^^^^^^^^^^^
 
@@ -246,6 +249,9 @@ astropy.tests
 
 astropy.time
 ^^^^^^^^^^^^
+
+- Prevent comparisons between ``Time`` and ``TimeDelta`` from sometimes succeeding.
+  [#10652]
 
 astropy.timeseries
 ^^^^^^^^^^^^^^^^^^

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -395,6 +395,8 @@ class Time(ShapedLikeNDArray):
             update_leap_seconds()
 
         if isinstance(val, cls):
+            if not type(val) is cls:
+                raise TypeError(f"cannot instantiate {cls} with a {type(val)}.")
             self = val.replicate(format=format, copy=copy)
         else:
             self = super().__new__(cls)

--- a/astropy/time/tests/test_delta.py
+++ b/astropy/time/tests/test_delta.py
@@ -605,3 +605,17 @@ def test_insert_timedelta():
     # Insert a scalar using an auto-parsed string
     tm2 = tm.insert(1, TimeDelta([10, 20], format='sec'))
     assert np.all(tm2 == TimeDelta([1, 10, 20, 2], format='sec'))
+
+
+def test_cannot_instantiate_via_time():
+    # Regression test for gh-10651.  This used to succeed.
+    tm = TimeDelta(1., format='jd', scale='tai')
+    with pytest.raises(TypeError):
+        Time(tm)
+
+
+def test_cannot_compare_with_time():
+    # Regression test for gh-10651.  This used to succeed.
+    tm = TimeDelta(1., format='jd', scale='tai')
+    with pytest.raises(TypeError, match='not supported'):
+        tm < Time('J2001')


### PR DESCRIPTION
fixes #10651 
