### PR TITLE
Do not create models for ufuncs that are only aliases

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1037,6 +1037,9 @@ astropy.modeling
 
 - Fixed reported module name of ``tabular`` model classes. [#10709]
 
+- Do not create new ``math_functions`` models for ufuncs that are
+  only aliases (divide and mod). [#10697]
+
 astropy.nddata
 ^^^^^^^^^^^^^^
 

--- a/astropy/modeling/math_functions.py
+++ b/astropy/modeling/math_functions.py
@@ -14,14 +14,23 @@ trig_ufuncs = ["sin", "cos", "tan", "arcsin", "arccos", "arctan", "arctan2",
                "arctanh", "deg2rad", "rad2deg"]
 
 
-math_ops = ["add", "subtract", "multiply", "divide", "logaddexp", "logaddexp2",
+math_ops = ["add", "subtract", "multiply", "logaddexp", "logaddexp2",
             "true_divide", "floor_divide", "negative", "positive", "power",
-            "remainder", "mod", "fmod", "divmod", "absolute", "fabs", "rint",
+            "remainder", "fmod", "divmod", "absolute", "fabs", "rint",
             "exp", "exp2", "log", "log2", "log10", "expm1", "log1p", "sqrt",
-            "square", "cbrt", "reciprocal"]
+            "square", "cbrt", "reciprocal", "divide", "mod"]
 
 
 supported_ufuncs = trig_ufuncs + math_ops
+
+
+# These names are just aliases for other ufunc objects
+# in the numpy API.  The alias name must occur later
+# in the lists above.
+alias_ufuncs = {
+    "divide": "true_divide",
+    "mod": "remainder",
+}
 
 
 class _NPUfuncModel(Model):
@@ -68,7 +77,13 @@ def ufunc_model(name):
 __all__ = []
 
 for name in supported_ufuncs:
-    m = ufunc_model(name)
-    klass_name = m.__name__
-    globals()[klass_name] = m
-    __all__.append(klass_name)
+    if name in alias_ufuncs:
+        klass_name = _make_class_name(name)
+        alias_klass_name = _make_class_name(alias_ufuncs[name])
+        globals()[klass_name] = globals()[alias_klass_name]
+        __all__.append(klass_name)
+    else:
+        m = ufunc_model(name)
+        klass_name = m.__name__
+        globals()[klass_name] = m
+        __all__.append(klass_name)

--- a/astropy/modeling/tests/test_math_func.py
+++ b/astropy/modeling/tests/test_math_func.py
@@ -22,3 +22,6 @@ def test_math():
             assert_allclose(model(x), func(x))
         elif model.n_inputs == 2:
             assert_allclose(model(x, x), func(x, x))
+
+    assert math_functions.ModUfunc is math_functions.RemainderUfunc
+    assert math_functions.DivideUfunc is math_functions.True_divideUfunc


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

`numpy.mod` and `numpy.divide` are alternate names for `numpy.remainder` and `numpy.true_divide`, respectively, but their corresponding model classes are distinct (`assert numpy.mod is numpy.remainder` succeeds, but `assert math_functions.ModUfunc is math_functions.RemainderUfunc` fails).  I think these should be the same class so that we can build a model using either name and end up with the same result.  If nothing else, the change will make model serialization to ASDF more consistent.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->
