### PR TITLE
Speedup local docs build following ideas from #10187

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -99,12 +99,13 @@ commands =
 # This lets developers to use tox to build docs and ignores warnings.
 # This is not used in CI; For that, we have RTD PR builder.
 [testenv:build_docs]
+usedevelop = true
 changedir = docs
 description = invoke sphinx-build to build the HTML docs
 extras = docs
 commands =
     pip freeze
-    sphinx-build -b html . _build/html
+    sphinx-build -j auto -b html . _build/html
 
 [testenv:linkcheck]
 changedir = docs

--- a/tox.ini
+++ b/tox.ini
@@ -99,7 +99,6 @@ commands =
 # This lets developers to use tox to build docs and ignores warnings.
 # This is not used in CI; For that, we have RTD PR builder.
 [testenv:build_docs]
-usedevelop = true
 changedir = docs
 description = invoke sphinx-build to build the HTML docs
 extras = docs


### PR DESCRIPTION
I was going to revive #10187 but found that `-W` was removed in #10497 since the
docs build is now done by RTD and tox is no more used for this. So basically we
no more need two envs as proposed in #10187, and `-W` is already gone, but
I think that some improvements proposed there by @astrofrog are still
worthwhile:

- use develop mode to speedup installation
- use parallel mode for Sphinx

With this a build on my laptop goes from 12m 53s to 5m 8s (with 4 CPUs).

