### PR TITLE
Backport cirs tete precision

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,16 @@
+4.2RC2 (unreleased)
+===================
+
+Bug Fixes
+---------
+
+astropy.coordinates
+^^^^^^^^^^^^^^^^^^^
+
+- Allow topocentric ``CIRS`` frames to avoid precision loss in ``AltAz``
+  calculations. With this, they are now accurate down to the milli-arcsecond
+  level. [#10994]
+
 4.2RC1 (2020-11-06)
 ===================
 

--- a/astropy/coordinates/builtin_frames/cirs.py
+++ b/astropy/coordinates/builtin_frames/cirs.py
@@ -2,10 +2,11 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 from astropy.utils.decorators import format_doc
-from astropy.coordinates.attributes import TimeAttribute
+from astropy.coordinates.attributes import (TimeAttribute,
+                                            EarthLocationAttribute)
 from astropy.coordinates.baseframe import base_doc
 from .baseradec import doc_components, BaseRADecFrame
-from .utils import DEFAULT_OBSTIME
+from .utils import DEFAULT_OBSTIME, EARTH_CENTER
 
 __all__ = ['CIRS']
 
@@ -16,6 +17,11 @@ doc_footer = """
     obstime : `~astropy.time.Time`
         The time at which the observation is taken.  Used for determining the
         position of the Earth and its precession.
+    location : `~astropy.coordinates.EarthLocation`
+        The location on the Earth.  This can be specified either as an
+        `~astropy.coordinates.EarthLocation` object or as anything that can be
+        transformed to an `~astropy.coordinates.ITRS` frame. The default is the
+        centre of the Earth.
 """
 
 
@@ -28,7 +34,7 @@ class CIRS(BaseRADecFrame):
     """
 
     obstime = TimeAttribute(default=DEFAULT_OBSTIME)
-
+    location = EarthLocationAttribute(default=EARTH_CENTER)
 
 # The "self-transform" is defined in icrs_cirs_transformations.py, because in
 # the current implementation it goes through ICRS (like GCRS)

--- a/astropy/coordinates/builtin_frames/cirs_observed_transforms.py
+++ b/astropy/coordinates/builtin_frames/cirs_observed_transforms.py
@@ -22,35 +22,23 @@ from ..erfa_astrom import erfa_astrom
 
 @frame_transform_graph.transform(FunctionTransformWithFiniteDifference, CIRS, AltAz)
 def cirs_to_altaz(cirs_coo, altaz_frame):
-    if np.any(cirs_coo.obstime != altaz_frame.obstime):
-        # the only frame attribute for the current CIRS is the obstime, but this
-        # would need to be updated if a future change allowed specifying an
-        # Earth location algorithm or something
-        cirs_coo = cirs_coo.transform_to(CIRS(obstime=altaz_frame.obstime))
-
-    # we use the same obstime everywhere now that we know they're the same
-    obstime = cirs_coo.obstime
+    if (np.any(altaz_frame.location != cirs_coo.location) or
+            np.any(cirs_coo.obstime != altaz_frame.obstime)):
+        cirs_coo = cirs_coo.transform_to(CIRS(obstime=altaz_frame.obstime,
+                                              location=altaz_frame.location))
 
     # if the data are UnitSphericalRepresentation, we can skip the distance calculations
     is_unitspherical = (isinstance(cirs_coo.data, UnitSphericalRepresentation) or
                         cirs_coo.cartesian.x.unit == u.one)
 
-    if is_unitspherical:
-        usrepr = cirs_coo.represent_as(UnitSphericalRepresentation)
-        cirs_ra = usrepr.lon.to_value(u.radian)
-        cirs_dec = usrepr.lat.to_value(u.radian)
-    else:
-        # compute an "astrometric" ra/dec -i.e., the direction of the
-        # displacement vector from the observer to the target in CIRS
-        loccirs = altaz_frame.location.get_itrs(cirs_coo.obstime).transform_to(cirs_coo)
-        diffrepr = (cirs_coo.cartesian - loccirs.cartesian).represent_as(UnitSphericalRepresentation)
-
-        cirs_ra = diffrepr.lon.to_value(u.radian)
-        cirs_dec = diffrepr.lat.to_value(u.radian)
+    # We used to do "astrometric" corrections here, but these are no longer necesssary
+    # CIRS has proper topocentric behaviour
+    usrepr = cirs_coo.represent_as(UnitSphericalRepresentation)
+    cirs_ra = usrepr.lon.to_value(u.radian)
+    cirs_dec = usrepr.lat.to_value(u.radian)
 
     # first set up the astrometry context for CIRS<->AltAz
-    astrom = erfa_astrom.get().apio13(altaz_frame)
-
+    astrom = erfa_astrom.get().apio(altaz_frame)
     az, zen, _, _, _ = erfa.atioq(cirs_ra, cirs_dec, astrom)
 
     if is_unitspherical:
@@ -58,13 +46,10 @@ def cirs_to_altaz(cirs_coo, altaz_frame):
                                           lon=u.Quantity(az, u.radian, copy=False),
                                           copy=False)
     else:
-        # now we get the distance as the cartesian distance from the earth
-        # location to the coordinate location
-        locitrs = altaz_frame.location.get_itrs(obstime)
-        distance = locitrs.separation_3d(cirs_coo)
+        # since we've transformed to CIRS at the observatory location, just use CIRS distance
         rep = SphericalRepresentation(lat=u.Quantity(PIOVER2 - zen, u.radian, copy=False),
                                       lon=u.Quantity(az, u.radian, copy=False),
-                                      distance=distance,
+                                      distance=cirs_coo.distance,
                                       copy=False)
     return altaz_frame.realize_frame(rep)
 
@@ -76,26 +61,20 @@ def altaz_to_cirs(altaz_coo, cirs_frame):
     zen = PIOVER2 - usrepr.lat.to_value(u.radian)
 
     # first set up the astrometry context for ICRS<->CIRS at the altaz_coo time
-    astrom = erfa_astrom.get().apio13(altaz_coo)
+    astrom = erfa_astrom.get().apio(altaz_coo)
 
     # the 'A' indicates zen/az inputs
-    cirs_ra, cirs_dec = erfa.atoiq('A', az, zen, astrom)*u.radian
+    cirs_ra, cirs_dec = erfa.atoiq('A', az, zen, astrom) << u.radian
     if isinstance(altaz_coo.data, UnitSphericalRepresentation) or altaz_coo.cartesian.x.unit == u.one:
-        cirs_at_aa_time = CIRS(ra=cirs_ra, dec=cirs_dec, distance=None,
-                               obstime=altaz_coo.obstime)
+        distance = None
     else:
-        # treat the output of atoiq as an "astrometric" RA/DEC, so to get the
-        # actual RA/Dec from the observers vantage point, we have to reverse
-        # the vector operation of cirs_to_altaz (see there for more detail)
+        distance = altaz_coo.distance
 
-        loccirs = altaz_coo.location.get_itrs(altaz_coo.obstime).transform_to(cirs_frame)
+    cirs_at_aa_time = CIRS(ra=cirs_ra, dec=cirs_dec, distance=distance,
+                           obstime=altaz_coo.obstime,
+                           location=altaz_coo.location)
 
-        astrometric_rep = SphericalRepresentation(lon=cirs_ra, lat=cirs_dec,
-                                                  distance=altaz_coo.distance)
-        newrepr = astrometric_rep + loccirs.cartesian
-        cirs_at_aa_time = CIRS(newrepr, obstime=altaz_coo.obstime)
-
-    # this final transform may be a no-op if the obstimes are the same
+    # this final transform may be a no-op if the obstimes and locations are the same
     return cirs_at_aa_time.transform_to(cirs_frame)
 
 

--- a/astropy/coordinates/builtin_frames/equatorial.py
+++ b/astropy/coordinates/builtin_frames/equatorial.py
@@ -11,13 +11,13 @@ TETE is a True equator, True Equinox coordinate frame often called the
 and can be combined with Local Apparent Sideral Time to calculate the
 hour angle.
 """
-import astropy.units as u
+
 from astropy.utils.decorators import format_doc
 from astropy.coordinates.representation import (CartesianRepresentation, CartesianDifferential)
 from astropy.coordinates.baseframe import BaseCoordinateFrame, base_doc
 from astropy.coordinates.builtin_frames.baseradec import BaseRADecFrame, doc_components
-from astropy.coordinates.attributes import TimeAttribute, CartesianRepresentationAttribute
-from .utils import DEFAULT_OBSTIME
+from astropy.coordinates.attributes import TimeAttribute, EarthLocationAttribute
+from .utils import DEFAULT_OBSTIME, EARTH_CENTER
 
 __all__ = ['TEME', 'TETE']
 
@@ -35,18 +35,11 @@ doc_footer_tete = """
     obstime : `~astropy.time.Time`
         The time at which the observation is taken.  Used for determining the
         position of the Earth.
-    obsgeoloc : `~astropy.coordinates.CartesianRepresentation`, `~astropy.units.Quantity`
-        The position of the observer relative to the center-of-mass of the
-        Earth, oriented the same as GCRS. Either [0, 0, 0],
-        `~astropy.coordinates.CartesianRepresentation`, or proper input for one,
-        i.e., a `~astropy.units.Quantity` with shape (3, ...) and length units.
-        Defaults to [0, 0, 0], meaning a geocentric observer.
-    obsgeovel : `~astropy.coordinates.CartesianRepresentation`, `~astropy.units.Quantity`
-        The velocity of the observer relative to the center-of-mass of the
-        Earth, oriented the same as GCRS. Either [0, 0, 0],
-        `~astropy.coordinates.CartesianRepresentation`, or proper input for one,
-        i.e., a `~astropy.units.Quantity` with shape (3, ...) and velocity
-        units.  Defaults to [0, 0, 0], meaning a geocentric observer.
+    location : `~astropy.coordinates.EarthLocation`
+        The location on the Earth.  This can be specified either as an
+        `~astropy.coordinates.EarthLocation` object or as anything that can be
+        transformed to an `~astropy.coordinates.ITRS` frame. The default is the
+        centre of the Earth.
 """
 
 
@@ -84,10 +77,7 @@ class TETE(BaseRADecFrame):
     """
 
     obstime = TimeAttribute(default=DEFAULT_OBSTIME)
-    obsgeoloc = CartesianRepresentationAttribute(default=[0, 0, 0],
-                                                 unit=u.m)
-    obsgeovel = CartesianRepresentationAttribute(default=[0, 0, 0],
-                                                 unit=u.m/u.s)
+    location = EarthLocationAttribute(default=EARTH_CENTER)
 
 # Self transform goes through ICRS and is defined in icrs_cirs_transforms.py
 

--- a/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
@@ -34,7 +34,7 @@ from ..erfa_astrom import erfa_astrom
 @frame_transform_graph.transform(FunctionTransformWithFiniteDifference, ICRS, CIRS)
 def icrs_to_cirs(icrs_coo, cirs_frame):
     # first set up the astrometry context for ICRS<->CIRS
-    astrom = erfa_astrom.get().apci(cirs_frame)
+    astrom = erfa_astrom.get().apco(cirs_frame)
 
     if icrs_coo.data.get_name() == 'unitspherical' or icrs_coo.data.to_cartesian().x.unit == u.one:
         # if no distance, just do the infinite-distance/no parallax calculation
@@ -66,7 +66,7 @@ def icrs_to_cirs(icrs_coo, cirs_frame):
 def cirs_to_icrs(cirs_coo, icrs_frame):
     # set up the astrometry context for ICRS<->cirs and then convert to
     # astrometric coordinate direction
-    astrom = erfa_astrom.get().apci(cirs_coo)
+    astrom = erfa_astrom.get().apco(cirs_coo)
     srepr = cirs_coo.represent_as(SphericalRepresentation)
     i_ra, i_dec = aticq(srepr.without_differentials(), astrom)
 
@@ -96,7 +96,8 @@ def cirs_to_icrs(cirs_coo, icrs_frame):
 
 @frame_transform_graph.transform(FunctionTransformWithFiniteDifference, CIRS, CIRS)
 def cirs_to_cirs(from_coo, to_frame):
-    if np.all(from_coo.obstime == to_frame.obstime):
+    if (np.all(from_coo.location == to_frame.location) and
+            np.all(from_coo.obstime == to_frame.obstime)):
         return to_frame.realize_frame(from_coo.data)
     else:
         # the CIRS<-> CIRS transform actually goes through ICRS.  This has a

--- a/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
@@ -271,9 +271,8 @@ def hcrs_to_hcrs(from_coo, to_frame):
 
 @frame_transform_graph.transform(FunctionTransformWithFiniteDifference, TETE, TETE)
 def tete_to_tete(from_coo, to_frame):
-    if (np.all(from_coo.obstime == to_frame.obstime) and
-            np.all(from_coo.obsgeoloc == to_frame.obsgeoloc) and
-            np.all(from_coo.obsgeovel == to_frame.obsgeovel)):
+    if (np.all(from_coo.location == to_frame.location)
+            and np.all(from_coo.obstime == to_frame.obstime)):
         return to_frame.realize_frame(from_coo.data)
     else:
         # We perform the self-transform through ICRS, since any change in obstime

--- a/astropy/coordinates/builtin_frames/utils.py
+++ b/astropy/coordinates/builtin_frames/utils.py
@@ -12,9 +12,10 @@ import numpy as np
 
 from astropy import units as u
 from astropy.time import Time
+from astropy.coordinates.earth import EarthLocation
 from astropy.utils import iers
 from astropy.utils.exceptions import AstropyWarning
-from ..representation import CartesianRepresentation, CartesianDifferential
+from ..representation import CartesianDifferential
 
 
 # We use tt as the time scale for this equinoxes, primarily because it is the
@@ -28,6 +29,10 @@ EQUINOX_B1950 = Time('B1950', scale='tt')
 # necessary.  Currently, we use J2000.
 DEFAULT_OBSTIME = Time('J2000', scale='tt')
 
+# This is an EarthLocation that is the default "location" when such an attribute is
+# necessary. It is the centre of the Earth.
+EARTH_CENTER = EarthLocation(0*u.km, 0*u.km, 0*u.km)
+
 PIOVER2 = np.pi / 2.
 
 # comes from the mean of the 1962-2014 IERS B data
@@ -36,7 +41,7 @@ _DEFAULT_PM = (0.035, 0.29)*u.arcsec
 
 def get_polar_motion(time):
     """
-    gets the two polar motion components in radians for use with apio13
+    gets the two polar motion components in radians for use with apio
     """
     # Get the polar motion from the IERS table
     iers_table = iers.earth_orientation_table.get()

--- a/astropy/coordinates/earth.py
+++ b/astropy/coordinates/earth.py
@@ -629,7 +629,7 @@ class EarthLocation(u.Quantity):
         """Convert to a tuple with X, Y, and Z as quantities"""
         return (self.x, self.y, self.z)
 
-    def get_itrs(self, obstime=None):
+    def get_itrs(self, obstime=None, include_velocity=False):
         """
         Generates an `~astropy.coordinates.ITRS` object with the location of
         this object at the requested ``obstime``.
@@ -639,6 +639,10 @@ class EarthLocation(u.Quantity):
         obstime : `~astropy.time.Time` or None
             The ``obstime`` to apply to the new `~astropy.coordinates.ITRS`, or
             if None, the default ``obstime`` will be used.
+
+        include_velocity: bool
+            If True, will return an `~astropy.coordinates.ITRS` coordinate
+            with zero velocity, i.e fixed to the Earth's surface.
 
         Returns
         -------
@@ -652,7 +656,11 @@ class EarthLocation(u.Quantity):
 
         # do this here to prevent a series of complicated circular imports
         from .builtin_frames import ITRS
-        return ITRS(x=self.x, y=self.y, z=self.z, obstime=obstime)
+        itrs_coo = ITRS(x=self.x, y=self.y, z=self.z, obstime=obstime)
+        if include_velocity:
+            zeros = np.broadcast_to(0. * (u.km / u.s), (3,) + itrs_coo.shape, subok=True)
+            itrs_coo.data.differentials['s'] = CartesianDifferential(zeros)
+        return itrs_coo
 
     itrs = property(get_itrs, doc="""An `~astropy.coordinates.ITRS` object  with
                                      for the location of this object at the
@@ -673,14 +681,8 @@ class EarthLocation(u.Quantity):
         """
         # do this here to prevent a series of complicated circular imports
         from .builtin_frames import GCRS
-
-        itrs = self.get_itrs(obstime)
-        # Assume the observatory itself is fixed on the ground.
-        # We do a direct assignment rather than an update to avoid validation
-        # and creation of a new object.
-        zeros = np.broadcast_to(0. * u.km / u.s, (3,) + itrs.shape, subok=True)
-        itrs.data.differentials['s'] = CartesianDifferential(zeros)
-        return itrs.transform_to(GCRS(obstime=obstime))
+        return (self.get_itrs(obstime, include_velocity=True)
+                .transform_to(GCRS(obstime=obstime)))
 
     def get_gcrs_posvel(self, obstime):
         """

--- a/astropy/coordinates/solar_system.py
+++ b/astropy/coordinates/solar_system.py
@@ -18,9 +18,9 @@ from astropy.utils.state import ScienceState
 from astropy.utils import indent
 from astropy import units as u
 from astropy.constants import c as speed_of_light
-from .representation import CartesianRepresentation
+from .representation import CartesianRepresentation, CartesianDifferential
 from .orbital_elements import calc_moon
-from .builtin_frames import GCRS, ICRS, TETE
+from .builtin_frames import GCRS, ICRS, ITRS, TETE
 from .builtin_frames.utils import get_jd12
 
 __all__ = ["get_body", "get_moon", "get_body_barycentric",
@@ -525,6 +525,12 @@ def _apparent_position_in_true_coordinates(skycoord):
     Convert Skycoord in GCRS frame into one in which RA and Dec
     are defined w.r.t to the true equinox and poles of the Earth
     """
-    tete_frame = TETE(obstime=skycoord.obstime, obsgeoloc=skycoord.obsgeoloc,
-                      obsgeovel=skycoord.obsgeovel)
+    location = getattr(skycoord, 'location', None)
+    if location is None:
+        gcrs_rep = skycoord.obsgeoloc.with_differentials(
+            {'s': CartesianDifferential.from_cartesian(skycoord.obsgeovel)})
+        location = (GCRS(gcrs_rep, obstime=skycoord.obstime)
+                    .transform_to(ITRS(obstime=skycoord.obstime))
+                    .earth_location)
+    tete_frame = TETE(obstime=skycoord.obstime, location=location)
     return skycoord.transform_to(tete_frame)

--- a/astropy/coordinates/tests/test_erfa_astrom.py
+++ b/astropy/coordinates/tests/test_erfa_astrom.py
@@ -4,7 +4,7 @@ import pytest
 import astropy.units as u
 from astropy.time import Time
 from astropy.utils.exceptions import AstropyWarning
-from astropy.coordinates import EarthLocation, AltAz, GCRS, SkyCoord
+from astropy.coordinates import EarthLocation, AltAz, GCRS, SkyCoord, CIRS
 
 from astropy.coordinates.erfa_astrom import (
     erfa_astrom, ErfaAstrom, ErfaAstromInterpolator
@@ -58,7 +58,7 @@ def test_erfa_astrom():
         interp_300s = coord.transform_to(altaz)
 
     # make sure they are actually different
-    assert np.any(ref.separation(interp_300s) > 0.01 * u.microarcsecond)
+    assert np.any(ref.separation(interp_300s) > 0.005 * u.microarcsecond)
 
     # make sure the resolution is as good as we expect
     assert np.all(ref.separation(interp_300s) < 1 * u.microarcsecond)
@@ -85,8 +85,9 @@ def test_interpolation_nd():
 
         altaz = AltAz(location=fact, obstime=obstime)
         gcrs = GCRS(obstime=obstime)
+        cirs = CIRS(obstime=obstime)
 
-        for frame, tcode in zip([altaz, altaz, gcrs], ['apio13', 'apci', 'apcs']):
+        for frame, tcode in zip([altaz, cirs, gcrs], ['apio', 'apco', 'apcs']):
             without_interp = getattr(provider, tcode)(frame)
             assert without_interp.shape == shape
 

--- a/astropy/coordinates/tests/test_intermediate_transformations.py
+++ b/astropy/coordinates/tests/test_intermediate_transformations.py
@@ -15,11 +15,11 @@ from astropy.coordinates import (
     PrecessedGeocentric, CartesianRepresentation, SkyCoord,
     CartesianDifferential, SphericalRepresentation, UnitSphericalRepresentation,
     HCRS, HeliocentricMeanEcliptic, TEME, TETE)
-from astropy.coordinates.solar_system import _apparent_position_in_true_coordinates
+from astropy.coordinates.solar_system import _apparent_position_in_true_coordinates, get_body
 from astropy.utils import iers
 from astropy.utils.exceptions import AstropyWarning, AstropyDeprecationWarning
 
-from .utils import randomly_sample_sphere
+from astropy.coordinates.tests.utils import randomly_sample_sphere
 from astropy.coordinates.builtin_frames.utils import get_jd12
 from astropy.coordinates import solar_system_ephemeris
 from astropy.units import allclose
@@ -616,7 +616,10 @@ def test_tete_transforms():
     # test TETE-ITRS transform by comparing GCRS-CIRS-ITRS to GCRS-TETE-ITRS
     itrs1 = moon.transform_to(CIRS()).transform_to(ITRS())
     itrs2 = moon.transform_to(TETE()).transform_to(ITRS())
-    assert_allclose(itrs1.separation_3d(itrs2), 0*u.mm, atol=1*u.mm)
+    # this won't be as close since it will round trip through ICRS until
+    # we have some way of translating between the GCRS obsgeoloc/obsgeovel
+    # attributes and the CIRS location attributes
+    assert_allclose(itrs1.separation_3d(itrs2), 0*u.mm, atol=100*u.mm)
 
     # test round trip GCRS->TETE->GCRS
     new_moon = moon.transform_to(TETE()).transform_to(moon)
@@ -631,3 +634,79 @@ def test_tete_transforms():
     with pytest.warns(AstropyDeprecationWarning, match='The use of'):
         tete_alt = _apparent_position_in_true_coordinates(moon)
     assert_allclose(tete_coo1.separation_3d(tete_alt), 0*u.mm, atol=100*u.mm)
+
+
+def test_straight_overhead():
+    """
+    With a precise CIRS<->AltAz transformation this should give Alt=90 exactly
+
+    If the CIRS self-transform breaks it won't, due to improper treatment of aberration
+    """
+    t = Time('J2010')
+    obj = EarthLocation(-1*u.deg, 52*u.deg, height=10.*u.km)
+    home = EarthLocation(-1*u.deg, 52*u.deg, height=0.*u.km)
+
+    # An object that appears straight overhead - FOR A GEOCENTRIC OBSERVER.
+    # Note, this won't be overhead for a topocentric observer because of
+    # aberration.
+    cirs_geo = obj.get_itrs(t).transform_to(CIRS(obstime=t))
+
+    # now get the Geocentric CIRS position of observatory
+    obsrepr = home.get_itrs(t).transform_to(CIRS(obstime=t)).cartesian
+
+    # topocentric CIRS position of a straight overhead object
+    cirs_repr = cirs_geo.cartesian - obsrepr
+
+    # create a CIRS object that appears straight overhead for a TOPOCENTRIC OBSERVER
+    topocentric_cirs_frame = CIRS(obstime=t, location=home)
+    cirs_topo = topocentric_cirs_frame.realize_frame(cirs_repr)
+
+    aa = cirs_topo.transform_to(AltAz(obstime=t, location=home))
+    assert_allclose(aa.alt, 90*u.deg)
+
+
+@pytest.mark.remote_data
+def test_aa_high_precision():
+    """
+    These tests are provided by @mkbrewer - see issue #10356.
+
+    The code that produces them agrees very well (<0.5 mas) with SkyField once Polar motion
+    is turned off, but SkyField does not include polar motion, so a comparison to Skyfield
+    or JPL Horizons will be ~1" off.
+
+    The absence of polar motion within Skyfield and the disagreement between Skyfield and Horizons
+    make high precision comparisons to those codes difficult.
+    """
+    lat = -22.959748*u.deg
+    lon = -67.787260*u.deg
+    elev = 5186*u.m
+    loc = EarthLocation.from_geodetic(lon, lat, elev)
+    t = Time('2017-04-06T00:00:00.0')
+    with solar_system_ephemeris.set('de430'):
+        moon = get_body('moon', t, loc)
+        moon_aa = moon.transform_to(AltAz(obstime=t, location=loc))
+        TARGET_AZ, TARGET_EL = 15.032673509*u.deg, 50.303110134*u.deg
+
+    assert_allclose(moon_aa.az - TARGET_AZ, 0*u.mas, atol=0.5*u.mas)
+    assert_allclose(moon_aa.alt - TARGET_EL, 0*u.mas, atol=0.5*u.mas)
+
+
+def test_aa_high_precision_nodata():
+    """
+    These tests are designed to ensure high precision alt-az transforms.
+
+    They are a slight fudge since the target values come from astropy itself. They are generated
+    with a version of the code that passes the tests above, but for the internal solar system
+    ephemerides to avoid the use of remote data.
+    """
+    TARGET_AZ, TARGET_EL = 15.0321908*u.deg, 50.30263625*u.deg
+    lat = -22.959748*u.deg
+    lon = -67.787260*u.deg
+    elev = 5186*u.m
+    loc = EarthLocation.from_geodetic(lon, lat, elev)
+    t = Time('2017-04-06T00:00:00.0')
+
+    moon = get_body('moon', t, loc)
+    moon_aa = moon.transform_to(AltAz(obstime=t, location=loc))
+    assert_allclose(moon_aa.az - TARGET_AZ, 0*u.mas, atol=0.5*u.mas)
+    assert_allclose(moon_aa.alt - TARGET_EL, 0*u.mas, atol=0.5*u.mas)

--- a/astropy/coordinates/tests/test_intermediate_transformations.py
+++ b/astropy/coordinates/tests/test_intermediate_transformations.py
@@ -604,9 +604,9 @@ def test_tete_transforms():
     gcrs_frame = GCRS(obstime=time, obsgeoloc=p, obsgeovel=v)
     moon = SkyCoord(169.24113968*u.deg, 10.86086666*u.deg, 358549.25381755*u.km, frame=gcrs_frame)
 
-    tete_frame = TETE(obstime=time, obsgeoloc=p, obsgeovel=v)
+    tete_frame = TETE(obstime=time, location=loc)
     # need to set obsgeoloc/vel explicity or skycoord behaviour over-writes
-    tete_geo = TETE(obstime=time, obsgeoloc=[0, 0, 0]*u.km, obsgeovel=[0, 0, 0]*u.km/u.s)
+    tete_geo = TETE(obstime=time, location=EarthLocation(*([0, 0, 0]*u.km)))
 
     # test self-transform by comparing to GCRS-TETE-ITRS-TETE route
     tete_coo1 = moon.transform_to(tete_frame)

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -695,7 +695,7 @@ def test_repr_altaz():
                                 "-4641767.) m, pressure=0.0 hPa, "
                          "temperature=0.0 deg_C, relative_humidity=0.0, "
                          "obswl=1.0 micron): (az, alt, distance) in "
-                         "(deg, deg, m)\n")
+                         "(deg, deg, kpc)\n")
 
 
 def test_ops():

--- a/astropy/coordinates/tests/test_solar_system.py
+++ b/astropy/coordinates/tests/test_solar_system.py
@@ -76,8 +76,7 @@ def test_positions_skyfield(tmpdir):
     skyfield_moon = earth.at(skyfield_t).observe(moon).apparent()
 
     if location is not None:
-        obsgeoloc, obsgeovel = location.get_gcrs_posvel(t)
-        frame = TETE(obstime=t, obsgeoloc=obsgeoloc, obsgeovel=obsgeovel)
+        frame = TETE(obstime=t, location=location)
     else:
         frame = TETE(obstime=t)
 
@@ -202,9 +201,7 @@ class TestPositionKittPeak:
                                                 lat=31.963333333333342*u.deg,
                                                 height=2120*u.m)
         self.t = Time('2014-09-25T00:00', location=kitt_peak)
