### PR TITLE
DOC: Update ci skip doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,19 +111,20 @@ Other Tips
         $ git commit --amend
 
 - To skip only the tests running on Travis CI use ``[skip travis]``.
+  This will still execute CircleCI.
 
 - If your commit makes substantial changes to the documentation but no code
-  changes, then you can use ``[skip travis]``, which will skip Travis CI
-  because documentation build is done on CircleCI. The exception to this rule
+  changes, then you can use ``[ci skip]``, which will all CI except RTD,
+  where the documentation is built. The exception to this rule
   is when your changes to documentation include code snippets that need to
   be tested using ``doctest``.
 
 - When contributing trivial documentation fixes (i.e., fixes to typos, spelling,
   grammar) that don't contain any special markup and are not associated with
-  code changes, please include the string ``[skip travis]`` in your commit
+  code changes, please include the string ``[ci skip]`` in your commit
   message.
 
-      $ git commit -m "Fixed typo [skip travis]"
+      $ git commit -m "Fixed typo [ci skip]"
 
 Checklist for Contributed Code
 ------------------------------

--- a/docs/development/docguide.rst
+++ b/docs/development/docguide.rst
@@ -16,13 +16,14 @@ Adding a Git Commit
 
 When your changes only affect documentation (i.e., docstring or RST files)
 and do not include any code snippets that require doctest to run, you may
-add a ``[skip travis]`` in your commit message. For example::
+add a ``[ci skip]`` in your commit message. For example::
 
-    git commit -m "Update documentation about this and that [skip travis]"
+    git commit -m "Update documentation about this and that [ci skip]"
 
 When this commit is pushed out to your branch associated with a pull request,
-Travis CI will be skipped because it is not required. This is because the
-CI job to build the documentation resides in CircleCI.
+all CI will be skipped because it is not required. This is because the
+the documentation build resides in RTD, which currently does not respect the
+``[ci skip]`` directive.
 
 
 Building the Documentation from source


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to address confusion about usage of `[ci skip]` when building documentation.

Will have to be updated again when readthedocs/readthedocs.org#871 is implemented. Maybe even have to fall back to `[skip travis]` if `[ci skip]` would also skip RTD, but that would kick off CircleCI unnecessarily. We'll revisit when that bridge exists.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #10521 