### PR TITLE
Reduce number in points in coordinate example, fixes #10794

### DIFF
--- a/docs/coordinates/performance.inc.rst
+++ b/docs/coordinates/performance.inc.rst
@@ -135,7 +135,7 @@ for ``time_resolution`` compared to the non-interpolating, default approach.
     np.random.seed(1337)
 
     # 100_000 times randomly distributed over 12 hours
-    t = Time('2020-01-01T20:00:00') + np.random.uniform(0, 12, 100_000) * u.hour
+    t = Time('2020-01-01T20:00:00') + np.random.uniform(0, 1, 10_000) * u.hour
 
     location = location = EarthLocation(
         lon=-17.89 * u.deg, lat=28.76 * u.deg, height=2200 * u.m
@@ -167,7 +167,7 @@ for ``time_resolution`` compared to the non-interpolating, default approach.
             duration = perf_counter() - t0
 
         print(
-            f'Interpolation with {resolution.value: 8.0f} {str(resolution.unit)}'
+            f'Interpolation with {resolution.value: 9.1f} {str(resolution.unit)}'
             f' resolution took {duration:.4f} s'
             f' ({reference / duration:5.1f}x faster) '
         )

--- a/docs/coordinates/performance.inc.rst
+++ b/docs/coordinates/performance.inc.rst
@@ -156,7 +156,7 @@ for ``time_resolution`` compared to the non-interpolating, default approach.
 
 
     # now the interpolating approach for different time resolutions
-    resolutions = 10.0**np.arange(-1, 6) * u.s
+    resolutions = 10.0**np.arange(-1, 5) * u.s
     times = []
     seps = []
 


### PR DESCRIPTION
Reduce number of points. New runtime on my machine: 7 seconds:


```
No Interpolation took 2.2064 s
Interpolation with       0.1 s resolution took 2.4585 s (  0.9x faster) 
Interpolation with       1.0 s resolution took 0.5930 s (  3.7x faster) 
Interpolation with      10.0 s resolution took 0.0804 s ( 27.4x faster) 
Interpolation with     100.0 s resolution took 0.0262 s ( 84.3x faster) 
Interpolation with    1000.0 s resolution took 0.0187 s (118.2x faster) 
Interpolation with   10000.0 s resolution took 0.0173 s (127.2x faster) 
Interpolation with  100000.0 s resolution took 0.0164 s (134.7x faster) 
python test.py  7,11s user 0,08s system 99% cpu 7,251 total
```

EDIT: Follow up of #10647, fix #10794