### PR TITLE
Allow adding None object column to table

### DIFF
--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -1055,12 +1055,22 @@ class Table:
             # could be MaskedColumn).
             col_cls = masked_col_cls
 
+        elif data is None:
+            # Special case for data passed as the None object (for broadcasting
+            # to an object column). Need to turn data into numpy `None` scalar
+            # object, otherwise `Column` interprets data=None as no data instead
+            # of a object column of `None`.
+            data = np.array(None)
+            col_cls = self.ColumnClass
+
         elif not hasattr(data, 'dtype'):
             # `data` is none of the above, convert to numpy array or MaskedArray
             # assuming only that it is a scalar or sequence or N-d nested
             # sequence. This function is relatively intricate and tries to
             # maintain performance for common cases while handling things like
-            # list input with embedded np.ma.masked entries.
+            # list input with embedded np.ma.masked entries. If `data` is a
+            # scalar then it gets returned unchanged so the original object gets
+            # passed to `Column` later.
             data = _convert_sequence_data_to_array(data, dtype)
             copy = False  # Already made a copy above
             col_cls = masked_col_cls if isinstance(data, np.ma.MaskedArray) else self.ColumnClass

--- a/astropy/table/tests/test_init_table.py
+++ b/astropy/table/tests/test_init_table.py
@@ -526,6 +526,16 @@ def test_init_and_ref_from_dict(table_type, copy):
         assert x2[1] == -100
 
 
+def test_add_none_object_column():
+    """Test fix for a problem introduced in #10636 (see
+    https://github.com/astropy/astropy/pull/10636#issuecomment-676847515)
+    """
+    t = Table(data={'a': [1, 2, 3]})
+    t['b'] = None
+    assert all(val is None for val in t['b'])
+    assert t['b'].dtype.kind == 'O'
+
+
 @pytest.mark.usefixtures('table_type')
 def test_init_from_row_OrderedDict(table_type):
     row1 = OrderedDict([('b', 1), ('a', 0)])

--- a/docs/table/modify_table.rst
+++ b/docs/table/modify_table.rst
@@ -83,18 +83,15 @@ of the correct size, or a scalar value that will be broadcast::
 
 For more explicit control, the :meth:`~astropy.table.Table.add_column` and
 :meth:`~astropy.table.Table.add_columns` methods can be used to add one or
-multiple columns to a table. In both cases the new columns must be specified as
-|Column| or |MaskedColumn| objects::
+multiple columns to a table. In both cases the new column(s) can be specified as
+a list, an array (including |Column| or |MaskedColumn|), or a scalar::
 
   >>> from astropy.table import Column
-  >>> aa = Column(np.arange(5), name='aa')
-  >>> t.add_column(aa, index=0)  # Insert before the first table column
-  >>> bb = Column(np.arange(5))
-  >>> t.add_column(bb, name='bb')  # Append unnamed column to the table with 'bb' as name
-
-  # Make a new table with the same number of rows and add columns to original table
-  >>> t2 = Table(np.arange(25).reshape(5, 5), names=('e', 'f', 'g', 'h', 'i'))
-  >>> t.add_columns(list(t2.itercols()))
+  >>> t.add_column(np.arange(5), name='aa', index=0)  # Insert before first table column
+  >>> t.add_column(1.0, name='bb')  # Add column of all 1.0 to end of table
+  >>> c = Column(np.arange(5), name='e')
+  >>> t.add_column(c, index=0)  # Add Column using the existing column name 'e'
+  >>> t.add_columns([[1, 2, 3, 4, 5], ['v', 'w', 'x', 'y', 'z']], names=['h', 'i'])
 
 Finally, columns can also be added from :class:`~astropy.units.Quantity`
 objects, which automatically sets the ``.unit`` attribute on the column:
@@ -117,9 +114,9 @@ objects, which automatically sets the ``.unit`` attribute on the column:
 
 To remove a column from a table::
 
-  >>> t.remove_column('f')
-  >>> t.remove_columns(['aa', 'd1', 'd2', 'd3', 'e'])
-  >>> del t['g']
+  >>> t.remove_column('d1')
+  >>> t.remove_columns(['aa', 'd2', 'e'])
+  >>> del t['d3']
   >>> del t['h', 'i']
   >>> t.keep_columns(['a', 'b'])
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to fix the regression / problem introduced by #10636, reported here: https://github.com/astropy/astropy/pull/10636#issuecomment-676847515

This fails:
```
>>> t = Table(data={'a': [1,2,3]})
>>> t['b'] = None  # this fails
```

The root issue here is that `Column` treats `data=None` as meaning there are no data (which gets used for making "empty" columns of a certain length), not that this should be a scalar dtype=object column of a `None` object. This PR fixes `_convert_data_to_col` so that `data=None` at that point gets turned into a numpy scalar object array and then everything works like any other object array.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->
