### PR TITLE
Fix logic and improve error message of name_resolve

### DIFF
--- a/astropy/coordinates/name_resolve.py
+++ b/astropy/coordinates/name_resolve.py
@@ -170,8 +170,8 @@ def get_icrs_coordinates(name, parse=False, cache=False):
             # There are some cases where urllib2 does not catch socket.timeout
             # especially while receiving response data on an already previously
             # working request
-            e.reason = "Request took longer than the allowed {:.1f} " \
-                       "seconds".format(data.conf.remote_timeout)
+            e.reason = ("Request took longer than the allowed "
+                        f"{data.conf.remote_timeout:.1f} seconds")
             exceptions.append(e)
             continue
 
@@ -181,16 +181,15 @@ def get_icrs_coordinates(name, parse=False, cache=False):
                     for url, e in zip(urls, exceptions)]
         raise NameResolveError("All Sesame queries failed. Unable to "
                                "retrieve coordinates. See errors per URL "
-                               "below: \n {}".format("\n".join(messages)))
+                               f"below: \n {os.linesep.join(messages)}")
 
     ra, dec = _parse_response(resp_data)
 
-    if ra is None and dec is None:
+    if ra is None or dec is None:
         if db == "A":
-            err = f"Unable to find coordinates for name '{name}'"
+            err = f"Unable to find coordinates for name '{name}' using {url}"
         else:
-            err = "Unable to find coordinates for name '{}' in database {}"\
-                  .format(name, database)
+            err = f"Unable to find coordinates for name '{name}' in database {database} using {url}"
 
         raise NameResolveError(err)
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to address an error in remote data test that I can reproduce locally. It does not seem to be one of those transient internet errors. Either there is a bug in the server or the test setup. Will need some `coordinates` expert to review.

While I am at it, also fixed a logic bug (`and` -> `or`) and upgrade some messages to use f-string.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Example log: https://travis-ci.org/github/astropy/astropy/jobs/723713161

**Todo**

- [x] How to fix the test? (Upstream fixed required.)

**To reproduce this error locally**

```python
>>> from astropy.coordinates import SkyCoord
>>> from astropy.coordinates.name_resolve import sesame_database
>>> with sesame_database.set('vizier'):
...     icrs = SkyCoord.from_name('NGC 3642')
```
```
.../coordinates/sky_coordinate.py in from_name(cls, name, frame, parse, cache)
   1947         from .name_resolve import get_icrs_coordinates
   1948 
-> 1949         icrs_coord = get_icrs_coordinates(name, parse, cache=cache)
   1950         icrs_sky_coord = cls(icrs_coord)
   1951         if frame in ('icrs', icrs_coord.__class__):

.../coordinates/name_resolve.py in get_icrs_coordinates(name, parse, cache)
    192             err = f"Unable to find coordinates for name '{name}' in database {database} using {url}"
    193 
--> 194         raise NameResolveError(err)
    195 
    196     # Return SkyCoord object

NameResolveError: Unable to find coordinates for name 'NGC 3642' in database vizier
using http://cdsweb.u-strasbg.fr/cgi-bin/nph-sesame/V?NGC%203642
```

Indeed, when I enter http://cdsweb.u-strasbg.fr/cgi-bin/nph-sesame/V?NGC%203642 in my browser, this is what I get:

```
# NGC 3642	#Q148742
#! *** NNNothing found ***  (from cache)

#====Done (2020-Sep-03,16:09:44z)====
```

But from the test setup, seems like this is what is expected:

```
# NGC 3642    #Q22523677
#=V=VizieR (local):    1
%J 170.56 +59.08 = 11:22.2     +59:05
%I.0 {NGC} 3642



#====Done (2013-Feb-12,16:37:42z)====
```

What happened to the galaxy, Vizier? https://en.wikipedia.org/wiki/NGC_3642