### PR TITLE
Notify slack on cron success

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ cache:
 
 notifications:
   slack:
-    on_success: never
+    on_success: always
     on_failure: always
     secure: gLrQgrHNqHs0lOPsfvjlh0v8k56mJifPNpht0BX55YV0n1u5alKCrKOVcKTFNFY0gOldhwFNFq4oy3o5EaZkDx+CO71qiwwJr7ex7zT70EjHzWxEG8l2Bww9J3xVzhGgQw6tMq57HHiuOoJ07TJPvVxL+E/WZmkxRAdlzUhcab4=
     if: type = cron


### PR DESCRIPTION
Currently we only see when the cron doesn't work on slack. I think it would be good to also know when it does work as some green would be nice from time to time! 😆 