### PR TITLE
Use EarthLocation instead of GCRS position for TETE observer.

### DIFF
--- a/astropy/coordinates/builtin_frames/equatorial.py
+++ b/astropy/coordinates/builtin_frames/equatorial.py
@@ -11,13 +11,13 @@ TETE is a True equator, True Equinox coordinate frame often called the
 and can be combined with Local Apparent Sideral Time to calculate the
 hour angle.
 """
-import astropy.units as u
+
 from astropy.utils.decorators import format_doc
 from astropy.coordinates.representation import (CartesianRepresentation, CartesianDifferential)
 from astropy.coordinates.baseframe import BaseCoordinateFrame, base_doc
 from astropy.coordinates.builtin_frames.baseradec import BaseRADecFrame, doc_components
-from astropy.coordinates.attributes import TimeAttribute, CartesianRepresentationAttribute
-from .utils import DEFAULT_OBSTIME
+from astropy.coordinates.attributes import TimeAttribute, EarthLocationAttribute
+from .utils import DEFAULT_OBSTIME, EARTH_CENTER
 
 __all__ = ['TEME', 'TETE']
 
@@ -35,18 +35,11 @@ doc_footer_tete = """
     obstime : `~astropy.time.Time`
         The time at which the observation is taken.  Used for determining the
         position of the Earth.
-    obsgeoloc : `~astropy.coordinates.CartesianRepresentation`, `~astropy.units.Quantity`
-        The position of the observer relative to the center-of-mass of the
-        Earth, oriented the same as GCRS. Either [0, 0, 0],
-        `~astropy.coordinates.CartesianRepresentation`, or proper input for one,
-        i.e., a `~astropy.units.Quantity` with shape (3, ...) and length units.
-        Defaults to [0, 0, 0], meaning a geocentric observer.
-    obsgeovel : `~astropy.coordinates.CartesianRepresentation`, `~astropy.units.Quantity`
-        The velocity of the observer relative to the center-of-mass of the
-        Earth, oriented the same as GCRS. Either [0, 0, 0],
-        `~astropy.coordinates.CartesianRepresentation`, or proper input for one,
-        i.e., a `~astropy.units.Quantity` with shape (3, ...) and velocity
-        units.  Defaults to [0, 0, 0], meaning a geocentric observer.
+    location : `~astropy.coordinates.EarthLocation`
+        The location on the Earth.  This can be specified either as an
+        `~astropy.coordinates.EarthLocation` object or as anything that can be
+        transformed to an `~astropy.coordinates.ITRS` frame. The default is the
+        centre of the Earth.
 """
 
 
@@ -84,10 +77,7 @@ class TETE(BaseRADecFrame):
     """
 
     obstime = TimeAttribute(default=DEFAULT_OBSTIME)
-    obsgeoloc = CartesianRepresentationAttribute(default=[0, 0, 0],
-                                                 unit=u.m)
-    obsgeovel = CartesianRepresentationAttribute(default=[0, 0, 0],
-                                                 unit=u.m/u.s)
+    location = EarthLocationAttribute(default=EARTH_CENTER)
 
 # Self transform goes through ICRS and is defined in icrs_cirs_transforms.py
 

--- a/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
@@ -271,9 +271,8 @@ def hcrs_to_hcrs(from_coo, to_frame):
 
 @frame_transform_graph.transform(FunctionTransformWithFiniteDifference, TETE, TETE)
 def tete_to_tete(from_coo, to_frame):
-    if (np.all(from_coo.obstime == to_frame.obstime) and
-            np.all(from_coo.obsgeoloc == to_frame.obsgeoloc) and
-            np.all(from_coo.obsgeovel == to_frame.obsgeovel)):
+    if (np.all(from_coo.location == to_frame.location)
+            and np.all(from_coo.obstime == to_frame.obstime)):
         return to_frame.realize_frame(from_coo.data)
     else:
         # We perform the self-transform through ICRS, since any change in obstime

--- a/astropy/coordinates/builtin_frames/intermediate_rotation_transforms.py
+++ b/astropy/coordinates/builtin_frames/intermediate_rotation_transforms.py
@@ -85,21 +85,37 @@ def gcrs_precession_mat(equinox):
     return erfa.fw2m(gamb, phib, psib, epsa)
 
 
+def get_location_gcrs(reference, gcrs_to_reference_matrix):
+    """Create a GCRS frame at the location and obstime of a given reference.
+
+    Helper function that avoids location.get_gcrs (which would trigger
+    infinite recursion in some cases), and uses an already calculated
+    GCRS to Reference matrix to calculate obsgeoloc and obsgeovel
+    required for GCRS.
+    """
+    # TODO: ideally, GCRS and other frames would share how they describe
+    # the location.  See gh-10996.
+    obstime = reference.obstime
+    gcrs_cart = (reference.location.get_itrs(obstime, include_velocity=True)
+                 .transform_to(reference.__class__(obstime=obstime))
+                 .cartesian
+                 .transform(matrix_transpose(gcrs_to_reference_matrix)))
+    return GCRS(obstime=obstime,
+                obsgeoloc=gcrs_cart.without_differentials(),
+                obsgeovel=gcrs_cart.differentials['s'].to_cartesian())
+
+
 # now the actual transforms
 
 @frame_transform_graph.transform(FunctionTransformWithFiniteDifference, GCRS, TETE)
 def gcrs_to_tete(gcrs_coo, tete_frame):
