### PR TITLE
TST: Handle non-deterministic utils test failure

### DIFF
--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -1054,10 +1054,11 @@ def test_data_noastropy_fallback(monkeypatch):
 
     with pytest.warns(CacheMissingWarning) as warning_lines:
         fnout = download_file(TESTURL, cache=True)
-    assert len(warning_lines) == 2, os.linesep.join(
+    # Sometimes 2 extra "unclosed socket" pop up in CI
+    assert len(warning_lines) in (2, 4), os.linesep.join(
         [str(w.message) for w in warning_lines])
     assert 'Remote data cache could not be accessed' in str(warning_lines[0].message)
-    assert 'temporary' in str(warning_lines[1].message)
+    assert 'temporary' in str(warning_lines[-1].message)
 
     assert os.path.isfile(fnout)
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to address this non-deterministic failure in CI:
```
        with pytest.warns(CacheMissingWarning) as warning_lines:
            fnout = download_file(TESTURL, cache=True)
>       assert len(warning_lines) == 2, os.linesep.join(
            [str(w.message) for w in warning_lines])
E       AssertionError: Remote data cache could not be accessed due to OSError
E         unclosed <socket.socket [closed] fd=13, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6>
E         unclosed <socket.socket [closed] fd=14, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6>
E         ('Cache directory cannot be read or created (), providing data in temporary file instead.', '/tmp/astropy-download-5853-saggci1x')
E       assert 4 == 2
E        +  where 4 = len(WarningsChecker(record=True))
../../.tox/py37-test-alldeps-numpy117-cov/lib/python3.7/site-packages/astropy/utils/tests/test_data.py:1058: AssertionError
```

Most of the time, it only has 2 warnings but sometimes it has extra 2 (unclosed socket). 🤷 

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Follow up of #10437 and #10671

cc @aarchiba 