### PR TITLE
Ensure possible astropy/_dev gets ignored in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -118,6 +118,7 @@ matrix:
           name: Python 3.8 with all optional dependencies
           stage: Initial tests
           env: TOXENV="py38-test-alldeps"
+               TOXARGS="-v --develop"
                TOXPOSARGS="--durations=50"
           compiler: clang
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -100,6 +100,7 @@ norecursedirs =
     "docs[\/]generated"
     "astropy[\/]extern"
     "astropy[\/]_erfa"
+    "astropy[\/]_dev"
 astropy_header = true
 doctest_plus = enabled
 text_file_format = rst


### PR DESCRIPTION
Follow-up on #10774, to ensure tests also run with `tox -e test --develop`.
As suggested by @astrofrog in https://github.com/astropy/astropy/pull/10774#issuecomment-706701886
I confirmed that this worked.

I guess a question is whether we should change one of the travis test runs to use `--develop` so we are sure this mode of working remains supported?

Milestoning 4.1.1 rather than 4.1 since it does not affect the release.