### PR TITLE
Split the Azure wheel jobs up

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,8 +49,16 @@ jobs:
 
       targets:
       - sdist
+      # The linux builds are the fastest so run all three in one job
       - wheels_cp3[678]*linux_i686
       - wheels_cp3[678]*linux_x86_64
-      - wheels_cp3[678]*macosx_x86_64
-      - wheels_cp3[678]*win32
-      - wheels_cp3[678]*win_amd64
+      # macos is a little slower so split it into two 
+      - wheels_cp36*macosx_x86_64
+      - wheels_cp3[78]*macosx_x86_64
+      # windows is the slowest, so do one python version per build
+      - wheels_cp36*win32
+      - wheels_cp36*win_amd64
+      - wheels_cp37*win32
+      - wheels_cp37*win_amd64
+      - wheels_cp38*win32
+      - wheels_cp38*win_amd64


### PR DESCRIPTION
This will mean we are always using our allowance of parallel builds and if one fails it will reduce the time taken on a restart.

This thought occurred to me while watching the 4.1 release build.

I tired to come up with a set of jobs which got us closest to 10 (ended up with 11) and which would give us the biggest benefits. Added comments so the next person understands.