-        obsgeoloc, obsgeovel = kitt_peak.get_gcrs_posvel(self.t)
-        self.apparent_frame = TETE(obstime=self.t,
-                                   obsgeoloc=obsgeoloc, obsgeovel=obsgeovel)
+        self.apparent_frame = TETE(obstime=self.t, location=kitt_peak)
         # Results returned by JPL Horizons web interface
         self.horizons = {
             'mercury': SkyCoord(ra='13h38m58.50s', dec='-13d34m42.6s',
@@ -319,7 +316,7 @@ def test_horizons_consistency_with_precision():
         times = Time('2020-04-06 00:00') + np.arange(0, 24, 1)*u.hour
         astropy = get_body('moon', times, loc)
 
-        apparent_frame = TETE(obstime=times, obsgeoloc=astropy.obsgeoloc, obsgeovel=astropy.obsgeovel)
+        apparent_frame = TETE(obstime=times, location=loc)
         astropy = astropy.transform_to(apparent_frame)
         usrepr = UnitSphericalRepresentation(ra_apparent_horizons, dec_apparent_horizons)
         horizons = apparent_frame.realize_frame(usrepr)

--- a/docs/coordinates/common_errors.rst
+++ b/docs/coordinates/common_errors.rst
@@ -1,0 +1,88 @@
+.. include:: references.txt
+
+.. _astropy-coordinates-common-errors:
+
+Common mistakes
+***************
+
+The following are some common sources of difficulty when using `~astropy.coordinates`.
+
+Object Separation
+-----------------
+
+When calculating the separation between objects, it is important to bear in mind that
+:meth:`astropy.coordinates.SkyCoord.separation` gives a different answer depending
+upon the order in which is used. For example::
+
+    >>> import numpy as np
+    >>> from astropy import units as u
+    >>> from astropy.coordinates import SkyCoord, GCRS
+    >>> from astropy.time import Time
+    >>> t = Time("2010-05-22T00:00")
+    >>> moon = SkyCoord(104.29*u.deg, 23.51*u.deg, 359367.3*u.km, frame=GCRS(obstime=t))
+    >>> star = SkyCoord(101.4*u.deg, 23.02*u.deg, frame='icrs')
+    >>> star.separation(moon) # doctest: +FLOAT_CMP
+    <Angle 139.84211884 deg>
+    >>> moon.separation(star) # doctest: +FLOAT_CMP
+    <Angle 2.70390995 deg>
+
+Why do these give such different answers?
+
+The reason is that :meth:`astropy.coordinates.SkyCoord.separation` gives the separation as measured
+in the frame of the |SkyCoord| object. So ``star.separation(moon)`` gives the angular separation
+in the ICRS frame. This is the separation as it would appear from the Solar System Barycenter. For a
+geocentric observer, ``moon.separation(star)`` gives the correct answer, since ``moon`` is in a
+geocentric frame.
+
+AltAz calculations for Earth-based objects
+------------------------------------------
+
+One might expect that the following code snippet would produce an altitude of exactly 90 degrees::
+
+    >>> from astropy.coordinates import EarthLocation, AltAz
+    >>> from astropy.time import Time
+    >>> from astropy import units as u
+
+    >>> t = Time('J2010')
+    >>> obj = EarthLocation(-1*u.deg, 52*u.deg, height=10.*u.km)
+    >>> home = EarthLocation(-1*u.deg, 52*u.deg, height=0.*u.km)
+    >>> altaz_frame = AltAz(obstime=t, location=home)
+    >>> obj.get_itrs(t).transform_to(altaz_frame).alt # doctest: +FLOAT_CMP
+    <Latitude 86.32878441 deg>
+
+Why is the result over three degrees away from the zenith? It is only possible to understand by taking a very careful
+look at what ``obj.get_itrs(t)`` returns. This call provides the ITRS position of the source ``obj``. ITRS is
+a geocentric coordinate system, and includes the aberration of light. So the code above provides the ITRS position
+of a source that appears directly overhead *for an observer at the geocenter*.
+
+Due to aberration, the actual position of this source will be displaced from its apparent position, by an angle of
+approximately 20.5 arcseconds. Because this source is about one Earth radius away, it's actual position is therefore
+around 600 metres away from where it appears to be. This 600 metre shift, for an object 10 km above the Earth's surface
+is an angular difference of just over three degrees - which is why this object does not appear overhead for a topocentric
+observer - one on the surface of the Earth.
+
+The correct way to construct a |SkyCoord| object for a source that is directly overhead a topocentric observer is
+as follows::
+
+    >>> from astropy.coordinates import EarthLocation, AltAz, ITRS, CIRS
+    >>> from astropy.time import Time
+    >>> from astropy import units as u
+
+    >>> t = Time('J2010')
+    >>> obj = EarthLocation(-1*u.deg, 52*u.deg, height=10.*u.km)
+    >>> home = EarthLocation(-1*u.deg, 52*u.deg, height=0.*u.km)
+
+    >>> # Now we make a ITRS vector of a straight overhead object
+    >>> itrs_vec = obj.get_itrs(t).cartesian - home.get_itrs(t).cartesian
+
+    >>> # Now we create a topocentric coordinate with this data
+    >>> # Any topocentric frame will work, we use CIRS
+    >>> # Start by transforming the ITRS vector to CIRS
+    >>> cirs_vec = ITRS(itrs_vec, obstime=t).transform_to(CIRS(obstime=t)).cartesian
+    >>> # Finally, make CIRS frame object with the correct data
+    >>> cirs_topo = CIRS(cirs_vec, obstime=t, location=home)
+
+    >>> # convert to AltAz
+    >>> aa = cirs_topo.transform_to(AltAz(obstime=t, location=home))
+    >>> aa.alt # doctest: +FLOAT_CMP
+    <Latitude 90. deg>

--- a/docs/coordinates/frames.rst
+++ b/docs/coordinates/frames.rst
@@ -218,7 +218,7 @@ Similar broadcasting happens if you transform to another frame. For example::
     >>> lcoo = coo.transform_to(lf)  # this can load finals2000A.all # doctest: +REMOTE_DATA +IGNORE_OUTPUT
     >>> lcoo  # doctest: +REMOTE_DATA +FLOAT_CMP
     <AltAz Coordinate (obstime=['2012-03-21T00:00:00.000' '2012-06-21T00:00:00.000'], location=(3980608.9024681724, -102.47522910648239, 4966861.273100675) m, pressure=0.0 hPa, temperature=0.0 deg_C, relative_humidity=0.0, obswl=1.0 micron): (az, alt) in deg
-        [( 94.71264944, 89.21424252), (307.69488825, 37.98077771)]>
+        [( 94.71264993, 89.21424259), (307.69488825, 37.98077772)]>
 
 Above, the shapes — ``()`` for ``coo`` and ``(2,)`` for ``lf`` — were
 broadcast against each other. If you wish to determine the positions for a
@@ -241,10 +241,10 @@ set of coordinates, you will need to make sure that the shapes allow this::
       '2012-03-21T00:00:00.000']
      ['2012-06-21T00:00:00.000' '2012-06-21T00:00:00.000'
       '2012-06-21T00:00:00.000']], location=(3980608.90246817, -102.47522911, 4966861.27310068) m, pressure=0.0 hPa, temperature=0.0 deg_C, relative_humidity=0.0, obswl=1.0 micron): (az, alt) in deg
