### PR TITLE
MNT: Use moar f-string

### DIFF
--- a/astropy/coordinates/builtin_frames/__init__.py
+++ b/astropy/coordinates/builtin_frames/__init__.py
@@ -120,23 +120,24 @@ def make_transform_graph_docs(transform_graph):
     from astropy.coordinates.transformations import trans_to_color
     html_list_items = []
     for cls, color in trans_to_color.items():
-        block = """
+        block = f"""
             <li style='list-style: none;'>
                 <p style="font-size: 12px;line-height: 24px;font-weight: normal;color: #848484;padding: 0;margin: 0;">
-                    <b>{}:</b>
-                    <span style="font-size: 24px; color: {};"><b>➝</b></span>
+                    <b>{cls.__name__}:</b>
+                    <span style="font-size: 24px; color: {color};"><b>➝</b></span>
                 </p>
             </li>
-        """.format(cls.__name__, color)
+        """
         html_list_items.append(block)
 
-    graph_legend = """
+    nl = '\n'
+    graph_legend = f"""
     .. raw:: html
 
         <ul>
-            {}
+            {nl.join(html_list_items)}
         </ul>
-    """.format("\n".join(html_list_items))
+    """
     docstr = docstr + dedent(graph_legend)
 
     return docstr

--- a/astropy/coordinates/spectral_coordinate.py
+++ b/astropy/coordinates/spectral_coordinate.py
@@ -290,8 +290,7 @@ class SpectralCoord(SpectralQuantity):
         # system.
         if 's' not in coord.data.differentials:
             warnings.warn(
-                "No velocity defined on frame, assuming {}.".format(
-                    ZERO_VELOCITIES),
+                f"No velocity defined on frame, assuming {ZERO_VELOCITIES}.",
                 NoVelocityWarning)
 
             coord = attach_zero_velocities(coord)

