### PR TITLE
Skip intermittent fail for wheels

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,7 +49,7 @@ jobs:
 
       # FIXME: we exclude the test_data_out_of_range test since it
       # currently fails, see https://github.com/astropy/astropy/issues/10409
-      test_command: pytest -p no:warnings --astropy-header -k "not test_data_out_of_range" --pyargs astropy
+      test_command: pytest -p no:warnings --astropy-header -k "not test_data_out_of_range" -k "not test_datetime_difference_agrees_with_timedelta" --pyargs astropy
       test_extras: test
 
       # NOTE: for v* tags, we auto-release to PyPI. See


### PR DESCRIPTION
https://github.com/astropy/astropy/issues/10724 is causing some of the nightly wheel builds to fail, so skip it.