### PR TITLE
When slicing a table mixin column, do not copy indices by default.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -216,6 +216,12 @@ astropy.table
   Instead, use the ``SCEngine`` indexing engine, which is similar in
   performance and relies on the ``sortedcontainers`` package. [#10622]
 
+- When slicing a mixin column in a table that had indices, the indices are no
+  longer copied since they generally are not useful, having the wrong shape.
+  With this, the behaviour becomes the same as that for a regular ``Column``.
+  (Note that this does not affect slicing of a table; sliced columns in those
+  will continue to carry a sliced version of any indices). [#10890]
+
 astropy.tests
 ^^^^^^^^^^^^^
 

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -1200,6 +1200,8 @@ class Table:
                 # still pass if this line is deleted.  (Each col.info attribute access
                 # is expensive).
                 col.info._copy_indices = True
+            else:
+                newcol.info.indices = []
 
             newcols.append(newcol)
 

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -3651,6 +3651,7 @@ class QTable(Table):
             q_cls = getattr(col.unit, '_quantity_class', Quantity)
             qcol = q_cls(col.data, col.unit, copy=False)
             qcol.info = col.info
+            qcol.info.indices = col.info.indices
             col = qcol
         else:
             col = super()._convert_col_for_table(col)

--- a/astropy/utils/data_info.py
+++ b/astropy/utils/data_info.py
@@ -501,7 +501,7 @@ class BaseColumnInfo(DataInfo):
     without importing the table package.
     """
     attr_names = DataInfo.attr_names.union(['parent_table', 'indices'])
-    _attrs_no_copy = set(['parent_table'])
+    _attrs_no_copy = set(['parent_table', 'indices'])
 
     # Context for serialization.  This can be set temporarily via
     # ``serialize_context_as(context)`` context manager to allow downstream
@@ -612,7 +612,6 @@ class BaseColumnInfo(DataInfo):
             if isinstance(item, np.ndarray) and item.dtype.kind == 'b':
                 # boolean mask
                 item = np.where(item)[0]
-            threshold = 0.6
             # Empirical testing suggests that recreating a BST/RBT index is
             # more effective than relabelling when less than ~60% of
             # the total number of rows are involved, and is in general


### PR DESCRIPTION
But rather only do it if the table is sliced.

Alternative to #10889 ~for now, just to discuss and check that all tests still pass (have to run...)~

EDIT: the advantage here is that it solves the problem at the table level.

EDIT 2: this actually affects regular columns as well...