### PR TITLE
Keep reference to parent_axes in TickLabels and AxisLabels

### DIFF
--- a/astropy/visualization/wcsaxes/axislabels.py
+++ b/astropy/visualization/wcsaxes/axislabels.py
@@ -65,6 +65,9 @@ class AxisLabels(Text):
         if not self.get_visible():
             return
 
+        ticklabels_bbox = self.parent_coords.parent_axes._ticklabels_bbox
+        coord_ticklabels_bbox = ticklabels_bbox[self.parent_coords]
+
         text_size = renderer.points_to_pixels(self.get_size())
 
         for axis in self.get_visible_axes():

--- a/astropy/visualization/wcsaxes/axislabels.py
+++ b/astropy/visualization/wcsaxes/axislabels.py
@@ -158,4 +158,4 @@ class AxisLabels(Text):
             super().draw(renderer)
 
             bb = super().get_window_extent(renderer)
-            bboxes.append(bb)
+            self.parent_coords.parent_axes._bboxes.append(bb)

--- a/astropy/visualization/wcsaxes/axislabels.py
+++ b/astropy/visualization/wcsaxes/axislabels.py
@@ -67,6 +67,8 @@ class AxisLabels(Text):
 
         ticklabels_bbox = self.parent_coords.parent_axes._ticklabels_bbox
         coord_ticklabels_bbox = ticklabels_bbox[self.parent_coords]
+        ticks_locs = self.parent_coords.parent_axes._ticks_locs
+        visible_ticks = self.parent_coords.ticklabels.get_visible_axes()
 
         text_size = renderer.points_to_pixels(self.get_size())
 

--- a/astropy/visualization/wcsaxes/coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/coordinate_helpers.py
@@ -104,6 +104,7 @@ class CoordinateHelper:
         self.dpi_transform = Affine2D()
         self.offset_transform = ScaledTranslation(0, 0, self.dpi_transform)
         self.ticks = Ticks(transform=parent_axes.transData + self.offset_transform)
+        self.ticks.parent_coords = self
 
         # Initialize tick labels
         self.ticklabels = TickLabels(self.frame,
@@ -593,19 +594,18 @@ class CoordinateHelper:
 
         renderer.close_group('grid lines')
 
-    def _draw_ticks(self, renderer, ticklabels_bbox, ticks_locs):
+    def _draw_ticks(self, renderer):
 
         renderer.open_group('ticks')
 
-        self.ticks.draw(renderer, ticks_locs)
-
+        self.ticks.draw(renderer, None)
         self.ticklabels.draw(renderer, bboxes=None,
                              ticklabels_bbox=None,
-                             tick_out_size=self.ticks.out_size)
+                             tick_out_size=None)
 
         renderer.close_group('ticks')
 
-    def _draw_axislabels(self, renderer, ticklabels_bbox, ticks_locs, visible_ticks):
+    def _draw_axislabels(self, renderer):
         # Render the default axis label if no axis label is set.
         if self._auto_axislabel and not self.get_axislabel():
             self.set_axislabel(self._get_default_axislabel())
@@ -615,8 +615,8 @@ class CoordinateHelper:
         self.axislabels.draw(renderer, bboxes=None,
                              ticklabels_bbox=None,
                              coord_ticklabels_bbox=None,
-                             ticks_locs=ticks_locs,
-                             visible_ticks=visible_ticks)
+                             ticks_locs=None,
+                             visible_ticks=None)
 
         renderer.close_group('axis labels')
 

--- a/astropy/visualization/wcsaxes/coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/coordinate_helpers.py
@@ -600,7 +600,7 @@ class CoordinateHelper:
         self.ticks.draw(renderer, ticks_locs)
 
         self.ticklabels.draw(renderer, bboxes=None,
-                             ticklabels_bbox=ticklabels_bbox,
+                             ticklabels_bbox=None,
                              tick_out_size=self.ticks.out_size)
 
         renderer.close_group('ticks')
