### PR TITLE
add .github_cache to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ venv
 cover
 htmlcov
 .hypothesis
+.github_cache
 
 # Mac OSX
 .DS_Store


### PR DESCRIPTION
This is a minor convenience tweak to ``.gitignore`` - ``.github_cache`` is generated by the generate_releaserst script (see #10377) and therefore might show up for people who are doing releases.