### PR TITLE
Added missing loopback coordinate transformations (plus internal functionality)

### DIFF
--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -1188,8 +1188,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
         -------
         transframe : coordinate-like
             A new object with the coordinate data represented in the
-            ``newframe`` system (meaning a `~astropy.coordinates.SkyCoord` will
-            remain a SkyCoord).
+            ``newframe`` system.
 
         Raises
         ------

--- a/astropy/coordinates/builtin_frames/ecliptic_transforms.py
+++ b/astropy/coordinates/builtin_frames/ecliptic_transforms.py
@@ -242,3 +242,14 @@ def icrs_to_custombaryecliptic(from_coo, to_frame):
                                  CustomBarycentricEcliptic, ICRS)
 def custombaryecliptic_to_icrs(from_coo, to_frame):
     return icrs_to_custombaryecliptic(to_frame, from_coo).T
+
+
+# Create loopback transformations
+frame_transform_graph._add_merged_transform(GeocentricMeanEcliptic, ICRS, GeocentricMeanEcliptic)
+frame_transform_graph._add_merged_transform(GeocentricTrueEcliptic, ICRS, GeocentricTrueEcliptic)
+frame_transform_graph._add_merged_transform(HeliocentricMeanEcliptic, ICRS, HeliocentricMeanEcliptic)
+frame_transform_graph._add_merged_transform(HeliocentricTrueEcliptic, ICRS, HeliocentricTrueEcliptic)
+frame_transform_graph._add_merged_transform(HeliocentricEclipticIAU76, ICRS, HeliocentricEclipticIAU76)
+frame_transform_graph._add_merged_transform(BarycentricMeanEcliptic, ICRS, BarycentricMeanEcliptic)
+frame_transform_graph._add_merged_transform(BarycentricTrueEcliptic, ICRS, BarycentricTrueEcliptic)
+frame_transform_graph._add_merged_transform(CustomBarycentricEcliptic, ICRS, CustomBarycentricEcliptic)

--- a/astropy/coordinates/builtin_frames/galactocentric.py
+++ b/astropy/coordinates/builtin_frames/galactocentric.py
@@ -585,3 +585,7 @@ def icrs_to_galactocentric(icrs_coord, galactocentric_frame):
 def galactocentric_to_icrs(galactocentric_coord, icrs_frame):
     _check_coord_repr_diff_types(galactocentric_coord)
     return get_matrix_vectors(galactocentric_coord, inverse=True)
+
+
+# Create loopback transformation
+frame_transform_graph._add_merged_transform(Galactocentric, ICRS, Galactocentric)

--- a/astropy/coordinates/builtin_frames/icrs_observed_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_observed_transforms.py
@@ -99,16 +99,12 @@ def observed_to_icrs(observed_coo, icrs_frame):
     return icrs_frame.realize_frame(icrs_srepr)
 
 
-@frame_transform_graph.transform(FunctionTransformWithFiniteDifference, AltAz, AltAz)
-@frame_transform_graph.transform(FunctionTransformWithFiniteDifference, HADec, HADec)
-def observed_to_observed(from_coo, to_frame):
-    if from_coo.is_equivalent_frame(to_frame):  # loopback to the same frame
-        return to_frame.realize_frame(from_coo.data)
-
-    # for now we just implement this through ICRS to make sure we get everything
-    # covered
-    # Before, this was using CIRS as intermediate frame, however this is much
-    # slower than the direct observed<->ICRS transform added in 4.3
-    # due to how the frame attribute broadcasting works, see
-    # https://github.com/astropy/astropy/pull/10994#issuecomment-722617041
-    return from_coo.transform_to(ICRS()).transform_to(to_frame)
+# Create loopback transformations
+frame_transform_graph._add_merged_transform(AltAz, ICRS, AltAz)
+frame_transform_graph._add_merged_transform(HADec, ICRS, HADec)
+# for now we just implement this through ICRS to make sure we get everything
+# covered
+# Before, this was using CIRS as intermediate frame, however this is much
+# slower than the direct observed<->ICRS transform added in 4.3
+# due to how the frame attribute broadcasting works, see
+# https://github.com/astropy/astropy/pull/10994#issuecomment-722617041

--- a/astropy/coordinates/builtin_frames/intermediate_rotation_transforms.py
+++ b/astropy/coordinates/builtin_frames/intermediate_rotation_transforms.py
@@ -275,5 +275,6 @@ def itrs_to_teme(itrs_coo, teme_frame):
 
 # Create loopback transformations
 frame_transform_graph._add_merged_transform(ITRS, CIRS, ITRS)
