### PR TITLE
Update link to USNO circular 179

### DIFF
--- a/astropy/coordinates/builtin_frames/gcrs.py
+++ b/astropy/coordinates/builtin_frames/gcrs.py
@@ -44,7 +44,7 @@ class GCRS(BaseRADecFrame):
     on the GCRS, see the references provided in the
     :ref:`astropy-coordinates-seealso` section of the documentation. (Of
     particular note is Section 1.2 of
-    `USNO Circular 179 <https://aa.usno.navy.mil/publications/docs/Circular_179.php>`_)
+    `USNO Circular 179 <https://arxiv.org/abs/astro-ph/0602086>`_)
 
     This frame also includes frames that are defined *relative* to the Earth,
     but that are offset (in both position and velocity) from the Earth.

--- a/docs/coordinates/index.rst
+++ b/docs/coordinates/index.rst
@@ -501,7 +501,7 @@ See Also
 Some references that are particularly useful in understanding subtleties of the
 coordinate systems implemented here include:
 
-* `USNO Circular 179 <https://aa.usno.navy.mil/publications/docs/Circular_179.php>`_
+* `USNO Circular 179 <https://arxiv.org/abs/astro-ph/0602086>`_
     A useful guide to the IAU 2000/2003 work surrounding ICRS/IERS/CIRS and
     related problems in precision coordinate system work.
 * `Standards Of Fundamental Astronomy <http://www.iausofa.org/>`_


### PR DESCRIPTION
This updates the (currently broken) link to the USNO Circular 179 from the `astropy.coordinates` documentation. It seems like the USNO astronomy special publications site is just...[gone](aa.usno.navy.mil/publications)?! The arxiv link should be more stable.

_doh - I forgot to skip ci ..._