### PR TITLE
MNT: Replace OrderedDict with dict in utils

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -324,6 +324,8 @@ Other Changes and Additions
 
 - Officially declared minversion of ``ipython`` to be 4.2. [#10942]
 
+- Minimum version of required PyYAML is now 5.1. [#10932]
+
 - Refactor conversions between ``GCRS`` and ``CIRS,TETE`` for better accuracy
   and substantially improved speed. [#11069]
 

--- a/astropy/io/ascii/ecsv.py
+++ b/astropy/io/ascii/ecsv.py
@@ -223,11 +223,7 @@ class EcsvData(basic.BasicData):
         # not even be any table meta, so punt in those cases.
 
         try:
-            if isinstance(self.header.table_meta, (list, tuple)):
-                tmeta = dict(self.header.table_meta)
-            else:
-                tmeta = self.header.table_meta
-            scs = tmeta['__serialized_columns__']
+            scs = self.header.table_meta['__serialized_columns__']
         except (AttributeError, KeyError):
             return
 

--- a/astropy/io/ascii/ecsv.py
+++ b/astropy/io/ascii/ecsv.py
@@ -221,8 +221,13 @@ class EcsvData(basic.BasicData):
 
         # Get the serialized columns spec.  It might not exist and there might
         # not even be any table meta, so punt in those cases.
+
         try:
-            scs = self.header.table_meta['__serialized_columns__']
+            if isinstance(self.header.table_meta, (list, tuple)):
+                tmeta = dict(self.header.table_meta)
+            else:
+                tmeta = self.header.table_meta
+            scs = tmeta['__serialized_columns__']
         except (AttributeError, KeyError):
             return
 

--- a/astropy/io/ascii/ecsv.py
+++ b/astropy/io/ascii/ecsv.py
@@ -221,7 +221,6 @@ class EcsvData(basic.BasicData):
 
         # Get the serialized columns spec.  It might not exist and there might
         # not even be any table meta, so punt in those cases.
-
         try:
             scs = self.header.table_meta['__serialized_columns__']
         except (AttributeError, KeyError):

--- a/astropy/io/ascii/tests/test_ecsv.py
+++ b/astropy/io/ascii/tests/test_ecsv.py
@@ -88,6 +88,8 @@ def test_write_full():
     """
     Write a full-featured table with common types and explicitly checkout output
     """
+    from astropy.utils.diff import report_diff_values
+
     t = T_DTYPES['bool', 'int64', 'float64', 'str']
     lines = ['# %ECSV 0.9',
              '# ---',
@@ -122,7 +124,7 @@ def test_write_full():
 
     out = StringIO()
     t.write(out, format='ascii.ecsv')
-    assert out.getvalue().splitlines() == lines
+    assert report_diff_values(os.linesep.join(lines), out.getvalue(), fileobj=sys.stderr)
 
 
 @pytest.mark.skipif('not HAS_YAML')

--- a/astropy/io/ascii/tests/test_ecsv.py
+++ b/astropy/io/ascii/tests/test_ecsv.py
@@ -88,8 +88,6 @@ def test_write_full():
     """
     Write a full-featured table with common types and explicitly checkout output
     """
-    from astropy.utils.diff import report_diff_values
-
     t = T_DTYPES['bool', 'int64', 'float64', 'str']
     lines = ['# %ECSV 0.9',
              '# ---',
@@ -114,8 +112,8 @@ def test_write_full():
              '#   datatype: string',
              '#   description: descr_str',
              '#   meta: {meta str: 1}',
-             '# meta: !!omap',
-             '# - comments: [comment1, comment2]',
+             '# meta:',
+             '#   comments: [comment1, comment2]',
              '# schema: astropy-2.0',
              'bool int64 float64 str',
              'False 0 0.0 "ab 0"',
@@ -124,7 +122,7 @@ def test_write_full():
 
     out = StringIO()
     t.write(out, format='ascii.ecsv')
-    assert report_diff_values(os.linesep.join(lines), out.getvalue(), fileobj=sys.stderr)
+    assert out.getvalue().splitlines() == lines
 
 
 @pytest.mark.skipif('not HAS_YAML')

--- a/astropy/io/ascii/tests/test_ecsv.py
+++ b/astropy/io/ascii/tests/test_ecsv.py
@@ -604,3 +604,26 @@ False
     assert isinstance(col, MaskedColumn)
     assert np.all(col.mask == [False, False, False, True, False])
     assert np.all(col == [True, False, True, False, False])
+
+
+@pytest.mark.skipif('not HAS_YAML')
+def test_read_ecsv_with_omap():
+    """Regression test to ensure that ordered mapping !!omap in ECSV works.
+
+    Starting with astropy 4.3 this tag is not used on output."""
+    txt = """\
+# %ECSV 0.9
+# ---
+# datatype:
+# - {name: a, datatype: int64}
+# meta: !!omap
+# - {1: 2}
+# - {0: 1}
+# schema: astropy-2.0
+a
+1
+2
+"""
+    dat = ascii.read(txt, format='ecsv')
+    assert list(dat.meta.keys()) == [1, 0]
+    assert dat.meta == {1: 2, 0: 1}

--- a/astropy/io/misc/yaml.py
+++ b/astropy/io/misc/yaml.py
@@ -19,7 +19,7 @@ classes to define custom YAML tags for the following astropy classes:
 - `astropy.coordinates.EarthLocation`
 - `astropy.table.SerializedColumn`
 
-.. note:: This module requires PyYaml version 3.13 or later.
+.. note:: This module requires PyYaml version 5.1 or later.
 
 Example
 =======
@@ -71,10 +71,10 @@ from astropy.table import SerializedColumn
 try:
     import yaml
 except ImportError:
-    raise ImportError('The PyYAML package is required for astropy.io.misc.yaml and must be 3.13 or later')
+    raise ImportError('The PyYAML package is required for astropy.io.misc.yaml and must be 5.1 or later')
 else:
-    if not minversion(yaml, '3.13'):
-        raise ImportError('The PyYAML package is required for astropy.io.misc.yaml and must be 3.13 or later')
+    if not minversion(yaml, '5.1'):
+        raise ImportError('The PyYAML package is required for astropy.io.misc.yaml and must be 5.1 or later')
 
 
 __all__ = ['AstropyLoader', 'AstropyDumper', 'load', 'load_all', 'dump']

--- a/astropy/nddata/tests/test_nddata.py
+++ b/astropy/nddata/tests/test_nddata.py
@@ -316,7 +316,7 @@ def test_param_meta():
     nd = NDData([1, 2, 3], meta={})
     assert len(nd.meta) == 0
     nd = NDData([1, 2, 3])
-    assert isinstance(nd.meta, OrderedDict)
+    assert isinstance(nd.meta, dict)
     assert len(nd.meta) == 0
     # Test conflicting meta (other NDData)
     nd2 = NDData(nd, meta={'image': 'sun'})

--- a/astropy/table/meta.py
+++ b/astropy/table/meta.py
@@ -1,7 +1,5 @@
 import textwrap
 import copy
-from collections import OrderedDict
-
 
 __all__ = ['get_header_from_yaml', 'get_yaml_from_header', 'get_yaml_from_table']
 
@@ -45,105 +43,6 @@ class ColumnDict(dict):
         way for column attributes.
         """
         return ColumnOrderList(super().items())
-
-
-def _construct_odict(load, node):
-    """
-    Construct OrderedDict from !!omap in yaml safe load.
-
-    Source: https://gist.github.com/weaver/317164
-    License: Unspecified
-
-    This is the same as SafeConstructor.construct_yaml_omap(),
-    except the data type is changed to OrderedDict() and setitem is
-    used instead of append in the loop
-
-    Examples
-    --------
-    ::
-
-      >>> yaml.load('''  # doctest: +SKIP
-      ... !!omap
-      ... - foo: bar
-      ... - mumble: quux
-      ... - baz: gorp
-      ... ''')
-      OrderedDict([('foo', 'bar'), ('mumble', 'quux'), ('baz', 'gorp')])
-
-      >>> yaml.load('''!!omap [ foo: bar, mumble: quux, baz : gorp ]''')  # doctest: +SKIP
-      OrderedDict([('foo', 'bar'), ('mumble', 'quux'), ('baz', 'gorp')])
-    """
-    import yaml
-
-    omap = OrderedDict()
-    yield omap
-    if not isinstance(node, yaml.SequenceNode):
-        raise yaml.constructor.ConstructorError(
-            "while constructing an ordered map", node.start_mark,
-            f"expected a sequence, but found {node.id}", node.start_mark)
-
-    for subnode in node.value:
-        if not isinstance(subnode, yaml.MappingNode):
-            raise yaml.constructor.ConstructorError(
-                "while constructing an ordered map", node.start_mark,
-                f"expected a mapping of length 1, but found {subnode.id}",
-                subnode.start_mark)
-
-        if len(subnode.value) != 1:
-            raise yaml.constructor.ConstructorError(
-                "while constructing an ordered map", node.start_mark,
-                f"expected a single mapping item, but found {len(subnode.value)} items",
-                subnode.start_mark)
-
-        key_node, value_node = subnode.value[0]
-        key = load.construct_object(key_node)
-        value = load.construct_object(value_node)
-        omap[key] = value
-
-
-def _repr_pairs(dump, tag, sequence, flow_style=None):
-    """
-    This is the same code as BaseRepresenter.represent_sequence(),
-    but the value passed to dump.represent_data() in the loop is a
-    dictionary instead of a tuple.
-
-    Source: https://gist.github.com/weaver/317164
-    License: Unspecified
-    """
-    import yaml
-
-    value = []
-    node = yaml.SequenceNode(tag, value, flow_style=flow_style)
-    if dump.alias_key is not None:
-        dump.represented_objects[dump.alias_key] = node
-    best_style = True
-    for (key, val) in sequence:
-        item = dump.represent_data({key: val})
-        if not (isinstance(item, yaml.ScalarNode) and not item.style):
-            best_style = False
-        value.append(item)
-    if flow_style is None:
-        if dump.default_flow_style is not None:
-            node.flow_style = dump.default_flow_style
-        else:
-            node.flow_style = best_style
-    return node
-
-
-def _repr_odict(dumper, data):
-    """
-    Represent OrderedDict in yaml dump.
-
-    Source: https://gist.github.com/weaver/317164
-    License: Unspecified
-
-    >>> data = OrderedDict([('foo', 'bar'), ('mumble', 'quux'), ('baz', 'gorp')])
-    >>> yaml.dump(data, default_flow_style=False)  # doctest: +SKIP
-    '!!omap\\n- foo: bar\\n- mumble: quux\\n- baz: gorp\\n'
-    >>> yaml.dump(data, default_flow_style=True)  # doctest: +SKIP
-    '!!omap [foo: bar, mumble: quux, baz: gorp]\\n'
-    """
-    return _repr_pairs(dumper, 'tag:yaml.org,2002:omap', data.items())
 
 
 def _repr_column_dict(dumper, data):
@@ -238,7 +137,7 @@ def get_yaml_from_header(header):
 
     class TableDumper(AstropyDumper):
         """
-        Custom Dumper that represents OrderedDict as an !!omap object.
+        Custom Dumper that represents dict (insertion-ordered) as an !!omap object.
         """
 
         def represent_mapping(self, tag, mapping, flow_style=None):
@@ -280,7 +179,6 @@ def get_yaml_from_header(header):
                     node.flow_style = best_style
             return node
 
-    TableDumper.add_representer(OrderedDict, _repr_odict)
     TableDumper.add_representer(ColumnDict, _repr_column_dict)
 
     header = copy.copy(header)  # Don't overwrite original
@@ -326,18 +224,10 @@ def get_header_from_yaml(lines):
 
     from astropy.io.misc.yaml import AstropyLoader
 
-    class TableLoader(AstropyLoader):
-        """
-        Custom Loader that constructs OrderedDict from an !!omap object.
-        This does nothing but provide a namespace for adding the
-        custom odict constructor.
-        """
-
-    TableLoader.add_constructor('tag:yaml.org,2002:omap', _construct_odict)
     # Now actually load the YAML data structure into `meta`
     header_yaml = textwrap.dedent('\n'.join(lines))
     try:
-        header = yaml.load(header_yaml, Loader=TableLoader)
+        header = yaml.load(header_yaml, Loader=AstropyLoader)
     except Exception as err:
         raise YamlParseError(str(err))
 

--- a/astropy/table/meta.py
+++ b/astropy/table/meta.py
@@ -1,59 +1,6 @@
 import textwrap
-import copy
 
 __all__ = ['get_header_from_yaml', 'get_yaml_from_header', 'get_yaml_from_table']
-
-
-class ColumnOrderList(list):
-    """
-    List of tuples that sorts in a specific order that makes sense for
-    astropy table column attributes.
-    """
-
-    def sort(self, *args, **kwargs):
-        super().sort()
-
-        column_keys = ['name', 'unit', 'datatype', 'format', 'description', 'meta']
-        in_dict = dict(self)
-        out_list = []
-
-        for key in column_keys:
-            if key in in_dict:
-                out_list.append((key, in_dict[key]))
-        for key, val in self:
-            if key not in column_keys:
-                out_list.append((key, val))
-
-        # Clear list in-place
-        del self[:]
-
-        self.extend(out_list)
-
-
-class ColumnDict(dict):
-    """
-    Specialized dict subclass to represent attributes of a Column
-    and return items() in a preferred order.  This is only for use
-    in generating a YAML map representation that has a fixed order.
-    """
-
-    def items(self):
-        """
-        Return items as a ColumnOrderList, which sorts in the preferred
-        way for column attributes.
-        """
-        return ColumnOrderList(super().items())
-
-
-def _repr_column_dict(dumper, data):
-    """
-    Represent ColumnDict in yaml dump.
-
-    This is the same as an ordinary mapping except that the keys
-    are written in a fixed order that makes sense for astropy table
-    columns.
-    """
-    return dumper.represent_mapping('tag:yaml.org,2002:map', data)
 
 
 def _get_col_attributes(col):
@@ -61,23 +8,29 @@ def _get_col_attributes(col):
     Extract information from a column (apart from the values) that is required
     to fully serialize the column.
     """
-    attrs = ColumnDict()
-    attrs['name'] = col.info.name
+    attrs = {}
 
-    type_name = col.info.dtype.type.__name__
-    if type_name.startswith(('bytes', 'str')):
-        type_name = 'string'
-    if type_name.endswith('_'):
-        type_name = type_name[:-1]  # string_ and bool_ lose the final _ for ECSV
-    attrs['datatype'] = type_name
+    def get_datatype(dtype):
+        datatype = dtype.type.__name__
+        if datatype.startswith(('bytes', 'str')):
+            datatype = 'string'
+        if datatype.endswith('_'):
+            datatype = datatype[:-1]  # string_ and bool_ lose the final _ for ECSV
+        return datatype
 
     # Set the output attributes
-    for attr, nontrivial, xform in (('unit', lambda x: x is not None, str),
+    for attr, nontrivial, xform in (('name', lambda x: True, None),
+                                    ('unit', lambda x: x is not None, str),
+                                    ('dtype', lambda x: True, get_datatype),
                                     ('format', lambda x: x is not None, None),
                                     ('description', lambda x: x is not None, None),
                                     ('meta', lambda x: x, None)):
         col_attr = getattr(col.info, attr)
         if nontrivial(col_attr):
+            if attr == 'dtype':
+                # ECSV uses `datatype` not `dtype` for similarity with ASDF and
+                # numpy agnosticism.
+                attr = 'datatype'
             attrs[attr] = xform(col_attr) if xform else col_attr
 
     return attrs
@@ -135,58 +88,12 @@ def get_yaml_from_header(header):
 
     from astropy.io.misc.yaml import AstropyDumper
 
-    class TableDumper(AstropyDumper):
-        """
-        Custom Dumper that represents dict (insertion-ordered) as an !!omap object.
-        """
-
-        def represent_mapping(self, tag, mapping, flow_style=None):
-            """
-            This is a combination of the Python 2 and 3 versions of this method
-            in the PyYAML library to allow the required key ordering via the
-            ColumnOrderList object.  The Python 3 version insists on turning the
-            items() mapping into a list object and sorting, which results in
-            alphabetical order for the column keys.
-            """
-            value = []
-            node = yaml.MappingNode(tag, value, flow_style=flow_style)
-            if self.alias_key is not None:
-                self.represented_objects[self.alias_key] = node
-            best_style = True
-            if hasattr(mapping, 'items'):
-                mapping = mapping.items()
-                if hasattr(mapping, 'sort'):
-                    mapping.sort()
-                else:
-                    mapping = list(mapping)
-                    try:
-                        mapping = sorted(mapping)
-                    except TypeError:
-                        pass
-
-            for item_key, item_value in mapping:
-                node_key = self.represent_data(item_key)
-                node_value = self.represent_data(item_value)
-                if not (isinstance(node_key, yaml.ScalarNode) and not node_key.style):
-                    best_style = False
-                if not (isinstance(node_value, yaml.ScalarNode) and not node_value.style):
-                    best_style = False
-                value.append((node_key, node_value))
-            if flow_style is None:
-                if self.default_flow_style is not None:
-                    node.flow_style = self.default_flow_style
-                else:
-                    node.flow_style = best_style
-            return node
-
-    TableDumper.add_representer(ColumnDict, _repr_column_dict)
-
-    header = copy.copy(header)  # Don't overwrite original
     header['datatype'] = [_get_col_attributes(col) for col in header['cols']]
+    header = {key: header[key] for key in sorted(header)}
     del header['cols']
 
-    lines = yaml.dump(header, default_flow_style=None,
-                      Dumper=TableDumper, width=130).splitlines()
+    lines = yaml.dump(header, default_flow_style=None, sort_keys=False,
+                      Dumper=AstropyDumper, width=130).splitlines()
     return lines
 
 

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -374,14 +374,14 @@ class TableAttribute(MetaAttribute):
 
     Examples
     --------
-      >>> from astropy.table import Table, TableAttribute
-      >>> class MyTable(Table):
-      ...     identifier = TableAttribute(default=1)
-      >>> t = MyTable(identifier=10)
-      >>> t.identifier
-      10
-      >>> t.meta
-      OrderedDict([('__attributes__', {'identifier': 10})])
+    >>> from astropy.table import Table, TableAttribute
+    >>> class MyTable(Table):
+    ...     identifier = TableAttribute(default=1)
+    >>> t = MyTable(identifier=10)
+    >>> t.identifier
+    10
+    >>> t.meta
+    {'__attributes__': {'identifier': 10}}
     """
 
 

--- a/astropy/utils/data_info.py
+++ b/astropy/utils/data_info.py
@@ -23,7 +23,6 @@ import warnings
 from io import StringIO
 from copy import deepcopy
 from functools import partial
-from collections import OrderedDict
 from contextlib import contextmanager
 
 import numpy as np
@@ -145,7 +144,7 @@ def data_info_factory(names, funcs):
             else:
                 outs.append(str(out))
 
-        return OrderedDict(zip(names, outs))
+        return dict(zip(names, outs))
     return func
 
 
@@ -268,7 +267,7 @@ class DataInfo(metaclass=DataInfoMeta):
     bound : bool
         If True this is a descriptor attribute in a class definition, else it
         is a DataInfo() object that is bound to a data object instance. Default is False.
-    """
+    """  # noqa: E501
     _stats = ['mean', 'std', 'min', 'max']
     attrs_from_parent = set()
     attr_names = set(['name', 'unit', 'dtype', 'format', 'description', 'meta'])
@@ -403,7 +402,7 @@ reference with ``c = col[3:5]`` followed by ``c.info``.""")
 
         If a function is specified then that function will be called with the
         data object as its single argument.  The function must return an
-        OrderedDict containing the information attributes.
+        dict (insertion-ordered) containing the information attributes.
 
         If a list is provided then the information attributes will be
         appended for each of the options, in order.
@@ -437,17 +436,18 @@ reference with ``c = col[3:5]`` followed by ``c.info``.""")
             Info option, defaults to 'attributes'.
         out : file-like object, None
             Output destination, defaults to sys.stdout.  If None then the
-            OrderedDict with information attributes is returned
+            dict (insertion-ordered) with information attributes is returned
 
         Returns
         -------
-        info : OrderedDict if out==None else None
+        info : dict or None
+            dict if out==None else None
         """
         if out == '':
             out = sys.stdout
 
         dat = self._parent
-        info = OrderedDict()
+        info = dict()
         name = dat.info.name
         if name is not None:
             info['name'] = name

--- a/astropy/utils/metadata.py
+++ b/astropy/utils/metadata.py
@@ -7,7 +7,6 @@ from functools import wraps
 
 import warnings
 
-from collections import OrderedDict
 from collections.abc import Mapping
 from copy import deepcopy
 
@@ -398,12 +397,12 @@ class MetaData:
         if instance is None:
             return self
         if not hasattr(instance, '_meta'):
-            instance._meta = OrderedDict()
+            instance._meta = dict()
         return instance._meta
 
     def __set__(self, instance, value):
         if value is None:
-            instance._meta = OrderedDict()
+            instance._meta = dict()
         else:
             if isinstance(value, Mapping):
                 if self.copy:

--- a/astropy/utils/metadata.py
+++ b/astropy/utils/metadata.py
@@ -405,9 +405,6 @@ class MetaData:
             instance._meta = dict()
             return
 
-        if isinstance(value, (list, tuple)):
-            value = dict(value)
-
         if isinstance(value, Mapping):
             if self.copy:
                 instance._meta = deepcopy(value)

--- a/astropy/utils/metadata.py
+++ b/astropy/utils/metadata.py
@@ -403,14 +403,18 @@ class MetaData:
     def __set__(self, instance, value):
         if value is None:
             instance._meta = dict()
-        else:
-            if isinstance(value, Mapping):
-                if self.copy:
-                    instance._meta = deepcopy(value)
-                else:
-                    instance._meta = value
+            return
+
+        if isinstance(value, (list, tuple)):
+            value = dict(value)
+
+        if isinstance(value, Mapping):
+            if self.copy:
+                instance._meta = deepcopy(value)
             else:
-                raise TypeError("meta attribute must be dict-like")
+                instance._meta = value
+        else:
+            raise TypeError(f"meta attribute must be dict-like, but got {value}")
 
 
 class MetaAttribute:

--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -20,7 +20,7 @@ import threading
 import re
 
 from contextlib import contextmanager
-from collections import defaultdict, OrderedDict
+from collections import defaultdict
 
 from astropy.utils.decorators import deprecated
 
@@ -49,7 +49,7 @@ def indent(s, shift=1, width=4):
     """Indent a block of text.  The indentation is applied to each line."""
 
     indented = '\n'.join(' ' * (width * shift) + l if l else ''
-                         for l in s.splitlines())
+                         for l in s.splitlines())  # noqa: E741
     if s[-1] == '\n':
         indented += '\n'
 
@@ -265,7 +265,7 @@ def find_api_page(obj, version=None, openinbrowser=True, timeout=None):
 
     resurl = None
 
-    for l in decompressed.strip().splitlines():
+    for l in decompressed.strip().splitlines():  # noqa: E741
         ls = l.split()
         name = ls[0]
         loc = ls[3]
@@ -517,9 +517,9 @@ class OrderedDescriptor(metaclass=abc.ABCMeta):
 
     Subclasses of `OrderedDescriptor` must define a value for a class attribute
     called ``_class_attribute_``.  This is the name of a class attribute on the
-    *container* class for these descriptors, which will be set to an
-    `~collections.OrderedDict` at class creation time.  This
-    `~collections.OrderedDict` will contain a mapping of all class attributes
+    *container* class for these descriptors, which will be set to a
+    `dict` (insertion-ordered) at class creation time.  This
+    `dict` will contain a mapping of all class attributes
     that were assigned instances of the `OrderedDescriptor` subclass, to the
     instances themselves.  See the documentation for
     `OrderedDescriptorContainer` for a concrete example.
@@ -610,7 +610,7 @@ class OrderedDescriptorContainer(type):
 
     Then when a class with the `OrderedDescriptorContainer` metaclass is
     created, it will automatically be assigned a class attribute ``_examples_``
-    referencing an `~collections.OrderedDict` containing all instances of
+    referencing a `dict` (insertion-ordered) containing all instances of
     ``ExampleDecorator`` defined in the class body, mapped to by the names of
     the attributes they were assigned to.
 
@@ -697,8 +697,7 @@ class OrderedDescriptorContainer(type):
     `OrderedDescriptorContainer` did for us::
 
         >>> Point2D.typed_attributes
-        OrderedDict([('x', <TypedAttribute(name=x, type=(float, int))>),
-        ('y', <TypedAttribute(name=y, type=(float, int))>)])
+        {'x': <TypedAttribute(name=x, type=(float, int))>, 'y': <TypedAttribute(name=y, type=(float, int))>}
 
     If we create a subclass, it does *not* by default add inherited descriptors
     to ``typed_attributes``::
@@ -707,7 +706,7 @@ class OrderedDescriptorContainer(type):
         ...     z = TypedAttribute((float, int))
         ...
         >>> Point3D.typed_attributes
-        OrderedDict([('z', <TypedAttribute(name=z, type=(float, int))>)])
+        {'z': <TypedAttribute(name=z, type=(float, int))>}
 
     However, if we specify ``_inherit_descriptors_`` from ``Point2D`` then
     it will do so::
@@ -717,16 +716,14 @@ class OrderedDescriptorContainer(type):
         ...     z = TypedAttribute((float, int))
         ...
         >>> Point3D.typed_attributes
-        OrderedDict([('x', <TypedAttribute(name=x, type=(float, int))>),
-        ('y', <TypedAttribute(name=y, type=(float, int))>),
-        ('z', <TypedAttribute(name=z, type=(float, int))>)])
+        {'x': <TypedAttribute(name=x, type=(float, int))>, 'y': <TypedAttribute(name=y, type=(float, int))>, 'z': <TypedAttribute(name=z, type=(float, int))>}
 
     .. note::
 
         Hopefully it is clear from these examples that this construction
         also allows a class of type `OrderedDescriptorContainer` to use
         multiple different `OrderedDescriptor` classes simultaneously.
-    """
+    """  # noqa: E501
 
     _inherit_descriptors_ = ()
 
@@ -787,7 +784,7 @@ class OrderedDescriptorContainer(type):
 
         for descriptor_cls, instances in descriptors.items():
             instances.sort()
-            instances = OrderedDict((key, value) for value, key in instances)
+            instances = dict((key, value) for value, key in instances)
             setattr(cls, descriptor_cls._class_attribute_, instances)
 
         super(OrderedDescriptorContainer, cls).__init__(cls_name, bases,
@@ -815,7 +812,7 @@ def _set_locale(name):
     ==========
     name : str
         Locale name, e.g. "C" or "fr_FR".
-    """
+    """  # noqa: E501
     name = str(name)
 
     with LOCALE_LOCK:

--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -784,7 +784,7 @@ class OrderedDescriptorContainer(type):
 
         for descriptor_cls, instances in descriptors.items():
             instances.sort()
-            instances = dict((key, value) for value, key in instances)
+            instances = {key: value for value, key in instances}
             setattr(cls, descriptor_cls._class_attribute_, instances)
 
         super(OrderedDescriptorContainer, cls).__init__(cls_name, bases,

--- a/astropy/utils/tests/test_metadata.py
+++ b/astropy/utils/tests/test_metadata.py
@@ -48,7 +48,7 @@ class MetaBaseTest:
     @pytest.mark.parametrize(('meta'), (["ceci n'est pas un meta", 1.2, [1, 2, 3]]))
     def test_non_mapping_set(self, meta):
         with pytest.raises(TypeError):
-            d = self.test_class(*self.args, meta=meta)
+            self.test_class(*self.args, meta=meta)
 
     def test_meta_fits_header(self):
 

--- a/astropy/utils/tests/test_metadata.py
+++ b/astropy/utils/tests/test_metadata.py
@@ -21,7 +21,7 @@ class MetaBaseTest:
 
     def test_none(self):
         d = self.test_class(*self.args)
-        assert isinstance(d.meta, OrderedDict)
+        assert isinstance(d.meta, dict)
         assert len(d.meta) == 0
 
     @pytest.mark.parametrize(('meta'), ([dict([('a', 1)]),

--- a/docs/nddata/mixins/ndarithmetic.rst
+++ b/docs/nddata/mixins/ndarithmetic.rst
@@ -198,17 +198,17 @@ Meta
 The ``handle_meta`` parameter for the arithmetic operations implements what the
 resulting ``meta`` will be. The options are the same as for the ``mask``:
 
-- If ``None`` the resulting ``meta`` will be an empty `collections.OrderedDict`.
+- If ``None`` the resulting ``meta`` will be an empty `dict`.
 
       >>> ndd1 = NDDataRef(1, meta={'object': 'sun'})
       >>> ndd2 = NDDataRef(1, meta={'object': 'moon'})
       >>> ndd1.add(ndd2, handle_meta=None).meta
-      OrderedDict()
+      {}
 
   For ``meta`` this is the default so you do not need to pass it in this case::
 
       >>> ndd1.add(ndd2).meta
-      OrderedDict()
+      {}
 
 - If ``"first_found"`` or ``"ff"``, the resulting ``meta`` will be the ``meta``
   of the first operand or if that contains no keys, the ``meta`` of the second

--- a/docs/nddata/nddata.rst
+++ b/docs/nddata/nddata.rst
@@ -299,15 +299,15 @@ also includes `~astropy.io.fits.Header` objects::
     'Edwin Hubble'
 
 If the ``meta`` property is not provided or explicitly set to ``None``, it will
-default to an empty `collections.OrderedDict`::
+default to an empty `dict`::
 
     >>> ndd.meta = None
     >>> ndd.meta
-    OrderedDict()
+    {}
 
     >>> ndd = NDData([1,2,3])
     >>> ndd.meta
-    OrderedDict()
+    {}
 
 The ``meta`` object therefore supports adding or updating these values::
 

--- a/docs/table/access_table.rst
+++ b/docs/table/access_table.rst
@@ -177,7 +177,7 @@ Accessing Properties
 
 The code below shows accessing the table columns as a |TableColumns| object,
 getting the column names, table metadata, and number of table rows. The table
-metadata is an ordered dictionary (OrderedDict_) by default.
+metadata is a dictionary (dict) by default.
 ::
 
   >>> t.columns

--- a/docs/table/construct_table.rst
+++ b/docs/table/construct_table.rst
@@ -256,12 +256,10 @@ will be marked as missing (masked)::
     5  10  --
    15  --  50
 
-You can also preserve the column order by using ``OrderedDict``. If the first
-item is an ``OrderedDict`` then the order is preserved:
+The column order is automatically the order given in the ``dict``:
 
-  >>> from collections import OrderedDict
-  >>> row1 = OrderedDict([('b', 1), ('a', 0)])
-  >>> row2 = OrderedDict([('b', 11), ('a', 10)])
+  >>> row1 = dict([('b', 1), ('a', 0)])
+  >>> row2 = dict([('b', 11), ('a', 10)])
   >>> rows = [row1, row2]
   >>> Table(rows=rows, dtype=('i4', 'i4'))
   <Table length=2>
@@ -642,8 +640,7 @@ for the ``data`` argument.
     key values in each dict define the column names and each row must
     have identical column names. The ``names`` argument may be supplied
     to specify column ordering. If it is not provided, the column order will
-    default to alphabetical. If the first item is an ``OrderedDict``, then the
-    column order is preserved. The ``dtype`` list may be specified, and must
+    default to insertion-order. The ``dtype`` list may be specified, and must
     correspond to the order of output columns. If any row's keys do not match
     the rest of the rows, a ValueError will be thrown.
 
@@ -690,10 +687,10 @@ meta
 ----
 
 The ``meta`` argument is an object that contains metadata associated
-with the table. It is recommended that this object be a dict or
-OrderedDict_, but the only firm requirement is that it can be copied with
+with the table. It is recommended that this object be a dict,
+but the only firm requirement is that it can be copied with
 the standard library ``copy.deepcopy()`` routine. By default, ``meta`` is
-an empty OrderedDict_.
+an empty dict.
 
 copy
 ----

--- a/docs/table/references.txt
+++ b/docs/table/references.txt
@@ -4,5 +4,4 @@
 .. |Column| replace:: :class:`~astropy.table.Column`
 .. |MaskedColumn| replace:: :class:`~astropy.table.MaskedColumn`
 .. |TableColumns| replace:: :class:`~astropy.table.TableColumns`
-.. _OrderedDict: https://docs.python.org/3/library/collections.html#collections.OrderedDict
 .. |Quantity| replace:: :class:`~astropy.units.Quantity`

--- a/setup.cfg
+++ b/setup.cfg
@@ -67,7 +67,7 @@ all =
     beautifulsoup4
     html5lib
     bleach
-    PyYAML>=3.13
+    PyYAML>=5.1
     pandas
     sortedcontainers
     pytz
@@ -82,7 +82,7 @@ docs =
     sphinx
     sphinx-astropy>=1.3
     pytest
-    PyYAML>=3.13
+    PyYAML>=5.1
     scipy>=1.1
     matplotlib>=3.1
 

--- a/tox.ini
+++ b/tox.ini
@@ -70,7 +70,7 @@ deps =
     oldestdeps: matplotlib==3.0.*
     oldestdeps: asdf==2.6.*
     oldestdeps: scipy==1.1.*
-    oldestdeps: pyyaml==3.13
+    oldestdeps: pyyaml==5.1.*
     oldestdeps: ipython==4.2.*
     # ipython did not pin traitlets, so we have to
     oldestdeps: traitlets<4.1


### PR DESCRIPTION
**Blocked by:** https://github.com/astropy/astropy/pull/10932#issuecomment-772468495

<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to address part of #10888 . I left `timer.py` alone because it is deprecated and removed in #10281 .

**TODO**

- ~Get the rest of `OrderedDict`.~ Too much work. Just smaller focus here.
- [x] Make sure tests pass.
- [x] Get approval from subpackage maintainers.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

**Resolved**

I see failures like this and not sure what to make of it. Maybe @taldcroft or @mhvk can advise.

```
__ TestMetaMaskedColumn.test_mapping_init[meta2] __

self = <astropy.table.tests.test_column.TestMetaMaskedColumn object at 0x7f0e559df7f0>, meta = {'a': 1}

    @pytest.mark.parametrize(('meta'), ([dict([('a', 1)]),
                                         dict([('a', 1)]),
                                         OrderedDictSubclass([('a', 1)])]))
    def test_mapping_init(self, meta):
        d = self.test_class(*self.args, meta=meta)
>       assert type(d.meta) == type(meta)
E       AssertionError: assert <class 'dict'> == <class 'astropy.utils.tests.test_metadata.OrderedDictSubclass'>
E        +  where <class 'dict'> = type({'a': 1})
E        +    where {'a': 1} = <MaskedColumn dtype='float64' length=0>\n.meta
E        +  and   <class 'astropy.utils.tests.test_metadata.OrderedDictSubclass'> = type({'a': 1})

astropy/utils/tests/test_metadata.py:30: AssertionError
__ TestMetaMaskedColumn.test_mapping_set[meta2] __
self = <astropy.table.tests.test_column.TestMetaMaskedColumn object at 0x7f0e5598c640>, meta = {'a': 1}

    @pytest.mark.parametrize(('meta'), ([dict([('a', 1)]),
                                         dict([('a', 1)]),
                                         OrderedDictSubclass([('a', 1)])]))
    def test_mapping_set(self, meta):
        d = self.test_class(*self.args, meta=meta)
>       assert type(d.meta) == type(meta)
E       AssertionError: assert <class 'dict'> == <class 'astropy.utils.tests.test_metadata.OrderedDictSubclass'>
E        +  where <class 'dict'> = type({'a': 1})
E        +    where {'a': 1} = <MaskedColumn dtype='float64' length=0>\n.meta
E        +  and   <class 'astropy.utils.tests.test_metadata.OrderedDictSubclass'> = type({'a': 1})

astropy/utils/tests/test_metadata.py:43: AssertionError

FAILED astropy/table/tests/test_column.py::TestMetaMaskedColumn::test_mapping_init[meta2] - AssertionError: assert <class 'dict'> == <class 'astropy.utils.tests.test_metadata.OrderedDictSubclass'>
FAILED astropy/table/tests/test_column.py::TestMetaMaskedColumn::test_mapping_set[meta2] - AssertionError: assert <class 'dict'> == <class 'astropy.utils.tests.test_metadata.OrderedDictSubclass'>
```

https://github.com/astropy/astropy/blob/ad37af00665febfc1b9647ae84f398a6f7a88e73/astropy/utils/tests/test_metadata.py#L32