### PR TITLE
Make sure access to Header items is case insensitive

### DIFF
--- a/astropy/io/fits/header.py
+++ b/astropy/io/fits/header.py
@@ -73,6 +73,11 @@ class Header:
         ...
 
     See the Astropy documentation for more details on working with headers.
+
+    Notes
+    -----
+    Although FITS keywords must be exclusively upper case, retrieving an item
+    in a `Header` object is case insensitive.
     """
 
     def __init__(self, cards=[], copy=False):

--- a/astropy/io/fits/tests/test_header.py
+++ b/astropy/io/fits/tests/test_header.py
@@ -77,6 +77,18 @@ class TestHeaderFunctions(FitsTestCase):
         assert header['B'] == 'B'
         assert header.comments['B'] == 'C'
 
+    @pytest.mark.parametrize('key', ['A', 'a'])
+    def test_indexing_case(self, key):
+        """Check that indexing is case insensitive"""
+        header = fits.Header([('A', 'B', 'C'), ('D', 'E', 'F')])
+        assert key in header
+        assert header[key] == 'B'
+        assert header.get(key) == 'B'
+        assert header.index(key) == 0
+        assert header.comments[key] == 'C'
+        assert header.count(key) == 1
+        header.remove(key, ignore_missing=False)
+
     def test_card_constructor_default_args(self):
         """Test Card constructor with default argument values."""
 


### PR DESCRIPTION
Fixes https://github.com/astropy/astropy/issues/11031. This adds a test to check that access is case insensitive, and adds a note to the `Header` docstring.