### PR TITLE
Fix table sorting for a single Time column

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -406,6 +406,9 @@ astropy.stats
 astropy.table
 ^^^^^^^^^^^^^
 
+- Fix a bug that prevented ``Time`` columns from being used to sort a table.
+  [#10824]
+
 astropy.tests
 ^^^^^^^^^^^^^
 
@@ -435,7 +438,7 @@ astropy.wcs
 - Add .upper() to ctype or ctype names to wcsapi/fitwcs.py to mitigate bugs from
   unintended lower/upper case issues [#10557]
 - Added bounds to ``fit_wcs_from_points`` to ensure CRPIX is on
-  input image. [#10346] 
+  input image. [#10346]
 
 Other Changes and Additions
 ---------------------------

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -2885,13 +2885,15 @@ class Table:
         if keys:
             # For multiple keys return a structured array which gets sorted,
             # while for a single key return a single ndarray.  Sorting a
-            # one-column structured array is much slower than ndarray, e.g. a
-            # factor of ~6 for a 10 million long random array.
+            # one-column structured array is slower than ndarray (e.g. a
+            # factor of ~6 for a 10 million long random array), and much slower
+            # for in principle sortable columns like Time, which get stored as
+            # object arrays.
             if len(keys) > 1:
                 kwargs['order'] = keys
                 data = self.as_array(names=keys)
             else:
-                data = self[keys[0]].view(np.ndarray)
+                data = self[keys[0]]
         else:
             # No keys provided so sort on all columns.
             data = self.as_array()
@@ -2899,7 +2901,9 @@ class Table:
         if kind:
             kwargs['kind'] = kind
 
-        idx = data.argsort(**kwargs)
+        # np.argsort will look for a possible .argsort method (e.g., for Time),
+        # and if that fails cast to an array and try sorting that way.
+        idx = np.argsort(data, **kwargs)
 
         return idx[::-1] if reverse else idx
 

--- a/astropy/table/tests/test_operations.py
+++ b/astropy/table/tests/test_operations.py
@@ -1757,8 +1757,16 @@ def test_join_non_1d_key_column():
         table.join(t1, t2, keys='a')
 
 
+def test_argsort_time_column():
+    """Regression test for #10823."""
+    times = Time(['2016-01-01', '2018-01-01', '2017-01-01'])
+    t = Table([times], names=['time'])
+    i = t.argsort('time')
+    assert np.all(i == times.argsort())
+
+
 def test_sort_indexed_table():
-    """Test fix for #9473 and #6545"""
+    """Test fix for #9473 and #6545 - and another regression test for #10823."""
     t = Table([[1, 3, 2], [6, 4, 5]], names=('a', 'b'))
     t.add_index('a')
     t.sort('a')
@@ -1768,9 +1776,18 @@ def test_sort_indexed_table():
     assert np.all(t['b'] == [4, 5, 6])
     assert np.all(t['a'] == [3, 2, 1])
 
-    from astropy.timeseries import TimeSeries
     times = ['2016-01-01', '2018-01-01', '2017-01-01']
     tm = Time(times)
+    t2 = Table([tm, [3, 2, 1]], names=['time', 'flux'])
+    t2.sort('flux')
+    assert np.all(t2['flux'] == [1, 2, 3])
+    t2.sort('time')
+    assert np.all(t2['flux'] == [3, 1, 2])
+    assert np.all(t2['time'] == tm[[0, 2, 1]])
+
+    # Using the table as a TimeSeries implicitly sets the index, so
+    # this test is a bit different from the above.
+    from astropy.timeseries import TimeSeries
     ts = TimeSeries(time=times)
     ts['flux'] = [3, 2, 1]
     ts.sort('flux')


### PR DESCRIPTION
fixes #10823 

Sorting on a single time column worked in 4.0, but is broken in 4.1-rc2. I milestoned 4.1.1, but perhaps it can still make it for 4.1.