### PR TITLE
Fix handling of 1d table elements with single entry in fits

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -47,8 +47,6 @@ astropy.io.ascii
 astropy.io.fits
 ^^^^^^^^^^^^^^^
 
-- Fix handling of 1-dimensional arrays with single elements in BinaryTableHDUs [#10768]
-
 astropy.io.misc
 ^^^^^^^^^^^^^^^
 
@@ -1033,6 +1031,8 @@ astropy.io.fits
   [#10640]
 
 - Fix compilation of cfitsio with Xcode 12. [#10772]
+
+- Fix handling of 1-dimensional arrays with a single element in ``BinTableHDU`` [#10768]
 
 astropy.io.misc
 ^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -47,6 +47,8 @@ astropy.io.ascii
 astropy.io.fits
 ^^^^^^^^^^^^^^^
 
+- Fix handling of 1-dimensional arrays with single elements in BinaryTableHDUs [#10768]
+
 astropy.io.misc
 ^^^^^^^^^^^^^^^
 

--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -1440,12 +1440,12 @@ class ColDefs(NotifierMixin):
             # Determine the appropriate dimensions for items in the column
             # (typically just 1D)
             dim = array.dtype[idx].shape[::-1]
-            if dim and (len(dim) > 1 or 'A' in format):
+            if dim and (len(dim) > 0 or 'A' in format):
                 if 'A' in format:
                     # n x m string arrays must include the max string
                     # length in their dimensions (e.g. l x n x m)
                     dim = (array.dtype[idx].base.itemsize,) + dim
-                dim = repr(dim).replace(' ', '')
+                dim = '(' + ','.join(str(d) for d in dim) + ')'
             else:
                 dim = None
 
@@ -2264,7 +2264,6 @@ def _parse_tdim(tdim):
     """Parse the ``TDIM`` value into a tuple (may return an empty tuple if
     the value ``TDIM`` value is empty or invalid).
     """
-
     m = tdim and TDIM_RE.match(tdim)
     if m:
         dims = m.group('dims')

--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -172,7 +172,7 @@ Regular expression for valid table column names.  See FITS Standard v3.0 section
 TDEF_RE = re.compile(r'(?P<label>^T[A-Z]*)(?P<num>[1-9][0-9 ]*$)')
 
 # table dimension keyword regular expression (fairly flexible with whitespace)
-TDIM_RE = re.compile(r'\(\s*(?P<dims>(?:\d+,\s*)+\s*\d+)\s*\)\s*')
+TDIM_RE = re.compile(r'\(\s*(?P<dims>(?:\d+\s*)(?:,\s*\d+\s*)*\s*)\)\s*')
 
 # value for ASCII table cell with value = TNULL
 # this can be reset by user.

--- a/astropy/io/fits/tests/test_connect.py
+++ b/astropy/io/fits/tests/test_connect.py
@@ -259,6 +259,15 @@ class TestSingleTable:
         del t1, t2, t3
         gc.collect()
 
+    def test_oned_single_element(self, tmpdir):
+        filename = str(tmpdir.join('test_oned_single_element.fits'))
+        table = Table({'x': [[1], [2]]})
+        table.write(filename, overwrite=True)
+
+        read = Table.read(filename)
+        assert read['x'].shape == (2, 1)
+        assert len(read['x'][0]) == 1
+
 
 class TestMultipleHDU:
 

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -1772,7 +1772,7 @@ class TestTableFunctions(FitsTestCase):
 
     def test_oned_array_single_element(self):
         # a table with rows that are 1d arrays of a single value
-        data = np.array([1, 2]).view([('x', 'int64', (1, ))])
+        data = np.array([(1, ), (2, )], dtype=([('x', 'i4', (1, ))]))
         thdu = fits.BinTableHDU.from_columns(data)
 
         thdu.writeto(self.temp('onedtable.fits'))

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -1768,6 +1768,19 @@ class TestTableFunctions(FitsTestCase):
         assert t.field(1).dtype.str[-1] == '5'
         assert t.field(1).shape == (3, 4, 3)
 
+    def test_oned_array_single_element(self):
+        # a table with rows that are 1d arrays of a single value
+        data = np.array([1, 2]).view([('x', 'int64', (1, ))])
+        thdu = fits.BinTableHDU.from_columns(data)
+
+        thdu.writeto(self.temp('onedtable.fits'))
+
+        with fits.open(self.temp('onedtable.fits')) as hdul:
+            thdu = hdul[1]
+
+            c = thdu.data.field(0)
+            assert c.shape == (2, 1)
+
     def test_bin_table_init_from_string_array_column(self):
         """
         Tests two ways of creating a new `BinTableHDU` from a column of

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -560,7 +560,7 @@ class TestTableFunctions(FitsTestCase):
         for i in range(len(t1[1].columns)):
             hdu.data.field(i)[nrows1:] = t2[1].data.field(i)
 
-        hdu.writeto(self.temp('newtable.fits'))
+        hdu.writeto(self.temp('newtable.fits'), overwrite=True,)
 
         info = [(0, 'PRIMARY', 1, 'PrimaryHDU', 4, (), '', ''),
                 (1, '', 1, 'BinTableHDU', 19, '8R x 5C', '[10A, J, 10A, 5E, L]',
@@ -1717,11 +1717,13 @@ class TestTableFunctions(FitsTestCase):
              ([2, 3, 4, 5, 6, 7], 'row3' * 2)], formats='6i4,a8')
 
         thdu = fits.BinTableHDU.from_columns(data)
-        # Modify the TDIM fields to my own specification
-        thdu.header['TDIM1'] = '(2,3)'
-        thdu.header['TDIM2'] = '(4,2)'
 
         thdu.writeto(self.temp('newtable.fits'))
+
+        with fits.open(self.temp('newtable.fits'), mode='update') as hdul:
+            # Modify the TDIM fields to my own specification
+            hdul[1].header['TDIM1'] = '(2,3)'
+            hdul[1].header['TDIM2'] = '(4,2)'
 
         with fits.open(self.temp('newtable.fits')) as hdul:
             thdu = hdul[1]

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -560,7 +560,7 @@ class TestTableFunctions(FitsTestCase):
         for i in range(len(t1[1].columns)):
             hdu.data.field(i)[nrows1:] = t2[1].data.field(i)
 
-        hdu.writeto(self.temp('newtable.fits'), overwrite=True,)
+        hdu.writeto(self.temp('newtable.fits'))
 
         info = [(0, 'PRIMARY', 1, 'PrimaryHDU', 4, (), '', ''),
                 (1, '', 1, 'BinTableHDU', 19, '8R x 5C', '[10A, J, 10A, 5E, L]',
@@ -1782,6 +1782,7 @@ class TestTableFunctions(FitsTestCase):
 
             c = thdu.data.field(0)
             assert c.shape == (2, 1)
+            assert thdu.header['TDIM1'] == '(1)'
 
     def test_bin_table_init_from_string_array_column(self):
         """


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description

Add test for and fix writing and reading of fits columns that contain single values in 1d columns
This pull request is to address #10765 

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #10765 
