### PR TITLE
VOTable unit format

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,6 +38,8 @@ astropy.io.misc
 astropy.io.votable
 ^^^^^^^^^^^^^^^^^^
 
+- Version 1.4 VOTables now use the VOUnit format specification. [#11032]
+
 astropy.modeling
 ^^^^^^^^^^^^^^^^
 

--- a/astropy/io/votable/exceptions.py
+++ b/astropy/io/votable/exceptions.py
@@ -1039,9 +1039,10 @@ class W49(VOTableSpecWarning):
 
 class W50(VOTableSpecWarning):
     """
-    Invalid unit string as defined in the `Standards for Astronomical
-    Catalogues, Version 2.0
-    <http://cdsarc.u-strasbg.fr/doc/catstd-3.2.htx>`_.
+    Invalid unit string as defined in the `Units in the VO, Version 1.0
+    <https://www.ivoa.net/documents/VOUnits>`_ (VOTable version >= 1.4)
+    or `Standards for Astronomical Catalogues, Version 2.0
+    <http://cdsarc.u-strasbg.fr/doc/catstd-3.2.htx>`_ (version < 1.4).
 
     Consider passing an explicit ``unit_format`` parameter if the units
     in this file conform to another specification.

--- a/astropy/io/votable/table.py
+++ b/astropy/io/votable/table.py
@@ -93,9 +93,8 @@ def parse(source, columns=None, invalid='exception', verify=None,
         ``vounit``.  A custom formatter may be provided by passing a
         `~astropy.units.UnitBase` instance.  If `None` (default),
         the unit format to use will be the one specified by the
-        VOTable specification (which is ``cds`` up to version 1.2 of
-        VOTable, and (probably) ``vounit`` in future versions of the
-        spec).
+        VOTable specification (which is ``cds`` up to version 1.3 of
+        VOTable, and ``vounit`` in more recent versions of the spec).
 
     datatype_mapping : dict of str to str, optional
         A mapping of datatype names to valid VOTable datatype names.

--- a/astropy/io/votable/tests/tree_test.py
+++ b/astropy/io/votable/tests/tree_test.py
@@ -30,3 +30,24 @@ def test_make_Fields():
 
     table.fields.extend([tree.Field(
         votable, name='Test', datatype="float", unit="mag")])
+
+
+def test_unit_format():
+    from astropy.io.votable.table import parse
+    from astropy.utils.data import get_pkg_data_filename
+
+    data = parse(get_pkg_data_filename('data/irsa-nph-error.xml'))
+    assert data._config['version'] == '1.0'
+    assert tree._get_default_unit_format(data._config) == 'cds'
+    data = parse(get_pkg_data_filename('data/names.xml'))
+    assert data._config['version'] == '1.1'
+    assert tree._get_default_unit_format(data._config) == 'cds'
+    data = parse(get_pkg_data_filename('data/gemini.xml'))
+    assert data._config['version'] == '1.2'
+    assert tree._get_default_unit_format(data._config) == 'cds'
+    data = parse(get_pkg_data_filename('data/binary2_masked_strings.xml'))
+    assert data._config['version'] == '1.3'
+    assert tree._get_default_unit_format(data._config) == 'cds'
+    data = parse(get_pkg_data_filename('data/timesys.xml'))
+    assert data._config['version'] == '1.4'
+    assert tree._get_default_unit_format(data._config) == 'vounit'

--- a/astropy/io/votable/tests/tree_test.py
+++ b/astropy/io/votable/tests/tree_test.py
@@ -2,7 +2,9 @@
 
 from astropy.io.votable import exceptions
 from astropy.io.votable import tree
+from astropy.io.votable.table import parse
 from astropy.tests.helper import raises
+from astropy.utils.data import get_pkg_data_filename
 
 
 @raises(exceptions.W07)
@@ -33,9 +35,6 @@ def test_make_Fields():
 
 
 def test_unit_format():
-    from astropy.io.votable.table import parse
-    from astropy.utils.data import get_pkg_data_filename
-
     data = parse(get_pkg_data_filename('data/irsa-nph-error.xml'))
     assert data._config['version'] == '1.0'
     assert tree._get_default_unit_format(data._config) == 'cds'

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -166,9 +166,12 @@ def _get_default_unit_format(config):
     """
     Get the default unit format as specified in the VOTable spec.
     """
-    # In the future, this should take into account the VOTable
-    # version.
-    return 'cds'
+    # The unit format changed between VOTable versions 1.3 and 1.4,
+    # see issue #10791.
+    if config['version_1_4_or_later']:
+        return 'vounit'
+    else:
+        return 'cds'
 
 
 def _get_unit_format(config):

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -1152,8 +1152,8 @@ class Field(SimpleElement, _IDProperty, _NameProperty, _XtypeProperty,
                  xtype=None,
                  config=None, pos=None, **extra):
         if config is None:
-            if hasattr(votable, '_get_version_flags'):
-                config = votable._get_version_flags()
+            if hasattr(votable, '_get_version_checks'):
+                config = votable._get_version_checks()
             else:
                 config = {}
         self._config = config
@@ -3511,7 +3511,7 @@ class VOTableFile(Element, _IDProperty, _DescriptionProperty):
         self.groups.append(group)
         group.parse(iterator, config)
 
-    def _get_version_flags(self):
+    def _get_version_checks(self):
         config = {}
         config['version_1_1_or_later'] = \
             util.version_compare(self.version, '1.1') >= 0
@@ -3566,7 +3566,7 @@ class VOTableFile(Element, _IDProperty, _DescriptionProperty):
                     break
                 else:
                     vo_raise(E19, (), config, pos)
-        config.update(self._get_version_flags())
+        config.update(self._get_version_checks())
 
         tag_mapping = {
             'PARAM': self._add_param,
@@ -3624,7 +3624,7 @@ class VOTableFile(Element, _IDProperty, _DescriptionProperty):
                 tabledata_format,
             '_debug_python_based_parser': _debug_python_based_parser,
             '_group_number': 1}
-        kwargs.update(self._get_version_flags())
+        kwargs.update(self._get_version_checks())
 
         with util.convert_to_writable_filelike(
             fd, compressed=compressed) as fd:

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -124,13 +124,13 @@ def test_votable_quantity_write(tmpdir):
     (io/fits/tests/test_connect.py and io/misc/tests/test_hdf5.py).
     """
     t = QTable()
-    t['a'] = u.Quantity([1, 2, 4], unit='Angstrom')
+    t['a'] = u.Quantity([1, 2, 4], unit='m')
 
     filename = str(tmpdir.join('table-tmp'))
     t.write(filename, format='votable', overwrite=True)
     qt = QTable.read(filename, format='votable')
     assert isinstance(qt['a'], u.Quantity)
-    assert qt['a'].unit == 'Angstrom'
+    assert qt['a'].unit == 'm'
 
 
 @pytest.mark.remote_data

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -124,13 +124,13 @@ def test_votable_quantity_write(tmpdir):
     (io/fits/tests/test_connect.py and io/misc/tests/test_hdf5.py).
     """
     t = QTable()
-    t['a'] = u.Quantity([1, 2, 4], unit='m')
+    t['a'] = u.Quantity([1, 2, 4], unit='nm')
 
     filename = str(tmpdir.join('table-tmp'))
     t.write(filename, format='votable', overwrite=True)
     qt = QTable.read(filename, format='votable')
     assert isinstance(qt['a'], u.Quantity)
-    assert qt['a'].unit == 'm'
+    assert qt['a'].unit == 'nm'
 
 
 @pytest.mark.remote_data

--- a/docs/units/format.rst
+++ b/docs/units/format.rst
@@ -141,7 +141,7 @@ formats:
     Données astronomiques de Strasbourg
     <http://vizier.u-strasbg.fr/vizier/doc/catstd-3.2.htx>`_: This is the
     standard used by `Vizier tables <http://vizier.u-strasbg.fr/>`__,
-    as well as what is used by VOTable versions 1.2 and earlier.
+    as well as what is used by VOTable versions 1.3 and earlier.
 
   - ``"ogip"``: A standard for storing units as recommended by the
     `Office of Guest Investigator Programs (OGIP)


### PR DESCRIPTION
The unit format of a VOTable is version dependent. Astropy has the capability of parsing the new unit format, but nonetheless assumes all VOTables are using the old unit specification.

This pull request would make Astropy use the old `'cds'` unit format up until VOTable version 1.3 and the new `'vounit'` unit format starting from VOTable version 1.4.

Addresses #10791