### PR TITLE
changed default in docstring for cylindrical equal area

### DIFF
--- a/astropy/modeling/projections.py
+++ b/astropy/modeling/projections.py
@@ -833,7 +833,7 @@ class Pix2Sky_CylindricalEqualArea(Pix2SkyProjection, Cylindrical):
     Parameters
     ----------
     lam : float
-        Radius of the cylinder in spherical radii, λ.  Default is 0.
+        Radius of the cylinder in spherical radii, λ.  Default is 1.
     """
 
     lam = Parameter(default=1)


### PR DESCRIPTION
Just a single character change in a docstring to use the correct default value.