@@ -613,8 +613,8 @@ class CoordinateHelper:
         renderer.open_group('axis labels')
 
         self.axislabels.draw(renderer, bboxes=None,
-                             ticklabels_bbox=ticklabels_bbox,
-                             coord_ticklabels_bbox=ticklabels_bbox[self],
+                             ticklabels_bbox=None,
+                             coord_ticklabels_bbox=None,
                              ticks_locs=ticks_locs,
                              visible_ticks=visible_ticks)
 

--- a/astropy/visualization/wcsaxes/coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/coordinate_helpers.py
@@ -109,6 +109,7 @@ class CoordinateHelper:
         self.ticklabels = TickLabels(self.frame,
                                      transform=None,  # display coordinates
                                      figure=parent_axes.get_figure())
+        self.ticklabels.parent_coords = self
         self.ticks.display_minor_ticks(rcParams['xtick.minor.visible'])
         self.minor_frequency = 5
 
@@ -117,6 +118,7 @@ class CoordinateHelper:
                                      transform=None,  # display coordinates
                                      figure=parent_axes.get_figure())
 
+        self.axislabels.parent_coords = self
         # Initialize container for the grid lines
         self.grid_lines = []
 
@@ -591,25 +593,26 @@ class CoordinateHelper:
 
         renderer.close_group('grid lines')
 
-    def _draw_ticks(self, renderer, bboxes, ticklabels_bbox, ticks_locs):
+    def _draw_ticks(self, renderer, ticklabels_bbox, ticks_locs):
 
         renderer.open_group('ticks')
 
         self.ticks.draw(renderer, ticks_locs)
