### PR TITLE
Use IAU 2006 matrix for converting to true coordinates.

### DIFF
--- a/astropy/coordinates/solar_system.py
+++ b/astropy/coordinates/solar_system.py
@@ -518,6 +518,8 @@ def _apparent_position_in_true_coordinates(skycoord):
     are defined w.r.t to the true equinox and poles of the Earth
     """
     jd1, jd2 = get_jd12(skycoord.obstime, 'tt')
-    _, _, _, _, _, _, _, rbpn = erfa.pn00a(jd1, jd2)
+    # Classical NPB matrix, IAU 2006/2000A
+    # (same as in builtin_frames.utils.get_cip).
+    rbpn = erfa.pnm06a(jd1, jd2)
     return SkyCoord(skycoord.frame.realize_frame(
         skycoord.cartesian.transform(rbpn)))


### PR DESCRIPTION
This is a private function, used only for tests inside astropy, but also used at times outside of astropy.  As noted by @mkbrewer, it should be made consistent with what is used elsewhere in astropy, in particular in `coordinates.builtin_frames.utils.get_cip`.

I milestoned it 4.0.3, since one might as well get consistency for all versions we still support, but as this is a private function, I don't think a changelog entry is appropriate. Its use outside of astropy will become unnecessary when #10230 is addressed.  

fixes #10827