### PR TITLE
Simplify prepare_earth_position_vel, removes calling epv00 twice, fixes #10813

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,6 +34,9 @@ astropy.coordinates
 - Method ``.realize_frame`` from coordinate frames now accepts ``**kwargs``,
   including ``representation_type``. [#10727]
 
+- Avoid an unnecessary call to ``erfa.epv00`` in transformations between
+  ``CIRS`` and ``ICRS``, improving performance by 50 %. [#10814]
+
 
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
### Description

This simplifies `prepare_earth_position_vel` to simply call `erfa.epv00`, which already provides everything needed.

Fixes #10813 