--- a/astropy/logger.py
+++ b/astropy/logger.py
@@ -503,8 +503,8 @@ class AstropyLogger(Logger):
                 fh = logging.FileHandler(log_file_path, encoding=encoding)
             except OSError as e:
                 warnings.warn(
-                    'log file {!r} could not be opened for writing: '
-                    '{}'.format(log_file_path, str(e)), RuntimeWarning)
+                    f'log file {log_file_path!r} could not be opened for writing: {str(e)}',
+                    RuntimeWarning)
             else:
                 formatter = logging.Formatter(conf.log_file_format)
                 fh.setFormatter(formatter)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -107,7 +107,7 @@ rst_epilog += """
 
 project = u'Astropy'
 author = u'The Astropy Developers'
-copyright = u'2011–{0}, '.format(datetime.utcnow().year) + author
+copyright = f'2011–{datetime.utcnow().year}, ' + author
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -168,7 +168,7 @@ modindex_common_prefix = ['astropy.']
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
-html_title = '{0} v{1}'.format(project, release)
+html_title = f'{project} v{release}'
 
 # Output file base name for HTML help builder.
 htmlhelp_basename = project + 'doc'
@@ -222,7 +222,7 @@ try:
     sphinx_gallery_conf = {
         'backreferences_dir': 'generated/modules', # path to store the module using example template
         'filename_pattern': '^((?!skip_).)*$', # execute all examples except those that start with "skip_"
-        'examples_dirs': '..{}examples'.format(os.sep), # path to the examples scripts
+        'examples_dirs': f'..{os.sep}examples', # path to the examples scripts
         'gallery_dirs': 'generated/examples', # path to save gallery generated examples
         'reference_url': {
             'astropy': None,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -89,19 +89,19 @@ templates_path.append('_templates')
 
 # This is added to the end of RST files - a good place to put substitutions to
 # be used globally.
-rst_epilog += """
-.. |minimum_python_version| replace:: {0.__minimum_python_version__}
-.. |minimum_numpy_version| replace:: {0.__minimum_numpy_version__}
-.. |minimum_erfa_version| replace:: {0.__minimum_erfa_version__}
-.. |minimum_scipy_version| replace:: {0.__minimum_scipy_version__}
-.. |minimum_yaml_version| replace:: {0.__minimum_yaml_version__}
-.. |minimum_asdf_version| replace:: {0.__minimum_asdf_version__}
-.. |minimum_matplotlib_version| replace:: {0.__minimum_matplotlib_version__}
+rst_epilog += f"""
+.. |minimum_python_version| replace:: {astropy.__minimum_python_version__}
+.. |minimum_numpy_version| replace:: {astropy.__minimum_numpy_version__}
+.. |minimum_erfa_version| replace:: {astropy.__minimum_erfa_version__}
+.. |minimum_scipy_version| replace:: {astropy.__minimum_scipy_version__}
+.. |minimum_yaml_version| replace:: {astropy.__minimum_yaml_version__}
+.. |minimum_asdf_version| replace:: {astropy.__minimum_asdf_version__}
+.. |minimum_matplotlib_version| replace:: {astropy.__minimum_matplotlib_version__}
 
 .. Astropy
 .. _`Astropy mailing list`: https://mail.python.org/mailman/listinfo/astropy
 .. _`astropy-dev mailing list`: http://groups.google.com/group/astropy-dev
-""".format(astropy)
+"""
 
 # -- Project information ------------------------------------------------------
 

--- a/docs/coordinates/formatting.rst
+++ b/docs/coordinates/formatting.rst
@@ -37,9 +37,9 @@ more). For example::
 You can also use Python's `format` string method to create more complex
 string expressions, such as IAU-style coordinates or even full sentences::
 
-  >>> 'SDSS J{0}{1}'.format(c.ra.to_string(unit=u.hourangle, sep='', precision=2, pad=True), c.dec.to_string(sep='', precision=2, alwayssign=True, pad=True))
+  >>> f'SDSS J{c.ra.to_string(unit=u.hourangle, sep="", precision=2, pad=True)}{c.dec.to_string(sep="", precision=2, alwayssign=True, pad=True)}'
   'SDSS J123049.42+122328.03'
-  >>> 'The galaxy M87, at an RA of {0.ra.hour:.2f} hours and Dec of {0.dec.deg:.1f} degrees, has an impressive jet.'.format(c)
+  >>> f'The galaxy M87, at an RA of {c.ra.hour:.2f} hours and Dec of {c.dec.deg:.1f} degrees, has an impressive jet.'
   'The galaxy M87, at an RA of 12.51 hours and Dec of 12.4 degrees, has an impressive jet.'
 
 ..

--- a/docs/coordinates/formatting.rst
+++ b/docs/coordinates/formatting.rst
@@ -17,18 +17,18 @@ To get the string representation of a coordinate::
 
   >>> from astropy.coordinates import ICRS
   >>> from astropy import units as u
-  >>> c = ICRS(187.70592*u.degree, 12.39112*u.degree)
-  >>> str(c.ra) + ' ' + str(c.dec)
+  >>> coo = ICRS(187.70592*u.degree, 12.39112*u.degree)
+  >>> str(coo.ra) + ' ' + str(coo.dec)
   '187d42m21.312s 12d23m28.032s'
 
 To get better control over the formatting, you can use the angles'
 :meth:`~astropy.coordinates.Angle.to_string` method (see :doc:`angles` for
 more). For example::
 
-  >>> rahmsstr = c.ra.to_string(u.hour)
+  >>> rahmsstr = coo.ra.to_string(u.hour)
   >>> str(rahmsstr)
   '12h30m49.4208s'
-  >>> decdmsstr = c.dec.to_string(u.degree, alwayssign=True)
+  >>> decdmsstr = coo.dec.to_string(u.degree, alwayssign=True)
   >>> str(decdmsstr)
   '+12d23m28.032s'
   >>> rahmsstr + ' ' + decdmsstr
@@ -37,9 +37,10 @@ more). For example::
 You can also use Python's `format` string method to create more complex
 string expressions, such as IAU-style coordinates or even full sentences::
 
-  >>> f'SDSS J{c.ra.to_string(unit=u.hourangle, sep="", precision=2, pad=True)}{c.dec.to_string(sep="", precision=2, alwayssign=True, pad=True)}'
+  >>> (f'SDSS J{coo.ra.to_string(unit=u.hourangle, sep="", precision=2, pad=True)}'
+  ...  f'{coo.dec.to_string(sep="", precision=2, alwayssign=True, pad=True)}')
   'SDSS J123049.42+122328.03'
-  >>> f'The galaxy M87, at an RA of {c.ra.hour:.2f} hours and Dec of {c.dec.deg:.1f} degrees, has an impressive jet.'
+  >>> f'The galaxy M87, at an RA of {coo.ra.hour:.2f} hours and Dec of {coo.dec.deg:.1f} degrees, has an impressive jet.'
   'The galaxy M87, at an RA of 12.51 hours and Dec of 12.4 degrees, has an impressive jet.'
 
 ..

--- a/docs/development/codeguide.rst
+++ b/docs/development/codeguide.rst
@@ -266,8 +266,7 @@ The following example class shows a way to implement this::
 
         def __repr__(self):
             # Return unicode object containing no non-ASCII characters
-            return '<FloatList [{0}]>'.format(', '.join(
-                str(x) for x in self.x))
+            return f'<FloatList [{", ".join(str(x) for x in self.x)}]>'
 
         def __bytes__(self):
             return b'|'.join(bytes(x) for x in self.x)

--- a/docs/io/unified.rst
+++ b/docs/io/unified.rst
@@ -374,7 +374,7 @@ a table you can view the available keywords in a readable format using:
 .. doctest-skip::
 
   >>> for key, value in t.meta.items():
-  ...     print('{0} = {1}'.format(key, value))
+  ...     print(f'{key} = {value}')
 
 This does not include the "internal" FITS keywords that are required to specify
 the FITS table properties (e.g., ``NAXIS``, ``TTYPE1``). ``HISTORY`` and

--- a/docs/modeling/compound-models.rst
+++ b/docs/modeling/compound-models.rst
@@ -334,7 +334,7 @@ example, to create the following compound model:
     for z in (0.2, 0.4, 0.6):
         g = RedshiftScaleFactor(z) | Gaussian1D(1, 0.75, 0.1)
         plt.plot(x, g(x), color=plt.cm.OrRd(z),
-                 label='$z={0}$'.format(z))
+                 label=f'$z={z}$')
 
     plt.xlabel('Energy')
     plt.ylabel('Flux')
@@ -362,7 +362,7 @@ model *instances*:
         sc = Scale(1. / (1 + z))  # Rescale the flux to conserve energy
         g = rs | g0 | sc
         plt.plot(x, g(x), color=plt.cm.OrRd(z),
-                 label='$z={0}$'.format(z))
+                 label=f'$z={z}$')
 
     plt.xlabel('Wavelength')
     plt.ylabel('Flux')
@@ -409,7 +409,7 @@ example:
         plt.imshow(g(x, y), origin='lower')
         plt.xticks([])
         plt.yticks([])
-        plt.title('Rotated $ {0}^\circ $'.format(theta))
+        plt.title(f'Rotated $ {theta}^\circ $')
 
 .. note::
 

--- a/docs/modeling/models.rst
+++ b/docs/modeling/models.rst
@@ -327,7 +327,7 @@ a factor of 10 with negligible loss of information.
     # Full model image
     plt.subplot(121)
     plt.imshow(full_image, origin='lower')
-    plt.title('Full Models\nTiming: {:.2f} seconds'.format(t_full), fontsize=16)
+    plt.title(f'Full Models\nTiming: {t_full:.2f} seconds', fontsize=16)
     plt.xlabel('x')
     plt.ylabel('y')
 
@@ -340,7 +340,7 @@ a factor of 10 with negligible loss of information.
         pos = (model.x_mean.value - dx / 2, model.y_mean.value - dy / 2)
         r = Rectangle(pos, dx, dy, edgecolor='w', facecolor='none', alpha=.25)
         ax.add_patch(r)
-    plt.title('Bounded Models\nTiming: {:.2f} seconds'.format(t_bb), fontsize=16)
+    plt.title(f'Bounded Models\nTiming: {t_bb:.2f} seconds', fontsize=16)
     plt.xlabel('x')
     plt.ylabel('y')
 
@@ -349,8 +349,7 @@ a factor of 10 with negligible loss of information.
     plt.subplot(111)
     plt.imshow(diff, vmin=-max_err, vmax=max_err)
     plt.colorbar(format='%.1e')
-    plt.title('Difference Image\nTotal Flux Err = {:.0e}'.format(
-        ((flux - np.sum(bb_image)) / flux)))
+    plt.title(f'Difference Image\nTotal Flux Err = {((flux - np.sum(bb_image)) / flux):.0e}')
     plt.xlabel('x')
     plt.ylabel('y')
     plt.show()

--- a/docs/modeling/physical_models.rst
+++ b/docs/modeling/physical_models.rst
@@ -61,8 +61,8 @@ default units returned by :class:`~astropy.modeling.physical_models.BlackBody`.
     ax.plot(wavelengths, bb_result, '-')
 
     ax.set_xscale('log')
-    ax.set_xlabel(r"$\lambda$ [{}]".format(wavelengths.unit))
-    ax.set_ylabel(r"$F(\lambda)$ [{}]".format(bb_result.unit))
+    ax.set_xlabel(fr"$\lambda$ [{wavelengths.unit}]")
+    ax.set_ylabel(fr"$F(\lambda)$ [{bb_result.unit}]")
 
     plt.tight_layout()
     plt.show()
@@ -124,7 +124,7 @@ with :math:`x_0 = 2175` Angstrom and :math:`f = 400` Angstrom is shown below.
     fig, ax = plt.subplots(ncols=1)
     ax.plot(wavelengths, mod_result, '-')
 
-    ax.set_xlabel(r"$\lambda$ [{}]".format(wavelengths.unit))
+    ax.set_xlabel(fr"$\lambda$ [{wavelengths.unit}]")
     ax.set_ylabel(r"$D(\lambda)$")
 
     plt.tight_layout()
@@ -135,17 +135,17 @@ with :math:`x_0 = 2175` Angstrom and :math:`f = 400` Angstrom is shown below.
 NFW
 =========
 
-The :class:`~astropy.modeling.physical_models.NFW` model computes a 
+The :class:`~astropy.modeling.physical_models.NFW` model computes a
 1-dimensional Navarro–Frenk–White profile. The dark matter density in an
 NFW profile is given by:
-  
+
 
 .. math::
 
    \rho(r)=\frac{\delta_c\rho_{c}}{r/r_s(1+r/r_s)^2}
 
-where :math:`\rho_{c}` is the critical density of the Universe at the redshift 
-of the profile, :math:`\delta_c` is the over density, and :math:`r_s` is the 
+where :math:`\rho_{c}` is the critical density of the Universe at the redshift
+of the profile, :math:`\delta_c` is the over density, and :math:`r_s` is the
 scale radius of the profile.
 
 
@@ -153,18 +153,18 @@ This model relies on three parameters:
 
   ``mass`` : the mass of the profile (in solar masses if no units are provided)
 
-  ``concentration`` : the profile concentration 
+  ``concentration`` : the profile concentration
 
-  ``redshift`` : the redshift of the profile 
+  ``redshift`` : the redshift of the profile
 
 As well as two optional initialization variables:
 
   ``massfactor`` : tuple or string specifying the overdensity type and factor (default ("critical", 200))
 
-  ``cosmo`` : the cosmology for density calculation (default default_cosmology)		
+  ``cosmo`` : the cosmology for density calculation (default default_cosmology)
 
 .. note::
-	Initialization of NFW profile object required before evaluation (in order to set mass 
+	Initialization of NFW profile object required before evaluation (in order to set mass
 	overdensity and cosmology).
 
 
@@ -176,8 +176,8 @@ Sample plots of an NFW profile with the following parameters are displayed below
   ``redshift`` = 0.63
 
 The first plot is of the NFW profile density as a function of radius.
-The second plot displays the profile density and radius normalized by the NFW scale 
-density and scale radius, respectively. The scale density and scale radius are available 
+The second plot displays the profile density and radius normalized by the NFW scale
+density and scale radius, respectively. The scale density and scale radius are available
 as attributes ``rho_s`` and ``r_s``, and the overdensity radius can be accessed via ``r_virial``.
 
 .. plot::
@@ -197,7 +197,7 @@ as attributes ``rho_s`` and ``r_s``, and the overdensity radius can be accessed 
     massfactor = ("critical", 200)
 
     # Create NFW Object
-    n = NFW(mass=mass, concentration=concentration, redshift=redshift, cosmo=cosmo, 
+    n = NFW(mass=mass, concentration=concentration, redshift=redshift, cosmo=cosmo,
 	    massfactor=massfactor)
 
     # Radial distribution for plotting
@@ -213,12 +213,12 @@ as attributes ``rho_s`` and ``r_s``, and the overdensity radius can be accessed 
     # Density profile subplot
     ax[0].plot(radii, n_result, '-')
     ax[0].set_yscale('log')
-    ax[0].set_xlabel(r"$r$ [{}]".format(radii.unit))
-    ax[0].set_ylabel(r"$\rho$ [{}]".format(n_result.unit))
+    ax[0].set_xlabel(fr"$r$ [{radii.unit}]")
+    ax[0].set_ylabel(fr"$\rho$ [{n_result.unit}]")
 
     # Create scaled density / scaled radius subplot
     # NFW Object
-    n = NFW(mass=mass, concentration=concentration, redshift=redshift, cosmo=cosmo, 
+    n = NFW(mass=mass, concentration=concentration, redshift=redshift, cosmo=cosmo,
 	    massfactor=massfactor)
 
     # Radial distribution for plotting
@@ -238,7 +238,7 @@ as attributes ``rho_s`` and ``r_s``, and the overdensity radius can be accessed 
 
 
 
-The :meth:`~astropy.modeling.physical_models.NFW.circular_velocity` member provides the circular 
+The :meth:`~astropy.modeling.physical_models.NFW.circular_velocity` member provides the circular
 velocity at each position ``r`` via the equation:
 
 
@@ -248,7 +248,7 @@ velocity at each position ``r`` via the equation:
 
 where x is the ratio ``r``:math:`/r_{vir}`. Circular velocities are provided in km/s.
 
-A sample plot of circular velocities of an NFW profile with the following parameters is displayed 
+A sample plot of circular velocities of an NFW profile with the following parameters is displayed
 below:
 
   ``mass`` = :math:`2.0 x 10^{15} M_{sun}`
@@ -257,7 +257,7 @@ below:
 
   ``redshift`` = 0.63
 
-The maximum circular velocity and radius of maximum circular velocity are available as attributes 
+The maximum circular velocity and radius of maximum circular velocity are available as attributes
 ``v_max`` and ``r_max``.
 
 
@@ -291,8 +291,8 @@ The maximum circular velocity and radius of maximum circular velocity are availa
     ax.set_title('NFW Profile Circular Velocity')
     ax.plot(radii, n_result, '-')
     ax.set_xscale('log')
-    ax.set_xlabel(r"$r$ [{}]".format(radii.unit))
-    ax.set_ylabel(r"$v_{circ}$" + " [{}]".format(n_result.unit))
+    ax.set_xlabel(fr"$r$ [{radii.unit}]")
+    ax.set_ylabel(r"$v_{circ}$" + f" [{n_result.unit}]")
 
     # Display plot
     plt.tight_layout(rect=[0, 0.03, 1, 0.95])

--- a/docs/table/construct_table.rst
+++ b/docs/table/construct_table.rst
@@ -910,11 +910,11 @@ following example this is used to make a LaTeX ready output::
 
     >>> t = Table([[1,2],[1.234e9,2.34e-12]], names = ('a','b'))
     >>> def latex_exp(value):
-    ...     val = '{0:8.2}'.format(value)
+    ...     val = f'{value:8.2}'
     ...     mant, exp = val.split('e')
     ...     # remove leading zeros
     ...     exp = exp[0] + exp[1:].lstrip('0')
-    ...     return '$ {0} \\times 10^{{ {1} }}$' .format(mant, exp)
+    ...     return f'$ {mant} \\times 10^{{ {exp} }}$'
     >>> t['b'].format = latex_exp
     >>> t['a'].format = '.4f'
     >>> import sys
@@ -1248,7 +1248,7 @@ breakage in this case. ::
                Additional keyword args (ignored currently).
           """
           if kwargs:
