### PR TITLE
add `spat` unit of solid angle

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -104,6 +104,9 @@ astropy.units
 - ``Quantity.to`` has gained a ``copy`` option to allow copies to be avoided
   when the units do not change. [#10517]
 
+- Added the ``spat`` unit of solid angle that represents the full sphere.
+  [#10726]
+
 astropy.utils
 ^^^^^^^^^^^^^
 

--- a/astropy/units/astrophys.py
+++ b/astropy/units/astrophys.py
@@ -59,6 +59,10 @@ def_unit(['cycle', 'cy'], 2.0 * _numpy.pi * si.rad,
          namespace=_ns, prefixes=False,
          doc="cycle: angular measurement, a full turn or rotation")
 
+def_unit(['spat', 'sp'], 4.0 * _numpy.pi * si.sr,
+         namespace=_ns, prefixes=False,
+         doc="spat: the solid angle of the sphere, 4pi sr")
+
 ###########################################################################
 # MASS
 

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -112,6 +112,7 @@ def test_units_conversion():
     assert_allclose(u.yr.to(u.Myr), 1.e-6)
     assert_allclose(u.AU.to(u.pc), 4.84813681e-6)
     assert_allclose(u.cycle.to(u.rad), 6.283185307179586)
+    assert_allclose(u.spat.to(u.sr), 12.56637061435917)
 
 
 def test_units_manipulation():
@@ -792,6 +793,8 @@ def test_unit_summary_prefixes():
         elif unit.name == 'barn':
             assert prefixes
         elif unit.name == 'cycle':
+            assert prefixes == 'No'
+        elif unit.name == 'spat':
             assert prefixes == 'No'
         elif unit.name == 'vox':
             assert prefixes == 'Yes'


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to address #10721. It adds the [`spat` unit (abbreviation `sp`, apparently)](https://en.wikipedia.org/wiki/Spat_(unit)) where `1 spat` corresponds to 4pi steradian, i.e. the solid angle of the entire sphere.

That makes it possible to convert `fsky` sky fractions to solid angle transparently:

```python
survey_area = fsky*u.spat
```

And also to convert solid angles to sky fractions:

```python
sky = survey_area.to_value(u.spat)
```

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #10721 