### PR TITLE
TST: yet more URLError alternate names

### DIFF
--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -2120,4 +2120,4 @@ def test_download_ftp_file_properly_handles_socket_error():
     with pytest.raises(urllib.error.URLError) as excinfo:
         download_file(faulty_url)
     errmsg = excinfo.exconly()
-    assert "Name or service not known" in errmsg or 'getaddrinfo failed' in errmsg
+    assert "Name or service not known" in errmsg or 'getaddrinfo failed' in errmsg or 'Temporary failure in name resolution' in errmsg


### PR DESCRIPTION
This is a follow-on to #10755 which is a follow-in to #10750 - it turns out on "some platforms" (which means... mine - Ubuntu 20.04 with who knows what odd network setup I may have done to it), instead of the `URLError` messages currently in ``test_download_ftp_file_properly_handles_socket_error``, I get a "Temporary failure in name resolution".  So this PR updates the error messages to allow that.