### PR TITLE
Refactor `quantity_input`

### DIFF
--- a/astropy/units/__init__.py
+++ b/astropy/units/__init__.py
@@ -15,6 +15,7 @@ code under a BSD license.
 # where most time is spent (e.g., using python -X importtime).
 from .core import *
 from .quantity import *
+from .unitspec import *
 
 from . import si
 from . import cgs

--- a/astropy/units/unitspec.py
+++ b/astropy/units/unitspec.py
@@ -1,0 +1,408 @@
+# -*- coding: utf-8 -*-
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+import abc
+from numbers import Number
+from collections.abc import ItemsView
+from types import MappingProxyType
+
+import numpy as np
+
+from astropy.utils.decorators import classproperty
+
+from .core import Unit, UnitBase, UnitConversionError, UnitsError
+from .physical import _physical_unit_mapping, _unit_physical_mapping, get_physical_type
+from .quantity import Quantity
+
+__all__ = ["UnitSpec", "CompoundUnitSpec", "NullUnitSpec", "UnitSpecBase"]
+
+# registry of UnitSpec action options
+_ACTION_USPEC_REGISTRY = {}
+_USPEC_ACTION_REGISTRY = {}
+
+
+class UnitSpecBase(metaclass=abc.ABCMeta):
+    """Abstract base class for Unit Specification.
+
+    Use this in ``isinstance`` checks.
+
+    Parameters
+    ----------
+    target : Any
+    qcls : `~astropy.units.Quantity` or subclass type
+        The Quantity class. This can be used to enforce, e.g.
+        `~astropy.coordinates.Angle` quantities.
+    bound : bool, optional
+        Whether the target type must be exactly 'qcls' (False) or any subtype
+        (inclusive) of 'qcls' (True, default).
+    **kw
+        Not used.
+    """
+
+    def __init__(self, target, qcls=Quantity, bound=True, **kw):
+        self.target = target
+        self.qcls = qcls
+        self.bound = bound
+
+    @classmethod
+    def _get_action(cls, kls=None):
+        # needed for `UnitSpec.__init_subclass__`, where `kls` is is passed by
+        # the wrap of `_get_action` by `classproperty`
+        return _USPEC_ACTION_REGISTRY[kls or cls]
+
+    @classproperty
+    def action(cls):
+        """Get action associated with unit specification."""
+        return cls._get_action()
+
+    @abc.abstractmethod
+    def __call__(self, value, **kwargs):
+        """The call method must be implemented by subclasses.
+
+        Subclasses should NOT call this with ``super``.
+        This raises a `NotImplementedError`.
+        """
+        raise NotImplementedError
+
+    def _check_bound(self, value, bound=None):
+        bound = self.bound if bound is None else bound
+
+        if not bound and value.__class__ is not self.qcls:  # the strict check
+            raise TypeError(f"{value!r} is not type {self.qcls!r}.")
+        elif not isinstance(value, self.qcls):  # bound=True but wrong type
+            raise TypeError(f"{value!r} is not qcls {self.qcls!r} (or subclass).")
+
+        return True
+
+    # =====================
+
+    def __add__(self, other):
+        # check if other is UnitSpecBase
+        if not isinstance(other, UnitSpecBase):
+            return NotImplemented
+
+        return CompoundUnitSpec(self, other)
+
+    def __repr__(self):
+        return f"{self.__class__.__qualname__}({self.target}, qcls={self.qcls.__name__})"
+
+
+class CompoundUnitSpec(UnitSpecBase):
+
+    def __init__(self, *specs):
+        # TODO! flatten specs to allow for CompoundUnitSpec(CompoundUnitSpec())
+        # also check if there are conflicting specs
+        self._specs = specs
+
+    def __call__(self, value, **kwargs):
+        # TODO! better iteration over specs
+        for spec in self._specs:
+            try:
+                out = spec(value, **kwargs)
+            except (UnitConversionError, TypeError):
+                pass
+            else:
+                return out
+
+        raise TypeError("All unitspecs failed")  # TODO! better error message
+
+    # =====================
+
+    def __iadd__(self, other):
+        # check if other is UnitSpecBase
+        if not isinstance(other, UnitSpecBase):
+            raise TypeError(f"{other!r} must be {UnitSpecBase!r}")
+
+        # allow for other to be CompoundUnitSpec
+        if isinstance(other, CompoundUnitSpec):
+            other = other._specs
+        else:
+            other = (other, )
+
+        self._specs = self._specs + other
+        return self
+
+    def __repr__(self):
+        # TODO! nicely split long lines
+        return f"{self.__class__.__qualname__}{self._specs!r}"
+
+# =============================================================================
+
+
+class UnitSpec(UnitSpecBase):
+    """Unit Specification.
+
+    Parameters
+    ----------
+    target : `UnitSpecBase` or None or Any
+    action : str or None, optional
+        The action to take on the target.
+    qcls : `~astropy.units.Quantity` or subclass type
+        The Quantity class. This can be used to enforce, e.g.
+        `~astropy.coordinates.Angle` quantities.
+    """
+
+    def __init_subclass__(cls, action, **kwargs):
+        # check registry
+        if action in _ACTION_USPEC_REGISTRY:
+            raise KeyError(f"`{action}` already in registry.")
+
+        # register subclass and action
+        _ACTION_USPEC_REGISTRY[action] = cls
+        _USPEC_ACTION_REGISTRY[cls] = action
+
+        # reimplement UnitSpecBase action
+        cls.action = classproperty(UnitSpecBase._get_action)
+
+    def __new__(cls, target=None, action=None, qcls=Quantity, **kw):
+        # First check if target is a UnitSpec. This class doesn't convert, so
+        # those pass thru directly. Note: UnitSpec subclasses can do whatever.
+        if isinstance(target, UnitSpecBase):
+            return target
+
+        # second check it's a valid action...
+        elif action not in _ACTION_USPEC_REGISTRY:
+            raise KeyError(f"action {action!r} must be one of {_ACTION_USPEC_REGISTRY.keys()}")
+
+        # if so, create the UnitSpec for that action.
+        self = super().__new__(cls)
+        if cls is UnitSpec:
+            # UnitSpec wraps its subclasses so only UnitSpec need ever be imported.
+            # Need to determine which subclass to wrap
+            self._uspec = _ACTION_USPEC_REGISTRY[action](target, qcls=qcls)
+            self.__doc__ = self._uspec.__doc__  # update docstring
+            # self.__call__.__doc__ = self._uspec.__call__.__doc__
+
+        return self
+
+    def __call__(self, value, **kwargs):
+        """Calls the wrapped UnitSpec."""
+        # pass through to wrapped UnitSpec
+        return self._uspec(value, **kwargs)
+
+    @property
+    def action(self):
+        """Unit Specification."""
+        return self._uspec.action
+
+    @action.setter
+    def action(self, value):
+        if value != self._uspec.action:
+            self._uspec = self._ACTION_USPEC_REGISTRY[value](self.target, qcls=self.qcls)
+
+    # =====================
+
+    def __repr__(self):
+        if self.__class__ is UnitSpec:
+            return f"[UnitSpec]{self._uspec}"
+
+        # can / should be overridden by subclasses. This is just a default.
+        return (f"{self.__class__.__qualname__}({self.target!r}, qcls={self.qcls.__qualname__}, "
+                f"action={self.action!r}, bound={self.bound})")
+
+
+# -----------------------------------------------------------------------------
+
+
+class NullUnitSpec(UnitSpec, action=None):
+    """Null Unit Specification. Returns value on call.
+
+    Examples
+    --------
+    >>> from astropy.units import NullUnitSpec
+    >>> nulluspec = NullUnitSpec()
+    >>> nulluspec
+    NullUnitSpec()
+
+    >>> print(nulluspec.action)
+    None
+
+    >>> nulluspec(1)
+    1
+    >>> nulluspec([1, 2, 3])
+    [1, 2, 3]
+
+    Alternatively to construct a `~astropy.units.unitspec.NullUnitSpec`
+    with `~astropy.units.unitspec.UnitSpec`:
+
+    >>> from astropy.units import UnitSpec
+    >>> UnitSpec(None)
+    [UnitSpec]NullUnitSpec()
+    """
+    
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def __call__(self, value):
+        """Returns 'value' unchanged."""
+        return value
+
+    def __repr__(self):
+        return f"{self.__class__.__qualname__}()"
+
+
+# -----------------------------------------------------------------------------
+
+
+class ValidatePhysicalType(UnitSpec, action="validate"):
+    """UnitSpec to validate physical type.
+
+    Parameters
+    ----------
+    physical_type : `~astropy.units.PhysicalType`-like
+        e.g. the string 'length'
+        This is the ``target`` in `UnitSpecBase`.
+    qcls : type
+        The :class:`~astropy.units.Quantity` class.
+        Can be used to check that an input is not only the correct physical
+        type, but also the correct Quantity type.
+    bound : bool, optional
+        Whether the target type must be exactly 'qcls' (False) or any subtype
+        (inclusive) of 'qcls' (True, default).
+
+    strict_dimensionless : bool, optional
+        Whether to be strict about stuff like numerics (`~number.Number` or
+        `~numpy.ndarray`) being equivalent to dimensionless quantities.
+
+    Examples
+    --------
+    >>> uspec = UnitSpec("length", action="validate")
+    >>> uspec
+    [UnitSpec]ValidatePhysicalType(PhysicalType('length'), qcls=Quantity,
+                                   action='validate', strict=False)
+    """
+
+    def __init__(self, physical_type, qcls=Quantity, bound=True, strict_dimensionless=False, **kw):
+        # make sure it's actually a physical type. this will catch any errors.
+        ptype = get_physical_type(physical_type)
+        super().__init__(ptype, qcls=qcls, bound=bound, **kw)
+
+        self.strict_dimensionless = strict_dimensionless
+
+    def __call__(self, value, bound=None, strict_dimensionless=None, **kw):
+        """
+
+        Parameters
+        ----------
+        value : Any
+        strict_dimensionless : bool or None, optional
+            None uses default value set at initialization.
+        **kw
+            Not used.
+        """
+        # what if 'value' was just a number? if not 'strict', numbers will be
+        # treated as dimensionless quantities.
+        strict = (self.strict_dimensionless if strict_dimensionless is None
+                  else strict_dimensionless)
+        bound = self.bound if bound is None else bound
+        if (not strict
+            and (self.target == "dimensionless")
+            and (isinstance(value, (Number, np.generic))
+                 or (isinstance(value, np.ndarray)
+                     and np.issubdtype(value.dtype, np.number)))):
+            pass  # He is the `~astropy.units.one`.
+
+        # checks that 'value' is the the correct class type
+        elif not self._check_bound(value, bound=bound):
+            pass # error messages handled in _check_bound
+
+        # check units is the correct physical type, including any enabled
+        # equivalencies. TODO! a cleaner check
+        if not value.unit.is_equivalent(self.target._unit):
+            raise UnitConversionError(f"`{value.unit.physical_type}` is not equivalent to type '{self.target}'")
+        else:
+            pass  # passes all checks!
+
+        return value
+
+
+# -----------------------------------------------------------------------------
+
+
+class ConvertToUnit(UnitSpec, action="to unit"):
+    """Convert input to target unit.
+
+    Parameters
+    ----------
+    unit : unit-like
+        Not Physical Type
+    qcls : type
+    bound : bool
+    """
+
+    def __init__(self, unit, qcls=Quantity, bound=True, **kw):
+        unit = Unit(unit)  # make sure it's a Unit. catches any errors.
+        super().__init__(unit, qcls=qcls, bound=bound, **kw)
+
+    def __call__(self, value, bound=None, **kw):
+        """Convert input to target units.
+
+        Parameters
+        ----------
+        value
+        bound : bool
+
+        Returns
+        -------
+        `~astropy.units.Quantity`
+        """
+        self._check_bound(value, bound=bound)
+        # convert value to desired quantity
+        return self.qcls(value, unit=self.target, copy=False)
+
+
+class ConvertToValue(ConvertToUnit, action="to value"):
+    """Convert input to value in target units.
+
+    Parameters
+    ----------
+    unit : unit-like
+        Not Physical Type
+    qcls : type
+    bound : bool
+    """
+
+    def __call__(self, value, bound=None, **kw):
+        """Convert input to value in target units.
+    
+        Parameters
+        ----------
+        value
+        bound : bool
+    
+        Returns
+        -------
+        `~astropy.units.Quantity`
+        """
+        return super().__call__(value, bound=bound, **kw).to_value()
+
+
+class AssignUnits(ConvertToUnit, action="from value"):
+    """Assign input target units.
+    
+    Equivalent to UnitSpec 'to unit', with strictness set to False.
+
+    Parameters
+    ----------
+    unit : unit-like
+        Not Physical Type
+    qcls : type
+    """
+
+    def __init__(self, unit, qcls=Quantity, **kw):
+        kw.pop("bound", None)  # make sure not present
+        super().__init__(unit, qcls=qcls, bound=True, **kw)
+
+    def __call__(self, value, **kw):
+        """Assign input target units.
+    
+        Parameters
+        ----------
+        value
+    
+        Returns
+        -------
+        `~astropy.units.Quantity`
+        """
+        kw.pop("bound", None)  # make sure not present
+        return self.qcls(value, unit=self.target, copy=False)


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

## Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This is a big set of changes, **PLEASE HELP**.

This DRAFT pull request is to coordinate a number of PRs improving `quantity_input` and unit-aware static typing:

The goals are:

1. Use `quantity_input` with statically typed code
2. Allow `SpecificTypeQuantity` subclasses, like Distance or Angle, to be used instead of `Quantity` in the input verification of `quantity_input`
3. Speed up calling `quantity_input`-wrapped functions by pre-computing as much of the conversion mechanics at wrapper initialization.
4.
    a) Allow inputs to be cast to specific units (or physical types), not just verified
    b) post-cast, to pass input to function as `.to_value()` so that functions can work with ndarrays guaranteed to be in the correct units
5. Expose all of these improvements to the user in a python-standard way, so that they can be changed even after the function has been initialized.


Select Ancillary Benefits:
_See whole comment for details_

- unit-aware static type hints can be used independently of `quantity_input`
- `UnitSpec` classes can be used independently of `quantity_input` to provide specific unit/physical-type validation/conversion/etc.
- User-defined `UnitSpec` subclasses are automatically registered and usable by `UnitSpec` and `quantity_input`


## Summary of each PR

1.  #10662 : Introduce unit aware annotations.

- [ ] set `Annotated[Quantity, <unit>]` as official unit-aware Quantity annotation
- [x] add `__class_getitem__` method to `Quantity` to shortcut creating.
      Caveat: py3.7+
