### PR TITLE
Use absolute path in setup_package.py

### DIFF
--- a/astropy/convolution/setup_package.py
+++ b/astropy/convolution/setup_package.py
@@ -6,7 +6,7 @@ from setuptools import Extension
 
 import numpy
 
-C_CONVOLVE_PKGDIR = os.path.relpath(os.path.dirname(__file__))
+C_CONVOLVE_PKGDIR = os.path.abspath(os.path.dirname(__file__))
 
 SRC_FILES = [os.path.join(C_CONVOLVE_PKGDIR, filename)
              for filename in ['src/convolve.c']]

--- a/astropy/io/ascii/setup_package.py
+++ b/astropy/io/ascii/setup_package.py
@@ -5,7 +5,7 @@ from setuptools import Extension
 
 import numpy
 
-ROOT = os.path.relpath(os.path.dirname(__file__))
+ROOT = os.path.abspath(os.path.dirname(__file__))
 
 
 def get_extensions():

--- a/astropy/modeling/setup_package.py
+++ b/astropy/modeling/setup_package.py
@@ -11,7 +11,7 @@ from extension_helpers import import_file
 wcs_setup_package = import_file(join('astropy', 'wcs', 'setup_package.py'))
 
 
-MODELING_ROOT = os.path.relpath(os.path.dirname(__file__))
+MODELING_ROOT = os.path.abspath(os.path.dirname(__file__))
 MODELING_SRC = join(MODELING_ROOT, 'src')
 SRC_FILES = [join(MODELING_SRC, 'projections.c.templ'),
              __file__]

--- a/astropy/table/setup_package.py
+++ b/astropy/table/setup_package.py
@@ -5,7 +5,7 @@ from setuptools import Extension
 
 import numpy
 
-ROOT = os.path.relpath(os.path.dirname(__file__))
+ROOT = os.path.abspath(os.path.dirname(__file__))
 
 
 def get_extensions():

--- a/astropy/timeseries/periodograms/bls/setup_package.py
+++ b/astropy/timeseries/periodograms/bls/setup_package.py
@@ -7,7 +7,7 @@ from setuptools import Extension
 
 import numpy
 
-BLS_ROOT = os.path.relpath(os.path.dirname(__file__))
+BLS_ROOT = os.path.abspath(os.path.dirname(__file__))
 
 
 def get_extensions():

--- a/astropy/utils/setup_package.py
+++ b/astropy/utils/setup_package.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 from setuptools import Extension
-from os.path import dirname, join, relpath
+from os.path import dirname, join, abspath
 
 ASTROPY_UTILS_ROOT = dirname(__file__)
 
@@ -9,5 +9,5 @@ ASTROPY_UTILS_ROOT = dirname(__file__)
 def get_extensions():
     return [
         Extension('astropy.utils._compiler',
-                  [relpath(join(ASTROPY_UTILS_ROOT, 'src', 'compiler.c'))])
+                  [abspath(join(ASTROPY_UTILS_ROOT, 'src', 'compiler.c'))])
     ]

--- a/astropy/wcs/setup_package.py
+++ b/astropy/wcs/setup_package.py
@@ -15,7 +15,7 @@ import numpy
 
 from extension_helpers import import_file, write_if_different, get_compiler, pkg_config
 
-WCSROOT = os.path.relpath(os.path.dirname(__file__))
+WCSROOT = os.path.abspath(os.path.dirname(__file__))
 WCSVERSION = "7.3.0"
 
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to address `ValueError: path is on mount 'C:', start on mount 'D:'` when `test_generate_config` is run with `astropy` installed on `C` drive but Python session is in `D` drive.

The following testing on Windows did not raise any related failures. Let's see what the CI says; remember to check the remote data job that is allowed to fail.

* Running `pytest --remote-data` in editable install.
* Running `python -c "import astropy; astropy.test(remote_data=True)"` in both editable and normal installs.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #10747

p.s. If you want it in LTS, please change the milestone.