### PR TITLE
Fix WCSAxes bbox calculation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -954,6 +954,10 @@ astropy.utils
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 
+- Fixed the caclulation of the tight bounding box of a ``WCSAxes``. This should
+  also significantly improve the application of ``tight_layout()`` to figures
+  containing ``WCSAxes``. [#10797]
+
 astropy.wcs
 ^^^^^^^^^^^
 
@@ -1232,10 +1236,6 @@ astropy.visualization
 
 - Fixed a bug where ``axes.xlabel``/``axes.ylabel`` where not correctly set
   nor returned on an ``EllipticalFrame`` class ``WCSAxes`` plot. [#10446]
-
-- Fixed the caclulation of the tight bounding box of a ``WCSAxes``. This should
-  also significantly improve the application of ``tight_layout()`` to figures
-  containing ``WCSAxes``. [#10797]
 
 astropy.wcs
 ^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1233,6 +1233,10 @@ astropy.visualization
 - Fixed a bug where ``axes.xlabel``/``axes.ylabel`` where not correctly set
   nor returned on an ``EllipticalFrame`` class ``WCSAxes`` plot. [#10446]
 
+- Fixed the caclulation of the tight bounding box of a ``WCSAxes``. This should
+  also significantly improve the application of ``tight_layout()`` to figures
+  containing ``WCSAxes``. [#10797]
+
 astropy.wcs
 ^^^^^^^^^^^
 

--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -623,6 +623,7 @@ class WCSAxes(Axes):
             return
 
         bb = [b for b in self._bboxes if b and (b.width != 0 or b.height != 0)]
+        bb.append(super().get_tightbbox(renderer, *args, **kwargs))
 
         if bb:
             _bbox = Bbox.union(bb)

--- a/astropy/visualization/wcsaxes/tests/test_misc.py
+++ b/astropy/visualization/wcsaxes/tests/test_misc.py
@@ -499,3 +499,17 @@ def test_set_labels_with_coords(ignore_matplotlibrc, frame_class):
     assert ax.get_ylabel() == labels[1]
     for i in range(2):
         assert ax.coords[i].get_axislabel() == labels[i]
+
+
+def test_bbox_size():
+    # Test for the size of a WCSAxes bbox
+    fig = plt.figure()
+    ax = WCSAxes(fig, [0.1, 0.1, 0.8, 0.8])
+    fig.add_axes(ax)
+    fig.canvas.draw()
+    renderer = fig.canvas.renderer
+    ax_bbox = ax.get_tightbbox(renderer)
+    assert ax_bbox.x0 == 11.38888888888889
+    assert ax_bbox.x1 == 576
+    assert ax_bbox.y0 == 3.5
+    assert ax_bbox.y1 == 432

--- a/astropy/visualization/wcsaxes/tests/test_misc.py
+++ b/astropy/visualization/wcsaxes/tests/test_misc.py
@@ -23,7 +23,7 @@ from astropy.visualization.wcsaxes.transforms import CurvedTransform
 mpl_version = Version(matplotlib.__version__)
 MATPLOTLIB_LT_21 = mpl_version < Version("2.1")
 MATPLOTLIB_LT_22 = mpl_version < Version("2.2")
-NOT_MATPLOTLIB_33 = mpl_version.major != 3 or mpl_version.minor != 3
+MATPLOTLIB_33 = mpl_version.major == 3 or mpl_version.minor == 3
 TEX_UNAVAILABLE = not matplotlib.checkdep_usetex(True)
 
 DATA = os.path.abspath(os.path.join(os.path.dirname(__file__), 'data'))
@@ -503,7 +503,7 @@ def test_set_labels_with_coords(ignore_matplotlibrc, frame_class):
         assert ax.coords[i].get_axislabel() == labels[i]
 
 
-@pytest.mark.skipif('NOT_MATPLOTLIB_33')
+@pytest.mark.skipif('not MATPLOTLIB_33')
 def test_bbox_size():
     # Test for the size of a WCSAxes bbox
     fig = plt.figure()

--- a/astropy/visualization/wcsaxes/tests/test_misc.py
+++ b/astropy/visualization/wcsaxes/tests/test_misc.py
@@ -510,6 +510,6 @@ def test_bbox_size():
     renderer = fig.canvas.renderer
     ax_bbox = ax.get_tightbbox(renderer)
     assert ax_bbox.x0 == 11.38888888888889
-    assert ax_bbox.x1 == 576
+    assert ax_bbox.x1 == 579.5
     assert ax_bbox.y0 == 3.5
     assert ax_bbox.y1 == 432

--- a/astropy/visualization/wcsaxes/tests/test_misc.py
+++ b/astropy/visualization/wcsaxes/tests/test_misc.py
@@ -20,8 +20,10 @@ from astropy.visualization.wcsaxes.frame import (
 from astropy.visualization.wcsaxes.utils import get_coord_meta
 from astropy.visualization.wcsaxes.transforms import CurvedTransform
 
-MATPLOTLIB_LT_21 = Version(matplotlib.__version__) < Version("2.1")
-MATPLOTLIB_LT_22 = Version(matplotlib.__version__) < Version("2.2")
+mpl_version = Version(matplotlib.__version__)
+MATPLOTLIB_LT_21 = mpl_version < Version("2.1")
+MATPLOTLIB_LT_22 = mpl_version < Version("2.2")
+NOT_MATPLOTLIB_33 = mpl_version.major != 3 or mpl_version.minor != 3
 TEX_UNAVAILABLE = not matplotlib.checkdep_usetex(True)
 
 DATA = os.path.abspath(os.path.join(os.path.dirname(__file__), 'data'))
@@ -501,6 +503,7 @@ def test_set_labels_with_coords(ignore_matplotlibrc, frame_class):
         assert ax.coords[i].get_axislabel() == labels[i]
 
 
+@pytest.mark.skipif('NOT_MATPLOTLIB_33')
 def test_bbox_size():
     # Test for the size of a WCSAxes bbox
     fig = plt.figure()
@@ -509,7 +512,7 @@ def test_bbox_size():
     fig.canvas.draw()
     renderer = fig.canvas.renderer
     ax_bbox = ax.get_tightbbox(renderer)
-    assert ax_bbox.x0 == 11.38888888888889
-    assert ax_bbox.x1 == 579.5
-    assert ax_bbox.y0 == 3.5
-    assert ax_bbox.y1 == 432
+    assert np.allclose(ax_bbox.x0, 11.38888888888889)
+    assert np.allclose(ax_bbox.x1, 576)
+    assert np.allclose(ax_bbox.y0, 3.5)
+    assert np.allclose(ax_bbox.y1, 432)


### PR DESCRIPTION
Fixes https://github.com/astropy/astropy/issues/10796.

This includes the axes bounding box in the caclulation; previously only the tick label bboxes were included.