### PR TITLE
ScienceState states

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -113,6 +113,21 @@ astropy.utils
 
 - ``ShapedLikeNDArray`` has gained the capability to use numpy functions
   that broadcast, change shape, or index. [#10337]
+- ``ScienceState`` adopts multiple-attribute states, now stored in dict
+  ``_state``. [#10751]
+
+  + Items in ``_state`` can be accessed as attributes.
+  + ``ScienceState.validate`` returns the whole state, not just primary value
+  + Central state value (previously "_value") now determined by attribute
+    ``_state_value_name_``, defaulting to "value".
+
+- ``ScienceStateContext`` is the new contextmanager returned by
+  ``ScienceState.set`` [#10751]
+
+  + Now works in ``with`` statements.
+  + ``ScienceState`` controls which ``ScienceStateContext`` or subclass is
+    returned, using the ``_context_`` attribute.
+
 
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
@@ -147,6 +162,9 @@ astropy.coordinates
   deprecated.  Frame classes can still be passed to the ``transform_to()``
   method of the high-level ``SkyCoord`` class, and using ``SkyCoord`` is
   recommended for all typical use cases of transforming coordinates. [#10475]
+
+- ``galactocentric_frame_defaults`` parameters and references can be accessed
+  as attributes. [#10751]
 
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,34 @@
+5.0 (unreleased)
+================
+
+New Features
+------------
+
+astropy.coordinates
+^^^^^^^^^^^^^^^^^^^
+
+- ``galactocentric_frame_defaults`` parameters and references can be accessed
+  as attributes. [#10751]
+
+astropy.utils
+^^^^^^^^^^^^^
+
+- ``ScienceState`` adopts multiple-attribute states, now stored in dict
+  ``_state``. [#10751]
+
+  + Items in ``_state`` can be accessed as attributes.
+  + ``ScienceState.validate`` returns the whole state, not just primary value
+  + Central state value (previously "_value") now determined by attribute
+    ``_state_value_name_``, defaulting to "value".
+
+- ``ScienceStateContext`` is the new contextmanager returned by
+  ``ScienceState.set`` [#10751]
+
+  + Now works in ``with`` statements.
+  + ``ScienceState`` controls which ``ScienceStateContext`` or subclass is
+    returned, using the ``_context_`` attribute.
+
+
 4.2 (unreleased)
 ================
 
@@ -113,21 +144,6 @@ astropy.utils
 
 - ``ShapedLikeNDArray`` has gained the capability to use numpy functions
   that broadcast, change shape, or index. [#10337]
-- ``ScienceState`` adopts multiple-attribute states, now stored in dict
-  ``_state``. [#10751]
-
-  + Items in ``_state`` can be accessed as attributes.
-  + ``ScienceState.validate`` returns the whole state, not just primary value
-  + Central state value (previously "_value") now determined by attribute
-    ``_state_value_name_``, defaulting to "value".
-
-- ``ScienceStateContext`` is the new contextmanager returned by
-  ``ScienceState.set`` [#10751]
-
-  + Now works in ``with`` statements.
-  + ``ScienceState`` controls which ``ScienceStateContext`` or subclass is
-    returned, using the ``_context_`` attribute.
-
 
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
@@ -162,9 +178,6 @@ astropy.coordinates
   deprecated.  Frame classes can still be passed to the ``transform_to()``
   method of the high-level ``SkyCoord`` class, and using ``SkyCoord`` is
   recommended for all typical use cases of transforming coordinates. [#10475]
-
-- ``galactocentric_frame_defaults`` parameters and references can be accessed
-  as attributes. [#10751]
 
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^

--- a/astropy/coordinates/solar_system.py
+++ b/astropy/coordinates/solar_system.py
@@ -104,7 +104,11 @@ class solar_system_ephemeris(ScienceState):
     .. [3] https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/a_old_versions/
     """
     _value = 'builtin'
-    _kernel = None
+    _state = {"kernel": None}  # _kernel = None
+
+    @classproperty  # read-only.
+    def _kernel(cls):
+        return cls._state["kernel"]
 
     @classmethod
     def validate(cls, value):
@@ -122,11 +126,11 @@ class solar_system_ephemeris(ScienceState):
         if cls._kernel is None or cls._kernel.origin != value:
             if cls._kernel is not None:
                 cls._kernel.daf.file.close()
-                cls._kernel = None
+                cls._state["kernel"] = None
             kernel = _get_kernel(value)
             if kernel is not None:
                 kernel.origin = value
-            cls._kernel = kernel
+            cls._state["kernel"] = kernel
         return cls._kernel
 
     @classproperty

--- a/astropy/utils/state.py
+++ b/astropy/utils/state.py
@@ -3,11 +3,208 @@ A simple class to manage a piece of global science state.  See
 :ref:`config-developer` for more details.
 """
 
+import copy
+from collections.abc import MappingView
+from types import MappingProxyType
 
-__all__ = ['ScienceState']
+__all__ = ["ScienceState"]
 
 
-class ScienceState:
+class _IndexedMappingView(MappingView):
+    """
+    `~collections.abc.MappingView` with a read-only ``getitem`` through
+    `~types.MappingProxyType`.
+
+    """
+
+    def __init__(self, mapping):
+        super().__init__(mapping)
+        self._mappingproxy = MappingProxyType(self._mapping)  # read-only
+
+    def __getitem__(self, key):
+        """Read-only ``getitem``."""
+        return self._mappingproxy[key]
+
+    def __deepcopy__(self, memo):
+        return copy.deepcopy(self._mapping, memo=memo)
+
+    def keys(self):
+        return self._mappingproxy.keys()
+
+    def values(self):
+        return self._mappingproxy.values()
+
+    def items(self):
+        return self._mappingproxy.items()
+
+
+class ScienceStateContext:
+    """
+    Science state context. Returned by :func:`~ScienceState.set`.
+
+    Parameters
+    ----------
+    parent : ClassType
+    state : dict
+
+    Examples
+    --------
+    ::
+
+        class MyState(ScienceState):
+            _value = None
+
+        old_context = MyState.set("test")
+
+        assert old_context._value is None
+        assert MyState._value == "test"
+
+    """
+
+    def __init__(self, parent, state):
+        super().__setattr__("_parent", parent)
+        super().__setattr__("_old_state", state)
+
+    @property
+    def _value(cls):
+        """Get value from parent ScienceState."""
+        return cls._parent._value
+
+    def __getattr__(self, key):
+        """
+        Get attribute from the class. Items in ``_state`` can also be accessed
+        as attributes of the class.
+
+        Raises
+        ------
+        AttributeError
+            If key is not in class or ``_state``
+
+        """
+        try:
+            return super().__getattribute__(key)
+        except AttributeError:
+            try:
+                return super().__getattribute__("_parent")._state[key]
+            except KeyError:
+                raise AttributeError
+
+    def __setattr__(cls, key, value):
+        """Cannot set. Read-only."""
+        raise NotImplementedError("Contexts are read-only.")
+
+    def __enter__(self):
+        """Enter ``with`` statement."""
+        return self
+
+    def __exit__(self, type, value, tb):
+        """Exit ``with`` statement, resetting value and clearing context."""
+        self._parent._state = self._old_state._mapping  # reset
+        self.__dict__.clear()  # clears on exit
+
+    def __repr__(self):
+        # Ensure we have a single-line repr, just in case our
+        # value is not something simple like a string.
+        value_repr, lb, _ = repr(self._parent._value).partition("\n")
+        if lb:
+            value_repr += "..."
+        return "<ScienceState {}: {}>".format(
+            self._parent.__name__, value_repr
+        )
+
+    def get(self):
+        """Get Value."""
+        return _IndexedMappingView(self._parent._state)
+
+    def set(self):
+        raise NotImplementedError("Contexts are read-only.")
+
+
+class _StateMixinMeta(type):
+    """
+    Metaclass for ScienceStates. Mixes ``_state`` into the class attributes.
+    Ensures existence of ``_state`` attribute. ScienceStates generally define
+    a ``_value`` attribute, which this metaclass moves to ``_state``.
+    """
+
+    @classmethod
+    def __prepare__(cls, *args):
+        """
+        Prepare class namespace. Called before class attributes.
+        the namespace is initialized with a ``_state`` field.
+        """
+        namespace = dict(_state=dict())
+        return namespace
+
+    def __new__(metacls, name, bases, namespace, **kwargs):
+        """
+        Creates a new instance of the class. Called after class attributes.
+        ScienceStates generally define a ``_value`` attribute, which must
+        be moved into the ``_state`` attribute.
+        """
+        # move _value to _state. This is for backward compatibility.
+        if "_value" in namespace:
+            key = namespace.get("_state_value_name_", "value")
+            namespace["_state"][key] = namespace.pop("_value")
+
+        return super().__new__(metacls, name, bases, namespace, **kwargs)
+
+    def __getattr__(cls, key):
+        """
+        Get attribute from the class. Items in ``_state`` can also be accessed
+        as attributes of the class.
+
+        Raises
+        ------
+        AttributeError
+            If key is not in class or ``_state``
+
+        """
+        try:  # first check if in class
+            return super().__getattribute__(key)
+        except AttributeError:  # it is not, check the _state
+            try:
+                return cls._state[key]
+            except KeyError:  # match Exception to method.
+                raise AttributeError
+            # All other Exceptions are raised normally.
+
+    def __setattr__(cls, key, value):
+        """
+        Set attribute to the class, if attribute already in class.
+        Since ``_state`` holds most things of interest, this
+        method should not change the state.
+
+        To forcibly set, use ``super().__setattr__(key, value)`` or
+        ``object.__setattr__(cls, key, value)``
+
+        Raises
+        ------
+        AttributeError
+            If key is not in class or ``_state``
+
+        """
+        try:
+            super().__getattribute__(key)
+        except Exception:
+            raise NotImplementedError(
+                "Can only set values to existing attributes."
+            )
+        else:  # Can only set if has
+            super().__setattr__(key, value)
+
+    @property
+    def _value(cls):
+        """Get value from ``_state``."""
+        return cls._state[cls._state_value_name_]
+
+    @_value.setter
+    def _value(cls, value):
+        """Set value in ``_state``."""
+        cls._state[cls._state_value_name_] = value
+
+
+class ScienceState(metaclass=_StateMixinMeta):
     """
     Science state subclasses are used to manage global items that can
     affect science results.  Subclasses will generally override
@@ -28,9 +225,19 @@ class ScienceState:
                 return value
     """
 
+    _context_ = ScienceStateContext  #
+    _state_value_name_ = "value"  # what cls._value gets from `_state`
+
     def __init__(self):
-        raise RuntimeError(
-            "This class is a singleton.  Do not instantiate.")
+        raise RuntimeError("This class is a singleton. Do not instantiate.")
+
+    def __repr__(self):
+        # Ensure we have a single-line repr, just in case our
+        # value is not something simple like a string.
+        value_repr, lb, _ = repr(self._value).partition("\n")
+        if lb:
+            value_repr += "..."
+        return "<ScienceState {}: {}>".format(self.__name__, value_repr)
 
     @classmethod
     def get(cls):
@@ -40,33 +247,33 @@ class ScienceState:
         return cls.validate(cls._value)
 
     @classmethod
+    def get_state(cls):
+        """
+        Get view of current science state.
+        """
+        return _IndexedMappingView(cls._state)
+
+    @classmethod
     def set(cls, value):
         """
         Set the current science state value.
         """
-        class _Context:
-            def __init__(self, parent, value):
-                self._value = value
-                self._parent = parent
+        # create context, storing old state
+        ctx = cls._context_(cls, _IndexedMappingView(copy.deepcopy(cls._state)))  # FIXME
 
-            def __enter__(self):
-                pass
+        # clear current state
+        # cls._state = {}  # FIXME
 
-            def __exit__(self, type, value, tb):
-                self._parent._value = self._value
+        try:  # get new state
+            value = cls.validate(value)
+        except Exception as e:  # If problems, restore previous state
+            cls._state = ctx._old_state._mapping
+            raise e
+        else:
+            cls._state[
+                cls._state_value_name_
+            ] = value  # TODO replace by cls._value = value
 
-            def __repr__(self):
-                # Ensure we have a single-line repr, just in case our
-                # value is not something simple like a string.
-                value_repr, lb, _ = repr(self._parent._value).partition('\n')
-                if lb:
-                    value_repr += '...'
-                return ('<ScienceState {}: {}>'
-                        .format(self._parent.__name__, value_repr))
-
-        ctx = _Context(cls, cls._value)
-        value = cls.validate(value)
-        cls._value = value
         return ctx
 
     @classmethod

--- a/astropy/utils/tests/test_state.py
+++ b/astropy/utils/tests/test_state.py
@@ -1,25 +1,35 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 from astropy.utils.state import ScienceState
+import pytest
 
 
 def test_ScienceState_and_Context():
     """
     Tests a ScienceState and spawned contexts.
     """
-
     class MyState(ScienceState):
         _value = "A"
         _state = dict(foo="bar")
 
-    state = {"foo": "bar"}
+        @classmethod
+        def validate(cls, value):
+            if value not in ('A', 'B', 'C'):
+                raise ValueError("Must be one of A, B, C")
+            return value
 
-    # test created ScienceState
     assert MyState.get() == "A"
     assert MyState.validate("B") == "B"
-    assert MyState._state == state
+    assert MyState._state == dict(foo="bar", value="A")
 
-    # test setting
-    with MyState.set("B"):
-        assert MyState.get() == "B"
-    assert MyState.get() == "A"  # test returning
+    old_context = MyState.set("B")
+    assert old_context._parent is MyState
+    assert old_context._value == "B"
+
+    with old_context:
+        assert MyState._value == "B"
+        assert MyState._state == dict(foo="bar", value="B")
+
+    # test context descopes
+    with pytest.raises(AttributeError):
+        old_context._value


### PR DESCRIPTION
## Description

ScienceStates are great. One shortcoming I've ran into is that they operate on a single-value paradigm. Workarounds are apparent in both ``galactocentric_frame_defaults`` (see #10624)  and ``solar_system_ephemeris``, which custom manage a '_references' and '_kernel' attribute, respectively.
This PR is to change ScienceStates to a multi-valued paradigm where the state (now "_state") is a dictionary. The name of the 'main' value can be set by an attribute on the ScienceState (see new ``galactocentric_frame_defaults`` implementation).

In addition, this PR also separates out the contextmanager returned by ``ScienceStates.set``, allows for custom contextmanagers to be used, and allows for the contextmanager to be used in `with` statements.

All these changes were introduced in  #10624, before being delayed for this PR.

## Examples

```python
class ExState(ScienceState):
    _state_value_name_ = "main"  # changes it from "value"
    _state = {"meta": "some more info"}
    _value = 2  # moved into `_state` as "main" by metaclass. Supported for backward compatibility.

ExState.main == ExState._value == 2
ExState.meta == "some more info"
```