### PR TITLE
Add MCMC sampling to models

### DIFF
--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -1672,7 +1672,10 @@ class EmceeFitter(Fitter):
 
         model_copy = _validate_model(model, self._opt_method.supported_constraints)
         farg = _convert_input(x, y)
-        farg = (model_copy, weights) + farg
+        if weights is not None:
+            farg = (model_copy, weights) + farg
+        else:
+            farg = (model_copy) + farg
         p0, _ = _model_to_fit_params(model_copy)
 
         fitparams, self.fit_info = self._opt_method(

--- a/astropy/modeling/samplers.py
+++ b/astropy/modeling/samplers.py
@@ -1,0 +1,100 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# pylint: disable=invalid-name
+
+"""
+Optimization algorithms used in `~astropy.modeling.fitting`.
+"""
+
+import numpy as np
+
+from astropy.modeling.optimizers import Optimization
+
+import emcee
+
+
+all = ["EmceeSampler"]
+
+
+class EmceeSampler(Optimization):
+    """
+    Interface to emcee sampler.
+    """
+
+    supported_constraints = ["bounds", "fixed", "tied"]
+
+    def __init__(self):
+        super().__init__(emcee)
+        self.fit_info = {"perparams": None, "samples": None, "sampler": None}
+
+    @staticmethod
+    def _get_best_fit_params(sampler):
+        """
+        Determine the best fit parameters given an emcee sampler object
+        """
+        # very likely a faster way
+        max_lnp = -1e6
+        nwalkers, nsteps = sampler.lnprobability.shape
+        for k in range(nwalkers):
+            tmax_lnp = np.nanmax(sampler.lnprobability[k])
+            if tmax_lnp > max_lnp:
+                max_lnp = tmax_lnp
+                (indxs,) = np.where(sampler.lnprobability[k] == tmax_lnp)
+                fit_params_best = sampler.chain[k, indxs[0], :]
+
+        return fit_params_best
+
+    def __call__(self, objfunc, initval, fargs, nsteps, save_samples=None, **kwargs):
+        """
+        Run the sampler.
+
+        Parameters
+        ----------
+        objfunc : callable
+            objection function
+        initval : iterable
+            initial guess for the parameter values
+        fargs : tuple
+            other arguments to be passed to the statistic function
+        kwargs : dict
+            other keyword arguments to be passed to the solver
+        """
+        # optresult = self.opt_method(objfunc, initval, args=fargs)
+        # fitparams = optresult['x']
+
+        ndim = len(initval)
+        nwalkers = 2 * ndim
+        pos = initval + 1e-4 * np.random.randn(nwalkers, ndim)
+
+        # ensure all the walkers start within the bounds
+        model = fargs[0]
+        for cp in pos:
+            k = 0
+            for cname in model.param_names:
+                if not model.fixed[cname]:
+                    if model.bounds[cname][0] is not None:
+                        if cp[k] < model.bounds[cname][0]:
+                            cp[k] = model.bounds[cname][0]
+                    if model.bounds[cname][1] is not None:
+                        if cp[k] > model.bounds[cname][1]:
+                            cp[k] = model.bounds[cname][1]
+                    # only non-fixed parameters are in initval
+                    # so only increment k when non-fixed
+                    k += 1
+
+        # Set up the backend
+        if save_samples:
+            # Don't forget to clear it in case the file already exists
+            save_backend = emcee.backends.HDFBackend(save_samples)
+            save_backend.reset(nwalkers, ndim)
+
+        sampler = self.opt_method.EnsembleSampler(
+            nwalkers, ndim, objfunc, backend=save_backend, args=fargs
+        )
+        sampler.run_mcmc(pos, nsteps, progress=True)
+        samples = sampler.get_chain()
+
+        fitparams = self._get_best_fit_params(sampler)
+        self.fit_info["sampler"] = sampler
+        self.fit_info["samples"] = samples
+
+        return fitparams, self.fit_info

--- a/astropy/modeling/samplers.py
+++ b/astropy/modeling/samplers.py
@@ -9,7 +9,12 @@ import numpy as np
 
 from astropy.modeling.optimizers import Optimization
 
-import emcee
+try:
+    import emcee
+except ImportError:
+    HAS_EMCEE = False
+else:
+    HAS_EMCEE = True
 
 
 all = ["EmceeSampler"]

--- a/astropy/modeling/samplers.py
+++ b/astropy/modeling/samplers.py
@@ -82,6 +82,7 @@ class EmceeSampler(Optimization):
                     k += 1
 
         # Set up the backend
+        save_backend = None
         if save_samples:
             # Don't forget to clear it in case the file already exists
             save_backend = emcee.backends.HDFBackend(save_samples)

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,6 +60,7 @@ test =
     coverage
     skyfield>=1.20
     sgp4>=2.3
+    emcee
 all =
     scipy>=0.18
     dask[array]
@@ -84,6 +85,7 @@ docs =
     PyYAML>=3.12
     scipy
     matplotlib
+    emcee
 
 [options.package_data]
 * = data/*, data/*/*, data/*/*/*, data/*/*/*/*, data/*/*/*/*/*, data/*/*/*/*/*/*


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request adds MCMC sampling to the modeling package.  It adds `samplers` to the possible solution for fitting.  `Samplers` sample the fitting in comparison to `optimizers` that find the best fit model.  This PR adds the interface to the popular `emcee` package.  Flat priors are supported.  The result of the sampling includes the best fit model, uncertainties, covariance matrix, and the parameter posteriors as astropy.uncertainty distributions.  The full sampler info is included as part of the fit_info.

*In progress PR*

More work needed including tests and documentation.

This is the result of discussion with various people over the last year or more.   In the past, @eteq has expressed interest in contributing to this PR with his work on this topic - especially on how to include more complete support for priors.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