-              warnings.warn('unexpected keyword args {}'.format(kwargs))
+              warnings.warn(f'unexpected keyword args {kwargs}')
 
           cols = list(self.values())
           names = list(self.keys())
@@ -1261,7 +1261,7 @@ breakage in this case. ::
           if not copy and strict_copy:
               for name, col in zip(names, cols):
                   if not isinstance(col, np.ndarray):
-                      raise ValueError('cannot have copy=False because column {} is '
-                                       'not an ndarray'.format(name))
+                      raise ValueError(f'cannot have copy=False because column {name} is '
+                                       'not an ndarray')
 
           return cls(cols, names=names, copy=copy)

--- a/docs/table/mixin_columns.rst
+++ b/docs/table/mixin_columns.rst
@@ -390,5 +390,4 @@ column.
           return self.data.shape
 
       def __repr__(self):
-          return ("<{0} name='{1}' data={2}>"
-                  .format(self.__class__.__name__, self.info.name, self.data))
+          return f"<{self.__class__.__name__} name='{self.info.name}' data={self.data}>"

--- a/docs/table/operations.rst
+++ b/docs/table/operations.rst
@@ -189,7 +189,7 @@ particular groups, for example::
 You can iterate over the group subtables and corresponding keys with::
 
   >>> for key, group in zip(obs_by_name.groups.keys, obs_by_name.groups):
