### PR TITLE
TST: Skip flaky float cmp doctest

### DIFF
--- a/docs/coordinates/spectralcoord.rst
+++ b/docs/coordinates/spectralcoord.rst
@@ -316,7 +316,7 @@ velocity frame stationary with respect to the center of the Earth (so removing
 the effect of the Earth's rotation), we can use the ``'gcrs'`` which stands for
 *Geocentric Celestial Reference System* (GCRS)::
 
-    >>> sc_ttau.with_observer_stationary_relative_to('gcrs')  # doctest: +FLOAT_CMP +REMOTE_DATA
+    >>> sc_ttau.with_observer_stationary_relative_to('gcrs')  # doctest: +SKIP
     <SpectralCoord
        (observer: <GCRS Coordinate (obstime=2019-04-24T02:32:10.000, obsgeoloc=(0., 0., 0.) m, obsgeovel=(0., 0., 0.) m / s): (x, y, z) in m
                       (-5878853.86171412, -192921.84773269, -2470794.19765021)


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to address remote data job failure caused by 10398

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

- [x] Remove draft PR status when we can confirm remote data job is green because I am not sure if more doctest on that page downstream is going to break or not.
