### PR TITLE
Fix Azure sdist job

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,7 +7,9 @@ include CITATION
 include astropy/CITATION
 
 include ah_bootstrap.py
+include setup.py
 include setup.cfg
+include pyproject.toml
 include astropy/tests/coveragerc
 recursive-include astropy *.pyx *.c *.h *.map *.templ
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+# NOTE: the v4.0.x branch of astropy still uses astropy-helpers
+# but we include pyproject.toml here so that python -m build can
+# work out of the box. In setup.py, we manually ensure that
+# astropy_helpers can be imported as an additional build time
+# dependency.
+
+[build-system]
+requires = ["setuptools",
+            "wheel",
+            "cython==0.29.14",
+            "jinja2==2.10.3",
+            # NOTE: we can't use the oldest-supported-numpy package
+            # here because it conflicts with the setup_requires
+            # setting in setup.cfg which is present in the v4.0.x
+            # branch.
+            "numpy==1.16.*; python_version<='3.7'",
+            "numpy==1.17.*; python_version>='3.8'"]
+build-backend = 'setuptools.build_meta'

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,11 @@
 import os
 import builtins
 
+# Because we have a pyproject.toml file, the isolated build environment
+# doesn't allow the ah_bootstrap file to be imported unless the current
+# directory is added to the Python path
+import sys
+sys.path.append(os.path.abspath("."))
 import ah_bootstrap  # noqa
 
 from astropy_helpers.distutils_helpers import is_distutils_display_option


### PR DESCRIPTION
I backported the Azure configuration to build the wheels to v4.0.x - however things don't work out of the box because v4.0.x doesn't use pyproject.toml for example. This PR makes some small infrastructure updates to allow things to work, including adding a simple pyproject.toml file. This means source installations will now be built with build isolation (which is a good thing) but none of  this should have any impact on users.