### PR TITLE
Skip test on Python 3.6 due to random failure

### DIFF
--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -842,7 +842,7 @@ def test_update_parallel(temp_cache, valid_urls):
         assert get_file_contents(f) == c2
 
 
-@pytest.mark.skipif((3, 7) <= sys.version_info < (3, 8),
+@pytest.mark.skipif(sys.version_info < (3, 8),
                     reason="causes mystery segfault! possibly bug #10008")
 def test_update_parallel_multi(temp_cache, valid_urls):
     u, c = next(valid_urls)


### PR DESCRIPTION
This test has random failures on Python 3.6 which I think must be related to #10008 so I'm extending the skip clause to include Python 3.6.

The error I'm seeing on Windows is:

```
E           OSError: [WinError 145] The directory is not empty: 'C:\\Users\\VssAdministrator\\AppData\\Local\\Temp\\pytest-of-VssAdministrator\\pytest-1\\test_update_parallel_multi0\\astropy\\download\\url\\rmtree-3xgi9c03'
```