### PR TITLE
TST: Fix pyinstaller not recognizing pytest fixture

### DIFF
--- a/.pyinstaller/run_astropy_tests.py
+++ b/.pyinstaller/run_astropy_tests.py
@@ -14,8 +14,8 @@ if len(sys.argv) > 1:
     print("Extra arguments passed, exiting early")
     sys.exit(1)
 
-# Copy over the astropy 'tests' directories and their contents
-for root, dirnames, _ in os.walk(os.path.join(ROOT, 'astropy')):
+for root, dirnames, files in os.walk(os.path.join(ROOT, 'astropy')):
+    # Copy over the astropy 'tests' directories and their contents
     for dirname in dirnames:
         final_dir = os.path.relpath(os.path.join(root.replace('astropy', 'astropy_tests'), dirname), ROOT)
         # We only copy over 'tests' directories, but not astropy/tests (only
@@ -31,6 +31,11 @@ for root, dirnames, _ in os.walk(os.path.join(ROOT, 'astropy')):
                 os.makedirs(final_dir, exist_ok=True)
                 with open(os.path.join(final_dir, '__init__.py'), 'w') as f:
                     f.write("#")
+    # Copy over all conftest.py files
+    for file in files:
+        if file == 'conftest.py':
+            final_file = os.path.relpath(os.path.join(root.replace('astropy', 'astropy_tests'), file), ROOT)
+            shutil.copy2(os.path.join(root, file), final_file)
 
 # Add the top-level __init__.py file
 with open(os.path.join('astropy_tests', '__init__.py'), 'w') as f:


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to fix pyinstaller failure caused by not recognizing fixture in `conftest.py`.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Example log: https://travis-ci.com/github/astropy/astropy/jobs/407154709

```
_________________ ERROR at setup of test_dropped_dimensions_4d _________________
file /home/travis/build/astropy/astropy/.pyinstaller/astropy_tests/wcs/wcsapi/wrappers/tests/test_sliced_wcs.py, line 849
  def test_dropped_dimensions_4d(cube_4d_fitswcs):
E       fixture 'cube_4d_fitswcs' not found
>       available fixtures: cache, capfd, capfdbinary, caplog, capsys, capsysbinary, doctest_namespace, header_time_1d, ignore_matplotlibrc, monkeypatch, pytestconfig, record_property, record_testsuite_property, record_xml_attribute, recwarn, time_1d_wcs, tmp_path, tmp_path_factory, tmpdir, tmpdir_factory
>       use 'pytest --fixtures [testpath]' for help on them.
/home/travis/build/astropy/astropy/.pyinstaller/astropy_tests/wcs/wcsapi/wrappers/tests/test_sliced_wcs.py:849
```

Direct follow-up of #10195

- [x] Make sure failure is gone. Done! See https://travis-ci.com/github/astropy/astropy/jobs/407765445
- [x] Move pyinstaller job back to Cron when fix is proven and clean up commit.