### PR TITLE
Restrict builds on push events to master

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -2,6 +2,9 @@ name: CI
 
 on:
   push:
+    branches:
+    - master
+    tags:
   pull_request:
 
 jobs:


### PR DESCRIPTION
This is to avoid running Actions twice, when pushing a branch and opening a PR.

This double build was also happening sometimes with Travis when pushing a branch directly on the repo and could be avoided with a 
```
branches:
  only:
  - master
```
block.

The difference with Actions is that it is also activated by default on forks, so when pushing a branch to a fork and opening a PR the workflow is run twice, on the fork (push event) and on the main repo (pull_request event).

Note: we should allow the maintenance branch if we backport Actions (#11050).