### PR TITLE
Fix a few issues with generate_config

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -361,6 +361,9 @@ Bug Fixes
 astropy.config
 ^^^^^^^^^^^^^^
 
+- Fix a few issues with ``generate_config`` when used with other packages.
+  [#10893]
+
 astropy.constants
 ^^^^^^^^^^^^^^^^^
 

--- a/astropy/config/configuration.py
+++ b/astropy/config/configuration.py
@@ -610,7 +610,7 @@ def generate_config(pkgname='astropy', filename=None):
     """
     package = importlib.import_module(pkgname)
     with warnings.catch_warnings():
-        warnings.simplefilter('ignore', AstropyDeprecationWarning)
+        warnings.simplefilter('ignore')
         for mod in pkgutil.walk_packages(path=package.__path__,
                                          prefix=package.__name__ + '.'):
 

--- a/astropy/config/configuration.py
+++ b/astropy/config/configuration.py
@@ -652,7 +652,6 @@ def generate_config(pkgname='astropy', filename=None):
             # Check that modules are not processed twice, which can happen
             # when they are imported in another module.
             if mod in processed:
-                print(mod, 'already processed')
                 continue
             else:
                 processed.add(mod)

--- a/astropy/config/configuration.py
+++ b/astropy/config/configuration.py
@@ -609,10 +609,16 @@ def generate_config(pkgname='astropy', filename=None, verbose=False):
         If None, the default configuration path is taken from `get_config`.
 
     """
-    verbosity = nullcontext if verbose else silence
+    if verbose:
+        verbosity = nullcontext
+        filter_warnings = AstropyDeprecationWarning
+    else:
+        verbosity = silence
+        filter_warnings = Warning
+
     package = importlib.import_module(pkgname)
     with verbosity(), warnings.catch_warnings():
-        warnings.simplefilter('ignore')
+        warnings.simplefilter('ignore', category=filter_warnings)
         for mod in pkgutil.walk_packages(path=package.__path__,
                                          prefix=package.__name__ + '.'):
 

--- a/astropy/config/configuration.py
+++ b/astropy/config/configuration.py
@@ -20,12 +20,13 @@ import contextlib
 from os import path
 from textwrap import TextWrapper
 from warnings import warn
-from contextlib import contextmanager, nullcontext
+from contextlib import contextmanager
 
 from astropy.extern.configobj import configobj, validate
 from astropy.utils import find_current_module, silence
 from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyWarning
 from astropy.utils.introspection import resolve_name
+from astropy.utils.compat.context import nullcontext
 
 from .paths import get_config_dir
 

--- a/astropy/config/configuration.py
+++ b/astropy/config/configuration.py
@@ -639,7 +639,24 @@ def generate_config(pkgname='astropy', filename=None):
 
         # Parse the subclasses, ordered by their module name
         subclasses = ConfigNamespace.__subclasses__()
+        processed = set()
+
         for conf in sorted(subclasses, key=lambda x: x.__module__):
+            mod = conf.__module__
+
+            # Skip modules for other packages, e.g. astropy modules that
+            # would be imported when running the function for astroquery.
+            if mod.split('.')[0] != pkgname:
+                continue
+
+            # Check that modules are not processed twice, which can happen
+            # when they are imported in another module.
+            if mod in processed:
+                print(mod, 'already processed')
+                continue
+            else:
+                processed.add(mod)
+
             print_module = True
             for item in conf().values():
                 if print_module:

--- a/astropy/config/configuration.py
+++ b/astropy/config/configuration.py
@@ -23,7 +23,7 @@ from warnings import warn
 from contextlib import contextmanager
 
 from astropy.extern.configobj import configobj, validate
-from astropy.utils import find_current_module
+from astropy.utils import find_current_module, silence
 from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyWarning
 from astropy.utils.introspection import resolve_name
 
@@ -609,7 +609,7 @@ def generate_config(pkgname='astropy', filename=None):
 
     """
     package = importlib.import_module(pkgname)
-    with warnings.catch_warnings():
+    with silence(), warnings.catch_warnings():
         warnings.simplefilter('ignore')
         for mod in pkgutil.walk_packages(path=package.__path__,
                                          prefix=package.__name__ + '.'):

--- a/astropy/config/configuration.py
+++ b/astropy/config/configuration.py
@@ -602,7 +602,7 @@ def generate_config(pkgname='astropy', filename=None):
 
     Parameters
     ----------
-    packageormod : str or None
+    pkgname : str or None
         The package for which to retrieve the configuration object.
     filename : str or file object or None
         If None, the default configuration path is taken from `get_config`.
@@ -628,7 +628,7 @@ def generate_config(pkgname='astropy', filename=None):
                           width=78)
 
     if filename is None:
-        filename = get_config(package).filename
+        filename = get_config(pkgname).filename
 
     with contextlib.ExitStack() as stack:
         if isinstance(filename, (str, pathlib.Path)):

--- a/astropy/config/configuration.py
+++ b/astropy/config/configuration.py
@@ -20,7 +20,7 @@ import contextlib
 from os import path
 from textwrap import TextWrapper
 from warnings import warn
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext
 
 from astropy.extern.configobj import configobj, validate
 from astropy.utils import find_current_module, silence
@@ -594,7 +594,7 @@ def get_config(packageormod=None, reload=False, rootname=None):
         return cobj
 
 
-def generate_config(pkgname='astropy', filename=None):
+def generate_config(pkgname='astropy', filename=None, verbose=False):
     """Generates a configuration file, from the list of `ConfigItem`
     objects for each subpackage.
 
@@ -608,8 +608,9 @@ def generate_config(pkgname='astropy', filename=None):
         If None, the default configuration path is taken from `get_config`.
 
     """
+    verbosity = nullcontext if verbose else silence
     package = importlib.import_module(pkgname)
-    with silence(), warnings.catch_warnings():
+    with verbosity(), warnings.catch_warnings():
         warnings.simplefilter('ignore')
         for mod in pkgutil.walk_packages(path=package.__path__,
                                          prefix=package.__name__ + '.'):

--- a/astropy/config/tests/test_configs.py
+++ b/astropy/config/tests/test_configs.py
@@ -8,8 +8,7 @@ import subprocess
 
 import pytest
 
-from astropy.config import configuration
-from astropy.config import paths
+from astropy.config import configuration, set_temp_config, paths
 from astropy.utils.data import get_pkg_data_filename
 from astropy.utils.exceptions import AstropyDeprecationWarning
 
@@ -163,6 +162,26 @@ def test_generate_config(tmp_path):
         assert '[visualization.wcsaxes]' in c
         assert '## Whether to log exceptions before raising them.' in c
         assert '# log_exceptions = False' in c
+
+
+def test_generate_config2(tmp_path):
+    """Test that generate_config works with the default filename."""
+
+    with set_temp_config(tmp_path):
+        from astropy.config.configuration import generate_config
+        generate_config('astropy')
+
+    assert os.path.exists(tmp_path / 'astropy' / 'astropy.cfg')
+
+    with open(tmp_path / 'astropy' / 'astropy.cfg') as fp:
+        conf = fp.read()
+
+    # test that the output contains some lines that we expect
+    assert '# unicode_output = False' in conf
+    assert '[io.fits]' in conf
+    assert '[visualization.wcsaxes]' in conf
+    assert '## Whether to log exceptions before raising them.' in conf
+    assert '# log_exceptions = False' in conf
 
 
 def test_configitem():


### PR DESCRIPTION
When using it with other packages (tried this with astroquery), this fixes several issues:

- Astropy modules where imported and then added to the config file.
- One module (`astroquery.mpc`) was added 3 times because it is imported in other modules.
- Astroquery instantiates its classes at import which causes a lot of warnings/logging messages, so I choose to silence all outputs.