### PR TITLE
TST: Skip more flaky utils tests on Windows CI

### DIFF
--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -388,8 +388,10 @@ def test_download_with_sources_and_bogus_original(
         assert is_url_in_cache(u)
 
 
-@pytest.mark.skipif((3, 7) <= sys.version_info < (3, 8),
-                    reason="causes mystery segfault! possibly bug #10008")
+@pytest.mark.skipif((3, 7) <= sys.version_info < (3, 8) or
+                    (sys.platform.startswith('win') and TRAVIS),
+                    reason="mystery segfault that is possibly bug #10008 "
+                           "for python < 3.8, flaky cache error on Windows CI")
 def test_download_file_threaded_many(temp_cache, valid_urls):
     """Hammer download_file with multiple threaded requests.
 
@@ -407,8 +409,10 @@ def test_download_file_threaded_many(temp_cache, valid_urls):
         assert get_file_contents(r) == c
 
 
-@pytest.mark.skipif((3, 7) <= sys.version_info < (3, 8),
-                    reason="causes mystery segfault! possibly bug #10008")
+@pytest.mark.skipif((3, 7) <= sys.version_info < (3, 8) or
+                    (sys.platform.startswith('win') and TRAVIS),
+                    reason="mystery segfault that is possibly bug #10008 "
+                           "for python < 3.8, flaky cache error on Windows CI")
 def test_threaded_segfault(valid_urls):
     """Demonstrate urllib's segfault."""
     def slurp_url(u):
@@ -423,8 +427,10 @@ def test_threaded_segfault(valid_urls):
                    [u for (u, c) in urls]))
 
 
-@pytest.mark.skipif((3, 7) <= sys.version_info < (3, 8),
-                    reason="causes mystery segfault! possibly bug #10008")
+@pytest.mark.skipif((3, 7) <= sys.version_info < (3, 8) or
+                    (sys.platform.startswith('win') and TRAVIS),
+                    reason="mystery segfault that is possibly bug #10008 "
+                           "for python < 3.8, flaky cache error on Windows CI")
 def test_download_file_threaded_many_partial_success(
         temp_cache, valid_urls, invalid_urls):
     """Hammer download_file with multiple threaded requests.
@@ -824,8 +830,10 @@ def test_download_parallel_update(temp_cache, tmpdir):
         assert get_file_contents(r_3) == c_plus
 
 
-@pytest.mark.skipif(sys.version_info < (3, 8),
-                    reason="causes mystery segfault! possibly bug #10008")
+@pytest.mark.skipif(sys.version_info < (3, 8) or
+                    (sys.platform.startswith('win') and TRAVIS),
+                    reason="mystery segfault that is possibly bug #10008 "
+                           "for python < 3.8, flaky cache error on Windows CI")
 def test_update_parallel(temp_cache, valid_urls):
     u, c = next(valid_urls)
     u2, c2 = next(valid_urls)


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is like #10924 for the rest of similarly marked tests in `test_data.py`. This is because despite #10924 , I see the same transient error pop up in one of these other ones too.

Example log: https://travis-ci.com/github/astropy/astropy/jobs/427871967

```
E               astropy.utils.data.CacheMissingWarning: ('Unable to remove directory
C:\\...\\download\\url\\68a7a47819ea35ade73101fa1380166c because a file in it is in use and you are on Windows',
'C:\\...\\astropy\\download\\url\\68a7a47819ea35ade73101fa1380166c')
```

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Also see #10008  #10914

cc @aarchiba 