### PR TITLE
EXP: run CI with MacOS X Big Sur

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -54,7 +54,7 @@ jobs:
             toxposargs: --durations=50
 
           - name: Python 3.7 with all optional dependencies (MacOS X)
-            os: macos-latest
+            os: macos-11.0
             python: 3.7
             toxenv: py37-test-alldeps
             toxposargs: --durations=50

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -16,43 +16,6 @@ jobs:
       matrix:
         include:
 
-          - name: Code style checks
-            os: ubuntu-latest
-            python: 3.x
-            toxenv: codestyle
-
-          - name: Python 3.7 with minimal dependencies
-            os: ubuntu-latest
-            python: 3.7
-            toxenv: py37-test
-
-          - name: Python 3.8 with all optional dependencies
-            os: ubuntu-latest
-            python: 3.8
-            toxenv: py38-test-alldeps
-            toxargs: -v --develop
-            toxposargs: --open-files
-
-          # NOTE: In the build below we also check that tests do not open and
-          # leave open any files. This has a performance impact on running the
-          # tests, hence why it is not enabled by default.
-          - name: Python 3.7 with oldest supported version of all dependencies
-            os: ubuntu-16.04
-            python: 3.7
-            toxenv: py37-test-oldestdeps
-
-          - name: Python 3.7 with numpy 1.17 and full coverage
-            os: ubuntu-latest
-            python: 3.7
-            toxenv: py37-test-alldeps-numpy117-cov-clocale
-            toxposargs: --remote-data=astropy
-
-          - name: Python 3.8 with all optional dependencies (Windows)
-            os: windows-latest
-            python: 3.8
-            toxenv: py38-test-alldeps
-            toxposargs: --durations=50
-
           - name: Python 3.7 with all optional dependencies (MacOS X)
             os: macos-11.0
             python: 3.7
@@ -81,33 +44,3 @@ jobs:
       uses: codecov/codecov-action@v1
       with:
         file: ./coverage.xml
-
-  allowed_failures:
-    name: ${{ matrix.name }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: (Allowed Failure) Python 3.7 with remote data and dev version of key dependencies
-            os: ubuntu-latest
-            python: 3.7
-            toxenv: py37-test-devdeps
-            toxposargs: --remote-data=any
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python }}
-    - name: Install language-pack-de and tzdata
-      if: startsWith(matrix.os, 'ubuntu')
-      run: sudo apt-get install language-pack-de tzdata
-    - name: Install Python dependencies
-      run: python -m pip install --upgrade tox codecov
-    - name: Run tests
-      run: tox ${{ matrix.toxargs }} -e ${{ matrix.toxenv }} -- ${{ matrix.toxposargs }}


### PR DESCRIPTION
Currently ``macos-latest`` uses MacOS X 10.15, but this PR is to check that everything works fine with MacOS X 11 (Big Sur). We don't actually have to merge this since I assume ``macos-latest`` will eventually point to MacOS X 11.