### PR TITLE
Make pixel_shape have integer values and correct its computation in fit_wcs_from_points

### DIFF
--- a/astropy/wcs/tests/test_utils.py
+++ b/astropy/wcs/tests/test_utils.py
@@ -1234,7 +1234,7 @@ RADESYS = 'ICRS'               / Equatorial coordinate system
     fit_wcs = fit_wcs_from_points((ypix, xpix), world_pix, proj_point='center')
 
     assert (fit_wcs.wcs.crpix.astype(int) == [1100, 1005]).all()
-    assert fit_wcs.pixel_shape == (200, 10)
+    assert fit_wcs.pixel_shape == (1200, 1010)
 
 
 @pytest.mark.skipif('not HAS_SCIPY')

--- a/astropy/wcs/tests/test_utils.py
+++ b/astropy/wcs/tests/test_utils.py
@@ -1234,7 +1234,7 @@ RADESYS = 'ICRS'               / Equatorial coordinate system
     fit_wcs = fit_wcs_from_points((ypix, xpix), world_pix, proj_point='center')
 
     assert (fit_wcs.wcs.crpix.astype(int) == [1100, 1005]).all()
-    assert fit_wcs.pixel_shape == (1200, 1010)
+    assert fit_wcs.pixel_shape == (1199, 1009)
 
 
 @pytest.mark.skipif('not HAS_SCIPY')

--- a/astropy/wcs/utils.py
+++ b/astropy/wcs/utils.py
@@ -1060,7 +1060,7 @@ def fit_wcs_from_points(xy, world_coords, proj_point='center',
         raise ValueError("sip_degree must be None, or integer.")
 
     # set pixel_shape to span of input points
-    wcs.pixel_shape = (xp.max()+1-xp.min(), yp.max()+1-yp.min())
+    wcs.pixel_shape = np.clip(np.ceil(np.max(xy, axis=1)).astype(int), 1, None)
 
     # determine CRVAL from input
     close = lambda l, p: p[np.argmin(np.abs(l))]

--- a/docs/changes/wcs/10865.bugfix.rst
+++ b/docs/changes/wcs/10865.bugfix.rst
@@ -1,0 +1,1 @@
+``fit_wcs_from_points`` now produces a WCS with integer ``NAXIXn`` values.


### PR DESCRIPTION
This PR fixes several issues with the computation of `pixel_shape` for the fitted WCS in `fit_wcs_from_points`:

1. IMO `pixel_shape` should be a list of integers. Having the meaning of image size (number of pixels along each axis) and also being related to `array_shape` I can't see how `pixel_shape` could take fractional values. In addition, these values get assigned to `NAXISn` and according to Wells (1981) paper these keywords take **integer values**.

2. I believe `pixel_shape` should not be computed as _difference_ between `max` and `min` of coordinates, but rather as `max` of coordinates. Assuming `x` and `y` coordinates are pixel coordinates from an image, the maximum of these coordinates would the best estimate for the size of the image from which these coordinates have been extracted.