### PR TITLE
Fix leap second update when using a non english locale

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -68,9 +68,9 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python }}
-    - name: Install language-pack-de and tzdata
+    - name: Install language-pack-fr and tzdata
       if: startsWith(matrix.os, 'ubuntu')
-      run: sudo apt-get install language-pack-de tzdata
+      run: sudo apt-get install language-pack-fr tzdata
     - name: Install Python dependencies
       run: python -m pip install --upgrade tox codecov
     - name: Run tests

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1110,6 +1110,8 @@ astropy.tests
 astropy.time
 ^^^^^^^^^^^^
 
+- Fix leap second update when using a non english locale. [#11062]
+
 astropy.timeseries
 ^^^^^^^^^^^^^^^^^^
 

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -1290,9 +1290,9 @@ def test_non_C_locale_with_fast_reader():
 
     try:
         if platform.system() == 'Darwin':
-            locale.setlocale(locale.LC_ALL, 'de_DE')
+            locale.setlocale(locale.LC_ALL, 'fr_FR')
         else:
-            locale.setlocale(locale.LC_ALL, 'de_DE.utf8')
+            locale.setlocale(locale.LC_ALL, 'fr_FR.utf8')
 
         for fast_reader in (True,
                             False,

--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -76,6 +76,9 @@ suppressed by setting the auto_max_age configuration variable to
   conf.auto_max_age = None
 """
 
+MONTH_ABBR = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug',
+              'Sep', 'Oct', 'Nov', 'Dec']
+
 
 def download_file(*args, **kwargs):
     """
@@ -1031,9 +1034,10 @@ class LeapSeconds(QTable):
             for line in lines:
                 match = cls._re_expires.match(line)
                 if match:
-                    expires = Time.strptime(match.groups()[0], '%d %B %Y',
-                                            scale='tai', format='iso',
-                                            out_subfmt='date')
+                    day, month, year = match.groups()[0].split()
+                    month_nb = MONTH_ABBR.index(month[:3]) + 1
+                    expires = Time(f'{year}-{month_nb:02d}-{day}',
+                                   scale='tai', out_subfmt='date')
                     break
             else:
                 raise ValueError(f'did not find expiration date in {file}')

--- a/astropy/utils/tests/test_misc.py
+++ b/astropy/utils/tests/test_misc.py
@@ -89,8 +89,8 @@ def test_set_locale():
     # First, test if the required locales are available
     current = locale.setlocale(locale.LC_ALL)
     try:
-        locale.setlocale(locale.LC_ALL, 'en_US')
-        locale.setlocale(locale.LC_ALL, 'de_DE')
+        locale.setlocale(locale.LC_ALL, 'en_US.utf8')
+        locale.setlocale(locale.LC_ALL, 'fr_FR.utf8')
     except locale.Error as e:
         pytest.skip(f'Locale error: {e}')
     finally:
@@ -99,11 +99,11 @@ def test_set_locale():
     date = datetime(2000, 10, 1, 0, 0, 0)
     day_mon = date.strftime('%a, %b')
 
-    with misc._set_locale('en_US'):
+    with misc._set_locale('en_US.utf8'):
         assert date.strftime('%a, %b') == 'Sun, Oct'
 
-    with misc._set_locale('de_DE'):
-        assert date.strftime('%a, %b') == 'So, Okt'
+    with misc._set_locale('fr_FR.utf8'):
+        assert date.strftime('%a, %b') == 'dim., oct.'
 
     # Back to original
     assert date.strftime('%a, %b') == day_mon


### PR DESCRIPTION
I'm working on a documentation, and for every build I see the leap second update with an expiration warning:
```
Downloading https://hpiers.obspm.fr/iers/bul/bulc/Leap_Second.dat
|==========================================================| 1.3k/1.3k (100.00%)         0s
Downloading https://www.ietf.org/timezones/data/leap-seconds.list [Done]
WARNING: IERSStaleWarning: leap-second file is expired. [astropy.utils.iers.iers]
```
I already saw this in the past, so this is not new, but I never took the time to investigate... I can reproduce with various documentations ([1](https://github.com/GeminiDRSoftware/DRAGONS/tree/master/astrodata/doc/ad_ProgManual), [2](https://github.com/GeminiDRSoftware/DRAGONS/tree/master/astrodata/doc/ad_UserManual), [3](https://github.com/musevlt/origin/tree/master/docs)), but the weird thing is that there is no warning when importing directly astropy.

Putting some prints in `LeapSeconds.auto_open` gives this for a normal import:
```
❯ python -c "import astropy.coordinates.earth_orientation"
open erfa
expires: 2017-06-30 00:00:00.000
open /home/simon/dev/astropy/astropy/utils/iers/data/Leap_Second.dat
expires: 2021-06-28
```
which is fine. And this for a Sphinx build:
```
open erfa
expires: 2017-06-30 00:00:00.000
open /home/simon/dev/astropy/astropy/utils/iers/data/Leap_Second.dat
ERROR: time data '28 June 2021' does not match format '%d %B %Y'
open https://hpiers.obspm.fr/iers/bul/bulc/Leap_Second.dat
ERROR: time data '28 June 2021' does not match format '%d %B %Y'
open https://hpiers.obspm.fr/iers/bul/bulc/Leap_Second.dat
Downloading https://hpiers.obspm.fr/iers/bul/bulc/Leap_Second.dat
|==========================================================| 1.3k/1.3k (100.00%)         0s
ERROR: time data '28 June 2021' does not match format '%d %B %Y'
open https://www.ietf.org/timezones/data/leap-seconds.list
Downloading https://www.ietf.org/timezones/data/leap-seconds.list [Done]
ERROR: time data '28 June 2021' does not match format '%d %B %Y'
WARNING: IERSStaleWarning: leap-second file is expired. [astropy.utils.iers.iers]
```
So when running with Sphinx, there is a parsing error with the `Leap_Second.dat` file, which lead to this:
```
ipdb> Time.strptime('28 June 2021', '%d %B %Y', scale='tai', format='iso', out_subfmt='date')
*** ValueError: time data '28 June 2021' does not match format '%d %B %Y'
```

`%B` is the _Locale's full month name_, but in both case my locale if `fr_FR`.
Diving deeper leads to [_strptime.py](https://github.com/astropy/astropy/blob/master/astropy/extern/_strptime.py) where `_getlang` returns `None` in one case and `fr_FR` in the other, the latter resulting in a regex with French month names :tada:
And I guess Sphinx is setting `LC_TIME` to the default locale, which triggers the error in `_strptime.py`.