-    # first apply GCRS self transform to correct time and observatory position/velocity
-    obsgeoloc, obsgeovel = tete_frame.location.get_gcrs_posvel(tete_frame.obstime)
-    gcrs_coo2 = gcrs_coo.transform_to(GCRS(obstime=tete_frame.obstime,
-                                           obsgeoloc=obsgeoloc,
-                                           obsgeovel=obsgeovel))
-
-    jd1, jd2 = get_jd12(tete_frame.obstime, 'tt')
     # Classical NPB matrix, IAU 2006/2000A
     # (same as in builtin_frames.utils.get_cip).
-    rbpn = erfa.pnm06a(jd1, jd2)
-
+    rbpn = erfa.pnm06a(*get_jd12(tete_frame.obstime, 'tt'))
+    # Get GCRS coordinates for the target observer location and time.
+    loc_gcrs = get_location_gcrs(tete_frame, rbpn)
+    gcrs_coo2 = gcrs_coo.transform_to(loc_gcrs)
+    # Now we are relative to the correct observer, do the transform to TETE.
     # These rotations are defined at the geocenter, but can be applied to
     # topocentric positions as well, assuming rigid Earth. See p57 of
     # https://www.usno.navy.mil/USNO/astronomical-applications/publications/Circular_179.pdf
@@ -109,19 +125,14 @@ def gcrs_to_tete(gcrs_coo, tete_frame):
 
 @frame_transform_graph.transform(FunctionTransformWithFiniteDifference, TETE, GCRS)
 def tete_to_gcrs(tete_coo, gcrs_frame):
-    # compute the pn matrix, and then multiply by its transpose
-
-    jd1, jd2 = get_jd12(tete_coo.obstime, 'tt')
-    # Classical NPB matrix, IAU 2006/2000A
-    # (same as in builtin_frames.utils.get_cip).
-    rbpn = erfa.pnm06a(jd1, jd2)
+    # Compute the pn matrix, and then multiply by its transpose.
+    rbpn = erfa.pnm06a(*get_jd12(tete_coo.obstime, 'tt'))
     newrepr = tete_coo.cartesian.transform(matrix_transpose(rbpn))
-
-    obsgeoloc, obsgeovel = tete_coo.location.get_gcrs_posvel(tete_coo.obstime)
-    gcrs = GCRS(newrepr, obstime=tete_coo.obstime,
-                obsgeoloc=obsgeoloc, obsgeovel=obsgeovel)
-
-    # now do any needed offsets (no-op if same obstime and 0 pos/vel)
+    # We now have a GCRS vector for the input location and obstime.
+    # Turn it into a GCRS frame instance.
+    loc_gcrs = get_location_gcrs(tete_coo, rbpn)
+    gcrs = loc_gcrs.realize_frame(newrepr)
+    # Finally, do any needed offsets (no-op if same obstime and location)
     return gcrs.transform_to(gcrs_frame)
 
 
@@ -148,31 +159,12 @@ def itrs_to_tete(itrs_coo, tete_frame):
     return tete.transform_to(tete_frame)
 
 
-def get_location_gcrs(location, obstime, gcrs_to_cirs_matrix):
-    """Create a GCRS frame at given location and obstime.
-
-    Helper function that avoids location.get_gcrs (which would
-    trigger infinite recursion), and uses the already calculated
-    GCRS to CIRS matrix to calculate obsgeoloc and obsgeovel
-    required for GCRS.
-    """
-    # TODO: ideally, GCRS would just use a location too;
-    # See gh-10996.
-    gcrs_cart = (location.get_itrs(obstime, include_velocity=True)
-                 .transform_to(CIRS(obstime=obstime))
-                 .cartesian
-                 .transform(matrix_transpose(gcrs_to_cirs_matrix)))
-    return GCRS(obstime=obstime,
-                obsgeoloc=gcrs_cart.without_differentials(),
-                obsgeovel=gcrs_cart.differentials['s'].to_cartesian())
-
-
 @frame_transform_graph.transform(FunctionTransformWithFiniteDifference, GCRS, CIRS)
 def gcrs_to_cirs(gcrs_coo, cirs_frame):
     # first get the pmatrix
     pmat = gcrs_to_cirs_mat(cirs_frame.obstime)
     # Get GCRS coordinates for the target observer location and time.
-    loc_gcrs = get_location_gcrs(cirs_frame.location, cirs_frame.obstime, pmat)
+    loc_gcrs = get_location_gcrs(cirs_frame, pmat)
     gcrs_coo2 = gcrs_coo.transform_to(loc_gcrs)
     # Now we are relative to the correct observer, do the transform to CIRS.
     crepr = gcrs_coo2.cartesian.transform(pmat)
