### PR TITLE
Fix model evaluation for arguments without units

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -317,6 +317,9 @@ astropy.io.votable
 astropy.modeling
 ^^^^^^^^^^^^^^^^
 
+- Fixed an issue where some models would not accept values without units as
+  dimensionless arguments. [#10982]
+
 astropy.nddata
 ^^^^^^^^^^^^^^
 

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -1746,9 +1746,8 @@ class Model(metaclass=_ModelMeta):
                     # If we allow dimensionless input, we add the units to the
                     # input values without conversion, otherwise we raise an
                     # exception.
-
                     if (not self.input_units_allow_dimensionless[input_name] and
-                        input_unit is not dimensionless_unscaled and
+                        not input_unit.is_equivalent(dimensionless_unscaled) and
                         input_unit is not None):
                         if np.any(inputs[i] != 0):
                             raise UnitsError("{0}: Units of input '{1}', (dimensionless), could not be "

--- a/astropy/modeling/tests/test_models_quantities.py
+++ b/astropy/modeling/tests/test_models_quantities.py
@@ -347,3 +347,14 @@ def test_models_fitting(model):
             assert par_aft.unit is None or par_aft.unit is u.rad
         else:
             assert par_aft.unit.is_equivalent(par_bef.unit)
+
+
+def test_model_dimensionless_inputs():
+    """
+    Regression test for #10982
+    Test that models accept non-Quantity inputs when coefficients have units
+    and the expected input is dimensionless.
+    """
+
+    model = Linear1D(3 * u.km, 5000 * u.m)
+    assert(model(6) == 23 * u.km)


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request fixes a corner case where a model such as `Linear1D` or `Polynomial1D` whose coefficients have mixed but equivalent units (e.g. all lengths) expects a dimensionless argument but fails to evaluate an input with no explicit units such as a float.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #10981
