### PR TITLE
MNT: Do not use IPython stream in console

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -151,6 +151,8 @@ astropy.utils
 
 - Removed deprecated ``utils.misc.InheritDocstrings`` and ``utils.timer``. [#10281]
 
+- Removed usage of deprecated ``ipython`` stream in ``utils.console``. [#10942]
+
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 
@@ -234,7 +236,7 @@ astropy.wcs
 Other Changes and Additions
 ---------------------------
 
-- Nothing changed yet.
+- Officially declared minversion of ``ipython`` to be 4.2. [#10942]
 
 
 

--- a/astropy/__init__.py
+++ b/astropy/__init__.py
@@ -25,6 +25,9 @@ __minimum_yaml_version__ = '3.13'
 # Matplotlib is an optional dependency, but this is the minimum version that is
 # advertised to be supported.
 __minimum_matplotlib_version__ = '3.0'
+# IPython is an optional dependency, but this is the minimum version that is
+# advertised to be supported.
+__minimum_ipython_version__ = '4.2'
 
 
 class UnsupportedPythonError(Exception):

--- a/astropy/utils/console.py
+++ b/astropy/utils/console.py
@@ -137,7 +137,8 @@ def isatty(file):
         return True
 
     if hasattr(file, 'stream'):
-        # FIXME: pyreadline has no had new release since 2015, drop it?
+        # FIXME: pyreadline has no had new release since 2015, drop it when
+        #        IPython minversion is 5.x.
         # On Windows, in IPython 2 the standard I/O streams will wrap
         # pyreadline.Console objects if pyreadline is available; this should
         # be considered a TTY.

--- a/astropy/utils/console.py
+++ b/astropy/utils/console.py
@@ -116,19 +116,7 @@ def _get_stdout(stderr=False):
         stream = 'stdout'
 
     sys_stream = getattr(sys, stream)
-    if not isatty(sys_stream) or _IPython.OutStream is None:
-        return sys_stream
-
-    # Our system stream is an atty and we're in ipython.
-    ipyio_stream = _IPython.get_stream(stream)
-
-    if ipyio_stream is not None and isatty(ipyio_stream):
-        # Use the IPython console output stream
-        return ipyio_stream
-    else:
-        # sys.stdout was set to some other non-TTY stream (a file perhaps)
-        # so just use it directly
-        return sys_stream
+    return sys_stream
 
 
 def isatty(file):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -97,6 +97,7 @@ rst_epilog += f"""
 .. |minimum_yaml_version| replace:: {astropy.__minimum_yaml_version__}
 .. |minimum_asdf_version| replace:: {astropy.__minimum_asdf_version__}
 .. |minimum_matplotlib_version| replace:: {astropy.__minimum_matplotlib_version__}
+.. |minimum_ipython_version| replace:: {astropy.__minimum_ipython_version__}
 
 .. Astropy
 .. _`Astropy mailing list`: https://mail.python.org/mailman/listinfo/astropy

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -89,8 +89,8 @@ The following packages can optionally be used when testing:
 
 - `objgraph <https://mg.pov.lt/objgraph/>`_: Used only in tests to test for reference leaks.
 
-- `IPython <https://ipython.org/>`__: Used for testing the notebook interface of
-  `~astropy.table.Table`.
+- `IPython <https://ipython.org/>`__ |minimum_ipython_version| or later:
+  Used for testing the notebook interface of `~astropy.table.Table`.
 
 - `coverage <https://coverage.readthedocs.io/>`_: Used for code coverage
   measurements.

--- a/setup.cfg
+++ b/setup.cfg
@@ -76,7 +76,7 @@ all =
     mpmath
     asdf>=2.6
     bottleneck
-    ipython
+    ipython>=4.2
     pytest
 docs =
     sphinx

--- a/tox.ini
+++ b/tox.ini
@@ -72,6 +72,9 @@ deps =
     oldestdeps: asdf==2.6.*
     oldestdeps: scipy==1.1.*
     oldestdeps: pyyaml==3.13
+    oldestdeps: ipython==4.2.*
+    # ipython did not pin traitlets, so we have to
+    oldestdeps: traitlets<4.1
 
     # The devdeps factor is intended to be used to install the latest developer version
     # or nightly wheel of key dependencies.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

I ran into a deprecation warning when I ran `pytest -s astropy/utils/tests/test_console.py`:

```
===== test session starts =====
platform linux -- Python 3.8.3, pytest-6.1.1, py-1.9.0, pluggy-0.13.1

Running tests with Astropy version 4.2.dev1143+g094254c55.
Running tests in astropy/utils/tests/test_console.py.

Date: 2020-10-26T15:37:25

Platform: Linux-3.10.0-1160.el7.x86_64-x86_64-with-glibc2.10

Executable: .../miniconda/envs/py38/bin/python

Full Python Version: 
3.8.3 (default, May 19 2020, 18:47:26) 
[GCC 7.3.0]

encodings: sys: utf-8, locale: UTF-8, filesystem: utf-8
byteorder: little
float info: dig: 15, mant_dig: 15

Package versions: 
Numpy: 1.19.1
Scipy: 1.5.1
Matplotlib: 3.3.1
h5py: 2.10.0
Pandas: 1.0.5
PyERFA: 1.7.0
Cython: not available
Scikit-image: 0.17.2
asdf: 2.6.0

Using Astropy options: remote_data: none.

rootdir: ..., configfile: setup.cfg
plugins: hypothesis-5.16.1, openfiles-0.5.0, remotedata-0.3.1, arraydiff-0.3, asdf-2.6.0, astropy-header-0.1.2,
doctestplus-0.8.0, filter-subpackage-0.1.1, cov-2.10.1, forked-1.3.0, xdist-2.1.0
collected 28 items

astropy/utils/tests/test_console.py ..foo
foobar
...überbær
.foo
..FFFFFF..............

========== FAILURES ===========
_____ test_progress_bar _____

    def test_progress_bar():
        # This stuff is hard to test, at least smoke test it
>       with console.ProgressBar(50) as bar:

astropy/utils/tests/test_console.py:126: 
_ _ _ _ _
astropy/utils/console.py:571: in __init__
    self.update(0)
astropy/utils/console.py:616: in update
    self._update_console(value)
astropy/utils/console.py:636: in _update_console
    write('\r|')
_ _ _ _ _

self = IPython.utils.io.IOStream(<_io.TextIOWrapper name='<stdout>' mode='w' encoding='utf-8'>), data = '\r|'

    def write(self,data):
>       warn('IOStream is deprecated since IPython 5.0, use sys.{stdin,stdout,stderr} instead',
             DeprecationWarning, stacklevel=2)
E       DeprecationWarning: IOStream is deprecated since IPython 5.0, use sys.{stdin,stdout,stderr} instead

.../IPython/utils/io.py:52: DeprecationWarning
_______ test_progress_bar2 _____

    def test_progress_bar2():
>       for x in console.ProgressBar(range(50)):

astropy/utils/tests/test_console.py:132: 
_ _ _ _ _
astropy/utils/console.py:571: in __init__
    self.update(0)
astropy/utils/console.py:616: in update
    self._update_console(value)
astropy/utils/console.py:636: in _update_console
    write('\r|')
_ _ _ _ _

self = IPython.utils.io.IOStream(<_io.TextIOWrapper name='<stdout>' mode='w' encoding='utf-8'>), data = '\r|'

    def write(self,data):
>       warn('IOStream is deprecated since IPython 5.0, use sys.{stdin,stdout,stderr} instead',
             DeprecationWarning, stacklevel=2)
E       DeprecationWarning: IOStream is deprecated since IPython 5.0, use sys.{stdin,stdout,stderr} instead

.../IPython/utils/io.py:52: DeprecationWarning
_____ test_progress_bar3 _____

    def test_progress_bar3():
        def do_nothing(*args, **kwargs):
            pass
    
>       console.ProgressBar.map(do_nothing, range(50))

astropy/utils/tests/test_console.py:140: 
_ _ _ _ _
astropy/utils/console.py:752: in map
    results = cls.map_unordered(
astropy/utils/console.py:825: in map_unordered
    with cls(len(items), ipython_widget=ipython_widget, file=file) as bar:
astropy/utils/console.py:571: in __init__
    self.update(0)
astropy/utils/console.py:616: in update
    self._update_console(value)
astropy/utils/console.py:636: in _update_console
    write('\r|')
_ _ _ _ _

self = IPython.utils.io.IOStream(<_io.TextIOWrapper name='<stdout>' mode='w' encoding='utf-8'>), data = '\r|'

    def write(self,data):
>       warn('IOStream is deprecated since IPython 5.0, use sys.{stdin,stdout,stderr} instead',
             DeprecationWarning, stacklevel=2)
E       DeprecationWarning: IOStream is deprecated since IPython 5.0, use sys.{stdin,stdout,stderr} instead

.../IPython/utils/io.py:52: DeprecationWarning
_____ test_zero_progress_bar ______

    def test_zero_progress_bar():
>       with console.ProgressBar(0) as bar:

astropy/utils/tests/test_console.py:144: 
_ _ _ _ _
astropy/utils/console.py:571: in __init__
    self.update(0)
astropy/utils/console.py:616: in update
    self._update_console(value)
astropy/utils/console.py:636: in _update_console
    write('\r|')
_ _ _ _ _

self = IPython.utils.io.IOStream(<_io.TextIOWrapper name='<stdout>' mode='w' encoding='utf-8'>), data = '\r|'

    def write(self,data):
>       warn('IOStream is deprecated since IPython 5.0, use sys.{stdin,stdout,stderr} instead',
             DeprecationWarning, stacklevel=2)
E       DeprecationWarning: IOStream is deprecated since IPython 5.0, use sys.{stdin,stdout,stderr} instead

.../IPython/utils/io.py:52: DeprecationWarning
_____ test_progress_bar_as_generator _____

    def test_progress_bar_as_generator():
        sum = 0
>       for x in console.ProgressBar(range(50)):

astropy/utils/tests/test_console.py:150: 
_ _ _ _ _
astropy/utils/console.py:571: in __init__
    self.update(0)
astropy/utils/console.py:616: in update
    self._update_console(value)
astropy/utils/console.py:636: in _update_console
    write('\r|')
_ _ _ _ _

self = IPython.utils.io.IOStream(<_io.TextIOWrapper name='<stdout>' mode='w' encoding='utf-8'>), data = '\r|'

    def write(self,data):
>       warn('IOStream is deprecated since IPython 5.0, use sys.{stdin,stdout,stderr} instead',
             DeprecationWarning, stacklevel=2)
E       DeprecationWarning: IOStream is deprecated since IPython 5.0, use sys.{stdin,stdout,stderr} instead

.../IPython/utils/io.py:52: DeprecationWarning
______ test_progress_bar_map ______

    def test_progress_bar_map():
        items = list(range(100))
>       result = console.ProgressBar.map(test_progress_bar_func.func,
                                         items, step=10, multiprocess=True)

astropy/utils/tests/test_console.py:162: 
_ _ _ _ _
astropy/utils/console.py:752: in map
    results = cls.map_unordered(
astropy/utils/console.py:825: in map_unordered
    with cls(len(items), ipython_widget=ipython_widget, file=file) as bar:
astropy/utils/console.py:571: in __init__
    self.update(0)
astropy/utils/console.py:616: in update
    self._update_console(value)
astropy/utils/console.py:636: in _update_console
    write('\r|')
_ _ _ _ _

self = IPython.utils.io.IOStream(<_io.TextIOWrapper name='<stdout>' mode='w' encoding='utf-8'>), data = '\r|'

    def write(self,data):
>       warn('IOStream is deprecated since IPython 5.0, use sys.{stdin,stdout,stderr} instead',
             DeprecationWarning, stacklevel=2)
E       DeprecationWarning: IOStream is deprecated since IPython 5.0, use sys.{stdin,stdout,stderr} instead

.../IPython/utils/io.py:52: DeprecationWarning
===== short test summary info =====
FAILED astropy/utils/tests/test_console.py::test_progress_bar - DeprecationWarning: IOStream is deprecated since IPython 5.0, use sys.{stdin,stdout,stderr} instead
FAILED astropy/utils/tests/test_console.py::test_progress_bar2 - DeprecationWarning: IOStream is deprecated since IPython 5.0, use sys.{stdin,stdout,stderr} instead
FAILED astropy/utils/tests/test_console.py::test_progress_bar3 - DeprecationWarning: IOStream is deprecated since IPython 5.0, use sys.{stdin,stdout,stderr} instead
FAILED astropy/utils/tests/test_console.py::test_zero_progress_bar - DeprecationWarning: IOStream is deprecated since IPython 5.0, use sys.{stdin,stdout,stderr} instead
FAILED astropy/utils/tests/test_console.py::test_progress_bar_as_generator - DeprecationWarning: IOStream is deprecated since IPython 5.0, use sys.{stdin,stdout,stderr} instead
FAILED astropy/utils/tests/test_console.py::test_progress_bar_map - DeprecationWarning: IOStream is deprecated since IPython 5.0, use sys.{stdin,stdout,stderr} instead
===== 6 failed, 22 passed in 0.98s ======
```

With this patch, the tests pass again:
```
astropy/utils/tests/test_console.py ..foo
foobar
...überbær
.foo
|=============================================================================================================================================================================|  50 / 50  (100.00%)         0s
|=============================================================================================================================================================================|  50 / 50  (100.00%)         0s
|=============================================================================================================================================================================|  50 / 50  (100.00%)         0s
|=============================================================================================================================================================================|   0 /  0  (100.00%)         0s
|=============================================================================================================================================================================|  50 / 50  (100.00%)         0s
|=============================================================================================================================================================================|  50 / 50  (100.00%)         0s
|=============================================================================================================================================================================| 100 /100  (100.00%)         0s
|=============================================================================================================================================================================| 100 /100  (100.00%)         0s
...............

===== 28 passed in 0.98s =====
```

I am not that familiar with `console.py`, so I opted not to try to gut the `_IPython` class. 

xref ipython/ipython#9504

Fix #11005

**TODO**

- [x] Finalize scope of refactoring.
- [x] Add change log.
- [ ] Open issue about pyreadline after merge.