### PR TITLE
MNT: Fix Windows and doc build issues due to setuptools 50

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,6 +12,7 @@ sphinx:
 # Then, install special pinning for RTD.
 python:
   version: 3.8
+  system_packages: false
   install:
     - method: pip
       path: .

--- a/astropy/io/fits/setup_package.py
+++ b/astropy/io/fits/setup_package.py
@@ -31,12 +31,12 @@ def _get_compression_extension():
             # which ensures on windows we do not include unistd.h (in regular
             # compilation of cfitsio, an empty file would be generated)
             cfg['extra_compile_args'].extend(
-                ['/D', '"WIN32"',
-                 '/D', '"_WINDOWS"',
-                 '/D', '"_MBCS"',
-                 '/D', '"_USRDLL"',
-                 '/D', '"_CRT_SECURE_NO_DEPRECATE"',
-                 '/D', '"FF_NO_UNISTD_H"'])
+                ['/D', 'WIN32',
+                 '/D', '_WINDOWS',
+                 '/D', '_MBCS',
+                 '/D', '_USRDLL',
+                 '/D', '_CRT_SECURE_NO_DEPRECATE',
+                 '/D', 'FF_NO_UNISTD_H'])
         else:
             cfg['extra_compile_args'].extend([
                 '-Wno-declaration-after-statement'


### PR DESCRIPTION
This PR fixes the Windows build by dropping quotes around MSVC compiler options, which setuptools 50 seems to be mangling somehow,.  It also disables system packages on readthedocs, which should resolve a different setuptools 50 issue in the doc build.  The docs are unfortunately still failing but I believe that is due to yet another problem introduced by readthedocs' own 5.4.1 release that came out yesterday in the middle of our troubleshooting.

Fix #10699 