### PR TITLE
Fix error with double Numpy requirement with LTS and pip 10

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -80,7 +80,7 @@ astropy.wcs
 Other Changes and Additions
 ---------------------------
 
-- Fixed installation of the source distribution with pip<19. [#10837]
+- Fixed installation of the source distribution with pip<19. [#10837, #10852]
 
 4.0.2 (2020-10-10)
 ==================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,10 +9,5 @@ requires = ["setuptools",
             "wheel",
             "cython==0.29.14",
             "jinja2==2.10.3",
-            # NOTE: we can't use the oldest-supported-numpy package
-            # here because it conflicts with the setup_requires
-            # setting in setup.cfg which is present in the v4.0.x
-            # branch.
-            "numpy==1.16.*; python_version<='3.7'",
-            "numpy==1.17.*; python_version>='3.8'"]
+            "oldest-supported-numpy"]
 build-backend = 'setuptools.build_meta'

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,8 +25,13 @@ classifiers =
 requires = numpy
 zip_safe = False
 tests_require = pytest-astropy
+# The numpy used for setup_requires is set to 1.13.3 rather than
+# 1.16 to be compatible with the use of oldest-supported-numpy
+# in pyproject.toml. It's ok for this version to be older than 1.16
+# because this is just for the purpose of building C extensions
+# and the Numpy ABI is forward-compatible.
 setup_requires =
-    numpy>=1.16
+    numpy>=1.13.3
     cython>=0.29.13
     jinja2>=2.7
 install_requires = numpy>=1.16


### PR DESCRIPTION
I'm going to preface this with: who doesn't love obscure Python packaging issues 🤦 

Some users have reported the following error with Astropy 4.0.2:

```
Processing ./.tox/.tmp/package/1/radio-beam-0.3.3.dev47+g5c926e5.tar.gz
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
Collecting astropy (from radio-beam==0.3.3.dev47+g5c926e5)
  Downloading https://files.pythonhosted.org/packages/12/73/4427013e2a50e4dcd17c808a3770f22ea0f27b6771decd3ad9b7f48f5753/astropy-4.0.2.tar.gz (7.8MB)
  Installing build dependencies: started
  Installing build dependencies: finished with status 'error'
  Complete output from command /home/travis/build/radio-astro-tools/radio-beam/.tox/py36-test-casa/bin/python -m pip install --ignore-installed --no-user --prefix /tmp/pip-build-env-d07tbcv5 https://files.pythonhosted.org/packages/44/a6/7fb6e8b3f4a6051e72e4e2218889351f0ee484b9ee17e995f5ccff780300/setuptools-50.3.0-py3-none-any.whl#sha256=c77b3920663a435c9450d9d971c48f5a7478fca8881b2cd2564e59f970f03536 https://files.pythonhosted.org/packages/a7/00/3df031b3ecd5444d572141321537080b40c1c25e1caa3d86cdd12e5e919c/wheel-0.35.1-py2.py3-none-any.whl#sha256=497add53525d16c173c2c1c733b8f655510e909ea78cc0e29d374243544b77a2 https://files.pythonhosted.org/packages/df/d1/4d3f8a7a920e805488a966cc6ab55c978a712240f584445d703c08b9f405/Cython-0.29.14-cp36-cp36m-manylinux1_x86_64.whl#sha256=03f6bbb380ad0acb744fb06e42996ea217e9d00016ca0ff6f2e7d60f580d0360 https://files.pythonhosted.org/packages/65/e0/eb35e762802015cab1ccee04e8a277b03f1d8e53da3ec3106882ec42558b/Jinja2-2.10.3-py2.py3-none-any.whl#sha256=74320bb91f31270f9551d46522e33af46a80c3d619f4a4bf42b3164d30b5911f https://files.pythonhosted.org/packages/90/b1/ba7e59da253c58aaf874ea790ae71d6870255a5243010d94688c41618678/numpy-1.16.6-cp36-cp36m-manylinux1_x86_64.whl#sha256=60c56922c9d759d664078fbef94132377ef1498ab27dd3d0cc7a21b346e68c06 https://files.pythonhosted.org/packages/ae/c9/69096779fd29bf3066e24124e1c88213e40bf9d2eab4786d21948a37c40b/numpy-1.17.5-cp36-cp36m-manylinux1_x86_64.whl#sha256=1739f079e2fcc985cc187aa3ce489d127a02ff12bcc5178269bb7ce5dc860e8f:
  Double requirement given: numpy==1.17.5 from https://files.pythonhosted.org/packages/ae/c9/69096779fd29bf3066e24124e1c88213e40bf9d2eab4786d21948a37c40b/numpy-1.17.5-cp36-cp36m-manylinux1_x86_64.whl#sha256=1739f079e2fcc985cc187aa3ce489d127a02ff12bcc5178269bb7ce5dc860e8f (already in numpy==1.16.6 from https://files.pythonhosted.org/packages/90/b1/ba7e59da253c58aaf874ea790ae71d6870255a5243010d94688c41618678/numpy-1.16.6-cp36-cp36m-manylinux1_x86_64.whl#sha256=60c56922c9d759d664078fbef94132377ef1498ab27dd3d0cc7a21b346e68c06, name='numpy')
```

Note the ``Double requirement given``. This happens with pip 10 because pip 10 sees:

```
            "numpy==1.16.*; python_version<='3.7'",
            "numpy==1.17.*; python_version>='3.8'"]
```

in the ``pyproject.toml`` file and doesn't understand the environment markers so ignores them and just tries to install two Numpy versions. The solution is to instead specify ``oldest-supported-numpy`` in ``pyproject.toml`` which is a meta-package that automatically provides the right version. Why does that package not have the same issue you ask? Because pip will install the wheel of oldest-supported-numpy not the source so doesn't have to parse pyproject.toml, and instead the information about which version to install on different Python versions is encoded in the wheel in a way that pip 10 does understand.

Anyway...

The issue is that using oldest-supported-numpy results in Numpy 1.13 being used at build time with Python 3.6 which is fine (even though older than the runtime requirement of 1.16) because this is just for building the C extensions and the Numpy ABI is forward-compatible. Which is why oldest-supported-numpy lists 1.13 in the first place. However, pip complains because setup_requires says Numpy>=1.16 which is in conflict with 1.13.

So...

I think the solution is to set setup_requires to have numpy>=1.13.3, same as oldest-supported-numpy. I think this is fine because again using an old numpy at setup time is ok. People with very old pip versions will anyway then have pyproject.toml ignored and setup_requires honored which will install the latest numpy (not 1.13 or 1.16) so nothing will change for them because setup_requires uses ``>=`` not ``==``.

I'd appreciate if someone can check my logic though (@Cadair or @saimn since we were discussing this on Slack?)