### PR TITLE
Merge pull request #11061 from mhvk/tete-location

### DIFF
--- a/astropy/coordinates/builtin_frames/equatorial.py
+++ b/astropy/coordinates/builtin_frames/equatorial.py
@@ -16,8 +16,8 @@ from astropy.utils.decorators import format_doc
 from astropy.coordinates.representation import (CartesianRepresentation, CartesianDifferential)
 from astropy.coordinates.baseframe import BaseCoordinateFrame, base_doc
 from astropy.coordinates.builtin_frames.baseradec import BaseRADecFrame, doc_components
-from astropy.coordinates.attributes import TimeAttribute, CartesianRepresentationAttribute
-from .utils import DEFAULT_OBSTIME
+from astropy.coordinates.attributes import TimeAttribute, EarthLocationAttribute
+from .utils import DEFAULT_OBSTIME, EARTH_CENTER
 
 __all__ = ['TEME', 'TETE']
 
@@ -35,18 +35,11 @@ doc_footer_tete = """
     obstime : `~astropy.time.Time`
         The time at which the observation is taken.  Used for determining the
         position of the Earth.
-    obsgeoloc : `~astropy.coordinates.CartesianRepresentation`, `~astropy.units.Quantity`
-        The position of the observer relative to the center-of-mass of the
-        Earth, oriented the same as GCRS. Either [0, 0, 0],
-        `~astropy.coordinates.CartesianRepresentation`, or proper input for one,
-        i.e., a `~astropy.units.Quantity` with shape (3, ...) and length units.
-        Defaults to [0, 0, 0], meaning a geocentric observer.
-    obsgeovel : `~astropy.coordinates.CartesianRepresentation`, `~astropy.units.Quantity`
-        The velocity of the observer relative to the center-of-mass of the
-        Earth, oriented the same as GCRS. Either [0, 0, 0],
-        `~astropy.coordinates.CartesianRepresentation`, or proper input for one,
-        i.e., a `~astropy.units.Quantity` with shape (3, ...) and velocity
-        units.  Defaults to [0, 0, 0], meaning a geocentric observer.
+    location : `~astropy.coordinates.EarthLocation`
+        The location on the Earth.  This can be specified either as an
+        `~astropy.coordinates.EarthLocation` object or as anything that can be
+        transformed to an `~astropy.coordinates.ITRS` frame. The default is the
+        centre of the Earth.
 """
 
 
@@ -84,10 +77,7 @@ class TETE(BaseRADecFrame):
     """
 
     obstime = TimeAttribute(default=DEFAULT_OBSTIME)
-    obsgeoloc = CartesianRepresentationAttribute(default=[0, 0, 0],
-                                                 unit=u.m)
-    obsgeovel = CartesianRepresentationAttribute(default=[0, 0, 0],
-                                                 unit=u.m/u.s)
+    location = EarthLocationAttribute(default=EARTH_CENTER)
 
 # Self transform goes through ICRS and is defined in icrs_cirs_transforms.py
 

--- a/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
@@ -270,9 +270,8 @@ def hcrs_to_hcrs(from_coo, to_frame):
 
 @frame_transform_graph.transform(FunctionTransformWithFiniteDifference, TETE, TETE)
 def tete_to_tete(from_coo, to_frame):
-    if (np.all(from_coo.obstime == to_frame.obstime) and
-            np.all(from_coo.obsgeoloc == to_frame.obsgeoloc) and
-            np.all(from_coo.obsgeovel == to_frame.obsgeovel)):
+    if (np.all(from_coo.location == to_frame.location)
+            and np.all(from_coo.obstime == to_frame.obstime)):
         return to_frame.realize_frame(from_coo.data)
     else:
         # We perform the self-transform through ICRS, since any change in obstime

--- a/astropy/coordinates/builtin_frames/utils.py
+++ b/astropy/coordinates/builtin_frames/utils.py
@@ -12,9 +12,10 @@ import numpy as np
 
 from astropy import units as u
 from astropy.time import Time
+from astropy.coordinates.earth import EarthLocation
 from astropy.utils import iers
 from astropy.utils.exceptions import AstropyWarning
-from ..representation import CartesianRepresentation, CartesianDifferential
+from ..representation import CartesianDifferential
 
 
 # We use tt as the time scale for this equinoxes, primarily because it is the
@@ -27,6 +28,10 @@ EQUINOX_B1950 = Time('B1950', scale='tt')
 # This is a time object that is the default "obstime" when such an attribute is
 # necessary.  Currently, we use J2000.
 DEFAULT_OBSTIME = Time('J2000', scale='tt')
+
+# This is an EarthLocation that is the default "location" when such an attribute is
+# necessary. It is the centre of the Earth.
+EARTH_CENTER = EarthLocation(0*u.km, 0*u.km, 0*u.km)
 
 PIOVER2 = np.pi / 2.
 

--- a/astropy/coordinates/solar_system.py
+++ b/astropy/coordinates/solar_system.py
@@ -18,9 +18,9 @@ from astropy.utils.state import ScienceState
 from astropy.utils import indent
 from astropy import units as u
 from astropy.constants import c as speed_of_light
-from .representation import CartesianRepresentation
+from .representation import CartesianRepresentation, CartesianDifferential
 from .orbital_elements import calc_moon
-from .builtin_frames import GCRS, ICRS, TETE
+from .builtin_frames import GCRS, ICRS, ITRS, TETE
 from .builtin_frames.utils import get_jd12
 
 __all__ = ["get_body", "get_moon", "get_body_barycentric",
@@ -525,6 +525,12 @@ def _apparent_position_in_true_coordinates(skycoord):
     Convert Skycoord in GCRS frame into one in which RA and Dec
     are defined w.r.t to the true equinox and poles of the Earth
     """
