### PR TITLE
Deprecate "accuracy" in all_world2pix

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -80,9 +80,6 @@ astropy.wcs
 ^^^^^^^^^^^
 - Add IVOA UCD mappings for some FITS WCS keywords commonly used in solar physics. [#10965]
 
-- Deprecate ``accuracy`` argument in ``all_world2pix`` which was mistakenly
-  *documented*, in the case ``accuracy`` was ever used. [#11055]
-
 API Changes
 -----------
 
@@ -167,6 +164,9 @@ astropy.visualization
 
 astropy.wcs
 ^^^^^^^^^^^
+
+- Deprecate ``accuracy`` argument in ``all_world2pix`` which was mistakenly
+  *documented*, in the case ``accuracy`` was ever used. [#11055]
 
 
 Bug Fixes

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -80,6 +80,9 @@ astropy.wcs
 ^^^^^^^^^^^
 - Add IVOA UCD mappings for some FITS WCS keywords commonly used in solar physics. [#10965]
 
+- Deprecate ``accuracy`` argument in ``all_world2pix`` which was mistakenly
+  *documented*, in the case ``accuracy`` was ever used. [#11055]
+
 API Changes
 -----------
 

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -50,6 +50,7 @@ from . import _wcs
 from astropy import units as u
 from astropy.utils.compat import possible_filename
 from astropy.utils.exceptions import AstropyWarning, AstropyUserWarning, AstropyDeprecationWarning
+from astropy.utils.decorators import deprecated_renamed_argument
 
 # Mix-in class that provides the APE 14 API
 from .wcsapi.fitswcs import FITSWCSAPIMixin, SlicedFITSWCS
@@ -1878,6 +1879,7 @@ reduce these to 2 dimensions using the naxis kwarg.
 
         return pix
 
+    @deprecated_renamed_argument('accuracy', 'tolerance', '4.3')
     def all_world2pix(self, *args, tolerance=1e-4, maxiter=20, adaptive=False,
                       detect_divergence=True, quiet=False, **kwargs):
         if self.wcs is None:
@@ -1893,7 +1895,7 @@ reduce these to 2 dimensions using the naxis kwarg.
         )
 
     all_world2pix.__doc__ = """
-        all_world2pix(*arg, accuracy=1.0e-4, maxiter=20,
+        all_world2pix(*arg, tolerance=1.0e-4, maxiter=20,
         adaptive=False, detect_divergence=True, quiet=False)
 
         Transforms world coordinates to pixel coordinates, using


### PR DESCRIPTION
Docstring for `WCS.all_world2pix()`  incorrectly uses ``accuracy`` instead of ``tolerance`` in the function signature. Assuming there are any users who might have used ``accuracy`` based on this incorrect documentation. 