### PR TITLE
Time fast reader bigendian fix

### DIFF
--- a/astropy/time/setup_package.py
+++ b/astropy/time/setup_package.py
@@ -15,7 +15,7 @@ SRC_FILES = [os.path.join(C_TIME_PKGDIR, filename)
 
 if sys.platform.startswith('win'):
     extra_compile_args = ['/DNDEBUG']
-    extra_link_args = ['/EXPORT:parse_ymdhms_times', '/EXPORT:check_unicode']
+    extra_link_args = ['/EXPORT:parse_ymdhms_times']
 else:
     extra_compile_args = ['-UNDEBUG', '-fPIC']
     extra_link_args = []

--- a/astropy/time/src/parse_times.c
+++ b/astropy/time/src/parse_times.c
@@ -254,8 +254,6 @@ int parse_ymdhms_times(char *times, int n_times, int max_str_len, int has_day_of
 {
     int str_len;
     int status = 0;
-    int isec;
-    double frac;
     char *time;
     int i, ii;
     struct time_struct_t *tm;

--- a/astropy/time/src/parse_times.c
+++ b/astropy/time/src/parse_times.c
@@ -343,21 +343,3 @@ int parse_ymdhms_times(char *times, int n_times, int max_str_len, int has_day_of
 
     return 0;
 }
-
-int check_unicode(char *chars, int n_unicode_char)
-// Check if *chars is pure ASCII, assuming input is UTF-32
-{
-    char *ch;
-    int ii;
-
-    ch = chars;
-    for (ii = 0; ii < n_unicode_char; ii++)
-    {
-        ch++;
-        if (*ch++) return 1;
-        if (*ch++) return 1;
-        if (*ch++) return 1;
-    }
-    return 0;
-
-}


### PR DESCRIPTION
Fixes #10930 

This should work on big-endian. Marking it as a draft only because once it succeeds, the `s390` run should be taken out of the regular CI runs again (or should it? but let's leave that for another issue...)

Note that following https://github.com/astropy/astropy/issues/10930#issuecomment-715578126, I've replaced the ascii C check with a faster numpy one.