### PR TITLE
Make QTable unit parsing more robust

### DIFF
--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -14,7 +14,7 @@ import numpy as np
 from numpy import ma
 
 from astropy import log
-from astropy.units import Quantity, QuantityInfo
+from astropy.units import Quantity, QuantityInfo, Unit
 from astropy.utils import isiterable, ShapedLikeNDArray
 from astropy.utils.console import color_print
 from astropy.utils.metadata import MetaData, MetaAttribute
@@ -3631,7 +3631,6 @@ class QTable(Table):
         return has_info_class(col, MixinInfo)
 
     def _convert_col_for_table(self, col):
-        from astropy.units import Unit
         if isinstance(col, Column) and getattr(col, 'unit', None) is not None:
             # What to do with MaskedColumn with units: leave as MaskedColumn or
             # turn into Quantity and drop mask?  Assuming we have masking support

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -3631,6 +3631,7 @@ class QTable(Table):
         return has_info_class(col, MixinInfo)
 
     def _convert_col_for_table(self, col):
+        from astropy.units import Unit
         if isinstance(col, Column) and getattr(col, 'unit', None) is not None:
             # What to do with MaskedColumn with units: leave as MaskedColumn or
             # turn into Quantity and drop mask?  Assuming we have masking support
@@ -3643,7 +3644,10 @@ class QTable(Table):
             # We need to turn the column into a quantity, or a subclass
             # identified in the unit (such as u.mag()).
             q_cls = getattr(col.unit, '_quantity_class', Quantity)
-            qcol = q_cls(col.data, col.unit, copy=False)
+            try:
+                qcol = q_cls(col.data, Unit(str(col.unit)), copy=False)
+            except ValueError:
+                qcol = q_cls(col.data, col.unit, copy=False)
             qcol.info = col.info
             col = qcol
         else:

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -2601,6 +2601,12 @@ def test_set_units_descriptions_read():
         assert t['a'].info.description == 'hi'
         assert t['b'].info.description == 'there'
 
+def test_qtable_unit_parsing():
+    """Test QTable unit parsing fix #10786"""
+    filename = get_pkg_data_filename('data/nonstandard_units.xml',
+                                     'astropy.io.votable.tests')
+    a = QTable.read(filename)
+    assert not isinstance(a['Flux1'].unit, u.UnrecognizedUnit)
 
 def test_broadcasting_8933():
     """Explicitly check re-work of code related to broadcasting in #8933"""

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -2601,12 +2601,14 @@ def test_set_units_descriptions_read():
         assert t['a'].info.description == 'hi'
         assert t['b'].info.description == 'there'
 
+
 def test_qtable_unit_parsing():
     """Test QTable unit parsing fix #10786"""
     filename = get_pkg_data_filename('data/nonstandard_units.xml',
                                      'astropy.io.votable.tests')
     a = QTable.read(filename)
     assert not isinstance(a['Flux1'].unit, u.UnrecognizedUnit)
+
 
 def test_broadcasting_8933():
     """Explicitly check re-work of code related to broadcasting in #8933"""


### PR DESCRIPTION
So far QTable has been much more stringent about the unit format than
units.Unit. For example, units such as km.s**-1 are not recognized by
QTable even though Unit is able to parse them just fine. As a result
QTable does not convert columns with such units into Quantities even
though it should. This update fixes the issue by making use of the unit
parsing capabilities that Unit already has.