### PR TITLE
Upgrade doctestplus on travis using pip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -272,6 +272,7 @@ install:
       fi
 
 script:
+    # for apt, doctestplus on focal is rather out of date, so get new version.
     - if [ $SETUP_METHOD == 'tox' ]; then
         pip install tox;
         tox $TOXARGS -- $TOXPOSARGS;
@@ -279,6 +280,7 @@ script:
         python3 -m venv --system-site-packages tests;
         source tests/bin/activate;
         pip3 install -e .[test];
+        pip3 install -U pytest-doctestplus;
         python3 -m pytest;
       fi
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -139,8 +139,6 @@ filterwarnings =
     # Ignore a warning we emit about not supporting the parallel
     # reading option for now, can be removed once the issue is fixed
     ignore:parallel reading does not currently work, so falling back to serial
-    # Need for old doctestplus like on Ubuntu/focal on travis.
-    ignore:Direct construction of DocTestModulePlus has been deprecated
 doctest_norecursedirs =
     */setup_package.py
 doctest_subpackage_requires =


### PR DESCRIPTION
The version in focal is too old and the deprecation warning is not
consistently caught.  So, now we can also remove its exception from
setup.cfg.

Follow-up of a comment of @pllim in #10908. Not sure why earlier I thought this didn't work.

Note: not running the tests again, since it all passed in https://travis-ci.com/github/astropy/astropy/builds/192443455
This PR does the changes to travis/setup only, since it can be backported, while #10931 will get only the changes to the time fast reader, which are for 4.2 only.