### PR TITLE
Fix #10785: work around matplotlib warning caused by PyInstaller

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,12 @@ distribute-*.tar.gz
 .venv
 venv
 
+# pyinstaller files
+.pyinstaller/astropy_tests/
+.pyinstaller/run_astropy_tests
+.pyinstaller/run_astropy_tests.spec
+
+
 # Other
 .cache
 .tox

--- a/astropy/conftest.py
+++ b/astropy/conftest.py
@@ -6,6 +6,7 @@ making use of astropy's test runner).
 """
 import os
 import builtins
+import sys
 import tempfile
 import warnings
 
@@ -19,6 +20,15 @@ import pytest
 from astropy.tests.helper import enable_deprecations_as_exceptions
 
 try:
+    # This is needed to silence a warning from matplotlib caused by
+    # PyInstaller's matplotlib runtime hook.  This can be removed once the
+    # issue is fixed upstream in PyInstaller, and only impacts us when running
+    # the tests from a PyInstaller bundle.
+    # See https://github.com/astropy/astropy/issues/10785
+    if getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS'):
+        # The above checks whether we are running in a PyInstaller bundle.
+        warnings.filterwarnings("ignore", "(?s).*MATPLOTLIBDATA.*",
+                                category=UserWarning)
     import matplotlib
 except ImportError:
     HAS_MATPLOTLIB = False


### PR DESCRIPTION
The warning is caused by PyInstaller's runtime hook for matplotlib, and prevents the Astropy tests from running without error when testing the PyInstaller build in our CI.
    
This workaround does not fix the issue in general: e.g. users using PyInstaller to bundle an application that users Astropy will have to include a similar fix in their own code (as the issue is not unique to Astropy).

EDIT: Fix #10785 