### PR TITLE
DOC: Replace broken RTD links for docs archive

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -775,7 +775,7 @@ astropy.visualization
 
 - The ``AsinhStretch`` and ``SinhStretch`` ``a`` value is restricted
   to be ``0 < a <= 1``. [#10177]
-  
+
 Bug Fixes
 ---------
 
@@ -7969,7 +7969,7 @@ Other Changes and Additions
   cluttering the ``astropy.coordinates`` documentation with increasingly
   irrelevant material.  To see the migration guide, we recommend you simply look
   to the archived documentation for previous versions, e.g.
-  https://docs.astropy.org/en/v1.0/coordinates/index.html#migrating-from-pre-v0-4-coordinates
+  https://docs.astropy.org/en/docs-archive/v1.0/coordinates/index.html#migrating-from-pre-v0-4-coordinates
   [#4203]
 
 - In ``astropy.coordinates``, the transformations between GCRS, CIRS,
@@ -11288,7 +11288,7 @@ New Features
       °
 
   See `handling-unicode
-  <https://docs.astropy.org/en/v0.3/development/codeguide.html#unicode-guidelines>`_
+  <https://docs.astropy.org/en/docs-archive/v0.3/development/codeguide.html#unicode-guidelines>`_
   for more information. [#1441]
 
 - ``astropy.utils.misc.find_api_page`` is now imported into the top-level.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to replace broken RTD links that linked to very old doc ~with GitHub ones~. ~The info is still there, just not as nicely rendered.~ I don't see this being worthy of backport, but feel free to remilestone if you feel otherwise.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #10918 

@eteq , this is what we can do if you are unable to get RTD to rebuild for the very old docs. Turns out, not just v1.0 but v0.3 too.