### PR TITLE
Numpy dev fixes for subarray dtype

### DIFF
--- a/astropy/io/votable/converters.py
+++ b/astropy/io/votable/converters.py
@@ -493,7 +493,7 @@ class VarArray(Array):
         Array.__init__(self, field, config)
 
         self._base = base
-        self.default = np.array([], dtype=self._base.format)
+        self.default = np.empty(0, dtype=self._base.format)
 
     def output(self, value, mask):
         output = self._base.output

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -383,6 +383,13 @@ class BaseColumn(_ColumnGetitemShim, np.ndarray):
             if meta is None:
                 meta = data.info.meta
 
+        elif isinstance(data, list) and data == []:
+            # We should special case the empty list since np.array([], dtype)
+            # does not return an empty array with the requested dtype, and in
+            # numpy 1.20-dev this is giving a DeprecationWarning.
+            # TODO: Adjust when/if the numpy behaviour behaviour changes.
+            # Hopefully, this clause can again be removed.  NUMPY_LT_1_20.
+            self_data = np.empty(0, dtype=dtype)
         else:
             if np.dtype(dtype).char == 'S':
                 data = cls._encode_str(data)


### PR DESCRIPTION
fixes #10815 

Not very happy with the fix for `Column`, but could not think of a better way. Ideally, this gets fixed better by numpy. See https://github.com/numpy/numpy/issues/17511.