### PR TITLE
DOC: Clarify Om0 in Planck18 cosmology

### DIFF
--- a/docs/cosmology/index.rst
+++ b/docs/cosmology/index.rst
@@ -307,10 +307,10 @@ Planck18  Planck Collab 2018, Paper VI   67.7  0.310 Yes
 
 .. note::
 
-  Unlike the Planck 2015 paper, the Planck 2018 paper included massive
-  neutrinos in ``Om0`` but Planck18 here included them in ``m_nu`` instead
+  Unlike the Planck 2015 paper, the Planck 2018 paper includes massive
+  neutrinos in ``Om0`` but the Planck18 object includes them in ``m_nu`` instead
   for consistency. Hence, the ``Om0`` value in Planck18 differs slightly
-  from the Planck 2018 paper.
+  from the Planck 2018 paper but represents the same cosmological model.
 
 Currently, all are instances of `~astropy.cosmology.FlatLambdaCDM`.
 More details about exactly where each set of parameters comes from

--- a/docs/cosmology/index.rst
+++ b/docs/cosmology/index.rst
@@ -305,6 +305,13 @@ Planck15  Planck Collab 2015, Paper XIII 67.7  0.307 Yes
 Planck18  Planck Collab 2018, Paper VI   67.7  0.310 Yes
 ========  ============================== ====  ===== =======
 
+.. note::
+
+  Unlike the Planck 2015 paper, the Planck 2018 paper included massive
+  neutrinos in ``Om0`` but Planck18 here included them in ``m_nu`` instead
+  for consistency. Hence, the ``Om0`` value in Planck18 differs slightly
+  from the Planck 2018 paper.
+
 Currently, all are instances of `~astropy.cosmology.FlatLambdaCDM`.
 More details about exactly where each set of parameters comes from
 are available in the docstring for each object::


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to clarify `Om0` value discrepancy between Planck18 and the associated paper.

@lewtonstein , does this make thing clearer? If not, please provide suggestion. Also, please note that `cosmology.Planck18_arXiv_v2` will be replaced with `cosmology.Planck18` from `astropy` 4.2 onwards (#10915).

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #10957 
