### PR TITLE
MNT: Force N to be int in _scipy_kraft_burrows_nousek

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -119,6 +119,9 @@ astropy.samp
 astropy.stats
 ^^^^^^^^^^^^^
 
+- Passing float ``n`` to ``poisson_conf_interval(..., interval='kraft-burrows-nousek')``
+  now raises ``TypeError`` as its value must be an integer. [#10838]
+
 astropy.table
 ^^^^^^^^^^^^^
 

--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -744,6 +744,14 @@ def poisson_conf_interval(n, interval='root-n', sigma=1, background=0,
         else:
             conf_interval[0, n == 0] = 0
     elif interval == 'kraft-burrows-nousek':
+        # Deprecation warning in Python 3.9 when N is float, so we force int,
+        # see https://github.com/astropy/astropy/issues/10832
+        if np.isscalar(n):
+            if not isinstance(n, int):
+                raise TypeError('Number of counts must be integer.')
+        elif not issubclass(n.dtype.type, np.integer):
+            raise TypeError('Number of counts must be integer.')
+
         if confidence_level is None:
             raise ValueError('Set confidence_level for method {}. (sigma is '
                              'ignored.)'.format(interval))
@@ -1101,11 +1109,6 @@ def _scipy_kraft_burrows_nousek(N, B, CL):
     from scipy.special import factorial
 
     from math import exp
-
-    # Deprecation warning in Python 3.9 when N is float, see
-    # https://github.com/astropy/astropy/issues/10832
-    if not isinstance(N, int):
-        N = round(N)
 
     def eqn8(N, B):
         n = np.arange(N + 1, dtype=np.float64)

--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -1102,6 +1102,11 @@ def _scipy_kraft_burrows_nousek(N, B, CL):
 
     from math import exp
 
+    # Deprecation warning in Python 3.9 when N is float, see
+    # https://github.com/astropy/astropy/issues/10832
+    if not isinstance(N, int):
+        N = int(N)
+
     def eqn8(N, B):
         n = np.arange(N + 1, dtype=np.float64)
         return 1. / (exp(-B) * np.sum(np.power(B, n) / factorial(n)))

--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -1105,7 +1105,7 @@ def _scipy_kraft_burrows_nousek(N, B, CL):
     # Deprecation warning in Python 3.9 when N is float, see
     # https://github.com/astropy/astropy/issues/10832
     if not isinstance(N, int):
-        N = int(N)
+        N = round(N)
 
     def eqn8(N, B):
         n = np.arange(N + 1, dtype=np.float64)

--- a/astropy/stats/tests/test_funcs.py
+++ b/astropy/stats/tests/test_funcs.py
@@ -456,7 +456,7 @@ def test_poisson_conf_large(interval):
 def test_poisson_conf_array_rootn0_zero():
     n = np.zeros((3, 4, 5))
     assert_allclose(funcs.poisson_conf_interval(n, interval='root-n-0'),
-                    funcs.poisson_conf_interval(n[0, 0, 0], interval='root-n-0')[:, None, None, None] * np.ones_like(n))
+                    funcs.poisson_conf_interval(n[0, 0, 0], interval='root-n-0')[:, None, None, None] * np.ones_like(n))  # noqa: E501
 
     assert not np.any(np.isnan(
         funcs.poisson_conf_interval(n, interval='root-n-0')))
@@ -467,7 +467,7 @@ def test_poisson_conf_array_frequentist_confidence_zero():
     n = np.zeros((3, 4, 5))
     assert_allclose(
         funcs.poisson_conf_interval(n, interval='frequentist-confidence'),
-        funcs.poisson_conf_interval(n[0, 0, 0], interval='frequentist-confidence')[:, None, None, None] * np.ones_like(n))
+        funcs.poisson_conf_interval(n[0, 0, 0], interval='frequentist-confidence')[:, None, None, None] * np.ones_like(n))  # noqa: E501
 
     assert not np.any(np.isnan(
         funcs.poisson_conf_interval(n, interval='root-n-0')))
