### PR TITLE
Add wheel and sdist auto-release Azure pipeline

### DIFF
--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -822,7 +822,7 @@ def test_download_parallel_update(temp_cache, tmpdir):
         assert get_file_contents(r_3) == c_plus
 
 
-@pytest.mark.skipif((3, 7) <= sys.version_info < (3, 8),
+@pytest.mark.skipif(sys.version_info < (3, 8),
                     reason="causes mystery segfault! possibly bug #10008")
 def test_update_parallel(temp_cache, valid_urls):
     u, c = next(valid_urls)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,6 +28,8 @@ jobs:
         pypi_connection_name : 'pypi_endpoint'
       targets:
       - sdist
-      - wheels_linux
+      - wheels_*linux_i686
+      - wheels_*linux_x86_64
       - wheels_macos
-      - wheels_windows
+      - wheels_*win32
+      - wheels_*win_amd64

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,8 +28,8 @@ jobs:
         pypi_connection_name : 'pypi_endpoint'
       targets:
       - sdist
-      - wheels_*linux_i686
-      - wheels_*linux_x86_64
-      - wheels_macos
-      - wheels_*win32
-      - wheels_*win_amd64
+      - wheels_cp3[678]*linux_i686
+      - wheels_cp3[678]*linux_x86_64
+      - wheels_cp3[678]*macosx_x86_64
+      - wheels_cp3[678]*win32
+      - wheels_cp3[678]*win_amd64

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,6 @@
-variables:
-  CIBW_BUILD: cp36-* cp37-* cp38-*
+# NOTE: this Azure configuration is used only for building the sdist and wheels.
+# It uses the OpenAstronomy azure template described in detail at
+# https://openastronomy-azure-pipelines.readthedocs.io/en/latest/
 
 resources:
   repositories:
@@ -9,10 +10,14 @@ resources:
     name: OpenAstronomy/azure-pipelines-templates
     ref: master
 
+# NOTE: for now we only use Azure Pipelines on v* branches and tags
+# for building the source and wheel distributions. If you want to
+# make changes to this configuration via a pull request, you can
+# *temporarily* change the branches include trigger to just '*'
 trigger:
   branches:
     include:
-    - '*'
+    - 'v*'
   tags:
     include:
     - 'v*'
@@ -20,12 +25,18 @@ trigger:
 jobs:
   - template: publish.yml@OpenAstronomy
     parameters:
+
       # FIXME: we exclude the test_data_out_of_range test since it
       # currently fails, see https://github.com/astropy/astropy/issues/10409
       test_command: pytest -p no:warnings --astropy-header -k "not test_data_out_of_range" --pyargs astropy
       test_extras: test
+
+      # NOTE: for v* tags, we auto-release to PyPI. See
+      # https://openastronomy-azure-pipelines.readthedocs.io/en/latest/publish.html
+      # for information on how to configure things on the Azure Pipelines side
       ${{ if startsWith(variables['Build.SourceBranch'], 'refs/tags/v') }}:
         pypi_connection_name : 'pypi_endpoint'
+
       targets:
       - sdist
       - wheels_cp3[678]*linux_i686

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,7 +20,7 @@ trigger:
 jobs:
   - template: publish.yml@OpenAstronomy
     parameters:
-      test_command: pytest -p no:warnings --pyargs astropy
+      test_command: pytest -p no:warnings --astropy-header --pyargs astropy
       test_extras: test
       ${{ if startsWith(variables['Build.SourceBranch'], 'refs/tags/v') }}:
         pypi_connection_name : 'pypi_endpoint'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,31 @@
+variables:
+  CIBW_BUILD: cp36-* cp37-* cp38-*
+
+resources:
+  repositories:
+  - repository: OpenAstronomy
+    type: github
+    endpoint: astropy
+    name: OpenAstronomy/azure-pipelines-templates
+    ref: master
+
+trigger:
+  branches:
+    include:
+    - '*'
+  tags:
+    include:
+    - 'v*'
+
+jobs:
+  - template: publish.yml@OpenAstronomy
+    parameters:
+      test_command: pytest -p no:warnings --pyargs astropy
+      test_extras: test
+      ${{ if startsWith(variables['Build.SourceBranch'], 'refs/tags/v') }}:
+        pypi_connection_name : 'pypi_endpoint'
+      targets:
+      - sdist
+      - wheels_linux
+      - wheels_macos
+      - wheels_windows

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,7 +20,9 @@ trigger:
 jobs:
   - template: publish.yml@OpenAstronomy
     parameters:
-      test_command: pytest -p no:warnings --astropy-header --pyargs astropy
+      # FIXME: we exclude the test_data_out_of_range test since it
+      # currently fails, see https://github.com/astropy/astropy/issues/10409
+      test_command: pytest -p no:warnings --astropy-header -k "not test_data_out_of_range" --pyargs astropy
       test_extras: test
       ${{ if startsWith(variables['Build.SourceBranch'], 'refs/tags/v') }}:
         pypi_connection_name : 'pypi_endpoint'

--- a/docs/development/releasing.rst
+++ b/docs/development/releasing.rst
@@ -141,7 +141,7 @@ packages that use the full bugfix/maintenance branch approach.)
   At this point if all goes well, the wheels and sdist will be build
   in the `Azure core package pipeline`_ and uploaded to PyPI!
 
