### PR TITLE
Do not copy info when getting scalar Time item

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -106,11 +106,6 @@ astropy.time
 - Add new ``isclose()`` method to ``Time`` and ``TimeDelta`` classes to allow
   comparison of time objects to within a specified tolerance. [#10646]
 
-- Change behavior so that when getting a single item out of an array-valued
-  ``Time`` or ``TimeDelta`` object, the ``info`` attribute is no longer copied.
-  This improves performance, especially when the object is an indexed column in
-  a ``Table``. [#10889]
-
 - Improve initialization time by a factor of four when creating a scalar ``Time``
   object in a format like ``unix`` or ``cxcsec`` (time delta from a reference
   epoch time). [#10406]
@@ -236,6 +231,11 @@ astropy.table
   With this, the behaviour becomes the same as that for a regular ``Column``.
   (Note that this does not affect slicing of a table; sliced columns in those
   will continue to carry a sliced version of any indices). [#10890]
+
+- Change behavior so that when getting a single item out of a mixin column such
+  as ``Time``, ``TimeDelta``, ``SkyCoord`` or ``Quantity``, the ``info``
+  attribute is no longer copied. This improves performance, especially when the
+  object is an indexed column in a ``Table``. [#10889]
 
 astropy.tests
 ^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -106,6 +106,11 @@ astropy.time
 - Add new ``isclose()`` method to ``Time`` and ``TimeDelta`` classes to allow
   comparison of time objects to within a specified tolerance. [#10646]
 
+- Change behavior so that when getting a single item out of an array-valued
+  ``Time`` or ``TimeDelta`` object, the ``info`` attribute is no longer copied.
+  This improves performance, especially when the object is an indexed column in
+  a ``Table``. [#10889]
+
 - Improve initialization time by a factor of four when creating a scalar ``Time``
   object in a format like ``unix`` or ``cxcsec`` (time delta from a reference
   epoch time). [#10406]
@@ -115,6 +120,10 @@ astropy.time
 
 astropy.timeseries
 ^^^^^^^^^^^^^^^^^^
+
+- Improve memory and speed performance when iterating over the entire time
+  column of a ``TimeSeries`` object. Previously this involved O(N^2) operations
+  and memory. [#10889]
 
 astropy.uncertainty
 ^^^^^^^^^^^^^^^^^^^

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -477,9 +477,9 @@ def test_add_column(mixin_cols):
                 assert getattr(t['m'].info, attr) == getattr(t[name].info, attr)
     # Also check that one can set using a scalar.
     s = m[0]
-    if type(s) is type(m):
+    if type(s) is type(m) and 'info' in s.__dict__:
         # We're not going to worry about testing classes for which scalars
-        # are a different class than the real array (and thus loose info, etc.)
+        # are a different class than the real array, or where info is not copied.
         t['s'] = m[0]
         assert_table_name_col_equal(t, 's', m[0])
         for attr in attrs:
@@ -488,7 +488,7 @@ def test_add_column(mixin_cols):
 
     # While we're add it, also check a length-1 table.
     t = QTable([m[1:2]], names=['m'])
-    if type(s) is type(m):
+    if type(s) is type(m) and 'info' in s.__dict__:
         t['s'] = m[0]
         assert_table_name_col_equal(t, 's', m[0])
         for attr in attrs:

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -1082,10 +1082,11 @@ class TimeBase(ShapedLikeNDArray):
 
             setattr(tm, attr, val)
 
-        # Copy other 'info' attr only if it has actually been defined.
+        # Copy other 'info' attr only if it has actually been defined and the
+        # time object is not a scalar (issue #10688).
         # See PR #3898 for further explanation and justification, along
         # with Quantity.__array_finalize__
-        if 'info' in self.__dict__:
+        if 'info' in self.__dict__ and tm.shape:
             tm.info = self.info
 
         # Make the new internal _time object corresponding to the format

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -1086,7 +1086,7 @@ class TimeBase(ShapedLikeNDArray):
         # time object is not a scalar (issue #10688).
         # See PR #3898 for further explanation and justification, along
         # with Quantity.__array_finalize__
-        if 'info' in self.__dict__ and tm.shape:
+        if 'info' in self.__dict__:
             tm.info = self.info
 
         # Make the new internal _time object corresponding to the format

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -2220,21 +2220,6 @@ def test_broadcasting_writeable():
     t[2] = Time(58000, format="mjd")
 
 
-def test_info_no_copy():
-    """Test that getting a single item from a Time object does not copy info.
-    See #10889.
-    """
-    tm = Time([1, 2], format='cxcsec')
-    t = Table([tm], names=['tm'])
-    t.add_index('tm')
-    val = t['tm'][0]
-    assert 'info' not in val.__dict__
-    assert val.info.indices is None
-    val = t['tm'][:]
-    assert 'info' in val.__dict__
-    assert val.info.indices is not None
-
-
 def test_format_subformat_compatibility():
     """Test that changing format with out_subfmt defined is not a problem.
     See #9812, #9810."""

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -2220,6 +2220,21 @@ def test_broadcasting_writeable():
     t[2] = Time(58000, format="mjd")
 
 
+def test_info_no_copy():
+    """Test that getting a single item from a Time object does not copy info.
+    See #10889.
+    """
+    tm = Time([1, 2], format='cxcsec')
+    t = Table([tm], names=['tm'])
+    t.add_index('tm')
+    val = t['tm'][0]
+    assert 'info' not in val.__dict__
+    assert val.info.indices is None
+    val = t['tm'][:]
+    assert 'info' in val.__dict__
+    assert val.info.indices is not None
+
+
 def test_format_subformat_compatibility():
     """Test that changing format with out_subfmt defined is not a problem.
     See #9812, #9810."""

--- a/astropy/utils/data_info.py
+++ b/astropy/utils/data_info.py
@@ -535,6 +535,16 @@ class BaseColumnInfo(DataInfo):
         if bound:
             self._format_funcs = {}
 
+    def __set__(self, instance, value):
+        # For Table columns do not set `info` when the instance is a scalar.
+        try:
+            if not instance.shape:
+                return
+        except AttributeError:
+            pass
+
+        super().__set__(instance, value)
+
     def iter_str_vals(self):
         """
         This is a mixin-safe version of Column.iter_str_vals.

--- a/astropy/utils/tests/test_data_info.py
+++ b/astropy/utils/tests/test_data_info.py
@@ -83,6 +83,9 @@ def test_info_no_copy_mixin_with_index(col):
     assert val.info.indices is None
     val = t['col'][:]
     assert 'info' in val.__dict__
+    assert val.info.indices is None
+    val = t[:]['col']
+    assert 'info' in val.__dict__
     assert isinstance(val.info.indices[0], SlicedIndex)
 
 
@@ -96,4 +99,6 @@ def test_info_no_copy_skycoord():
     assert 'info' not in val.__dict__
     assert val.info.indices is None
     val = t['col'][:]
+    assert val.info.indices is None
+    val = t[:]['col']
     assert val.info.indices == []

--- a/astropy/utils/tests/test_data_info.py
+++ b/astropy/utils/tests/test_data_info.py
@@ -7,6 +7,12 @@ import pytest
 import numpy as np
 
 from astropy.utils.data_info import dtype_info_name
+from astropy.table import QTable
+from astropy.table.index import SlicedIndex
+from astropy.time import Time
+from astropy.coordinates import SkyCoord
+import astropy.units as u
+
 
 STRING_TYPE_NAMES = {(True, 'S'): 'bytes',
                      (True, 'U'): 'str'}
@@ -43,3 +49,51 @@ def test_dtype_info_name(input, output):
       'V' raw data (void)
     """
     assert dtype_info_name(input) == output
+
+
+def test_info_no_copy_numpy():
+    """Test that getting a single item from Table column object does not copy info.
+    See #10889.
+    """
+    col = [1, 2]
+    t = QTable([col], names=['col'])
+    t.add_index('col')
+    val = t['col'][0]
+    # Returns a numpy scalar (e.g. np.float64) with no .info
+    assert isinstance(val, np.number)
+    with pytest.raises(AttributeError):
+        val.info
+    val = t['col'][:]
+    assert val.info.indices == []
+
+
+cols = [[1, 2] * u.m,
+        Time([1, 2], format='cxcsec')]
+
+
+@pytest.mark.parametrize('col', cols)
+def test_info_no_copy_mixin_with_index(col):
+    """Test that getting a single item from Table column object does not copy info.
+    See #10889.
+    """
+    t = QTable([col], names=['col'])
+    t.add_index('col')
+    val = t['col'][0]
+    assert 'info' not in val.__dict__
+    assert val.info.indices is None
+    val = t['col'][:]
+    assert 'info' in val.__dict__
+    assert isinstance(val.info.indices[0], SlicedIndex)
+
+
+def test_info_no_copy_skycoord():
+    """Test that getting a single item from Table SkyCoord column object does
+    not copy info.  Cannot create an index on a SkyCoord currently.
+    """
+    col = SkyCoord([1, 2], [1, 2], unit='deg'),
+    t = QTable([col], names=['col'])
+    val = t['col'][0]
+    assert 'info' not in val.__dict__
+    assert val.info.indices is None
+    val = t['col'][:]
+    assert val.info.indices == []


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to address a memory and speed performance problem when iterating over a `Time` column that is indexed (e.g. in a `TimeSeries` object). See #10688 for details.

The simple fix is to not copy the `info` attribute when getting a scalar `Time` from an array-valued `Time` object. This is consistent with the behavior of `Column`.

Being very conservative I have milestoned this for 4.2 instead of as a pure performance fix. It seems quite unlikely, but maybe possible that some code is using the `info` data that were previously being copied for a scalar getitem.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #10688
