### PR TITLE
Speed up GCRS<->(TETE, CIRS) by smarter location conversions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -251,6 +251,8 @@ Other Changes and Additions
 
 - Officially declared minversion of ``ipython`` to be 4.2. [#10942]
 
+- Refactor conversions between ``GCRS`` and ``CIRS,TETE`` for better accuracy
+  and substantially improved speed. [#10994]
 
 
 4.2 (unreleased)

--- a/astropy/coordinates/earth.py
+++ b/astropy/coordinates/earth.py
@@ -28,12 +28,17 @@ GeodeticLocation = collections.namedtuple('GeodeticLocation', ['lon', 'lat', 'he
 # Available ellipsoids (defined in erfam.h, with numbers exposed in erfa).
 ELLIPSOIDS = ('WGS84', 'GRS80', 'WGS72')
 
-OMEGA_EARTH = u.Quantity(7.292115855306589e-5, 1./u.s)
+OMEGA_EARTH = ((1.002_737_811_911_354_48 * u.cycle/u.day)
+               .to(1/u.s, u.dimensionless_angles()))
 """
-Rotational velocity of Earth. In UT1 seconds, this would be 2 pi / (24 * 3600),
-but we need the value in SI seconds.
-See Explanatory Supplement to the Astronomical Almanac, ed. P. Kenneth Seidelmann (1992),
-University Science Books.
+Rotational velocity of Earth, following SOFA's pvtob.
+
+In UT1 seconds, this would be 2 pi / (24 * 3600), but we need the value
+in SI seconds, so multiply by the ratio of stellar to solar day.
+See Explanatory Supplement to the Astronomical Almanac, ed. P. Kenneth
+Seidelmann (1992), University Science Books. The constant is the
+convential, exact one (IERS conventions 2003); see
+http://hpiers.obspm.fr/eop-pc/index.php?index=constants.
 """
 
 

--- a/astropy/coordinates/tests/test_intermediate_transformations.py
+++ b/astropy/coordinates/tests/test_intermediate_transformations.py
@@ -631,10 +631,7 @@ def test_tete_transforms():
     # test TETE-ITRS transform by comparing GCRS-CIRS-ITRS to GCRS-TETE-ITRS
     itrs1 = moon.transform_to(CIRS()).transform_to(ITRS())
     itrs2 = moon.transform_to(TETE()).transform_to(ITRS())
-    # this won't be as close since it will round trip through ICRS until
-    # we have some way of translating between the GCRS obsgeoloc/obsgeovel
-    # attributes and the CIRS location attributes
-    assert_allclose(itrs1.separation_3d(itrs2), 0*u.mm, atol=100*u.mm)
+    assert_allclose(itrs1.separation_3d(itrs2), 0*u.mm, atol=1*u.mm)
 
     # test round trip GCRS->TETE->GCRS
     new_moon = moon.transform_to(TETE()).transform_to(moon)

--- a/docs/whatsnew/4.3.rst
+++ b/docs/whatsnew/4.3.rst
@@ -14,7 +14,7 @@ the 4.2.x series of releases.
 
 In particular, this release includes:
 
-*
+* :ref:`whatsnew-4.3-coordinates`
 *
 
 In addition to these major changes, Astropy v4.3 includes a large number of
@@ -25,6 +25,18 @@ smaller improvements and bug fixes, which are described in the
 * xxx pull requests have been merged since v4.2
 * xxx distinct people have contributed code
 
+.. _whatsnew-4.3-coordinates:
+
+Transformations to AltAz are now much more precise (and faster)
+===============================================================
+
+Following advice from M. K. Brewer and comparisons with accurate verification
+samples, the implementations for the transformations to AltAz coordinates were
+made much more precise (down to the milli-arcsec level).  To help this, the
+``CIRS`` frame has gained an observer ``location`` attribute.
+
+Furthermore, by ensuring expensive calculations of the precession-nutation
+matrix are only done once, the transformations have been sped up considerably.
 
 Full change log
 ===============


### PR DESCRIPTION
Following the suggestion by @mkbrewer in #11067, this speeds up TETE<->GCRS considerably by using the `rbpn` matrix also for getting the sidereal time for the conversion of the observer location from ITRS to TETE.

fixes #11067

~Note: need to re-unify code so for now just a draft so we have something to look at.~ (done)

EDIT: quick timing:
```
from astropy.coordinates import SkyCoord, EarthLocation
from astropy import units as u

tete = SkyCoord(10*u.deg, 11*u.deg, frame='tete', location=EarthLocation(11*u.deg, 12*u.deg))
%timeit tete.transform_to('gcrs')
# current master
# 16.6 ms ± 1.13 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
# this PR
# 6.51 ms ± 609 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)
```