### PR TITLE
TST: URLError has different message on Windows

### DIFF
--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -2119,4 +2119,5 @@ def test_download_ftp_file_properly_handles_socket_error():
     faulty_url = "ftp://anonymous:mail%40astropy.org@nonexisting/pub/products/iers/finals2000A.all"
     with pytest.raises(urllib.error.URLError) as excinfo:
         download_file(faulty_url)
-    assert "Name or service not known" in excinfo.exconly()
+    errmsg = excinfo.exconly()
+    assert "Name or service not known" in errmsg or 'getaddrinfo failed' in errmsg


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to address slightly different error message seen on Windows.

```
____________ test_download_ftp_file_properly_handles_socket_error _____________

    @pytest.mark.remote_data
    def test_download_ftp_file_properly_handles_socket_error():
        faulty_url = "ftp://anonymous:mail%40astropy.org@nonexisting/pub/products/iers/finals2000A.all"
        with pytest.raises(urllib.error.URLError) as excinfo:
            download_file(faulty_url)
>       assert "Name or service not known" in excinfo.exconly()
E       AssertionError: assert 'Name or service not known' in 'urllib.error.URLError: <urlopen error [Errno 11001] getaddrinfo failed>'
E        +  where 'urllib.error.URLError: <urlopen error [Errno 11001] getaddrinfo failed>' = <bound method ExceptionInfo.exconly of <ExceptionInfo URLError(gaierror(11001, 'getaddrinfo failed')) tblen=9>>()
E        +    where <bound method ExceptionInfo.exconly of <ExceptionInfo URLError(gaierror(11001, 'getaddrinfo failed')) tblen=9>> = <ExceptionInfo URLError(gaierror(11001, 'getaddrinfo failed')) tblen=9>.exconly

```

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

This is a direct follow-up of #10750 .