### PR TITLE
Remove OrderedDict from astropy.coordinates, small BaseCoordinateFrame.__init__ refactor

### DIFF
--- a/astropy/coordinates/attributes.py
+++ b/astropy/coordinates/attributes.py
@@ -102,7 +102,7 @@ class Attribute(OrderedDescriptor):
 
         out, converted = self.convert_input(out)
         if instance is not None:
-            instance_shape = getattr(instance, 'shape', None)
+            instance_shape = getattr(instance, 'shape', None)  # None if instance (frame) has no data!
             if instance_shape is not None and (getattr(out, 'shape', ()) and
                                                out.shape != instance_shape):
                 # If the shapes do not match, try broadcasting.

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -423,8 +423,8 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
         _normalize_representation_type(kwargs)
         representation_type = kwargs.pop('representation_type', representation_type)
 
-        self._representation = self._infer_representation_differential_type(representation_type, differential_type)
-        self._data = self._infer_representation_differential_data(args, copy, kwargs)  # possibly None.
+        self._representation = self._infer_representation(representation_type, differential_type)
+        self._data = self._infer_data(args, copy, kwargs)  # possibly None.
 
         # Set frame attributes, if any
 
@@ -491,7 +491,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
             # Set up representation cache.
             self.cache['representation'][key] = self._data
 
-    def _infer_representation_differential_type(self, representation_type, differential_type):
+    def _infer_representation(self, representation_type, differential_type):
         if representation_type is None and differential_type is None:
             return {'base': self.default_representation, 's': self.default_differential}
 
@@ -518,7 +518,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
 
         return _get_repr_classes(representation_type, **differential_type)
 
-    def _infer_representation_differential_data(self, args, copy, kwargs):
+    def _infer_data(self, args, copy, kwargs):
         # if not set below, this is a frame with no data
         representation_data = None
         differential_data = None

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -10,7 +10,7 @@ classes.
 import abc
 import copy
 import inspect
-from collections import namedtuple, OrderedDict, defaultdict
+from collections import namedtuple, defaultdict
 import warnings
 
 # Dependencies
@@ -409,7 +409,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
 
     _inherit_descriptors_ = (Attribute,)
 
