### PR TITLE
undoes part of #8108 that was incorrect

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1081,6 +1081,8 @@ astropy.modeling
 - Do not create new ``math_functions`` models for ufuncs that are
   only aliases (divide and mod). [#10697]
 
+- Fix calculation of the ``Moffat2D`` derivative with respect to gamma. [#10784]
+
 astropy.nddata
 ^^^^^^^^^^^^^^
 

--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -2324,7 +2324,7 @@ class Moffat2D(Fittable2DModel):
                  (gamma ** 2 * (1 + rr_gg)))
         d_alpha = -amplitude * d_A * np.log(1 + rr_gg)
         d_gamma = (2 * amplitude * alpha * d_A * rr_gg /
-                   (gamma ** 3 * (1 + rr_gg)))
+                   (gamma * (1 + rr_gg)))
         return [d_A, d_x_0, d_y_0, d_gamma, d_alpha]
 
     @property


### PR DESCRIPTION
# Description

This pull request is to address #8094 which was not a bug, but a bug was introduced by PR #8108

The `Moffat2D` gamma derivative is now (once again) correctly calculated, as shown in comments at the end of #8094
