### PR TITLE
Remove unnecessary array copy in pixel_scale_matrix

### DIFF
--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -3222,7 +3222,7 @@ reduce these to 2 dimensions using the naxis kwarg.
             except AttributeError:
                 pc = 1
 
-        pccd = np.array(np.dot(cdelt, pc))
+        pccd = np.dot(cdelt, pc)
 
         return pccd
 


### PR DESCRIPTION
This PR removes unnecessary `np.array()` (effectively array copy) after `np.dot()` in https://github.com/astropy/astropy/blob/ac313b3f17c19c734d8cd7e329470ef467ef1a71/astropy/wcs/wcs.py#L3221