### PR TITLE
Experiments with model sets and non-linear fitters

### DIFF
--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -1958,6 +1958,22 @@ class Model(metaclass=_ModelMeta):
         """
         return 1
 
+    @property
+    def iter_models(self):
+        """
+        An iterable of model instances with parameters shared with this model set.
+        """
+        if len(self) == 1:
+            return self
+
+        for i in range(len(self)):
+            params = {}
+            for pname in self.param_names:
+                pslice = [slice(None)] * len(self._param_metrics[pname]['shape'])
+                pslice[self._model_set_axis] = slice(i, i+1)
+                params[pname] = getattr(self, pname)[tuple(pslice)]
+            yield type(self)(**params)
+
     def _initialize_constraints(self, kwargs):
         """
         Pop parameter constraint values off the keyword arguments passed to

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -2155,12 +2155,12 @@ class Model(metaclass=_ModelMeta):
                 _val = param._setter(value)
             if isinstance(_val, Quantity):
                 param.internal_unit = _val.unit
-                param._internal_value = np.array(_val.value)
+                param._internal_value = np.array(_val.value, copy=False)
             else:
                 param.internal_unit = None
-                param._internal_value = np.array(_val)
+                param._internal_value = np.array(_val, copy=False)
         else:
-            param._value = np.array(value)
+            param._value = np.array(value, copy=False)
 
     def _initialize_slices(self):
 

--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -340,10 +340,10 @@ class Parameter(OrderedDescriptor):
                             "a parameter to a quantity simply set the "
                             "parameter directly without using .value")
         if self._setter is None:
-            self._value = np.array(value, dtype=np.float64)
+            self._value = np.array(value, dtype=np.float64, copy=False)
         else:
             self._internal_value = np.array(self._setter(value),
-                                            dtype=np.float64)
+                                            dtype=np.float64, copy=False)
 
     @property
     def unit(self):

--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -340,10 +340,16 @@ class Parameter(OrderedDescriptor):
                             "a parameter to a quantity simply set the "
                             "parameter directly without using .value")
         if self._setter is None:
-            self._value = np.array(value, dtype=np.float64, copy=False)
+            if hasattr(self, '_value') and isinstance(self._value, np.ndarray) and self._value.ndim > 0:
+                self._value[:] = value
+            else:
+                self._value = np.array(value, dtype=np.float64, copy=False)
         else:
-            self._internal_value = np.array(self._setter(value),
-                                            dtype=np.float64, copy=False)
+            if hasattr(self, '_internal_value') and isinstance(self._internal_value, np.ndarray) and self._internal_value.ndim > 0:
+                self._internal_value[:] = self._setter(value)
+            else:
+                self._internal_value = np.array(self._setter(value),
+                                                dtype=np.float64, copy=False)
 
     @property
     def unit(self):

--- a/astropy/units/utils.py
+++ b/astropy/units/utils.py
@@ -290,6 +290,6 @@ def resolve_fractions(a, b):
 def quantity_asanyarray(a, dtype=None):
     from .quantity import Quantity
     if not isinstance(a, np.ndarray) and not np.isscalar(a) and any(isinstance(x, Quantity) for x in a):
-        return Quantity(a, dtype=dtype)
+        return Quantity(a, dtype=dtype, copy=False)  # don't copy to match asanyarray
     else:
         return np.asanyarray(a, dtype=dtype)


### PR DESCRIPTION
This is a very draft set of hacks to improve the workflow around, and hopefully parallelise non-linear fitters over model sets.

At the moment this PR enables you to update parameters in place in a model, and also adds a flag to the `LevMarLSQFitter` to not copy the model before fitting it. Using this allows the following code to work:

```python
gen_curve = m.Gaussian1D(amplitude=12,
                         stddev=6,
                         mean=0)

x = np.arange(-20, 21)

n_models = 12

data = gen_curve(x)
data = np.repeat(data[None,:], n_models, axis=0)
data += np.random.normal(0., data*0.1, size=data.shape)

curve = m.Gaussian1D(amplitude=np.zeros((n_models,)) + 12,
                     stddev=np.zeros((n_models,)) + 6,
                     mean=np.zeros((n_models,)) + 1,
                     model_set_axis=-1)

fit = fitting.LevMarLSQFitter(inplace=True)

for sub, sub_data in zip(curve.iter_models, data):
    fit(sub, x, sub_data)

print(curve)
```
```
Model: Gaussian1D
Inputs: ('x',)
Outputs: ('y',)
Model set size: 12
Parameters:
        amplitude               mean               stddev     
    ------------------ --------------------- -----------------
     11.95422133571381  -0.07266095118471086  5.99545327963244
    12.156119072050434  -0.07862513063747723 5.896005724939767
    12.661097809541358  -0.12937266599014197 5.914236165562634
    12.145417357362323  0.061064016793466167 5.902466367263756
    11.908985742644665   0.06705609240645635   6.1386506413625
     11.32213839228508    0.0728347476209994 6.110827573154081
    12.824222438558532  -0.02555400772144983 5.972700110188168
    11.564129843035015    0.0529231958392127 6.197163202260534
     11.51237244367314  -0.08100330081726208  6.08075381821545
    12.069120479400457 -0.042293890464727577 5.985331749660404
    10.994796721724828   0.16992100295058366 6.270956201788193
     11.27045189430589   -0.0313423860725926 6.124522140219055

```

This is already a lot cleaner than having to manually reconstruct the model set from the output of 12 calls to the fitter. The potential next steps for this are:

* [x] Provide a method or helper function which returns an iterable of sub models for each element in a model set
* [x] Provide an example of using something like subprocess.map to parallelise fitting across the model sets
* [ ] Use dask to distribute the fitting.

I am opening this as draft now to get initial feedback from people who are more familiar with the fitting machinery, so they can wave me off if this is the wrong tree to bark up.

@astrofrog @perrygreenfield @nden

related to https://github.com/astropy/astropy/issues/3670