-  ...     print('****** {0} *******'.format(key['name']))
+  ...     print(f'****** {key["name"]} *******')
   ...     print(group)
   ...     print('')
   ...
@@ -241,7 +241,7 @@ To generate grouping in columns::
   >>> cg = c.group_by(key_vals)
 
   >>> for key, group in zip(cg.groups.keys, cg.groups):
-  ...     print('****** {0} *******'.format(key))
+  ...     print(f'****** {key} *******')
   ...     print(group)
   ...     print('')
   ...
@@ -318,7 +318,7 @@ A single column of data can be aggregated as well::
   >>> cg = c.group_by(key_vals)
   >>> cg_sums = cg.groups.aggregate(np.sum)
   >>> for key, cg_sum in zip(cg.groups.keys, cg_sums):
-  ...     print('Sum for {0} = {1}'.format(key, cg_sum))
+  ...     print(f'Sum for {key} = {cg_sum}')
   ...
   Sum for bar = 2
   Sum for foo = 8

--- a/docs/timeseries/lombscargle.rst
+++ b/docs/timeseries/lombscargle.rst
@@ -326,7 +326,7 @@ We can then phase the data and plot the Lomb-Scargle model fit:
     ax.invert_yaxis()
     ax.set(xlabel='phase',
            ylabel='magnitude',
-           title='phased data at frequency={0:.2f}'.format(best_frequency))
+           title=f'phased data at frequency={best_frequency:.2f}')
 
 The best-fit model parameters can be computed with the
 :func:`~astropy.timeseries.LombScargle.model_parameters` method of the