-#. In the unlikely event there are any issues with the wheel building for the tag
+#. In the event there are any issues with the wheel building for the tag
    (which shouldn't really happen if it was passing for the release branch),
    you'll have to fix whatever the problem is. First you will need to back out
    the release procedure by dropping the commits you made for release and

--- a/docs/development/releasing.rst
+++ b/docs/development/releasing.rst
@@ -89,9 +89,11 @@ packages that use the full bugfix/maintenance branch approach.)
       $ git checkout v1.2.x
 
 #. Make sure that the continuous integration services (e.g., Travis or CircleCI) are passing
-   for the `astropy core repository`_ branch you are going to release. You may
-   also want to locally run the tests (with remote data on to ensure all of the
-   tests actually run), using tox to do a thorough test in an isolated environment::
+   for the `astropy core repository`_ branch you are going to release. Also check that
+   the `Azure core package pipeline`_ which builds wheels on the ``v*`` branches is passing. This
+   You may also want to locally run the tests (with remote data on to ensure all
+   of the tests actually run), using tox to do a thorough test in an isolated
+   environment::
 
       $ pip install tox --upgrade
       $ TEST_READ_HUGE_FILE=1 tox -e test-alldeps -- --remote-data=any
@@ -108,47 +110,26 @@ packages that use the full bugfix/maintenance branch approach.)
       $ git add CHANGES.rst
       $ git commit -m "Finalizing changelog for v<version>"
 
+#. Push the branch back to GitHub, e.g.::
+
+      $ git push upstream v1.2.x
+
+   and make sure that the CI services mentioned above (includnig the Azure pipeline)
+   are still passing.
+
+   .. note::
+
+      You may need to replace ``upstream`` here with ``astropy`` or
+      whatever remote name you use for the `astropy core repository`_.
+
 #. Tag the commit with ``v<version>``, being certain to sign the tag with the
    ``-s`` option::
 
       $ git tag -s v<version> -m "Tagging v<version>"
 
-#. Now go back and check out the tag of the released version with
-   ``git checkout v<version>``.  For example::
+#. Push up the tag to the `astropy core repository`_.
 
