### PR TITLE
Remove extension auto-building machinery

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -354,6 +354,8 @@ Other Changes and Additions
   reduce the number of FITS ``VerifyWarning`` warnings when working with WCSes
   containing lookup table distortions. [#10513]
 
+- When importing astropy without first building the extension modules first,
+  raise an error directly instead of trying to auto-build. [#10883]
 
 4.1.1 (unreleased)
 ==================

--- a/astropy/__init__.py
+++ b/astropy/__init__.py
@@ -203,9 +203,7 @@ def _initialize_astropy():
                               'modules first. Either run:\n\n'
                               '  pip install -e .\n\nor\n\n'
                               '  python setup.py build_ext --inplace\n\n'
-                              'to make sure the extension modules are built '
-                              '(note that if you use the latter you may need '
-                              'to install build dependencies manually)')
+                              'to make sure the extension modules are built ')
         else:
             # Outright broken installation, just raise standard error
             raise


### PR DESCRIPTION
This might be controversial but I'm on a mission to try and simplify things wherever possible and remove magic.

I personally get frustrated when trying to import astropy in e.g. a notebook and astropy is installed in develop mode and it then just starts trying to build the extension modules on the fly, a slow process. I'd rather just have an error telling me the extension modules aren't built and how to fix it. I'm also not very comfortable with the rolling back of the import which modifies ``sys.modules``.

Furthermore, ``setup.py build_ext --inplace`` may not always work if build-time dependencies (extension-helpers, Cython, etc) are missing, so I'm putting the ``pip`` suggestion first and mentioning the build dependency issue.

But maybe it's just me and others find this feature useful? We should wait for a number of core devs to weigh in before merging this - approve if you agree, leave a comment if you don't. 