### PR TITLE
Simplify handling of tick locations in WCSAxes

### DIFF
--- a/astropy/visualization/wcsaxes/coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/coordinate_helpers.py
@@ -591,18 +591,20 @@ class CoordinateHelper:
 
         renderer.close_group('grid lines')
 
-    def _draw_ticks(self, renderer, bboxes, ticklabels_bbox, ticks_locs):
+    def _draw_ticks(self, renderer, bboxes, ticklabels_bbox):
+        """
+        Draw all ticks and ticklabels.
+        """
 
         renderer.open_group('ticks')
-
-        self.ticks.draw(renderer, ticks_locs)
+        self.ticks.draw(renderer)
         self.ticklabels.draw(renderer, bboxes=bboxes,
                              ticklabels_bbox=ticklabels_bbox,
                              tick_out_size=self.ticks.out_size)
 
         renderer.close_group('ticks')
 
-    def _draw_axislabels(self, renderer, bboxes, ticklabels_bbox, ticks_locs, visible_ticks):
+    def _draw_axislabels(self, renderer, bboxes, ticklabels_bbox, visible_ticks):
         # Render the default axis label if no axis label is set.
         if self._auto_axislabel and not self.get_axislabel():
             self.set_axislabel(self._get_default_axislabel())
@@ -612,7 +614,7 @@ class CoordinateHelper:
         self.axislabels.draw(renderer, bboxes=bboxes,
                              ticklabels_bbox=ticklabels_bbox,
                              coord_ticklabels_bbox=ticklabels_bbox[self],
-                             ticks_locs=ticks_locs,
+                             ticks_locs=self.ticks.ticks_locs,
                              visible_ticks=visible_ticks)
 
         renderer.close_group('axis labels')

--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -404,7 +404,6 @@ class WCSAxes(Axes):
         self._bboxes = []
         # This generates a structure like [coords][axis] = [...]
         ticklabels_bbox = defaultdict(partial(defaultdict, list))
-        ticks_locs = defaultdict(partial(defaultdict, list))
 
         visible_ticks = []
 
@@ -418,8 +417,7 @@ class WCSAxes(Axes):
 
             for coord in coords:
                 coord._draw_ticks(renderer, bboxes=self._bboxes,
-                                  ticklabels_bbox=ticklabels_bbox[coord],
-                                  ticks_locs=ticks_locs[coord])
+                                  ticklabels_bbox=ticklabels_bbox[coord])
                 visible_ticks.extend(coord.ticklabels.get_visible_axes())
 
         for coords in self._all_coords:
@@ -427,7 +425,6 @@ class WCSAxes(Axes):
             for coord in coords:
                 coord._draw_axislabels(renderer, bboxes=self._bboxes,
                                        ticklabels_bbox=ticklabels_bbox,
-                                       ticks_locs=ticks_locs[coord],
                                        visible_ticks=visible_ticks)
 
         self.coords.frame.draw(renderer)

--- a/astropy/visualization/wcsaxes/ticks.py
+++ b/astropy/visualization/wcsaxes/ticks.py
@@ -1,5 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+from collections import defaultdict
+import warnings
 
 import numpy as np
 
@@ -30,6 +32,12 @@ class Ticks(Line2D):
     * `xtick.major.width`
     * `xtick.minor.size`
     * `xtick.color`
+
+    Attributes
+    ----------
+    ticks_locs : dict
+        This is set when the ticks are drawn, and is a mapping from axis to
+        the locations of the ticks for that axis.
     """
 
     def __init__(self, ticksize=None, tick_out=None, **kwargs):
@@ -147,21 +155,30 @@ class Ticks(Line2D):
 
     _tickvert_path = Path([[0., 0.], [1., 0.]])
 
-    def draw(self, renderer, ticks_locs):
+    def draw(self, renderer, ticks_locs=None):
         """
         Draw the ticks.
         """
+        if ticks_locs is None:
+            # Deprecated in astropy 4.3
+            warnings.warn(
+                "The ticks_loc argument is deprecated, and no longer has any effect. "
+                "Set the .ticks_locs attribute before drawing "
+                "to modify the ticks being drawn.",
+                AstropyDeprecationWarning)
+
+        self.ticks_locs = defaultdict(list)
 
         if not self.get_visible():
             return
 
         offset = renderer.points_to_pixels(self.get_ticksize())
-        self._draw_ticks(renderer, self.pixel, self.angle, offset, ticks_locs)
+        self._draw_ticks(renderer, self.pixel, self.angle, offset)
         if self._display_minor_ticks:
             offset = renderer.points_to_pixels(self.get_minor_ticksize())
-            self._draw_ticks(renderer, self.minor_pixel, self.minor_angle, offset, ticks_locs)
+            self._draw_ticks(renderer, self.minor_pixel, self.minor_angle, offset)
 
-    def _draw_ticks(self, renderer, pixel_array, angle_array, offset, ticks_locs):
+    def _draw_ticks(self, renderer, pixel_array, angle_array, offset):
         """
         Draw the minor ticks.
         """
@@ -196,6 +213,6 @@ class Ticks(Line2D):
                 # Reset the tick rotation before moving to the next tick
                 marker_rotation.clear()
 
-                ticks_locs[axis].append(locs)
+                self.ticks_locs[axis].append(locs)
 
         gc.restore()

--- a/astropy/visualization/wcsaxes/ticks.py
+++ b/astropy/visualization/wcsaxes/ticks.py
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 from collections import defaultdict
-import warnings
 
 import numpy as np
 
@@ -155,18 +154,10 @@ class Ticks(Line2D):
 
     _tickvert_path = Path([[0., 0.], [1., 0.]])
 
-    def draw(self, renderer, ticks_locs=None):
+    def draw(self, renderer):
         """
         Draw the ticks.
         """
-        if ticks_locs is None:
-            # Deprecated in astropy 4.3
-            warnings.warn(
-                "The ticks_loc argument is deprecated, and no longer has any effect. "
-                "Set the .ticks_locs attribute before drawing "
-                "to modify the ticks being drawn.",
-                AstropyDeprecationWarning)
-
         self.ticks_locs = defaultdict(list)
 
         if not self.get_visible():


### PR DESCRIPTION
Currently the location of ticks are stored in a dictionary within a `WCSAxes` object. With this PR the locations of ticks are stored inside the actual `Ticks` obejct, which makes for more readable code and reduces the number of arguments passed around to various draw functions.

This is a refactor to improve maintainability and doesn't change any functionality.