-    frame_attributes = OrderedDict()
+    frame_attributes = {}
     # Default empty frame_attributes dict
 
     def __init__(self, *args, copy=True, representation_type=None,
@@ -711,8 +711,8 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
 
     @classmethod
     def get_frame_attr_names(cls):
-        return OrderedDict((name, getattr(cls, name))
-                           for name in cls.frame_attributes)
+        return {name: getattr(cls, name)
+                for name in cls.frame_attributes}
 
     def get_representation_cls(self, which='base'):
         """The class used for part of this frame's data.
@@ -846,7 +846,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
         return self._get_representation_info()
 
     def get_representation_component_names(self, which='base'):
-        out = OrderedDict()
+        out = {}
         repr_or_diff_cls = self.get_representation_cls(which)
         if repr_or_diff_cls is None:
             return out
@@ -857,7 +857,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
         return out
 
     def get_representation_component_units(self, which='base'):
-        out = OrderedDict()
+        out = {}
         repr_or_diff_cls = self.get_representation_cls(which)
         if repr_or_diff_cls is None:
             return out
@@ -1893,7 +1893,7 @@ class GenericFrame(BaseCoordinateFrame):
     name = None  # it's not a "real" frame so it doesn't have a name
 
     def __init__(self, frame_attrs):
-        self.frame_attributes = OrderedDict()
+        self.frame_attributes = {}
         for name, default in frame_attrs.items():
             self.frame_attributes[name] = Attribute(default)
             setattr(self, '_' + name, default)

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -427,6 +427,9 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
             representation_type, differential_type = self._infer_representation_differential_type(
                 representation_type, differential_type)
             self.set_representation_cls(representation_type, **differential_type)
+        else:
+            self._representation = {'base': self.default_representation,
+                                    's': self.default_differential}
 
         representation_data, differential_data = self._infer_representation_differential_data(
             args, copy, kwargs)
@@ -552,10 +555,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
                                      'velocity differential is supported. Got: '
                                      '{}'.format(diffs))
 
-        # This calls self.get_representation_cls()
-        # and sets self._representation to the defaults if it was not set earlier
-        # (specifically if representation_type or differential_type were passed to the initializer)
-        elif self.representation_type:
+        else:
             representation_cls = self.get_representation_cls()
             # Get any representation data passed in to the frame initializer
             # using keyword or positional arguments for the component names
@@ -748,10 +748,6 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
         -------
         representation : `~astropy.coordinates.BaseRepresentation` or `~astropy.coordinates.BaseDifferential`.
         """
-        if not hasattr(self, '_representation'):
-            self._representation = {'base': self.default_representation,
-                                    's': self.default_differential}
-
         if which is not None:
             return self._representation[which]
         else:

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -423,16 +423,8 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
         _normalize_representation_type(kwargs)
         representation_type = kwargs.pop('representation_type', representation_type)
 
-        if representation_type is not None or differential_type is not None:
-            representation_type, differential_type = self._infer_representation_differential_type(
-                representation_type, differential_type)
-            self.set_representation_cls(representation_type, **differential_type)
-        else:
-            self._representation = {'base': self.default_representation,
-                                    's': self.default_differential}
-
-        representation_data = self._infer_representation_differential_data(args, copy, kwargs)
-        self._data = representation_data  # possibly None.
+        self._representation = self._infer_representation_differential_type(representation_type, differential_type)
+        self._data = self._infer_representation_differential_data(args, copy, kwargs)  # possibly None.
 
         # Set frame attributes, if any
 
@@ -500,6 +492,9 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
             self.cache['representation'][key] = self._data
 
     def _infer_representation_differential_type(self, representation_type, differential_type):
+        if representation_type is None and differential_type is None:
+            return {'base': self.default_representation, 's': self.default_differential}
+
         if representation_type is None:
             representation_type = self.default_representation
 
@@ -521,7 +516,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
             else:
                 differential_type = {'s': 'base'}  # see set_representation_cls()
 
-        return representation_type, differential_type
+        return _get_repr_classes(representation_type, **differential_type)
 
     def _infer_representation_differential_data(self, args, copy, kwargs):
         # if not set below, this is a frame with no data

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -451,8 +451,8 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
             if fnm in kwargs:
                 value = kwargs.pop(fnm)
                 setattr(self, '_' + fnm, value)
-                # Validate attribute by getting it.  If the instance has data,
-                # this also checks its shape is OK.  If not, we do it below.
+                # Validate attribute by getting it. If the instance has data,
+                # this also checks its shape is OK. If not, we do it below.
                 values[fnm] = getattr(self, fnm)
             else:
                 setattr(self, '_' + fnm, fdefault)

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -431,14 +431,8 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
             self._representation = {'base': self.default_representation,
                                     's': self.default_differential}
 
-        representation_data, differential_data = self._infer_representation_differential_data(
-            args, copy, kwargs)
-
-        if differential_data:
-            self._data = representation_data.with_differentials(
-                {'s': differential_data})
-        else:
-            self._data = representation_data  # possibly None.
+        representation_data = self._infer_representation_differential_data(args, copy, kwargs)
+        self._data = representation_data  # possibly None.
 
         # Set frame attributes, if any
 
@@ -489,7 +483,6 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
             else:
                 self._no_data_shape = ()
 
-        # else:
         # The logic of this block is not related to the previous one
         if self._data is not None:
             # This makes the cache keys backwards-compatible, but also adds
@@ -665,7 +658,9 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
                             "Differential data units are not compatible with"
                             "time-derivative of representation data units")
 
-        return representation_data, differential_data
+            representation_data = representation_data.with_differentials({'s': differential_data})
+
+        return representation_data
 
     @lazyproperty
     def cache(self):

