### PR TITLE
Relax tolerances in test_bbox_size on Freetype version mismatch

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,10 @@ astropy.io.ascii
 astropy.io.fits
 ^^^^^^^^^^^^^^^
 
+- Check that the SIMPLE card is present when opening a file, to ensure that the
+  file is a valid FITS file and raise a better error when opening a non FITS
+  one. ``ignore_missing_simple`` can be used to skip this verification. [#10895]
+
 astropy.io.misc
 ^^^^^^^^^^^^^^^
 

--- a/astropy/io/fits/connect.py
+++ b/astropy/io/fits/connect.py
@@ -22,9 +22,7 @@ from .util import first
 
 
 # FITS file signature as per RFC 4047
-FITS_SIGNATURE = (b"\x53\x49\x4d\x50\x4c\x45\x20\x20\x3d\x20\x20\x20\x20\x20"
-                  b"\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20"
-                  b"\x20\x54")
+FITS_SIGNATURE = b'SIMPLE  =                    T'
 
 # Keywords to remove for all tables that are read in
 REMOVE_KEYWORDS = ['XTENSION', 'BITPIX', 'NAXIS', 'NAXIS1', 'NAXIS2',

--- a/astropy/io/fits/connect.py
+++ b/astropy/io/fits/connect.py
@@ -17,12 +17,9 @@ from astropy.utils.exceptions import (AstropyUserWarning,
 from . import HDUList, TableHDU, BinTableHDU, GroupsHDU
 from .column import KEYWORD_NAMES, _fortran_to_python_format
 from .convenience import table_to_hdu
-from .hdu.hdulist import fitsopen as fits_open
+from .hdu.hdulist import fitsopen as fits_open, FITS_SIGNATURE
 from .util import first
 
-
-# FITS file signature as per RFC 4047
-FITS_SIGNATURE = b'SIMPLE  =                    T'
 
 # Keywords to remove for all tables that are read in
 REMOVE_KEYWORDS = ['XTENSION', 'BITPIX', 'NAXIS', 'NAXIS1', 'NAXIS2',

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -405,6 +405,7 @@ class HDUList(list, _Verify):
 
         return cls._readfrom(fileobj=fileobj, mode=mode, memmap=memmap,
                              save_backup=save_backup, cache=cache,
+                             ignore_missing_simple=ignore_missing_simple,
                              lazy_load_hdus=lazy_load_hdus, **kwargs)
 
     @classmethod

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -1075,7 +1075,8 @@ class HDUList(list, _Verify):
             # fromstring case; the data type of ``data`` will be checked in the
             # _BaseHDU.fromstring call.
 
-        if hdulist._file and hdulist._file.readonly:
+        if (hdulist._file and hdulist._file.mode != 'ostream' and
+                hdulist._file.size > 0):
             pos = hdulist._file.tell()
             simple = hdulist._file.read(30)
             match_sig = (simple[:-1] == FITS_SIGNATURE[:-1] and

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -1063,6 +1063,16 @@ class HDUList(list, _Verify):
             # fromstring case; the data type of ``data`` will be checked in the
             # _BaseHDU.fromstring call.
 
+        if hdulist._file and hdulist._file.readonly:
+            pos = hdulist._file.tell()
+            simple = hdulist._file.read(30).decode('ascii')
+            if simple != 'SIMPLE  =                    T':
+                if simple == 'SIMPLE  =                    F':
+                    pass
+                else:
+                    raise Exception
+            hdulist._file.seek(0)
+
         # Store additional keyword args that were passed to fits.open
         hdulist._open_kwargs = kwargs
 

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -87,12 +87,6 @@ def fitsopen(name, mode='readonly', memmap=None, save_backup=False,
 
         .. versionadded:: 1.3
 
-    ignore_missing_simple : bool, optional
-        Do not issue an exception when the SIMPLE keyword is missing.
-        Default is `False`.
-
-        .. versionadded:: 4.2
-
     uint : bool, optional
         Interpret signed integer data where ``BZERO`` is the central value and
         ``BSCALE == 1`` as unsigned integer data.  For example, ``int16`` data
@@ -103,6 +97,12 @@ def fitsopen(name, mode='readonly', memmap=None, save_backup=False,
     ignore_missing_end : bool, optional
         Do not issue an exception when opening a file that is missing an
         ``END`` card in the last header. Default is `False`.
+
+    ignore_missing_simple : bool, optional
+        Do not issue an exception when the SIMPLE keyword is missing.
+        Default is `False`.
+
+        .. versionadded:: 4.2
 
     checksum : bool, str, optional
         If `True`, verifies that both ``DATASUM`` and ``CHECKSUM`` card values

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -31,6 +31,9 @@ except ImportError:
 else:
     HAS_BZ2 = True
 
+# FITS file signature as per RFC 4047
+FITS_SIGNATURE = b'SIMPLE  =                    T'
+
 
 def fitsopen(name, mode='readonly', memmap=None, save_backup=False,
              cache=True, lazy_load_hdus=None, ignore_missing_simple=False,
@@ -1074,25 +1077,16 @@ class HDUList(list, _Verify):
 
         if hdulist._file and hdulist._file.readonly:
             pos = hdulist._file.tell()
-            raise_error = False
+            simple = hdulist._file.read(30)
+            match_sig = (simple[:-1] == FITS_SIGNATURE[:-1] and
+                         simple[-1:] in (b'T', b'F'))
 
-            try:
-                simple = hdulist._file.read(30).decode('ascii')
-            except UnicodeDecodeError:
-                raise_error = True
-            else:
-                if simple != 'SIMPLE  =                    T':
-                    if simple == 'SIMPLE  =                    F':
-                        # This case is managed by _NonstandardHDU
-                        pass
-                    elif not ignore_missing_simple:
-                        raise_error = True
-
-            if raise_error:
+            if not match_sig and not ignore_missing_simple:
                 if hdulist._file.close_on_error:
                     hdulist._file.close()
                 raise OSError('No SIMPLE card found, this file does not '
                               'appear to be a valid FITS file')
+
             hdulist._file.seek(pos)
 
         # Store additional keyword args that were passed to fits.open

--- a/astropy/io/fits/tests/test_hdulist.py
+++ b/astropy/io/fits/tests/test_hdulist.py
@@ -954,10 +954,18 @@ class TestHDUListFunctions(FitsTestCase):
         with open(filename, mode='w', encoding='utf=8') as f:
             f.write('Not a FITS file')
 
+        match = ('No SIMPLE card found, this file '
+                 'does not appear to be a valid FITS file')
+
         # This should raise an OSError because there is no end card.
-        with pytest.raises(OSError, match='No SIMPLE card found, this file '
-                           'does not appear to be a valid FITS file'):
+        with pytest.raises(OSError, match=match):
             fits.open(filename)
+
+        with pytest.raises(OSError, match=match):
+            fits.open(filename, mode='append')
+
+        with pytest.raises(OSError, match=match):
+            fits.open(filename, mode='update')
 
     def test_proper_error_raised_on_invalid_fits_file(self):
         filename = self.temp('bad-fits.fits')
@@ -972,10 +980,18 @@ class TestHDUListFunctions(FitsTestCase):
         with open(filename, mode='wb') as f:
             f.write(buf.read())
 
+        match = ('No SIMPLE card found, this file '
+                 'does not appear to be a valid FITS file')
+
         # This should raise an OSError because there is no end card.
-        with pytest.raises(OSError, match='No SIMPLE card found, this file '
-                           'does not appear to be a valid FITS file'):
+        with pytest.raises(OSError, match=match):
             fits.open(filename)
+
+        with pytest.raises(OSError, match=match):
+            fits.open(filename, mode='append')
+
+        with pytest.raises(OSError, match=match):
+            fits.open(filename, mode='update')
 
         with fits.open(filename, ignore_missing_simple=True) as hdul:
             assert isinstance(hdul[0], _ValidHDU)

--- a/astropy/io/fits/tests/test_hdulist.py
+++ b/astropy/io/fits/tests/test_hdulist.py
@@ -946,9 +946,7 @@ class TestHDUListFunctions(FitsTestCase):
 
         # This should raise an OSError because there is no end card.
         with pytest.raises(OSError):
-            with pytest.warns(AstropyUserWarning, match=r'non-ASCII characters '
-                              r'are present in the FITS file header'):
-                fits.open(filename)
+            fits.open(filename)
 
     def test_no_resource_warning_raised_on_non_fits_file(self):
         """

--- a/astropy/io/fits/tests/test_hdulist.py
+++ b/astropy/io/fits/tests/test_hdulist.py
@@ -939,13 +939,13 @@ class TestHDUListFunctions(FitsTestCase):
         with unicode content that is not actually a FITS file. See:
         https://github.com/astropy/astropy/issues/5594#issuecomment-266583218
         """
-        import codecs
         filename = self.temp('not-fits-with-unicode.fits')
-        with codecs.open(filename, mode='w', encoding='utf=8') as f:
+        with open(filename, mode='w', encoding='utf=8') as f:
             f.write('Ce\xe7i ne marche pas')
 
         # This should raise an OSError because there is no end card.
-        with pytest.raises(OSError):
+        with pytest.raises(OSError, match='No SIMPLE card found, this file '
+                           'does not appear to be a valid FITS file'):
             fits.open(filename)
 
     def test_no_resource_warning_raised_on_non_fits_file(self):

--- a/astropy/visualization/wcsaxes/tests/test_misc.py
+++ b/astropy/visualization/wcsaxes/tests/test_misc.py
@@ -24,7 +24,9 @@ from astropy.visualization.wcsaxes.utils import get_coord_meta
 from astropy.visualization.wcsaxes.transforms import CurvedTransform
 
 mpl_version = Version(matplotlib.__version__)
+ft_version = Version(matplotlib.ft2font.__freetype_version__)
 MATPLOTLIB_LT_31 = mpl_version < Version('3.1')
+FREETYPE_261 = ft_version == Version("2.6.1")
 TEX_UNAVAILABLE = not matplotlib.checkdep_usetex(True)
 
 
@@ -504,13 +506,10 @@ def test_set_labels_with_coords(ignore_matplotlibrc, frame_class):
         assert ax.coords[i].get_axislabel() == labels[i]
 
 
-def test_bbox_size():
-    # Test for the size of a WCSAxes bbox
-    x0 = 11.38888888888889
-    y0 = 3.5
-    # Upper bounding box limits (only have Matplotlib >= 3.0 now)
-    x1 = 576.0
-    y1 = 432.0
+@pytest.mark.parametrize('atol', [0.2, 1.0e-8])
+def test_bbox_size(atol):
+    # Test for the size of a WCSAxes bbox (only have Matplotlib >= 3.0 now)
+    extents = [11.38888888888889, 3.5, 576.0, 432.0]
 
     fig = plt.figure()
     ax = WCSAxes(fig, [0.1, 0.1, 0.8, 0.8])
@@ -518,7 +517,6 @@ def test_bbox_size():
     fig.canvas.draw()
     renderer = fig.canvas.renderer
     ax_bbox = ax.get_tightbbox(renderer)
-    assert np.allclose(ax_bbox.x0, x0)
-    assert np.allclose(ax_bbox.x1, x1)
-    assert np.allclose(ax_bbox.y0, y0)
-    assert np.allclose(ax_bbox.y1, y1)
+    if atol < 0.1 and not FREETYPE_261:
+        pytest.xfail("Exact BoundingBox dimensions are only ensured with FreeType 2.6.1")
+    assert np.allclose(ax_bbox.extents, extents, atol=atol)


### PR DESCRIPTION
### Description
Checks for Freetype library Matplotlib is linked against; if not the reference version 2.6.1 Matplotlib mandates for its own tests to reproduce exact comparison images, allow `test_bbox_size` to check the bounding box extent with relaxed tolerance.

Fixes #11007

This combines several possible approaches to the problem: assuming the failure on Debian is related to its Freetype 2.10, run the test once with wider tolerance and allow it to fail on the stricter comparison. We may only need one of these – assuming the test as introduced by @dstansby in #10797 should assure that the plot fits comfortably within the `tightbbox`, `atol` of 0.1 – 0.2 pt would certainly be always acceptable.