### PR TITLE
Make QTable Quantity int to float conversion less surprising

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -127,6 +127,9 @@ astropy.stats
 astropy.table
 ^^^^^^^^^^^^^
 
+- ``QTable``: Issue a warning when assigning a unit to a ``Column`` of ``int`` ``dtype``,
+  because it is converted to ``float`` during the conversion to ``Quantity``.  [#10992]
+
 astropy.tests
 ^^^^^^^^^^^^^
 

--- a/astropy/io/fits/tests/test_connect.py
+++ b/astropy/io/fits/tests/test_connect.py
@@ -108,8 +108,11 @@ class TestSingleTable:
     def test_with_units(self, table_type, tmpdir):
         filename = str(tmpdir.join('test_with_units.fits'))
         t1 = table_type(self.data)
-        t1['a'].unit = u.m
-        t1['c'].unit = u.km / u.s
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", message=".*dtype is converted to float.*")
+            # Some test data generated warnings. Ignore them (warning emission has its own test)
+            t1['a'].unit = u.m
+            t1['c'].unit = u.km / u.s
         t1.write(filename, overwrite=True)
         t2 = table_type.read(filename)
         assert equal_data(t1, t2)

--- a/astropy/table/connect.py
+++ b/astropy/table/connect.py
@@ -73,9 +73,7 @@ class TableRead(registry.UnifiedReadWrite):
                 raise TypeError('could not convert reader output to {} '
                                 'class.'.format(cls.__name__))
 
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", message=".*dtype is converted to float.*")
-            out._set_column_attribute('unit', units)
+        out._set_column_attribute('unit', units)
         out._set_column_attribute('description', descriptions)
 
         return out

--- a/astropy/table/connect.py
+++ b/astropy/table/connect.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+import warnings
 from astropy.io import registry
 
 from .info import serialize_method_as
@@ -72,7 +73,9 @@ class TableRead(registry.UnifiedReadWrite):
                 raise TypeError('could not convert reader output to {} '
                                 'class.'.format(cls.__name__))
 
-        out._set_column_attribute('unit', units)
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", message=".*dtype is converted to float.*")
+            out._set_column_attribute('unit', units)
         out._set_column_attribute('description', descriptions)
 
         return out

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -3665,6 +3665,17 @@ class QTable(Table):
                           "".format(col.info.name))
             self._dtype_before_conversion = None
 