-        self.ticklabels.draw(renderer, bboxes=bboxes,
+
+        self.ticklabels.draw(renderer, bboxes=None,
                              ticklabels_bbox=ticklabels_bbox,
                              tick_out_size=self.ticks.out_size)
 
         renderer.close_group('ticks')
 
-    def _draw_axislabels(self, renderer, bboxes, ticklabels_bbox, ticks_locs, visible_ticks):
+    def _draw_axislabels(self, renderer, ticklabels_bbox, ticks_locs, visible_ticks):
         # Render the default axis label if no axis label is set.
         if self._auto_axislabel and not self.get_axislabel():
             self.set_axislabel(self._get_default_axislabel())
 
         renderer.open_group('axis labels')
 
-        self.axislabels.draw(renderer, bboxes=bboxes,
+        self.axislabels.draw(renderer, bboxes=None,
                              ticklabels_bbox=ticklabels_bbox,
                              coord_ticklabels_bbox=ticklabels_bbox[self],
                              ticks_locs=ticks_locs,

--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -403,7 +403,7 @@ class WCSAxes(Axes):
 
         self._bboxes = []
         # This generates a structure like [coords][axis] = [...]
-        ticklabels_bbox = defaultdict(partial(defaultdict, list))
+        self._ticklabels_bbox = defaultdict(partial(defaultdict, list))
         ticks_locs = defaultdict(partial(defaultdict, list))
 
         visible_ticks = []
@@ -418,7 +418,7 @@ class WCSAxes(Axes):
 
             for coord in coords:
                 coord._draw_ticks(renderer,
-                                  ticklabels_bbox=ticklabels_bbox[coord],
+                                  ticklabels_bbox=None,
                                   ticks_locs=ticks_locs[coord])
                 visible_ticks.extend(coord.ticklabels.get_visible_axes())
 
@@ -426,7 +426,7 @@ class WCSAxes(Axes):
 
             for coord in coords:
                 coord._draw_axislabels(renderer,
-                                       ticklabels_bbox=ticklabels_bbox,
+                                       ticklabels_bbox=None,
                                        ticks_locs=ticks_locs[coord],
                                        visible_ticks=visible_ticks)
 

--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -417,7 +417,7 @@ class WCSAxes(Axes):
         for coords in self._all_coords:
 
             for coord in coords:
-                coord._draw_ticks(renderer, bboxes=self._bboxes,
+                coord._draw_ticks(renderer,
                                   ticklabels_bbox=ticklabels_bbox[coord],
                                   ticks_locs=ticks_locs[coord])
                 visible_ticks.extend(coord.ticklabels.get_visible_axes())
@@ -425,7 +425,7 @@ class WCSAxes(Axes):
         for coords in self._all_coords:
 
             for coord in coords:
-                coord._draw_axislabels(renderer, bboxes=self._bboxes,
+                coord._draw_axislabels(renderer,
                                        ticklabels_bbox=ticklabels_bbox,
                                        ticks_locs=ticks_locs[coord],
                                        visible_ticks=visible_ticks)

--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -404,31 +404,23 @@ class WCSAxes(Axes):
         self._bboxes = []
         # This generates a structure like [coords][axis] = [...]
         self._ticklabels_bbox = defaultdict(partial(defaultdict, list))
-        ticks_locs = defaultdict(partial(defaultdict, list))
+        self._ticks_locs = defaultdict(partial(defaultdict, list))
 
         visible_ticks = []
 
         for coords in self._all_coords:
-
             coords.frame.update()
             for coord in coords:
                 coord._draw_grid(renderer)
 
         for coords in self._all_coords:
-
             for coord in coords:
-                coord._draw_ticks(renderer,
-                                  ticklabels_bbox=None,
-                                  ticks_locs=ticks_locs[coord])
+                coord._draw_ticks(renderer)
                 visible_ticks.extend(coord.ticklabels.get_visible_axes())
 
         for coords in self._all_coords:
-
             for coord in coords:
-                coord._draw_axislabels(renderer,
-                                       ticklabels_bbox=None,
-                                       ticks_locs=ticks_locs[coord],
-                                       visible_ticks=visible_ticks)
+                coord._draw_axislabels(renderer)
 
         self.coords.frame.draw(renderer)
 

--- a/astropy/visualization/wcsaxes/ticklabels.py
+++ b/astropy/visualization/wcsaxes/ticklabels.py
@@ -227,6 +227,7 @@ class TickLabels(Text):
                 # that has a key starting bit such as -0:30 where the -0
                 # might be dropped from all other labels.
 
+                bboxes = self.parent_coords.parent_axes._bboxes
                 if not self._exclude_overlapping or bb.count_overlaps(bboxes) == 0:
                     super().draw(renderer)
                     bboxes.append(bb)

--- a/astropy/visualization/wcsaxes/ticklabels.py
+++ b/astropy/visualization/wcsaxes/ticklabels.py
@@ -120,6 +120,7 @@ class TickLabels(Text):
         if not self.get_visible():
             return
 
+        tick_out_size = self.parent_coords.ticks.out_size
         ticklabels_bbox = self.parent_coords.parent_axes._ticklabels_bbox[self.parent_coords]
 
         self.simplify_labels()

--- a/astropy/visualization/wcsaxes/ticklabels.py
+++ b/astropy/visualization/wcsaxes/ticklabels.py
@@ -120,6 +120,8 @@ class TickLabels(Text):
         if not self.get_visible():
             return
 
+        ticklabels_bbox = self.parent_coords.parent_axes._ticklabels_bbox[self.parent_coords]
+
         self.simplify_labels()
 
         text_size = renderer.points_to_pixels(self.get_size())

--- a/astropy/visualization/wcsaxes/ticks.py
+++ b/astropy/visualization/wcsaxes/ticks.py
@@ -151,6 +151,7 @@ class Ticks(Line2D):
         """
         Draw the ticks.
         """
+        ticks_locs = self.parent_coords.parent_axes._ticks_locs[self.parent_coords]
 
         if not self.get_visible():
             return


### PR DESCRIPTION
The motivation for this is that `draw()` methods should not really depend on any parameters apart from `renderer`, as all the information needed to draw an `Artist` should be contained within the artist object. Making these changes will make it substantially easier to re-factor out the code in `draw()` that is used to update properties that are needed for other methods (currently not present), such as `get_tightbbox()` and `get_window_extent()`.

Instead of passing `bboxes` down a few layers of function calls, just to have it appended to, it is much clearer to retain a reference to `parent_coords`, and directly append to `self.parent_coords.parent_axes._bboxes`. I have retained function signatures here for API compatibility. I will leave inline notes explaining this, but maybe there is a better way to do this.