### PR TITLE
Skip setup_package files when running generate_config

### DIFF
--- a/astropy/config/configuration.py
+++ b/astropy/config/configuration.py
@@ -622,8 +622,9 @@ def generate_config(pkgname='astropy', filename=None, verbose=False):
         for mod in pkgutil.walk_packages(path=package.__path__,
                                          prefix=package.__name__ + '.'):
 
-            if mod.module_finder.path.endswith(('test', 'tests')):
-                # Skip test modules
+            if (mod.module_finder.path.endswith(('test', 'tests')) or
+                    mod.name.endswith('setup_package')):
+                # Skip test and setup_package modules
                 continue
             if mod.name.split('.')[-1].startswith('_'):
                 # Skip private modules

--- a/astropy/config/tests/test_configs.py
+++ b/astropy/config/tests/test_configs.py
@@ -147,13 +147,7 @@ def test_config_file():
 def test_generate_config(tmp_path):
     from astropy.config.configuration import generate_config
     out = io.StringIO()
-    try:
-        generate_config('astropy', out)
-    except ValueError as err:
-        if sys.platform.startswith('win') and 'path is on mount' in str(err):
-            pytest.xfail("See Github issue 10747")
-        else:
-            raise
+    generate_config('astropy', out)
     conf = out.getvalue()
 
     outfile = tmp_path / 'astropy.cfg'


### PR DESCRIPTION
Follow-up to the recent issue with  abspath in setup package (#10927).