### PR TITLE
Add note to isclose/allclose about atol

### DIFF
--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -1747,6 +1747,17 @@ def isclose(a, b, rtol=1.e-5, atol=None, equal_nan=False, **kwargs):
     Return a boolean array where two arrays are element-wise equal
     within a tolerance.
 
+    .. note::
+
+        `astropy.units.isclose()` behaves slightly different than
+        `numpy.isclose` because of the default absolute tolerance in
+        `numpy.isclose`. In ``numpy``, the default absolute tolerance,
+        ``atol``, is set to ``atol=1e-8`` because there can be a proper
+        absolute comparison between the input without having to scale them by
+        unit conversions. In this function, there is no natural way to set
+        ``atol`` by default because it will depend on the units of the input.
+
+
     Parameters
     ----------
     a, b : array_like or :class:`~astropy.units.Quantity`

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -1747,17 +1747,6 @@ def isclose(a, b, rtol=1.e-5, atol=None, equal_nan=False, **kwargs):
     Return a boolean array where two arrays are element-wise equal
     within a tolerance.
 
-    .. note::
-
-        `astropy.units.isclose()` behaves slightly different than
-        `numpy.isclose` because of the default absolute tolerance in
-        `numpy.isclose`. In ``numpy``, the default absolute tolerance,
-        ``atol``, is set to ``atol=1e-8`` because there can be a proper
-        absolute comparison between the input without having to scale them by
-        unit conversions. In this function, there is no natural way to set
-        ``atol`` by default because it will depend on the units of the input.
-
-
     Parameters
     ----------
     a, b : array_like or :class:`~astropy.units.Quantity`
@@ -1778,7 +1767,11 @@ def isclose(a, b, rtol=1.e-5, atol=None, equal_nan=False, **kwargs):
     Notes
     -----
     This is a :class:`~astropy.units.Quantity`-aware version of
-    :func:`numpy.isclose`.
+    :func:`numpy.isclose`. However, this differs from the `numpy` function in
+    that the default for the absolute tolerance here is zero instead of
+    ``atol=1e-8`` in `numpy`, as there is no natural way to set a default
+    *absolute* tolerance given two inputs that may have differently scaled
+    units.
 
     Raises
     ------
@@ -1798,16 +1791,6 @@ def allclose(a, b, rtol=1.e-5, atol=None, equal_nan=False, **kwargs) -> bool:
     """
     Whether two arrays are element-wise equal within a tolerance.
 
-    .. note::
-
-        `astropy.units.allclose()` behaves slightly different than
-        `numpy.allclose` because of the default absolute tolerance in
-        `numpy.allclose`. In ``numpy``, the default absolute tolerance,
-        ``atol``, is set to ``atol=1e-8`` because there can be a proper
-        absolute comparison between the input without having to scale them by
-        unit conversions. In this function, there is no natural way to set
-        ``atol`` by default because it will depend on the units of the input.
-
     Parameters
     ----------
     a, b : array_like or :class:`~astropy.units.Quantity`
@@ -1828,7 +1811,11 @@ def allclose(a, b, rtol=1.e-5, atol=None, equal_nan=False, **kwargs) -> bool:
     Notes
     -----
     This is a :class:`~astropy.units.Quantity`-aware version of
-    :func:`numpy.allclose`.
+    :func:`numpy.allclose`. However, this differs from the `numpy` function in
+    that the default for the absolute tolerance here is zero instead of
+    ``atol=1e-8`` in `numpy`, as there is no natural way to set a default
+    *absolute* tolerance given two inputs that may have differently scaled
+    units.
 
     Raises
     ------

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -1798,6 +1798,16 @@ def allclose(a, b, rtol=1.e-5, atol=None, equal_nan=False, **kwargs) -> bool:
     """
     Whether two arrays are element-wise equal within a tolerance.
 
+    .. note::
+
+        `astropy.units.allclose()` behaves slightly different than
+        `numpy.allclose` because of the default absolute tolerance in
+        `numpy.allclose`. In ``numpy``, the default absolute tolerance,
+        ``atol``, is set to ``atol=1e-8`` because there can be a proper
+        absolute comparison between the input without having to scale them by
+        unit conversions. In this function, there is no natural way to set
+        ``atol`` by default because it will depend on the units of the input.
+
     Parameters
     ----------
     a, b : array_like or :class:`~astropy.units.Quantity`


### PR DESCRIPTION
This fixes #10892.

This adds a note to the docstring of both `astropy.units.isclose()` and `astropy.units.allclose()` that describes differences with numpy's equivalent functions that may arise because numpy's functions have default values for `atol`.

cc @nstarman 