### PR TITLE
Include a realistic treatment of solar light deflection for nearby objects

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -937,6 +937,10 @@ astropy.convolution
 astropy.coordinates
 ^^^^^^^^^^^^^^^^^^^
 
+- Fix a bug where for light deflection by the Sun it was always assumed that the
+  source was at infinite distance, which in the (rare and) absolute worst-case
+  scenario could lead to errors up to 3 arcsec. [#10666]
+
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 

--- a/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
@@ -37,10 +37,7 @@ def icrs_to_cirs(icrs_coo, cirs_frame):
 
     if icrs_coo.data.get_name() == 'unitspherical' or icrs_coo.data.to_cartesian().x.unit == u.one:
         # if no distance, just do the infinite-distance/no parallax calculation
-        usrepr = icrs_coo.represent_as(UnitSphericalRepresentation)
-        i_ra = usrepr.lon.to_value(u.radian)
-        i_dec = usrepr.lat.to_value(u.radian)
-        cirs_ra, cirs_dec = atciqz(i_ra, i_dec, astrom)
+        cirs_ra, cirs_dec = atciqz(icrs_coo.cartesian.without_differentials(), astrom)
 
         newrep = UnitSphericalRepresentation(lat=u.Quantity(cirs_dec, u.radian, copy=False),
                                              lon=u.Quantity(cirs_ra, u.radian, copy=False),
@@ -53,11 +50,8 @@ def icrs_to_cirs(icrs_coo, cirs_frame):
         astrom_eb = CartesianRepresentation(astrom['eb'], unit=u.au,
                                             xyz_axis=-1, copy=False)
         newcart = icrs_coo.cartesian - astrom_eb
-
         srepr = newcart.represent_as(SphericalRepresentation)
-        i_ra = srepr.lon.to_value(u.radian)
-        i_dec = srepr.lat.to_value(u.radian)
-        cirs_ra, cirs_dec = atciqz(i_ra, i_dec, astrom)
+        cirs_ra, cirs_dec = atciqz(newcart.without_differentials(), astrom)
 
         newrep = SphericalRepresentation(lat=u.Quantity(cirs_dec, u.radian, copy=False),
                                          lon=u.Quantity(cirs_ra, u.radian, copy=False),
@@ -68,14 +62,10 @@ def icrs_to_cirs(icrs_coo, cirs_frame):
 
 @frame_transform_graph.transform(FunctionTransformWithFiniteDifference, CIRS, ICRS)
 def cirs_to_icrs(cirs_coo, icrs_frame):
-    srepr = cirs_coo.represent_as(SphericalRepresentation)
-    cirs_ra = srepr.lon.to_value(u.radian)
-    cirs_dec = srepr.lat.to_value(u.radian)
-
     # set up the astrometry context for ICRS<->cirs and then convert to
     # astrometric coordinate direction
     astrom = erfa_astrom.get().apci(cirs_coo)
-    i_ra, i_dec = aticq(cirs_ra, cirs_dec, astrom)
+    i_ra, i_dec = aticq(cirs_coo.cartesian.without_differentials(), astrom)
 
     if cirs_coo.data.get_name() == 'unitspherical' or cirs_coo.data.to_cartesian().x.unit == u.one:
         # if no distance, just use the coordinate direction to yield the
@@ -89,6 +79,7 @@ def cirs_to_icrs(cirs_coo, icrs_frame):
 
         # the distance in intermedrep is *not* a real distance as it does not
         # include the offset back to the SSB
+        srepr = cirs_coo.represent_as(SphericalRepresentation)
         intermedrep = SphericalRepresentation(lat=u.Quantity(i_dec, u.radian, copy=False),
                                               lon=u.Quantity(i_ra, u.radian, copy=False),
                                               distance=srepr.distance,
@@ -124,10 +115,7 @@ def icrs_to_gcrs(icrs_coo, gcrs_frame):
 
     if icrs_coo.data.get_name() == 'unitspherical' or icrs_coo.data.to_cartesian().x.unit == u.one:
         # if no distance, just do the infinite-distance/no parallax calculation
-        usrepr = icrs_coo.represent_as(UnitSphericalRepresentation)
-        i_ra = usrepr.lon.to_value(u.radian)
-        i_dec = usrepr.lat.to_value(u.radian)
-        gcrs_ra, gcrs_dec = atciqz(i_ra, i_dec, astrom)
+        gcrs_ra, gcrs_dec = atciqz(icrs_coo.cartesian.without_differentials(), astrom)
 
         newrep = UnitSphericalRepresentation(lat=u.Quantity(gcrs_dec, u.radian, copy=False),
                                              lon=u.Quantity(gcrs_ra, u.radian, copy=False),
@@ -142,9 +130,7 @@ def icrs_to_gcrs(icrs_coo, gcrs_frame):
         newcart = icrs_coo.cartesian - astrom_eb
 
         srepr = newcart.represent_as(SphericalRepresentation)
-        i_ra = srepr.lon.to_value(u.radian)
-        i_dec = srepr.lat.to_value(u.radian)
-        gcrs_ra, gcrs_dec = atciqz(i_ra, i_dec, astrom)
+        gcrs_ra, gcrs_dec = atciqz(newcart.without_differentials(), astrom)
 
         newrep = SphericalRepresentation(lat=u.Quantity(gcrs_dec, u.radian, copy=False),
                                          lon=u.Quantity(gcrs_ra, u.radian, copy=False),
@@ -156,15 +142,11 @@ def icrs_to_gcrs(icrs_coo, gcrs_frame):
 @frame_transform_graph.transform(FunctionTransformWithFiniteDifference,
                                  GCRS, ICRS)
 def gcrs_to_icrs(gcrs_coo, icrs_frame):
-    srepr = gcrs_coo.represent_as(SphericalRepresentation)
-    gcrs_ra = srepr.lon.to_value(u.radian)
-    gcrs_dec = srepr.lat.to_value(u.radian)
-
     # set up the astrometry context for ICRS<->GCRS and then convert to BCRS
     # coordinate direction
     astrom = erfa_astrom.get().apcs(gcrs_coo)
 
-    i_ra, i_dec = aticq(gcrs_ra, gcrs_dec, astrom)
+    i_ra, i_dec = aticq(gcrs_coo.cartesian.without_differentials(), astrom)
 
     if gcrs_coo.data.get_name() == 'unitspherical' or gcrs_coo.data.to_cartesian().x.unit == u.one:
         # if no distance, just use the coordinate direction to yield the
@@ -178,6 +160,7 @@ def gcrs_to_icrs(gcrs_coo, icrs_frame):
 
         # the distance in intermedrep is *not* a real distance as it does not
         # include the offset back to the SSB
+        srepr = gcrs_coo.represent_as(SphericalRepresentation)
         intermedrep = SphericalRepresentation(lat=u.Quantity(i_dec, u.radian, copy=False),
                                               lon=u.Quantity(i_ra, u.radian, copy=False),
                                               distance=srepr.distance,
@@ -210,14 +193,10 @@ def gcrs_to_hcrs(gcrs_coo, hcrs_frame):
         frameattrs['obstime'] = hcrs_frame.obstime
         gcrs_coo = gcrs_coo.transform_to(GCRS(**frameattrs))
 
-    srepr = gcrs_coo.represent_as(SphericalRepresentation)
-    gcrs_ra = srepr.lon.to_value(u.radian)
-    gcrs_dec = srepr.lat.to_value(u.radian)
-
     # set up the astrometry context for ICRS<->GCRS and then convert to ICRS
     # coordinate direction
     astrom = erfa_astrom.get().apcs(gcrs_coo)
-    i_ra, i_dec = aticq(gcrs_ra, gcrs_dec, astrom)
+    i_ra, i_dec = aticq(gcrs_coo.cartesian.without_differentials(), astrom)
 
     # convert to Quantity objects
     i_ra = u.Quantity(i_ra, u.radian, copy=False)
@@ -233,6 +212,7 @@ def gcrs_to_hcrs(gcrs_coo, hcrs_frame):
 
         # Note that the distance in intermedrep is *not* a real distance as it
         # does not include the offset back to the Heliocentre
+        srepr = gcrs_coo.represent_as(SphericalRepresentation)
         intermedrep = SphericalRepresentation(lat=i_dec, lon=i_ra,
                                               distance=srepr.distance,
                                               copy=False)

--- a/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
@@ -37,7 +37,8 @@ def icrs_to_cirs(icrs_coo, cirs_frame):
 
     if icrs_coo.data.get_name() == 'unitspherical' or icrs_coo.data.to_cartesian().x.unit == u.one:
         # if no distance, just do the infinite-distance/no parallax calculation
-        cirs_ra, cirs_dec = atciqz(icrs_coo.cartesian.without_differentials(), astrom)
+        srepr = icrs_coo.spherical
+        cirs_ra, cirs_dec = atciqz(srepr.without_differentials(), astrom)
 
         newrep = UnitSphericalRepresentation(lat=u.Quantity(cirs_dec, u.radian, copy=False),
                                              lon=u.Quantity(cirs_ra, u.radian, copy=False),
@@ -51,7 +52,7 @@ def icrs_to_cirs(icrs_coo, cirs_frame):
                                             xyz_axis=-1, copy=False)
         newcart = icrs_coo.cartesian - astrom_eb
         srepr = newcart.represent_as(SphericalRepresentation)
-        cirs_ra, cirs_dec = atciqz(newcart.without_differentials(), astrom)
+        cirs_ra, cirs_dec = atciqz(srepr.without_differentials(), astrom)
 
         newrep = SphericalRepresentation(lat=u.Quantity(cirs_dec, u.radian, copy=False),
                                          lon=u.Quantity(cirs_ra, u.radian, copy=False),
@@ -65,7 +66,8 @@ def cirs_to_icrs(cirs_coo, icrs_frame):
     # set up the astrometry context for ICRS<->cirs and then convert to
     # astrometric coordinate direction
     astrom = erfa_astrom.get().apci(cirs_coo)
-    i_ra, i_dec = aticq(cirs_coo.cartesian.without_differentials(), astrom)
+    srepr = cirs_coo.represent_as(SphericalRepresentation)
+    i_ra, i_dec = aticq(srepr.without_differentials(), astrom)
 
     if cirs_coo.data.get_name() == 'unitspherical' or cirs_coo.data.to_cartesian().x.unit == u.one:
         # if no distance, just use the coordinate direction to yield the
@@ -79,7 +81,6 @@ def cirs_to_icrs(cirs_coo, icrs_frame):
 
         # the distance in intermedrep is *not* a real distance as it does not
         # include the offset back to the SSB
-        srepr = cirs_coo.represent_as(SphericalRepresentation)
         intermedrep = SphericalRepresentation(lat=u.Quantity(i_dec, u.radian, copy=False),
                                               lon=u.Quantity(i_ra, u.radian, copy=False),
                                               distance=srepr.distance,
@@ -115,7 +116,8 @@ def icrs_to_gcrs(icrs_coo, gcrs_frame):
 
     if icrs_coo.data.get_name() == 'unitspherical' or icrs_coo.data.to_cartesian().x.unit == u.one:
         # if no distance, just do the infinite-distance/no parallax calculation
-        gcrs_ra, gcrs_dec = atciqz(icrs_coo.cartesian.without_differentials(), astrom)
+        srepr = icrs_coo.represent_as(SphericalRepresentation)
+        gcrs_ra, gcrs_dec = atciqz(srepr.without_differentials(), astrom)
 
         newrep = UnitSphericalRepresentation(lat=u.Quantity(gcrs_dec, u.radian, copy=False),
                                              lon=u.Quantity(gcrs_ra, u.radian, copy=False),
@@ -130,7 +132,7 @@ def icrs_to_gcrs(icrs_coo, gcrs_frame):
         newcart = icrs_coo.cartesian - astrom_eb
 
         srepr = newcart.represent_as(SphericalRepresentation)
-        gcrs_ra, gcrs_dec = atciqz(newcart.without_differentials(), astrom)
+        gcrs_ra, gcrs_dec = atciqz(srepr.without_differentials(), astrom)
 
         newrep = SphericalRepresentation(lat=u.Quantity(gcrs_dec, u.radian, copy=False),
                                          lon=u.Quantity(gcrs_ra, u.radian, copy=False),
@@ -146,7 +148,8 @@ def gcrs_to_icrs(gcrs_coo, icrs_frame):
     # coordinate direction
     astrom = erfa_astrom.get().apcs(gcrs_coo)
 
-    i_ra, i_dec = aticq(gcrs_coo.cartesian.without_differentials(), astrom)
+    srepr = gcrs_coo.represent_as(SphericalRepresentation)
+    i_ra, i_dec = aticq(srepr.without_differentials(), astrom)
 
     if gcrs_coo.data.get_name() == 'unitspherical' or gcrs_coo.data.to_cartesian().x.unit == u.one:
         # if no distance, just use the coordinate direction to yield the
@@ -160,7 +163,6 @@ def gcrs_to_icrs(gcrs_coo, icrs_frame):
 
         # the distance in intermedrep is *not* a real distance as it does not
         # include the offset back to the SSB
-        srepr = gcrs_coo.represent_as(SphericalRepresentation)
         intermedrep = SphericalRepresentation(lat=u.Quantity(i_dec, u.radian, copy=False),
                                               lon=u.Quantity(i_ra, u.radian, copy=False),
                                               distance=srepr.distance,
@@ -196,7 +198,8 @@ def gcrs_to_hcrs(gcrs_coo, hcrs_frame):
     # set up the astrometry context for ICRS<->GCRS and then convert to ICRS
     # coordinate direction
     astrom = erfa_astrom.get().apcs(gcrs_coo)
-    i_ra, i_dec = aticq(gcrs_coo.cartesian.without_differentials(), astrom)
+    srepr = gcrs_coo.represent_as(SphericalRepresentation)
+    i_ra, i_dec = aticq(srepr.without_differentials(), astrom)
 
     # convert to Quantity objects
     i_ra = u.Quantity(i_ra, u.radian, copy=False)
@@ -212,7 +215,6 @@ def gcrs_to_hcrs(gcrs_coo, hcrs_frame):
 
         # Note that the distance in intermedrep is *not* a real distance as it
         # does not include the offset back to the Heliocentre
-        srepr = gcrs_coo.represent_as(SphericalRepresentation)
         intermedrep = SphericalRepresentation(lat=i_dec, lon=i_ra,
                                               distance=srepr.distance,
                                               copy=False)

--- a/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
@@ -111,7 +111,7 @@ def cirs_to_cirs(from_coo, to_frame):
 
 @frame_transform_graph.transform(FunctionTransformWithFiniteDifference, ICRS, GCRS)
 def icrs_to_gcrs(icrs_coo, gcrs_frame):
-    # first set up the astrometry context for ICRS<->GCRS. There are a few steps...
+    # first set up the astrometry context for ICRS<->GCRS.
     astrom = erfa_astrom.get().apcs(gcrs_frame)
 
     if icrs_coo.data.get_name() == 'unitspherical' or icrs_coo.data.to_cartesian().x.unit == u.one:

--- a/astropy/coordinates/builtin_frames/utils.py
+++ b/astropy/coordinates/builtin_frames/utils.py
@@ -14,6 +14,7 @@ from astropy import units as u
 from astropy.time import Time
 from astropy.utils import iers
 from astropy.utils.exceptions import AstropyWarning
+from ..representation import CartesianRepresentation
 
 
 # We use tt as the time scale for this equinoxes, primarily because it is the
@@ -163,12 +164,15 @@ def get_cip(jd1, jd2):
     return x, y, s
 
 
-def aticq(ri, di, astrom):
+def aticq(astrometric, astrom):
     """
     A slightly modified version of the ERFA function ``eraAticq``.
 
     ``eraAticq`` performs the transformations between two coordinate systems,
     with the details of the transformation being encoded into the ``astrom`` array.
+
+    There are two issues with the version of aticq in ERFA. Both are associated
+    with the handling of light deflection.
 
     The companion function ``eraAtciqz`` is meant to be its inverse. However, this
     is not true for directions close to the Solar centre, since the light deflection
@@ -179,22 +183,39 @@ def aticq(ri, di, astrom):
     same approach used by the ERFA functions above, except that they use a threshold of
     9 arcseconds.
 
+    In addition, ERFA's aticq assumes a distant source, so there is no difference between
+    the object-Sun vector and the observer-Sun vector. This can lead to errors of up to a
+    few arcseconds in the worst case (e.g a Venus transit).
+
     Parameters
     ----------
-    ri : float or `~numpy.ndarray`
-        right ascension, radians
-    di : float or `~numpy.ndarray`
-        declination, radians
+    astrometric : `~astropy.coordinates.CartesianRepresentation`
+        Astrometric GCRS or CIRS position of object from observer
     astrom : eraASTROM array
         ERFA astrometry context, as produced by, e.g. ``eraApci13`` or ``eraApcs13``
 
     Returns
     --------
     rc : float or `~numpy.ndarray`
+        Right Ascension in radians
     dc : float or `~numpy.ndarray`
+        Declination in radians
     """
+    # first of all get distance from object to observer
+    object_observer_distance = astrometric.norm()
+    # ignore parallax effects if no distance, or far away
+    ignore_distance = object_observer_distance.unit == u.one
+
     # RA, Dec to cartesian unit vectors
-    pos = erfa.s2c(ri, di)
+    if not ignore_distance and u.allclose(astrometric.xyz, 0*u.km):
+        # special casing for positions at origin of frame
+        # replicating the behaviour of erfa.s2c with 0, 0 input
+        # which for reasons unknown gives the vector (1, 0, 0)
+        xhat = astrometric.unit_vectors()['x']
+        tmp = astrometric + 1*astrometric.x.unit*xhat
+        pos = (tmp/tmp.norm()).get_xyz(xyz_axis=-1).value
+    else:
+        pos = (astrometric / object_observer_distance).get_xyz(xyz_axis=-1).value
 
     # Bias-precession-nutation, giving GCRS proper direction.
     ppr = erfa.trxp(astrom['bpn'], pos)
@@ -211,7 +232,26 @@ def aticq(ri, di, astrom):
     d = np.zeros_like(pnat)
     for j in range(5):
         before = norm(pnat-d)
-        after = erfa.ld(1.0, before, before, astrom['eh'], astrom['em'], 5e-8)
+        if ignore_distance:
+            # No distance to object, assume a long way away
+            q = before
+        else:
+            # Find BCRS direction of Sun to object.
+            # astrom['eh'] and astrom['em'] contain Sun to observer unit vector,
+            # and distance, respectively.
+            eh = astrom['em'] * CartesianRepresentation(astrom['eh'], unit=u.au, xyz_axis=-1, copy=False)
+            # unit vector from Sun to object
+            q = eh + object_observer_distance*CartesianRepresentation(before, unit=u.one, xyz_axis=-1, copy=False)
+            sundist = q.norm()
+            q /= sundist
+            # calculation above is extremely unstable very close to the sun
+            # in these situations, default back to ldsun-style behaviour,
+            # since this is reversible and drops to zero within stellar limb
+            close_to_sun = (sundist > 10*u.m)[..., np.newaxis]
+            q = np.where(close_to_sun,
+                         q.get_xyz(xyz_axis=-1).value, before)
+
+        after = erfa.ld(1.0, before, q, astrom['eh'], astrom['em'], 1e-6)
         d = after - before
     pco = norm(pnat-d)
 
@@ -220,12 +260,15 @@ def aticq(ri, di, astrom):
     return erfa.anp(rc), dc
 
 
-def atciqz(rc, dc, astrom):
+def atciqz(astrometric, astrom):
     """
     A slightly modified version of the ERFA function ``eraAtciqz``.
 
     ``eraAtciqz`` performs the transformations between two coordinate systems,
     with the details of the transformation being encoded into the ``astrom`` array.
+
+    There are two issues with the version of atciqz in ERFA. Both are associated
+    with the handling of light deflection.
 
     The companion function ``eraAticq`` is meant to be its inverse. However, this
     is not true for directions close to the Solar centre, since the light deflection
@@ -236,25 +279,61 @@ def atciqz(rc, dc, astrom):
     same approach used by the ERFA functions above, except that they use a threshold of
     9 arcseconds.
 
+    In addition, ERFA's atciqz assumes a distant source, so there is no difference between
+    the object-Sun vector and the observer-Sun vector. This can lead to errors of up to a
+    few arcseconds in the worst case (e.g a Venus transit).
+
     Parameters
     ----------
-    rc : float or `~numpy.ndarray`
-        right ascension, radians
-    dc : float or `~numpy.ndarray`
-        declination, radians
+    astrometric : `~astropy.coordinates.CartesianRepresentation`
+        Astrometric ICRS position of object from observer
     astrom : eraASTROM array
         ERFA astrometry context, as produced by, e.g. ``eraApci13`` or ``eraApcs13``
 
     Returns
     --------
     ri : float or `~numpy.ndarray`
+        Right Ascension in radians
     di : float or `~numpy.ndarray`
+        Declination in radians
     """
+    # first of all get distance from object to observer
+    object_observer_distance = astrometric.norm()
+    # ignore parallax effects if no distance, or far away
+    ignore_distance = object_observer_distance.unit == u.one
+
     # BCRS coordinate direction (unit vector).
-    pco = erfa.s2c(rc, dc)
+    if not ignore_distance and u.allclose(astrometric.xyz, 0*u.km):
+        # special casing for positions at origin of frame
+        # replicating the behaviour of erfa.s2c with 0, 0 input
+        # which for reasons unknown gives the vector (1, 0, 0)
+        xhat = astrometric.unit_vectors()['x']
+        tmp = astrometric + 1*astrometric.x.unit*xhat
+        pco = (tmp/tmp.norm()).get_xyz(xyz_axis=-1).value
+    else:
+        pco = (astrometric / object_observer_distance).get_xyz(xyz_axis=-1).value
+
+    # Find BCRS direction of Sun to object
+    if ignore_distance:
+        # No distance to object, assume a long way away
+        q = pco
+    else:
+        # astrom['eh'] and astrom['em'] contain Sun to observer unit vector,
+        # and distance, respectively.
+        eh = astrom['em'] * CartesianRepresentation(astrom['eh'], unit=u.au, xyz_axis=-1, copy=False)
+        # apply parallax to find unit vector from Sun to object
+        q = eh + astrometric
+        sundist = q.norm()
+        q /= sundist
+        # calculation above is extremely unstable very close to the sun
+        # in these situations, default back to ldsun-style behaviour,
+        # since this is reversible and drops to zero within stellar limb
+        close_to_sun = (sundist > 10*u.m)[..., np.newaxis]
+        q = np.where(close_to_sun,
+                     q.get_xyz(xyz_axis=-1).value, pco)
 
     # Light deflection by the Sun, giving BCRS natural direction.
-    pnat = erfa.ld(1.0, pco, pco, astrom['eh'], astrom['em'], 5e-8)
+    pnat = erfa.ld(1.0, pco, q, astrom['eh'], astrom['em'], 1e-6)
 
     # Aberration, giving GCRS proper direction.
     ppr = erfa.ab(pnat, astrom['v'], astrom['em'], astrom['bm1'])

--- a/astropy/coordinates/tests/test_atc_replacements.py
+++ b/astropy/coordinates/tests/test_atc_replacements.py
@@ -12,7 +12,7 @@ from astropy.tests.helper import assert_quantity_allclose as assert_allclose
 from astropy.time import Time
 from .utils import randomly_sample_sphere
 from astropy.coordinates.builtin_frames.utils import get_jd12, atciqz, aticq
-from astropy.coordinates import UnitSphericalRepresentation
+from astropy.coordinates import SphericalRepresentation
 
 times = [Time("2014-06-25T00:00"), Time(["2014-06-25T00:00", "2014-09-24"])]
 ra, dec, _ = randomly_sample_sphere(2)
@@ -28,8 +28,8 @@ def test_atciqz_aticq(st):
     astrom, _ = erfa.apci13(jd1, jd2)
 
     ra, dec = pos
-    cartesian = UnitSphericalRepresentation(ra, dec).to_cartesian()
+    srepr = SphericalRepresentation(ra, dec, 1)
     ra = ra.value
     dec = dec.value
-    assert_allclose(erfa.atciqz(ra, dec, astrom), atciqz(cartesian, astrom))
-    assert_allclose(erfa.aticq(ra, dec, astrom), aticq(cartesian, astrom))
+    assert_allclose(erfa.atciqz(ra, dec, astrom), atciqz(srepr, astrom))
+    assert_allclose(erfa.aticq(ra, dec, astrom), aticq(srepr, astrom))

--- a/astropy/coordinates/tests/test_atc_replacements.py
+++ b/astropy/coordinates/tests/test_atc_replacements.py
@@ -12,6 +12,7 @@ from astropy.tests.helper import assert_quantity_allclose as assert_allclose
 from astropy.time import Time
 from .utils import randomly_sample_sphere
 from astropy.coordinates.builtin_frames.utils import get_jd12, atciqz, aticq
+from astropy.coordinates import UnitSphericalRepresentation
 
 times = [Time("2014-06-25T00:00"), Time(["2014-06-25T00:00", "2014-09-24"])]
 ra, dec, _ = randomly_sample_sphere(2)
@@ -27,7 +28,8 @@ def test_atciqz_aticq(st):
     astrom, _ = erfa.apci13(jd1, jd2)
 
     ra, dec = pos
+    cartesian = UnitSphericalRepresentation(ra, dec).to_cartesian()
     ra = ra.value
     dec = dec.value
-    assert_allclose(erfa.atciqz(ra, dec, astrom), atciqz(ra, dec, astrom))
-    assert_allclose(erfa.aticq(ra, dec, astrom), aticq(ra, dec, astrom))
+    assert_allclose(erfa.atciqz(ra, dec, astrom), atciqz(cartesian, astrom))
+    assert_allclose(erfa.aticq(ra, dec, astrom), aticq(cartesian, astrom))

--- a/astropy/coordinates/tests/test_regression.py
+++ b/astropy/coordinates/tests/test_regression.py
@@ -19,7 +19,7 @@ from astropy.coordinates import (
     get_moon, FK4, FK4NoETerms, BaseCoordinateFrame, ITRS,
     QuantityAttribute, UnitSphericalRepresentation,
     SphericalRepresentation, CartesianRepresentation,
-    FunctionTransform,
+    FunctionTransform, get_body,
     CylindricalRepresentation, CylindricalDifferential,
     CartesianDifferential)
 from astropy.coordinates.sites import get_builtin_sites
@@ -656,3 +656,20 @@ def test_regression_10422(mjd):
         loc = EarthLocation(88258.0 * u.m, -4924882.2 * u.m, 3943729.0 * u.m)
         p, v = loc.get_gcrs_posvel(obstime=t)
         assert p.shape == v.shape == t.shape
+
+
+@pytest.mark.remote_data
+def test_regression_10291():
+    """
+    According to https://eclipse.gsfc.nasa.gov/OH/transit12.html,
+    the minimum separation between Venus and the Sun during the 2012
+    transit is 554 arcseconds for an observer at the Geocenter.
+
+    If light deflection from the Sun is incorrectly applied, this increases
+    to 557 arcseconds.
+    """
+    t = Time('2012-06-06 01:29:36')
+    sun = get_body('sun', t)
+    venus = get_body('venus', t)
+    assert_quantity_allclose(venus.separation(sun),
+                             554.427*u.arcsecond, atol=0.001*u.arcsecond)


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request addresses an issue where the Solar light deflection was always being applied assuming the source was an infinite distance away, so that the observer -> source vector equalled the Sun -> source vector. In the absolute worst case, this causes errors of up to 3 arc seconds. See #10291 for full details.

Implementation was more awkward than I expected, since we need special case treatments for objects which appear to actually be the Sun itself, and objects at the origin of their frames. I've also special cased the example where there is no distance, to reduce performance impact.

Despite the added complexity in ```astropy.coordinates.builtin_frames.utils.atciqz``` and ```astropy.coordinates.builtin_frames.utils.aticq``` there is no major performance impact. Obtaining the GCRS position of the Moon at 400 times and transforming to ICRS and thence to CIRS took no detectable extra time compared to astropy master - as determined using the test code below.

```python
from time import perf_counter
import numpy as np
from astropy.time import Time
import astropy.units as u
from astropy.coordinates import EarthLocation, CIRS, ICRS, get_body

times = Time('2020-08-21T00:00') + np.linspace(-3*u.hour, 3*u.hour, 400)
location = EarthLocation.of_site('lapalma')
t0 = perf_counter()
moon = get_body('moon', times, location=location)
moon_icrs = moon.transform_to(ICRS)
moon_cirs = moon.transform_to(CIRS(obstime=moon.obstime))
print(f'Transforms took {perf_counter() - t0:.2f} s')
```

Despite these changes, I have not been able to reproduce without any discrepancies the Moon positions supplied by @mkbrewer in #10291. The discrepancies are however reduced:

![master_comparison](https://user-images.githubusercontent.com/4570807/90519104-8358d080-e15f-11ea-854d-1924b44d13e7.png)
![current_comparison](https://user-images.githubusercontent.com/4570807/90519106-8489fd80-e15f-11ea-9332-169d9a2529d2.png)

I've attached the output of @mkbrewer s test script and the script itself:

[moon_topo_astropy_thispr.txt](https://github.com/astropy/astropy/files/5090651/moon_topo_astropy_thispr.txt)
[skyfield_topo_test.py.txt](https://github.com/astropy/astropy/files/5090671/skyfield_topo_test.py.txt)

If @mkbrewer has any input as to the remaining discrepancies I'd be extremely grateful to receive it!

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #10291
