### PR TITLE
Fixed missing induced velocity for helioecliptic transforms

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1167,6 +1167,11 @@ astropy.coordinates
   to be specified.  The ``norm()`` method for other non-Cartesian differential
   classes now gives a clearer error message if ``base`` is not specified. [#10969]
 
+- The transformations between ``ICRS`` and any of the heliocentric ecliptic
+  frames (``HeliocentricMeanEcliptic``, ``HeliocentricTrueEcliptic``, and
+  ``HeliocentricEclipticIAU76``) now correctly account for the small motion of
+  the Sun when transforming a coordinate with velocity information. [#10970]
+
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 

--- a/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
@@ -25,7 +25,7 @@ from .gcrs import GCRS
 from .cirs import CIRS
 from .hcrs import HCRS
 from .equatorial import TETE
-from .utils import aticq, atciqz
+from .utils import aticq, atciqz, get_offset_sun_from_barycenter
 
 from ..erfa_astrom import erfa_astrom
 
@@ -245,19 +245,8 @@ def hcrs_to_icrs(hcrs_coo, icrs_frame):
     if isinstance(hcrs_coo.data, UnitSphericalRepresentation):
         raise u.UnitsError(_NEED_ORIGIN_HINT.format(hcrs_coo.__class__.__name__))
 
-    if hcrs_coo.data.differentials:
-        from astropy.coordinates.solar_system import get_body_barycentric_posvel
-        bary_sun_pos, bary_sun_vel = get_body_barycentric_posvel('sun',
-                                                                 hcrs_coo.obstime)
-        bary_sun_vel = bary_sun_vel.represent_as(CartesianDifferential)
-        bary_sun_pos = bary_sun_pos.with_differentials(bary_sun_vel)
-
-    else:
-        from astropy.coordinates.solar_system import get_body_barycentric
-        bary_sun_pos = get_body_barycentric('sun', hcrs_coo.obstime)
-        bary_sun_vel = None
-
-    return None, bary_sun_pos
+    return None, get_offset_sun_from_barycenter(hcrs_coo.obstime,
+                                                include_velocity=bool(hcrs_coo.data.differentials))
 
 
 @frame_transform_graph.transform(AffineTransform, ICRS, HCRS)
@@ -266,20 +255,8 @@ def icrs_to_hcrs(icrs_coo, hcrs_frame):
     if isinstance(icrs_coo.data, UnitSphericalRepresentation):
         raise u.UnitsError(_NEED_ORIGIN_HINT.format(icrs_coo.__class__.__name__))
 
-    if icrs_coo.data.differentials:
-        from astropy.coordinates.solar_system import get_body_barycentric_posvel
-        bary_sun_pos, bary_sun_vel = get_body_barycentric_posvel('sun',
-                                                                 hcrs_frame.obstime)
-        bary_sun_pos = -bary_sun_pos
-        bary_sun_vel = -bary_sun_vel.represent_as(CartesianDifferential)
-        bary_sun_pos = bary_sun_pos.with_differentials(bary_sun_vel)
-
-    else:
-        from astropy.coordinates.solar_system import get_body_barycentric
-        bary_sun_pos = -get_body_barycentric('sun', hcrs_frame.obstime)
-        bary_sun_vel = None
-
-    return None, bary_sun_pos
+    return None, get_offset_sun_from_barycenter(hcrs_frame.obstime, reverse=True,
+                                                include_velocity=bool(icrs_coo.data.differentials))
 
 
 @frame_transform_graph.transform(FunctionTransformWithFiniteDifference, HCRS, HCRS)

--- a/astropy/coordinates/builtin_frames/utils.py
+++ b/astropy/coordinates/builtin_frames/utils.py
@@ -389,7 +389,7 @@ def get_offset_sun_from_barycenter(time, include_velocity=False, reverse=False):
     include_velocity : `bool`
         If ``True``, attach the velocity as a differential.  Defaults to ``False``.
     reverse : `bool`
-        If ``True``, return the offset of the barycenter from the SSB.  Defaults to ``False``.
+        If ``True``, return the offset of the barycenter from the Sun.  Defaults to ``False``.
 
     Returns
     -------

--- a/astropy/coordinates/tests/test_utils.py
+++ b/astropy/coordinates/tests/test_utils.py
@@ -1,5 +1,7 @@
+from astropy.tests.helper import assert_quantity_allclose
 from astropy.time import Time
-from astropy.coordinates.builtin_frames.utils import get_polar_motion
+from astropy.coordinates.builtin_frames.utils import get_polar_motion, get_offset_sun_from_barycenter
+from astropy.coordinates.solar_system import get_body_barycentric_posvel
 from astropy.utils.exceptions import AstropyWarning
 import pytest
 
@@ -12,3 +14,24 @@ def test_polar_motion_unsupported_dates():
 
     with pytest.warns(AstropyWarning, match=msg.format('after')):
         get_polar_motion(Time('2100-01-01'))
+
+
+def test_sun_from_barycenter_offset():
+    time = Time('2020-01-01')
+    pos, vel = get_body_barycentric_posvel('sun', time)
+
+    offset = get_offset_sun_from_barycenter(time)
+    assert_quantity_allclose(offset.xyz, pos.xyz)
+    assert not bool(offset.differentials)
+
+    offset_with_vel = get_offset_sun_from_barycenter(time, include_velocity=True)
+    assert_quantity_allclose(offset_with_vel.xyz, pos.xyz)
+    assert_quantity_allclose(offset_with_vel.differentials['s'].d_xyz, vel.xyz)
+
+    reverse = get_offset_sun_from_barycenter(time, reverse=True)
+    assert_quantity_allclose(reverse.xyz, -pos.xyz)
+    assert not bool(reverse.differentials)
+
+    reverse_with_vel = get_offset_sun_from_barycenter(time, reverse=True, include_velocity=True)
+    assert_quantity_allclose(reverse_with_vel.xyz, -pos.xyz)
+    assert_quantity_allclose(reverse_with_vel.differentials['s'].d_xyz, -vel.xyz)


### PR DESCRIPTION
The affine transformations between ICRS and any of the helioecliptic frames (`HeliocentricMeanEcliptic`, `HeliocentricTrueEcliptic`, and `HeliocentricEclipticIAU76`) are missing the induced-velocity offset if the to-be-transformed coordinate has differentials.  I move the code from the ICRS<->HCRS transformations to a separate function in `astropy.coordinates.utils` and used it for all of the transformations.