### PR TITLE
Use manylinux1 for LTS wheels

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,7 +38,9 @@ jobs:
 
       # FIXME: we exclude the test_data_out_of_range test since it
       # currently fails, see https://github.com/astropy/astropy/issues/10409
-      test_command: pytest -p no:warnings --astropy-header -k "not test_data_out_of_range" --pyargs astropy
+      # FIXME: we exclude the test_data_at_range_limit test since it
+      # currently fails, see https://github.com/astropy/astropy/issues/10853
+      test_command: pytest -p no:warnings --astropy-header -k "not test_data_out_of_range and not test_data_at_range_limit" --pyargs astropy
       test_extras: test
 
       # NOTE: for v* tags, we auto-release to PyPI. See

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,6 +26,12 @@ pr:
     include:
     - 'v*'
 
+# Build Linux wheels using manylinux1 for compatibility with old versions
+# of pip and old platforms.
+variables:
+  CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
+  CIBW_MANYLINUX_I686_IMAGE: manylinux1
+
 jobs:
   - template: publish.yml@OpenAstronomy
     parameters:


### PR DESCRIPTION
Before this is merged we need to check the Azure logs to make sure the correct manylinux1 wheels are produced.