### PR TITLE
TST: Pin bleach until they fix deprecation warning

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -63,7 +63,7 @@ all =
     h5py
     beautifulsoup4
     html5lib
-    bleach
+    bleach<3.2.0
     PyYAML>=3.12
     pandas
     sortedcontainers


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to address this deprecation warning caused by `bleach` 3.2.0 release last night.

```
.../astropy/utils/xml/writer.py:195: in <lambda>
    self.xml_escape_cdata = lambda x: bleach.clean(x, **clean_kwargs)
.../bleach/__init__.py:84: in clean
    return cleaner.clean(text)
.../bleach/sanitizer.py:175: in clean
    filtered = BleachSanitizerFilter(
.../bleach/sanitizer.py:273: in __init__
    return super(BleachSanitizerFilter, self).__init__(source, **kwargs)
...
E       DeprecationWarning: html5lib's sanitizer is deprecated;
see https://github.com/html5lib/html5lib-python/issues/443 and
please let us know if Bleach is unsuitable for your needs
```

I debated with myself whether we should pin or ignore warning. I think pinning is more explicit as a reminder that this is temporary and should be undone in near future. We tend to forget why we ignore the warnings and leave them there.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

p.s. If this blocks RC testing, you might want to backport or something. Not sure.

Also see mozilla/bleach#557 and https://github.com/html5lib/html5lib-python/issues/443#issuecomment-694214795 .