### PR TITLE
Un-pin matplotlib in pyinstaller CI

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -160,10 +160,6 @@ deps =
     # so for now we pin to the latest working commit.
     git+https://github.com/pyinstaller/pyinstaller.git@c111ec5c#egg=PyInstaller
     pytest-mpl
-    # PyInstaller is not yet compatible with Matplotlib 3.3 so we pin
-    # Matplotlib to an older version for now - see the following issue
-    # for more details: https://github.com/pyinstaller/pyinstaller/issues/5004
-    matplotlib<3.3
 extras = test
 commands =
     pyinstaller --onefile run_astropy_tests.py \


### PR DESCRIPTION
Fixes https://github.com/astropy/astropy/issues/10639 - the upstream issue on the pyinstaller side seems to be fixed now, so I think this can be removed.