### PR TITLE
Removing python3.6 from azure

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -50,14 +50,12 @@ jobs:
       targets:
       - sdist
       # The linux builds are the fastest so run all three in one job
-      - wheels_cp3[678]*linux_i686
-      - wheels_cp3[678]*linux_x86_64
-      # macos is a little slower so split it into two 
-      - wheels_cp36*macosx_x86_64
-      - wheels_cp3[78]*macosx_x86_64
+      - wheels_cp3[78]*linux_i686
+      - wheels_cp3[78]*linux_x86_64
+      # macos is a little slower so split it into two
+      - wheels_cp37*macosx_x86_64
+      - wheels_cp38*macosx_x86_64
       # windows is the slowest, so do one python version per build
-      - wheels_cp36*win32
-      - wheels_cp36*win_amd64
       - wheels_cp37*win32
       - wheels_cp37*win_amd64
       - wheels_cp38*win32

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,7 +49,7 @@ jobs:
 
       targets:
       - sdist
-      # The linux builds are the fastest so run all three in one job
+      # The linux builds are the fastest so run all in one job
       - wheels_cp3[78]*linux_i686
       - wheels_cp3[78]*linux_x86_64
       # macos is a little slower so split it into two


### PR DESCRIPTION
Small PR to be backported. 
Python3.9 should also be added, but I think it's better be done in a separate PR, once we have it up and running for normal test builds.