@@ -181,13 +173,14 @@ def gcrs_to_cirs(gcrs_coo, cirs_frame):
 
 @frame_transform_graph.transform(FunctionTransformWithFiniteDifference, CIRS, GCRS)
 def cirs_to_gcrs(cirs_coo, gcrs_frame):
-    # compute the pmatrix, and then multiply by its transpose
+    # Compute the pmatrix, and then multiply by its transpose,
     pmat = gcrs_to_cirs_mat(cirs_coo.obstime)
     newrepr = cirs_coo.cartesian.transform(matrix_transpose(pmat))
-    # Transform to GCRS but still at the CIRS location and obstime.
-    loc_gcrs = get_location_gcrs(cirs_coo.location, cirs_coo.obstime, pmat)
+    # We now have a GCRS vector for the input location and obstime.
+    # Turn it into a GCRS frame instance.
+    loc_gcrs = get_location_gcrs(cirs_coo, pmat)
     gcrs = loc_gcrs.realize_frame(newrepr)
-    # now do any needed offsets (no-op if same obstime and pos/vel)
+    # Finally, do any needed offsets (no-op if same obstime and location)
     return gcrs.transform_to(gcrs_frame)
 
 

--- a/astropy/coordinates/tests/test_intermediate_transformations.py
+++ b/astropy/coordinates/tests/test_intermediate_transformations.py
@@ -619,9 +619,9 @@ def test_tete_transforms():
     gcrs_frame = GCRS(obstime=time, obsgeoloc=p, obsgeovel=v)
     moon = SkyCoord(169.24113968*u.deg, 10.86086666*u.deg, 358549.25381755*u.km, frame=gcrs_frame)
 
-    tete_frame = TETE(obstime=time, obsgeoloc=p, obsgeovel=v)
+    tete_frame = TETE(obstime=time, location=loc)
     # need to set obsgeoloc/vel explicity or skycoord behaviour over-writes
-    tete_geo = TETE(obstime=time, obsgeoloc=[0, 0, 0]*u.km, obsgeovel=[0, 0, 0]*u.km/u.s)
+    tete_geo = TETE(obstime=time, location=EarthLocation(*([0, 0, 0]*u.km)))
 
     # test self-transform by comparing to GCRS-TETE-ITRS-TETE route
     tete_coo1 = moon.transform_to(tete_frame)

--- a/astropy/coordinates/tests/test_solar_system.py
+++ b/astropy/coordinates/tests/test_solar_system.py
@@ -76,8 +76,7 @@ def test_positions_skyfield(tmpdir):
     skyfield_moon = earth.at(skyfield_t).observe(moon).apparent()
 
     if location is not None:
-        obsgeoloc, obsgeovel = location.get_gcrs_posvel(t)
-        frame = TETE(obstime=t, obsgeoloc=obsgeoloc, obsgeovel=obsgeovel)
+        frame = TETE(obstime=t, location=location)
     else:
         frame = TETE(obstime=t)
 
@@ -202,9 +201,7 @@ class TestPositionKittPeak:
                                                 lat=31.963333333333342*u.deg,
                                                 height=2120*u.m)
         self.t = Time('2014-09-25T00:00', location=kitt_peak)
-        obsgeoloc, obsgeovel = kitt_peak.get_gcrs_posvel(self.t)
-        self.apparent_frame = TETE(obstime=self.t,
-                                   obsgeoloc=obsgeoloc, obsgeovel=obsgeovel)
+        self.apparent_frame = TETE(obstime=self.t, location=kitt_peak)
         # Results returned by JPL Horizons web interface
         self.horizons = {
             'mercury': SkyCoord(ra='13h38m58.50s', dec='-13d34m42.6s',
@@ -319,7 +316,7 @@ def test_horizons_consistency_with_precision():
         times = Time('2020-04-06 00:00') + np.arange(0, 24, 1)*u.hour
         astropy = get_body('moon', times, loc)
 
-        apparent_frame = TETE(obstime=times, obsgeoloc=astropy.obsgeoloc, obsgeovel=astropy.obsgeovel)
+        apparent_frame = TETE(obstime=times, location=loc)
         astropy = astropy.transform_to(apparent_frame)
         usrepr = UnitSphericalRepresentation(ra_apparent_horizons, dec_apparent_horizons)
         horizons = apparent_frame.realize_frame(usrepr)


### PR DESCRIPTION
As discussed in #10994 and #10996, the TETE frame that was introduced for 4.2 should more logically use `EarthLocation` to indicate the location of the observer, instead of `obsgeoloc` and `obsgeovel`. This PR makes that change.

One important question is whether this can still be included in 4.2, even though it is *very* late. The main advantage is that in that case we do not have to deprecate `obsgeoloc` and `obsgeovel`. (The PR is only a bug fix in this regard.)

Input from @astropy/core-release-maintainers much appreciated!!

cc @mkbrewer, @StuartLittlefair 