### PR TITLE
Account for removal of financial functions in numpy 1.20

### DIFF
--- a/astropy/units/quantity_helper/function_helpers.py
+++ b/astropy/units/quantity_helper/function_helpers.py
@@ -42,7 +42,8 @@ import numpy as np
 
 from astropy.units.core import (
     UnitsError, UnitTypeError, dimensionless_unscaled)
-from astropy.utils.compat import NUMPY_LT_1_17, NUMPY_LT_1_18
+from astropy.utils.compat import (NUMPY_LT_1_17, NUMPY_LT_1_18,
+                                  NUMPY_LT_1_20)
 from astropy.utils import isiterable
 
 
@@ -128,10 +129,12 @@ IGNORED_FUNCTIONS = {
     np.save, np.savez, np.savetxt, np.savez_compressed,
     # Polynomials
     np.poly, np.polyadd, np.polyder, np.polydiv, np.polyfit, np.polyint,
-    np.polymul, np.polysub, np.polyval, np.roots, np.vander,
+    np.polymul, np.polysub, np.polyval, np.roots, np.vander}
+if NUMPY_LT_1_20:
     # financial
-    np.fv, np.ipmt, np.irr, np.mirr, np.nper, np.npv, np.pmt, np.ppmt,
-    np.pv, np.rate}
+    IGNORED_FUNCTIONS |= {np.fv, np.ipmt, np.irr, np.mirr, np.nper,
+                          np.npv, np.pmt, np.ppmt, np.pv, np.rate}
+
 if NUMPY_LT_1_18:
     IGNORED_FUNCTIONS |= {np.rank}
 else:

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -11,7 +11,7 @@ from astropy import units as u
 from astropy.units.quantity_helper.function_helpers import (
     ARRAY_FUNCTION_ENABLED, SUBCLASS_SAFE_FUNCTIONS, UNSUPPORTED_FUNCTIONS,
     FUNCTION_HELPERS, DISPATCHED_FUNCTIONS, IGNORED_FUNCTIONS)
-from astropy.utils.compat import NUMPY_LT_1_18
+from astropy.utils.compat import NUMPY_LT_1_18, NUMPY_LT_1_20
 
 
 needs_array_function = pytest.mark.xfail(
@@ -2039,9 +2039,10 @@ class TestLinAlg(metaclass=CoverageMeta):
 
 
 untested_functions = set()
-financial_functions = {f for f in all_wrapped_functions.values()
-                       if f in np.lib.financial.__dict__.values()}
-untested_functions |= financial_functions
+if NUMPY_LT_1_20:
+    financial_functions = {f for f in all_wrapped_functions.values()
+                           if f in np.lib.financial.__dict__.values()}
+    untested_functions |= financial_functions
 
 deprecated_functions = {
     np.asscalar

--- a/astropy/utils/compat/numpycompat.py
+++ b/astropy/utils/compat/numpycompat.py
@@ -6,7 +6,8 @@ earlier versions of Numpy.
 from astropy.utils import minversion
 
 
-__all__ = ['NUMPY_LT_1_17', 'NUMPY_LT_1_18', 'NUMPY_LT_1_19']
+__all__ = ['NUMPY_LT_1_17', 'NUMPY_LT_1_18', 'NUMPY_LT_1_19',
+           'NUMPY_LT_1_20']
 
 # TODO: It might also be nice to have aliases to these named for specific
 # features/bugs we're checking for (ex:
@@ -14,3 +15,4 @@ __all__ = ['NUMPY_LT_1_17', 'NUMPY_LT_1_18', 'NUMPY_LT_1_19']
 NUMPY_LT_1_17 = not minversion('numpy', '1.17')
 NUMPY_LT_1_18 = not minversion('numpy', '1.18')
 NUMPY_LT_1_19 = not minversion('numpy', '1.19')
+NUMPY_LT_1_20 = not minversion('numpy', '1.20')


### PR DESCRIPTION
For once, I may have made the fix before @pllim found the problem! (But I had warning from failures with numpy and astropy-dev in my own package...). Numpy is removing the financial functions and that causes failures because I accessed these just to then ignore them for anything `Quantity` related. So, the fix is just to ignore them more.

Should be easy to backport...

EDIT: measure of success is that tests pass, with the -dev run only giving the trim-zeroes error.