--- a/astropy/coordinates/solar_system.py
+++ b/astropy/coordinates/solar_system.py
@@ -5,7 +5,6 @@ ephemerides from jplephem.
 """
 
 from urllib.parse import urlparse
-from collections import OrderedDict
 import os.path
 
 import numpy as np
@@ -30,31 +29,32 @@ __all__ = ["get_body", "get_moon", "get_body_barycentric",
 DEFAULT_JPL_EPHEMERIS = 'de430'
 
 """List of kernel pairs needed to calculate positions of a given object."""
-BODY_NAME_TO_KERNEL_SPEC = OrderedDict([
-    ('sun', [(0, 10)]),
-    ('mercury', [(0, 1), (1, 199)]),
-    ('venus', [(0, 2), (2, 299)]),
-    ('earth-moon-barycenter', [(0, 3)]),
-    ('earth', [(0, 3), (3, 399)]),
-    ('moon', [(0, 3), (3, 301)]),
-    ('mars', [(0, 4)]),
-    ('jupiter', [(0, 5)]),
-    ('saturn', [(0, 6)]),
-    ('uranus', [(0, 7)]),
-    ('neptune', [(0, 8)]),
-    ('pluto', [(0, 9)])
-])
+BODY_NAME_TO_KERNEL_SPEC = {
+    'sun': [(0, 10)],
+    'mercury': [(0, 1), (1, 199)],
+    'venus': [(0, 2), (2, 299)],
+    'earth-moon-barycenter': [(0, 3)],
+    'earth': [(0, 3), (3, 399)],
+    'moon': [(0, 3), (3, 301)],
+    'mars': [(0, 4)],
+    'jupiter': [(0, 5)],
+    'saturn': [(0, 6)],
+    'uranus': [(0, 7)],
+    'neptune': [(0, 8)],
+    'pluto': [(0, 9)],
+}
 
 """Indices to the plan94 routine for the given object."""
-PLAN94_BODY_NAME_TO_PLANET_INDEX = OrderedDict(
-    (('mercury', 1),
-     ('venus', 2),
-     ('earth-moon-barycenter', 3),
-     ('mars', 4),
-     ('jupiter', 5),
-     ('saturn', 6),
-     ('uranus', 7),
-     ('neptune', 8)))
+PLAN94_BODY_NAME_TO_PLANET_INDEX = {
+    'mercury': 1,
+    'venus': 2,
+    'earth-moon-barycenter': 3,
+    'mars': 4,
+    'jupiter': 5,
+    'saturn': 6,
+    'uranus': 7,
+    'neptune': 8,
+}
 
 _EPHEMERIS_NOTE = """
 You can either give an explicit ephemeris or use a default, which is normally

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -2,7 +2,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 from copy import deepcopy
-from collections import OrderedDict
 
 import pytest
 import numpy as np
@@ -1093,9 +1092,9 @@ def test_subclass_representation():
             return self
 
     class SphericalWrap180Representation(SphericalRepresentation):
-        attr_classes = OrderedDict([('lon', Longitude180),
-                                    ('lat', Latitude),
-                                    ('distance', u.Quantity)])
+        attr_classes = {'lon': Longitude180,
+                        'lat': Latitude,
+                        'distance': u.Quantity}
 
     class ICRSWrap180(ICRS):
         frame_specific_representation_info = ICRS._frame_specific_representation_info.copy()
@@ -1114,9 +1113,9 @@ def test_minimal_subclass():
     # Basically to check what we document works;
     # see doc/coordinates/representations.rst
     class LogDRepresentation(BaseRepresentation):
-        attr_classes = OrderedDict([('lon', Longitude),
-                                    ('lat', Latitude),
-                                    ('logd', u.Dex)])
+        attr_classes = {'lon': Longitude,
+                        'lat': Latitude,
+                        'logd': u.Dex}
 
         def to_cartesian(self):
             d = self.logd.physical
@@ -1162,9 +1161,9 @@ def test_minimal_subclass():
     # so we raise
     with pytest.raises(ValueError):
         class LogDRepresentation(BaseRepresentation):