+frame_transform_graph._add_merged_transform(PrecessedGeocentric, GCRS, PrecessedGeocentric)
 frame_transform_graph._add_merged_transform(TEME, ITRS, TEME)
 frame_transform_graph._add_merged_transform(TETE, ICRS, TETE)

--- a/astropy/coordinates/builtin_frames/intermediate_rotation_transforms.py
+++ b/astropy/coordinates/builtin_frames/intermediate_rotation_transforms.py
@@ -13,7 +13,7 @@ from astropy.coordinates.baseframe import frame_transform_graph
 from astropy.coordinates.transformations import FunctionTransformWithFiniteDifference
 from astropy.coordinates.matrix_utilities import matrix_transpose
 
-
+from .icrs import ICRS
 from .gcrs import GCRS, PrecessedGeocentric
 from .cirs import CIRS
 from .itrs import ITRS
@@ -218,11 +218,10 @@ def itrs_to_cirs(itrs_coo, cirs_frame):
     return cirs.transform_to(cirs_frame)
 
 
-@frame_transform_graph.transform(FunctionTransformWithFiniteDifference, ITRS, ITRS)
-def itrs_to_itrs(from_coo, to_frame):
-    # this self-transform goes through CIRS right now, which implicitly also
-    # goes back to ICRS
-    return from_coo.transform_to(CIRS()).transform_to(to_frame)
+# TODO: implement GCRS<->CIRS if there's call for it.  The thing that's awkward
+# is that they both have obstimes, so an extra set of transformations are necessary.
+# so unless there's a specific need for that, better to just have it go through the above
+# two steps anyway
 
 
 @frame_transform_graph.transform(FunctionTransformWithFiniteDifference, GCRS, PrecessedGeocentric)
@@ -274,11 +273,7 @@ def itrs_to_teme(itrs_coo, teme_frame):
     return teme_frame.realize_frame(newrepr)
 
 
-@frame_transform_graph.transform(FunctionTransformWithFiniteDifference, TEME, TEME)
-def teme_to_teme(from_coo, to_frame):
-    if np.all(from_coo.obstime == to_frame.obstime):
-        return to_frame.realize_frame(from_coo.data)
-    else:
-        # this self-transform goes through ITRS right now, which implicitly also
-        # goes back to ICRS
-        return from_coo.transform_to(ITRS(obstime=from_coo.obstime)).transform_to(to_frame)
+# Create loopback transformations
+frame_transform_graph._add_merged_transform(ITRS, CIRS, ITRS)
+frame_transform_graph._add_merged_transform(TEME, ITRS, TEME)
+frame_transform_graph._add_merged_transform(TETE, ICRS, TETE)

--- a/astropy/coordinates/builtin_frames/lsr.py
+++ b/astropy/coordinates/builtin_frames/lsr.py
@@ -80,6 +80,7 @@ def lsr_to_icrs(lsr_coord, icrs_frame):
     offset = r.CartesianRepresentation([0, 0, 0]*u.au, differentials=-v_offset)
     return None, offset
 
+
 # ------------------------------------------------------------------------------
 
 
@@ -261,3 +262,10 @@ def icrs_to_lsrd(icrs_coord, lsr_frame):
 @frame_transform_graph.transform(AffineTransform, LSRD, ICRS)
 def lsrd_to_icrs(lsr_coord, icrs_frame):
     return None, LSRD_ICRS_OFFSET
+
+
+# ------------------------------------------------------------------------------
+
+# Create loopback transformations
+frame_transform_graph._add_merged_transform(LSR, ICRS, LSR)
+frame_transform_graph._add_merged_transform(GalacticLSR, Galactic, GalacticLSR)

--- a/astropy/coordinates/tests/test_intermediate_transformations.py
+++ b/astropy/coordinates/tests/test_intermediate_transformations.py
@@ -600,6 +600,43 @@ def test_teme_itrf():
     )
 
 
