### PR TITLE
Make frame attribute equivalency checks symmetric

### DIFF
--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -1131,18 +1131,42 @@ def test_equivalent_frame_coordinateattribute():
         coord_attr = CoordinateAttribute(HCRS)
 
     # These frames should not be considered equivalent
+    f0 = FrameWithCoordinateAttribute()
     f1 = FrameWithCoordinateAttribute(coord_attr=HCRS(1*u.deg, 2*u.deg, obstime='J2000'))
     f2 = FrameWithCoordinateAttribute(coord_attr=HCRS(3*u.deg, 4*u.deg, obstime='J2000'))
     f3 = FrameWithCoordinateAttribute(coord_attr=HCRS(1*u.deg, 2*u.deg, obstime='J2001'))
 
+    assert not f0.is_equivalent_frame(f1)
+    assert not f1.is_equivalent_frame(f0)
     assert not f1.is_equivalent_frame(f2)
     assert not f1.is_equivalent_frame(f3)
     assert not f2.is_equivalent_frame(f3)
 
     # They each should still be equivalent to a deep copy of themselves
+    assert f0.is_equivalent_frame(deepcopy(f0))
     assert f1.is_equivalent_frame(deepcopy(f1))
     assert f2.is_equivalent_frame(deepcopy(f2))
     assert f3.is_equivalent_frame(deepcopy(f3))
+
+
+def test_equivalent_frame_locationattribute():
+    from astropy.coordinates import BaseCoordinateFrame, EarthLocation
+    from astropy.coordinates.attributes import EarthLocationAttribute
+
+    class FrameWithLocationAttribute(BaseCoordinateFrame):
+        loc_attr = EarthLocationAttribute()
+
+    # These frames should not be considered equivalent
+    f0 = FrameWithLocationAttribute()
+    location = EarthLocation(lat=-34, lon=19, height=300)
+    f1 = FrameWithLocationAttribute(loc_attr=location)
+
+    assert not f0.is_equivalent_frame(f1)
+    assert not f1.is_equivalent_frame(f0)
+
+    # They each should still be equivalent to a deep copy of themselves
+    assert f0.is_equivalent_frame(deepcopy(f0))
+    assert f1.is_equivalent_frame(deepcopy(f1))
 
 
 def test_representation_subclass():

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -17,7 +17,7 @@ from erfa import ErfaWarning
 from astropy import units as u
 from astropy.tests.helper import assert_quantity_allclose as assert_allclose
 from astropy.coordinates.representation import REPRESENTATION_CLASSES, DUPLICATE_REPRESENTATIONS
-from astropy.coordinates import (ICRS, FK4, FK5, Galactic, SkyCoord, Angle,
+from astropy.coordinates import (ICRS, FK4, FK5, Galactic, GCRS, SkyCoord, Angle,
                                  SphericalRepresentation, CartesianRepresentation,
                                  UnitSphericalRepresentation, AltAz,
                                  BaseCoordinateFrame, Attribute,
@@ -1409,6 +1409,20 @@ def test_equiv_skycoord():
     assert scf2.is_equivalent_frame(FK5(equinox='J2005'))
     assert not scf3.is_equivalent_frame(scf1)
     assert not scf3.is_equivalent_frame(FK5(equinox='J2005'))
+
+
+def test_equiv_skycoord_with_extra_attrs():
+    """Regression test for #10658."""
+    # GCRS has a CartesianRepresentationAttribute called obsgeoloc
+    gcrs = GCRS(1*u.deg, 2*u.deg, obsgeoloc=CartesianRepresentation([1, 2, 3], unit=u.m))
+    # Create a SkyCoord where obsgeoloc tags along as an extra attribute
+    sc1 = SkyCoord(gcrs).transform_to(ICRS)
+    # Now create a SkyCoord with an equivalent frame but without the extra attribute
+    sc2 = SkyCoord(sc1.frame)
+    # The SkyCoords are therefore not equivalent, but check both directions
+    assert not sc1.is_equivalent_frame(sc2)
+    # This way around raised a TypeError which is fixed by #10658
+    assert not sc2.is_equivalent_frame(sc1)
 
 
 def test_constellations():


### PR DESCRIPTION
### Description

The `BaseCoordinateFrame._frameattr_equiv(left_fattr, right_fattr)` check is not symmetric with respect to the two attributes.

If the left attribute is a coordinate frame or representation and the right one isn't, the method returns `False`.

If the right attribute is a coordinate frame or representation and the left one isn't, one is at the mercy of the underlying equality operator instead. This typically results in a `TypeError` (or a `FutureWarning` in the case of an `EarthLocationAttribute` vs an unspecified `None`).

This was encountered when calculating the angular separation between a star and the Sun in a common AltAz frame. The Sun `SkyCoord` had an extra `obsgeoloc` frame attribute due to its GCRS origins while the star `SkyCoord` had this as `None`. Then `sun.separation(star)` works but `star.separation(sun)` raises a `TypeError`.
`
This extends @ayshih's changes in #10290, so it can be considered a bug fix of the development version.