### PR TITLE
TST: Replace np.bool with bool

### DIFF
--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -1635,7 +1635,7 @@ False   5
     assert col[0] == "1"
 
     # Force col0 to be read as bool
-    converters = {'col0': [convert_numpy(np.bool)]}
+    converters = {'col0': [convert_numpy(bool)]}
     dat = ascii.read(txt, format='basic', converters=converters)
     col = dat['col0']
     assert isinstance(col, MaskedColumn)


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to address numpy-dev failure due to this warning:

```
DeprecationWarning: `np.bool` is a deprecated alias for the builtin `bool`.
Use `bool` by itself, which is identical in behavior, to silence this warning.
If you specifically wanted the numpy scalar type, use `np.bool_` here.
```

Example log: https://travis-ci.com/github/astropy/astropy/jobs/430645862