### PR TITLE
Speed up EarthLocation.get_gcrs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -254,6 +254,10 @@ Other Changes and Additions
 - Refactor conversions between ``GCRS`` and ``CIRS,TETE`` for better accuracy
   and substantially improved speed. [#10994]
 
+- Also refactor ``EarthLocation.get_gcrs`` for an increase in performance of
+  an order of magnitude, which enters as well in getting observed positions of
+  planets using ``get_body``. [#11073]
+
 
 4.2 (unreleased)
 ================

--- a/astropy/coordinates/earth.py
+++ b/astropy/coordinates/earth.py
@@ -629,7 +629,7 @@ class EarthLocation(u.Quantity):
         """Convert to a tuple with X, Y, and Z as quantities"""
         return (self.x, self.y, self.z)
 
-    def get_itrs(self, obstime=None, include_velocity=False):
+    def get_itrs(self, obstime=None):
         """
         Generates an `~astropy.coordinates.ITRS` object with the location of
         this object at the requested ``obstime``.
@@ -639,10 +639,6 @@ class EarthLocation(u.Quantity):
         obstime : `~astropy.time.Time` or None
             The ``obstime`` to apply to the new `~astropy.coordinates.ITRS`, or
             if None, the default ``obstime`` will be used.
-
-        include_velocity: bool
-            If True, will return an `~astropy.coordinates.ITRS` coordinate
-            with zero velocity, i.e fixed to the Earth's surface.
 
         Returns
         -------
@@ -656,11 +652,7 @@ class EarthLocation(u.Quantity):
 
         # do this here to prevent a series of complicated circular imports
         from .builtin_frames import ITRS
-        itrs_coo = ITRS(x=self.x, y=self.y, z=self.z, obstime=obstime)
-        if include_velocity:
-            zeros = np.broadcast_to(0. * (u.km / u.s), (3,) + itrs_coo.shape, subok=True)
-            itrs_coo.data.differentials['s'] = CartesianDifferential(zeros)
-        return itrs_coo
+        return ITRS(x=self.x, y=self.y, z=self.z, obstime=obstime)
 
     itrs = property(get_itrs, doc="""An `~astropy.coordinates.ITRS` object  with
                                      for the location of this object at the

--- a/astropy/coordinates/tests/test_intermediate_transformations.py
+++ b/astropy/coordinates/tests/test_intermediate_transformations.py
@@ -699,10 +699,13 @@ def test_aa_high_precision():
     with solar_system_ephemeris.set('de430'):
         moon = get_body('moon', t, loc)
         moon_aa = moon.transform_to(AltAz(obstime=t, location=loc))
-        TARGET_AZ, TARGET_EL = 15.032673509*u.deg, 50.303110134*u.deg
 
-    assert_allclose(moon_aa.az - TARGET_AZ, 0*u.mas, atol=0.5*u.mas)
-    assert_allclose(moon_aa.alt - TARGET_EL, 0*u.mas, atol=0.5*u.mas)
+    TARGET_AZ, TARGET_EL = 15.0326735105*u.deg, 50.3031101339*u.deg
+    TARGET_DISTANCE = 376252883.2473*u.m
+
+    assert_allclose(moon_aa.az, TARGET_AZ, atol=2*u.uas, rtol=0)
+    assert_allclose(moon_aa.alt, TARGET_EL, atol=2*u.uas, rtol=0)
+    assert_allclose(moon_aa.distance, TARGET_DISTANCE, atol=2*u.mm, rtol=0)
 
 
 def test_aa_high_precision_nodata():

--- a/astropy/coordinates/tests/test_intermediate_transformations.py
+++ b/astropy/coordinates/tests/test_intermediate_transformations.py
@@ -735,7 +735,7 @@ class TestGetLocationGCRS:
             np.linspace(0, 360, 6)*u.deg, np.linspace(-90, 90, 6)*u.deg, 100*u.m)
         cls.obstime = obstime = Time(np.linspace(2000, 2010, 6), format='jyear')
         # Get comparison via a full transformation.  We do not use any methods
-        # since those may depend on the fast transform in the future.
+        # of EarthLocation, since those depend on the fast transform.
         loc_itrs = ITRS(loc.x, loc.y, loc.z, obstime=obstime)
         zeros = np.broadcast_to(0. * (u.km / u.s), (3,) + loc_itrs.shape, subok=True)
         loc_itrs.data.differentials['s'] = CartesianDifferential(zeros)

--- a/docs/coordinates/solarsystem.rst
+++ b/docs/coordinates/solarsystem.rst
@@ -45,8 +45,8 @@ without the need to download a large ephemerides file)::
   >>> with solar_system_ephemeris.set('builtin'):
   ...     jup = get_body('jupiter', t, loc) # doctest: +REMOTE_DATA +IGNORE_OUTPUT
   >>> jup  # doctest: +FLOAT_CMP +REMOTE_DATA
