### PR TITLE
Capitalize semver

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -58,7 +58,7 @@ plot_pre_code = ""
 needs_sphinx = '1.7'
 
 # To perform a Sphinx version check that needs to be more specific than
-# major.minor, call `check_sphinx_version("x.y.z")` here.
+# major.minor, call `check_sphinx_version("X.Y.Z")` here.
 check_sphinx_version("1.2.1")
 
 # The intersphinx_mapping in sphinx_astropy.sphinx refers to astropy for

--- a/docs/development/astropy-package-template.rst
+++ b/docs/development/astropy-package-template.rst
@@ -164,7 +164,7 @@ Modifications for a beta/release candidate release
 
    * When entering the new version number, instead of just removing the
      ``.dev``, enter "1.2b1" or "1.2rc1".  It is critical that you follow this
-     numbering scheme (``x.yb#`` or ``x.y.zrc#``), as it will ensure the release
+     numbering scheme (``X.Yb#`` or ``X.Y.Zrc#``), as it will ensure the release
      is ordered "before" the main release by various automated tools, and also
      tells PyPI that this is a "pre-release".
 

--- a/docs/development/releasing.rst
+++ b/docs/development/releasing.rst
@@ -268,7 +268,7 @@ The primary modifications to the release procedure are:
 
 * When entering tagging the release, include a ``b?`` or ``rc??`` suffix after
   the version number, e.g. "1.2b1" or "1.2rc1".  It is critical that you follow this
-  numbering scheme (``x.yb#`` or ``x.y.zrc#``), as it will ensure the release
+  numbering scheme (``X.Yb#`` or ``X.Y.Zrc#``), as it will ensure the release
   is ordered "before" the main release by various automated tools, and also
   tells PyPI that this is a "pre-release."
 * Do not do steps in :ref:`post-release-procedure`.


### PR DESCRIPTION
A very small change from x.y.z to X.Y.Z, to better follow the [semantic versioning](https://semver.org/) standard syntax.

From https://github.com/astropy/package-template/pull/487#issuecomment-703842849  (@bsipocz )

Signed-off-by: Nathaniel Starkman <nstarkman@protonmail.com>