-    tete_frame = TETE(obstime=skycoord.obstime, obsgeoloc=skycoord.obsgeoloc,
-                      obsgeovel=skycoord.obsgeovel)
+    location = getattr(skycoord, 'location', None)
+    if location is None:
+        gcrs_rep = skycoord.obsgeoloc.with_differentials(
+            {'s': CartesianDifferential.from_cartesian(skycoord.obsgeovel)})
+        location = (GCRS(gcrs_rep, obstime=skycoord.obstime)
+                    .transform_to(ITRS(obstime=skycoord.obstime))
+                    .earth_location)
+    tete_frame = TETE(obstime=skycoord.obstime, location=location)
     return skycoord.transform_to(tete_frame)

--- a/astropy/coordinates/tests/test_intermediate_transformations.py
+++ b/astropy/coordinates/tests/test_intermediate_transformations.py
@@ -604,9 +604,9 @@ def test_tete_transforms():
     gcrs_frame = GCRS(obstime=time, obsgeoloc=p, obsgeovel=v)
     moon = SkyCoord(169.24113968*u.deg, 10.86086666*u.deg, 358549.25381755*u.km, frame=gcrs_frame)
 
-    tete_frame = TETE(obstime=time, obsgeoloc=p, obsgeovel=v)
+    tete_frame = TETE(obstime=time, location=loc)
     # need to set obsgeoloc/vel explicity or skycoord behaviour over-writes
-    tete_geo = TETE(obstime=time, obsgeoloc=[0, 0, 0]*u.km, obsgeovel=[0, 0, 0]*u.km/u.s)
+    tete_geo = TETE(obstime=time, location=EarthLocation(*([0, 0, 0]*u.km)))
 
     # test self-transform by comparing to GCRS-TETE-ITRS-TETE route
     tete_coo1 = moon.transform_to(tete_frame)
@@ -616,7 +616,10 @@ def test_tete_transforms():
     # test TETE-ITRS transform by comparing GCRS-CIRS-ITRS to GCRS-TETE-ITRS
     itrs1 = moon.transform_to(CIRS()).transform_to(ITRS())
     itrs2 = moon.transform_to(TETE()).transform_to(ITRS())
-    assert_allclose(itrs1.separation_3d(itrs2), 0*u.mm, atol=1*u.mm)
+    # this won't be as close since it will round trip through ICRS until
+    # we have some way of translating between the GCRS obsgeoloc/obsgeovel
+    # attributes and the TETE location attributes.
+    assert_allclose(itrs1.separation_3d(itrs2), 0*u.mm, atol=100*u.mm)
 
     # test round trip GCRS->TETE->GCRS
     new_moon = moon.transform_to(TETE()).transform_to(moon)

--- a/astropy/coordinates/tests/test_solar_system.py
+++ b/astropy/coordinates/tests/test_solar_system.py
@@ -76,8 +76,7 @@ def test_positions_skyfield(tmpdir):
     skyfield_moon = earth.at(skyfield_t).observe(moon).apparent()
 
     if location is not None:
-        obsgeoloc, obsgeovel = location.get_gcrs_posvel(t)
-        frame = TETE(obstime=t, obsgeoloc=obsgeoloc, obsgeovel=obsgeovel)
+        frame = TETE(obstime=t, location=location)
     else:
         frame = TETE(obstime=t)
 
@@ -202,9 +201,7 @@ class TestPositionKittPeak:
                                                 lat=31.963333333333342*u.deg,
                                                 height=2120*u.m)
         self.t = Time('2014-09-25T00:00', location=kitt_peak)
-        obsgeoloc, obsgeovel = kitt_peak.get_gcrs_posvel(self.t)
-        self.apparent_frame = TETE(obstime=self.t,
-                                   obsgeoloc=obsgeoloc, obsgeovel=obsgeovel)
+        self.apparent_frame = TETE(obstime=self.t, location=kitt_peak)
         # Results returned by JPL Horizons web interface
         self.horizons = {
             'mercury': SkyCoord(ra='13h38m58.50s', dec='-13d34m42.6s',
@@ -319,7 +316,7 @@ def test_horizons_consistency_with_precision():
         times = Time('2020-04-06 00:00') + np.arange(0, 24, 1)*u.hour
         astropy = get_body('moon', times, loc)
 
-        apparent_frame = TETE(obstime=times, obsgeoloc=astropy.obsgeoloc, obsgeovel=astropy.obsgeovel)
+        apparent_frame = TETE(obstime=times, location=loc)
         astropy = astropy.transform_to(apparent_frame)
         usrepr = UnitSphericalRepresentation(ra_apparent_horizons, dec_apparent_horizons)
         horizons = apparent_frame.realize_frame(usrepr)


### PR DESCRIPTION
Use EarthLocation instead of GCRS position for TETE observer.

This fails for reasons that are not entirely clear to me, but may be related to CIRS not having a location.
Here only so @StuartLittlefair and @mkbrewer can have a look.

EDIT: xref #11061 