### PR TITLE
TST: Handle PY_SSIZE_T_CLEAN warnings

### DIFF
--- a/astropy/visualization/wcsaxes/tests/test_misc.py
+++ b/astropy/visualization/wcsaxes/tests/test_misc.py
@@ -1,7 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-import sys
-
 from packaging.version import Version
 import pytest
 import numpy as np
@@ -22,9 +20,7 @@ from astropy.visualization.wcsaxes.frame import (
 from astropy.visualization.wcsaxes.utils import get_coord_meta
 from astropy.visualization.wcsaxes.transforms import CurvedTransform
 
-mpl_version = Version(matplotlib.__version__)
 ft_version = Version(matplotlib.ft2font.__freetype_version__)
-MATPLOTLIB_LT_31 = mpl_version < Version('3.1')
 FREETYPE_261 = ft_version == Version("2.6.1")
 TEX_UNAVAILABLE = not matplotlib.checkdep_usetex(True)
 
@@ -74,9 +70,6 @@ COORDSYS= 'icrs    '
 """, sep='\n')
 
 
-@pytest.mark.skipif(MATPLOTLIB_LT_31 and sys.version_info >= (3, 8),
-                    reason='PY_SSIZE_T_CLEAN warning with Python 3.8+ and '
-                    'Matplotlib 3.0, GH issue 10954')
 @pytest.mark.parametrize('grid_type', ['lines', 'contours'])
 def test_no_numpy_warnings(ignore_matplotlibrc, tmpdir, grid_type):
     ax = plt.subplot(1, 1, 1, projection=WCS(TARGET_HEADER))
@@ -96,7 +89,8 @@ def test_no_numpy_warnings(ignore_matplotlibrc, tmpdir, grid_type):
         w_msg = str(w.message)
         assert ('converting a masked element to nan' in w_msg or
                 'No contour levels were found within the data range' in w_msg or
-                'np.asscalar(a) is deprecated since NumPy v1.16' in w_msg)
+                'np.asscalar(a) is deprecated since NumPy v1.16' in w_msg or
+                'PY_SSIZE_T_CLEAN will be required' in w_msg)
 
 
 def test_invalid_frame_overlay(ignore_matplotlibrc):

--- a/astropy/visualization/wcsaxes/tests/test_misc.py
+++ b/astropy/visualization/wcsaxes/tests/test_misc.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-import os
 import sys
 
 from packaging.version import Version
@@ -75,8 +74,8 @@ COORDSYS= 'icrs    '
 """, sep='\n')
 
 
-@pytest.mark.skipif(MATPLOTLIB_LT_31 and sys.version_info >= (3, 9),
-                    reason='PY_SSIZE_T_CLEAN warning with Python 3.9 and '
+@pytest.mark.skipif(MATPLOTLIB_LT_31 and sys.version_info >= (3, 8),
+                    reason='PY_SSIZE_T_CLEAN warning with Python 3.8+ and '
                     'Matplotlib 3.0, GH issue 10954')
 @pytest.mark.parametrize('grid_type', ['lines', 'contours'])
 def test_no_numpy_warnings(ignore_matplotlibrc, tmpdir, grid_type):

--- a/setup.cfg
+++ b/setup.cfg
@@ -124,7 +124,6 @@ filterwarnings =
     ignore:Using a non-tuple sequence:FutureWarning:scipy
     ignore:Using or importing the ABCs from 'collections':DeprecationWarning
     ignore:can't resolve package from __spec__
-    ignore:PY_SSIZE_T_CLEAN will be required for '#' formats
     ignore:::astropy.tests.plugins.display
     ignore:::astropy.tests.disable_internet
     ignore:direct construction of Asdf:pytest.PytestDeprecationWarning


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to un-ignore PY_SSIZE_T_CLEAN warnings and handle them. We get reports of these warnings during RC testing because `astropy.test()` ignores `setup.cfg`. I forgot why we ignored this warning, but maybe we don't have to anymore.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #10954

Follow up of #10956 
