### PR TITLE
MNT: Monthly cron to handle stale issues and PRs (dry run)

### DIFF
--- a/.github/workflows/ci_cron_daily.yml
+++ b/.github/workflows/ci_cron_daily.yml
@@ -45,3 +45,33 @@ jobs:
       run: python -m pip install --upgrade tox
     - name: Run tests
       run: tox ${{ matrix.toxargs}} -e ${{ matrix.toxenv}} -- ${{ matrix.toxposargs}}
+
+  # TODO: Remove debug-only when ready for production.
+  stalebot:
+    runs-on: ubuntu-latest
+    if: github.repository == 'astropy/astropy' && github.event_name == 'schedule'
+    steps:
+    - uses: actions/stale@v3
+      with:
+        debug-only: true
+
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        operations-per-run: 50
+        ascending: true
+
+        days-before-issue-stale: -1
+        days-before-issue-close: 7
+        remove-issue-stale-when-updated: false
+        close-issue-message: 'I am going to close this issue because it was marked with **Close?**, but if you feel that this issue should stay open, then feel free to re-open, remove **Close?** and **closed-by-bot** labels, and apply **keep-open** label.'
+        close-issue-label: 'closed-by-bot'
+        exempt-issue-labels: 'keep-open'
+        any-of-issue-labels: 'Close?'
+
+        days-before-pr-stale: 150
+        days-before-pr-close: 30
+        remove-pr-stale-when-updated: true
+        stale-pr-message: 'This pull request is stale because it has been open 150 days with no activity. Remove **Close?**, comment, or push, or this will be closed in 30 days.'
+        close-pr-message: 'I am going to close this pull request as per my previous message, but if you feel that this PR should stay open, then feel free to re-open, remove **Close?** and **closed-by-bot** labels, and apply **keep-open** label.'
+        stale-pr-label: 'Close?'
+        close-pr-label: 'closed-by-bot'
+        exempt-pr-labels: 'keep-open'

--- a/.github/workflows/label_issue_actions.yml
+++ b/.github/workflows/label_issue_actions.yml
@@ -1,0 +1,25 @@
+name: On Issue Labeled
+
+on:
+  issues:
+    types:
+      - labeled
+
+jobs:
+  # The label here needs to be the same as that set for actions/stale (stalebot)
+  # job in ci_cron_daily.yml
+  stalebot:
+    runs-on: ubuntu-latest
+    if: contains(github.event.issue.labels.*.name, 'Close?')
+    steps:
+    - name: Stale issue message
+      uses: actions/github-script@v3
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          github.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: 'This issue was labeled as **Close?**. Remove **Close?** label or this will be closed after 7 days. (This is currently a dry-run.)'
+          })


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is an attempt to see if we can replace the stale issues/PRs bot with GitHub Actions (https://github.com/actions/stale).

What we want:

* Close issues manually marked with `Close?` label after 7 days after a warning.
* Mark PRs as stale (`Close?`) after 5 months of inactivity, and then close a month after. Push will reset the clock.
* For both issues and PRs:
    * Those marked with `keep-open` label are skipped regardless.
    * Those closed by Action will have `closed-by-bot` label applied.

Currently blocked by:

- [x] actions/stale#214
- [x] actions/stale#219
- [x] actions/stale#373 -- some useful suggestions from action devs there we can implement
- [x] actions/stale#380
- [x] actions/stale#383

~(These new features need to be "released" upstream first.)~ https://github.com/actions/stale/releases/tag/v3.0.19

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Note: ~If we decide to move forward with this, the current stale bot cron job needs to be disabled by Tom R first.~ (Tom's  bot is already broken anyway.) Though we can also merge this with its dry run option turned on and see what happens in parallel...

# TODO

- [x] Finalize YAML logic when blockers are removed.
- [x] Have logic to ensure this won't run in bug fix branches (future-proofing). Also see #11392 . Perhaps this is a non-issue, see https://github.community/t/scheduled-builds-of-non-default-branch/16306/19
- [x] Move this into existing ~weekly~ daily cron YAML?
- [x] Squash commits.
- [x] How to test this? Maybe deploy in parallel with existing bot in dry run mode for a while with debugging on and check the logs? (Yes, that is probably the best way, so this PR only implements the "dry run" option and we will open follow-up issue and PR to put it in production after a period of vetting.)
- [ ] Open a follow-up issue to deploy for real (remove dry run, `debug-only`, option) if we're satisfied. Also update listing in astropy/astropy-bot#125 .