### PR TITLE
TST: Show all warnings when assert fails

### DIFF
--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -1054,7 +1054,8 @@ def test_data_noastropy_fallback(monkeypatch):
 
     with pytest.warns(CacheMissingWarning) as warning_lines:
         fnout = download_file(TESTURL, cache=True)
-    assert len(warning_lines) == 2
+    assert len(warning_lines) == 2, os.linesep.join(
+        [str(w.message) for w in warning_lines])
     assert 'Remote data cache could not be accessed' in str(warning_lines[0].message)
     assert 'temporary' in str(warning_lines[1].message)
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to address a failure that sometimes is seen in cron job but I cannot reproduce locally. This would show all the warnings in the traceback and give us a clue. This is a direct follow-up of #10437. cc @aarchiba 

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Example log: https://travis-ci.org/github/astropy/astropy/jobs/719866551

```
_________________________ test_data_noastropy_fallback _________________________
monkeypatch = <_pytest.monkeypatch.MonkeyPatch object at 0x7f7ef61fd5f8>
    @pytest.mark.remote_data(source="astropy")
    def test_data_noastropy_fallback(monkeypatch):
        """
        Tests to make sure the default behavior when the cache directory can't
        be located is correct
        """
    
        # better yet, set the configuration to make sure the temp files are deleted
        conf.delete_temporary_downloads_at_exit = True
    
        # make sure the config and cache directories are not searched
        monkeypatch.setenv("XDG_CONFIG_HOME", "foo")
        monkeypatch.delenv("XDG_CONFIG_HOME")
        monkeypatch.setenv("XDG_CACHE_HOME", "bar")
        monkeypatch.delenv("XDG_CACHE_HOME")
    
        monkeypatch.setattr(paths.set_temp_config, "_temp_path", None)
        monkeypatch.setattr(paths.set_temp_cache, "_temp_path", None)
    
        # make sure the _find_or_create_astropy_dir function fails as though the
        # astropy dir could not be accessed
        def osraiser(dirnm, linkto, pkgname=None):
            raise OSError()
        monkeypatch.setattr(paths, '_find_or_create_root_dir', osraiser)
    
        with pytest.raises(OSError):
            # make sure the config dir search fails
            paths.get_cache_dir(rootname='astropy')
    
        with pytest.warns(CacheMissingWarning) as warning_lines:
            fnout = download_file(TESTURL, cache=True)
>       assert len(warning_lines) == 2
E       assert 4 == 2
E        +  where 4 = len(WarningsChecker(record=True))
../../.tox/py37-test-devdeps/lib/python3.7/site-packages/astropy/utils/tests/test_data.py:1057: AssertionError
```