### PR TITLE
DOC: Remove broken UCO/Lick link

### DIFF
--- a/docs/time/index.rst
+++ b/docs/time/index.rst
@@ -364,7 +364,6 @@ local  Local Time Scale          (LOCAL)
 .. [#] Wikipedia `time standard <https://en.wikipedia.org/wiki/Time_standard>`_ article
 .. [#] SOFA_ Time Scale and Calendar Tools
        `(PDF) <http://www.iausofa.org/sofa_ts_c.pdf>`_
-.. [#] `<https://www.ucolick.org/~sla/leapsecs/timescales.html>`_
 
 .. note:: The ``local`` time scale is meant for free-running clocks or
    simulation times (i.e., to represent a time without a properly defined

--- a/docs/time/index.rst
+++ b/docs/time/index.rst
@@ -342,7 +342,7 @@ Time Scale
 The time scale (or `time standard
 <https://en.wikipedia.org/wiki/Time_standard>`_) is "a specification for
 measuring time: either the rate at which time passes; or points in time; or
-both" [#]_. See also [#]_ and [#]_.
+both" [#]_, [#]_.
 ::
 
   >>> Time.SCALES


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description

Cron job linkcheck reports that https://www.ucolick.org/~sla/leapsecs/timescales.html is broken. I confirmed that the site is unreachable. Can't tell if this is temporary or permanent. If the latter, we should remove it or find a replacement.
