### PR TITLE
TST: XPASS to not fail IERS test

### DIFF
--- a/astropy/utils/iers/tests/test_iers.py
+++ b/astropy/utils/iers/tests/test_iers.py
@@ -14,7 +14,6 @@ from astropy import units as u
 from astropy.table import QTable
 from astropy.time import Time, TimeDelta
 
-
 TRAVIS = os.environ.get('TRAVIS', False)
 
 FILE_NOT_FOUND_ERROR = getattr(__builtins__, 'FileNotFoundError', OSError)
@@ -346,7 +345,7 @@ def test_IERS_B_parameters_loading_into_IERS_Auto():
 
 
 # Issue with FTP, rework test into previous one when it's fixed
-@pytest.mark.xfail('TRAVIS')
+@pytest.mark.skipif("TRAVIS", reason="Flaky on Travis CI")
 @pytest.mark.remote_data
 def test_iers_a_dl():
     iersa_tab = iers.IERS_A.open(iers.IERS_A_URL, cache=False)


### PR DESCRIPTION
Sometimes the remote data job fails with only this message:

```
________________________________ test_iers_a_dl ________________________________
[XPASS(strict)] condition: TRAVIS
```

It is annoying because it should have given a green status.

Not sure on the milestone... If you think it needs backporting, please re-milestone.