### PR TITLE
TST: Fix doctest failures

### DIFF
--- a/docs/known_issues.rst
+++ b/docs/known_issues.rst
@@ -124,11 +124,14 @@ Numpy array creation functions cannot be used to initialize Quantity
 Trying the following example will throw an UnitConversionError::
 
     >>> my_quantity = u.Quantity(1, u.m)
-    >>> np.full(10, my_quantity)
+    >>> np.full(10, my_quantity)  # doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    ...
     UnitConversionError: 'm' (length) and '' (dimensionless) are not convertible
 
 A workaround for this at the moment would be to do::
     >>> np.full(10, 1) << u.m
+    <Quantity [1., 1., 1., 1., 1., 1., 1., 1., 1., 1.] m>
 
 As well as with `~numpy.full` one cannot do `~numpy.zeros`, `~numpy.ones`, and `~numpy.empty`.
 

--- a/docs/known_issues.rst
+++ b/docs/known_issues.rst
@@ -121,7 +121,10 @@ See: https://github.com/astropy/astropy/issues/7582
 
 Numpy array creation functions cannot be used to initialize Quantity
 --------------------------------------------------------------------
-Trying the following example will throw an UnitConversionError::
+Trying the following example will throw an UnitConversionError
+on NumPy before version 1.20 and ignore the unit in later versions:
+
+.. doctest-requires:: numpy<1.20
 
     >>> my_quantity = u.Quantity(1, u.m)
     >>> np.full(10, my_quantity)  # doctest: +IGNORE_EXCEPTION_DETAIL
@@ -130,6 +133,7 @@ Trying the following example will throw an UnitConversionError::
     UnitConversionError: 'm' (length) and '' (dimensionless) are not convertible
 
 A workaround for this at the moment would be to do::
+
     >>> np.full(10, 1) << u.m
     <Quantity [1., 1., 1., 1., 1., 1., 1., 1., 1., 1.] m>
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to fix doctest failures caused by #10848 

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->
