### PR TITLE
Support masked bool data in ASCII files with blank string

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1186,6 +1186,13 @@ astropy.io.ascii
   reading, so we now ignore the parallel option and fall back to serial reading.
   [#10880]
 
+- Fixed a bug where "" (blank string) as input data for a boolean type column
+  was causing an exception instead of indicating a masked value. As a
+  consequence of the fix, the values "0" and "1" are now also allowed as valid
+  inputs for boolean type columns. These new allowed values apply for both ECSV
+  and for basic character-delimited data files ('basic' format with appropriate
+  ``converters`` specified). [#10995]
+
 astropy.io.fits
 ^^^^^^^^^^^^^^^
 

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -944,13 +944,18 @@ def convert_numpy(numpy_type):
         # Try a smaller subset first for a long array
         if len(vals) > 10000:
             svals = numpy.asarray(vals[:1000])
-            if not numpy.all((svals == 'False') | (svals == 'True')):
-                raise ValueError('bool input strings must be only False or True')
+            if not numpy.all((svals == 'False')
+                             | (svals == 'True')
+                             | (svals == '0')
+                             | (svals == '1')):
+                raise ValueError('bool input strings must be False, True, 0, 1, or ""')
         vals = numpy.asarray(vals)
-        trues = vals == 'True'
-        falses = vals == 'False'
+
+        trues = (vals == 'True') | (vals == '1')
+        falses = (vals == 'False') | (vals == '0')
         if not numpy.all(trues | falses):
-            raise ValueError('bool input strings must be only False or True')
+            raise ValueError('bool input strings must be only False, True, 0, 1, or ""')
+
         return trues
 
     def generic_converter(vals):

--- a/astropy/io/ascii/tests/test_ecsv.py
+++ b/astropy/io/ascii/tests/test_ecsv.py
@@ -6,6 +6,7 @@ reader/writer.
 
 Requires `pyyaml <https://pyyaml.org/>`_ to be installed.
 """
+from astropy.table.column import MaskedColumn
 import os
 import copy
 import sys
@@ -581,3 +582,25 @@ def test_round_trip_user_defined_unit(table_cls, tmpdir):
         t4 = table_cls.read(filename)
         assert t4['l'].unit is unit
         assert np.all(t4['l'] == t['l'])
+
+
+@pytest.mark.skipif('not HAS_YAML')
+def test_read_masked_bool():
+    txt = """\
+# %ECSV 0.9
+# ---
+# datatype:
+# - {name: col0, datatype: bool}
+# schema: astropy-2.0
+col0
+1
+0
+True
+""
+False
+"""
+    dat = ascii.read(txt, format='ecsv')
+    col = dat['col0']
+    assert isinstance(col, MaskedColumn)
+    assert np.all(col.mask == [False, False, False, True, False])
+    assert np.all(col == [True, False, True, False, False])


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to address issue #10988 to support nulls in ECSV data.

The implementation brought along another "feature", namely support for "0" and "1" as False and True, respectively. I did not necessarily *want* to make that change, but the way masking is supported in `io.ascii` it was unavoidable without a much larger code change. Masking works by finding empty "" data values and replacing those with the string "0" and setting that entry as masked, so it was necessary to allow "0" as a column value. For symmetry I added "1".  Some people might view this change as a feature.

Once this was done for ECSV it also worked for reading from a regular character-separated data file as long as an appropriate `converters` is provided.

For now I milestoned this for 4.3 because it changes the behavior somewhat. But I can't immediately think of a way this would change existing working code, so maybe it could be a bug-fix for LTS.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #10988
