### PR TITLE
Fix interpolator

### DIFF
--- a/astropy/coordinates/erfa_astrom.py
+++ b/astropy/coordinates/erfa_astrom.py
@@ -213,10 +213,6 @@ class ErfaAstromInterpolator(ErfaAstrom):
             For this function, a CIRS frame is expected.
         '''
         obstime = frame_or_coord.obstime
-        # no point in interpolating for a single value
-        if obstime.size == 1:
-            return super().apci(frame_or_coord)
-
         support = self._get_support_points(obstime)
 
         cip = self._get_cip(support, obstime)
@@ -239,9 +235,6 @@ class ErfaAstromInterpolator(ErfaAstrom):
         '''
         obstime = frame_or_coord.obstime
         # no point in interpolating for a single value
-        if obstime.size == 1:
-            return super().apcs(frame_or_coord)
-
         support = self._get_support_points(obstime)
 
         # get the position and velocity arrays for the observatory.  Need to

--- a/astropy/coordinates/erfa_astrom.py
+++ b/astropy/coordinates/erfa_astrom.py
@@ -240,7 +240,7 @@ class ErfaAstromInterpolator(ErfaAstrom):
         obstime = frame_or_coord.obstime
         # no point in interpolating for a single value
         if obstime.size == 1:
-            return super().apci(frame_or_coord)
+            return super().apcs(frame_or_coord)
 
         support = self._get_support_points(obstime)
 


### PR DESCRIPTION
Adresses a copy paste error and a general comment by @mhvk and @mkbrewer by completely removing the special casing in the erfa interpolator.

See also the initial discussion in #10647 on this special casing.
