### PR TITLE
TST: Skip test_update_parallel_multi on Windows CI too

### DIFF
--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -57,7 +57,7 @@ from astropy.utils.data import (
     download_files_in_parallel,
 )
 
-TRAVIS = os.environ.get('TRAVIS', False)
+TRAVIS = os.environ.get('TRAVIS', False) == "true"
 TESTURL = "http://www.astropy.org"
 TESTURL2 = "http://www.astropy.org/about.html"
 TESTLOCAL = get_pkg_data_filename(os.path.join("data", "local.dat"))

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -843,8 +843,10 @@ def test_update_parallel(temp_cache, valid_urls):
         assert get_file_contents(f) == c2
 
 
-@pytest.mark.skipif(sys.version_info < (3, 8),
-                    reason="causes mystery segfault! possibly bug #10008")
+@pytest.mark.skipif(sys.version_info < (3, 8) or
+                    (sys.platform.startswith('win') and TRAVIS),
+                    reason="mystery segfault that is possibly bug #10008 "
+                           "for python < 3.8, flaky cache error on Windows CI")
 def test_update_parallel_multi(temp_cache, valid_urls):
     u, c = next(valid_urls)
     iucs = list(islice(valid_urls, N_THREAD_HAMMER))


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to skip `test_update_parallel_multi` on Windows CI as well. It is already skipped for `python < 3.8` due to "mystery segfault" (#10008). I could not reproduce it locally (2 tries) and it is only intermittent on CI.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #10914

cc @aarchiba 

- [x] Check if it is really skipped on the jobs it is supposed to skip. -- Hard to tell from the logs. Will just have to trust the green status.