### PR TITLE
Added a Quadrangle patch for WCSAxes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -140,6 +140,11 @@ astropy.utils
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 
+- Added the ``Quadrangle`` patch for ``WCSAxes`` for a latitude-longitude
+  quadrangle.  Unlike ``matplotlib.patches.Rectangle``, the edges of this
+  patch will be rendered as curved lines if appropriate for the WCS
+  transformation. [#10862]
+
 astropy.wcs
 ^^^^^^^^^^^
 

--- a/astropy/visualization/wcsaxes/patches.py
+++ b/astropy/visualization/wcsaxes/patches.py
@@ -9,7 +9,7 @@ from astropy.coordinates.representation import UnitSphericalRepresentation
 from astropy.coordinates.matrix_utilities import rotation_matrix, matrix_product
 
 
-__all__ = ['SphericalCircle', 'WarpableRectangle']
+__all__ = ['Quadrangle', 'SphericalCircle']
 
 
 def _rotate_polygon(lon, lat, lon0, lat0):
@@ -90,13 +90,17 @@ class SphericalCircle(Polygon):
         super().__init__(vertices, **kwargs)
 
 
-class WarpableRectangle(Polygon):
+class Quadrangle(Polygon):
     """
-    Create a rectangular patch that can be visually warped.  This functions
-    similarly to `matplotlib.patches.Rectangle` except that:
-    * Each of the edges of the rectangle has a large number of vertices so that
-      it will render as a curved line if appropriate for the WCS transformation.
-    * It accepts `~astropy.units.Quantity` inputs.
+    Create a patch representing a latitude-longitude quadrangle.
+
+    The edges of the quadrangle lie on two lines of constant longitude and two
+    lines of constant latitude (or the equivalent component names in the
+    coordinate frame of interest, such as right ascension and declination).
+    Note that lines of constant latitude are not great circles.
+
+    Unlike `matplotlib.patches.Rectangle`, the edges of this patch will render
+    as curved lines if appropriate for the WCS transformation.
 
     Parameters
     ----------
@@ -104,12 +108,12 @@ class WarpableRectangle(Polygon):
         This can be either a tuple of two `~astropy.units.Quantity` objects, or
         a single `~astropy.units.Quantity` array with two elements.
     width : `~astropy.units.Quantity`
-        The width of the rectangle (e.g., longitude or right ascension)
+        The width of the quadrangle in longitude (or, e.g., right ascension)
     height : `~astropy.units.Quantity`
-        The height of the rectangle (e.g., latitude or declination)
+        The height of the quadrangle in latitude (or, e.g., declination)
     resolution : int, optional
-        The number of points that make up each side of the rectangle -
-        increase this to get a smoother rectangle.
+        The number of points that make up each side of the quadrangle -
+        increase this to get a smoother quadrangle.
     vertex_unit : `~astropy.units.Unit`
         The units in which the resulting polygon should be defined - this
         should match the unit that the transformation (e.g. the WCS
@@ -126,7 +130,7 @@ class WarpableRectangle(Polygon):
         # a single 2-element Quantity.
         longitude, latitude = u.Quantity(anchor).to_value(vertex_unit)
 
-        # Convert the rectangle dimensions to the appropriate units
+        # Convert the quadrangle dimensions to the appropriate units
         width = width.to_value(vertex_unit)
         height = height.to_value(vertex_unit)
 
@@ -134,7 +138,7 @@ class WarpableRectangle(Polygon):
         lon_seq = longitude + np.linspace(0, width, resolution + 1)
         lat_seq = latitude + np.linspace(0, height, resolution + 1)
 
-        # Trace the path of the rectangle
+        # Trace the path of the quadrangle
         lon = np.concatenate([lon_seq[:-1],
                               np.repeat(lon_seq[-1], resolution),
                               np.flip(lon_seq[1:]),

--- a/astropy/visualization/wcsaxes/tests/test_images.py
+++ b/astropy/visualization/wcsaxes/tests/test_images.py
@@ -16,7 +16,7 @@ from astropy.tests.image_tests import IMAGE_REFERENCE_DIR
 from astropy.utils.data import get_pkg_data_filename
 from astropy.visualization.wcsaxes import WCSAxes
 from astropy.visualization.wcsaxes.frame import EllipticalFrame
-from astropy.visualization.wcsaxes.patches import SphericalCircle
+from astropy.visualization.wcsaxes.patches import Quadrangle, SphericalCircle
 from astropy.wcs import WCS
 
 
@@ -669,6 +669,34 @@ class TestBasic(BaseImageTests):
         r = SphericalCircle((266.4 * u.deg, -29.1 * u.deg), 0.15 * u.degree,
                             edgecolor='purple', facecolor='none',
                             transform=ax.get_transform('fk5'))
+        ax.add_patch(r)
+
+        ax.coords[0].set_ticklabel_visible(False)
+        ax.coords[1].set_ticklabel_visible(False)
+
+        return fig
+
+    @pytest.mark.remote_data(source='astropy')
+    @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
+                                   tolerance=0, style={})
+    def test_quadrangle(self, tmpdir):
+        # Test that Quadrangle can have curved edges while Rectangle does not
+        wcs = WCS(self.msx_header)
+        fig = plt.figure(figsize=(3, 3))
+        ax = fig.add_axes([0.25, 0.25, 0.5, 0.5], projection=wcs, aspect='equal')
+        ax.set_xlim(0, 10000)
+        ax.set_ylim(-10000, 0)
+
+        # Add a quadrangle patch (100 degrees by 20 degrees)
+        q = Quadrangle((255, -70)*u.deg, 100*u.deg, 20*u.deg,
+                       label='Quadrangle', edgecolor='blue', facecolor='none',
+                       transform=ax.get_transform('icrs'))
+        ax.add_patch(q)
+
+        # Add a rectangle patch (100 degrees by 20 degrees)
+        r = Rectangle((255, -70), 100, 20,
+                       label='Rectangle', edgecolor='red', facecolor='none', linestyle='--',
+                       transform=ax.get_transform('icrs'))
         ax.add_patch(r)
 
         ax.coords[0].set_ticklabel_visible(False)


### PR DESCRIPTION
This PR adds a new patch (`Quadrangle`) for plotting with WCSAxes.  A [quadrangle](https://en.wikipedia.org/wiki/Quadrangle_(geography)) has edges that lie on lines of constant longitude and constant latitude.  Unlike `matplotlib.patches.Rectangle`, the edges of this patch will render as curved lines if appropriate for the WCS transformation.  Also, `Quadrangle` accepts `Quantity` inputs.

- [x] Add tests
- [x] Add documentation

## Example using `Quadrangle` from this PR
I use SunPy for the example because the benefit is readily apparent.  Here's a quadrangle that spans 15 degrees in heliographic longitude and 60 degrees in heliographic latitude.
```python
import matplotlib.pyplot as plt

from astropy import units as u
from astropy.visualization.wcsaxes import Quadrangle

import sunpy.map
from sunpy.coordinates import HeliographicStonyhurst
from sunpy.data.sample import AIA_171_IMAGE

# Typical SunPy plot
aiamap = sunpy.map.Map(AIA_171_IMAGE)
ax = plt.subplot(projection=aiamap)
aiamap.plot(clip_interval=(1, 99.9)*u.percent)
aiamap.draw_grid()

# Add a `astropy.visualization.wcsaxes.Quadrangle`
heliographic_frame = HeliographicStonyhurst(obstime=aiamap.date)
q = Quadrangle((50, -10)*u.deg, 15*u.deg, 60*u.deg,
               edgecolor='blue', facecolor='none', linewidth=2,
               transform=ax.get_transform(heliographic_frame))
ax.add_patch(q)

plt.show()
```
![Quadrangle](https://user-images.githubusercontent.com/991759/96071996-3cdad600-0e71-11eb-8c5a-dcc3e9ab2881.png)


## Using `matplotlib.patches.Rectangle` instead
```python
from matplotlib.patches import Rectangle

# Typical SunPy plot
ax = plt.subplot(projection=aiamap)
aiamap.plot(clip_interval=(1, 99.9)*u.percent)
aiamap.draw_grid()

# Add a `matplotlib.patches.Rectangle`
r = Rectangle((50, -10), 15, 60,
              edgecolor='red', facecolor='none', linewidth=2,
              transform=ax.get_transform(heliographic_frame))
ax.add_patch(r)

plt.show()
```
![Rectangle](https://user-images.githubusercontent.com/991759/96071938-1b79ea00-0e71-11eb-81aa-e5d7caab6cc0.png)
