### PR TITLE
MNT: test LogStretch without all in-place operations

### DIFF
--- a/astropy/visualization/stretch.py
+++ b/astropy/visualization/stretch.py
@@ -416,10 +416,16 @@ class LogStretch(BaseStretch):
         with np.errstate(invalid='ignore'):
             if replace_invalid:
                 idx = (values < 0)
-            np.multiply(values, self.exp, out=values)
-            np.add(values, 1., out=values)
-            np.log(values, out=values)
-            np.true_divide(values, np.log(self.exp + 1.), out=values)
+            if out is None:
+                values = np.multiply(values, self.exp)
+                values = np.add(values, 1.)
+                values = np.log(values)
+                values = np.true_divide(values, np.log(self.exp + 1.))
+            else:
+                np.multiply(values, self.exp, out=values)
+                np.add(values, 1., out=values)
+                np.log(values, out=values)
+                np.true_divide(values, np.log(self.exp + 1.), out=values)
 
         if replace_invalid:
             # Assign new NaN (i.e., NaN not in the original input


### PR DESCRIPTION
Experimental PR to probe `RuntimeWarning: divide by zero encountered in log` seen in dumpy-dev Github Actions job and addressed in #11042.
Appears to be related to `values` array not being fully updated before the `np.log` call with only the `devdeps` Numpy version on the GH build host; just testing here if calling numpy functions without in-place operations changes results.
Not sure how to proceed if it does...