### PR TITLE
TST: Allow remote data job to fail, cron org

### DIFF
--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -1,4 +1,4 @@
-name: cron_daily
+name: Daily cron
 
 on:
   schedule:

--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -1,9 +1,9 @@
-name: cron_daily
+name: cron_weekly
 
 on:
   schedule:
-    # run every day at 3am UTC
-    - cron: '0 3 * * *'
+    # run every Monday at 6am UTC
+    - cron: '0 6 * * 1'
 
 jobs:
   tests:
@@ -14,20 +14,17 @@ jobs:
       matrix:
         include:
 
-          # We check numpy-dev also in a job that only runs from cron, so that
-          # we can spot issues sooner. We do not use remote data here, since
-          # that gives too many false positives due to URL timeouts. We also
-          # install all dependencies via pip here so we pick up the latest
-          # releases.
-          - name: Python 3.7 with dev version of key dependencies
+          - name: Documentation link check
             os: ubuntu-latest
             python: 3.7
-            toxenv: py37-test-devdeps
+            toxenv: linkcheck
 
-          - name: Bundling with pyinstaller
+          # TODO: Bump Python when 3.10a is out.
+          # Test against Python dev in cron job.
+          - name: Python dev with basic dependencies
             os: ubuntu-latest
-            python: 3.8
-            toxenv: pyinstaller
+            python: 3.9-dev
+            toxenv: pydev-test
 
     steps:
     - name: Checkout code
@@ -41,6 +38,9 @@ jobs:
     - name: Install language-pack-de and tzdata
       if: ${{ matrix.os == 'ubuntu-latest' }}
       run: sudo apt-get install language-pack-de tzdata
+    - name: Install graphviz
+      if: ${{ matrix.toxenv == 'linkcheck' }}
+      run: sudo apt-get install graphviz
     - name: Install Python dependencies
       run: python -m pip install --upgrade tox codecov
     - name: Run tests

--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -1,4 +1,4 @@
-name: cron_weekly
+name: Weekly cron
 
 on:
   schedule:

--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -19,12 +19,12 @@ jobs:
             python: 3.7
             toxenv: linkcheck
 
-          # TODO: Bump Python when 3.10a is out.
+          # TODO: Uncomment when 3.10 is more mature. Should we use devdeps?
           # Test against Python dev in cron job.
-          - name: Python dev with basic dependencies
-            os: ubuntu-latest
-            python: 3.9-dev
-            toxenv: pydev-test
+          #- name: Python dev with basic dependencies
+          #  os: ubuntu-latest
+          #  python: 3.10-dev
+          #  toxenv: pydev-test
 
     steps:
     - name: Checkout code

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -52,7 +52,7 @@ jobs:
           - name: Python 3.7 with all optional dependencies (MacOS X)
             os: macos-latest
             python: 3.7
-            toxenv: py37-test-devdeps
+            toxenv: py37-test-alldeps
 
     steps:
     - name: Checkout code

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -9,8 +9,7 @@ jobs:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     strategy:
-      # TODO: Change to true when we know how to handle remote data job correctly
-      fail-fast: false
+      fail-fast: true
       matrix:
         include:
 
@@ -55,13 +54,6 @@ jobs:
             python: 3.7
             toxenv: py37-test-devdeps
 
-          - name: Python 3.7 with remote data and dev version of key dependencies
-            os: ubuntu-latest
-            python: 3.7
-            toxenv: py37-test-devdeps
-            toxposargs: --remote-data=any
-
-
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
@@ -84,3 +76,33 @@ jobs:
       uses: codecov/codecov-action@v1
       with:
         file: ./coverage.xml
