### PR TITLE
Renewed attempt to add the InterferometricVisibility frame

### DIFF
--- a/astropy/coordinates/interferometric_visibility.py
+++ b/astropy/coordinates/interferometric_visibility.py
@@ -1,0 +1,22 @@
+"""
+Provide the interferometric visibility frame, also known as the UVW frame, of radio astronomy to a precision
+suitable for VLBI. The accuracy is comparable to CALC11.
+
+In order to compute the coordinates in this frame we follow the approach of computing the proper time for a given
+geodesic (which forms the w coordinate) and then computing the u and v coordinates from the directional derivatives of
+proper time w.r.t the l and m coordinates.
+
+w = proper-time
+u = dw/dl
+v = dw/dm
+
+In order to perform VLBI-precise calcuations we must take into account the velocity of the local reference frame of each
+geodesic origin.
+
+TODO(@tikk3r, @joshuaalbert): derive the exact solution
+TODO(@tikk3r, @joshuaalbert): Investigate setting up the frame using astropy.coordinates.SkyOffset
+TODO(@tikk3r, @joshuaalbert): If possible, set up the frame using astropy.coordinates.SkyOffset
+TODO(@tikk3r, @joshuaalbert): Set up CALC11 server to do testing
+TODO(@tikk3r, @joshuaalbert): Investigate setting up CALC11 server as part of continuous integration
+"""
+pass


### PR DESCRIPTION
This PR reopens #9869 and is a solution for issue #7766. 

Individuals that should follow and give input: @caseyjlaw, @eteq, @mhvk, @tikk3r

I think given the prior PR we can largely break this PR into the following tasks:

- [ ] Derive the exact solution
- [ ] Investigate setting up the frame using astropy.coordinates.SkyOffset
- [ ] If possible, set up the frame using astropy.coordinates.SkyOffset or else find other solution
- [ ] Set up CALC11 server to do testing
- [ ] Investigate setting up CALC11 server as part of continuous integration unittesting

## The exact solution

In order to compute the coordinates in this frame we follow the approach of computing the proper time for a given
geodesic (which forms the `w` coordinate) and then computing the `u` and `v` coordinates from the directional derivatives of
proper time w.r.t the `l` and `m` coordinates.

```
w = c * proper_time
u = dw/dl
v = dw/dm
```

Note: In order to perform VLBI-precise calcuations we must take into account the velocity of the local reference frame of each
geodesic origin.

Computing the coordinates can be expensive, which is why VLBI folks compute them over a temporal abscissa of about 120 seconds and do spline interpolation between. I think we should provide the exact coordinates, and let the user choose if they want to use spline interpolation. 