-  <SkyCoord (GCRS: obstime=2014-09-22 23:22:00.000, obsgeoloc=(3949481.68990863, -550931.91188162, 4961151.73733451) m, obsgeovel=(40.15954083, 287.47876693, -0.04597867) m / s): (ra, dec, distance) in (deg, deg, AU)
-      (136.91116209, 17.02935409, 5.94386022)>
+  <SkyCoord (GCRS: obstime=2014-09-22 23:22:00.000, obsgeoloc=(3949481.69182405, -550931.91022387, 4961151.73597633) m, obsgeovel=(40.159527, 287.47873161, -0.04597922) m / s): (ra, dec, distance) in (deg, deg, AU)
+      (136.91116253, 17.02935396, 5.94386022)>
 
 Above, we used ``solar_system_ephemeris`` as a context, which sets the default
 ephemeris while in the ``with`` clause, and resets it at the end.
@@ -63,11 +63,11 @@ ephemeris is set):
   >>> solar_system_ephemeris.set('de432s') # doctest: +REMOTE_DATA, +IGNORE_OUTPUT
   <ScienceState solar_system_ephemeris: 'de432s'>
   >>> get_body('jupiter', t, loc) # doctest: +REMOTE_DATA, +FLOAT_CMP
-  <SkyCoord (GCRS: obstime=2014-09-22 23:22:00.000, obsgeoloc=(3949481.69230491, -550931.90674055, 4961151.73597586) m, obsgeovel=(40.15954083, 287.47863521, -0.0459789) m / s): (ra, dec, distance) in (deg, deg, km)
-      (136.90234802, 17.03160667, 8.89196021e+08)>
+  <SkyCoord (GCRS: obstime=2014-09-22 23:22:00.000, obsgeoloc=(3949481.69182405, -550931.91022387, 4961151.73597633) m, obsgeovel=(40.159527, 287.47873161, -0.04597922) m / s): (ra, dec, distance) in (deg, deg, km)
+      (136.90234846, 17.03160654, 8.89196021e+08)>
   >>> get_moon(t, loc) # doctest: +REMOTE_DATA, +FLOAT_CMP
-  <SkyCoord (GCRS: obstime=2014-09-22 23:22:00.000, obsgeoloc=(3949481.69230491, -550931.90674055, 4961151.73597586) m, obsgeovel=(40.15954083, 287.47863521, -0.0459789) m / s): (ra, dec, distance) in (deg, deg, km)
-      (165.51849203, 2.32863886, 407229.6503193)>
+  <SkyCoord (GCRS: obstime=2014-09-22 23:22:00.000, obsgeoloc=(3949481.69182405, -550931.91022387, 4961151.73597633) m, obsgeovel=(40.159527, 287.47873161, -0.04597922) m / s): (ra, dec, distance) in (deg, deg, km)
+      (165.51854528, 2.32861794, 407229.55638763)>
   >>> get_body_barycentric('moon', t) # doctest: +REMOTE_DATA, +FLOAT_CMP
   <CartesianRepresentation (x, y, z) in km
       (  1.50107535e+08, -866789.11996916, -418963.55218495)>


### PR DESCRIPTION
Now that we have a faster method for calculating `obsgeoloc` and `obsgeovel` from an `EarthLocation`, there was no reason not to use it inside `EarthLocation` as well. The speed up is dramatic (see below). This partially addresses #11072.

Note that with this change, the new `include_velocity` argument introduced to `get_itrs()` is no longer used. I thought it made most sense to just revert it, as I think we still have larger decisions to make on how to deal with storing a location. 

It also changes the calculation slightly (see in-line comment); if it is felt this makes the code too unclear, I can revert that commit.

cc @mkbrewer

```
from astropy import units as u
from astropy.time import Time
from astropy.coordinates import EarthLocation
el = EarthLocation([10., 20.]*u.deg, [11, 21]*u.deg)
t = Time('J2010')
%timeit el.get_gcrs(t)
# current master: 33.9 ms ± 180 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
# first commit: 2.09 ms ± 11.5 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
# full PR: 1.74 ms ± 29.7 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```

EDIT: also
```
%timeit get_body('mars', t, location=el)
# current master: 44.3 ms ± 558 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
# this PR: 11.1 ms ± 147 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```
