### PR TITLE
Enable test for bbox_size limits in all Matplotlib 3 versions

### DIFF
--- a/astropy/visualization/wcsaxes/tests/test_misc.py
+++ b/astropy/visualization/wcsaxes/tests/test_misc.py
@@ -21,7 +21,6 @@ from astropy.visualization.wcsaxes.utils import get_coord_meta
 from astropy.visualization.wcsaxes.transforms import CurvedTransform
 
 mpl_version = Version(matplotlib.__version__)
-MATPLOTLIB_EQ_33 = mpl_version.major == 3 and mpl_version.minor == 3
 TEX_UNAVAILABLE = not matplotlib.checkdep_usetex(True)
 
 DATA = os.path.abspath(os.path.join(os.path.dirname(__file__), 'data'))
@@ -500,17 +499,21 @@ def test_set_labels_with_coords(ignore_matplotlibrc, frame_class):
         assert ax.coords[i].get_axislabel() == labels[i]
 
 
-# The bounding box calculation is very dependent on Matplotlib versions.
-@pytest.mark.skipif('not MATPLOTLIB_EQ_33')
 def test_bbox_size():
     # Test for the size of a WCSAxes bbox
+    x0 = 11.38888888888889
+    y0 = 3.5
+    # Upper bounding box limits (only have Matplotlib >= 3.0 now)
+    x1 = 576.0
+    y1 = 432.0
+
     fig = plt.figure()
     ax = WCSAxes(fig, [0.1, 0.1, 0.8, 0.8])
     fig.add_axes(ax)
     fig.canvas.draw()
     renderer = fig.canvas.renderer
     ax_bbox = ax.get_tightbbox(renderer)
-    assert np.allclose(ax_bbox.x0, 11.38888888888889)
-    assert np.allclose(ax_bbox.x1, 576)
-    assert np.allclose(ax_bbox.y0, 3.5)
-    assert np.allclose(ax_bbox.y1, 432)
+    assert np.allclose(ax_bbox.x0, x0)
+    assert np.allclose(ax_bbox.x1, x1)
+    assert np.allclose(ax_bbox.y0, y0)
+    assert np.allclose(ax_bbox.y1, y1)


### PR DESCRIPTION
Experimental PR to confirm or disprove the conclusions on how `get_tightbbox` calculation changes over Matplotlib version from https://github.com/astropy/astropy/pull/10900#discussion_r512333375
(tested locally against mpl 2.2.5, 3.0.3 and 3.3.2).