### PR TITLE
Fix compilation of cfitsio with Xcode 12

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1027,6 +1027,8 @@ astropy.io.fits
 - Fix repr for commentary cards and strip spaces for commentary keywords.
   [#10640]
 
+- Fix compilation of cfitsio with Xcode 12. [#10772]
+
 astropy.io.misc
 ^^^^^^^^^^^^^^^
 

--- a/astropy/io/fits/setup_package.py
+++ b/astropy/io/fits/setup_package.py
@@ -42,6 +42,8 @@ def _get_compression_extension():
                 '-Wno-declaration-after-statement'
             ])
 
+            cfg['define_macros'].append(('HAVE_UNISTD_H', None))
+
             if not debug:
                 # these switches are to silence warnings from compiling CFITSIO
                 # For full silencing, some are added that only are used in


### PR DESCRIPTION
Fix compilation of cfitsio with Xcode 12

Fix #10770: Xcode 12 defines `-Werror=implicit-function-declaration`
flag by default which breaks the compilation of cfitsio. To fix this
we could shut off this flag but it's better to define `HAVE_UNISTD_H`
to really fix the warning.
