### PR TITLE
EXP: Investigate Windows failure on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -258,6 +258,7 @@ install:
         sudo apt-get -qq update;
         sudo apt-get install -t testing -y --no-install-recommends ${APT_DEPENDENCIES};
       fi
+    - where python
 
 script:
     - if [ $SETUP_METHOD == 'tox' ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -261,7 +261,7 @@ install:
 
 script:
     - if [ $SETUP_METHOD == 'tox' ]; then
-        pip install -U pip tox;
+        pip install -U pip wheel setuptools tox;
         tox $TOXARGS -- $TOXPOSARGS;
       else
         python3 -m venv --system-site-packages tests;

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ env:
         # that tox passes through to the {posargs} indicator in tox.ini.
         # The latter can be used for example to pass arguments to pytest.
         - TOXENV='test'
-        - TOXARGS='-rv'
+        - TOXARGS='-v'
         - TOXPOSARGS=''
 
         # For installing without tox, we can rely mostly on what Debian already

--- a/.travis.yml
+++ b/.travis.yml
@@ -258,11 +258,10 @@ install:
         sudo apt-get -qq update;
         sudo apt-get install -t testing -y --no-install-recommends ${APT_DEPENDENCIES};
       fi
-    - copy C:\\tools\\miniconda3\\envs\\test\\python.exe C:\\tools\\miniconda3\\envs\\test\\Lib\\venv\\scripts\\nt\\
 
 script:
     - if [ $SETUP_METHOD == 'tox' ]; then
-        pip install tox;
+        pip install -U pip tox;
         tox $TOXARGS -- $TOXPOSARGS;
       else
         python3 -m venv --system-site-packages tests;

--- a/.travis.yml
+++ b/.travis.yml
@@ -136,7 +136,7 @@ matrix:
           stage: Initial tests
           name: Python 3.7 with all optional dependencies
           env: PYTHON_VERSION=3.7
-               TOXENV='py37-test-alldeps'
+               TOXENV='py37-test-windeps'
 
         # Do a PEP8/pyflakes test with flake8
         - language: python
@@ -258,7 +258,6 @@ install:
         sudo apt-get -qq update;
         sudo apt-get install -t testing -y --no-install-recommends ${APT_DEPENDENCIES};
       fi
-    - where python
 
 script:
     - if [ $SETUP_METHOD == 'tox' ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -136,7 +136,7 @@ matrix:
           stage: Initial tests
           name: Python 3.7 with all optional dependencies
           env: PYTHON_VERSION=3.7
-               TOXENV='py37-test-windeps'
+               TOXENV='py37-test-alldeps'
 
         # Do a PEP8/pyflakes test with flake8
         - language: python
@@ -261,7 +261,7 @@ install:
 
 script:
     - if [ $SETUP_METHOD == 'tox' ]; then
-        pip install tox;
+        pip install tox virtualenv==20.0.33;
         tox $TOXARGS -- $TOXPOSARGS;
       else
         python3 -m venv --system-site-packages tests;

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,7 +82,7 @@ matrix:
         - language: python
           python: 3.7
           name: Python 3.7 with minimal dependencies
-          stage: Initial tests
+          stage: Cron tests
           env: TOXENV="py37-test"
 
         # Try MacOS X.
@@ -116,7 +116,7 @@ matrix:
           python: 3.8
           dist: bionic
           name: Python 3.8 with all optional dependencies
-          stage: Initial tests
+          stage: Cron tests
           env: TOXENV="py38-test-alldeps"
                TOXARGS="-v --develop"
                TOXPOSARGS="--durations=50"
@@ -133,7 +133,7 @@ matrix:
 
         # Try on Windows
         - os: windows
-          stage: Final tests
+          stage: Initial tests
           name: Python 3.7 with all optional dependencies
           env: PYTHON_VERSION=3.7
                TOXENV='py37-test-alldeps'
@@ -142,7 +142,7 @@ matrix:
         - language: python
           python: 3.7
           name: Code style checks
-          stage: Initial tests
+          stage: Cron tests
           env: TOXENV='codestyle'
 
         # Try developer version of Numpy with optional dependencies and also

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ env:
         # that tox passes through to the {posargs} indicator in tox.ini.
         # The latter can be used for example to pass arguments to pytest.
         - TOXENV='test'
-        - TOXARGS='-v'
+        - TOXARGS='-rv'
         - TOXPOSARGS=''
 
         # For installing without tox, we can rely mostly on what Debian already

--- a/.travis.yml
+++ b/.travis.yml
@@ -258,10 +258,11 @@ install:
         sudo apt-get -qq update;
         sudo apt-get install -t testing -y --no-install-recommends ${APT_DEPENDENCIES};
       fi
+    - copy C:\\tools\\miniconda3\\envs\\test\\python.exe C:\\tools\\miniconda3\\envs\\test\\Lib\\venv\\scripts\\nt\\
 
 script:
     - if [ $SETUP_METHOD == 'tox' ]; then
-        pip install tox virtualenv==20.0.33;
+        pip install tox;
         tox $TOXARGS -- $TOXPOSARGS;
       else
         python3 -m venv --system-site-packages tests;

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{36,37,38,dev}-test{,-alldeps,-oldestdeps,-devdeps,-numpy117,-numpy118,-numpy119}{,-cov}
+    py{36,37,38,dev}-test{,-alldeps,-windeps,-oldestdeps,-devdeps,-numpy117,-numpy118,-numpy119}{,-cov}
     build_docs
     linkcheck
     codestyle
@@ -62,6 +62,8 @@ deps =
 
     image: pytest-mpl
 
+    windeps: virtualenv==20.0.33
+
     # The oldestdeps factor is intended to be used to install the oldest versions of all
     # dependencies that have a minimum version.
     # pytest-openfiles pinned because of https://github.com/astropy/astropy/issues/10160
@@ -89,6 +91,7 @@ deps =
 extras =
     test
     alldeps: all
+    windeps: all
 
 commands =
     pip freeze

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ requires =
     setuptools >= 30.3.0
     pip >= 19.3.1
     tox-pypi-filter >= 0.12
+    virtualenv == 20.0.33
 isolated_build = true
 indexserver =
     NIGHTLY = https://pypi.anaconda.org/scipy-wheels-nightly/simple

--- a/tox.ini
+++ b/tox.ini
@@ -91,7 +91,6 @@ extras =
     alldeps: all
 
 commands =
-    where python
     pip freeze
     !cov-!double: pytest --pyargs astropy {toxinidir}/docs {env:MPLFLAGS} {posargs}
     cov-!double: pytest --pyargs astropy {toxinidir}/docs {env:MPLFLAGS} --cov astropy --cov-config={toxinidir}/setup.cfg {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{36,37,38,dev}-test{,-alldeps,-windeps,-oldestdeps,-devdeps,-numpy117,-numpy118,-numpy119}{,-cov}
+    py{36,37,38,dev}-test{,-alldeps,-oldestdeps,-devdeps,-numpy117,-numpy118,-numpy119}{,-cov}
     build_docs
     linkcheck
     codestyle
@@ -62,8 +62,6 @@ deps =
 
     image: pytest-mpl
 
-    windeps: virtualenv==20.0.33
-
     # The oldestdeps factor is intended to be used to install the oldest versions of all
     # dependencies that have a minimum version.
     # pytest-openfiles pinned because of https://github.com/astropy/astropy/issues/10160
@@ -91,7 +89,6 @@ deps =
 extras =
     test
     alldeps: all
-    windeps: all
 
 commands =
     pip freeze

--- a/tox.ini
+++ b/tox.ini
@@ -91,6 +91,7 @@ extras =
     alldeps: all
 
 commands =
+    where python
     pip freeze
     !cov-!double: pytest --pyargs astropy {toxinidir}/docs {env:MPLFLAGS} {posargs}
     cov-!double: pytest --pyargs astropy {toxinidir}/docs {env:MPLFLAGS} --cov astropy --cov-config={toxinidir}/setup.cfg {posargs}


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

Windows job on Travis CI suddenly cannot find `python.exe`. Larry saw same problem over at `photutils`. Not sure what had changed.

p.s. My job is queued. Looks like this gonna take a while.