### PR TITLE
MNT: Change config home path logic

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -119,6 +119,9 @@ astropy.config
   it and relying on reloading it from the previous config file. This ensures
   that any programmatically made changes are preserved as well. [#10474]
 
+- Configuration path detection for Windows will now only look for ``HOMESHARE``
+  if all other options are exhausted. [#10705]
+
 astropy.constants
 ^^^^^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -119,8 +119,9 @@ astropy.config
   it and relying on reloading it from the previous config file. This ensures
   that any programmatically made changes are preserved as well. [#10474]
 
-- Configuration path detection for Windows will now only look for ``HOMESHARE``
-  if all other options are exhausted. [#10705]
+- Configuration path detection logic has changed: Now, it looks for ``~`` first
+  before falling back to older logic. In addition, ``HOMESHARE`` is no longer
+  used in Windows. [#10705]
 
 astropy.constants
 ^^^^^^^^^^^^^^^^^
@@ -1064,7 +1065,7 @@ astropy.stats
 
 - Fixed bug in ``funcs.poisson_conf_interval`` with
   ``interval='kraft-burrows-nousek'`` where certain combinations of source
-  and background count numbers led to ``ValueError`` due to the choice of 
+  and background count numbers led to ``ValueError`` due to the choice of
   starting value for numerical optimization. [#10618]
 
 

--- a/astropy/config/paths.py
+++ b/astropy/config/paths.py
@@ -15,7 +15,7 @@ __all__ = ['get_config_dir', 'get_cache_dir', 'set_temp_config',
 
 
 def _find_home():
-    """ Locates and return the home directory (or best approximation) on this
+    """Locates and return the home directory (or best approximation) on this
     system.
 
     Raises
@@ -25,57 +25,51 @@ def _find_home():
         Astropy on some obscure platform that doesn't have standard home
         directories.
     """
-
-    # First find the home directory - this is inspired by the scheme ipython
-    # uses to identify "home"
-    if os.name == 'posix':
+    try:
+        homedir = os.path.expanduser('~')
+    except Exception:
         # Linux, Unix, AIX, OS X
-        if 'HOME' in os.environ:
-            homedir = os.environ['HOME']
-        else:
-            try:
-                return os.path.expanduser('~')
-            except Exception:
+        if os.name == 'posix':
+            if 'HOME' in os.environ:
+                homedir = os.environ['HOME']
+            else:
                 raise OSError('Could not find unix home directory to search for '
                               'astropy config dir')
-    elif os.name == 'nt':  # This is for all modern Windows (NT or after)
-        if 'MSYSTEM' in os.environ and os.environ.get('HOME'):
-            # Likely using an msys shell; use whatever it is using for its
-            # $HOME directory
-            homedir = os.environ['HOME']
-        # See if there's a local home
-        elif 'HOMEDRIVE' in os.environ and 'HOMEPATH' in os.environ:
-            homedir = os.path.join(os.environ['HOMEDRIVE'],
-                                   os.environ['HOMEPATH'])
-        # Maybe a user profile?
-        elif 'USERPROFILE' in os.environ:
-            homedir = os.path.join(os.environ['USERPROFILE'])
-        else:
-            try:
-                import winreg as wreg
-                shell_folders = r'Software\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders'
-                key = wreg.OpenKey(wreg.HKEY_CURRENT_USER, shell_folders)
+        elif os.name == 'nt':  # This is for all modern Windows (NT or after)
+            if 'MSYSTEM' in os.environ and os.environ.get('HOME'):
+                # Likely using an msys shell; use whatever it is using for its
+                # $HOME directory
+                homedir = os.environ['HOME']
+            # See if there's a local home
+            elif 'HOMEDRIVE' in os.environ and 'HOMEPATH' in os.environ:
+                homedir = os.path.join(os.environ['HOMEDRIVE'],
+                                       os.environ['HOMEPATH'])
+            # Maybe a user profile?
+            elif 'USERPROFILE' in os.environ:
+                homedir = os.path.join(os.environ['USERPROFILE'])
+            else:
+                try:
+                    import winreg as wreg
+                    shell_folders = r'Software\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders'  # noqa: E501
+                    key = wreg.OpenKey(wreg.HKEY_CURRENT_USER, shell_folders)
 
-                homedir = wreg.QueryValueEx(key, 'Personal')[0]
-                key.Close()
-            except Exception:
-                # As a final possible resort, see if HOME is present
-                if 'HOME' in os.environ:
-                    homedir = os.environ['HOME']
-                # Final final resort: Network home
-                elif 'HOMESHARE' in os.environ:
-                    homedir = os.environ['HOMESHARE']
-                else:
-                    raise OSError('Could not find windows home directory to '
-                                  'search for astropy config dir')
-    else:
-        # for other platforms, try HOME, although it probably isn't there
-        if 'HOME' in os.environ:
-            homedir = os.environ['HOME']
+                    homedir = wreg.QueryValueEx(key, 'Personal')[0]
+                    key.Close()
+                except Exception:
+                    # As a final possible resort, see if HOME is present
+                    if 'HOME' in os.environ:
+                        homedir = os.environ['HOME']
+                    else:
+                        raise OSError('Could not find windows home directory to '
+                                      'search for astropy config dir')
         else:
-            raise OSError('Could not find a home directory to search for '
-                          'astropy config dir - are you on an unsupported '
-                          'platform?')
+            # for other platforms, try HOME, although it probably isn't there
+            if 'HOME' in os.environ:
+                homedir = os.environ['HOME']
+            else:
+                raise OSError('Could not find a home directory to search for '
+                              'astropy config dir - are you on an unsupported '
+                              'platform?')
     return homedir
 
 

--- a/astropy/config/paths.py
+++ b/astropy/config/paths.py
@@ -35,7 +35,7 @@ def _find_home():
         else:
             try:
                 return os.path.expanduser('~')
-            except Exception as e:
+            except Exception:
                 raise OSError('Could not find unix home directory to search for '
                               'astropy config dir')
     elif os.name == 'nt':  # This is for all modern Windows (NT or after)
@@ -43,9 +43,6 @@ def _find_home():
             # Likely using an msys shell; use whatever it is using for its
             # $HOME directory
             homedir = os.environ['HOME']
-        # Next try for a network home
-        elif 'HOMESHARE' in os.environ:
-            homedir = os.environ['HOMESHARE']
         # See if there's a local home
         elif 'HOMEDRIVE' in os.environ and 'HOMEPATH' in os.environ:
             homedir = os.path.join(os.environ['HOMEDRIVE'],
@@ -65,6 +62,9 @@ def _find_home():
                 # As a final possible resort, see if HOME is present
                 if 'HOME' in os.environ:
                     homedir = os.environ['HOME']
+                # Final final resort: Network home
+                elif 'HOMESHARE' in os.environ:
+                    homedir = os.environ['HOMESHARE']
                 else:
                     raise OSError('Could not find windows home directory to '
                                   'search for astropy config dir')


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to address the problems Windows users encounter because `config` looks in `HOMESHARE` (either inaccessible or simply missing) too early. Now, it only looks for `HOMESHARE` if all the other options are exhausted.

I thought about removing it altogether but maybe some people do use `HOMESHARE` to store config; who knows. 🤷 

If this is too controversial, we can move the milestone down to 5.0.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #10661 
Fixes #8731