+def test_precessedgeocentric_loopback():
+    from_coo = PrecessedGeocentric(1*u.deg, 2*u.deg, 3*u.AU,
+                                   obstime='2001-01-01', equinox='2001-01-01')
+
+    # Change just the obstime
+    to_frame = PrecessedGeocentric(obstime='2001-06-30', equinox='2001-01-01')
+
+    explicit_coo = from_coo.transform_to(ICRS()).transform_to(to_frame)
+    implicit_coo = from_coo.transform_to(to_frame)
+
+    # Confirm that the explicit transformation changes the coordinate
+    assert not allclose(explicit_coo.ra, from_coo.ra, rtol=1e-10)
+    assert not allclose(explicit_coo.dec, from_coo.dec, rtol=1e-10)
+    assert not allclose(explicit_coo.distance, from_coo.distance, rtol=1e-10)
+
+    # Confirm that the loopback matches the explicit transformation
+    assert_allclose(explicit_coo.ra, implicit_coo.ra, rtol=1e-10)
+    assert_allclose(explicit_coo.dec, implicit_coo.dec, rtol=1e-10)
+    assert_allclose(explicit_coo.distance, implicit_coo.distance, rtol=1e-10)
+
+    # Change just the equinox
+    to_frame = PrecessedGeocentric(obstime='2001-01-01', equinox='2001-06-30')
+
+    explicit_coo = from_coo.transform_to(ICRS()).transform_to(to_frame)
+    implicit_coo = from_coo.transform_to(to_frame)
+
+    # Confirm that the explicit transformation changes the direction but not the distance
+    assert not allclose(explicit_coo.ra, from_coo.ra, rtol=1e-10)
+    assert not allclose(explicit_coo.dec, from_coo.dec, rtol=1e-10)
+    assert allclose(explicit_coo.distance, from_coo.distance, rtol=1e-10)
+
+    # Confirm that the loopback matches the explicit transformation
+    assert_allclose(explicit_coo.ra, implicit_coo.ra, rtol=1e-10)
+    assert_allclose(explicit_coo.dec, implicit_coo.dec, rtol=1e-10)
+    assert_allclose(explicit_coo.distance, implicit_coo.distance, rtol=1e-10)
+
+
 def test_teme_loopback():
     from_coo = TEME(1*u.AU, 2*u.AU, 3*u.AU, obstime='2001-01-01')
     to_frame = TEME(obstime='2001-06-30')

--- a/astropy/coordinates/transformations.py
+++ b/astropy/coordinates/transformations.py
@@ -1408,7 +1408,7 @@ class CompositeTransform(CoordinateTransform):
         curr_coord = fromcoord
         for t in self.transforms:
             # build an intermediate frame with attributes taken from either
-            # `fromframe`, or if not there, `toframe`, or if not there, use
+            # `toframe`, or if not there, `fromcoord`, or if not there, use
             # the defaults
             # TODO: caching this information when creating the transform may
             # speed things up a lot
@@ -1427,6 +1427,84 @@ class CompositeTransform(CoordinateTransform):
         # this is safe even in the case where self.transforms is empty, because
         # coordinate objects are immutible, so copying is not needed
         return curr_coord
