### PR TITLE
Refactor TickLabels drawing code in WCSAxes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -455,6 +455,10 @@ astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 - Fixed an issue where ticks were sometimes not drawn at the edges of a spherical
   projection on a WCSAxes. [#10442]
+- The position of tick labels are now only calculated when needed. If any text
+  parameters are changed (color, font weight, size etc.) that don't effect the
+  tick label position, the positions are not recomputed, improving performance.
+  [#10806]
 
 astropy.wcs
 ^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -148,6 +148,10 @@ astropy.visualization
   quadrangle.  Unlike ``matplotlib.patches.Rectangle``, the edges of this
   patch will be rendered as curved lines if appropriate for the WCS
   transformation. [#10862]
+- The position of tick labels are now only calculated when needed. If any text
+  parameters are changed (color, font weight, size etc.) that don't effect the
+  tick label position, the positions are not recomputed, improving performance.
+  [#10806]
 
 astropy.wcs
 ^^^^^^^^^^^
@@ -455,11 +459,6 @@ astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 - Fixed an issue where ticks were sometimes not drawn at the edges of a spherical
   projection on a WCSAxes. [#10442]
-
-- The position of tick labels are now only calculated when needed. If any text
-  parameters are changed (color, font weight, size etc.) that don't effect the
-  tick label position, the positions are not recomputed, improving performance.
-  [#10806]
 
 astropy.wcs
 ^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -455,6 +455,7 @@ astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 - Fixed an issue where ticks were sometimes not drawn at the edges of a spherical
   projection on a WCSAxes. [#10442]
+
 - The position of tick labels are now only calculated when needed. If any text
   parameters are changed (color, font weight, size etc.) that don't effect the
   tick label position, the positions are not recomputed, improving performance.


### PR DESCRIPTION
xref https://github.com/astropy/astropy/issues/8703. This refactors code with the following aims:

- More methods with descriptive names makes the code more readable
- Move the logic for calculating x/y/alignments out of `draw()`, so eventually it can be used by a `get_tight_bbox()` method to calculate the bounding box without doing a draw
- Only recompute x/y/alignments when needed, checked using the `_stale` flag. This has the nice side effect that if any text parameters are changed (color, font weight, size etc.) that don't effect the text position, the positions are not re-computed (they were before)