### PR TITLE
TST: Fix error message regex due to upstream change

### DIFF
--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -576,7 +576,7 @@ def test_insert_exceptions():
 
     # Bad shape
     with pytest.raises(ValueError, match='could not broadcast input array from '
-                       r'shape \(2,2\) into shape \(2\)'):
+                       r'shape \(2,2\) into shape \(2,?\)'):
         sc0.insert(0, sc4)
 
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to address numpy-dev job failure due to a slight change in expected error message from

```
could not broadcast input array from shape (2,2) into shape (2)
```

to

```
could not broadcast input array from shape (2,2) into shape (2,)
```

Example log: https://travis-ci.org/github/astropy/astropy/jobs/733096867

**Note to reviewer:** Check the numpy-dev/remote-data job that is allowed to fail.

p.s. I am guessing this needs to be backported to LTS so its CI would pass with a future numpy release (1.20?). But if that is not the case, feel free to re-milestone.