### PR TITLE
TST: Ignore dtype with a subarray field deprecation warning

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -131,6 +131,7 @@ filterwarnings =
     ignore:Unknown pytest.mark.mpl_image_compare:pytest.PytestUnknownMarkWarning
     ignore:Unknown config option:pytest.PytestConfigWarning
     ignore:matplotlibrc text.usetex:UserWarning:matplotlib
+    ignore:using a dtype with a subarray field is deprecated:DeprecationWarning
     # Triggered by ProgressBar > ipykernel.iostream
     ignore:the imp module is deprecated:DeprecationWarning
     # toolz internal deprecation warning https://github.com/pytoolz/toolz/issues/500


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to temporarily ignore deprecation warnings from #10815 because they make the log really hard to read while we await resolution upstream. We will ignore the warning for now so we can see if any new warnings crop up.

- [ ] Make sure numpy-dev job passes with this patch. It is allowed to fail.
- [ ] On merge, edit #10815 with a reminder to undo this later when we can.