### PR TITLE
Fix biweight stats when MAD=0 and axis is input

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -966,6 +966,9 @@ astropy.samp
 astropy.stats
 ^^^^^^^^^^^^^
 
+- Fixed an issue in biweight stats when MAD=0 to give the same output
+  with and without an input ``axis``. [#10912]
+
 astropy.table
 ^^^^^^^^^^^^^
 

--- a/astropy/stats/biweight.py
+++ b/astropy/stats/biweight.py
@@ -621,7 +621,9 @@ def biweight_midcovariance(data, c=9.0, M=None, modify_sample_size=False):
         u = (d.T / (c * mad)).T
 
     # now remove the outlier points
-    mask = np.abs(u) < 1
+    # ignore RuntimeWarnings for comparisons with NaN data values
+    with np.errstate(invalid='ignore'):
+        mask = np.abs(u) < 1
     u = u ** 2
 
     if modify_sample_size:

--- a/astropy/stats/tests/test_biweight.py
+++ b/astropy/stats/tests/test_biweight.py
@@ -344,9 +344,11 @@ def test_biweight_midvariance_constant_axis_2d():
     data = np.arange(50).reshape(10, 5)
     data[2] = 100.
     data[7] = 2.
+    data[8] = [5.0, 0.8, 5.0, -0.8, 5.0]
     bw = biweight_midvariance(data, axis=1)
     assert_allclose(bw[2], 0.)
     assert_allclose(bw[7], 0.)
+    assert_allclose(bw[8], 0.)
 
 
 def test_biweight_midvariance_constant_axis_3d():
@@ -385,8 +387,18 @@ def test_biweight_midcovariance_2d():
 
 def test_biweight_midcovariance_constant():
     data = np.ones((3, 10))
+    val3 = 5.0
+    data[1] = [val3, 0.8, val3, -0.8, val3, val3, val3, 1.0, val3, -0.7]
     cov = biweight_midcovariance(data)
     assert_allclose(cov, np.zeros((3, 3)))
+
+    rng = np.random.default_rng(123)
+    data = rng.random((5, 5))
+    val3 = 5.0
+    data[1] = [val3, 0.8, val3, -0.8, val3]
+    cov = biweight_midcovariance(data)
+    assert_allclose(cov[1, :], 0.)
+    assert_allclose(cov[:, 1], 0.)
 
 
 def test_biweight_midcovariance_midvariance():

--- a/astropy/stats/tests/test_biweight.py
+++ b/astropy/stats/tests/test_biweight.py
@@ -35,12 +35,15 @@ def test_biweight_location_constant_axis_2d():
 
     val1 = 100.
     val2 = 2.
+    val3 = 5.
     data = np.arange(50).reshape(10, 5)
     data[2] = val1
     data[7] = val2
+    data[8] = [val3, 0.8, val3, -0.8, val3]
     cbl = biweight_location(data, axis=1)
     assert_allclose(cbl[2], val1)
     assert_allclose(cbl[7], val2)
+    assert_allclose(cbl[8], val3)
 
 
 def test_biweight_location_constant_axis_3d():

--- a/astropy/stats/tests/test_biweight.py
+++ b/astropy/stats/tests/test_biweight.py
@@ -162,7 +162,9 @@ def test_biweight_location_masked():
     assert bw_loc_masked.mask[-1]  # last mask element is True
 
     data1d_masked.data[0] = np.nan  # unmasked NaN
-    assert biweight_location(data1d_masked) is np.ma.masked
+    bw_loc = biweight_location(data1d_masked)
+    assert bw_loc.shape == ()
+    assert np.all(bw_loc.mask) or bw_loc is np.ma.masked
     assert_equal(biweight_location(data1d_masked, ignore_nan=True),
                  biweight_location(data1d[1:], ignore_nan=True))
 


### PR DESCRIPTION
As demonstrated in #10820, biweight stat functions currently give inconsistent results when `median_absolute_deviation=0` and using an ``axis`` or not.  This PR fixes the issue for all cases when `MAD=0`, which occurs when the data are constant or mostly-constant.  When `MAD=0`:

* `biweight_location` returns the median
* `biweight_scale`, `biweight_midvariance`, and `biweight_midcovariance` return 0.0

Fixes #10820.