--- a/docs/units/format.rst
+++ b/docs/units/format.rst
@@ -54,7 +54,7 @@ like ``0.003f`` will not work when applied to a ``numpy`` array or non-scalar
 |Quantity|. Use :func:`numpy.array_str` instead. For instance::
 
     >>> q = np.linspace(0,1,10) * u.m
-    >>> "{0} {1}".format(np.array_str(q.value, precision=1), q.unit)  # doctest: +FLOAT_CMP
+    >>> f"{np.array_str(q.value, precision=1)} {q.unit}"  # doctest: +FLOAT_CMP
     '[0.  0.1 0.2 0.3 0.4 0.6 0.7 0.8 0.9 1. ] m'
 
 Examine the NumPy documentation for more examples with :func:`numpy.array_str`.

--- a/docs/visualization/histogram.rst
+++ b/docs/visualization/histogram.rst
@@ -41,7 +41,7 @@ matplotlib's default of 10 bins, the second with an arbitrarily chosen
         ax[i].hist(t, bins=bins, histtype='stepfilled', alpha=0.2, density=True)
         ax[i].set_xlabel('t')
         ax[i].set_ylabel('P(t)')
-        ax[i].set_title('plt.hist(t, bins={0})'.format(bins),
+        ax[i].set_title(f'plt.hist(t, bins={bins})',
                         fontdict=dict(family='monospace'))
 
 Upon visual inspection, it is clear that each of these choices is suboptimal:
@@ -97,7 +97,7 @@ The following figure shows the results of these two rules on the above dataset:
              alpha=0.2, density=True)
         ax[i].set_xlabel('t')
         ax[i].set_ylabel('P(t)')
