### PR TITLE
TST: Relax warning check in remote coordinates test with IERS download

### DIFF
--- a/astropy/coordinates/tests/test_intermediate_transformations.py
+++ b/astropy/coordinates/tests/test_intermediate_transformations.py
@@ -544,7 +544,8 @@ def test_earth_orientation_table(monkeypatch):
         assert n_warnings <= 1, f'Expected at most one warning but got {n_warnings}'
         if n_warnings == 1:
             w_msg = str(warning_lines[0].message)
-            assert 'using local IERS-B' in w_msg, f'Got unexpected warning: {w_msg}'
+            # This also captures unclosed socket warning that is ignored in setup.cfg
+            assert 'using local IERS-B' in w_msg or 'unclosed' in w_msg, f'Got unexpected warning: {w_msg}'
     else:
         assert n_warnings == 0, f'Expected no warning but got {n_warnings}'
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to address the transient remote data failure caused by a warning we cannot control. This warning affects unrelated PRs, causing their remote data jobs to fail.

```
E           astropy.utils.exceptions.AstropyWarning: failed to download
ftp://anonymous:mail%40astropy.org@gdc.cddis.eosdis.nasa.gov/pub/products/iers/finals2000A.all
and https://datacenter.iers.org/data/9/finals2000A.all, using local IERS-B:
<urlopen error Unable to open any source!
Exceptions were {'ftp://anonymous:mail%40astropy.org@gdc.cddis.eosdis.nasa.gov/pub/products/iers/finals2000A.all':
URLError("ftp error: error_temp('425 Security: Bad IP connecting.')"),
'https://datacenter.iers.org/data/9/finals2000A.all':
URLError(gaierror(-5, 'No address associated with hostname'))}>
```

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Example log: https://travis-ci.com/github/astropy/astropy/jobs/432522565