### PR TITLE
DOC: Fix h5py link warnings

### DIFF
--- a/astropy/io/misc/hdf5.py
+++ b/astropy/io/misc/hdf5.py
@@ -12,7 +12,7 @@ import numpy as np
 
 # NOTE: Do not import anything from astropy.table here.
 # https://github.com/astropy/astropy/issues/6604
-from astropy.utils.exceptions import AstropyUserWarning, AstropyDeprecationWarning
+from astropy.utils.exceptions import AstropyUserWarning
 
 HDF5_SIGNATURE = b'\x89HDF\r\n\x1a\n'
 META_KEY = '__table_column_meta__'
@@ -68,8 +68,8 @@ def read_table_hdf5(input, path=None, character_as_bytes=True):
 
     Parameters
     ----------
-    input : str or :class:`h5py:File` or :class:`h5py:Group` or
-        :class:`h5py:Dataset` If a string, the filename to read the table from.
+    input : str or :class:`h5py.File` or :class:`h5py.Group` or
+        :class:`h5py.Dataset` If a string, the filename to read the table from.
         If an h5py object, either the file or the group object to read the
         table from.
     path : str
@@ -203,7 +203,7 @@ def _encode_mixins(tbl):
     # YAML bit, for backward compatibility (i.e. not requiring YAML to write
     # Quantity).
     try:
-        import yaml
+        import yaml  # noqa
     except ImportError:
         for col in tbl.itercols():
             if (has_info_class(col, MixinInfo) and
@@ -232,7 +232,7 @@ def write_table_hdf5(table, output, path=None, compression=False,
     ----------
     table : `~astropy.table.Table`
         Data table that is to be written to file.
-    output : str or :class:`h5py:File` or :class:`h5py:Group`
+    output : str or :class:`h5py.File` or :class:`h5py.Group`
         If a string, the filename to write the table to. If an h5py object,
         either the file or the group object to write the table to.
     path : str


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to address the following warnings that started to appear in RTD log:

```
.../astropy/io/misc/hdf5.py:docstring of astropy.io.misc.hdf5.read_table_hdf5:13: WARNING: py:class reference target not found: h5py:File
.../astropy/io/misc/hdf5.py:docstring of astropy.io.misc.hdf5.read_table_hdf5:13: WARNING: py:class reference target not found: h5py:Group
.../astropy/io/misc/hdf5.py:docstring of astropy.io.misc.hdf5.read_table_hdf5:11: WARNING: py:class reference target not found: h5py:Dataset
.../astropy/io/misc/hdf5.py:docstring of astropy.io.misc.hdf5.write_table_hdf5:13: WARNING: py:class reference target not found: h5py:File
.../astropy/io/misc/hdf5.py:docstring of astropy.io.misc.hdf5.write_table_hdf5:13: WARNING: py:class reference target not found: h5py:Group
```

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

The warnings cause RTD to fail in CI, affecting unrelated PRs.