### PR TITLE
Raise more helpful error message in SkyCoord for mixed components

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,9 +34,6 @@ astropy.coordinates
 - Method ``.realize_frame`` from coordinate frames now accepts ``**kwargs``,
   including ``representation_type``. [#10727]
 
-- The initializer of ``SkyCoord`` now raises a more helpful error if mixed
-  quantities and unit-less components are passed. [#10749]
-
 
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,6 +34,9 @@ astropy.coordinates
 - Method ``.realize_frame`` from coordinate frames now accepts ``**kwargs``,
   including ``representation_type``. [#10727]
 
+- The initializer of ``SkyCoord`` now raises a more helpful error if mixed
+  quantities and unit-less components are passed. [#10749]
+
 
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -222,9 +222,9 @@ class SkyCoord(ShapedLikeNDArray):
     unit : `~astropy.units.Unit`, string, or tuple of :class:`~astropy.units.Unit` or str, optional
         Units for supplied coordinate values.
         If only one unit is supplied then it applies to all values.
-        Notice that passing only one unit might lead to unit conversion errors
+        Note that passing only one unit might lead to unit conversion errors
         if the coordinate values are expected to have mixed physical meanings
-        (e.g. angles and distances).
+        (e.g., angles and distances).
     obstime : valid `~astropy.time.Time` initializer, optional
         Time(s) of observation.
     equinox : valid `~astropy.time.Time` initializer, optional

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -220,9 +220,11 @@ class SkyCoord(ShapedLikeNDArray):
         Type of coordinate frame this `SkyCoord` should represent. Defaults to
         to ICRS if not given or given as None.
     unit : `~astropy.units.Unit`, string, or tuple of :class:`~astropy.units.Unit` or str, optional
-        Units for supplied ``LON`` and ``LAT`` values, respectively.  If
-        only one unit is supplied then it applies to both ``LON`` and
-        ``LAT``.
+        Units for supplied coordinate values.
+        If only one unit is supplied then it applies to all values.
+        Notice that passing only one unit might lead to unit conversion errors
+        if the coordinate values are expected to have mixed physical meanings
+        (e.g. angles and distances).
     obstime : valid `~astropy.time.Time` initializer, optional
         Time(s) of observation.
     equinox : valid `~astropy.time.Time` initializer, optional

--- a/astropy/coordinates/sky_coordinate_parsers.py
+++ b/astropy/coordinates/sky_coordinate_parsers.py
@@ -591,16 +591,14 @@ def _get_representation_attrs(frame, units, kwargs):
             try:
                 valid_kwargs[frame_attr_name] = repr_attr_class(value, unit=unit)
             except u.UnitConversionError as err:
-                error_message = "Unit '{unit}' ({type}) could not be applied to '{name}'. ".format(
-                    unit=unit, type=unit.physical_type, name=frame_attr_name
-                )
-                error_message += (
+                error_message = (
+                    f"Unit '{unit}' ({unit.physical_type}) could not be applied to '{frame_attr_name}'. "
                     "This can occur when passing units for some coordinate components "
                     "when other components are specified as Quantity objects. "
                     "Either pass a list of units for all components (and unit-less coordinate data), "
                     "or pass Quantities for all components"
                 )
-                raise ValueError(error_message) from err
+                raise u.UnitConversionError(error_message) from err
 
     # also check the differentials.  They aren't included in the units keyword,
     # so we only look for the names.

--- a/astropy/coordinates/sky_coordinate_parsers.py
+++ b/astropy/coordinates/sky_coordinate_parsers.py
@@ -588,7 +588,19 @@ def _get_representation_attrs(frame, units, kwargs):
     for frame_attr_name, repr_attr_class, unit in zip(frame_attr_names, repr_attr_classes, units):
         value = kwargs.pop(frame_attr_name, None)
         if value is not None:
-            valid_kwargs[frame_attr_name] = repr_attr_class(value, unit=unit)
+            try:
+                valid_kwargs[frame_attr_name] = repr_attr_class(value, unit=unit)
+            except u.UnitConversionError as err:
+                error_message = "Unit '{unit}' ({type}) could not be applied to '{name}'. ".format(
+                    unit=unit, type=unit.physical_type, name=frame_attr_name
+                )
+                error_message += (
+                    "This can occur when passing units for some coordinate components "
+                    "when other components are specified as Quantity objects. "
+                    "Either pass a list of units for all components (and unit-less coordinate data), "
+                    "or pass Quantities for all components"
+                )
+                raise ValueError(error_message) from err
 
     # also check the differentials.  They aren't included in the units keyword,
     # so we only look for the names.

--- a/astropy/coordinates/sky_coordinate_parsers.py
+++ b/astropy/coordinates/sky_coordinate_parsers.py
@@ -596,7 +596,7 @@ def _get_representation_attrs(frame, units, kwargs):
                     "This can occur when passing units for some coordinate components "
                     "when other components are specified as Quantity objects. "
                     "Either pass a list of units for all components (and unit-less coordinate data), "
-                    "or pass Quantities for all components"
+                    "or pass Quantities for all components."
                 )
                 raise u.UnitConversionError(error_message) from err
 

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -1809,3 +1809,22 @@ def test_multiple_aliases():
     assert isinstance(coord.transform_to('alias_2').frame, MultipleAliasesFrame)
 
     ftrans.unregister(frame_transform_graph)
+
+
+@pytest.mark.parametrize("kwargs, error_message", [
+    (
+        {"ra": 1, "dec": 1, "distance": 1 * u.pc, "unit": "deg"},
+        "Unit 'deg' (angle) could not be applied to 'distance'",
+    ),
+    (
+        {"rho": 1 * u.m, "phi": 1, "z": 1 * u.m, "unit": "deg", "representation_type": "cylindrical"},
+        "Unit 'deg' (angle) could not be applied to 'rho'",
+    ),
+])
+def test_passing_inconsistent_coordinates_and_units_raises_helpful_error(kwargs, error_message):
+    # https://github.com/astropy/astropy/issues/10725
+    with pytest.raises(ValueError) as excinfo:
+        SkyCoord(**kwargs)
+    assert (
+        error_message in excinfo.exconly()
+    )

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -1814,17 +1814,14 @@ def test_multiple_aliases():
 @pytest.mark.parametrize("kwargs, error_message", [
     (
         {"ra": 1, "dec": 1, "distance": 1 * u.pc, "unit": "deg"},
-        "Unit 'deg' (angle) could not be applied to 'distance'",
+        r"Unit 'deg' \(angle\) could not be applied to 'distance'. ",
     ),
     (
         {"rho": 1 * u.m, "phi": 1, "z": 1 * u.m, "unit": "deg", "representation_type": "cylindrical"},
-        "Unit 'deg' (angle) could not be applied to 'rho'",
+        r"Unit 'deg' \(angle\) could not be applied to 'rho'. ",
     ),
 ])
 def test_passing_inconsistent_coordinates_and_units_raises_helpful_error(kwargs, error_message):
     # https://github.com/astropy/astropy/issues/10725
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ValueError, match=error_message):
         SkyCoord(**kwargs)
-    assert (
-        error_message in excinfo.exconly()
-    )


### PR DESCRIPTION
### Description

This pull request fixes the outdated docstring for the `units` parameter of the `SkyCoord` initializer and provides a more helpful error message when an inconsistent mix of quantities and unit-less components is used (credit to @adrn for writing the actual message). This supersedes gh-10728, which was too strict.

Fix gh-10725.