### PR TITLE
Add topocentric CIRS and fix the CIRS to AltAz transformations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,8 +16,9 @@ astropy.convolution
 astropy.coordinates
 ^^^^^^^^^^^^^^^^^^^
 
-- Adds the ability to create topocentric ``CIRS`` frames, improving accuracy of
-  ``AltAz`` calculations to of order milli-arcsecond. [#10994]
+- Adds the ability to create topocentric ``CIRS`` frames. Using these,
+  ``AltAz`` calculations are now accurate down to the milli-arcsecond
+  level. [#10994]
 
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,9 @@ astropy.convolution
 astropy.coordinates
 ^^^^^^^^^^^^^^^^^^^
 
+- Adds the ability to create topocentric ``CIRS`` frames, improving accuracy of
+  ``AltAz`` calculations to of order milli-arcsecond. [#10994]
+
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 

--- a/astropy/coordinates/builtin_frames/cirs.py
+++ b/astropy/coordinates/builtin_frames/cirs.py
@@ -4,8 +4,9 @@
 from astropy import units as u
 from astropy.utils.decorators import format_doc
 from astropy.coordinates.attributes import (TimeAttribute,
-                                            CartesianRepresentationAttribute)
+                                            EarthLocationAttribute)
 from astropy.coordinates.baseframe import base_doc
+from astropy.coordinates.earth import EarthLocation
 from .baseradec import doc_components, BaseRADecFrame
 from .utils import DEFAULT_OBSTIME
 
@@ -18,18 +19,10 @@ doc_footer = """
     obstime : `~astropy.time.Time`
         The time at which the observation is taken.  Used for determining the
         position of the Earth and its precession
-    obsgeoloc : `~astropy.coordinates.CartesianRepresentation`, `~astropy.units.Quantity`
-        The position of the observer relative to the center-of-mass of the
-        Earth, oriented the same as GCRS. Either [0, 0, 0],
-        `~astropy.coordinates.CartesianRepresentation`, or proper input for one,
-        i.e., a `~astropy.units.Quantity` with shape (3, ...) and length units.
-        Defaults to [0, 0, 0], meaning a geocentric observer.
-    obsgeovel : `~astropy.coordinates.CartesianRepresentation`, `~astropy.units.Quantity`
-        The velocity of the observer relative to the center-of-mass of the
-        Earth, oriented the same as GCRS. Either [0, 0, 0],
-        `~astropy.coordinates.CartesianRepresentation`, or proper input for one,
-        i.e., a `~astropy.units.Quantity` with shape (3, ...) and velocity
-        units.  Defaults to [0, 0, 0], meaning a geocentric observer.
+    location : `~astropy.coordinates.EarthLocation`
+        The location on the Earth.  This can be specified either as an
+        `~astropy.coordinates.EarthLocation` object or as anything that can be
+        transformed to an `~astropy.coordinates.ITRS` frame.
 """
 
 
@@ -42,10 +35,7 @@ class CIRS(BaseRADecFrame):
     """
 
     obstime = TimeAttribute(default=DEFAULT_OBSTIME)
-    obsgeoloc = CartesianRepresentationAttribute(default=[0, 0, 0],
-                                                 unit=u.m)
-    obsgeovel = CartesianRepresentationAttribute(default=[0, 0, 0],
-                                                 unit=u.m/u.s)
+    location = EarthLocationAttribute(default=EarthLocation(0*u.km, 0*u.km, 0*u.km))
 
 # The "self-transform" is defined in icrs_cirs_transformations.py, because in
 # the current implementation it goes through ICRS (like GCRS)

--- a/astropy/coordinates/builtin_frames/cirs.py
+++ b/astropy/coordinates/builtin_frames/cirs.py
@@ -1,14 +1,12 @@
 # -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from astropy import units as u
 from astropy.utils.decorators import format_doc
 from astropy.coordinates.attributes import (TimeAttribute,
                                             EarthLocationAttribute)
 from astropy.coordinates.baseframe import base_doc
-from astropy.coordinates.earth import EarthLocation
 from .baseradec import doc_components, BaseRADecFrame
-from .utils import DEFAULT_OBSTIME
+from .utils import DEFAULT_OBSTIME, EARTH_CENTER
 
 __all__ = ['CIRS']
 
@@ -36,7 +34,7 @@ class CIRS(BaseRADecFrame):
     """
 
     obstime = TimeAttribute(default=DEFAULT_OBSTIME)
-    location = EarthLocationAttribute(default=EarthLocation(0*u.km, 0*u.km, 0*u.km))
+    location = EarthLocationAttribute(default=EARTH_CENTER)
 
 # The "self-transform" is defined in icrs_cirs_transformations.py, because in
 # the current implementation it goes through ICRS (like GCRS)

--- a/astropy/coordinates/builtin_frames/cirs.py
+++ b/astropy/coordinates/builtin_frames/cirs.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+from astropy import units as u
 from astropy.utils.decorators import format_doc
-from astropy.coordinates.attributes import TimeAttribute
+from astropy.coordinates.attributes import (TimeAttribute,
+                                            CartesianRepresentationAttribute)
 from astropy.coordinates.baseframe import base_doc
 from .baseradec import doc_components, BaseRADecFrame
 from .utils import DEFAULT_OBSTIME
@@ -15,7 +17,19 @@ doc_footer = """
     ----------------
     obstime : `~astropy.time.Time`
         The time at which the observation is taken.  Used for determining the
-        position of the Earth and its precession.
+        position of the Earth and its precession
+    obsgeoloc : `~astropy.coordinates.CartesianRepresentation`, `~astropy.units.Quantity`
+        The position of the observer relative to the center-of-mass of the
+        Earth, oriented the same as GCRS. Either [0, 0, 0],
+        `~astropy.coordinates.CartesianRepresentation`, or proper input for one,
+        i.e., a `~astropy.units.Quantity` with shape (3, ...) and length units.
+        Defaults to [0, 0, 0], meaning a geocentric observer.
+    obsgeovel : `~astropy.coordinates.CartesianRepresentation`, `~astropy.units.Quantity`
+        The velocity of the observer relative to the center-of-mass of the
+        Earth, oriented the same as GCRS. Either [0, 0, 0],
+        `~astropy.coordinates.CartesianRepresentation`, or proper input for one,
+        i.e., a `~astropy.units.Quantity` with shape (3, ...) and velocity
+        units.  Defaults to [0, 0, 0], meaning a geocentric observer.
 """
 
 
@@ -28,7 +42,10 @@ class CIRS(BaseRADecFrame):
     """
 
     obstime = TimeAttribute(default=DEFAULT_OBSTIME)
-
+    obsgeoloc = CartesianRepresentationAttribute(default=[0, 0, 0],
+                                                 unit=u.m)
+    obsgeovel = CartesianRepresentationAttribute(default=[0, 0, 0],
+                                                 unit=u.m/u.s)
 
 # The "self-transform" is defined in icrs_cirs_transformations.py, because in
 # the current implementation it goes through ICRS (like GCRS)

--- a/astropy/coordinates/builtin_frames/cirs.py
+++ b/astropy/coordinates/builtin_frames/cirs.py
@@ -18,11 +18,12 @@ doc_footer = """
     ----------------
     obstime : `~astropy.time.Time`
         The time at which the observation is taken.  Used for determining the
-        position of the Earth and its precession
+        position of the Earth and its precession.
     location : `~astropy.coordinates.EarthLocation`
         The location on the Earth.  This can be specified either as an
         `~astropy.coordinates.EarthLocation` object or as anything that can be
-        transformed to an `~astropy.coordinates.ITRS` frame.
+        transformed to an `~astropy.coordinates.ITRS` frame. The default is the
+        centre of the Earth.
 """
 
 

--- a/astropy/coordinates/builtin_frames/cirs_observed_transforms.py
+++ b/astropy/coordinates/builtin_frames/cirs_observed_transforms.py
@@ -22,11 +22,13 @@ from ..erfa_astrom import erfa_astrom
 
 @frame_transform_graph.transform(FunctionTransformWithFiniteDifference, CIRS, AltAz)
 def cirs_to_altaz(cirs_coo, altaz_frame):
-    if np.any(cirs_coo.obstime != altaz_frame.obstime):
-        # the only frame attribute for the current CIRS is the obstime, but this
-        # would need to be updated if a future change allowed specifying an
-        # Earth location algorithm or something
-        cirs_coo = cirs_coo.transform_to(CIRS(obstime=altaz_frame.obstime))
+
+    obsgeoloc, obsgeovel = altaz_frame.location.get_gcrs_posvel(altaz_frame.obstime)
+    if (np.any(cirs_coo.obstime != altaz_frame.obstime) or
+            np.any(cirs_coo.obsgeoloc != obsgeoloc)):
+        cirs_coo = cirs_coo.transform_to(CIRS(obstime=altaz_frame.obstime,
+                                              obsgeoloc=obsgeoloc,
+                                              obsgeovel=obsgeovel))
 
     # we use the same obstime everywhere now that we know they're the same
     obstime = cirs_coo.obstime
@@ -35,22 +37,15 @@ def cirs_to_altaz(cirs_coo, altaz_frame):
     is_unitspherical = (isinstance(cirs_coo.data, UnitSphericalRepresentation) or
                         cirs_coo.cartesian.x.unit == u.one)
 
-    if is_unitspherical:
-        usrepr = cirs_coo.represent_as(UnitSphericalRepresentation)
-        cirs_ra = usrepr.lon.to_value(u.radian)
-        cirs_dec = usrepr.lat.to_value(u.radian)
-    else:
-        # compute an "astrometric" ra/dec -i.e., the direction of the
-        # displacement vector from the observer to the target in CIRS
-        loccirs = altaz_frame.location.get_itrs(cirs_coo.obstime).transform_to(cirs_coo)
-        diffrepr = (cirs_coo.cartesian - loccirs.cartesian).represent_as(UnitSphericalRepresentation)
-
-        cirs_ra = diffrepr.lon.to_value(u.radian)
-        cirs_dec = diffrepr.lat.to_value(u.radian)
+    # We used to do "astrometric" corrections here, but these are no longer necesssary
+    # CIRS has proper topocentric behaviour
+    usrepr = cirs_coo.represent_as(UnitSphericalRepresentation)
+    cirs_ra = usrepr.lon.to_value(u.radian)
+    cirs_dec = usrepr.lat.to_value(u.radian)
 
     # first set up the astrometry context for CIRS<->AltAz
     astrom = erfa_astrom.get().apio13(altaz_frame)
-
+    astrom['diurab'] = 0
     az, zen, _, _, _ = erfa.atioq(cirs_ra, cirs_dec, astrom)
 
     if is_unitspherical:
@@ -77,23 +72,20 @@ def altaz_to_cirs(altaz_coo, cirs_frame):
 
     # first set up the astrometry context for ICRS<->CIRS at the altaz_coo time
     astrom = erfa_astrom.get().apio13(altaz_coo)
+    astrom['diurab'] = 0
 
     # the 'A' indicates zen/az inputs
     cirs_ra, cirs_dec = erfa.atoiq('A', az, zen, astrom)*u.radian
+    obsgeoloc, obsgeovel = altaz_coo.location.get_gcrs_posvel(altaz_coo.obstime)
     if isinstance(altaz_coo.data, UnitSphericalRepresentation) or altaz_coo.cartesian.x.unit == u.one:
-        cirs_at_aa_time = CIRS(ra=cirs_ra, dec=cirs_dec, distance=None,
-                               obstime=altaz_coo.obstime)
+        distance = None
     else:
-        # treat the output of atoiq as an "astrometric" RA/DEC, so to get the
-        # actual RA/Dec from the observers vantage point, we have to reverse
-        # the vector operation of cirs_to_altaz (see there for more detail)
+        distance = altaz_coo.distance
 
-        loccirs = altaz_coo.location.get_itrs(altaz_coo.obstime).transform_to(cirs_frame)
-
-        astrometric_rep = SphericalRepresentation(lon=cirs_ra, lat=cirs_dec,
-                                                  distance=altaz_coo.distance)
-        newrepr = astrometric_rep + loccirs.cartesian
-        cirs_at_aa_time = CIRS(newrepr, obstime=altaz_coo.obstime)
+    cirs_at_aa_time = CIRS(ra=cirs_ra, dec=cirs_dec, distance=distance,
+                           obstime=altaz_coo.obstime,
+                           obsgeoloc=obsgeoloc,
+                           obsgeovel=obsgeovel)
 
     # this final transform may be a no-op if the obstimes are the same
     return cirs_at_aa_time.transform_to(cirs_frame)

--- a/astropy/coordinates/builtin_frames/cirs_observed_transforms.py
+++ b/astropy/coordinates/builtin_frames/cirs_observed_transforms.py
@@ -22,7 +22,7 @@ from ..erfa_astrom import erfa_astrom
 
 @frame_transform_graph.transform(FunctionTransformWithFiniteDifference, CIRS, AltAz)
 def cirs_to_altaz(cirs_coo, altaz_frame):
-    if (altaz_frame.location != cirs_coo.location or
+    if (np.any(altaz_frame.location != cirs_coo.location) or
             np.any(cirs_coo.obstime != altaz_frame.obstime)):
         cirs_coo = cirs_coo.transform_to(CIRS(obstime=altaz_frame.obstime,
                                               location=altaz_frame.location))
@@ -64,7 +64,7 @@ def altaz_to_cirs(altaz_coo, cirs_frame):
     astrom = erfa_astrom.get().apio(altaz_coo)
 
     # the 'A' indicates zen/az inputs
-    cirs_ra, cirs_dec = erfa.atoiq('A', az, zen, astrom)*u.radian
+    cirs_ra, cirs_dec = erfa.atoiq('A', az, zen, astrom) << u.radian
     if isinstance(altaz_coo.data, UnitSphericalRepresentation) or altaz_coo.cartesian.x.unit == u.one:
         distance = None
     else:

--- a/astropy/coordinates/builtin_frames/cirs_observed_transforms.py
+++ b/astropy/coordinates/builtin_frames/cirs_observed_transforms.py
@@ -41,7 +41,7 @@ def cirs_to_altaz(cirs_coo, altaz_frame):
     cirs_dec = usrepr.lat.to_value(u.radian)
 
     # first set up the astrometry context for CIRS<->AltAz
-    astrom = erfa_astrom.get().apio13(altaz_frame)
+    astrom = erfa_astrom.get().apio(altaz_frame)
     az, zen, _, _, _ = erfa.atioq(cirs_ra, cirs_dec, astrom)
 
     if is_unitspherical:
@@ -64,7 +64,7 @@ def altaz_to_cirs(altaz_coo, cirs_frame):
     zen = PIOVER2 - usrepr.lat.to_value(u.radian)
 
     # first set up the astrometry context for ICRS<->CIRS at the altaz_coo time
-    astrom = erfa_astrom.get().apio13(altaz_coo)
+    astrom = erfa_astrom.get().apio(altaz_coo)
 
     # the 'A' indicates zen/az inputs
     cirs_ra, cirs_dec = erfa.atoiq('A', az, zen, astrom)*u.radian

--- a/astropy/coordinates/builtin_frames/cirs_observed_transforms.py
+++ b/astropy/coordinates/builtin_frames/cirs_observed_transforms.py
@@ -30,9 +30,6 @@ def cirs_to_altaz(cirs_coo, altaz_frame):
                                               obsgeoloc=obsgeoloc,
                                               obsgeovel=obsgeovel))
 
-    # we use the same obstime everywhere now that we know they're the same
-    obstime = cirs_coo.obstime
-
     # if the data are UnitSphericalRepresentation, we can skip the distance calculations
     is_unitspherical = (isinstance(cirs_coo.data, UnitSphericalRepresentation) or
                         cirs_coo.cartesian.x.unit == u.one)
@@ -45,11 +42,6 @@ def cirs_to_altaz(cirs_coo, altaz_frame):
 
     # first set up the astrometry context for CIRS<->AltAz
     astrom = erfa_astrom.get().apio13(altaz_frame)
-    # Note: this is inefficient. Really we should write our own apio13 version and
-    # strip out pvobs calls. However, we don't need a diurnal aberration/parallax
-    # term because we have already accounted for that in transforming to topocentric
-    # CIRS.
-    astrom['diurab'] = 0
     az, zen, _, _, _ = erfa.atioq(cirs_ra, cirs_dec, astrom)
 
     if is_unitspherical:
@@ -73,7 +65,6 @@ def altaz_to_cirs(altaz_coo, cirs_frame):
 
     # first set up the astrometry context for ICRS<->CIRS at the altaz_coo time
     astrom = erfa_astrom.get().apio13(altaz_coo)
-    astrom['diurab'] = 0
 
     # the 'A' indicates zen/az inputs
     cirs_ra, cirs_dec = erfa.atoiq('A', az, zen, astrom)*u.radian

--- a/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
@@ -34,7 +34,7 @@ from ..erfa_astrom import erfa_astrom
 @frame_transform_graph.transform(FunctionTransformWithFiniteDifference, ICRS, CIRS)
 def icrs_to_cirs(icrs_coo, cirs_frame):
     # first set up the astrometry context for ICRS<->CIRS
-    astrom = erfa_astrom.get().apci(cirs_frame)
+    astrom = erfa_astrom.get().apco(cirs_frame)
 
     if icrs_coo.data.get_name() == 'unitspherical' or icrs_coo.data.to_cartesian().x.unit == u.one:
         # if no distance, just do the infinite-distance/no parallax calculation
@@ -66,7 +66,7 @@ def icrs_to_cirs(icrs_coo, cirs_frame):
 def cirs_to_icrs(cirs_coo, icrs_frame):
     # set up the astrometry context for ICRS<->cirs and then convert to
     # astrometric coordinate direction
-    astrom = erfa_astrom.get().apci(cirs_coo)
+    astrom = erfa_astrom.get().apco(cirs_coo)
     srepr = cirs_coo.represent_as(SphericalRepresentation)
     i_ra, i_dec = aticq(srepr.without_differentials(), astrom)
 
@@ -96,8 +96,8 @@ def cirs_to_icrs(cirs_coo, icrs_frame):
 
 @frame_transform_graph.transform(FunctionTransformWithFiniteDifference, CIRS, CIRS)
 def cirs_to_cirs(from_coo, to_frame):
-    if (np.all(from_coo.obstime == to_frame.obstime) and
-            np.all(from_coo.obsgeoloc == to_frame.obsgeoloc)):
+    if (from_coo.location == to_frame.location and
+            np.all(from_coo.obstime == to_frame.obstime)):
         return to_frame.realize_frame(from_coo.data)
     else:
         # the CIRS<-> CIRS transform actually goes through ICRS.  This has a

--- a/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
@@ -96,16 +96,15 @@ def cirs_to_icrs(cirs_coo, icrs_frame):
 
 @frame_transform_graph.transform(FunctionTransformWithFiniteDifference, CIRS, CIRS)
 def cirs_to_cirs(from_coo, to_frame):
-    if np.all(from_coo.obstime == to_frame.obstime):
+    if (np.all(from_coo.obstime == to_frame.obstime) and
+            np.all(from_coo.obsgeoloc == to_frame.obsgeoloc)):
         return to_frame.realize_frame(from_coo.data)
     else:
-        # the CIRS<-> CIRS transform actually goes through ICRS.  This has a
-        # subtle implication that a point in CIRS is uniquely determined
-        # by the corresponding astrometric ICRS coordinate *at its
-        # current time*.  This has some subtle implications in terms of GR, but
-        # is sort of glossed over in the current scheme because we are dropping
-        # distances anyway.
-        return from_coo.transform_to(ICRS()).transform_to(to_frame)
+        # the CIRS<-> CIRS transform actually goes through GCRS. Previously
+        # this went through ICRS, but this seems unecessary since the
+        # transform between GCRS and ICRS for the same topocentric position
+        # is a simple matrix transform.
+        return from_coo.transform_to(GCRS()).transform_to(to_frame)
 
 
 # Now the GCRS-related transforms to/from ICRS

--- a/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
@@ -100,14 +100,16 @@ def cirs_to_cirs(from_coo, to_frame):
             np.all(from_coo.obsgeoloc == to_frame.obsgeoloc)):
         return to_frame.realize_frame(from_coo.data)
     else:
-        # the CIRS<-> CIRS transform actually goes through GCRS. Previously
-        # this went through ICRS, but this seems unecessary since the
-        # transform between GCRS and ICRS for the same topocentric position
-        # is a simple matrix transform.
-        return from_coo.transform_to(GCRS()).transform_to(to_frame)
-
+        # the CIRS<-> CIRS transform actually goes through ICRS.  This has a
+        # subtle implication that a point in CIRS is uniquely determined
+        # by the corresponding astrometric ICRS coordinate *at its
+        # current time*.  This has some subtle implications in terms of GR, but
+        # is sort of glossed over in the current scheme because we are dropping
+        # distances anyway.
+        return from_coo.transform_to(ICRS()).transform_to(to_frame)
 
 # Now the GCRS-related transforms to/from ICRS
+
 
 @frame_transform_graph.transform(FunctionTransformWithFiniteDifference, ICRS, GCRS)
 def icrs_to_gcrs(icrs_coo, gcrs_frame):

--- a/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
@@ -108,8 +108,8 @@ def cirs_to_cirs(from_coo, to_frame):
         # distances anyway.
         return from_coo.transform_to(ICRS()).transform_to(to_frame)
 
-# Now the GCRS-related transforms to/from ICRS
 
+# Now the GCRS-related transforms to/from ICRS
 
 @frame_transform_graph.transform(FunctionTransformWithFiniteDifference, ICRS, GCRS)
 def icrs_to_gcrs(icrs_coo, gcrs_frame):

--- a/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
@@ -96,7 +96,7 @@ def cirs_to_icrs(cirs_coo, icrs_frame):
 
 @frame_transform_graph.transform(FunctionTransformWithFiniteDifference, CIRS, CIRS)
 def cirs_to_cirs(from_coo, to_frame):
-    if (from_coo.location == to_frame.location and
+    if (np.all(from_coo.location == to_frame.location) and
             np.all(from_coo.obstime == to_frame.obstime)):
         return to_frame.realize_frame(from_coo.data)
     else:

--- a/astropy/coordinates/builtin_frames/intermediate_rotation_transforms.py
+++ b/astropy/coordinates/builtin_frames/intermediate_rotation_transforms.py
@@ -13,13 +13,13 @@ import astropy.units as u
 from astropy.coordinates.baseframe import frame_transform_graph
 from astropy.coordinates.transformations import FunctionTransformWithFiniteDifference
 from astropy.coordinates.matrix_utilities import matrix_transpose
-from astropy.coordinates.earth import EarthLocation
+
 
 from .gcrs import GCRS, PrecessedGeocentric
 from .cirs import CIRS
 from .itrs import ITRS
 from .equatorial import TEME, TETE
-from .utils import get_polar_motion, get_jd12
+from .utils import get_polar_motion, get_jd12, EARTH_CENTER
 
 # # first define helper functions
 
@@ -194,7 +194,7 @@ def cirs_to_gcrs(cirs_coo, gcrs_frame):
 def cirs_to_itrs(cirs_coo, itrs_frame):
     # first get us to geocentric CIRS at the target obstime
     cirs_coo2 = cirs_coo.transform_to(CIRS(obstime=itrs_frame.obstime,
-                                           location=EarthLocation(0*u.km, 0*u.km, 0*u.km)))
+                                           location=EARTH_CENTER))
 
     # now get the pmatrix
     pmat = cirs_to_itrs_mat(itrs_frame.obstime)

--- a/astropy/coordinates/builtin_frames/intermediate_rotation_transforms.py
+++ b/astropy/coordinates/builtin_frames/intermediate_rotation_transforms.py
@@ -154,7 +154,7 @@ def gcrs_to_cirs(gcrs_coo, cirs_frame):
 
     # now get us to GCRS at the target obstime and pos/vel
     # can't use location.get_gcrs_posvel as that would trigger infinite recursion
-    obscirsloc, obscirsvel = cirs_frame.location.get_cirs_posvel(cirs_frame.obstime)
+    obscirsloc, obscirsvel = cirs_frame.location.get_posvel(cirs_frame.obstime, CIRS)
     obsgeoloc = obscirsloc.transform(matrix_transpose(pmat))
     obsgeovel = obscirsvel.transform(matrix_transpose(pmat))
     gcrs_coo2 = gcrs_coo.transform_to(GCRS(obstime=cirs_frame.obstime,
@@ -171,7 +171,7 @@ def cirs_to_gcrs(cirs_coo, gcrs_frame):
     pmat = gcrs_to_cirs_mat(cirs_coo.obstime)
     newrepr = cirs_coo.cartesian.transform(matrix_transpose(pmat))
     # can't use location.get_gcrs_posvel as that would trigger infinite recursion
-    obscirsloc, obscirsvel = cirs_coo.location.get_cirs_posvel(cirs_coo.obstime)
+    obscirsloc, obscirsvel = cirs_coo.location.get_posvel(cirs_coo.obstime, CIRS)
     obsgeoloc = obscirsloc.transform(matrix_transpose(pmat))
     obsgeovel = obscirsvel.transform(matrix_transpose(pmat))
     gcrs = GCRS(newrepr,

--- a/astropy/coordinates/builtin_frames/intermediate_rotation_transforms.py
+++ b/astropy/coordinates/builtin_frames/intermediate_rotation_transforms.py
@@ -179,7 +179,7 @@ def cirs_to_gcrs(cirs_coo, gcrs_frame):
                 obsgeoloc=obsgeoloc,
                 obsgeovel=obsgeovel)
 
-    # now do any needed offsets (no-op if same obstime and 0 pos/vel)
+    # now do any needed offsets (no-op if same obstime and pos/vel)
     return gcrs.transform_to(gcrs_frame)
 
 

--- a/astropy/coordinates/builtin_frames/utils.py
+++ b/astropy/coordinates/builtin_frames/utils.py
@@ -36,7 +36,7 @@ _DEFAULT_PM = (0.035, 0.29)*u.arcsec
 
 def get_polar_motion(time):
     """
-    gets the two polar motion components in radians for use with apio13
+    gets the two polar motion components in radians for use with apio
     """
     # Get the polar motion from the IERS table
     iers_table = iers.earth_orientation_table.get()

--- a/astropy/coordinates/builtin_frames/utils.py
+++ b/astropy/coordinates/builtin_frames/utils.py
@@ -12,9 +12,10 @@ import numpy as np
 
 from astropy import units as u
 from astropy.time import Time
+from astropy.coordinates.earth import EarthLocation
 from astropy.utils import iers
 from astropy.utils.exceptions import AstropyWarning
-from ..representation import CartesianRepresentation, CartesianDifferential
+from ..representation import CartesianDifferential
 
 
 # We use tt as the time scale for this equinoxes, primarily because it is the
@@ -27,6 +28,10 @@ EQUINOX_B1950 = Time('B1950', scale='tt')
 # This is a time object that is the default "obstime" when such an attribute is
 # necessary.  Currently, we use J2000.
 DEFAULT_OBSTIME = Time('J2000', scale='tt')
+
+# This is an EarthLocation that is the default "location" when such an attribute is
+# necessary. It is the centre of the Earth.
+EARTH_CENTER = EarthLocation(0*u.km, 0*u.km, 0*u.km)
 
 PIOVER2 = np.pi / 2.
 

--- a/astropy/coordinates/earth.py
+++ b/astropy/coordinates/earth.py
@@ -7,7 +7,6 @@ import json
 import urllib.request
 import urllib.error
 import urllib.parse
-import inspect
 
 import numpy as np
 import erfa
@@ -637,7 +636,7 @@ class EarthLocation(u.Quantity):
 
         include_velocity: bool
             If True, will return an `~astropy.coordinates.ITRS` coordinate
-            with zero velocity, i.e fixed to the Earth's surface
+            with zero velocity, i.e fixed to the Earth's surface.
 
         Returns
         -------
@@ -661,35 +660,6 @@ class EarthLocation(u.Quantity):
                                      for the location of this object at the
                                      default ``obstime``.""")
 
-    def get_posvel(self, obstime, frame):
-        """
-        Calculate the position and velocity of this object in a given
-        ``frame`` at the requested ``obstime``.
-
-        Parameters
-        ----------
-        obstime : `~astropy.time.Time`
-            The ``obstime`` to calculate the GCRS position/velocity at.
-        frame : class
-            The coordinate frame in which the position and velocity should
-            be measured.
-
-        Returns
-        --------
-        location : `~astropy.coordinates.CartesianRepresentation`
-            The position of the object in the specified ``frame``.
-        velocity : `~astropy.coordinates.CartesianRepresentation`
-            The velocity of the object in the specified ``frame``.
-        """
-        if not inspect.isclass(frame):
-            raise TypeError('frame must be a class')
-
-        frame_instance = frame(obstime=obstime)
-        data = self.get_itrs(obstime=obstime, include_velocity=True).transform_to(frame_instance).data
-        location = data.without_differentials()
-        velocity = data.differentials['s'].to_cartesian()
-        return location, velocity
-
     def get_gcrs(self, obstime):
         """GCRS position with velocity at ``obstime`` as a GCRS coordinate.
 
@@ -705,9 +675,8 @@ class EarthLocation(u.Quantity):
         """
         # do this here to prevent a series of complicated circular imports
         from .builtin_frames import GCRS
-        return self.get_itrs(obstime, include_velocity=True).transform_to(
-            GCRS(obstime=obstime)
-        )
+        return (self.get_itrs(obstime, include_velocity=True)
+                .transform_to(GCRS(obstime=obstime)))
 
     def get_gcrs_posvel(self, obstime):
         """

--- a/astropy/coordinates/earth.py
+++ b/astropy/coordinates/earth.py
@@ -652,7 +652,7 @@ class EarthLocation(u.Quantity):
         from .builtin_frames import ITRS
         itrs_coo = ITRS(x=self.x, y=self.y, z=self.z, obstime=obstime)
         if include_velocity:
-            zeros = np.broadcast_to(0. * u.km / u.s, (3,) + itrs_coo.shape, subok=True)
+            zeros = np.broadcast_to(0. * (u.km / u.s), (3,) + itrs_coo.shape, subok=True)
             itrs_coo.data.differentials['s'] = CartesianDifferential(zeros)
         return itrs_coo
 

--- a/astropy/coordinates/erfa_astrom.py
+++ b/astropy/coordinates/erfa_astrom.py
@@ -207,6 +207,16 @@ class ErfaAstromInterpolator(ErfaAstrom):
         return earth_pv, earth_heliocentric
 
     @staticmethod
+    def _get_c2i(support, obstime):
+        jd1_tt_support, jd2_tt_support = get_jd12(support, 'tt')
+        c2i_support = erfa.c2i06a(jd1_tt_support, jd2_tt_support)
+        c2i = np.empty(obstime.shape + (3, 3))
+        for dim1 in range(3):
+            for dim2 in range(3):
+                c2i[..., dim1, dim2] = np.interp(obstime.mjd, support.mjd, c2i_support[..., dim1, dim2])
+        return c2i
+
+    @staticmethod
     def _get_cip(support, obstime):
         jd1_tt_support, jd2_tt_support = get_jd12(support, 'tt')
         cip_support = get_cip(jd1_tt_support, jd2_tt_support)
@@ -244,7 +254,7 @@ class ErfaAstromInterpolator(ErfaAstrom):
 
         jd1_tt, jd2_tt = get_jd12(obstime, 'tt')
         astrom = erfa.apcs(jd1_tt, jd2_tt, pv, earth_pv, earth_heliocentric)
-        astrom['bpn'] = erfa.c2i06a(jd1_tt, jd2_tt)
+        astrom['bpn'] = self._get_c2i(support, obstime)
         return astrom
 
     def apcs(self, frame_or_coord):

--- a/astropy/coordinates/erfa_astrom.py
+++ b/astropy/coordinates/erfa_astrom.py
@@ -93,7 +93,7 @@ class ErfaAstrom:
         jd1_utc, jd2_utc = get_jd12(frame_or_coord.obstime, 'utc')
         dut1utc = get_dut1utc(frame_or_coord.obstime)
 
-        return erfa.apio13(
+        astrom = erfa.apio13(
             jd1_utc, jd2_utc, dut1utc,
             lon.to_value(u.radian),
             lat.to_value(u.radian),
@@ -105,6 +105,12 @@ class ErfaAstrom:
             frame_or_coord.relative_humidity.value,
             frame_or_coord.obswl.value,
         )
+        # Note: this is inefficient. Really we should write our own apio13 version and
+        # strip out pvobs calls. However, we don't need a diurnal aberration/parallax
+        # term because we have already accounted for that in transforming to topocentric
+        # CIRS.
+        astrom['diurab'] = 0
+        return astrom
 
 
 class ErfaAstromInterpolator(ErfaAstrom):

--- a/astropy/coordinates/erfa_astrom.py
+++ b/astropy/coordinates/erfa_astrom.py
@@ -216,6 +216,12 @@ class ErfaAstromInterpolator(ErfaAstrom):
 
     @staticmethod
     def _prepare_earth_position_vel(support, obstime):
+        """
+        Calculate Earth's position and velocity.
+
+        Uses the coarser grid ``support`` to do the calculation, and interpolates
+        onto the finer grid ``obstime``.
+        """
         pv_support, heliocentric_support = prepare_earth_position_vel(support)
 
         # do interpolation
@@ -236,6 +242,12 @@ class ErfaAstromInterpolator(ErfaAstrom):
 
     @staticmethod
     def _get_c2i(support, obstime):
+        """
+        Calculate the Celestial-to-Intermediate rotation matrix.
+
+        Uses the coarser grid ``support`` to do the calculation, and interpolates
+        onto the finer grid ``obstime``.
+        """
         jd1_tt_support, jd2_tt_support = get_jd12(support, 'tt')
         c2i_support = erfa.c2i06a(jd1_tt_support, jd2_tt_support)
         c2i = np.empty(obstime.shape + (3, 3))
@@ -246,6 +258,12 @@ class ErfaAstromInterpolator(ErfaAstrom):
 
     @staticmethod
     def _get_cip(support, obstime):
+        """
+        Find the X, Y coordinates of the CIP and the CIO locator, s.
+
+        Uses the coarser grid ``support`` to do the calculation, and interpolates
+        onto the finer grid ``obstime``.
+        """
         jd1_tt_support, jd2_tt_support = get_jd12(support, 'tt')
         cip_support = get_cip(jd1_tt_support, jd2_tt_support)
         return tuple(
@@ -255,7 +273,12 @@ class ErfaAstromInterpolator(ErfaAstrom):
 
     @staticmethod
     def _get_polar_motion(support, obstime):
-        # TODO: do we need this? It's just a table lookup
+        """
+        Find the two polar motion components in radians
+
+        Uses the coarser grid ``support`` to do the calculation, and interpolates
+        onto the finer grid ``obstime``.
+        """
         polar_motion_support = get_polar_motion(support)
         return tuple(
             np.interp(obstime.mjd, support.mjd, polar_motion_component)

--- a/astropy/coordinates/erfa_astrom.py
+++ b/astropy/coordinates/erfa_astrom.py
@@ -75,33 +75,6 @@ class ErfaAstrom:
         )
 
     @staticmethod
-    def apci(frame_or_coord):
-        '''
-        Prepare astrometry context used in conversions CIRS <-> ICRS
-
-        Despite the name this doesn't actually call erfa.apci, since that does not
-        allow for non-geocentric CIRS. Instead, we call apcs and change the
-        bias-precession-matrix from a no-op to the celestial-intermediate matrix.
-
-        Arguments
-        ---------
-        frame_or_coord: ``astropy.coordinates.BaseCoordinateFrame`` or ``astropy.coordinates.SkyCoord``
-            Frame or coordinate instance in the corresponding frame
-            for which to calculate the calculate the astrom values.
-            For this function, a CIRS frame is expected.
-        '''
-        jd1_tt, jd2_tt = get_jd12(frame_or_coord.obstime, 'tt')
-        obsgeoloc, obsgeovel = frame_or_coord.location.get_gcrs_posvel(frame_or_coord.obstime)
-        obs_pv = pav2pv(
-            obsgeoloc.get_xyz(xyz_axis=-1).value,
-            obsgeovel.get_xyz(xyz_axis=-1).value
-        )
-        earth_pv, earth_heliocentric = prepare_earth_position_vel(frame_or_coord.obstime)
-        astrom = erfa.apcs(jd1_tt, jd2_tt, obs_pv, earth_pv, earth_heliocentric)
-        astrom['bpn'] = erfa.c2i06a(jd1_tt, jd2_tt)
-        return astrom
-
-    @staticmethod
     def apcs(frame_or_coord):
         '''
         Wrapper for ``erfa.apcs``, used in conversions GCRS <-> ICRS
@@ -354,39 +327,6 @@ class ErfaAstromInterpolator(ErfaAstrom):
             height.to_value(u.m),
             xp, yp, sp, refa, refb
         )
-
-    def apci(self, frame_or_coord):
-        '''
-        Prepare astrometry context used in conversions CIRS <-> ICRS
-
-        Despite the name this doesn't actually call erfa.apci, since that does not
-        allow for non-geocentric CIRS. Instead, we call apcs and change the
-        bias-precession-matrix from a no-op to the celestial-intermediate matrix.
-
-        Arguments
-        ---------
-        frame_or_coord: ``astropy.coordinates.BaseCoordinateFrame`` or ``astropy.coordinates.SkyCoord``
-            Frame or coordinate instance in the corresponding frame
-            for which to calculate the calculate the astrom values.
-            For this function, a CIRS frame is expected.
-        '''
-        obstime = frame_or_coord.obstime
-        # no point in interpolating for a single value
-        support = self._get_support_points(obstime)
-
-        # get the position and velocity arrays for the observatory.  Need to
-        # have xyz in last dimension, and pos/vel in one-but-last.
-        earth_pv, earth_heliocentric = self._prepare_earth_position_vel(support, obstime)
-        obsgeoloc, obsgeovel = frame_or_coord.location.get_gcrs_posvel(frame_or_coord.obstime)
-        pv = pav2pv(
-            obsgeoloc.get_xyz(xyz_axis=-1).value,
-            obsgeovel.get_xyz(xyz_axis=-1).value
-        )
-
-        jd1_tt, jd2_tt = get_jd12(obstime, 'tt')
-        astrom = erfa.apcs(jd1_tt, jd2_tt, pv, earth_pv, earth_heliocentric)
-        astrom['bpn'] = self._get_c2i(support, obstime)
-        return astrom
 
     def apcs(self, frame_or_coord):
         '''

--- a/astropy/coordinates/tests/test_celestial_transformations.py
+++ b/astropy/coordinates/tests/test_celestial_transformations.py
@@ -8,7 +8,7 @@ from astropy import units as u
 from astropy.coordinates import galactocentric_frame_defaults
 from astropy.coordinates.distances import Distance
 from astropy.coordinates.builtin_frames import (
-    ICRS, FK5, FK4, FK4NoETerms, Galactic,
+    ICRS, FK5, FK4, FK4NoETerms, Galactic, CIRS,
     Supergalactic, Galactocentric, HCRS, GCRS, LSR)
 from astropy.coordinates import SkyCoord
 from astropy.tests.helper import assert_quantity_allclose as assert_allclose
@@ -313,3 +313,33 @@ def test_hcrs_icrs_differentials():
     # The values should round trip
     assert allclose(hcrs.cartesian.xyz, hcrs2.cartesian.xyz, rtol=1e-12)
     assert allclose(hcrs.velocity.d_xyz, hcrs2.velocity.d_xyz, rtol=1e-12)
+
+
+def test_cirs_icrs():
+    """
+    Test CIRS<->ICRS transformations, including self transform
+    """
+    t = Time("J2010")
+    MOONDIST = 385000*u.km  # approximate moon semi-major orbit axis of moon
+    MOONDIST_CART = CartesianRepresentation(3**-0.5*MOONDIST, 3**-0.5*MOONDIST, 3**-0.5*MOONDIST)
+
+    loc = EarthLocation(lat=0*u.deg, lon=0*u.deg)
+    pos, vel = loc.get_gcrs_posvel(t)
+    cirs_geo_frame = CIRS(obstime=t)
+    cirs_topo_frame = CIRS(obstime=t, obsgeoloc=pos, obsgeovel=vel)
+
+    moon_geo = cirs_geo_frame.realize_frame(MOONDIST_CART)
+    moon_topo = moon_geo.transform_to(cirs_topo_frame)
+
+    # now check that the distance change is similar to earth radius
+    assert 1000*u.km < np.abs(moon_topo.distance - moon_geo.distance).to(u.au) < 7000*u.km
+
+    # now check that it round-trips
+    moon2 = moon_topo.transform_to(moon_geo)
+    assert_allclose(moon_geo.cartesian.xyz, moon2.cartesian.xyz)
+
+    # now check ICRS transform gives a decent distance from Barycentre
+    moon_icrs = moon_geo.transform_to(ICRS())
+    assert moon_icrs.distance - 1*u.au < 1*u.R_sun
+
+

--- a/astropy/coordinates/tests/test_celestial_transformations.py
+++ b/astropy/coordinates/tests/test_celestial_transformations.py
@@ -339,4 +339,4 @@ def test_cirs_icrs():
 
     # now check ICRS transform gives a decent distance from Barycentre
     moon_icrs = moon_geo.transform_to(ICRS())
-    assert moon_icrs.distance - 1*u.au < 1*u.R_sun
+    assert_allclose(moon_icrs.distance - 1*u.au, 0.0*u.R_sun, atol=3*u.R_sun)

--- a/astropy/coordinates/tests/test_celestial_transformations.py
+++ b/astropy/coordinates/tests/test_celestial_transformations.py
@@ -341,5 +341,3 @@ def test_cirs_icrs():
     # now check ICRS transform gives a decent distance from Barycentre
     moon_icrs = moon_geo.transform_to(ICRS())
     assert moon_icrs.distance - 1*u.au < 1*u.R_sun
-
-

--- a/astropy/coordinates/tests/test_celestial_transformations.py
+++ b/astropy/coordinates/tests/test_celestial_transformations.py
@@ -324,9 +324,8 @@ def test_cirs_icrs():
     MOONDIST_CART = CartesianRepresentation(3**-0.5*MOONDIST, 3**-0.5*MOONDIST, 3**-0.5*MOONDIST)
 
     loc = EarthLocation(lat=0*u.deg, lon=0*u.deg)
-    pos, vel = loc.get_gcrs_posvel(t)
     cirs_geo_frame = CIRS(obstime=t)
-    cirs_topo_frame = CIRS(obstime=t, obsgeoloc=pos, obsgeovel=vel)
+    cirs_topo_frame = CIRS(obstime=t, location=loc)
 
     moon_geo = cirs_geo_frame.realize_frame(MOONDIST_CART)
     moon_topo = moon_geo.transform_to(cirs_topo_frame)

--- a/astropy/coordinates/tests/test_erfa_astrom.py
+++ b/astropy/coordinates/tests/test_erfa_astrom.py
@@ -58,7 +58,7 @@ def test_erfa_astrom():
         interp_300s = coord.transform_to(altaz)
 
     # make sure they are actually different
-    assert np.any(ref.separation(interp_300s) > 0.01 * u.microarcsecond)
+    assert np.any(ref.separation(interp_300s) > 0.005 * u.microarcsecond)
 
     # make sure the resolution is as good as we expect
     assert np.all(ref.separation(interp_300s) < 1 * u.microarcsecond)

--- a/astropy/coordinates/tests/test_erfa_astrom.py
+++ b/astropy/coordinates/tests/test_erfa_astrom.py
@@ -87,7 +87,7 @@ def test_interpolation_nd():
         gcrs = GCRS(obstime=obstime)
         cirs = CIRS(obstime=obstime)
 
-        for frame, tcode in zip([altaz, cirs, gcrs], ['apio13', 'apci', 'apcs']):
+        for frame, tcode in zip([altaz, cirs, gcrs], ['apio', 'apci', 'apcs']):
             without_interp = getattr(provider, tcode)(frame)
             assert without_interp.shape == shape
 

--- a/astropy/coordinates/tests/test_erfa_astrom.py
+++ b/astropy/coordinates/tests/test_erfa_astrom.py
@@ -87,7 +87,7 @@ def test_interpolation_nd():
         gcrs = GCRS(obstime=obstime)
         cirs = CIRS(obstime=obstime)
 
-        for frame, tcode in zip([altaz, cirs, gcrs], ['apio', 'apci', 'apcs']):
+        for frame, tcode in zip([altaz, cirs, gcrs], ['apio', 'apco', 'apcs']):
             without_interp = getattr(provider, tcode)(frame)
             assert without_interp.shape == shape
 

--- a/astropy/coordinates/tests/test_erfa_astrom.py
+++ b/astropy/coordinates/tests/test_erfa_astrom.py
@@ -4,7 +4,7 @@ import pytest
 import astropy.units as u
 from astropy.time import Time
 from astropy.utils.exceptions import AstropyWarning
-from astropy.coordinates import EarthLocation, AltAz, GCRS, SkyCoord
+from astropy.coordinates import EarthLocation, AltAz, GCRS, SkyCoord, CIRS
 
 from astropy.coordinates.erfa_astrom import (
     erfa_astrom, ErfaAstrom, ErfaAstromInterpolator
@@ -85,8 +85,9 @@ def test_interpolation_nd():
 
         altaz = AltAz(location=fact, obstime=obstime)
         gcrs = GCRS(obstime=obstime)
+        cirs = CIRS(obstime=obstime)
 
-        for frame, tcode in zip([altaz, altaz, gcrs], ['apio13', 'apci', 'apcs']):
+        for frame, tcode in zip([altaz, cirs, gcrs], ['apio13', 'apci', 'apcs']):
             without_interp = getattr(provider, tcode)(frame)
             assert without_interp.shape == shape
 

--- a/astropy/coordinates/tests/test_intermediate_transformations.py
+++ b/astropy/coordinates/tests/test_intermediate_transformations.py
@@ -16,7 +16,7 @@ from astropy.coordinates import (
     PrecessedGeocentric, CartesianRepresentation, SkyCoord,
     CartesianDifferential, SphericalRepresentation, UnitSphericalRepresentation,
     HCRS, HeliocentricMeanEcliptic, TEME, TETE)
-from astropy.coordinates.solar_system import _apparent_position_in_true_coordinates
+from astropy.coordinates.solar_system import _apparent_position_in_true_coordinates, get_body
 from astropy.utils import iers
 from astropy.utils.exceptions import AstropyWarning, AstropyDeprecationWarning
 
@@ -646,3 +646,80 @@ def test_tete_transforms():
     with pytest.warns(AstropyDeprecationWarning, match='The use of'):
         tete_alt = _apparent_position_in_true_coordinates(moon)
     assert_allclose(tete_coo1.separation_3d(tete_alt), 0*u.mm, atol=100*u.mm)
+
+
+def test_straight_overhead():
+    """
+    With a precise CIRS<->AltAz transformation this should give Alt=90 exactly
+
+    If the CIRS self-transform breaks it won't, due to improper treatment of aberration
+    """
+    t = Time('J2010')
+    obj = EarthLocation(-1*u.deg, 52*u.deg, height=10.*u.km)
+    home = EarthLocation(-1*u.deg, 52*u.deg, height=0.*u.km)
+    obsloc_gcrs, obsvel_gcrs = home.get_gcrs_posvel(t)
+
+    # An object that appears straight overhead - FOR A GEOCENTRIC OBSERVER.
+    # Note, this won't be overhead for a topocentric observer because of
+    # aberration.
+    cirs_geo = obj.get_itrs(t).transform_to(CIRS(obstime=t))
+
+    # now get the Geocentric CIRS position of observatory
+    obsrepr = home.get_itrs(t).transform_to(CIRS(obstime=t)).cartesian
+
+    # topocentric CIRS position of a straight overhead object
+    cirs_repr = cirs_geo.cartesian - obsrepr
+
+    # create a CIRS object that appears straight overhead for a TOPOCENTRIC OBSERVER
+    topocentric_cirs_frame = CIRS(obstime=t, obsgeoloc=obsloc_gcrs, obsgeovel=obsvel_gcrs)
+    cirs_topo = topocentric_cirs_frame.realize_frame(cirs_repr)
+
+    aa = cirs_topo.transform_to(AltAz(obstime=t, location=home))
+    assert_allclose(aa.alt, 90*u.deg)
+
+
+@pytest.mark.remote_data
+def test_aa_high_precision():
+    """
+    These tests are provided by @mkbrewer - see issue #10356.
+
+    The code that produces them agrees very well (<0.5 mas) with SkyField once Polar motion
+    is turned off, but SkyField does not include polar motion, so a comparison to Skyfield
+    or JPL Horizons will be ~1" off.
+
+    The absence of polar motion within Skyfield and the disagreement between Skyfield and Horizons
+    make high precision comparisons to those codes difficult.
+    """
+    lat = -22.959748*u.deg
+    lon = -67.787260*u.deg
+    elev = 5186*u.m
+    loc = EarthLocation.from_geodetic(lon, lat, elev)
+    t = Time('2017-04-06T00:00:00.0')
+    with solar_system_ephemeris.set('de430'):
+        moon = get_body('moon', t, loc)
+        moon_aa = moon.transform_to(AltAz(obstime=t, location=loc))
+        TARGET_AZ, TARGET_EL = 15.032673509*u.deg, 50.303110134*u.deg
+
+    assert_allclose(moon_aa.az - TARGET_AZ, 0*u.mas, atol=0.5*u.mas)
+    assert_allclose(moon_aa.alt - TARGET_EL, 0*u.mas, atol=0.5*u.mas)
+
+
+def test_aa_high_precision_nodata():
+    """
+    These tests are designed to ensure high precision alt-az transforms.
+
+    They are a slight fudge since the target values come from astropy itself. They are generated
+    with a version of the code that passes the tests above, but for the internal solar system
+    ephemerides to avoid the use of remote data.
+    """
+    TARGET_AZ, TARGET_EL = 15.0321908*u.deg, 50.30263625*u.deg
+    lat = -22.959748*u.deg
+    lon = -67.787260*u.deg
+    elev = 5186*u.m
+    loc = EarthLocation.from_geodetic(lon, lat, elev)
+    t = Time('2017-04-06T00:00:00.0')
+
+    moon = get_body('moon', t, loc)
+    moon_aa = moon.transform_to(AltAz(obstime=t, location=loc))
+    assert_allclose(moon_aa.az - TARGET_AZ, 0*u.mas, atol=0.5*u.mas)
+    assert_allclose(moon_aa.alt - TARGET_EL, 0*u.mas, atol=0.5*u.mas)

--- a/astropy/coordinates/tests/test_regression.py
+++ b/astropy/coordinates/tests/test_regression.py
@@ -332,12 +332,25 @@ def test_regression_5133():
 
 
 def test_itrs_vals_5133():
+    """
+    Test to check if alt-az calculations respect height of observer
+
+    Because ITRS is geocentric and includes aberration, an object that
+    appears 'straight up' to a geocentric observer (ITRS) won't be
+    straight up to a topocentric observer - see
+
+    https://github.com/astropy/astropy/issues/10983
+
+    This is worse for small height above the Earth, which is why this test
+    uses large distances.
+    """
     time = Time('2010-1-1')
-    el = EarthLocation.from_geodetic(lon=20*u.deg, lat=45*u.deg, height=0*u.km)
+    height = 500000. * u.km
+    el = EarthLocation.from_geodetic(lon=20*u.deg, lat=45*u.deg, height=height)
 
     lons = [20, 30, 20]*u.deg
     lats = [44, 45, 45]*u.deg
-    alts = [0, 0, 10]*u.km
+    alts = u.Quantity([height, height, 10*height])
     coos = [EarthLocation.from_geodetic(lon, lat, height=alt).get_itrs(time)
             for lon, lat, alt in zip(lons, lats, alts)]
 
@@ -346,30 +359,42 @@ def test_itrs_vals_5133():
 
     assert all([coo.isscalar for coo in aacs])
 
-    # the ~1 arcsec tolerance is b/c aberration makes it not exact
-    assert_quantity_allclose(aacs[0].az, 180*u.deg, atol=1*u.arcsec)
+    # the ~1 degree tolerance is b/c aberration makes it not exact
+    assert_quantity_allclose(aacs[0].az, 180*u.deg, atol=1*u.deg)
     assert aacs[0].alt < 0*u.deg
-    assert aacs[0].distance > 50*u.km
+    assert aacs[0].distance > 5000*u.km
 
     # it should *not* actually be 90 degrees, b/c constant latitude is not
     # straight east anywhere except the equator... but should be close-ish
     assert_quantity_allclose(aacs[1].az, 90*u.deg, atol=5*u.deg)
     assert aacs[1].alt < 0*u.deg
-    assert aacs[1].distance > 50*u.km
+    assert aacs[1].distance > 5000*u.km
 
-    assert_quantity_allclose(aacs[2].alt, 90*u.deg, atol=1*u.arcsec)
-    assert_quantity_allclose(aacs[2].distance, 10*u.km)
+    assert_quantity_allclose(aacs[2].alt, 90*u.deg, atol=1*u.arcminute)
+    assert_quantity_allclose(aacs[2].distance, 9*height)
 
 
 def test_regression_simple_5133():
+    """
+    Simple test to check if alt-az calculations respect height of observer
+
+    Because ITRS is geocentric and includes aberration, an object that
+    appears 'straight up' to a geocentric observer (ITRS) won't be
+    straight up to a topocentric observer - see
+
+    https://github.com/astropy/astropy/issues/10983
+
+    This is worse for small height above the Earth, which is why this test
+    uses large distances.
+    """
     t = Time('J2010')
-    obj = EarthLocation(-1*u.deg, 52*u.deg, height=[100., 0.]*u.km)
-    home = EarthLocation(-1*u.deg, 52*u.deg, height=10.*u.km)
+    obj = EarthLocation(-1*u.deg, 52*u.deg, height=[100000., 0.]*u.km)
+    home = EarthLocation(-1*u.deg, 52*u.deg, height=50000.*u.km)
     aa = obj.get_itrs(t).transform_to(AltAz(obstime=t, location=home))
 
     # az is more-or-less undefined for straight up or down
-    assert_quantity_allclose(aa.alt, [90, -90]*u.deg, rtol=1e-5)
-    assert_quantity_allclose(aa.distance, [90, 10]*u.km)
+    assert_quantity_allclose(aa.alt, [90, -90]*u.deg, rtol=1e-4)
+    assert_quantity_allclose(aa.distance, 50000*u.km)
 
 
 def test_regression_5743():

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -695,7 +695,7 @@ def test_repr_altaz():
                                 "-4641767.) m, pressure=0.0 hPa, "
                          "temperature=0.0 deg_C, relative_humidity=0.0, "
                          "obswl=1.0 micron): (az, alt, distance) in "
-                         "(deg, deg, m)\n")
+                         "(deg, deg, kpc)\n")
 
 
 def test_ops():

--- a/docs/coordinates/common_errors.rst
+++ b/docs/coordinates/common_errors.rst
@@ -1,0 +1,84 @@
+.. include:: references.txt
+
+.. _astropy-coordinates-common-errors:
+
+Common mistakes
+***************
+
+The following are some common sources of difficulty when using `~astropy.coordinates`.
+
+Object Separation
+-----------------
+
+When calculating the separation between objects, it is important to bear in mind that
+:meth:`astropy.coordinates.SkyCoord.separation` gives a different answer depending
+upon the order in which is used. For example::
+
+    >>> import numpy as np
+    >>> from astropy import units as u
+    >>> from astropy.coordinates import SkyCoord, GCRS
+    >>> from astropy.time import Time
+    >>> t = Time("2010-05-22T00:00")
+    >>> moon = SkyCoord(104.29*u.deg, 23.51*u.deg, 359367.3*u.km, frame=GCRS(obstime=t))
+    >>> star = SkyCoord(101.4*u.deg, 23.02*u.deg, frame='icrs')
+    >>> star.separation(moon) # doctest: +FLOAT_CMP
+    <Angle 139.84211884 deg>
+    >>> moon.separation(star) # doctest: +FLOAT_CMP
+    <Angle 2.70390995 deg>
+
+Why do these give such different answers?
+
+The reason is that :meth:`astropy.coordinates.SkyCoord.separation` gives the separation as measured
+in the frame of the |SkyCoord| object. So ``star.separation(moon)`` gives the angular separation
+in the ICRS frame. This is the separation as it would appear from the Solar System Barycenter. For a
+geocentric observer, ``moon.separation(star)`` gives the correct answer, since ``moon`` is in a
+geocentric frame.
+
+AltAz calculations for Earth-based objects
+------------------------------------------
+
+One might expect that the following code snippet would produce an altitude of exactly 90 degrees::
+
+    >>> from astropy.coordinates import EarthLocation
+    >>> from astropy.time import Time
+    >>> from astropy import units as u
+
+    >>> t = Time('J2010')
+    >>> obj = EarthLocation(-1*u.deg, 52*u.deg, height=10.*u.km)
+    >>> home = EarthLocation(-1*u.deg, 52*u.deg, height=0.*u.km)
+    >>> altaz_frame = AltAz(obstime=t, location=home)
+    >>> obj.get_itrs(t).transform_to(altaz_frame).alt # doctest: +FLOAT_CMP
+    <Latitude 86.32878441 deg>
+
+Why is the result over three degrees away from the zenith? It is only possible to understand by taking a very careful
+look at what ``obj.get_itrs(t)`` returns. This call provides the ITRS position of the source ``obj``. ITRS is
+a geocentric coordinate system, and includes the aberration of light. So the code above provides the ITRS position
+of a source that appears directly overhead *for an observer at the geocenter*.
+
+Due to aberration, the actual position of this source will be displaced from its apparent position, by an angle of
+approximately 20.5 arcseconds. Because this source is about one Earth radius away, it's actual position is therefore
+around 600 metres away from where it appears to be. This 600 metre shift, for an object 10 km above the Earth's surface
+is an angular difference of just over three degrees - which is why this object does not appear overhead for a topocentric
+observer - one on the surface of the Earth.
+
+The correct way to construct a |SkyCoord| object for a source that is directly overhead a topocentric observer is
+as follows::
+
+    >>> t = Time('J2010')
+    >>> obj = EarthLocation(-1*u.deg, 52*u.deg, height=10.*u.km)
+    >>> home = EarthLocation(-1*u.deg, 52*u.deg, height=0.*u.km)
+    >>> obsloc_gcrs, obsvel_gcrs = home.get_gcrs_posvel(t)
+    >>> # An object that appears straight overhead - FOR A GEOCENTRIC OBSERVER.
+    >>> gcrs_geo = obj.get_itrs(t).transform_to(GCRS(obstime=t))
+    >>> # The geocentric GCRS position of observatory
+    >>> obsrepr = home.get_itrs(t).transform_to(GCRS(obstime=t)).cartesian
+    >>> # Now we make a GCRS vector of a straight overhead object
+    >>> gcrs_repr = gcrs_geo.cartesian - obsrepr
+    >>> # And create a topocentric GCRS coordinate with this data.
+    >>> # An object that appears straight overhead a topocentric observer
+    >>> topocentric_gcrs_frame = GCRS(obstime=t, obsgeoloc=obsloc_gcrs, obsgeovel=obsvel_gcrs)
+    >>> gcrs_topo = topocentric_gcrs_frame.realize_frame(gcrs_repr)
+    >>> # convert to AltAz
+    >>> aa = gcrs_topo.transform_to(AltAz(obstime=t, location=home))
+    >>> aa.alt # doctest: +FLOAT_CMP
+    <Latitude 90. deg>

--- a/docs/coordinates/common_errors.rst
+++ b/docs/coordinates/common_errors.rst
@@ -39,7 +39,7 @@ AltAz calculations for Earth-based objects
 
 One might expect that the following code snippet would produce an altitude of exactly 90 degrees::
 
-    >>> from astropy.coordinates import EarthLocation
+    >>> from astropy.coordinates import EarthLocation, AltAz
     >>> from astropy.time import Time
     >>> from astropy import units as u
 
@@ -64,20 +64,29 @@ observer - one on the surface of the Earth.
 The correct way to construct a |SkyCoord| object for a source that is directly overhead a topocentric observer is
 as follows::
 
+    >>> from astropy.coordinates import EarthLocation, AltAz
+    >>> from astropy.time import Time
+    >>> from astropy import units as u
+
     >>> t = Time('J2010')
     >>> obj = EarthLocation(-1*u.deg, 52*u.deg, height=10.*u.km)
     >>> home = EarthLocation(-1*u.deg, 52*u.deg, height=0.*u.km)
     >>> obsloc_gcrs, obsvel_gcrs = home.get_gcrs_posvel(t)
+
     >>> # An object that appears straight overhead - FOR A GEOCENTRIC OBSERVER.
     >>> gcrs_geo = obj.get_itrs(t).transform_to(GCRS(obstime=t))
+
     >>> # The geocentric GCRS position of observatory
     >>> obsrepr = home.get_itrs(t).transform_to(GCRS(obstime=t)).cartesian
+
     >>> # Now we make a GCRS vector of a straight overhead object
     >>> gcrs_repr = gcrs_geo.cartesian - obsrepr
+
     >>> # And create a topocentric GCRS coordinate with this data.
     >>> # An object that appears straight overhead a topocentric observer
     >>> topocentric_gcrs_frame = GCRS(obstime=t, obsgeoloc=obsloc_gcrs, obsgeovel=obsvel_gcrs)
     >>> gcrs_topo = topocentric_gcrs_frame.realize_frame(gcrs_repr)
+
     >>> # convert to AltAz
     >>> aa = gcrs_topo.transform_to(AltAz(obstime=t, location=home))
     >>> aa.alt # doctest: +FLOAT_CMP

--- a/docs/coordinates/common_errors.rst
+++ b/docs/coordinates/common_errors.rst
@@ -78,11 +78,9 @@ as follows::
     >>> # Now we create a topocentric coordinate with this data
     >>> # Any topocentric frame will work, we use CIRS
     >>> # Start by transforming the ITRS vector to CIRS
-    >>> cirs_vec = ITRS(obstime=t).realize_frame(itrs_vec).transform_to(CIRS(obstime=t))
-    >>> # Now create a topocentric CIRS frame
-    >>> topocentric_cirs_frame = CIRS(obstime=t, location=home)
+    >>> cirs_vec = ITRS(itrs_vec, obstime=t).transform_to(CIRS(obstime=t)).cartesian
     >>> # Finally, make CIRS frame object with the correct data
-    >>> cirs_topo = topocentric_cirs_frame.realize_frame(cirs_vec.cartesian)
+    >>> cirs_topo = CIRS(cirs_vec, obstime=t, location=home)
 
     >>> # convert to AltAz
     >>> aa = cirs_topo.transform_to(AltAz(obstime=t, location=home))

--- a/docs/coordinates/frames.rst
+++ b/docs/coordinates/frames.rst
@@ -218,7 +218,7 @@ Similar broadcasting happens if you transform to another frame. For example::
     >>> lcoo = coo.transform_to(lf)  # this can load finals2000A.all # doctest: +REMOTE_DATA +IGNORE_OUTPUT
     >>> lcoo  # doctest: +REMOTE_DATA +FLOAT_CMP
     <AltAz Coordinate (obstime=['2012-03-21T00:00:00.000' '2012-06-21T00:00:00.000'], location=(3980608.9024681724, -102.47522910648239, 4966861.273100675) m, pressure=0.0 hPa, temperature=0.0 deg_C, relative_humidity=0.0, obswl=1.0 micron): (az, alt) in deg
-        [( 94.71264944, 89.21424252), (307.69488825, 37.98077771)]>
+        [( 94.71264993, 89.21424259), (307.69488825, 37.98077772)]>
 
 Above, the shapes — ``()`` for ``coo`` and ``(2,)`` for ``lf`` — were
 broadcast against each other. If you wish to determine the positions for a
@@ -241,10 +241,10 @@ set of coordinates, you will need to make sure that the shapes allow this::
       '2012-03-21T00:00:00.000']
      ['2012-06-21T00:00:00.000' '2012-06-21T00:00:00.000'
       '2012-06-21T00:00:00.000']], location=(3980608.90246817, -102.47522911, 4966861.27310068) m, pressure=0.0 hPa, temperature=0.0 deg_C, relative_humidity=0.0, obswl=1.0 micron): (az, alt) in deg
-        [[( 93.09845185, 89.21613128), (126.85789663, 25.4660055 ),
+        [[( 93.09845183, 89.21613128), (126.85789664, 25.4660055 ),
           ( 51.37993234, 37.18532527)],
          [(307.71713698, 37.99437658), (231.3740787 , 26.36768329),
-          ( 85.4218724 , 89.69297998)]]>
+          ( 85.42187236, 89.69297998)]]>
 
 .. Note::
    Frames without data have a ``shape`` that is determined by their frame

--- a/docs/coordinates/index.rst
+++ b/docs/coordinates/index.rst
@@ -474,6 +474,7 @@ listed below.
    spectralcoord
    galactocentric
    remote_methods
+   common_errors
    definitions
    inplace
 

--- a/docs/coordinates/satellites.rst
+++ b/docs/coordinates/satellites.rst
@@ -104,8 +104,8 @@ Or, if you want to find the altitude and azimuth of the satellite from a particu
     >>> siding_spring = EarthLocation.of_site('aao')  # doctest: +SKIP
     >>> aa = teme.transform_to(AltAz(obstime=t, location=siding_spring))  # doctest: +IGNORE_WARNINGS
     >>> aa.alt  # doctest: +FLOAT_CMP
-    <Latitude 10.94798428 deg>
+    <Latitude 10.95229446 deg>
     >>> aa.az  # doctest: +FLOAT_CMP
-    <Longitude 59.28807348 deg>
+    <Longitude 59.30081255 deg>
 
 .. EXAMPLE END


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

As pointed out by @mkbrewer, our lack of topocentric CIRS frames meant that transformations into the AltAz
frames did not properly handle aberration and therefore could be incorrect by several arcseconds for nearby objects like the moon, and up to three degrees for the ridiculous case of an object 10km above the Earth's surface.

This PR adds a topocentric position to the CIRS frame and provides accurate CIRS transformations such that Alt-Az is now comparable to MKB's code to hundredths of a milli-arcsecond, and compares to Skyfield to accuracies of tens of milli-arcseconds, if one disables polar motion.

The cost of this precision is a rather severe slowdown in the transformation code - approximately a factor of 10. This is because the calls to ```erfa.apcs``` and calculation of the celestial-to-intermediate matrix are more expensive that the calls to ```erfa.apci``` we use in the master branch. On the face of it, this trade-off between speed and accuracy would be a challenge for us, but I believe we can sidestep it by implementing the direct ICRS->AltAz transform as requested in #10887, which will make the ICRS->AltAz transform faster than the current master.

An implementation detail that is open for discussion: I chose to specify observer location for CIRS frames using the GCRS position and velocity. This is to make transforms easy, since attributes can be shared between GCRS and CIRS, but also to make it easy to define a frame using `EarthLocation.get_gcrs_posvel`. This is similar to the recently implemented TETE frame.

Pinging @maxnoe here as this touches his Erfa interpolation code.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #10356 and the ancient #4269.