### PR TITLE
Fix overly pessimistic polar motion warning, fixes #10645

### DIFF
--- a/astropy/coordinates/builtin_frames/utils.py
+++ b/astropy/coordinates/builtin_frames/utils.py
@@ -42,25 +42,23 @@ def get_polar_motion(time):
     iers_table = iers.earth_orientation_table.get()
     xp, yp, status = iers_table.pm_xy(time, return_status=True)
 
-    wmsg = None
+    wmsg = (
+        'Tried to get polar motions for times {} IERS data is '
+        'valid. Defaulting to polar motion from the 50-yr mean for those. '
+        'This may affect precision at the arcsec level'
+    )
     if np.any(status == iers.TIME_BEFORE_IERS_RANGE):
-        wmsg = ('Tried to get polar motions for times before IERS data is '
-                'valid. Defaulting to polar motion from the 50-yr mean for those. '
-                'This may affect precision at the 10s of arcsec level')
         xp[status == iers.TIME_BEFORE_IERS_RANGE] = _DEFAULT_PM[0]
         yp[status == iers.TIME_BEFORE_IERS_RANGE] = _DEFAULT_PM[1]
 
-        warnings.warn(wmsg, AstropyWarning)
+        warnings.warn(wmsg.format('before'), AstropyWarning)
 
     if np.any(status == iers.TIME_BEYOND_IERS_RANGE):
-        wmsg = ('Tried to get polar motions for times after IERS data is '
-                'valid. Defaulting to polar motion from the 50-yr mean for those. '
-                'This may affect precision at the 10s of arcsec level')
 
         xp[status == iers.TIME_BEYOND_IERS_RANGE] = _DEFAULT_PM[0]
         yp[status == iers.TIME_BEYOND_IERS_RANGE] = _DEFAULT_PM[1]
 
-        warnings.warn(wmsg, AstropyWarning)
+        warnings.warn(wmsg.format('after'), AstropyWarning)
 
     return xp.to_value(u.radian), yp.to_value(u.radian)
 

--- a/astropy/coordinates/tests/test_utils.py
+++ b/astropy/coordinates/tests/test_utils.py
@@ -1,0 +1,14 @@
+from astropy.time import Time
+from astropy.coordinates.builtin_frames.utils import get_polar_motion
+from astropy.utils.exceptions import AstropyWarning
+import pytest
+
+
+def test_polar_motion_unsupported_dates():
+    msg = r'Tried to get polar motions for times {} IERS.*'
+
+    with pytest.warns(AstropyWarning, match=msg.format('before')):
+        get_polar_motion(Time('1900-01-01'))
+
+    with pytest.warns(AstropyWarning, match=msg.format('after')):
+        get_polar_motion(Time('2100-01-01'))


### PR DESCRIPTION
Just removes the `10s` and fixes duplication of the warning message.