### PR TITLE
Fix empty Column initialization for structured dtype.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -435,7 +435,7 @@ astropy.wcs
 - Add .upper() to ctype or ctype names to wcsapi/fitwcs.py to mitigate bugs from
   unintended lower/upper case issues [#10557]
 - Added bounds to ``fit_wcs_from_points`` to ensure CRPIX is on
-  input image. [#10346] 
+  input image. [#10346]
 
 Other Changes and Additions
 ---------------------------
@@ -1155,6 +1155,9 @@ astropy.table
 
 - Avoid crash when reading a FITS table that contains mixin info and PyYAML
   is missing. [#10485]
+
+- Fixed a small bug where initializing an empty ``Column`` with a structured dtype
+  with a length and a shape failed to give the requested dtype. [#10819]
 
 astropy.tests
 ^^^^^^^^^^^^^

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -352,8 +352,7 @@ class BaseColumn(_ColumnGetitemShim, np.ndarray):
                 description=None, unit=None, format=None, meta=None,
                 copy=False, copy_indices=True):
         if data is None:
-            dtype = (np.dtype(dtype).str, shape)
-            self_data = np.zeros(length, dtype=dtype)
+            self_data = np.zeros((length,)+shape, dtype=dtype)
         elif isinstance(data, BaseColumn) and hasattr(data, '_name'):
             # When unpickling a MaskedColumn, ``data`` will be a bare
             # BaseColumn with none of the expected attributes.  In this case

--- a/astropy/table/tests/test_column.py
+++ b/astropy/table/tests/test_column.py
@@ -896,3 +896,11 @@ def test_structured_masked_column_roundtrip():
     assert len(mc.dtype.fields) == 2
     mc2 = table.MaskedColumn(mc)
     assert_array_equal(mc2, mc)
+
+
+@pytest.mark.parametrize('dtype', ['i4,f4', 'f4,(2,)f8'])
+def test_structured_empty_column_init(dtype):
+    dtype = np.dtype(dtype)
+    c = table.Column(length=5, shape=(2,), dtype=dtype)
+    assert c.shape == (5, 2)
+    assert c.dtype == dtype


### PR DESCRIPTION
This failed when a shape was passed in as well.

Found while writing #10818