### PR TITLE
Fix specialized comoving distance functions for iterable and broadcastable redshift arguments

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -296,6 +296,9 @@ astropy.coordinates
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 
+- Fixed an issue where specilaisations of the comoving distance calculation
+  for certain cosmologies could not handle redshift arrays. [#10980]
+
 astropy.extern
 ^^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -296,7 +296,7 @@ astropy.coordinates
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 
-- Fixed an issue where specilaisations of the comoving distance calculation
+- Fixed an issue where specializations of the comoving distance calculation
   for certain cosmologies could not handle redshift arrays. [#10980]
 
 astropy.extern

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -1758,14 +1758,10 @@ class LambdaCDM(FLRW):
           Comoving distance in Mpc between each input redshift.
         """
         from scipy.special import ellipkinc
-        if isiterable(z1):
-            z1 = np.asarray(z1)
-        if isiterable(z2):
-            z2 = np.asarray(z2)
-        if isiterable(z1) and isiterable(z2):
-            if z1.shape != z2.shape:
-                msg = "z1 and z2 have different shapes"
-                raise ValueError(msg)
+        try:
+            z1, z2 = np.broadcast_arrays(z1, z2)
+        except ValueError as e:
+            raise ValueError("z1 and z2 have different shapes") from e
 
         # The analytic solution is not valid for any of Om0, Ode0, Ok0 == 0.
         # Use the explicit integral solution for these cases.
@@ -1829,12 +1825,10 @@ class LambdaCDM(FLRW):
         d : `~astropy.units.Quantity`
           Comoving distance in Mpc between each input redshift.
         """
-        if isiterable(z1):
-            z1 = np.asarray(z1)
-            z2 = np.asarray(z2)
-            if z1.shape != z2.shape:
-                msg = "z1 and z2 have different shapes"
-                raise ValueError(msg)
+        try:
+            z1, z2 = np.broadcast_arrays(z1, z2)
+        except ValueError as e:
+            raise ValueError("z1 and z2 have different shapes") from e
 
         return self._hubble_distance * (z2 - z1)
 
@@ -1858,12 +1852,10 @@ class LambdaCDM(FLRW):
         d : `~astropy.units.Quantity`
           Comoving distance in Mpc between each input redshift.
         """
-        if isiterable(z1):
-            z1 = np.asarray(z1)
-            z2 = np.asarray(z2)
-            if z1.shape != z2.shape:
-                msg = "z1 and z2 have different shapes"
-                raise ValueError(msg)
+        try:
+            z1, z2 = np.broadcast_arrays(z1, z2)
+        except ValueError as e:
+            raise ValueError("z1 and z2 have different shapes") from e
 
         prefactor = 2 * self._hubble_distance
         return prefactor * ((1+z1)**(-1./2) - (1+z2)**(-1./2))
@@ -1891,12 +1883,10 @@ class LambdaCDM(FLRW):
         d : `~astropy.units.Quantity`
           Comoving distance in Mpc between each input redshift.
         """
-        if isiterable(z1):
-            z1 = np.asarray(z1)
-            z2 = np.asarray(z2)
-            if z1.shape != z2.shape:
-                msg = "z1 and z2 have different shapes"
-                raise ValueError(msg)
+        try:
+            z1, z2 = np.broadcast_arrays(z1, z2)
+        except ValueError as e:
+            raise ValueError("z1 and z2 have different shapes") from e
 
         s = ((1 - self._Om0) / self._Om0) ** (1./3)
         # Use np.sqrt here to handle negative s (Om0>1).

--- a/astropy/cosmology/tests/test_cosmology.py
+++ b/astropy/cosmology/tests/test_cosmology.py
@@ -1675,9 +1675,9 @@ def test_comoving_distance_broadcast(cosmo):
     Test that specialized comoving distance methods broadcast array arguments.
     """
 
-    z1 = np.random.uniform(size=(2, 1, 5))
-    z2 = np.random.uniform(size=(3, 5))
-    z3 = np.random.uniform(size=(7, 5))
+    z1 = np.zeros((2, 5))
+    z2 = np.ones((3, 1, 5))
+    z3 = np.ones((7, 5))
     output_shape = np.broadcast(z1, z2).shape
 
     # Check compatible array arguments return an array with the correct shape
@@ -1685,4 +1685,4 @@ def test_comoving_distance_broadcast(cosmo):
 
     # Check incompatible array arguments raise an error
     with pytest.raises(ValueError, match='z1 and z2 have different shapes'):
-        cosmo._comoving_distance_z1z2(z2, z3)
+        cosmo._comoving_distance_z1z2(z1, z3)

--- a/astropy/cosmology/tests/test_cosmology.py
+++ b/astropy/cosmology/tests/test_cosmology.py
@@ -1637,3 +1637,52 @@ def test_elliptic_comoving_distance_z1z2():
                     cosmo._integral_comoving_distance_z1z2(0., z))
     assert allclose(cosmo._elliptic_comoving_distance_z1z2(0., z),
                     cosmo._integral_comoving_distance_z1z2(0., z))
+
+
+SPECIALIZED_COMOVING_DISTANCE_COSMOLOGIES = [
+    core.FlatLambdaCDM(H0=70, Om0=0.0, Tcmb0=0.0),  # de Sitter
+    core.FlatLambdaCDM(H0=70, Om0=1.0, Tcmb0=0.0),  # Einstein - de Sitter
+    core.FlatLambdaCDM(H0=70, Om0=0.3, Tcmb0=0.0),  # Hypergeometric
+    core.LambdaCDM(H0=70, Om0=0.3, Ode0=0.6, Tcmb0=0.0),  # Elliptic
+]
+
+
+ITERABLE_REDSHIFTS = [
+    (0, 1, 2, 3, 4),  # tuple
+    [0, 1, 2, 3, 4],  # list
+    np.array([0, 1, 2, 3, 4]),  # array
+]
+
+
+@pytest.mark.skipif('not HAS_SCIPY')
+@pytest.mark.parametrize('cosmo', SPECIALIZED_COMOVING_DISTANCE_COSMOLOGIES)
+@pytest.mark.parametrize('z', ITERABLE_REDSHIFTS)
+def test_comoving_distance_iterable_argument(cosmo, z):
+    """
+    Regression test for #10980
+    Test that specialized comoving distance methods handle iterable arguments.
+    """
+
+    assert allclose(cosmo.comoving_distance(z),
+                    cosmo._integral_comoving_distance_z1z2(0., z))
+
+
+@pytest.mark.skipif('not HAS_SCIPY')
+@pytest.mark.parametrize('cosmo', SPECIALIZED_COMOVING_DISTANCE_COSMOLOGIES)
+def test_comoving_distance_broadcast(cosmo):
+    """
+    Regression test for #10980
+    Test that specialized comoving distance methods broadcast array arguments.
+    """
+
+    z1 = np.random.uniform(size=(2, 1, 5))
+    z2 = np.random.uniform(size=(3, 5))
+    z3 = np.random.uniform(size=(7, 5))
+    output_shape = np.broadcast(z1, z2).shape
+
+    # Check compatible array arguments return an array with the correct shape
+    assert cosmo._comoving_distance_z1z2(z1, z2).shape == output_shape
+
+    # Check incompatible array arguments raise an error
+    with pytest.raises(ValueError, match='z1 and z2 have different shapes'):
+        cosmo._comoving_distance_z1z2(z2, z3)


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request fixes the following four specializations of the `FLRW._comoving_distance_z1z2` method so that they correctly handle iterable and broadcastable redshift arguments:

- `_dS_comoving_distance_z1z2`
- `_EdS_comoving_distance_z1z2`
- `_hypergeometric_comoving_distance_z1z2`
- `_elliptic_comoving_distance_z1z2`

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #10979 