-        [[( 93.09845185, 89.21613128), (126.85789663, 25.4660055 ),
+        [[( 93.09845183, 89.21613128), (126.85789664, 25.4660055 ),
           ( 51.37993234, 37.18532527)],
          [(307.71713698, 37.99437658), (231.3740787 , 26.36768329),
-          ( 85.4218724 , 89.69297998)]]>
+          ( 85.42187236, 89.69297998)]]>
 
 .. Note::
    Frames without data have a ``shape`` that is determined by their frame

--- a/docs/coordinates/index.rst
+++ b/docs/coordinates/index.rst
@@ -474,6 +474,7 @@ listed below.
    spectralcoord
    galactocentric
    remote_methods
+   common_errors
    definitions
    inplace
 

--- a/docs/coordinates/satellites.rst
+++ b/docs/coordinates/satellites.rst
@@ -104,8 +104,8 @@ Or, if you want to find the altitude and azimuth of the satellite from a particu
     >>> siding_spring = EarthLocation.of_site('aao')  # doctest: +SKIP
     >>> aa = teme.transform_to(AltAz(obstime=t, location=siding_spring))  # doctest: +IGNORE_WARNINGS
     >>> aa.alt  # doctest: +FLOAT_CMP
-    <Latitude 10.94798428 deg>
+    <Latitude 10.95229446 deg>
     >>> aa.az  # doctest: +FLOAT_CMP
