### PR TITLE
add wcs slices as argument to functions in wcsaxes 

### DIFF
--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -536,7 +536,7 @@ class WCSAxes(Axes):
 
         return coords
 
-    def get_transform(self, frame):
+    def get_transform(self, frame, slices=None):
         """
         Return a transform from the specified frame to display coordinates.
 
@@ -567,16 +567,16 @@ class WCSAxes(Axes):
                   the specified frame to the pixel/data coordinates.
                 * :class:`~astropy.coordinates.BaseCoordinateFrame` instance.
         """
-        return self._get_transform_no_transdata(frame).inverted() + self.transData
+        return self._get_transform_no_transdata(frame, slices).inverted() + self.transData
 
-    def _get_transform_no_transdata(self, frame):
+    def _get_transform_no_transdata(self, frame, slices=None):
         """
         Return a transform from data to the specified frame
         """
 
         if isinstance(frame, WCS):
 
-            transform, coord_meta = transform_coord_meta_from_wcs(frame, self.frame_class)
+            transform, coord_meta = transform_coord_meta_from_wcs(frame, self.frame_class, slices)
             transform_world2pixel = transform.inverted()
 
             if self._transform_pixel2world.frame_out == transform_world2pixel.frame_in:

--- a/astropy/visualization/wcsaxes/wcsapi.py
+++ b/astropy/visualization/wcsaxes/wcsapi.py
@@ -22,7 +22,6 @@ IDENTITY.wcs.cdelt = [1., 1.]
 
 
 def transform_coord_meta_from_wcs(wcs, frame_class, slices=None):
-
     if slices is not None:
         slices = tuple(slices)
 


### PR DESCRIPTION
This fix is needed for https://github.com/aplpy/aplpy/pull/457

The contour plot function in aplpy doesn't allow >2D WCS, this fixes that by allowing WCS slices to be passed in to some of the functions in wcsaxes. 
