### PR TITLE
Run cron workflows only on the main repo

### DIFF
--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -9,6 +9,7 @@ jobs:
   tests:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
+    if: github.repository == 'astropy/astropy'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -9,6 +9,7 @@ jobs:
   tests:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
+    if: github.repository == 'astropy/astropy'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
To avoid running cron jobs on forks (see discussion in https://github.com/astropy/astropy/pull/11054#issuecomment-729001804).

_edit:_ I canceled the normal workflow since it is not affected by this.