### PR TITLE
Ignore imp warning triggered by ProgressBar + IPython

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -127,6 +127,8 @@ filterwarnings =
     ignore:Unknown pytest.mark.mpl_image_compare:pytest.PytestUnknownMarkWarning
     ignore:Unknown config option:pytest.PytestConfigWarning
     ignore:matplotlibrc text.usetex:UserWarning:matplotlib
+    # Triggered by ProgressBar > ipykernel.iostream
+    ignore:the imp module is deprecated:DeprecationWarning
     # toolz internal deprecation warning https://github.com/pytoolz/toolz/issues/500
     ignore:The toolz.compatibility module is no longer needed:DeprecationWarning
 doctest_norecursedirs =


### PR DESCRIPTION
Running a test with ``download_file`` fails in verbose mode (e.g. ``pytest
--remote-data=any
astropy/utils/tests/test_data.py::test_download_nocache_from_internet -sv``),
when IPython is installed. Because ``ProgressBar`` imports ``IPython`` which
uses a deprecated ``imp`` import. The solution is just to ignore this warning.


```
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
astropy/utils/data.py:1190: in download_file
    f_name = _download_file_from_source(
astropy/utils/data.py:1040: in _download_file_from_source
    with ProgressBarOrSpinner(size, dlmsg, file=progress_stream) as p:
astropy/utils/console.py:1027: in __init__
    color_print(msg, color, file=file)
astropy/utils/console.py:356: in color_print
    file = kwargs.get('file', _get_stdout())
astropy/utils/console.py:119: in _get_stdout
    if not isatty(sys_stream) or _IPython.OutStream is None:
astropy/utils/decorators.py:676: in __get__
    val = self.fget.__wrapped__(objtype)
astropy/utils/console.py:62: in OutStream
    from ipykernel.iostream import OutStream
../../.pyenv/versions/3.8.1/lib/python3.8/site-packages/ipykernel/iostream.py:14: in <module>
    from imp import lock_held as import_lock_held
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

    """This module provides the components needed to build your own __import__
    function.  Undocumented functions are obsolete.
    
    In most cases it is preferred you consider using the importlib module's
    functionality over this module.
    
    """
    # (Probably) need to stay in _imp
    from _imp import (lock_held, acquire_lock, release_lock,
                      get_frozen_object, is_frozen_package,
                      init_frozen, is_builtin, is_frozen,
                      _fix_co_filename)
    try:
        from _imp import create_dynamic
    except ImportError:
        # Platform doesn't support dynamic loading.
        create_dynamic = None
    
    from importlib._bootstrap import _ERR_MSG, _exec, _load, _builtin_from_name
    from importlib._bootstrap_external import SourcelessFileLoader
    
    from importlib import machinery
    from importlib import util
    import importlib
    import os
    import sys
    import tokenize
    import types
    import warnings
    
>   warnings.warn("the imp module is deprecated in favour of importlib; "
                  "see the module's documentation for alternative uses",
                  DeprecationWarning, stacklevel=2)
E   DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses

../../.pyenv/versions/3.8.1/lib/python3.8/imp.py:31: DeprecationWarning
```
