### PR TITLE
Use jyear format instead of decimalyear in apply_space_motion example

### DIFF
--- a/docs/coordinates/apply_space_motion.rst
+++ b/docs/coordinates/apply_space_motion.rst
@@ -147,7 +147,7 @@ epoch provided by the TGAS catalog (J2015.0)::
     ...              distance=Distance(parallax=result_tgas['parallax'] * u.mas),
     ...              pm_ra_cosdec=result_tgas['pmra'] * u.mas/u.yr,
     ...              pm_dec=result_tgas['pmdec'] * u.mas/u.yr,
-    ...              obstime=Time(result_tgas['ref_epoch'], format='decimalyear'))
+    ...              obstime=Time(result_tgas['ref_epoch'], format='jyear'))
 
 We next create a |SkyCoord| object with the sky positions from the 2MASS
 catalog, and an `~astropy.time.Time` object for the date of the 2MASS


### PR DESCRIPTION
This fixes #11009 

As @tboch uncovered and @eerovaher figured out, the example fixed in this PR incorrectly used the decimalyear time format for parsing the Gaia epoch '2015.5', which lead to some confusion when comparing `apply_space_motion()` to other epoch propagation algorithms.
