### PR TITLE
Improved norm handling for Differential classes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1163,6 +1163,10 @@ astropy.convolution
 astropy.coordinates
 ^^^^^^^^^^^^^^^^^^^
 
+- The ``norm()`` method for ``RadialDifferential`` no longer requires ``base``
+  to be specified.  The ``norm()`` method for other non-Cartesian differential
+  classes now gives a clearer error message if ``base`` is not specified. [#10969]
+
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -2402,7 +2402,7 @@ class BaseDifferential(BaseRepresentationOrDifferential,
         ----------
         other_class : `~astropy.coordinates.BaseRepresentation` subclass
             The type of representation to turn the coordinates into.
-        base : instance of ``self.base_representation``, optional
+        base : instance of ``self.base_representation``
             Base relative to which the differentials are defined.  If the other
             class is a differential representation, the base will be converted
             to its ``base_representation``.
@@ -2500,13 +2500,17 @@ class BaseDifferential(BaseRepresentationOrDifferential,
         base : instance of ``self.base_representation``
             Base relative to which the differentials are defined. This is
             required to calculate the physical size of the differential for
-            all but cartesian differentials.
+            all but Cartesian differentials or radial differentials.
 
         Returns
         -------
         norm : `astropy.units.Quantity`
             Vector norm, with the same shape as the representation.
         """
+        # RadialDifferential overrides this function, so there is no handling here
+        if not isinstance(self, CartesianDifferential) and base is None:
+            raise ValueError("`base` must be provided to calculate the norm of a"
+                             f" {type(self).__name__}")
         return self.to_cartesian(base).norm()
 
 
@@ -3005,6 +3009,9 @@ class RadialDifferential(BaseDifferential):
     def to_cartesian(self, base):
         return self.d_distance * base.represent_as(
             UnitSphericalRepresentation).to_cartesian()
+
+    def norm(self, base=None):
+        return self.d_distance
 
     @classmethod
     def from_cartesian(cls, other, base):

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -28,6 +28,10 @@ from astropy.coordinates.representation import (REPRESENTATION_CLASSES,
                                                 CartesianDifferential,
                                                 SphericalDifferential,
                                                 RadialDifferential,
+                                                CylindricalDifferential,
+                                                PhysicsSphericalDifferential,
+                                                UnitSphericalDifferential,
+                                                UnitSphericalCosLatDifferential,
                                                 _combine_xyz)
 
 
@@ -1665,3 +1669,23 @@ class TestInfo:
         as_dict = rep_or_diff.info._represent_as_dict()
         new = rep_or_diff.__class__.info._construct_from_dict(as_dict)
         assert np.all(representation_equal(new, rep_or_diff))
+
+
+@pytest.mark.parametrize('cls',
+                         [SphericalDifferential,
+                          SphericalCosLatDifferential,
+                          CylindricalDifferential,
+                          PhysicsSphericalDifferential,
+                          UnitSphericalDifferential,
+                          UnitSphericalCosLatDifferential])
+def test_differential_norm_noncartesian(cls):
+    # The norm of a non-Cartesian differential without specifying `base` should error
+    rep = cls(0, 0, 0)
+    with pytest.raises(ValueError, match=r"`base` must be provided .* " + cls.__name__):
+        rep.norm()
+
+
+def test_differential_norm_radial():
+    # Unlike most non-Cartesian differentials, the norm of a radial differential does not require `base`
+    rep = RadialDifferential(1*u.km/u.s)
+    assert_allclose_quantity(rep.norm(), 1*u.km/u.s)


### PR DESCRIPTION
Calling `.norm()` on non-Cartesian `Differential` classes without providing the `base` argument gives an unhelpful error/traceback:
```python
>>> from astropy.coordinates import SphericalDifferential
>>> import astropy.units as u
>>> s = SphericalDifferential(1*u.deg/u.s, 2*u.deg/u.s, 3*u.km/u.s)
>>> s.norm()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "c:\users\ayshih\onedrive\code\astropy\astropy\coordinates\representation.py", line 2510, in norm
    return self.to_cartesian(base).norm()
  File "c:\users\ayshih\onedrive\code\astropy\astropy\coordinates\representation.py", line 2369, in to_cartesian
    base_e, base_sf = self._get_base_vectors(base)
  File "c:\users\ayshih\onedrive\code\astropy\astropy\coordinates\representation.py", line 2353, in _get_base_vectors
    cls._check_base(base)
  File "c:\users\ayshih\onedrive\code\astropy\astropy\coordinates\representation.py", line 2295, in _check_base
    if cls not in base._compatible_differentials:
AttributeError: 'NoneType' object has no attribute '_compatible_differentials'
```
A similarly unhelpful error occurs for `RadialDifferential` because it tries to go through Cartesian, but the norm can be returned without doing so.

This PR:
* Adds a check for `.norm()` when the user fails to provide `base` for non-Cartesian differentials.  With this PR:
```python
>>> s.norm()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "c:\users\ayshih\onedrive\code\astropy\astropy\coordinates\representation.py", line 2512, in norm
    raise ValueError("`base` must be provided to calculate the norm of a"
ValueError: `base` must be provided to calculate the norm of a SphericalDifferential
```
* Overrides `.norm()` for `RadialDifferential` so it doesn't go through Cartesian.