-      $ git checkout v1.2.2
-
-   Don't forget to remove any non-committed files both from the main working tree with::
-
-      $ git clean -dfx
-
-#. Make sure the source distribution doesn't inherit limited permissions
-   following your default umask::
-
-     $ umask 0022
-     $ chmod -R a+Xr .
-
-#. (Optional) Create the source distribution by doing::
-
-     $ python -m pep517.build --source .
-
-#. (Optional) Run the tests in an environment that mocks up a "typical user" scenario.
-   This is not strictly necessary because you ran the tests above, but
-   it can sometimes be useful to catch subtle bugs that might come from you
-   using a customized developer environment.  For more on setting up virtual
-   environments, see :ref:`virtual_envs`, but for the sake of example we will
-   assume you're using `Anaconda`_. Do::
-
-      $ conda create -n astropy_release_test_v<version> numpy
-      $ conda activate astropy_release_test_v<version>
-      $ pip install dist/astropy-<version>.tar.gz[all]
-      $ python -c 'import astropy; astropy.test(remote_data=True)'
-      $ conda deactivate
-
-#. Push up the tag to the `astropy core repository`_
-   (the tag needs to be available for wheels in the next step)::
-
-      $ git push upstream v<version branch>
+      $ git push upstream v<tag version>
 
    .. note::
 
@@ -157,19 +138,14 @@ packages that use the full bugfix/maintenance branch approach.)
       Also, it might be tempting to use the ``--tags`` argument to ``git push``,
       but this should *not* be done, as it might push up some unintended tags.
 
-#. Build and test the Astropy wheels.  See the `wheel builder README
-   <https://github.com/MacPython/astropy-wheels>`_ for instructions.  In
-   summary, clone the wheel-building repo, edit the ``.travis.yml``
-   text file with the branch or commit for the release,
-   commit and then push back up to github.  This will trigger a wheel build
-   and test on OSX, Linux, and Windows. Check the build has passed on on the
-   Travis-CI interface at https://travis-ci.org/MacPython/astropy-wheels.
-   You'll need commit privileges to the ``astropy-wheels`` repo; ask Tom Kooij
-   or on the mailing list if you do not have them.
+  At this point if all goes well, the wheels and sdist will be build
+  in the `Azure core package pipeline`_ and uploaded to PyPI!
 
-#. If the tests do *not* pass, you'll have to fix whatever the problem is.
-   First you will need to back out the release procedure by dropping the commits
-   you made for release and removing the tag you created::
+#. In the unlikely event there are any issues with the wheel building for the tag
+   (which shouldn't really happen if it was passing for the release branch),
+   you'll have to fix whatever the problem is. First you will need to back out
+   the release procedure by dropping the commits you made for release and
+   removing the tag you created::
 
       $ git reset --hard HEAD^^^^ # you could also use the SHA hash of the commit before your first changelog edit
       $ git tag -d v<version>
@@ -179,35 +155,7 @@ packages that use the full bugfix/maintenance branch approach.)
       Any re-pushing the same tag back out to GitHub hereafter would be
       a force-push.
 
