### PR TITLE
Ignore parallel option in fast C reader

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -953,6 +953,11 @@ astropy.extern
 astropy.io.ascii
 ^^^^^^^^^^^^^^^^
 
+- Partially fixed a performance issue when reading in parallel mode. Parallel
+  reading does not work correctly and has worse performance than serial
+  reading, so we now ignore the parallel option and fall back to serial reading.
+  [#10880]
+
 astropy.io.fits
 ^^^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -954,7 +954,7 @@ astropy.io.ascii
 ^^^^^^^^^^^^^^^^
 
 - Partially fixed a performance issue when reading in parallel mode. Parallel
-  reading does not work correctly and has worse performance than serial
+  reading currently has substantially worse performance than the default serial
   reading, so we now ignore the parallel option and fall back to serial reading.
   [#10880]
 

--- a/astropy/io/ascii/cparser.pyx
+++ b/astropy/io/ascii/cparser.pyx
@@ -224,7 +224,8 @@ cdef class CParser:
         # warning. We keep the parallel code below so that it can be fixed in
         # future, but if it cannot be fixed we should remove the parallel code
         # and deprecate the option itself. For now the warning is not a
-        # deprecation warning since we may still fix it in future.
+        # deprecation warning since we may still fix it in future. See
+        # https://github.com/astropy/astropy/issues/8858 for more details.
         if parallel:
             warnings.warn('parallel reading does not currently work, '
                           'so falling back to serial reading', AstropyWarning)

--- a/astropy/io/ascii/cparser.pyx
+++ b/astropy/io/ascii/cparser.pyx
@@ -228,7 +228,8 @@ cdef class CParser:
         # https://github.com/astropy/astropy/issues/8858 for more details.
         if parallel:
             warnings.warn('parallel reading does not currently work, '
-                          'so falling back to serial reading', AstropyWarning)
+                          'so falling back to serial reading (see '
+                          'https://github.com/astropy/astropy/issues/8858 for more details)', AstropyWarning)
             parallel = False
 
         if fast_reader:

--- a/astropy/io/ascii/cparser.pyx
+++ b/astropy/io/ascii/cparser.pyx
@@ -219,6 +219,17 @@ cdef class CParser:
                 expchar = 'A'
         parallel = fast_reader.pop('parallel', False)
 
+        # FIXME: for now the parallel mode does not work correctly and is worse
+        # than non-parallel mode so we disable parallel mode if set and emit a
+        # warning. We keep the parallel code below so that it can be fixed in
+        # future, but if it cannot be fixed we should remove the parallel code
+        # and deprecate the option itself. For now the warning is not a
+        # deprecation warning since we may still fix it in future.
+        if parallel:
+            warnings.warn('parallel reading does not currently work, '
+                          'so falling back to serial reading', AstropyWarning)
+            parallel = False
+
         if fast_reader:
             raise core.FastOptionsError("Invalid parameter in fast_reader dict")
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -138,7 +138,7 @@ filterwarnings =
     ignore:The toolz.compatibility module is no longer needed:DeprecationWarning
     # Ignore a warning we emit about not supporting the parallel
     # reading option for now, can be removed once the issue is fixed
-    ignore:parallel reading does not currently work, so falling back to serial mode
+    ignore:parallel reading does not currently work, so falling back to serial
 doctest_norecursedirs =
     */setup_package.py
 doctest_subpackage_requires =

--- a/setup.cfg
+++ b/setup.cfg
@@ -136,6 +136,9 @@ filterwarnings =
     ignore:the imp module is deprecated:DeprecationWarning
     # toolz internal deprecation warning https://github.com/pytoolz/toolz/issues/500
     ignore:The toolz.compatibility module is no longer needed:DeprecationWarning
+    # Ignore a warning we emit about not supporting the parallel
+    # reading option for now, can be removed once the issue is fixed
+    ignore:parallel reading does not currently work, so falling back to serial mode
 doctest_norecursedirs =
     */setup_package.py
 doctest_subpackage_requires =


### PR DESCRIPTION
As discussed in https://github.com/astropy/astropy/issues/8858, this ignores for now the parallel option in the fast C reader in io.ascii, since serial reading has better performance. The warning is deliberately not a deprecation warning as this may be fixed in future.

This does mean that we now have some code that isn't tested and I think it's important that we simply remove this code if the bug isn't fixed in a timely way, so I'll open an issue to remind us to remove this code, and I'll milestone it for 4.2 initially though we could discuss what a good time frame is. I think it makes sense to be reasonably aggressive or we'll forget about it. In any case we should keep this present PR simple and we can backport it to LTS and 4.1.

Running the test suite before this PR on MacOS X with Python 3.8:

```
% pytest astropy/io/ascii                            
...
======= 547 passed, 27 skipped, 6 xfailed in 293.08s (0:04:53) =======
```

and with this PR: 

```
======= 547 passed, 27 skipped, 6 xfailed in 18.73s =======
```

Fixes https://github.com/astropy/astropy/issues/9864