@@ -485,7 +485,7 @@ def test_poisson_conf_list_rootn0_zero():
 def test_poisson_conf_array_rootn0():
     n = 7 * np.ones((3, 4, 5))
     assert_allclose(funcs.poisson_conf_interval(n, interval='root-n-0'),
-                    funcs.poisson_conf_interval(n[0, 0, 0], interval='root-n-0')[:, None, None, None] * np.ones_like(n))
+                    funcs.poisson_conf_interval(n[0, 0, 0], interval='root-n-0')[:, None, None, None] * np.ones_like(n))  # noqa: E501
 
     n[1, 2, 3] = 0
     assert not np.any(np.isnan(
@@ -497,7 +497,7 @@ def test_poisson_conf_array_fc():
     n = 7 * np.ones((3, 4, 5))
     assert_allclose(
         funcs.poisson_conf_interval(n, interval='frequentist-confidence'),
-        funcs.poisson_conf_interval(n[0, 0, 0], interval='frequentist-confidence')[:, None, None, None] * np.ones_like(n))
+        funcs.poisson_conf_interval(n[0, 0, 0], interval='frequentist-confidence')[:, None, None, None] * np.ones_like(n))  # noqa: E501
 
     n[1, 2, 3] = 0
     assert not np.any(np.isnan(
@@ -589,23 +589,21 @@ def test_scipy_poisson_limit():
     Kraft, Burrows and Nousek in
     `ApJ 374, 344 (1991) <https://ui.adsabs.harvard.edu/abs/1991ApJ...374..344K>`_
     '''
-    assert_allclose(funcs._scipy_kraft_burrows_nousek(5., 2.5, .99),
-                    (0, 10.67), rtol=1e-3)
     assert_allclose(funcs._scipy_kraft_burrows_nousek(5, 2.5, .99),
                     (0, 10.67), rtol=1e-3)
     assert_allclose(funcs._scipy_kraft_burrows_nousek(np.int32(5.), 2.5, .99),
                     (0, 10.67), rtol=1e-3)
     assert_allclose(funcs._scipy_kraft_burrows_nousek(np.int64(5.), 2.5, .99),
                     (0, 10.67), rtol=1e-3)
-    assert_allclose(funcs._scipy_kraft_burrows_nousek(5., np.float32(2.5), .99),
+    assert_allclose(funcs._scipy_kraft_burrows_nousek(5, np.float32(2.5), .99),
                     (0, 10.67), rtol=1e-3)
-    assert_allclose(funcs._scipy_kraft_burrows_nousek(5., np.float64(2.5), .99),
+    assert_allclose(funcs._scipy_kraft_burrows_nousek(5, np.float64(2.5), .99),
                     (0, 10.67), rtol=1e-3)
-    assert_allclose(funcs._scipy_kraft_burrows_nousek(5., 2.5, np.float32(.99)),
+    assert_allclose(funcs._scipy_kraft_burrows_nousek(5, 2.5, np.float32(.99)),
                     (0, 10.67), rtol=1e-3)
-    assert_allclose(funcs._scipy_kraft_burrows_nousek(5., 2.5, np.float64(.99)),
+    assert_allclose(funcs._scipy_kraft_burrows_nousek(5, 2.5, np.float64(.99)),
                     (0, 10.67), rtol=1e-3)
-    conf = funcs.poisson_conf_interval([5., 6.], 'kraft-burrows-nousek',
+    conf = funcs.poisson_conf_interval([5, 6], 'kraft-burrows-nousek',
                                        background=[2.5, 2.],
                                        confidence_level=[.99, .9])
     assert_allclose(conf[:, 0], (0, 10.67), rtol=1e-3)
@@ -643,47 +641,49 @@ def test_mpmath_poisson_limit():
     # For this one we do not have the "true" answer from the publication,
     # but we want to make sure that it at least runs without error
     # see https://github.com/astropy/astropy/issues/9596
-    out = funcs._mpmath_kraft_burrows_nousek(1000., 900., .9)
+    _ = funcs._mpmath_kraft_burrows_nousek(1000., 900., .9)
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
 def test_poisson_conf_value_errors():
-    with pytest.raises(ValueError) as e:
+    with pytest.raises(ValueError, match='Only sigma=1 supported'):
         funcs.poisson_conf_interval([5, 6], 'root-n', sigma=2)
-    assert 'Only sigma=1 supported' in str(e.value)
 
-    with pytest.raises(ValueError) as e:
+    with pytest.raises(ValueError, match='background not supported'):
         funcs.poisson_conf_interval([5, 6], 'pearson', background=[2.5, 2.])
-    assert 'background not supported' in str(e.value)
 
-    with pytest.raises(ValueError) as e:
+    with pytest.raises(ValueError, match='confidence_level not supported'):
         funcs.poisson_conf_interval([5, 6], 'sherpagehrels',
                                     confidence_level=[2.5, 2.])
-    assert 'confidence_level not supported' in str(e.value)
 
-    with pytest.raises(ValueError) as e:
+    with pytest.raises(ValueError, match='Invalid method'):
         funcs.poisson_conf_interval(1, 'foo')
-    assert 'Invalid method' in str(e.value)
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
 def test_poisson_conf_kbn_value_errors():
-    with pytest.raises(ValueError) as e:
-        funcs.poisson_conf_interval(5., 'kraft-burrows-nousek',
+    with pytest.raises(ValueError, match='number between 0 and 1'):
+        funcs.poisson_conf_interval(5, 'kraft-burrows-nousek',
                                     background=2.5,
                                     confidence_level=99)
-    assert 'number between 0 and 1' in str(e.value)
 
-    with pytest.raises(ValueError) as e:
-        funcs.poisson_conf_interval(5., 'kraft-burrows-nousek',
+    with pytest.raises(ValueError, match='Set confidence_level for method'):
+        funcs.poisson_conf_interval(5, 'kraft-burrows-nousek',
                                     background=2.5)
-    assert 'Set confidence_level for method' in str(e.value)
 
-    with pytest.raises(ValueError) as e:
-        funcs.poisson_conf_interval(5., 'kraft-burrows-nousek',
+    with pytest.raises(ValueError, match='Background must be'):
+        funcs.poisson_conf_interval(5, 'kraft-burrows-nousek',
                                     background=-2.5,
                                     confidence_level=.99)
-    assert 'Background must be' in str(e.value)
+
+    with pytest.raises(TypeError, match='Number of counts must be integer'):
+        funcs.poisson_conf_interval(5., 'kraft-burrows-nousek',
+                                    background=2.5, confidence_level=.99)
+
+    with pytest.raises(TypeError, match='Number of counts must be integer'):
+        funcs.poisson_conf_interval([5., 6.], 'kraft-burrows-nousek',
+                                    background=[2.5, 2.],
+                                    confidence_level=[.99, .9])
 
 
 @pytest.mark.skipif('HAS_SCIPY or HAS_MPMATH')

--- a/astropy/stats/tests/test_funcs.py
+++ b/astropy/stats/tests/test_funcs.py
@@ -690,7 +690,7 @@ def test_poisson_conf_kbn_value_errors():
 def test_poisson_limit_nodependencies():
     with pytest.raises(ImportError):
         with pytest.warns(AstropyDeprecationWarning):
-            funcs.poisson_conf_interval(20., interval='kraft-burrows-nousek',
+            funcs.poisson_conf_interval(20, interval='kraft-burrows-nousek',
                                         background=10., conflevel=.95)
 
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to address deprecation warning when `N` is not an integer in Python 3.9. Not sure why our cron job didn't catch it, but regardless, I don't see how it can hurt to force `N` to be `int` anyway.

I originally thought about throwing an exception but from the tests, it seems like the function is supposed to accept `N` as `float` even when the docstring says `int`.  🤷 

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #10832
