### PR TITLE
Disallow passing both unit= and Quantities in SkyCoord

### DIFF
--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -220,9 +220,10 @@ class SkyCoord(ShapedLikeNDArray):
         Type of coordinate frame this `SkyCoord` should represent. Defaults to
         to ICRS if not given or given as None.
     unit : `~astropy.units.Unit`, string, or tuple of :class:`~astropy.units.Unit` or str, optional
-        Units for supplied ``LON`` and ``LAT`` values, respectively.  If
-        only one unit is supplied then it applies to both ``LON`` and
-        ``LAT``.
+        Units for supplied coordinate values.
+        If only one unit is supplied then it applies to all values.
+        It can only be used if none of the coordinate values is a :class:`~astropy.units.Quantity`,
+        otherwise an error is raised.
     obstime : valid `~astropy.time.Time` initializer, optional
         Time(s) of observation.
     equinox : valid `~astropy.time.Time` initializer, optional

--- a/astropy/coordinates/sky_coordinate_parsers.py
+++ b/astropy/coordinates/sky_coordinate_parsers.py
@@ -588,6 +588,8 @@ def _get_representation_attrs(frame, units, kwargs):
     for frame_attr_name, repr_attr_class, unit in zip(frame_attr_names, repr_attr_classes, units):
         value = kwargs.pop(frame_attr_name, None)
         if value is not None:
+            if unit is not None and isinstance(value, u.Quantity):
+                raise ValueError("Cannot specify unit= and pass Quantities as keyword arguments at the same time")
             valid_kwargs[frame_attr_name] = repr_attr_class(value, unit=unit)
 
     # also check the differentials.  They aren't included in the units keyword,

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -1809,3 +1809,20 @@ def test_multiple_aliases():
     assert isinstance(coord.transform_to('alias_2').frame, MultipleAliasesFrame)
 
     ftrans.unregister(frame_transform_graph)
+
+
+@pytest.mark.parametrize("kwargs", [
+    {"ra": 1, "dec": 1 * u.deg, "unit": "deg"},
+    {"ra": 1, "dec": 1 * u.deg, "unit": ("deg", "deg")},
+    {"ra": 1 * u.deg, "dec": 1 * u.deg, "unit": "deg"},
+    {"ra": 1 * u.deg, "dec": 1 * u.deg, "unit": ("deg", "deg")},
+    {"ra": 1, "dec": 1, "distance": 1 * u.pc, "unit": "deg"},
+    {"ra": 1, "dec": 1, "distance": 1 * u.pc, "unit": ("deg", "deg", "pc")},
+])
+def test_passing_both_unit_and_quantities_raises_error(kwargs):
+    # https://github.com/astropy/astropy/issues/10725
+    with pytest.raises(ValueError) as excinfo:
+        SkyCoord(**kwargs)
+    assert (
+        "Cannot specify unit= and pass Quantities as keyword arguments at the same time" in excinfo.exconly()
+    )


### PR DESCRIPTION
### Description

This closes gh-10725 by disallowing the use of both `unit=` and `Quantity`es as keyword parameters in the `SkyCoord` initializer, which is somewhat ambiguous.

Unsure if this deserves a changelog entry.