+
+  allowed_failures:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: (Allowed Failure) Python 3.7 with remote data and dev version of key dependencies
+            os: ubuntu-latest
+            python: 3.7
+            toxenv: py37-test-devdeps
+            toxposargs: --remote-data=any
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python }}
+    - name: Install language-pack-de and tzdata
+      if: startsWith(matrix.os, 'ubuntu')
+      run: sudo apt-get install language-pack-de tzdata
+    - name: Install Python dependencies
+      run: python -m pip install --upgrade tox codecov
+    - name: Run tests
+      run: tox ${{ matrix.toxargs }} -e ${{ matrix.toxenv }} -- ${{ matrix.toxposargs }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,7 +98,7 @@ Other Tips
 ----------
 
 - Behind the scenes, we conduct a number of tests or checks with new pull requests.
-  This is a technique that is called continuous integration, and we use Travis CI
+  This is a technique that is called continuous integration, and we use GitHub Actions
   and CircleCI. To prevent the automated tests from running, you can add ``[ci skip]``
   to your commit message. This is useful if your PR is a work in progress (WIP) and
   you are not yet ready for the tests to run. For example:
@@ -110,8 +110,9 @@ Other Tips
 
         $ git commit --amend
 
-- To skip only the tests running on Travis CI use ``[skip travis]``.
-  This will still execute CircleCI.
+- Unfortunately, GitHub Actions ignores ``[ci skip]`` for a PR, so we recommend
+  you only push your commits to GitHub when you are ready for the CI to run.
+  Please do not push a lot of commits for every small WIP changes.
 
 - If your commit makes substantial changes to the documentation but no code
   changes, then you can use ``[ci skip]``, which will skip all CI except RTD,
@@ -180,6 +181,6 @@ package.
   * Are there any conflicts with this code and existing codes?
 
 **Astropy requirements**
-  * Do all the Travis CI and CircleCI tests pass?
+  * Do all the GitHub Actions and CircleCI tests pass? If not, are they allowed to fail?
   * If applicable, has an entry been added into the changelog?
   * Can you check out the pull request and repeat the examples and tests?

--- a/astropy/coordinates/tests/test_earth.py
+++ b/astropy/coordinates/tests/test_earth.py
@@ -8,7 +8,6 @@ import pickle
 import pytest
 import numpy as np
 
-
 from astropy.coordinates.earth import EarthLocation, ELLIPSOIDS
 from astropy.coordinates.angles import Longitude, Latitude
 from astropy.units import allclose as quantity_allclose
@@ -287,7 +286,7 @@ def test_repr_latex():
 
 @pytest.mark.remote_data
 # TODO: this parametrize should include a second option with a valid Google API
-# key. For example, we should make an API key for Astropy, and add it to Travis
+# key. For example, we should make an API key for Astropy, and add it to GitHub Actions
 # as an environment variable (for security).
 @pytest.mark.parametrize('google_api_key', [None])
 def test_of_address(google_api_key):
@@ -303,7 +302,7 @@ def test_of_address(google_api_key):
     try:
         loc = EarthLocation.of_address("New York, NY")
     except NameResolveError as e:
-        # API limit might surface even here in Travis CI.
+        # API limit might surface even here in CI.
         if 'unknown failure with' not in str(e):
             pytest.xfail(str(e))
     else:

--- a/astropy/coordinates/tests/test_intermediate_transformations.py
+++ b/astropy/coordinates/tests/test_intermediate_transformations.py
@@ -25,7 +25,7 @@ from astropy.coordinates.builtin_frames.utils import get_jd12
 from astropy.coordinates import solar_system_ephemeris
 from astropy.units import allclose
 
-TRAVIS = os.environ.get('TRAVIS', False) == "true"
+CI = os.environ.get('CI', False) == "true"
 
 try:
     import jplephem  # pylint: disable=W0611  # noqa
@@ -540,7 +540,7 @@ def test_earth_orientation_table(monkeypatch):
 
     # Server occasionally blocks IERS download in CI.
     n_warnings = len(warning_lines)
-    if TRAVIS:
+    if CI:
         assert n_warnings <= 1, f'Expected at most one warning but got {n_warnings}'
         if n_warnings == 1:
             w_msg = str(warning_lines[0].message)

--- a/astropy/io/ascii/tests/test_c_reader.py
+++ b/astropy/io/ascii/tests/test_c_reader.py
@@ -21,7 +21,7 @@ from .common import assert_equal, assert_almost_equal, assert_true
 
 
 StringIO = lambda x: BytesIO(x.encode('ascii'))  # noqa
-TRAVIS = os.environ.get('TRAVIS', False)
+CI = os.environ.get('CI', False)
 
 
 def assert_table_equal(t1, t2, check_meta=False, rtol=1.e-15, atol=1.e-300):
@@ -71,8 +71,8 @@ def _read(tmpdir, table, Reader=None, format=None, parallel=False, check_meta=Fa
     assert_table_equal(t4, t5, check_meta=check_meta)
 
     if parallel:
-        if TRAVIS:
-            pytest.xfail("Multiprocessing can sometimes fail on Travis CI")
+        if CI:
+            pytest.xfail("Multiprocessing can sometimes fail on CI")
         t6 = ascii.read(table, format=format, guess=False, fast_reader={
             'parallel': True}, **kwargs)
         assert_table_equal(t1, t6, check_meta=check_meta)
@@ -1071,8 +1071,8 @@ def test_data_out_of_range(parallel, fast_reader, guess):
     if parallel:
         if not fast_reader:
             pytest.skip("Multiprocessing only available in fast reader")
-        elif TRAVIS:
-            pytest.xfail("Multiprocessing can sometimes fail on Travis CI")
+        elif CI:
+            pytest.xfail("Multiprocessing can sometimes fail on CI")
 
     test_for_warnings = fast_reader and not parallel
 
@@ -1150,8 +1150,8 @@ def test_data_at_range_limit(parallel, fast_reader, guess):
     if parallel:
         if not fast_reader:
             pytest.skip("Multiprocessing only available in fast reader")
-        elif TRAVIS:
-            pytest.xfail("Multiprocessing can sometimes fail on Travis CI")
+        elif CI:
+            pytest.xfail("Multiprocessing can sometimes fail on CI")
 
     # Test very long fixed-format strings (to strtod range limit w/o Overflow)
     for D in 99, 202, 305:
@@ -1296,8 +1296,8 @@ def test_fortran_invalid_exp(parallel, guess):
     exponent-like patterns (no triple-digits) to make sure they are returned
     as strings instead, as with the standard C parser.
     """
-    if parallel and TRAVIS:
-        pytest.xfail("Multiprocessing can sometimes fail on Travis CI")
+    if parallel and CI:
+        pytest.xfail("Multiprocessing can sometimes fail on CI")
 
     formats = {'basic': ' ', 'tab': '\t', 'csv': ','}
     header = ['S1', 'F2', 'S2', 'F3', 'S3', 'F4', 'F5', 'S4', 'I1', 'F6', 'F7']

--- a/astropy/utils/iers/tests/test_iers.py
+++ b/astropy/utils/iers/tests/test_iers.py
@@ -14,7 +14,7 @@ from astropy import units as u
 from astropy.table import QTable
 from astropy.time import Time, TimeDelta
 
-TRAVIS = os.environ.get('TRAVIS', False)
+CI = os.environ.get('CI', False)
 
 FILE_NOT_FOUND_ERROR = getattr(__builtins__, 'FileNotFoundError', OSError)
 
@@ -345,7 +345,7 @@ def test_IERS_B_parameters_loading_into_IERS_Auto():
 
 
 # Issue with FTP, rework test into previous one when it's fixed
-@pytest.mark.skipif("TRAVIS", reason="Flaky on Travis CI")
+@pytest.mark.skipif("CI", reason="Flaky on CI")
 @pytest.mark.remote_data
 def test_iers_a_dl():
     iersa_tab = iers.IERS_A.open(iers.IERS_A_URL, cache=False)

--- a/astropy/utils/iers/tests/test_leap_second.py
+++ b/astropy/utils/iers/tests/test_leap_second.py
@@ -209,7 +209,7 @@ class TestDefaultAutoOpen:
         assert ls.meta['data_url'] == iers.IERS_LEAP_SECOND_FILE
 
     # The test below is marked remote_data only to ensure it runs
-    # as an allowed-fail job on travis: i.e., we will notice it (eventually)
+    # as an allowed-fail job on CI: i.e., we will notice it (eventually)
     # but will not be misled in thinking that a PR is bad.
     @pytest.mark.remote_data
     def test_builtin_not_expired(self):

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -58,7 +58,6 @@ from astropy.utils.data import (
     is_url
 )
 
-TRAVIS = os.environ.get('TRAVIS', False) == "true"
 CI = os.environ.get('CI', False) == "true"
 TESTURL = "http://www.astropy.org"
 TESTURL2 = "http://www.astropy.org/about.html"
@@ -390,7 +389,7 @@ def test_download_with_sources_and_bogus_original(
 
 
 @pytest.mark.skipif((3, 7) <= sys.version_info < (3, 8) or
-                    (sys.platform.startswith('win') and TRAVIS),
+                    (sys.platform.startswith('win') and CI),
                     reason="mystery segfault that is possibly bug #10008 "
                            "for python < 3.8, flaky cache error on Windows CI")
 def test_download_file_threaded_many(temp_cache, valid_urls):
@@ -411,7 +410,7 @@ def test_download_file_threaded_many(temp_cache, valid_urls):
 
 
 @pytest.mark.skipif((3, 7) <= sys.version_info < (3, 8) or
-                    (sys.platform.startswith('win') and TRAVIS),
+                    (sys.platform.startswith('win') and CI),
                     reason="mystery segfault that is possibly bug #10008 "
                            "for python < 3.8, flaky cache error on Windows CI")
 def test_threaded_segfault(valid_urls):
@@ -429,7 +428,7 @@ def test_threaded_segfault(valid_urls):
 
 
 @pytest.mark.skipif((3, 7) <= sys.version_info < (3, 8) or
-                    (sys.platform.startswith('win') and TRAVIS),
+                    (sys.platform.startswith('win') and CI),
                     reason="mystery segfault that is possibly bug #10008 "
                            "for python < 3.8, flaky cache error on Windows CI")
 def test_download_file_threaded_many_partial_success(
@@ -2128,7 +2127,7 @@ def test_clear_download_cache_variants(temp_cache, valid_urls):
     assert not is_url_in_cache(u)
 
 
-@pytest.mark.skipif("TRAVIS", reason="Flaky on Travis CI")
+@pytest.mark.skipif("CI", reason="Flaky on CI")
 @pytest.mark.remote_data
 def test_ftp_tls_auto(temp_cache):
     url = "ftp://anonymous:mail%40astropy.org@gdc.cddis.eosdis.nasa.gov/pub/products/iers/finals2000A.all"  # noqa

--- a/astropy/wcs/tests/extension/test_extension.py
+++ b/astropy/wcs/tests/extension/test_extension.py
@@ -50,14 +50,13 @@ def test_wcsapi_extension(tmpdir):
     # dependencies necessary to compile an extension may be missing.
     # If it passes, however, we want to continue and ensure that the
     # extension created is actually usable.  However, if we're on
-    # Travis-CI, or another generic continuous integration setup, we
+    # continuous integration setup, we
     # don't want to ever skip, because having it fail in that
     # environment probably indicates something more serious that we
     # want to know about.
     if (not ('CI' in os.environ or
-             'TRAVIS' in os.environ or
              'CONTINUOUS_INTEGRATION' in os.environ) and
-        p.returncode):
+            p.returncode):
         pytest.skip("system unable to compile extensions")
         return
 

--- a/docs/development/astropy-package-template.rst
+++ b/docs/development/astropy-package-template.rst
@@ -28,7 +28,7 @@ by ``CHANGES.md`` in the instructions.
           we recommend that you read over the more complete astropy
           :doc:`releasing` and adapt them for your package.
 
-#. Make sure that Travis and any other continuous integration is passing.
+#. Make sure that continuous integration is passing.
 
 #. Update the ``CHANGES.rst`` file to make sure that all the changes are listed,
    and update the release date, which should currently be set to

--- a/docs/development/releasing.rst
+++ b/docs/development/releasing.rst
@@ -82,7 +82,7 @@ packages that use the full bugfix/maintenance branch approach.)
 
       $ git checkout v1.2.x
 
-#. Make sure that the continuous integration services (e.g., Travis or CircleCI) are passing
+#. Make sure that the continuous integration services (e.g., GitHub Actions or CircleCI) are passing
    for the `astropy core repository`_ branch you are going to release. Also check that
    the `Azure core package pipeline`_ which builds wheels on the ``v*`` branches is passing.
    You may also want to locally run the tests (with remote data on to ensure all

--- a/docs/development/testguide.rst
+++ b/docs/development/testguide.rst
@@ -1063,10 +1063,10 @@ Astropy uses the following continuous integration (CI) services:
 
 * `GitHub Actions <https://github.com/astropy/astropy/actions>`_ for
   64-bit Linux, OS X, and Windows setups
-  * Note: GitHub Actions does not have "allowed failures" yet, so you might
-    see a fail job reported for your PR with "(Allowed Failure)" in its name.
-    Still, some failures might be real and related to your changes, so check
-    it anyway!
+  (Note: GitHub Actions does not have "allowed failures" yet, so you might
+  see a fail job reported for your PR with "(Allowed Failure)" in its name.
+  Still, some failures might be real and related to your changes, so check
+  it anyway!)
 * `CircleCI <https://circleci.com>`_ for 32-bit Linux,
   documentation build, and visualization tests
 

--- a/docs/development/testguide.rst
+++ b/docs/development/testguide.rst
@@ -1061,8 +1061,12 @@ Overview
 
 Astropy uses the following continuous integration (CI) services:
 
-* `Travis <https://travis-ci.org/astropy/astropy>`_ for
+* `GitHub Actions <https://github.com/astropy/astropy/actions>`_ for
   64-bit Linux, OS X, and Windows setups
+  * Note: GitHub Actions does not have "allowed failures" yet, so you might
+    see a fail job reported for your PR with "(Allowed Failure)" in its name.
+    Still, some failures might be real and related to your changes, so check
+    it anyway!
 * `CircleCI <https://circleci.com>`_ for 32-bit Linux,
   documentation build, and visualization tests
 
@@ -1071,12 +1075,10 @@ pushed to GitHub to notice when something breaks.
 
 Astropy and many affiliated packages use an external package called
 `ci-helpers <https://github.com/astropy/ci-helpers>`_ to provide
-support for the generic parts of the CI systems. ``ci-helpers`` consists of
-a set of scripts that are used by the ``.travis.yml`` and ``appveyor.yml``
-files to set up the conda environment, and install dependencies.
+support for the generic parts of the CI systems.
 
 Dependencies can be customized for different packages using the appropriate
-environment variables in ``.travis.yml`` and ``appveyor.yml``. For more
+environment variables in the relevant YAML files. For more
 details on how to set up this machinery, see the `package-template
 <https://github.com/astropy/package-template>`_ and `ci-helpers`_.
 


### PR DESCRIPTION
* Allow remote data job to fail, while not letting it block the rest of the jobs that have "fail fast" on.
* Split cron jobs into daily and weekly.
* Downgrade Python dev to 3.9-dev. Also see #10875

**Out of scope:** Fixing failing cron and remote-data jobs. We can do that in separate PRs. The main goal for this PR is to allow the "fail fast" mode so we don't waste CPU cycles.

**TODO:**

- [ ] Get approval.
- [x] Add doc to ask people not to panic at the ❌ for allowed failure.

<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

This is a direct follow up of #10388 .