### PR TITLE
Remove temporary warning in modeling

### DIFF
--- a/astropy/modeling/math_functions.py
+++ b/astropy/modeling/math_functions.py
@@ -2,7 +2,6 @@
 """
 Define Numpy Ufuncs as Models.
 """
-import warnings
 import numpy as np
 
 from astropy.modeling.core import Model
@@ -54,13 +53,11 @@ def ufunc_model(name):
         separable = True
 
         def evaluate(self, x):
-            warnings.warn("Models in math_functions are experimental.", AstropyUserWarning)
             return self.func(x)
     else:
         separable = False
 
         def evaluate(self, x, y):
-            warnings.warn("Models in math_functions are experimental.", AstropyUserWarning)
             return self.func(x, y)
 
     klass_name = _make_class_name(name)

--- a/astropy/modeling/tests/test_math_func.py
+++ b/astropy/modeling/tests/test_math_func.py
@@ -9,8 +9,6 @@ from astropy.modeling import math_functions
 x = np.linspace(-20, 360, 100)
 
 
-@pytest.mark.filterwarnings(
-    r'ignore:Models in math_functions are experimental\.')
 @pytest.mark.filterwarnings(r'ignore:.*:RuntimeWarning')
 def test_math():
     for name in math_functions.__all__:


### PR DESCRIPTION
Removed a Warning when evaluating math models:
`Models in math_functions are experimental.`