-            attr_classes = OrderedDict([('lon', Longitude),
-                                        ('lat', Latitude),
-                                        ('logr', u.Dex)])
+            attr_classes = {'lon': Longitude,
+                            'lat': Latitude,
+                            'logr': u.Dex}
 
 
 def test_duplicate_warning():
@@ -1173,8 +1172,8 @@ def test_duplicate_warning():
 
     with pytest.warns(DuplicateRepresentationWarning):
         class UnitSphericalRepresentation(BaseRepresentation):
-            attr_classes = OrderedDict([('lon', Longitude),
-                                        ('lat', Latitude)])
+            attr_classes = {'lon': Longitude,
+                            'lat': Latitude}
 
     assert 'unitspherical' in DUPLICATE_REPRESENTATIONS
     assert 'unitspherical' not in REPRESENTATION_CLASSES
@@ -1528,8 +1527,8 @@ def unitphysics():
         had_unit = True
 
     class UnitPhysicsSphericalRepresentation(BaseRepresentation):
-        attr_classes = OrderedDict([('phi', Angle),
-                                    ('theta', Angle)])
+        attr_classes = {'phi': Angle,
+                        'theta': Angle}
 
         def __init__(self, *args, copy=True, **kwargs):
             super().__init__(*args, copy=copy, **kwargs)
@@ -1557,17 +1556,17 @@ def unitphysics():
         def unit_vectors(self):
             sinphi, cosphi = np.sin(self.phi), np.cos(self.phi)
             sintheta, costheta = np.sin(self.theta), np.cos(self.theta)
-            return OrderedDict(
-                (('phi', CartesianRepresentation(-sinphi, cosphi, 0., copy=False)),
-                 ('theta', CartesianRepresentation(costheta*cosphi,
-                                                   costheta*sinphi,
-                                                   -sintheta, copy=False))))
+            return {
+                'phi': CartesianRepresentation(-sinphi, cosphi, 0., copy=False),
+                'theta': CartesianRepresentation(costheta*cosphi,
+                                                 costheta*sinphi,
+                                                 -sintheta, copy=False)}
 
         def scale_factors(self):
             sintheta = np.sin(self.theta)
             l = np.broadcast_to(1.*u.one, self.shape, subok=True)
-            return OrderedDict((('phi', sintheta),
-                                ('theta', l)))
+            return {'phi', sintheta,
+                    'theta', l}
 
         def to_cartesian(self):
             x = np.sin(self.theta) * np.cos(self.phi)