+    def _set_column_attribute(self, attr, values):
+        # some internal codes use ``_set_column_attribute()`` to assign units to a column,
+        # which might trigger the warnings. Suppress them as ,they are internal codes that
+        # should know what they are doing.
+        if attr != 'unit':
+            super()._set_column_attribute(attr, values)
+        else:
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", message=".*dtype is converted to float.*")
+                super()._set_column_attribute(attr, values)
+
 
 class NdarrayMixin(np.ndarray):
     """

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -3593,6 +3593,9 @@ class QTable(Table):
     except that columns with an associated ``unit`` attribute are converted to
     `~astropy.units.Quantity` objects.
 
+    Note: when a column of ``int`` ``dtype`` is converted to ``Quantity``, its
+    ``dtype`` is converted to ``float``.
+
     See also:
 
     - https://docs.astropy.org/en/stable/table/

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -3593,9 +3593,8 @@ class QTable(Table):
     except that columns with an associated ``unit`` attribute are converted to
     `~astropy.units.Quantity` objects.
 
-    Note: when a column of ``int`` ``dtype`` is converted to ``Quantity``, its
-    ``dtype`` is converted to ``float``.
-
+    .. note:: When a column of ``int`` ``dtype`` is converted to ``Quantity``, its
+              ``dtype`` is converted to ``float``.
     See also:
 
     - https://docs.astropy.org/en/stable/table/
@@ -3667,7 +3666,7 @@ class QTable(Table):
 
     def _set_column_attribute(self, attr, values):
         # some internal codes use ``_set_column_attribute()`` to assign units to a column,
-        # which might trigger the warnings. Suppress them as ,they are internal codes that
+        # which might trigger the warnings. Suppress them as they are internal codes that
         # should know what they are doing.
         if attr != 'unit':
             super()._set_column_attribute(attr, values)

--- a/astropy/table/tests/test_column.py
+++ b/astropy/table/tests/test_column.py
@@ -595,7 +595,8 @@ def test_qtable_column_conversion():
     assert isinstance(qtab['i'], table.column.Column)
     assert isinstance(qtab['f'], table.column.Column)
 
-    qtab['i'].unit = 'km/s'
+    with pytest.warns(UserWarning, match="dtype is converted to float"):
+        qtab['i'].unit = 'km/s'
     assert isinstance(qtab['i'], u.Quantity)
     assert isinstance(qtab['f'], table.column.Column)
 

--- a/astropy/table/tests/test_operations.py
+++ b/astropy/table/tests/test_operations.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 from collections import OrderedDict
+import warnings
 
 import pytest
 import numpy as np
@@ -399,8 +400,11 @@ class TestJoin():
         meta2 = OrderedDict([('b', [3, 4]), ('c', {'b': 1}), ('a', 1)])
 
         # Key col 'a', should first value ('cm')
-        t1['a'].unit = 'cm'
-        t2['a'].unit = 'm'
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", message=".*dtype is converted to float.*")
+            # Some test data generated warnings. Ignore them (warning emission has its own test)
+            t1['a'].unit = 'cm'
+            t2['a'].unit = 'm'
         # Key col 'b', take first value 't1_b'
         t1['b'].info.description = 't1_b'
         # Key col 'b', take first non-empty value 't1_b'

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -2267,12 +2267,14 @@ def test_qtable_quantity_int_conversion():
 
     tab = QTable(dict(time=[1, 2, 3]))
     tab['length'] = [9, 8, 7]
-    tab['length'].unit = u.m
+    with pytest.warns(UserWarning, match="dtype is converted to float"):
+        tab['length'].unit = u.m
     assert np.issubdtype(tab['length'].dtype, np.float)
 
     # same for dimensionless unit
     tab['col2'] = [6, 5, 4]
-    tab['col2'].unit = u.dimensionless_unscaled
+    with pytest.warns(UserWarning, match="dtype is converted to float"):
+        tab['col2'].unit = u.dimensionless_unscaled
     assert np.issubdtype(tab['col2'].dtype, np.float)
 
     # An implied behavior is that when QTable reads a file with a Column of int data with units,

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -2291,6 +2291,13 @@ def test_qtable_quantity_int_conversion():
         if os.path.isfile(filename):
             os.remove(filename)
 
+    # Ensure warnings only happen in column update, but not column add
+    # - case adding a column
+    tab = QTable(dict(time=[1, 2, 3]))
+    tab['length'] = Column([9, 8, 7], unit=u.m)
+    # - case initial creation
+    tab = QTable([[1, 2, 3]], names=['time'], units=[u.m])
+
 
 def test_replace_column_qtable():
     """Replace existing Quantity column with a new column in a QTable"""

--- a/astropy/timeseries/tests/test_common.py
+++ b/astropy/timeseries/tests/test_common.py
@@ -45,7 +45,7 @@ class CommonTimeSeriesTests:
         self.series.add_row(self._row)
 
     def test_set_unit(self):
-        self.series['d'] = [1, 2, 3]
+        self.series['d'] = [1., 2., 3.]
         self.series['d'].unit = 's'
 
     def test_replace_column(self):


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to address the issue that during `QTable` `Quantity` conversion, it will convert `int` to `float`.
- add test to make it explicit that the behavior is intentional (rather than a bug)
- Add note to `QTable` apidoc.
- Emit warnings when int-to-float conversion happened. The intent is to catch use cases such as `qtab['col'].unit = u.m`. 

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #10964
