### PR TITLE
Write keys to ASDF only if the value is present

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -50,6 +50,9 @@ astropy.io.fits
 astropy.io.misc
 ^^^^^^^^^^^^^^^
 
+- Write keys to ASDF only if the value is present, to account
+  for a change in behavior in asdf 2.8. [#10674]
+
 astropy.io.votable
 ^^^^^^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -50,9 +50,6 @@ astropy.io.fits
 astropy.io.misc
 ^^^^^^^^^^^^^^^
 
-- Write keys to ASDF only if the value is present, to account
-  for a change in behavior in asdf 2.8. [#10674]
-
 astropy.io.votable
 ^^^^^^^^^^^^^^^^^^
 
@@ -1044,6 +1041,9 @@ astropy.io.misc
 ^^^^^^^^^^^^^^^
 
 - Fix id URL in ``baseframe-1.0.0`` ASDF schema. [#10223]
+
+- Write keys to ASDF only if the value is present, to account
+  for a change in behavior in asdf 2.8. [#10674]
 
 astropy.io.registry
 ^^^^^^^^^^^^^^^^^^^

--- a/astropy/io/misc/asdf/tags/coordinates/spectralcoord.py
+++ b/astropy/io/misc/asdf/tags/coordinates/spectralcoord.py
@@ -25,8 +25,10 @@ class SpectralCoordType(AstropyType):
         if isinstance(spec_coord, SpectralCoord):
             node['value'] = spec_coord.value
             node['unit'] = spec_coord.unit
-            node['observer'] = spec_coord.observer
-            node['target'] = spec_coord.target
+            if spec_coord.observer is not None:
+                node['observer'] = spec_coord.observer
+            if spec_coord.target is not None:
+                node['target'] = spec_coord.target
             return node
         raise TypeError(f"'{spec_coord}' is not a valid SpectralCoord")
 

--- a/astropy/io/misc/asdf/tags/transform/tabular.py
+++ b/astropy/io/misc/asdf/tags/transform/tabular.py
@@ -47,12 +47,12 @@ class TabularType(TransformType):
     @classmethod
     def to_tree_transform(cls, model, ctx):
         node = {}
-        node["fill_value"] = model.fill_value
+        if model.fill_value is not None:
+            node["fill_value"] = model.fill_value
         node["lookup_table"] = model.lookup_table
         node["points"] = [p for p in model.points]
         node["method"] = str(model.method)
         node["bounds_error"] = model.bounds_error
-        node["name"] = model.name
         return node
 
     @classmethod


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This PR changes ASDF serialization support to write keys only if the corresponding value is present.  This anticipates a change in behavior of asdf library 2.8, which will stop automatically removing keys with `None` values.  See https://github.com/asdf-format/asdf/pull/863 for more information.

I ran the astropy tests with the asdf branch that implements the change and these were the two `ExtensionType` subclasses that broke.  The updated subclasses are compatible with prior releases of asdf.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->