### PR TITLE
Fix installation of Astropy LTS with old pip versions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -80,7 +80,7 @@ astropy.wcs
 Other Changes and Additions
 ---------------------------
 
-- Fixed installation with pip<19. [#10837]
+- Fixed installation of the source distribution with pip<19. [#10837]
 
 4.0.2 (2020-10-10)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -80,6 +80,7 @@ astropy.wcs
 Other Changes and Additions
 ---------------------------
 
+- Fixed installation with pip<19. [#10837]
 
 4.0.2 (2020-10-10)
 ==================

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,10 @@ classifiers =
 requires = numpy
 zip_safe = False
 tests_require = pytest-astropy
-setup_requires = numpy>=1.16
+setup_requires =
+    numpy>=1.16
+    cython>=0.29.13
+    jinja2>=2.7
 install_requires = numpy>=1.16
 python_requires = >=3.6
 

--- a/setup.py
+++ b/setup.py
@@ -32,9 +32,5 @@ if is_distutils_display_option():
     setup_requires = []
 else:
     setup_requires = read_configuration('setup.cfg')['options']['setup_requires']
-    # Make sure we have the packages needed for building astropy, but do not
-    # require them when installing from an sdist as the c files are included.
-    if not os.path.exists(os.path.join(os.path.dirname(__file__), 'PKG-INFO')):
-        setup_requires.extend(['cython>=0.29.13', 'jinja2>=2.7'])
 
 setup(setup_requires=setup_requires)


### PR DESCRIPTION
The issue in https://github.com/astropy/astropy/issues/10834 was triggered by the fact that the way the source distribution is now produced for LTS is using the python [build](https://pypi.org/project/build/) package which doesn't make it easy to run the pre-processing step in astropy that bundles the generated C files from Cython. This is not an issue when installing the source distribution with pip 19 and later since the pyproject.toml file is then recognized as a way to specify the build dependencies, but for older pip versions, we need setup_requires to now specify cython and jinja2 as build-time dependencies.

To be clear, this is a corner case of specifically installing the source distribution with old pip versions - most users should not be affected by this. Nevertheless, a quick 4.0.3 may be warranted (waiting a few days to see if other issues surface).

(An alternative is to disable the building of the sdist on Azure Pipelines and instead go back to building the sdist manually and using Azure only for the wheels - but I think the fix in this PR is fine and should solve the issue in practice).

EDIT: Fix  #10834 