### PR TITLE
DOC: Update coordinates doctest result

### DIFF
--- a/docs/coordinates/performance.inc.rst
+++ b/docs/coordinates/performance.inc.rst
@@ -104,7 +104,7 @@ To use interpolation for the astrometric values in coordinate transformation, us
 
    >>> err = crab_altaz.separation(crab_altaz_interpolated)  # doctest:+IGNORE_WARNINGS +REMOTE_DATA
    >>> print(f'Mean error of interpolation: {err.to(u.microarcsecond).mean():.4f}')  # doctest:+ELLIPSIS +REMOTE_DATA
-   Mean error of interpolation: 0.0198 uarcsec
+   Mean error of interpolation: 0.0... uarcsec
 
    >>> # To set erfa_astrom for a whole session, use it without context manager:
    >>> erfa_astrom.set(ErfaAstromInterpolator(300 * u.s))  # doctest:+SKIP

--- a/docs/coordinates/performance.inc.rst
+++ b/docs/coordinates/performance.inc.rst
@@ -104,7 +104,7 @@ To use interpolation for the astrometric values in coordinate transformation, us
 
    >>> err = crab_altaz.separation(crab_altaz_interpolated)  # doctest:+IGNORE_WARNINGS +REMOTE_DATA
    >>> print(f'Mean error of interpolation: {err.to(u.microarcsecond).mean():.4f}')  # doctest:+ELLIPSIS +REMOTE_DATA
-   Mean error of interpolation: 0.0167 uarcsec
+   Mean error of interpolation: 0.0198 uarcsec
 
    >>> # To set erfa_astrom for a whole session, use it without context manager:
    >>> erfa_astrom.set(ErfaAstromInterpolator(300 * u.s))  # doctest:+SKIP
@@ -113,7 +113,7 @@ To use interpolation for the astrometric values in coordinate transformation, us
   EXAMPLE END
 
 
-Here, we look into choosing an appropriate ``time_resolution``. 
+Here, we look into choosing an appropriate ``time_resolution``.
 We will transform a single sky coordinate for lots of observation times from
 ``ICRS`` to ``AltAz`` and evaluate precision and runtime for different values
 for ``time_resolution`` compared to the non-interpolating, default approach.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to address doctest failure in remote data cron job that I can reproduce locally. Example log: https://travis-ci.org/github/astropy/astropy/jobs/727302683

```
________________________ [doctest] performance.inc.rst _________________________
097 
098    >>> # transform with interpolating astrometric values
099    >>> t0 = perf_counter()
100    >>> with erfa_astrom.set(ErfaAstromInterpolator(300 * u.s)): # doctest:+REMOTE_DATA
101    ...     crab_altaz_interpolated = crab.transform_to(frame)  # doctest:+IGNORE_WARNINGS +REMOTE_DATA
102    >>> print(f'Transformation took {perf_counter() - t0:.2f} s')  # doctest:+IGNORE_OUTPUT
103    Transformation took 0.03 s
104 
105    >>> err = crab_altaz.separation(crab_altaz_interpolated)  # doctest:+IGNORE_WARNINGS +REMOTE_DATA
106    >>> print(f'Mean error of interpolation: {err.to(u.microarcsecond).mean():.4f}')  # doctest:+ELLIPSIS +REMOTE_DATA
Expected:
    Mean error of interpolation: 0.0167 uarcsec
Got:
    Mean error of interpolation: 0.0198 uarcsec
.../docs/coordinates/performance.inc.rst:106: DocTestFailure
```

Local run:

```python
>>> from astropy.coordinates import SkyCoord, EarthLocation, AltAz 
>>> from astropy.coordinates.erfa_astrom import erfa_astrom, ErfaAstromInterpolator 
>>> from astropy.time import Time 
>>> import numpy as np 
>>> import astropy.units as u
>>> obstime = Time('2010-01-01T20:00') + np.linspace(0, 6, 10000) * u.hour 
>>> location = location = EarthLocation(lon=-17.89 * u.deg, lat=28.76 * u.deg, height=2200 * u.m) 
>>> frame = AltAz(obstime=obstime, location=location) 
>>> crab = SkyCoord(ra='05h34m31.94s', dec='22d00m52.2s')                                
>>> crab_altaz = crab.transform_to(frame)                                                       
>>> with erfa_astrom.set(ErfaAstromInterpolator(300 * u.s)): 
...     crab_altaz_interpolated = crab.transform_to(frame) 
>>> err = crab_altaz.separation(crab_altaz_interpolated)                                        
>>> print(f'Mean error of interpolation: {err.to(u.microarcsecond).mean():.4f}')                
Mean error of interpolation: 0.0198 uarcsec
```

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

This example was last changed in #10647 by @MaxNoe .