### PR TITLE
Re-include astropy/*/src/*.c in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,10 @@
 __pycache__
 
 # Ignore .c files by default to avoid including generated code. If you want to
-# add a non-generated .c extension, use `git add -f filename.c`.
+# add a non-generated .c extension, put that into the src/ subdirectory of a
+# package or else use `git add -f filename.c`.
 *.c
+! astropy/*/src/*.c
 
 # Other generated files
 MANIFEST

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ __pycache__
 # add a non-generated .c extension, put that into the src/ subdirectory of a
 # package or else use `git add -f filename.c`.
 *.c
-! astropy/*/src/*.c
+!astropy/*/src/*.c
 
 # Other generated files
 MANIFEST


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

The blanket exclusion of `*.c` in `.gitignore` is inconvenient when working with C code. This prevents my editor from quickly finding the file or including it in search, etc.  I think that `astropy/*/src/*.c` is fine, but maybe we could just allow everything in `astropy/*/src/*`?
```
✗ ls astropy/*/src/   
astropy/convolution/src/:
convolve.c  convolve.h

astropy/modeling/src/:
projections.c        projections.c.templ  wcsconfig.h

astropy/utils/src/:
compiler.c

astropy/wcs/src/:
astropy_wcs.c         pyutil.c              wcslib_auxprm_wrap.c
astropy_wcs_api.c     sip.c                 wcslib_tabprm_wrap.c*
distortion.c          sip_wrap.c            wcslib_wrap.c*
distortion_wrap.c     str_list_proxy.c      wcslib_wtbarr_wrap.c
docstrings.c          unit_list_proxy.c
pipeline.c            util.c
```
