### PR TITLE
Correct the formula for CRPIX computation in WCS.slice()

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -985,6 +985,7 @@ astropy.visualization
 astropy.wcs
 ^^^^^^^^^^^
 
+- Fixed incorrect value computed for ``CRPIX`` in ``WCS.slice()``. [#10897]
 
 Other Changes and Additions
 ---------------------------

--- a/astropy/wcs/tests/test_utils.py
+++ b/astropy/wcs/tests/test_utils.py
@@ -110,12 +110,12 @@ def test_slice():
     mywcs = WCS(naxis=2)
     mywcs.wcs.crval = [1, 1]
     mywcs.wcs.cdelt = [0.1, 0.1]
-    mywcs.wcs.crpix = [1, 1]
+    mywcs.wcs.crpix = [5, 6]
     mywcs._naxis = [1000, 500]
     pscale = 0.1  # from cdelt
 
     slice_wcs = mywcs.slice([slice(1, None), slice(0, None)])
-    assert np.all(slice_wcs.wcs.crpix == np.array([1, 0]))
+    assert np.all(slice_wcs.wcs.crpix == np.array([5, 5]))
     assert slice_wcs._naxis == [1000, 499]
 
     # test that CRPIX maps to CRVAL:
@@ -125,7 +125,7 @@ def test_slice():
     )
 
     slice_wcs = mywcs.slice([slice(1, None, 2), slice(0, None, 4)])
-    assert np.all(slice_wcs.wcs.crpix == np.array([0.625, 0.25]))
+    assert np.all(slice_wcs.wcs.crpix == np.array([2, 3]))
     assert np.all(slice_wcs.wcs.cdelt == np.array([0.4, 0.2]))
     assert slice_wcs._naxis == [250, 250]
 
@@ -189,20 +189,20 @@ def test_slice_getitem():
     mywcs = WCS(naxis=2)
     mywcs.wcs.crval = [1, 1]
     mywcs.wcs.cdelt = [0.1, 0.1]
-    mywcs.wcs.crpix = [1, 1]
+    mywcs.wcs.crpix = [5, 6]
 
     slice_wcs = mywcs[1::2, 0::4]
-    assert np.all(slice_wcs.wcs.crpix == np.array([0.625, 0.25]))
+    assert np.all(slice_wcs.wcs.crpix == np.array([2, 3]))
     assert np.all(slice_wcs.wcs.cdelt == np.array([0.4, 0.2]))
 
     mywcs.wcs.crpix = [2, 2]
     slice_wcs = mywcs[1::2, 0::4]
-    assert np.all(slice_wcs.wcs.crpix == np.array([0.875, 0.75]))
+    assert np.all(slice_wcs.wcs.crpix == np.array([1.25, 1]))
     assert np.all(slice_wcs.wcs.cdelt == np.array([0.4, 0.2]))
 
     # Default: numpy order
     slice_wcs = mywcs[1::2]
-    assert np.all(slice_wcs.wcs.crpix == np.array([2, 0.75]))
+    assert np.all(slice_wcs.wcs.crpix == np.array([2, 1]))
     assert np.all(slice_wcs.wcs.cdelt == np.array([0.1, 0.2]))
 
 
@@ -210,17 +210,17 @@ def test_slice_fitsorder():
     mywcs = WCS(naxis=2)
     mywcs.wcs.crval = [1, 1]
     mywcs.wcs.cdelt = [0.1, 0.1]
-    mywcs.wcs.crpix = [1, 1]
+    mywcs.wcs.crpix = [3, 3]
 
     slice_wcs = mywcs.slice([slice(1, None), slice(0, None)], numpy_order=False)
-    assert np.all(slice_wcs.wcs.crpix == np.array([0, 1]))
+    assert np.all(slice_wcs.wcs.crpix == np.array([2, 3]))
 
     slice_wcs = mywcs.slice([slice(1, None, 2), slice(0, None, 4)], numpy_order=False)
-    assert np.all(slice_wcs.wcs.crpix == np.array([0.25, 0.625]))
+    assert np.all(slice_wcs.wcs.crpix == np.array([1.5, 1.5]))
     assert np.all(slice_wcs.wcs.cdelt == np.array([0.2, 0.4]))
 
     slice_wcs = mywcs.slice([slice(1, None, 2)], numpy_order=False)
-    assert np.all(slice_wcs.wcs.crpix == np.array([0.25, 1]))
+    assert np.all(slice_wcs.wcs.crpix == np.array([1.5, 3]))
     assert np.all(slice_wcs.wcs.cdelt == np.array([0.2, 0.1]))
 
 

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -3093,11 +3093,7 @@ reduce these to 2 dimensions using the naxis kwarg.
                 if iview.step not in (None, 1):
                     crpix = self.wcs.crpix[wcs_index]
                     cdelt = self.wcs.cdelt[wcs_index]
-                    # equivalently (keep this comment so you can compare eqns):
-                    # wcs_new.wcs.crpix[wcs_index] =
-                    # (crpix - iview.start)*iview.step + 0.5 - iview.step/2.
-                    crp = ((crpix - iview.start - 1.)/iview.step
-                           + 0.5 + 1./iview.step/2.)
+                    crp = (crpix - 1 - iview.start) / iview.step + 1
                     wcs_new.wcs.crpix[wcs_index] = crp
                     if wcs_new.sip is not None:
                         sip_crpix[wcs_index] = crp


### PR DESCRIPTION
Fixes #10864