-        ax[i].set_title('hist(t, bins="{0}")'.format(bins),
+        ax[i].set_title(f'hist(t, bins="{bins}")',
                         fontdict=dict(family='monospace'))
 
 
@@ -152,7 +152,7 @@ the results of these procedures for the above dataset:
                 alpha=0.2, density=True)
         ax[i].set_xlabel('t')
         ax[i].set_ylabel('P(t)')
-        ax[i].set_title('hist(t, bins="{0}")'.format(bins),
+        ax[i].set_title(f'hist(t, bins="{bins}")',
                         fontdict=dict(family='monospace'))
 
 

--- a/examples/coordinates/plot_galactocentric-frame.py
+++ b/examples/coordinates/plot_galactocentric-frame.py
@@ -180,7 +180,7 @@ plt.show()
 # observable coordinates:
 gal_rings = gc_rings.transform_to(coord.Galactic)
 
-fig,ax = plt.subplots(1, 1, figsize=(8,6))
+fig, ax = plt.subplots(1, 1, figsize=(8, 6))
 for i in range(len(ring_distances)):
     ax.plot(gal_rings[i].l.degree, gal_rings[i].pm_l_cosb.value,
             label=str(ring_distances[i]), marker='None', linewidth=3)
@@ -188,7 +188,7 @@ for i in range(len(ring_distances)):
 ax.set_xlim(360, 0)
 
 ax.set_xlabel('$l$ [deg]')
-ax.set_ylabel(r'$\mu_l \, \cos b$ [{0}]'.format((u.mas/u.yr).to_string('latex_inline')))
+ax.set_ylabel(fr'$\mu_l \, \cos b$ [{(u.mas/u.yr).to_string("latex_inline")}]')
 
 ax.legend()
 

--- a/examples/coordinates/plot_galactocentric-frame.py
+++ b/examples/coordinates/plot_galactocentric-frame.py
@@ -168,8 +168,8 @@ axes[1].plot(gc_rings.v_x.T, gc_rings.v_y.T, marker='None', linewidth=3)
 axes[1].set_xlim(-250, 250)
 axes[1].set_ylim(-250, 250)
 
-axes[1].set_xlabel('$v_x$ [{0}]'.format((u.km/u.s).to_string("latex_inline")))
-axes[1].set_ylabel('$v_y$ [{0}]'.format((u.km/u.s).to_string("latex_inline")))
+axes[1].set_xlabel(f"$v_x$ [{(u.km / u.s).to_string('latex_inline')}]")
+axes[1].set_ylabel(f"$v_y$ [{(u.km / u.s).to_string('latex_inline')}]")
 
 fig.tight_layout()
 

--- a/examples/coordinates/plot_obs-planning.py
+++ b/examples/coordinates/plot_obs-planning.py
@@ -74,7 +74,7 @@ time = Time('2012-7-12 23:00:00') - utcoffset
 # observed from Bear Mountain at 11pm on 2012 July 12.
 
 m33altaz = m33.transform_to(AltAz(obstime=time,location=bear_mountain))
-print("M33's Altitude = {0.alt:.2}".format(m33altaz))
+print(f"M33's Altitude = {m33altaz.alt:.2}")
 
 ##############################################################################
 # This is helpful since it turns out M33 is barely above the horizon at this

--- a/examples/coordinates/plot_sgr-coordinate-frame.py
+++ b/examples/coordinates/plot_sgr-coordinate-frame.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
+r"""
 ==========================================================
 Create a new coordinate class (for the Sagittarius stream)
 ==========================================================
@@ -218,20 +218,20 @@ axes[0].plot(sgr.Lambda.degree,
              sgr.pm_Lambda_cosBeta.value,
              linestyle='none', marker='.')
 axes[0].set_xlabel(r"$\Lambda$ [deg]")
-axes[0].set_ylabel(r"$\mu_\Lambda \, \cos B$ [{0}]"
-                   .format(sgr.pm_Lambda_cosBeta.unit.to_string('latex_inline')))
+axes[0].set_ylabel(
+    fr"$\mu_\Lambda \, \cos B$ [{sgr.pm_Lambda_cosBeta.unit.to_string('latex_inline')}]")
 
 axes[1].set_title("ICRS")
 axes[1].plot(icrs.ra.degree, icrs.pm_ra_cosdec.value,
              linestyle='none', marker='.')
-axes[1].set_ylabel(r"$\mu_\alpha \, \cos\delta$ [{0}]"
-                   .format(icrs.pm_ra_cosdec.unit.to_string('latex_inline')))
+axes[1].set_ylabel(
+    fr"$\mu_\alpha \, \cos\delta$ [{icrs.pm_ra_cosdec.unit.to_string('latex_inline')}]")
 
 axes[2].set_title("ICRS")
 axes[2].plot(icrs.ra.degree, icrs.pm_dec.value,
              linestyle='none', marker='.')
 axes[2].set_xlabel("RA [deg]")
-axes[2].set_ylabel(r"$\mu_\delta$ [{0}]"
-                   .format(icrs.pm_dec.unit.to_string('latex_inline')))
+axes[2].set_ylabel(
+    fr"$\mu_\delta$ [{icrs.pm_dec.unit.to_string('latex_inline')}]")
 
 plt.show()

--- a/examples/io/skip_create-large-fits.py
+++ b/examples/io/skip_create-large-fits.py
@@ -88,7 +88,7 @@ with open('large.fits', 'rb+') as fobj:
 ##############################################################################
 # More generally, this can be written:
 
-shape = tuple(header['NAXIS{0}'.format(ii)] for ii in range(1, header['NAXIS']+1))
+shape = tuple(header[f'NAXIS{ii}'] for ii in range(1, header['NAXIS']+1))
 with open('large.fits', 'rb+') as fobj:
     fobj.seek(len(header.tostring()) + (np.product(shape) * np.abs(header['BITPIX']//8)) - 1)
     fobj.write(b'\0')


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

I was curious of how much did the automated tools catch in #8958 and #10896 . Turns out there are quite a few lines of codes left and I don't feel like manually changing them all. Changing them are not urgent anyway and can be done bit by bit (e.g., when we happen to see them while working on other stuff). See for yourselves with the following commands:

```
$ grep "\"\.format(" -r astropy
$ grep "'\.format(" -r astropy
```

However, I did run `flynt` again and also manually change the rest in `docs`, `examples`, and some low-hanging fruits. I figured updating the docs is more important so new contributors can emulate the style. So, here it is, f-string round three!

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

This is a direct follow-up of #10896 . 