- [x] create stand-in Annotated class. Not valid for static typing. Run-time only. But same API as static implementation.
- [x] work with `quantity_input`


2. Rewrite `quantity_input` internals so that all information is stored in `wrapper.__annotations__`, converting valid inputs to `Quantity[<unit or pt>]` from PR#1. This is still not valid static typing, but it will trivially solve #10156 by having a) non-unit / physicaltype return annotations ignored and b) allowing `quantity_input(return=None)` to store None in `wrapper.__annotations__` instead of `Quantity[<unit or pt>]`

3. `UnitSpec` to  solve #7368 and multiple annotations
> * Extend Unit to your `UnitSpec` so that `quantity_input` becomes more powerful (addressing #7368)
> * Change `quantity_input` so that it uses the actual class, making `Angle` and `Distance` possible (maybe will be easiest if done together with (2)).
> have `quantity_input` convert this to `Annotated[Quantity, UnitSpec(<unit>), other]` for internal use.
> Add method to `Quantity` to create `UnitSpec` annotations

4. switch to valid static typing, having had time to discuss this more broadly with the rest of Astropy.

<br><br>

- - -

## Overall Summary

Subject to change.


### Static Typing

**Current State:**

There is no means to create unit-aware type annotations. For instance, the annotations used by `quantity_input`, like `u.km` or `distance`, are not compliant with static typing since the inputs are of (sub)type `Quantity`.

**Proposed Change:**

This problem can be solved by the `typing.Annotated` class, from [this PEP](https://www.python.org/dev/peps/pep-0593/#id13) which allows valid static type annotations to include metadata. Now, unit-aware type annotations will be of the form `Annotated[Quantity, <unit>, other_annotations]`, where the unit must be the first annotation.

A `__class_getitem__` method will be added to `Quantity` to shortcut creating unit aware annotations.
`Quantity[<unit>, other_annotations] == Annotated[Quantity, <unit>, other_annotation]`.
As a class method, this will similarly work for all subclasses of `Quantity`.

`quantity_input` will accept unit-aware quantity annotations of this type. Both the type (eg Quantity) and unit must be valid inputs.

**Implementation Details:**

[typing_extensions](https://github.com/python/typing/blob/master/typing_extensions/src_py3/typing_extensions.py) is the official backport for Annotated and works on any py3.5+. Until py3.9+ is the minimum python version, when `Annotated` is in the built-in `typing` library, we use the `typing_extension` backport. Until the `typing_extension` backport is added as an astropy dependency we emulate API for unsupported features.

<br>

### Pre-Computation and User Accessibility

**Current State:**

`quantity_input` uses function annotations to determine the required argument units and since it also uses `functools.wraps` those annotations are propagated to the wrapper returned by `quantity_input`. However, other inputs to `quantity_input`, such as keyword arguments are not similarly stored. 

**Proposed Change:**

The wrapper's `__annotations__`   will store all  unit/physical_type information, merging the information provided from the keyword arguments with the original function's `__annotations__`. The original function will be unchanged and accessible in the `__wrapped__` attribute. Since decorators can be applied as functions, not just with the "pie" syntax, this will allow multiple different versions of the same function to be created with different unit specifications. Not only that, but storing all information in `__annotations__` means that the desired units are pre-computed, increasing function call speed, and are also editable by knowledgeable users in a python-standard format.

<br>

### `UnitSpec`

For `quantity_input`, the `Annotated[Quantity, <unit>, other_annotations]` is not specific enough, since it only annotates which argument should be processed, not what to actually do with them.  We introduce a `UnitSpec` (abbreviation for "unit specification") class to do both. 

`quantity_input` will accept the standard `Annotated[Quantity, <unit>, other_annotations]`, but also accept the more detailed annotation `Annotated[Quantity, UnitSpec(<unit>), other_annotations]`. Internally, any of non-unitspec annotations will be converted.

The `UnitSpec.__call__` will control how `quantity_input` interacts with each input — if it just verifies unit / physical_type, or casts to unit / physical_type, or does `to_value`, etc. UnitSpec will enable different treatment of each input: for a function ``func(x, y)``,  ``x`` might just be verified, but ``y = y.to_value(u.km)``.

`UnitSpec` will have the following pre-specified options for the `__call__` output, set with the "action" attribute.
- "validate" : to only validate physical type
- "convert" : to convert quantities to specific units / physical type
- "to_value" : takes `.to_value` after conversion
- "from_value" : reassigns units if none present & verifies units if present.

The following subclasses of `UnitSpec` will also be implemented:
- `UnitSpecValidate` : which can only validate physical type
- `UnitSpecConvert` : which will convert quantities to specific units / physical type
- `UnitSpecValue` : a subclass of `UnitSpecConvert` which takes `.to_value` after conversion
- `UnitSpecAssign` : which reassigns units if none present & verifies units if present.

Using `__init_subclass__` these and any user-created subclasses of `UnitSpec` will be added to a registry. The "action" kwarg of `UnitSpec` must be a key in this registry and will be used by `UnitSpec` to set the behavior of `UnitSpec.__call__`. In this way `UnitSpec` can stand in for any of its subclasses, which are only really needed to make a behavior immutable.

`UnitSpec` will drastically simplify a few things in `quantity_input`, and potentially elsewhere.

For instance, in `quantity_input`, all that's needed to check a multiply-annotated argument and then perform the validation is
```python
if isAnnotated(antn):
    md = [isinstance(x, UnitSpecBase) for x in antn.__metadata__]
    if not any(md):  # skip to next argument
        continue
    elif sum(md) > 1 :  # more than one UnitSpec
        raise Exception()

    unitspec = antn.__metadata__[np.nonzero(md)]
    if name == "return":  # save the return casting until actually call function.
        return_spec = unitspec
    else:
        ba.arguments[name] = unitspec(ba.arguments[name])
```


### `quantity_input` implementation

Order of precedence of unit specifications:
1. Kwargs into `quantity_input`: 
    `quantity_input(x=u.hour)(foo)`.
     This allows `quantity_input` to wrap functions from external libraries without modifying the function.
2. function annotations
    So that calling `quantity_input` as a function overrides the default unit specifications.
3. units from argument default values
    To respect type hints

Argument-specific behavior in `quantity_input` is allowed by mixing `UnitSpec` subclasses in `wrapper.__annotations__`.

For simple means of ensuring uniform `UnitSpec` behavior, there will be a few subclasses of `QuantityInput` which convert any user-created unit-aware Quantity annotations to the appropriate `UnitSpec` subclasses. The complexities of the `wrapper` construction can happen in `super` and only ever need to be written once. The `UnitSpec` auto-registry very easily allows user-created `UnitSpec` and therefore user-created `QuantityInput` subclasses. 

- `ValidateQuantityInput` : converts `UnitSpec` to `UnitSpecValidate`
- `ConvertQuantityInput` : converts `UnitSpec` to `UnitSpecConvert`
- `DeQuantityInput`  : converts `UnitSpec` to `UnitSpecValue`


For example, to make a `to_value` flavor of `quantity_input` is a simple for-loop replacing `UnitSpec` with `UnitSpecValue`, the subclass that performs conversion and takes the value. While this is the default behavior for `UnitSpec` and the subclass used by `UnitSpec(...action = 'value')`, the subclass is immutable and more explicit.

```python
class DeQuantityInput(QuantityInput):
    """QuantityInput, with ``to_value(unit)`` on all specified inputs."""

    def __call__(self, wrapped_function):

        # use all the machinery from superclass
        wrapper = super().__call__(wrapped_function)

        # but now need to ensure that everything is correct UnitSpec
        _antns_ = dict()
        for name, antn in wrapper.__annotations__.items():

            if isAnnotated(antn):
                unitspec = antn.__metadata__[0]
                if isinstance(unitspec, UnitSpecBase):
                    if name == "return":
                        _antns_[name] = UnitSpec(unitspec, action="from_value")
                    else:
                        _antns_[name] = UnitSpecValue(unitspec)

        wrapper.__annotations__.update(_antns_)

        return wrapper
```

<br>


## Examples
Assuming the following imports
```python
import typing_extensions as T
from typing_extensions import Annotated
import astropy.units as u
from astropy.units import quantity_input, Quantity, UnitSpec
import astropy.coordinates as coord
```

Example 1)

```python
@quantity_input(v="speed")
def foo(x: u.m, v: u.Quantity, t=2 * u.s, y: T.Optional[u.Quantity[u.km]]=None, flag: T.Optional[str]=None) -> u.Quantity["distance"]:
     return x + v * t

# annotations
foo.__annotations__
```
> {
>     "x": Annotated[Quantity, UnitSpec(u.m | validate Quantity)],
>     "v": Annotated[Quantity, UnitSpec("speed" | validate Quantity)],
>     "t": Annotated[Quantity, UnitSpec(u.s | validate Quantity)],
>     "y":  T.Union[Annotated[Quantity, UnitSpec(u.km | validate Quantity)], NoneType]
>     "flag": T.Union[str, NoneType],
>     "return": Annotated[Quantity, UnitSpec("distance" | validate Quantity)]
> }

```python
# and the original function
foo.__wrapped__.__annotations__
```
> {
>     "x": u.m, "v": Quantity, "flag": T.Optional[str],
>     "y": T.Union[Annotated[Quantity, u.km], NoneType], "return": "distance"
> }

To force `x` input to be Distance or subclass
```python
foo.__annotations__["x"].__origin__ = coord.Distance
foo.__annotations__["x"].__metadata__[0].dtype = coord.Distance
foo.__annotations__["x"]
```
> Annotated[Distance, UnitSpec(u.m | validate Distance)]

To change `t` to action "convert"
```python
foo.__annotations__["t"].__metadata_[0].action = "convert"
foo.__annotations__["t"]
```
> Annotated[Quantity, UnitSpec(u.s | convert Quantity)]



To make a `to_value` flavor of `quantity_input` is a simple for-loop replacing `UnitSpec` with `UnitSpecValue`, the subclass that performs conversion and takes the value. While this is the default behavior for `UnitSpec` and the subclass used by `UnitSpec(...action = 'value')`, the subclass is immutable and more explicit.

```python
class DeQuantityInput(QuantityInput):
    """QuantityInput, with ``to_value(unit)`` on all specified inputs."""

    def __call__(self, wrapped_function):

        # use all the machinery from superclass
        wrapper = super().__call__(wrapped_function)

        # but now need to ensure that everything is correct UnitSpec
        _antns_ = dict()
        for name, antn in wrapper.__annotations__.items():

            if isAnnotated(antn):
                unitspec = antn.__metadata__[0]
                if isinstance(unitspec, UnitSpecBase):
                    if name == "return":
                        _antns_[name] = UnitSpec(unitspec, action="from_value")
                    else:
                        _antns_[name] = UnitSpecValue(unitspec)

        wrapper.__annotations__.update(_antns_)

        return wrapper
```


<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #10156, #5606,  #7368
