### PR TITLE
Set representation type using argument class when appropriate

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,6 +34,11 @@ astropy.coordinates
 - Method ``.realize_frame`` from coordinate frames now accepts ``**kwargs``,
   including ``representation_type``. [#10727]
 
+- Initializing a ``BaseCoordinateFrame`` from a ``BaseRepresentation`` now sets its ``representation_type``
+  to the class of the argument. This means that the default representation of the frame might be overridden,
+  and therefore the readily available attributes might change. To retain the previous behaviour,
+  pass a explicit ``representation_type=`` to the initializer and to methods like ``.realize_frame```. [#10788]
+
 
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -463,6 +463,13 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
                     'and other positional arguments')
 
             if representation_data is not None:
+                if not hasattr(self, '_representation'):
+                    # Representation has not been set yet, do it now
+                    # This saves the need to specify the type twice in cases like
+                    # `ICRS(CartesianRepresentation(...), representation_type="cartesian")`
+                    # and effectively overrides the default representation of the frame,
+                    # see https://github.com/astropy/astropy/issues/6435
+                    self.set_representation_cls(representation_data.__class__)
                 diffs = representation_data.differentials
                 differential_data = diffs.get('s', None)
                 if ((differential_data is None and len(diffs) > 0) or

--- a/astropy/coordinates/builtin_frames/cirs_observed_transforms.py
+++ b/astropy/coordinates/builtin_frames/cirs_observed_transforms.py
@@ -91,7 +91,7 @@ def altaz_to_cirs(altaz_coo, cirs_frame):
         loccirs = altaz_coo.location.get_itrs(altaz_coo.obstime).transform_to(cirs_frame)
 
         astrometric_rep = SphericalRepresentation(lon=cirs_ra, lat=cirs_dec,
-                                                  distance=altaz_coo.distance)
+                                                  distance=altaz_coo.spherical.distance)
         newrepr = astrometric_rep + loccirs.cartesian
         cirs_at_aa_time = CIRS(newrepr, obstime=altaz_coo.obstime)
 

--- a/astropy/coordinates/builtin_frames/ecliptic_transforms.py
+++ b/astropy/coordinates/builtin_frames/ecliptic_transforms.py
@@ -70,14 +70,14 @@ def gcrs_to_geoecliptic(gcrs_coo, to_frame):
 
     rmat = _mean_ecliptic_rotation_matrix(to_frame.equinox)
     newrepr = gcrs_coo2.cartesian.transform(rmat)
-    return to_frame.realize_frame(newrepr)
+    return to_frame.realize_frame(newrepr, representation_type=gcrs_coo.representation_type)
 
 
 @frame_transform_graph.transform(FunctionTransformWithFiniteDifference, GeocentricMeanEcliptic, GCRS)
 def geoecliptic_to_gcrs(from_coo, gcrs_frame):
     rmat = _mean_ecliptic_rotation_matrix(from_coo.equinox)
     newrepr = from_coo.cartesian.transform(matrix_transpose(rmat))
-    gcrs = GCRS(newrepr, obstime=from_coo.obstime)
+    gcrs = GCRS(newrepr, obstime=from_coo.obstime, representation_type=from_coo.representation_type)
 
     # now do any needed offsets (no-op if same obstime and 0 pos/vel)
     return gcrs.transform_to(gcrs_frame)
@@ -148,14 +148,14 @@ def gcrs_to_true_geoecliptic(gcrs_coo, to_frame):
 
     rmat = _true_ecliptic_rotation_matrix(to_frame.equinox)
     newrepr = gcrs_coo2.cartesian.transform(rmat)
-    return to_frame.realize_frame(newrepr)
+    return to_frame.realize_frame(newrepr, representation_type=gcrs_coo.representation_type)
 
 
 @frame_transform_graph.transform(FunctionTransformWithFiniteDifference, GeocentricTrueEcliptic, GCRS)
 def true_geoecliptic_to_gcrs(from_coo, gcrs_frame):
     rmat = _true_ecliptic_rotation_matrix(from_coo.equinox)
     newrepr = from_coo.cartesian.transform(matrix_transpose(rmat))
-    gcrs = GCRS(newrepr, obstime=from_coo.obstime)
+    gcrs = GCRS(newrepr, obstime=from_coo.obstime, representation_type=from_coo.representation_type)
 
     # now do any needed offsets (no-op if same obstime and 0 pos/vel)
     return gcrs.transform_to(gcrs_frame)

--- a/astropy/coordinates/builtin_frames/fk4.py
+++ b/astropy/coordinates/builtin_frames/fk4.py
@@ -163,7 +163,7 @@ def fk4_to_fk4_no_e(fk4coord, fk4noeframe):
     # if no obstime was given in the new frame, use the old one for consistency
     newobstime = fk4coord._obstime if fk4noeframe._obstime is None else fk4noeframe._obstime
 
-    fk4noe = FK4NoETerms(rep, equinox=fk4coord.equinox, obstime=newobstime)
+    fk4noe = FK4NoETerms(rep, equinox=fk4coord.equinox, obstime=newobstime, representation_type=fk4coord.representation_type)
     if fk4coord.equinox != fk4noeframe.equinox:
         # precession
         fk4noe = fk4noe.transform_to(fk4noeframe)
@@ -206,4 +206,4 @@ def fk4_no_e_to_fk4(fk4noecoord, fk4frame):
     if isinstance(fk4noecoord.data, UnitSphericalRepresentation):
         rep = rep.represent_as(UnitSphericalRepresentation)
 
-    return fk4frame.realize_frame(rep)
+    return fk4frame.realize_frame(rep, representation_type=fk4noecoord.representation_type)

--- a/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
@@ -96,7 +96,7 @@ def cirs_to_icrs(cirs_coo, icrs_frame):
 @frame_transform_graph.transform(FunctionTransformWithFiniteDifference, CIRS, CIRS)
 def cirs_to_cirs(from_coo, to_frame):
     if np.all(from_coo.obstime == to_frame.obstime):
-        return to_frame.realize_frame(from_coo.data)
+        return to_frame.realize_frame(from_coo.data, representation_type=from_coo.representation_type)
     else:
         # the CIRS<-> CIRS transform actually goes through ICRS.  This has a
         # subtle implication that a point in CIRS is uniquely determined
@@ -179,7 +179,7 @@ def gcrs_to_icrs(gcrs_coo, icrs_frame):
 def gcrs_to_gcrs(from_coo, to_frame):
     if (np.all(from_coo.obstime == to_frame.obstime) and
             np.all(from_coo.obsgeoloc == to_frame.obsgeoloc)):
-        return to_frame.realize_frame(from_coo.data)
+        return to_frame.realize_frame(from_coo.data, representation_type=from_coo.representation_type)
     else:
         # like CIRS, we do this self-transform via ICRS
         return from_coo.transform_to(ICRS()).transform_to(to_frame)

--- a/astropy/coordinates/builtin_frames/intermediate_rotation_transforms.py
+++ b/astropy/coordinates/builtin_frames/intermediate_rotation_transforms.py
@@ -76,7 +76,7 @@ def gcrs_to_cirs(gcrs_coo, cirs_frame):
     # now get the pmatrix
     pmat = gcrs_to_cirs_mat(cirs_frame.obstime)
     crepr = gcrs_coo2.cartesian.transform(pmat)
-    return cirs_frame.realize_frame(crepr)
+    return cirs_frame.realize_frame(crepr, representation_type=gcrs_coo.representation_type)
 
 
 @frame_transform_graph.transform(FunctionTransformWithFiniteDifference, CIRS, GCRS)
@@ -84,7 +84,7 @@ def cirs_to_gcrs(cirs_coo, gcrs_frame):
     # compute the pmatrix, and then multiply by its transpose
     pmat = gcrs_to_cirs_mat(cirs_coo.obstime)
     newrepr = cirs_coo.cartesian.transform(matrix_transpose(pmat))
-    gcrs = GCRS(newrepr, obstime=cirs_coo.obstime)
+    gcrs = GCRS(newrepr, obstime=cirs_coo.obstime, representation_type=cirs_coo.representation_type)
 
     # now do any needed offsets (no-op if same obstime and 0 pos/vel)
     return gcrs.transform_to(gcrs_frame)
@@ -98,7 +98,7 @@ def cirs_to_itrs(cirs_coo, itrs_frame):
     # now get the pmatrix
     pmat = cirs_to_itrs_mat(itrs_frame.obstime)
     crepr = cirs_coo2.cartesian.transform(pmat)
-    return itrs_frame.realize_frame(crepr)
+    return itrs_frame.realize_frame(crepr, representation_type=cirs_coo.representation_type)
 
 
 @frame_transform_graph.transform(FunctionTransformWithFiniteDifference, ITRS, CIRS)
@@ -106,7 +106,7 @@ def itrs_to_cirs(itrs_coo, cirs_frame):
     # compute the pmatrix, and then multiply by its transpose
     pmat = cirs_to_itrs_mat(itrs_coo.obstime)
     newrepr = itrs_coo.cartesian.transform(matrix_transpose(pmat))
-    cirs = CIRS(newrepr, obstime=itrs_coo.obstime)
+    cirs = CIRS(newrepr, obstime=itrs_coo.obstime, representation_type=itrs_coo.representation_type)
 
     # now do any needed offsets (no-op if same obstime)
     return cirs.transform_to(cirs_frame)
@@ -134,7 +134,7 @@ def gcrs_to_precessedgeo(from_coo, to_frame):
     # now precess to the requested equinox
     pmat = gcrs_precession_mat(to_frame.equinox)
     crepr = gcrs_coo.cartesian.transform(pmat)
-    return to_frame.realize_frame(crepr)
+    return to_frame.realize_frame(crepr, representation_type=from_coo.representation_type)
 
 
 @frame_transform_graph.transform(FunctionTransformWithFiniteDifference, PrecessedGeocentric, GCRS)
@@ -145,7 +145,8 @@ def precessedgeo_to_gcrs(from_coo, to_frame):
     gcrs_coo = GCRS(crepr,
                     obstime=to_frame.obstime,
                     obsgeoloc=to_frame.obsgeoloc,
-                    obsgeovel=to_frame.obsgeovel)
+                    obsgeovel=to_frame.obsgeovel,
+                    representation_type=from_coo.representation_type)
 
     # then move to the GCRS that's actually desired
     return gcrs_coo.transform_to(to_frame)
@@ -160,7 +161,7 @@ def teme_to_itrs(teme_coo, itrs_frame):
     # now get the pmatrix
     pmat = teme_to_itrs_mat(itrs_frame.obstime)
     crepr = teme_coo2.cartesian.transform(pmat)
-    return itrs_frame.realize_frame(crepr)
+    return itrs_frame.realize_frame(crepr, representation_type=teme_coo.representation_type)
 
 
 @frame_transform_graph.transform(FunctionTransformWithFiniteDifference, ITRS, TEME)
@@ -168,7 +169,7 @@ def itrs_to_teme(itrs_coo, teme_frame):
     # compute the pmatrix, and then multiply by its transpose
     pmat = teme_to_itrs_mat(itrs_coo.obstime)
     newrepr = itrs_coo.cartesian.transform(matrix_transpose(pmat))
-    teme = TEME(newrepr, obstime=itrs_coo.obstime)
+    teme = TEME(newrepr, obstime=itrs_coo.obstime, representation_type=itrs_coo.representation_type)
 
     # now do any needed offsets (no-op if same obstime)
     return teme.transform_to(teme_frame)

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -624,6 +624,10 @@ class SkyCoord(ShapedLikeNDArray):
                      set(frame_kwargs.keys())):
             frame_kwargs.pop(attr)
 
+        # Ensure transformed coordinates have representation and differential types
+        # as set by the destination frame
+        new_coord.set_representation_cls(frame.default_representation, frame.default_differential)
+
         return self.__class__(new_coord, **frame_kwargs)
 
     def apply_space_motion(self, new_obstime=None, dt=None):

--- a/astropy/coordinates/solar_system.py
+++ b/astropy/coordinates/solar_system.py
@@ -522,4 +522,4 @@ def _apparent_position_in_true_coordinates(skycoord):
     # (same as in builtin_frames.utils.get_cip).
     rbpn = erfa.pnm06a(jd1, jd2)
     return SkyCoord(skycoord.frame.realize_frame(
-        skycoord.cartesian.transform(rbpn)))
+        skycoord.cartesian.transform(rbpn), representation_type="spherical"))

--- a/astropy/coordinates/tests/test_api_ape5.py
+++ b/astropy/coordinates/tests/test_api_ape5.py
@@ -200,7 +200,7 @@ def test_frame_api():
     assert_allclose(icrs.dec, 5*u.deg)
     assert_allclose(fk5.ra, 8*u.hourangle)
 
-    assert icrs.representation_type == SphericalRepresentation
+    assert icrs.representation_type == UnitSphericalRepresentation
 
     # low-level classes can also be initialized with names valid for that representation
     # and frame:

--- a/astropy/coordinates/tests/test_distance.py
+++ b/astropy/coordinates/tests/test_distance.py
@@ -98,7 +98,7 @@ def test_distances():
     # system
     # csum = ICRS(c1.cartesian + c2.cartesian)
     csumrep = CartesianRepresentation(c1.cartesian.xyz + c2.cartesian.xyz)
-    csum = ICRS(csumrep)
+    csum = ICRS(csumrep, representation_type="spherical")
 
     npt.assert_allclose(csumrep.x.value, -8.12016610185)
     npt.assert_allclose(csumrep.y.value, 3.19380597435)

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -1510,3 +1510,24 @@ def test_realize_frame_accepts_kwargs():
 
     assert c2.representation_type == r.CartesianRepresentation
     assert c3.representation_type == r.CylindricalRepresentation
+
+
+@pytest.mark.parametrize("distance", (None, 10 * u.au))
+def test_transform_to_retains_representation(distance):
+    c = ICRS(ra=1 * u.deg, dec=2 * u.deg, distance=distance)
+    g = c.transform_to(Galactic())
+    fk4 = c.transform_to(FK4())
+    cfk4 = fk4.transform_to(ICRS())
+
+    c2 = FK5(ra=150 * u.deg, dec=-17 * u.deg, distance=1 * u.pc)
+    g2 = c2.transform_to(Galactic())
+
+    # Representation of ICRS is always SphericalRepresentation,
+    # even when underlying data is UnitSphericalRepresentation
+    assert c.representation_type == r.SphericalRepresentation
+
+    assert g.representation_type == g.default_representation
+    assert fk4.representation_type == fk4.default_representation
+    assert cfk4.representation_type == cfk4.default_representation
+
+    assert g2.representation_type == g2.default_representation

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -1531,3 +1531,25 @@ def test_transform_to_retains_representation(distance):
     assert cfk4.representation_type == cfk4.default_representation
 
     assert g2.representation_type == g2.default_representation
+
+
+def test_instantiate_frame_with_representation_keeps_type():
+    # https://github.com/astropy/astropy/issues/6435
+    # and https://github.com/astropy/astropy/issues/10253
+    rep = r.CartesianRepresentation([1, 2, 3] * u.au)
+    c1 = ICRS(rep)
+
+    assert c1.representation_type == rep.__class__
+
+
+def test_representation_can_be_overridden():
+    # See discussion in https://github.com/astropy/astropy/issues/6435
+    rep = r.CartesianRepresentation([1, 2, 3] * u.au)
+    c1 = ICRS(rep, representation_type=r.CylindricalRepresentation)
+
+    assert c1.representation_type == r.CylindricalRepresentation
+
+    urep = r.UnitSphericalRepresentation(10 * u.deg, 20 * u.deg)
+    c2 = ICRS(urep, representation_type=r.SphericalRepresentation)
+
+    assert c2.representation_type == r.SphericalRepresentation

--- a/astropy/coordinates/tests/test_frames_with_velocity.py
+++ b/astropy/coordinates/tests/test_frames_with_velocity.py
@@ -325,4 +325,4 @@ def test_velocity_units():
 def test_frame_with_velocity_without_distance_can_be_transformed():
     frame = CIRS(1*u.deg, 2*u.deg, pm_dec=1*u.mas/u.yr, pm_ra_cosdec=2*u.mas/u.yr)
     rep = frame.transform_to(ICRS())
-    assert "<ICRS Coordinate: (ra, dec, distance) in" in repr(rep)
+    assert "<ICRS Coordinate: (ra, dec) in" in repr(rep)

--- a/astropy/coordinates/tests/test_intermediate_transformations.py
+++ b/astropy/coordinates/tests/test_intermediate_transformations.py
@@ -89,7 +89,7 @@ def test_icrs_gcrs(icoo):
     gcrscoo = icoo.transform_to(gcrs_frames[0])  # uses the default time
     # first do a round-tripping test
     icoo2 = gcrscoo.transform_to(ICRS())
-    assert_allclose(icoo.distance, icoo2.distance)
+    assert_allclose(icoo.spherical.distance, icoo2.spherical.distance)
     assert_allclose(icoo.ra, icoo2.ra)
     assert_allclose(icoo.dec, icoo2.dec)
     assert isinstance(icoo2.data, icoo.data.__class__)
@@ -181,9 +181,9 @@ def test_gcrs_itrs():
     assert not allclose(gcrs.dec, gcrs6_2.dec)
 
     # also try with the cartesian representation
-    gcrsc = gcrs.realize_frame(gcrs.data)
-    gcrsc.representation_type = CartesianRepresentation
+    gcrsc = gcrs.realize_frame(gcrs.data, representation_type=CartesianRepresentation)
     gcrsc2 = gcrsc.transform_to(ITRS()).transform_to(gcrsc)
+    gcrsc2.representation_type = SphericalRepresentation
     assert_allclose(gcrsc.spherical.lon.deg, gcrsc2.ra.deg)
     assert_allclose(gcrsc.spherical.lat, gcrsc2.dec)
 
@@ -324,7 +324,7 @@ def test_gcrs_altaz_moonish(testframe):
     Sanity-check that an object resembling the moon goes to the right place with
     a GCRS->AltAz transformation
     """
-    moon = GCRS(MOONDIST_CART, obstime=testframe.obstime)
+    moon = GCRS(MOONDIST_CART, obstime=testframe.obstime, representation_type=SphericalRepresentation)
 
     moonaa = moon.transform_to(testframe)
 
@@ -362,7 +362,7 @@ def test_cirs_altaz_moonish(testframe):
     Sanity-check that an object resembling the moon goes to the right place with
     a CIRS<->AltAz transformation
     """
-    moon = CIRS(MOONDIST_CART, obstime=testframe.obstime)
+    moon = CIRS(MOONDIST_CART, obstime=testframe.obstime, representation_type=SphericalRepresentation)
 
     moonaa = moon.transform_to(testframe)
     assert 1000*u.km < np.abs(moonaa.distance - moon.distance).to(u.km) < 7000*u.km

--- a/astropy/coordinates/tests/test_regression.py
+++ b/astropy/coordinates/tests/test_regression.py
@@ -408,8 +408,12 @@ def test_regression_6236():
     rep1 = UnitSphericalRepresentation([0., 1]*u.deg, [2., 3.]*u.deg)
     rep2 = SphericalRepresentation([10., 11]*u.deg, [12., 13.]*u.deg,
                                    [14., 15.]*u.kpc)
-    mf1 = MyFrame(rep1, my_attr=1.*u.km)
-    mf2 = mf1.realize_frame(rep2)
+    # NOTE: As discussed in https://github.com/astropy/astropy/issues/6435,
+    # the type of the representation should take precedence over the frame default representation
+    # and having to set the representation_type here is an acceptable change
+    # after https://github.com/astropy/astropy/issues/7784 was fixed in https://github.com/astropy/astropy/pull/10727
+    mf1 = MyFrame(rep1, my_attr=1.*u.km, representation_type=CartesianRepresentation)
+    mf2 = mf1.realize_frame(rep2, representation_type=CartesianRepresentation)
     # Normally, data is stored as is, but the representation gets set to a
     # default, even if a different representation instance was passed in.
     # realize_frame should do the same. Just in case, check attrs are passed.
@@ -418,9 +422,9 @@ def test_regression_6236():
     assert mf1.representation_type is CartesianRepresentation
     assert mf2.representation_type is CartesianRepresentation
     assert mf2.my_attr == mf1.my_attr
-    # It should be independent of whether I set the reprensentation explicitly
+    # It should be independent of whether I set the representation explicitly
     mf3 = MyFrame(rep1, my_attr=1.*u.km, representation_type='unitspherical')
-    mf4 = mf3.realize_frame(rep2)
+    mf4 = mf3.realize_frame(rep2, representation_type=CartesianRepresentation)
     assert mf3.data is rep1
     assert mf4.data is rep2
     assert mf3.representation_type is UnitSphericalRepresentation

--- a/astropy/coordinates/tests/test_skyoffset_transformations.py
+++ b/astropy/coordinates/tests/test_skyoffset_transformations.py
@@ -292,10 +292,10 @@ def test_skyoffset_lonwrap():
     sc2 = SkyCoord(-10*u.deg, -45*u.deg, frame=SkyOffsetFrame(origin=origin))
     assert sc2.lon < 180 * u.deg
 
-    sc3 = sc.realize_frame(sc.represent_as('cartesian'))
+    sc3 = sc.realize_frame(sc.represent_as('cartesian'), representation_type="spherical")
     assert sc3.lon < 180 * u.deg
 
-    sc4 = sc2.realize_frame(sc2.represent_as('cartesian'))
+    sc4 = sc2.realize_frame(sc2.represent_as('cartesian'), representation_type="spherical")
     assert sc4.lon < 180 * u.deg
 
 

--- a/astropy/coordinates/transformations.py
+++ b/astropy/coordinates/transformations.py
@@ -933,14 +933,14 @@ class FunctionTransformWithFiniteDifference(FunctionTransform):
             if self.symmetric_finite_difference:
                 fwdxyz = (fromcoord_cart.xyz +
                           fromcoord_cart.differentials['s'].d_xyz*halfdt)
-                fwd = supcall(fromcoord.realize_frame(CartesianRepresentation(fwdxyz)), toframe)
+                fwd = supcall(fromcoord.realize_frame(CartesianRepresentation(fwdxyz), representation_type=fromcoord.representation_type), toframe)
                 backxyz = (fromcoord_cart.xyz -
                            fromcoord_cart.differentials['s'].d_xyz*halfdt)
-                back = supcall(fromcoord.realize_frame(CartesianRepresentation(backxyz)), toframe)
+                back = supcall(fromcoord.realize_frame(CartesianRepresentation(backxyz), representation_type=fromcoord.representation_type), toframe)
             else:
                 fwdxyz = (fromcoord_cart.xyz +
                           fromcoord_cart.differentials['s'].d_xyz*dt)
-                fwd = supcall(fromcoord.realize_frame(CartesianRepresentation(fwdxyz)), toframe)
+                fwd = supcall(fromcoord.realize_frame(CartesianRepresentation(fwdxyz), representation_type=fromcoord.representation_type), toframe)
                 back = reprwithoutdiff
             diffxyz = (fwd.cartesian - back.cartesian).xyz / dt
 
@@ -990,7 +990,7 @@ class FunctionTransformWithFiniteDifference(FunctionTransform):
 
             newdiff = CartesianDifferential(diffxyz)
             reprwithdiff = reprwithoutdiff.data.to_cartesian().with_differentials(newdiff)
-            return reprwithoutdiff.realize_frame(reprwithdiff)
+            return reprwithoutdiff.realize_frame(reprwithdiff, representation_type=reprwithoutdiff.representation_type)
         else:
             return supcall(fromcoord, toframe)
 
@@ -1210,7 +1210,7 @@ class AffineTransform(BaseAffineTransform):
         M, vec = self.transform_func(fromcoord, toframe)
         newrep = self._apply_transform(fromcoord, M, vec)
 
-        return toframe.realize_frame(newrep)
+        return toframe.realize_frame(newrep, representation_type=fromcoord.representation_type)
 
 
 class StaticMatrixTransform(BaseAffineTransform):
@@ -1259,7 +1259,7 @@ class StaticMatrixTransform(BaseAffineTransform):
 
     def __call__(self, fromcoord, toframe):
         newrep = self._apply_transform(fromcoord, self.matrix, None)
-        return toframe.realize_frame(newrep)
+        return toframe.realize_frame(newrep, representation_type=fromcoord.representation_type)
 
 
 class DynamicMatrixTransform(BaseAffineTransform):
@@ -1309,7 +1309,7 @@ class DynamicMatrixTransform(BaseAffineTransform):
     def __call__(self, fromcoord, toframe):
         M = self.matrix_func(fromcoord, toframe)
         newrep = self._apply_transform(fromcoord, M, None)
-        return toframe.realize_frame(newrep)
+        return toframe.realize_frame(newrep, representation_type=fromcoord.representation_type)
 
 
 class CompositeTransform(CoordinateTransform):

--- a/docs/coordinates/skycoord.rst
+++ b/docs/coordinates/skycoord.rst
@@ -1051,6 +1051,7 @@ As the next step, those coordinates are transformed into an
 Again, as in the last example, we need to convert the coordinates in radians
 and make sure they are between :math:`-\pi` and :math:`\pi`:
 
+    >>> c_gal_icrs.representation_type = "spherical"
     >>> ra_rad = c_gal_icrs.ra.wrap_at(180 * u.deg).radian
     >>> dec_rad = c_gal_icrs.dec.radian
 

--- a/docs/coordinates/velocities.rst
+++ b/docs/coordinates/velocities.rst
@@ -225,7 +225,7 @@ the existing frame using
         (1., 2., 3.)>
     >>> vel_to_add = CartesianDifferential(4*u.km/u.s, 5*u.km/u.s, 6*u.km/u.s)
     >>> newdata = icrs.data.to_cartesian().with_differentials(vel_to_add)
-    >>> icrs.realize_frame(newdata) # doctest: +FLOAT_CMP
+    >>> icrs.realize_frame(newdata, representation_type="spherical", differential_type="sphericalcoslat") # doctest: +FLOAT_CMP
     <ICRS Coordinate: (ra, dec, distance) in (deg, deg, kpc)
         (1., 2., 3.)
      (pm_ra_cosdec, pm_dec, radial_velocity) in (mas / yr, mas / yr, km / s)
@@ -243,7 +243,7 @@ specifying the differentials because of the lack of explicit unit information::
         (1., 2.)>
     >>> rv_to_add = RadialDifferential(500*u.km/u.s)
     >>> data_with_rv = icrs_no_distance.data.with_differentials({'s':rv_to_add})
-    >>> icrs_no_distance.realize_frame(data_with_rv) # doctest: +FLOAT_CMP
+    >>> icrs_no_distance.realize_frame(data_with_rv, differential_type="sphericalcoslat") # doctest: +FLOAT_CMP
     <ICRS Coordinate: (ra, dec) in deg
         (1., 2.)
      (radial_velocity) in km / s


### PR DESCRIPTION
### Description

This pull request fixes #6435 by setting the `representation_type` of the frame from the args if they are `BaseRepresentation` objects. This avoids tedious code like `GCRS(CartesianRepresentation(...), representation="cartesian")`.

This made me realize that there might be places where unnecessary round-tripping conversion is done between representations. For example, many transformations starting from spherical coordinates will convert to cartesian, and then back to spherical because it is assumed everywhere that the spherical attributes of the transformed frame can be accessed without `.spherical` intermediate steps. This is related to [@ayshih comment here](https://github.com/astropy/astropy/issues/6435#issuecomment-688567347):

> It's admittedly odd that `.data` can be a different representation than what shows in the `repr`, but what I tell SunPy users is to never use `.data`. If they want to access the component data and the type of representation matters, I tell them to be explicit: e.g., use `.spherical`.

Nothing is said in `SkyCoord.transform_to` or `BaseCoordinateFrame.transform_to` about this assumption, but I decided to retain it anyway. This required setting explicit `representation_type=` in several `realize_frame` calls in the transformation functions, as well as initializers, which will require downstream users to adapt, as was already discussed in #6435 (SunPy will surely be affected). All coordinates tests passed locally, but I will give another closer look.

I made changes in 7 tests to adapt to this new behaviour.