-#. Once the tests are all passing, it's time to actually proceed with the
-   release! This has two steps:
-
-   * build and upload the Astropy wheels;
-   * make and upload the Astropy source release.
-
-#. For the wheel build / upload, follow the `wheel builder README`_
-   instructions again.  Edit the ``.travis.yml`` file
-   to give the release tag to build.  Check the build has passed on on the
-   Travis-CI interface at https://travis-ci.org/MacPython/astropy-wheels.  Now
-   follow the instructions in the page above to download the built wheels to a
-   local machine and upload to PyPI. If you use the ``wheel_download.py`` script,
-   make sure you loop through all the available OS to get all the wheels.
-
-#. Now the wheels are built and uploaded, you can upload the source release.
-   For safety's sake, you may want to clean the repo yet again to make sure
-   you didn't leave anything from the previous step::
-
-      $ git clean -dfx
-
-#. Upload the source distribution to PyPI; this is preceded by re-running
-   the source build command, which makes sure the source code is packaged up and ready
-   to be uploaded. You also need to GPG sign the release, before using twine to
-   upload it to PyPI. (You may need to install `twine`_ if you haven't used it yet)::
-
-      $ python -m pep517.build --source .
-      $ gpg --detach-sign -a dist/astropy-<version>.tar.gz
-      $ twine check dist/*
-      $ twine upload dist/astropy-<version>*
+  Once the sdist and wheels are uploaded, the release is done!
 
 Congratulations!  You have completed the release! Now there are just a few
 clean-up tasks to finalize the process.
@@ -759,3 +707,4 @@ that for you.  You can delete this tag by doing::
 .. _astropy-procedures repository: https://github.com/astropy/astropy-procedures
 .. _Anaconda: https://conda.io/docs/
 .. _twine: https://packaging.python.org/key_projects/#twine
+.. _Azure core package pipeline: https://dev.azure.com/astropy-project/astropy/_build


### PR DESCRIPTION
*Note: this is a variant on https://github.com/astropy/astropy/pull/10405 - the present PR is for stable releases and I've tried to address some common concerns that were raised in #10405*

### Background

The [astropy-wheels](https://github.com/MacPython/astropy-wheels) machinery is currently broken and needs work to update its infrastructure to follow other projects. However no one from astropy has yet had the time to get it working fully (unlike conda-forge, there is no bot to update these things). It looks like other -wheels repos have moved to Azure so if that's the case why not just use Azure here?

In addition, the current wheel building process can be frustrating, because it is in a separate repo so it often takes a while to iterate on fixing issues. Further, the LTS, nightly and main builds are in different branches of the astropy-wheels repo which are a pain to sync. With this PR we have one fewer repo to maintain.

Finally the astropy-wheels approach is specific to the core package and can therefore not be used for coordinated packages (unless we create many -wheels repos).

This PR is a *suggestion* (emphasis) to switch to using the OpenAstronomy Azure template for building and auto-releasing wheels. I don't want to force this on people but I want to highlight how simple the configuration is here.

### Ugh, another CI service to look after?

We are probably going to have to deal with Azure even if we stick with astropy-wheels since other projects are doing that. Also the Azure configuration here is really minimal.

### Isn't this going to mean more things to maintain?

No. The OpenAstronomy template is simpler than the astropy-wheels repo and is being maintained already for other projects. The cibuildwheel tool that the template uses is actively maintained by others outside the project. In addition the wheels will be built in our repo so no dancing around between repos when issues come up.

@Cadair and I have commited to maintain the template and if this PR is merged I commit to maintaining the astropy use of the template.

### Is this actually reliable?

Yes. We already use this appoach for packages such as pyerfa, reproject, and astropy-healpix and it is also used by sunpy, glue, and fast-histogram. There have been zero complaints about the generated wheels. In addition we can test this first for 4.1rc2 to minimize any risks.

### Are there other benefits?

I'm glad you asked! This automatically uploads the wheels, and the source distribution, to PyPI when a ``v*`` tag is pushed. So that's fewer steps in the release process.

### Wait this is going to increase CI time and complexity for PRs... 🙄 

No - I want to make this only run on ``v*`` tags and ``v*`` branches (and optionally other staging branches if we want, for testing). Releases would only be uploaded to PyPI if all wheels build successfully, and only for ``v*`` tags. For now it is enabled for all PRs to allow this PR to be tested

### GitHub Actions FTW!

If someone is willing to write and maintain a GitHub Action that does all this, I'm on board. But that means fragmenting things more since a bunch of projects in the astropy org already use this. This template works right now.

### You are going to update the dev docs if we decide to go with this, right? 📖 

Of course!

### The CI on this PR is failing! Ha, i knew it we shouldn't use this!

If any issues come up they might be real issues with astropy not highlighte by the astropy-wheels process! I'll work on fixing issues that come up :)

### Wait do we discuss it here or in https://github.com/astropy/astropy/pull/10405?

Let's discuss things here and keep the discussion in https://github.com/astropy/astropy/pull/10405 specific to building **nightly** wheels. If we go ahead with this PR, https://github.com/astropy/astropy/pull/10405 is a trivial extension.
