### PR TITLE
Allow **kwargs in `realize_frame`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,10 @@ astropy.coordinates
 
 - ``galactocentric_frame_defaults`` can now also be used as a registry, with user-defined parameter values and metadata. [#10624]
 
+- Method ``.realize_frame`` from coordinate frames now accepts ``**kwargs``,
+  including ``representation_type``. [#10727]
+
+
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -973,7 +973,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
         """
         return self._replicate(None, copy=copy, **kwargs)
 
-    def realize_frame(self, data):
+    def realize_frame(self, data, **kwargs):
         """
         Generates a new frame with new data from another frame (which may or
         may not have data). Roughly speaking, the converse of
@@ -984,13 +984,16 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
         data : `~astropy.coordinates.BaseRepresentation`
             The representation to use as the data for the new frame.
 
+        Any additional keywords are treated as frame attributes to be set on the
+        new frame object. In particular, `representation_type` can be specified.
+
         Returns
         -------
         frameobj : same as this frame
             A new object with the same frame attributes as this one, but
             with the ``data`` as the coordinate data.
         """
-        return self._replicate(data)
+        return self._replicate(data, **kwargs)
 
     def represent_as(self, base, s='base', in_frame_units=False):
         """

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -1498,3 +1498,15 @@ def test_coordinateattribute_transformation():
     assert f2_frame.coord_attr.obstime == gcrs.obstime
     # The output should not be different if a SkyCoord is provided
     assert f2_skycoord.coord_attr == f2_frame.coord_attr
+
+
+def test_realize_frame_accepts_kwargs():
+    c1 = ICRS(x=1*u.pc, y=2*u.pc, z=3*u.pc,
+              representation_type=r.CartesianRepresentation)
+    new_data = r.CartesianRepresentation(x=11*u.pc, y=12*u.pc, z=13*u.pc)
+
+    c2 = c1.realize_frame(new_data, representation_type="cartesian")
+    c3 = c1.realize_frame(new_data, representation_type="cylindrical")
+
+    assert c2.representation_type == r.CartesianRepresentation
+    assert c3.representation_type == r.CylindricalRepresentation


### PR DESCRIPTION
### Description

This pull request closes gh-7784 by allowing `**kwargs` in `realize_frame`, for simmetry with `replicate_without_data` and especially to allow `representation_type`, which makes it possible to realize a frame and explicitly set the representation type in one line.

This also paves the way to changes discussed in gh-6435 about making a frame instantiated with a `BaseRepresentation` object automatically infer the `representation_type`, but allow the user to override it.