-    <Longitude 59.28807348 deg>
+    <Longitude 59.30081255 deg>
 
 .. EXAMPLE END

--- a/docs/whatsnew/4.2.rst
+++ b/docs/whatsnew/4.2.rst
@@ -26,6 +26,25 @@ smaller improvements and bug fixes, which are described in the
 * xxx pull requests have been merged since v4.1
 * xxx distinct people have contributed code
 
+.. _whatsnew-4.2-coordinates:
+
+Transformations to AltAz are now much more precise
+==================================================
+
+Following advice from M. K. Brewer and comparisons with accurate comparison
+samples, the implementations for the transformations to AltAz coordinates were
+made much more precise (down to the milli-arcsec level).  To help this, the
+``CIRS`` frame has gained an observer ``location`` attribute.
+
+A True Equator and True Equinox frame
+=====================================
+
+A new equatorial coordinate frame has been introduced, with RA and Dec
+measured with respect to the True Equator and Equinox (TETE). This frame is
+commonly known as "apparent place" and is the correct frame for coordinates
+returned from JPL Horizons.
+
+
 .. _whatsnew-4.2-cosmology:
 
 Planck 2018 is accepted and now the default cosmology


### PR DESCRIPTION
@bsiposc - it turned out that the backport of #11061 without #10994 was difficult, but with it straightforward. So, I combined them here and even added a what's new entry, with the logic that #11061 fixes a bug in that our `AltAz` were always off by quite a bit.

But I realize this is really not what release candidates are for, so please do feel free to tell me to let things be and keep #11061 for 4.3.