### PR TITLE
fix division by zero warnings for values near sun

### DIFF
--- a/astropy/coordinates/builtin_frames/utils.py
+++ b/astropy/coordinates/builtin_frames/utils.py
@@ -233,12 +233,8 @@ def aticq(srepr, astrom):
             eh = astrom['em'][..., np.newaxis] * astrom['eh']
             # unit vector from Sun to object
             q = eh + srepr_distance[..., np.newaxis].to_value(u.au) * before
-            sundist = np.linalg.norm(q, axis=-1, keepdims=True)
-            # division by small sun distances will raise warnings/errors that
-            # we can ignore, since any affected values are removed in lines
-            # that follow.
-            with np.errstate(divide='ignore', invalid='ignore'):
-                q /= sundist
+            sundist, q = erfa.pn(q)
+            sundist = sundist[..., np.newaxis]
             # calculation above is extremely unstable very close to the sun
             # in these situations, default back to ldsun-style behaviour,
             # since this is reversible and drops to zero within stellar limb
@@ -308,12 +304,8 @@ def atciqz(srepr, astrom):
         eh = astrom['em'][..., np.newaxis] * astrom['eh']
         # unit vector from Sun to object
         q = eh + srepr_distance[..., np.newaxis].to_value(u.au) * pco
-        sundist = np.linalg.norm(q, axis=-1, keepdims=True)
-        # division by small sun distances will raise warnings/errors that
-        # we can ignore, since any affected values are removed in lines
-        # that follow.
-        with np.errstate(divide='ignore', invalid='ignore'):
-            q /= sundist
+        sundist, q = erfa.pn(q)
+        sundist = sundist[..., np.newaxis]
         # calculation above is extremely unstable very close to the sun
         # in these situations, default back to ldsun-style behaviour,
         # since this is reversible and drops to zero within stellar limb

--- a/astropy/coordinates/builtin_frames/utils.py
+++ b/astropy/coordinates/builtin_frames/utils.py
@@ -234,7 +234,11 @@ def aticq(srepr, astrom):
             # unit vector from Sun to object
             q = eh + srepr_distance[..., np.newaxis].to_value(u.au) * before
             sundist = np.linalg.norm(q, axis=-1, keepdims=True)
-            q /= sundist
+            # division by small sun distances will raise warnings/errors that
+            # we can ignore, since any affected values are removed in lines
+            # that follow.
+            with np.errstate(divide='ignore', invalid='ignore'):
+                q /= sundist
             # calculation above is extremely unstable very close to the sun
             # in these situations, default back to ldsun-style behaviour,
             # since this is reversible and drops to zero within stellar limb
@@ -305,7 +309,11 @@ def atciqz(srepr, astrom):
         # unit vector from Sun to object
         q = eh + srepr_distance[..., np.newaxis].to_value(u.au) * pco
         sundist = np.linalg.norm(q, axis=-1, keepdims=True)
-        q /= sundist
+        # division by small sun distances will raise warnings/errors that
+        # we can ignore, since any affected values are removed in lines
+        # that follow.
+        with np.errstate(divide='ignore', invalid='ignore'):
+            q /= sundist
         # calculation above is extremely unstable very close to the sun
         # in these situations, default back to ldsun-style behaviour,
         # since this is reversible and drops to zero within stellar limb


### PR DESCRIPTION
The changes to light deflection in #10666 caused some problems for the actual centre of the Sun. In that case the code raises division by zero warnings which can break continuous integration tools. These warnings are also ugly and unnecessary since any affected vectors are replaced with the original directions.

As suggested by @ayshih we wrap these lines in ```np.errstate``` to prevent the warnings.
 
#10666 is currently milestoned for 4.1, so this has been given the same milestone.

Fixes #10878
