### PR TITLE
TST: Ignore unknown config ini key (pytest 6.1)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -125,6 +125,7 @@ filterwarnings =
     ignore:::astropy.tests.disable_internet
     ignore:direct construction of Asdf:pytest.PytestDeprecationWarning
     ignore:Unknown pytest.mark.mpl_image_compare:pytest.PytestUnknownMarkWarning
+    ignore:Unknown config ini key:pytest.PytestConfigWarning
     ignore:matplotlibrc text.usetex:UserWarning:matplotlib
 doctest_norecursedirs =
     */setup_package.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -125,7 +125,7 @@ filterwarnings =
     ignore:::astropy.tests.disable_internet
     ignore:direct construction of Asdf:pytest.PytestDeprecationWarning
     ignore:Unknown pytest.mark.mpl_image_compare:pytest.PytestUnknownMarkWarning
-    ignore:Unknown config ini key:pytest.PytestConfigWarning
+    ignore:Unknown config option:pytest.PytestConfigWarning
     ignore:matplotlibrc text.usetex:UserWarning:matplotlib
 doctest_norecursedirs =
     */setup_package.py


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to utilize pytest-dev/pytest#7700 to silence this warning below that does not break tests but is kinda annoying. It will not be proven work (or not) until pytest 6.1 is out (pytest-dev/pytest#7703), so there is no point in merging this too soon.

```
=============================== warnings summary ===============================
.../_pytest/config/__init__.py:1148
  .../_pytest/config/__init__.py:1148: PytestConfigWarning: Unknown config ini key: qt_no_exception_capture
  
    self._warn_or_fail_if_strict("Unknown config ini key: {}\n".format(key))

-- Docs: https://docs.pytest.org/en/stable/warnings.html
```

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

We need to keep the unused plugin config due to #7572
