### PR TITLE
Use manylinux1 for linux wheels

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,6 +26,12 @@ pr:
     include:
     - 'v*'
 
+# Build Linux wheels using manylinux1 for compatibility with old versions
+# of pip and old platforms.
+variables:
+  CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
+  CIBW_MANYLINUX_I686_IMAGE: manylinux1
+
 jobs:
   - template: publish.yml@OpenAstronomy
     parameters:


### PR DESCRIPTION
I made this fix already for v4.0.3 but I think we might want to do it for v4.1 - basically manylinux2010 wheels require pip 19 or later which is maybe a little too restrictive, so I think for now and until we make a conscious decision to move to manylinux2010 we should use manylinux1.

Does anyone have a good argument for using manylinux2010?