### PR TITLE
Do not access uninitialized info when adding a mixin to a table.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -221,6 +221,11 @@ astropy.stats
 astropy.table
 ^^^^^^^^^^^^^
 
+- Ensure that adding a ``Quantity`` or other mixin column to a ``Table``
+  does not have side effects, such as creating an associated ``info``
+  instance (which would lead to slow-down of, e.g., slicing afterwards).
+  [#11077]
+
 astropy.tests
 ^^^^^^^^^^^^^
 

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -85,9 +85,6 @@ def col_copy(col, copy_indices=True):
             for index in newcol.info.indices:
                 index.replace_col(col, newcol)
 
-    # TODO: bit strange that this is needed. Why not the default?
-    newcol.info.indices = newcol.info.indices or []
-
     return newcol
 
 

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -172,7 +172,11 @@ def descr(col):
 
 
 def has_info_class(obj, cls):
-    return hasattr(obj, 'info') and isinstance(obj.info, cls)
+    """Check if the object's info is an instance of cls."""
+    # We check info on the class of the instance, since on the instance
+    # itself accessing 'info' has side effects in that it sets
+    # obj.__dict__['info'] if it does not exist already.
+    return isinstance(getattr(obj.__class__, 'info', None), cls)
 
 
 def _get_names_from_list_of_dict(rows):

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -1012,9 +1012,11 @@ class Table:
             data_is_mixin = True
 
         # Get the final column name using precedence.  Some objects may not
-        # have an info attribute.
+        # have an info attribute. Also avoid creating info as a side effect.
         if not name:
-            if hasattr(data, 'info'):
+            if isinstance(data, Column):
+                name = data.name or default_name
+            elif 'info' in getattr(data, '__dict__', ()):
                 name = data.info.name or default_name
             else:
                 name = default_name

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -1040,7 +1040,6 @@ class Table:
             try:
                 col = data[0].__class__(data)
                 col.info.name = name
-                col.info.indices = []
                 return col
             except Exception:
                 # If that didn't work for some reason, just turn it into np.array of object
@@ -1197,8 +1196,6 @@ class Table:
                 # still pass if this line is deleted.  (Each col.info attribute access
                 # is expensive).
                 col.info._copy_indices = True
-            else:
-                newcol.info.indices = []
 
             newcols.append(newcol)
 

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -829,3 +829,21 @@ def test_skycoord_with_velocity():
     s.seek(0)
     t2 = Table.read(s.read(), format='ascii.ecsv')
     assert skycoord_equal(t2['col0'], sc)
+
+
+@pytest.mark.parametrize('table_cls', [Table, QTable])
+def test_ensure_input_info_is_unchanged(table_cls):
+    """If a mixin input to a table has no info, it should stay that way.
+
+    This since having 'info' slows down slicing, etc.
+    See gh-11066.
+    """
+    q = [1, 2] * u.m
+    assert 'info' not in q.__dict__
+    t = table_cls({'q': q})
+    assert 'info' not in q.__dict__
+    t['q2'] = q
+    assert 'info' not in q.__dict__
+    sc = SkyCoord([1, 2], [2, 3], unit='deg')
+    t['sc'] = sc
+    assert 'info' not in sc.__dict__

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -840,6 +840,10 @@ def test_ensure_input_info_is_unchanged(table_cls):
     """
     q = [1, 2] * u.m
     assert 'info' not in q.__dict__
+    t = table_cls([q], names=['q'])
+    assert 'info' not in q.__dict__
+    t = table_cls([q])
+    assert 'info' not in q.__dict__
     t = table_cls({'q': q})
     assert 'info' not in q.__dict__
     t['q2'] = q

--- a/astropy/utils/data_info.py
+++ b/astropy/utils/data_info.py
@@ -346,7 +346,14 @@ reference with ``c = col[3:5]`` followed by ``c.info``.""")
 
         if isinstance(value, DataInfo):
             info = instance.__dict__['info'] = self.__class__(bound=True)
-            for attr in info.attr_names - info.attrs_from_parent - info._attrs_no_copy:
+            attr_names = info.attr_names
+            if value.__class__ is self.__class__:
+                # For same class, attributes are guaranteed to be stored in
+                # _attrs, so speed matters up by not accessing defaults.
+                # Doing this before difference in for loop helps speed.
+                attr_names = attr_names & set(value._attrs)  # NOT in-place!
+
+            for attr in attr_names - info.attrs_from_parent - info._attrs_no_copy:
                 info._attrs[attr] = deepcopy(getattr(value, attr))
 
         else:

--- a/astropy/utils/data_info.py
+++ b/astropy/utils/data_info.py
@@ -566,6 +566,18 @@ class BaseColumnInfo(DataInfo):
         for str_val in _pformat_col_iter(col, -1, False, False, {}):
             yield str_val
 
+    @property
+    def indices(self):
+        # Implementation note: the auto-generation as an InfoAttribute cannot
+        # be used here, since on access, one should not just return the
+        # default (empty list is this case), but set _attrs['indices'] so that
+        # if the list is appended to, it is registered here.
+        return self._attrs.setdefault('indices', [])
+
+    @indices.setter
+    def indices(self, indices):
+        self._attrs['indices'] = indices
+
     def adjust_indices(self, index, value, col_len):
         '''
         Adjust info indices after column modification.

--- a/astropy/utils/tests/test_data_info.py
+++ b/astropy/utils/tests/test_data_info.py
@@ -80,10 +80,10 @@ def test_info_no_copy_mixin_with_index(col):
     t.add_index('col')
     val = t['col'][0]
     assert 'info' not in val.__dict__
-    assert val.info.indices is None
+    assert val.info.indices == []
     val = t['col'][:]
     assert 'info' in val.__dict__
-    assert val.info.indices is None
+    assert val.info.indices == []
     val = t[:]['col']
     assert 'info' in val.__dict__
     assert isinstance(val.info.indices[0], SlicedIndex)
@@ -97,8 +97,8 @@ def test_info_no_copy_skycoord():
     t = QTable([col], names=['col'])
     val = t['col'][0]
     assert 'info' not in val.__dict__
-    assert val.info.indices is None
+    assert val.info.indices == []
     val = t['col'][:]
-    assert val.info.indices is None
+    assert val.info.indices == []
     val = t[:]['col']
     assert val.info.indices == []


### PR DESCRIPTION
As noted in #11066, when one adds a quantity (or other mixin column) to a table, it has the strange side effect that subsequent operations on that quantity are substantially slower. This is because `info` has been accessed, which now gets copied in any further operations. 

When something is copied to become part of the table, the expectation should be that original remains unchanged, so this PR avoids accessing `.info` unless it already exists.

In the process, it was also found that in current master, not only does `q.__dict__['info']` get created, it also has its `indices` set to ~an empty list~ `None`. ~Indeed~ Also, in several places, `col.info.indices` is explicitly set to `[]`. This seems unnecessary, so the PR here also just ensures that whenever one accesses `col.info.indices` for the first time, it gets initialized to `[]`. (In principle, the same could be done for `Column`, but there it felt a bit less necessary - can add that if wished.)

fixes #11066

Notes:
- while I think side effects of setting something in a table are undesired and thus labelled this as a bug, it seemed not important enough to backport.
- the first commit is less essential given that 'info' no longer is accessed, but will somewhat speed up performance for mixin column inside a table, so I left it in.
- EDIT: I had to change a couple of very recent tests that checked that `.info.indices is None` for uninitialized info. Would seem fine that those become empty lists.