+
+    def _as_single_transform(self):
+        """
+        Return an encapsulated version of the composite transform so that it appears to
+        be a single transform.
+
+        The returned transform internally calls the constituent transforms.  If all of
+        the transforms are affine, the merged transform is
+        `~astropy.coordinates.transformations.DynamicMatrixTransform` (if there are no
+        origin shifts) or `~astropy.coordinates.transformations.AffineTransform`
+        (otherwise).  If at least one of the transforms is not affine, the merged
+        transform is
+        `~astropy.coordinates.transformations.FunctionTransformWithFiniteDifference`.
+        """
+        # Create a list of the transforms including flattening any constituent CompositeTransform
+        transforms = [t if not isinstance(t, CompositeTransform) else t._as_single_transform()
+                      for t in self.transforms]
+
+        if all([isinstance(t, BaseAffineTransform) for t in transforms]):
+            # Check if there may be an origin shift
+            fixed_origin = all([isinstance(t, (StaticMatrixTransform, DynamicMatrixTransform))
+                                for t in transforms])
+
+            # Dynamically define the transformation function
+            def single_transform(from_coo, to_frame):
+                if from_coo.is_equivalent_frame(to_frame):  # loopback to the same frame
+                    return None if fixed_origin else (None, None)
+
+                # Create a merged attribute dictionary for any intermediate frames
+                # For any attributes shared by the "from"/"to" frames, the "to" frame takes
+                #   precedence because this is the same choice implemented in __call__()
+                merged_attr = {name: getattr(from_coo, name)
+                               for name in from_coo.frame_attributes}
+                merged_attr.update({name: getattr(to_frame, name)
+                                    for name in to_frame.frame_attributes})
+
+                affine_params = (None, None)
+                # Step through each transform step (frame A -> frame B)
+                for i, t in enumerate(transforms):
+                    # Extract the relevant attributes for frame A
+                    if i == 0:
+                        # If frame A is actually the initial frame, preserve its attributes
+                        a_attr = {name: getattr(from_coo, name)
+                                  for name in from_coo.frame_attributes}
+                    else:
+                        a_attr = {k: v for k, v in merged_attr.items()
+                                  if k in t.fromsys.frame_attributes}
+
+                    # Extract the relevant attributes for frame B
+                    b_attr = {k: v for k, v in merged_attr.items()
+                              if k in t.tosys.frame_attributes}
+
+                    # Obtain the affine parameters for the transform
+                    # Note that we insert some dummy data into frame A because the transformation
+                    #   machinery requires there to be data present.  Removing that limitation
+                    #   is a possible TODO, but some care would need to be taken because some affine
+                    #   transforms have branching code depending on the presence of differentials.
+                    next_affine_params = t._affine_params(t.fromsys(from_coo.data, **a_attr),
+                                                          t.tosys(**b_attr))
+
+                    # Combine the affine parameters with the running set
+                    affine_params = _combine_affine_params(affine_params, next_affine_params)
+
+                # If there is no origin shift, return only the matrix
+                return affine_params[0] if fixed_origin else affine_params
+
+            # The return type depends on whether there is any origin shift
+            transform_type = DynamicMatrixTransform if fixed_origin else AffineTransform
+        else:
+            # Dynamically define the transformation function
+            def single_transform(from_coo, to_frame):
+                if from_coo.is_equivalent_frame(to_frame):  # loopback to the same frame
+                    return to_frame.realize_frame(from_coo.data)
+                return self(from_coo, to_frame)
+
+            transform_type = FunctionTransformWithFiniteDifference
+
+        return transform_type(single_transform, self.fromsys, self.tosys, priority=self.priority)
 
 
 def _combine_affine_params(params, next_params):

--- a/docs/changes/coordinates/10909.feature.rst
+++ b/docs/changes/coordinates/10909.feature.rst
@@ -1,0 +1,1 @@
+Added missing coordinate transformations where the starting and ending frames are the same (i.e., loopback transformations).


### PR DESCRIPTION
Edit: Another round of under-the-hood changes.

This PR adds all of the missing loopback transformations (closes #8835).  This PR adds internal functionality to make it easy to create loopback transformations, including auto-detecting the best type of transform to use.  Accordingly, nearly all existing loopback code can be removed (aside from FK4/FK5 loopbacks).  For example, the HCRS loopback is now just one line:
```python
frame_transform_graph._add_merged_transform(HCRS, ICRS, HCRS)  # will register an AffineTransform
```

This PR:
- Adds all of the missing loopback transformations (closes #8835), although not all of them can be immediately written as affine transformations.
- Adds a private method to `TransformGraph` to create and register a single-step transform from a multi-step transformation path, using the transforms that already exist in the graph
  - If the starting frame and the final frame classes are the same, this will be a loopback transformation
  - If all of the transforms are affine, the merged transform will be affine (either `AffineTransform` or `DynamicMatrixTransform`)
  - Otherwise, the merged transform will be `FunctionTransformWithFiniteDifference`
- Adds a private method to `CompositeTransform` to return a single transform that encapsulates all of the constituent transforms.
  - If all of the transforms are affine, the single transform will be affine (either `AffineTransform` or `DynamicMatrixTransform`)
  - Otherwise, the single transform will be `FunctionTransformWithFiniteDifference`
- Adds a private function to combine two sets of affine parameters into one set.
- Modifies the subclassing of `BaseAffineTransform` so that the different types of affine transformations have the same (private) method to obtain the affine parameters.

---
Context:

Currently, a coordinate transformation that is a composite of separately-defined affine transformations is very difficult to implement except as a `FunctionTransform` or `FunctionTransformWithFiniteDifference`.  For example, here's the HCRS loopback transformation:
```python
@frame_transform_graph.transform(FunctionTransformWithFiniteDifference, HCRS, HCRS)
def hcrs_to_hcrs(from_coo, to_frame):
     ...
        return from_coo.transform_to(ICRS()).transform_to(to_frame)
```
Even though the HCRS->ICRS and ICRS->HCRS transformations are both `AffineTransform`, that fact is not exposed outside of the `.transform_to()` machinery.  This approach is problematic because `FunctionTransformWithFiniteDifference` entrains unnecessary computations and inaccuracies when working with coordinates with velocities due to the finite differencing.