### PR TITLE
BUG: Revert abspath in setup package

### DIFF
--- a/astropy/config/tests/test_configs.py
+++ b/astropy/config/tests/test_configs.py
@@ -175,7 +175,13 @@ def test_generate_config2(tmp_path):
 
     with set_temp_config(tmp_path):
         from astropy.config.configuration import generate_config
-        generate_config('astropy')
+        try:
+            generate_config('astropy')
+        except ValueError as err:
+            if sys.platform.startswith('win') and 'path is on mount' in str(err):
+                pytest.xfail("See Github issue 10747")
+            else:
+                raise
 
     assert os.path.exists(tmp_path / 'astropy' / 'astropy.cfg')
 

--- a/astropy/config/tests/test_configs.py
+++ b/astropy/config/tests/test_configs.py
@@ -147,7 +147,13 @@ def test_config_file():
 def test_generate_config(tmp_path):
     from astropy.config.configuration import generate_config
     out = io.StringIO()
-    generate_config('astropy', out)
+    try:
+        generate_config('astropy', out)
+    except ValueError as err:
+        if sys.platform.startswith('win') and 'path is on mount' in str(err):
+            pytest.xfail("See Github issue 10747")
+        else:
+            raise
     conf = out.getvalue()
 
     outfile = tmp_path / 'astropy.cfg'

--- a/astropy/convolution/setup_package.py
+++ b/astropy/convolution/setup_package.py
@@ -6,7 +6,7 @@ from setuptools import Extension
 
 import numpy
 
-C_CONVOLVE_PKGDIR = os.path.abspath(os.path.dirname(__file__))
+C_CONVOLVE_PKGDIR = os.path.relpath(os.path.dirname(__file__))
 
 SRC_FILES = [os.path.join(C_CONVOLVE_PKGDIR, filename)
              for filename in ['src/convolve.c']]

--- a/astropy/io/ascii/setup_package.py
+++ b/astropy/io/ascii/setup_package.py
@@ -5,7 +5,7 @@ from setuptools import Extension
 
 import numpy
 
-ROOT = os.path.abspath(os.path.dirname(__file__))
+ROOT = os.path.relpath(os.path.dirname(__file__))
 
 
 def get_extensions():

--- a/astropy/modeling/setup_package.py
+++ b/astropy/modeling/setup_package.py
@@ -11,7 +11,7 @@ from extension_helpers import import_file
 wcs_setup_package = import_file(join('astropy', 'wcs', 'setup_package.py'))
 
 
-MODELING_ROOT = os.path.abspath(os.path.dirname(__file__))
+MODELING_ROOT = os.path.relpath(os.path.dirname(__file__))
 MODELING_SRC = join(MODELING_ROOT, 'src')
 SRC_FILES = [join(MODELING_SRC, 'projections.c.templ'),
              __file__]

--- a/astropy/table/setup_package.py
+++ b/astropy/table/setup_package.py
@@ -5,7 +5,7 @@ from setuptools import Extension
 
 import numpy
 
-ROOT = os.path.abspath(os.path.dirname(__file__))
+ROOT = os.path.relpath(os.path.dirname(__file__))
 
 
 def get_extensions():

--- a/astropy/timeseries/periodograms/bls/setup_package.py
+++ b/astropy/timeseries/periodograms/bls/setup_package.py
@@ -7,7 +7,7 @@ from setuptools import Extension
 
 import numpy
 
-BLS_ROOT = os.path.abspath(os.path.dirname(__file__))
+BLS_ROOT = os.path.relpath(os.path.dirname(__file__))
 
 
 def get_extensions():

--- a/astropy/utils/setup_package.py
+++ b/astropy/utils/setup_package.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 from setuptools import Extension
-from os.path import dirname, join, abspath
+from os.path import dirname, join, relpath
 
 ASTROPY_UTILS_ROOT = dirname(__file__)
 
@@ -9,5 +9,5 @@ ASTROPY_UTILS_ROOT = dirname(__file__)
 def get_extensions():
     return [
         Extension('astropy.utils._compiler',
-                  [abspath(join(ASTROPY_UTILS_ROOT, 'src', 'compiler.c'))])
+                  [relpath(join(ASTROPY_UTILS_ROOT, 'src', 'compiler.c'))])
     ]

--- a/astropy/wcs/setup_package.py
+++ b/astropy/wcs/setup_package.py
@@ -15,7 +15,7 @@ import numpy
 
 from extension_helpers import import_file, write_if_different, get_compiler, pkg_config
 
-WCSROOT = os.path.abspath(os.path.dirname(__file__))
+WCSROOT = os.path.relpath(os.path.dirname(__file__))
 WCSVERSION = "7.3.0"
 
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to revert #10753 due to https://github.com/astropy/astropy/pull/10753#issuecomment-715468492 . Added a test to accept #10747 as `xfail`.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

(Not sure who should really review this, so I tagged some usual suspects.)

With this patch, when I install on Windows with `pip install .` and then run `python -c "import astropy;astropy.test(package='config')"`, I get the following:

```
============================= test session starts =============================
platform win32 -- Python 3.8.5, pytest-6.0.2, py-1.9.0, pluggy-0.13.1

Running tests with Astropy version 4.2.dev1031+gb0868e81f.d20201023.
Running tests in C:\...\lib\site-packages\astropy\config.

Date: 2020-10-23T14:01:03

Platform: Windows-10-10.0.19041-SP0

Executable: C:\...\envs\py38\python.exe

Full Python Version:
3.8.5 | packaged by conda-forge | (default, Jul 31 2020, 01:53:45) [MSC v.1916 64 bit (AMD64)]

encodings: sys: utf-8, locale: cp1252, filesystem: utf-8
byteorder: little
float info: dig: 15, mant_dig: 15

Package versions:
Numpy: 1.19.1
Scipy: 1.5.0
Matplotlib: 3.3.1
h5py: 2.10.0
Pandas: 1.1.2
PyERFA: 1.7.0
Cython: 0.29.21
Scikit-image: not available
asdf: 2.7.1

Using Astropy options: remote_data: none.

rootdir: D:\...
plugins: asdf-2.7.1, hypothesis-5.29.4, arraydiff-0.3, astropy-header-0.1.2, cov-2.10.1, doctestplus-0.8.0, filter-subpackage-0.1.1, forked-1.3.0, openfiles-0.5.0, remotedata-0.3.2, xdist-2.1.0
collected 18 items

tests\test_configs.py .....xx...........                                 [100%]

======================== 16 passed, 2 xfailed in 1.97s ========================
```