### PR TITLE
Refactor `Time` and `TimeDelta` to inherit from common `TimeBase` class

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -216,6 +216,11 @@ astropy.tests
 astropy.time
 ^^^^^^^^^^^^
 
+- Refactor ``Time`` and ``TimeDelta`` classes to inherit from a common
+  ``TimeBase`` class. The ``TimeDelta`` class no longer inherits from ``Time``.
+  A number of methods that only apply to ``Time`` (e.g. ``light_travel_time``)
+  are no longer available in the ``TimeDelta`` class. [#10656]
+
 astropy.timeseries
 ^^^^^^^^^^^^^^^^^^
 

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -3374,10 +3374,10 @@ class Table:
             astropy Columns + appropriate meta-data to allow subsequent decoding.
             """
             from . import serialize
-            from astropy.time import Time, TimeDelta
+            from astropy.time import TimeBase, TimeDelta
 
             # Convert any Time or TimeDelta columns and pay attention to masking
-            time_cols = [col for col in tbl.itercols() if isinstance(col, Time)]
+            time_cols = [col for col in tbl.itercols() if isinstance(col, TimeBase)]
             if time_cols:
 
                 # Make a light copy of table and clear any indices

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -1440,10 +1440,6 @@ class TimeBase(ShapedLikeNDArray):
     def __radd__(self, other):
         return self.__add__(other)
 
-    def __rsub__(self, other):
-        out = self.__sub__(other)
-        return -out
-
     def _time_comparison(self, other, op):
         """If other is of same class as self, compare difference in self.scale.
         Otherwise, return NotImplemented

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -320,12 +320,6 @@ class TimeDeltaInfo(TimeInfo):
 class TimeBase(ShapedLikeNDArray):
     """Base time class from which Time and TimeDelta inherit."""
 
-    SCALES = TIME_SCALES
-    """List of time scales"""
-
-    FORMATS = TIME_FORMATS
-    """Dict of time formats"""
-
     # Make sure that reverse arithmetic (e.g., TimeDelta.__rmul__)
     # gets called over the __mul__ of Numpy arrays.
     __array_priority__ = 20000
@@ -1385,14 +1379,6 @@ class TimeBase(ShapedLikeNDArray):
     def __ge__(self, other):
         return self._time_comparison(other, operator.ge)
 
-    def to_datetime(self, timezone=None):
-        # TODO: this could likely go through to_value, as long as that
-        # had an **kwargs part that was just passed on to _time.
-        tm = self.replicate(format='datetime')
-        return tm._shaped_like_input(tm._time.to_value(timezone))
-
-    to_datetime.__doc__ = TimeDatetime.to_value.__doc__
-
 
 class Time(TimeBase):
     """
@@ -1441,6 +1427,12 @@ class Time(TimeBase):
     copy : bool, optional
         Make a copy of the input values
     """
+    SCALES = TIME_SCALES
+    """List of time scales"""
+
+    FORMATS = TIME_FORMATS
+    """Dict of time formats"""
+
     def __new__(cls, val, val2=None, format=None, scale=None,
                 precision=None, in_subfmt=None, out_subfmt=None,
                 location=None, copy=False):
@@ -2075,6 +2067,14 @@ class Time(TimeBase):
     # but there is no case of <something> - T, so no __rsub__.
     def __radd__(self, other):
         return self.__add__(other)
+
+    def to_datetime(self, timezone=None):
+        # TODO: this could likely go through to_value, as long as that
+        # had an **kwargs part that was just passed on to _time.
+        tm = self.replicate(format='datetime')
+        return tm._shaped_like_input(tm._time.to_value(timezone))
+
+    to_datetime.__doc__ = TimeDatetime.to_value.__doc__
 
 
 class TimeDelta(TimeBase):

--- a/astropy/timeseries/binned.py
+++ b/astropy/timeseries/binned.py
@@ -107,10 +107,10 @@ class BinnedTimeSeries(BaseTimeSeries):
         if time_bin_end is None and time_bin_size is None:
             raise TypeError("Either 'time_bin_size' or 'time_bin_end' should be specified")
 
-        if not isinstance(time_bin_start, Time):
+        if not isinstance(time_bin_start, (Time, TimeDelta)):
             time_bin_start = Time(time_bin_start)
 
-        if time_bin_end is not None and not isinstance(time_bin_end, Time):
+        if time_bin_end is not None and not isinstance(time_bin_end, (Time, TimeDelta)):
             time_bin_end = Time(time_bin_end)
 
         if time_bin_size is not None and not isinstance(time_bin_size, (Quantity, TimeDelta)):

--- a/astropy/timeseries/periodograms/bls/core.py
+++ b/astropy/timeseries/periodograms/bls/core.py
@@ -101,7 +101,7 @@ class BoxLeastSquares(BasePeriodogram):
 
         self.t = t
 
-        if isinstance(self.t, Time):
+        if isinstance(self.t, (Time, TimeDelta)):
             self._tstart = self.t[0]
             trel = (self.t - self._tstart).to(u.day)
         else:

--- a/astropy/timeseries/sampled.py
+++ b/astropy/timeseries/sampled.py
@@ -38,11 +38,11 @@ class TimeSeries(BaseTimeSeries):
         Data to initialize time series. This does not need to contain the times,
         which can be provided separately, but if it does contain the times they
         should be in a column called ``'time'`` to be automatically recognized.
-    time : `~astropy.time.Time` or iterable
+    time : `~astropy.time.Time`, `~astropy.time.TimeDelta` or iterable
         The times at which the values are sampled - this can be either given
-        directly as a `~astropy.time.Time` array or as any iterable that
-        initializes the `~astropy.time.Time` class. If this is given, then
-        the remaining time-related arguments should not be used.
+        directly as a `~astropy.time.Time` or `~astropy.time.TimeDelta` array
+        or as any iterable that initializes the `~astropy.time.Time` class. If
+        this is given, then the remaining time-related arguments should not be used.
     time_start : `~astropy.time.Time` or str
         The time of the first sample in the time series. This is an alternative
         to providing ``time`` and requires that ``time_delta`` is also provided.
@@ -92,7 +92,7 @@ class TimeSeries(BaseTimeSeries):
         elif time is not None and time_start is not None:
             raise TypeError("Cannot specify both 'time' and 'time_start'")
 
-        if time is not None and not isinstance(time, Time):
+        if time is not None and not isinstance(time, (Time, TimeDelta)):
             time = Time(time)
 
         if time_start is not None and not isinstance(time_start, Time):

--- a/astropy/timeseries/sampled.py
+++ b/astropy/timeseries/sampled.py
@@ -95,7 +95,7 @@ class TimeSeries(BaseTimeSeries):
         if time is not None and not isinstance(time, (Time, TimeDelta)):
             time = Time(time)
 
-        if time_start is not None and not isinstance(time_start, Time):
+        if time_start is not None and not isinstance(time_start, (Time, TimeDelta)):
             time_start = Time(time_start)
 
         if time_delta is not None and not isinstance(time_delta, (Quantity, TimeDelta)):


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to address a longstanding issue that `TimeDelta` inherited from `Time` but many of the methods (e.g. `light_travel_time()` were really not applicable. Instead now there is a base class `TimeBase` that has the common methods and each independently inherits from `TimeBase`.

After this refactor there were only two problems that showed up in the entire astropy code base, both related to assuming `Time` as the base class. In one case `TimeBase.insert()` this was fixed using `self.__class__` and in the other `Table.to_pandas()` using `TimeBase`. There were no other code changes apart from moving methods around intact.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #6828
Fixes #10654.
