### PR TITLE
Ignore cache warnings to catch non-deterministic socket warnings

### DIFF
--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -1023,6 +1023,7 @@ def test_get_pkg_data_contents():
     assert contents1 == contents2
 
 
+# FIXME: Undo PR 10686 after socket warnings mystery is solved.
 @pytest.mark.remote_data(source="astropy")
 @pytest.mark.filterwarnings("ignore:Remote data cache could not be accessed")
 @pytest.mark.filterwarnings(r"ignore:.*Cache directory cannot be read or created .*")

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -1024,6 +1024,8 @@ def test_get_pkg_data_contents():
 
 
 @pytest.mark.remote_data(source="astropy")
+@pytest.mark.filterwarnings("ignore:Remote data cache could not be accessed")
+@pytest.mark.filterwarnings(r"ignore:.*Cache directory cannot be read or created .*")
 def test_data_noastropy_fallback(monkeypatch):
     """
     Tests to make sure the default behavior when the cache directory can't
@@ -1052,13 +1054,7 @@ def test_data_noastropy_fallback(monkeypatch):
         # make sure the config dir search fails
         paths.get_cache_dir(rootname='astropy')
 
-    with pytest.warns(CacheMissingWarning) as warning_lines:
-        fnout = download_file(TESTURL, cache=True)
-    assert len(warning_lines) == 2, os.linesep.join(
-        [str(w.message) for w in warning_lines])
-    assert 'Remote data cache could not be accessed' in str(warning_lines[0].message)
-    assert 'temporary' in str(warning_lines[1].message)
-
+    fnout = download_file(TESTURL, cache=True)
     assert os.path.isfile(fnout)
 
     # clearing the cache should be a no-up that doesn't affect fnout


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to address investigate https://github.com/astropy/astropy/pull/10685#issuecomment-682463852 . I need to know more about the socket warnings before deciding on the best course of action. We use pytest, so we cannot simply use `-Werror` (if I am mistaken, please correct me).

Related: #10437 and #10671
