### PR TITLE
Add `Column.value` as an alias for `Column.data` for consistency with `Quantity` and `Time`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -127,7 +127,7 @@ astropy.table
 
 - Added ``Column.value`` as an alias for the existing ``Column.data`` attribute.
   This makes accessing a column's underlying data array consistent with the
-  ``.value`` attribute available for ``Time`` and ``Quantity`` objects. [#10859]
+  ``.value`` attribute available for ``Time`` and ``Quantity`` objects. [#10962]
 
 astropy.tests
 ^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -125,6 +125,10 @@ astropy.stats
 astropy.table
 ^^^^^^^^^^^^^
 
+- Added ``Column.value`` as an alias for the existing ``Column.data`` attribute.
+  This makes accessing a column's underlying data array consistent with the
+  ``.value`` attribute available for ``Time`` and ``Quantity`` objects. [#10859]
+
 astropy.tests
 ^^^^^^^^^^^^^
 

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -405,6 +405,10 @@ class BaseColumn(_ColumnGetitemShim, np.ndarray):
         return self.view(np.ndarray)
 
     @property
+    def value(self):
+        return self.data
+
+    @property
     def parent_table(self):
         # Note: It seems there are some cases where _parent_table is not set,
         # such after restoring from a pickled Column.  Perhaps that should be

--- a/astropy/table/tests/test_column.py
+++ b/astropy/table/tests/test_column.py
@@ -10,6 +10,7 @@ from numpy.testing import assert_array_equal
 
 from astropy.tests.helper import assert_follows_unicode_guidelines
 from astropy import table
+from astropy import time
 from astropy import units as u
 
 
@@ -904,3 +905,17 @@ def test_structured_empty_column_init(dtype):
     c = table.Column(length=5, shape=(2,), dtype=dtype)
     assert c.shape == (5, 2)
     assert c.dtype == dtype
+
+
+def test_column_value_access():
+    """Can a column's underlying data consistently be accessed via `.value`,
+    whether it is a `Column`, `MaskedColumn`, `Quantity`, or `Time`?"""
+    data = np.array([1, 2, 3])
+    tbl = table.QTable({'a': table.Column(data),
+                        'b': table.MaskedColumn(data),
+                        'c': u.Quantity(data),
+                        'd': time.Time(data, format='mjd')})
+    assert type(tbl['a'].value) == np.ndarray
+    assert type(tbl['b'].value) == np.ma.MaskedArray
+    assert type(tbl['c'].value) == np.ndarray
+    assert type(tbl['d'].value) == np.ndarray


### PR DESCRIPTION
(Fixes #10859.)

### Description

This PR proposes to make the `Table` API more user-friendly by adding `Column.value` as an alias for `Column.data`, so that the underlying array can be accessed in a way that is consistent with the `Time` and `Quantity` classes, which provide `Time.value` and `Quantity.value` properties.


### Example

This change would particularly benefit the user experience when dealing with tables which contain a mix of `Time`, `Quantity`, `Column` and/or `MaskedColumn` fields. This will be common in `TimeSeries` objects.  For example, I frequently make the following mistake at present:

```python
In [1]: from astropy.timeseries import TimeSeries
   ...: from astropy.time import Time
   ...: from astropy.units import Quantity
   ...: from astropy.table import Column
   ...:
   ...: ts = TimeSeries({'time': Time([50000, 50001, 50002], format='mjd'),
   ...:                  'flux': Quantity([1., 2., 3.], unit='electron/s'),
   ...:                  'flag': Column(['clear', 'clear', 'cloudy'])})

In [2]: ts['time'].value
Out[2]: array([50000., 50001., 50002.])

In [3]: ts['flux'].value
Out[3]: array([1., 2., 3.])

In [4]: ts['flag'].value
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-4-7973ebc06f9d> in <module>
----> 1 ts['flag'].value

AttributeError: 'Column' object has no attribute 'value'
```

If we merge this PR, the new behavior will be:
```python
In [4]: ts['flag'].value
Out[4]: array(['clear', 'clear', 'cloudy'], dtype='<U6')
```

### Do we really need this? 

I am aware that, in an ideal world, users should not have to worry about accessing `.value`.  Indeed it looks like `Column` objects work seamlessly with ~all numpy/astropy functions these days (thank you whoever made this happen!!).  The situation is different for `Time` however, e.g. `np.median(Time)` does not work.  And, while `Quantity` objects are seamless, I believe its `.value` property will always be a popular (if dangerous) shortcut for silencing conversion errors.

/cc @taldcroft @mhvk @pllim @orionlee