### PR TITLE
Add 10666 what's new entry for 4.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -822,6 +822,10 @@ astropy.convolution
 astropy.coordinates
 ^^^^^^^^^^^^^^^^^^^
 
+- Fix a bug where for light deflection by the Sun it was always assumed that the
+  source was at infinite distance, which in the (rare and) absolute worst-case
+  scenario could lead to errors up to 3 arcsec. [#10666]
+
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 
@@ -936,10 +940,6 @@ astropy.convolution
 
 astropy.coordinates
 ^^^^^^^^^^^^^^^^^^^
-
-- Fix a bug where for light deflection by the Sun it was always assumed that the
-  source was at infinite distance, which in the (rare and) absolute worst-case
-  scenario could lead to errors up to 3 arcsec. [#10666]
 
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^

--- a/docs/whatsnew/4.1.rst
+++ b/docs/whatsnew/4.1.rst
@@ -282,9 +282,10 @@ Realistic treatment of solar light deflection for nearby objects
 
 The machinery underlying the `astropy.coordinates` transformations was updated
 to correct an issue where coordinates were always assumed to be at infinite
-distance when computing the effect of light deflection by the sun.  While this
-change is undeniably more accurate, this will change previous results that may
-have already corrected for this effect.
+distance when computing the effect of light deflection by the sun.  With this
+change, light deflection by the Sun is accurate also for solar system objects.
+Even for those, the results will change only slightly (by 3 arcsec in the
+worst case).
 
 For more context and discussion on this topic see
 `Github issue #10666 <https://github.com/astropy/astropy/pull/10666>`_.

--- a/docs/whatsnew/4.1.rst
+++ b/docs/whatsnew/4.1.rst
@@ -274,6 +274,21 @@ Support for ASDF serialization of models
 All models (excluding model sets) can be written to an ASDF file. Constraints
 of type ``fixed`` and ``bounds`` can also be serialized.
 
+
+.. _whatsnew-4.1-light-defelction-fix:
+
+Realistic treatment of solar light deflection for nearby objects
+================================================================
+
+The machinery underlying the `astropy.coordinates` transformations was updated
+to correct an issue where coordinates were always assumed to be at infinite
+distance when computing the effect of light deflection by the sun.  While this
+change is undeniably more accurate, this will change previous results that may
+have already corrected for this effect.
+
+For more context and discussion on this topic see
+`Github issue #10666 <https://github.com/astropy/astropy/pull/10666>`_.
+
 Full change log
 ===============
 


### PR DESCRIPTION
This adds a mention of #10666 to the what's new, mainly as a "warning" given that this bug has long existed such that some users may have worked around it, and this will give a bit more visibility so that they know to un-do any workaround they might have.

Not I also moved the CHANGES.rst entry to 4.1 - this is mainly to be consistent with the What's new, but as discussed in #10666 we can certainly move it back if we agree it should go in the LTS branch!

cc @StuartLittlefair @mhvk