### PR TITLE
Store bboxes in child objects of WCSAxes

### DIFF
--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -31,6 +31,11 @@ __all__ = ['isiterable', 'silence', 'format_exception', 'NumpyRNGContext',
            'OrderedDescriptor', 'OrderedDescriptorContainer']
 
 
+# Create a dummy object to pass interanlly to deprecated parameteres; if a user passes
+# anything that isn't this object, we know to raise an unused argument warning
+_NONE = object()
+
+
 def isiterable(obj):
     """Returns `True` if the given object is iterable."""
 

--- a/astropy/visualization/wcsaxes/axislabels.py
+++ b/astropy/visualization/wcsaxes/axislabels.py
@@ -7,6 +7,8 @@ from matplotlib import rcParams
 from matplotlib.text import Text
 import matplotlib.transforms as mtransforms
 
+from astropy.utils.exceptions import AstropyDeprecationWarning
+from astropy.utils.misc import _NONE
 from .frame import RectangularFrame
 
 
@@ -30,6 +32,7 @@ class AxisLabels(Text):
         self.set_va('center')
         self._minpad = minpad
         self._visibility_rule = 'labels'
+        self._bboxes = []
 
     def get_minpad(self, axis):
         try:
@@ -62,8 +65,15 @@ class AxisLabels(Text):
     def draw(self, renderer, bboxes, ticklabels_bbox,
              coord_ticklabels_bbox, ticks_locs, visible_ticks):
 
+        if bboxes is not _NONE:
+            warnings.warn('The "bboxes" argument is deprecated and un-used.',
+                          AstropyDeprecationWarning)
+
         if not self.get_visible():
             return
+
+        # Reset list of bounding boxes
+        self._bboxes = []
 
         text_size = renderer.points_to_pixels(self.get_size())
 
@@ -158,4 +168,4 @@ class AxisLabels(Text):
             super().draw(renderer)
 
             bb = super().get_window_extent(renderer)
-            bboxes.append(bb)
+            self._bboxes.append(bb)

--- a/astropy/visualization/wcsaxes/coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/coordinate_helpers.py
@@ -17,6 +17,7 @@ from matplotlib import rcParams
 
 from astropy import units as u
 from astropy.utils.exceptions import AstropyDeprecationWarning
+from astropy.utils.misc import _NONE
 
 from .frame import RectangularFrame1D, EllipticalFrame
 from .formatter_locator import AngleFormatterLocator, ScalarFormatterLocator
@@ -560,6 +561,10 @@ class CoordinateHelper:
     def formatter(self):
         return self._formatter_locator.formatter
 
+    @property
+    def _bboxes(self):
+        return self.ticklabels._bboxes + self.axislabels._bboxes
+
     def _draw_grid(self, renderer):
 
         renderer.open_group('grid lines')
@@ -591,25 +596,25 @@ class CoordinateHelper:
 
         renderer.close_group('grid lines')
 
-    def _draw_ticks(self, renderer, bboxes, ticklabels_bbox, ticks_locs):
+    def _draw_ticks(self, renderer, ticklabels_bbox, ticks_locs):
 
         renderer.open_group('ticks')
 
         self.ticks.draw(renderer, ticks_locs)
-        self.ticklabels.draw(renderer, bboxes=bboxes,
+        self.ticklabels.draw(renderer, bboxes=_NONE,
                              ticklabels_bbox=ticklabels_bbox,
                              tick_out_size=self.ticks.out_size)
 
         renderer.close_group('ticks')
 
-    def _draw_axislabels(self, renderer, bboxes, ticklabels_bbox, ticks_locs, visible_ticks):
+    def _draw_axislabels(self, renderer, ticklabels_bbox, ticks_locs, visible_ticks):
         # Render the default axis label if no axis label is set.
         if self._auto_axislabel and not self.get_axislabel():
             self.set_axislabel(self._get_default_axislabel())
 
         renderer.open_group('axis labels')
 
-        self.axislabels.draw(renderer, bboxes=bboxes,
+        self.axislabels.draw(renderer, bboxes=_NONE,
                              ticklabels_bbox=ticklabels_bbox,
                              coord_ticklabels_bbox=ticklabels_bbox[self],
                              ticks_locs=ticks_locs,

--- a/astropy/visualization/wcsaxes/ticklabels.py
+++ b/astropy/visualization/wcsaxes/ticklabels.py
@@ -6,6 +6,8 @@ import numpy as np
 from matplotlib import rcParams
 from matplotlib.text import Text
 
+from astropy.utils.exceptions import AstropyDeprecationWarning
+from astropy.utils.misc import _NONE
 from .frame import RectangularFrame
 
 
@@ -23,6 +25,7 @@ class TickLabels(Text):
         self.set_visible_axes('all')
         self.set_pad(rcParams['xtick.major.pad'])
         self._exclude_overlapping = False
+        self._bboxes = []
 
         # Check rcParams
 
@@ -117,8 +120,15 @@ class TickLabels(Text):
 
     def draw(self, renderer, bboxes, ticklabels_bbox, tick_out_size):
 
+        if bboxes is not _NONE:
+            warnings.warn('The "bboxes" argument is deprecated and un-used.',
+                          AstropyDeprecationWarning)
+
         if not self.get_visible():
             return
+
+        # Reset list of bounding boxes
+        self._bboxes = []
 
         self.simplify_labels()
 
@@ -227,7 +237,7 @@ class TickLabels(Text):
                 # that has a key starting bit such as -0:30 where the -0
                 # might be dropped from all other labels.
 
-                if not self._exclude_overlapping or bb.count_overlaps(bboxes) == 0:
+                if not self._exclude_overlapping or bb.count_overlaps(self._bboxes) == 0:
                     super().draw(renderer)
-                    bboxes.append(bb)
+                    self._bboxes.append(bb)
                     ticklabels_bbox[axis].append(bb)


### PR DESCRIPTION
Previously `WCSAxes` had a `_bboxes` attribute. This list was passed down the call stack to various child `draw()` methods, which after drawing appended their `bboxes` to this list.

This has been changed here so that the child objects (axis labels and ticklabels) store their own bbox list, and `WCSAxes` now just takes all of those bboxes and adds them into one list to get all the `bboxes`. This avoids having to hand a list by reference down the call stack, and makes it much clearer where all of the bboxes are coming from.