--- a/astropy/coordinates/tests/test_unit_representation.py
+++ b/astropy/coordinates/tests/test_unit_representation.py
@@ -2,7 +2,6 @@
 This file tests the behavior of subclasses of Representation and Frames
 """
 from copy import deepcopy
-from collections import OrderedDict
 
 import pytest
 
@@ -45,13 +44,13 @@ def test_unit_representation_subclass():
             return self
 
     class UnitSphericalWrap180Representation(UnitSphericalRepresentation):
-        attr_classes = OrderedDict([('lon', Longitude180),
-                                    ('lat', Latitude)])
+        attr_classes = {'lon': Longitude180,
+                        'lat': Latitude}
 
     class SphericalWrap180Representation(SphericalRepresentation):
-        attr_classes = OrderedDict([('lon', Longitude180),
-                                    ('lat', Latitude),
-                                    ('distance', u.Quantity)])
+        attr_classes = {'lon': Longitude180,
+                        'lat': Latitude,
+                        'distance': u.Quantity}
 
         _unit_representation = UnitSphericalWrap180Representation
 

--- a/astropy/coordinates/transformations.py
+++ b/astropy/coordinates/transformations.py
@@ -21,7 +21,7 @@ import subprocess
 from warnings import warn
 
 from abc import ABCMeta, abstractmethod
-from collections import defaultdict, OrderedDict
+from collections import defaultdict
 from contextlib import suppress, contextmanager
 from inspect import signature
 
@@ -1427,7 +1427,7 @@ class CompositeTransform(CoordinateTransform):
 
 
 # map class names to colorblind-safe colors
-trans_to_color = OrderedDict()
+trans_to_color = {}
 trans_to_color[AffineTransform] = '#555555'  # gray
 trans_to_color[FunctionTransform] = '#783001'  # dark red-ish/brown
 trans_to_color[FunctionTransformWithFiniteDifference] = '#d95f02'  # red-ish

--- a/docs/coordinates/frames.rst
+++ b/docs/coordinates/frames.rst
@@ -49,7 +49,7 @@ their default values) are available as the class method
 ``get_frame_attr_names``::
 
     >>> FK5.get_frame_attr_names()
-    OrderedDict([('equinox', <Time object: scale='tt' format='jyear_str' value=J2000.000>)])
+    {'equinox': <Time object: scale='tt' format='jyear_str' value=J2000.000>}
 
 You can access any of the attributes on a frame by using standard Python
 attribute access. Note that for cases like ``equinox``, which are time
@@ -109,7 +109,7 @@ frame to the attribute name on the representation class::
     >>> icrs.representation_type
     <class 'astropy.coordinates.representation.SphericalRepresentation'>
     >>> icrs.representation_component_names
-    OrderedDict([('ra', 'lon'), ('dec', 'lat'), ('distance', 'distance')])
+    {'ra': 'lon', 'dec': 'lat', 'distance': 'distance'}
 
 You can get the data in a different representation if needed::
 

--- a/docs/coordinates/inplace.rst
+++ b/docs/coordinates/inplace.rst
@@ -31,7 +31,7 @@ mapping between frame attributes (e.g., ``.ra``) and representation attributes
 (e.g., ``.lon``) you can look at the following dictionary::
 
     >>> sc.representation_component_names
-    OrderedDict([('ra', 'lon'), ('dec', 'lat'), ('distance', 'distance')])
+    {'ra': 'lon', 'dec': 'lat', 'distance': 'distance'}
 
 .. warning::
 

--- a/docs/coordinates/skycoord.rst
+++ b/docs/coordinates/skycoord.rst
@@ -532,10 +532,10 @@ coordinates. How does the object know what to call its values? The answer
 lies in some less obvious attributes::
 
   >>> sc_gal.representation_component_names
-  OrderedDict([('l', 'lon'), ('b', 'lat'), ('distance', 'distance')])
+  {'l': 'lon', 'b': 'lat', 'distance': 'distance'}
 
   >>> sc_gal.representation_component_units
-  OrderedDict([('l', Unit("deg")), ('b', Unit("deg"))])
+  {'l': Unit("deg"), 'b': Unit("deg")}
 
   >>> sc_gal.representation_type
   <class 'astropy.coordinates.representation.SphericalRepresentation'>
@@ -551,7 +551,7 @@ additional attributes that are required to fully define the frame::
 
   >>> sc_fk4 = SkyCoord(1, 2, frame='fk4', unit='deg')
   >>> sc_fk4.get_frame_attr_names()
-  OrderedDict([('equinox', <Time object: scale='tt' format='byear_str' value=B1950.000>), ('obstime', None)])
+  {'equinox': <Time object: scale='tt' format='byear_str' value=B1950.000>, 'obstime': None}
 
 The key values correspond to the defaults if no explicit value is provided by
 the user. This example shows that the `~astropy.coordinates.FK4` frame has two
@@ -837,7 +837,7 @@ names for that frame to the component name on the representation class::
     >>> icrs.representation_type
     <class 'astropy.coordinates.representation.SphericalRepresentation'>
     >>> icrs.representation_component_names
-    OrderedDict([('ra', 'lon'), ('dec', 'lat'), ('distance', 'distance')])
+    {'ra': 'lon', 'dec': 'lat', 'distance': 'distance'}
 
 Changing Representation
 -----------------------


### PR DESCRIPTION
### Description

* Remove `OrderedDict` from `astropy.coordinates`, see gh-10888
* Small refactor of `BaseCoordinateFrame.__init__` to clarify some comments and move part of the code to two separate internal methods. It was not justified in itself, but used this opportunity to include it. The removal of `OrderedDict` is in a separate commit that applies cleanly without the rest.