### PR TITLE
Direct icrs altaz

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,9 @@ astropy.coordinates
   ``AltAz`` calculations are now accurate down to the milli-arcsecond
   level. [#10994]
 
+- Adds a direct transformation from ``ICRS`` to ``AltAz`` frames. This
+  provides a modest speedup of approximately 10 percent. [#11079]
+
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 

--- a/astropy/coordinates/builtin_frames/__init__.py
+++ b/astropy/coordinates/builtin_frames/__init__.py
@@ -47,6 +47,7 @@ from . import galactic_transforms
 from . import supergalactic_transforms
 from . import icrs_cirs_transforms
 from . import cirs_observed_transforms
+from . import icrs_observed_transforms
 from . import intermediate_rotation_transforms
 from . import ecliptic_transforms
 

--- a/astropy/coordinates/builtin_frames/icrs_observed_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_observed_transforms.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Contains the transformation functions for getting to "observed" systems from ICRS.
+Currently that just means AltAz.
+"""
+
+import numpy as np
+import erfa
+
+from astropy import units as u
+from astropy.coordinates.builtin_frames.utils import atciqz, aticq
+from astropy.coordinates.baseframe import frame_transform_graph
+from astropy.coordinates.transformations import FunctionTransformWithFiniteDifference
+from astropy.coordinates.representation import (SphericalRepresentation,
+                                                CartesianRepresentation,
+                                                UnitSphericalRepresentation)
+
+from .icrs import ICRS
+from .altaz import AltAz
+from .utils import PIOVER2
+from ..erfa_astrom import erfa_astrom
+
+
+@frame_transform_graph.transform(FunctionTransformWithFiniteDifference, ICRS, AltAz)
+def icrs_to_altaz(icrs_coo, altaz_frame):
+    # if the data are UnitSphericalRepresentation, we can skip the distance calculations
+    is_unitspherical = (isinstance(icrs_coo.data, UnitSphericalRepresentation) or
+                        icrs_coo.cartesian.x.unit == u.one)
+    # first set up the astrometry context for ICRS<->AltAz
+    astrom = erfa_astrom.get().apco(altaz_frame)
+
+    # correct for parallax to find BCRS direction from observer (as in erfa.pmpx)
+    if is_unitspherical:
+        srepr = icrs_coo.spherical
+    else:
+        observer_icrs = CartesianRepresentation(astrom['eb'] * u.au, xyz_axis=-1)
+        srepr = (icrs_coo.cartesian - observer_icrs).represent_as(
+            SphericalRepresentation)
+
+    # convert to topocentric CIRS
+    cirs_ra, cirs_dec = atciqz(srepr, astrom)
+
+    # now perform AltAz conversion
+    az, zen, ha, odec, ora = erfa.atioq(cirs_ra, cirs_dec, astrom)
+    alt = np.pi/2-zen
+    aa_srepr = SphericalRepresentation(az*u.radian, alt*u.radian, srepr.distance)
+    return altaz_frame.realize_frame(aa_srepr)
+
+
+@frame_transform_graph.transform(FunctionTransformWithFiniteDifference, AltAz, ICRS)
+def altaz_to_icrs(altaz_coo, icrs_frame):
+    # if the data are UnitSphericalRepresentation, we can skip the distance calculations
+    is_unitspherical = (isinstance(altaz_coo.data, UnitSphericalRepresentation) or
+                        altaz_coo.cartesian.x.unit == u.one)
+
+    usrepr = altaz_coo.represent_as(UnitSphericalRepresentation)
+    az = usrepr.lon.to_value(u.radian)
+    zen = PIOVER2 - usrepr.lat.to_value(u.radian)
+
+    # first set up the astrometry context for ICRS<->CIRS at the altaz_coo time
+    astrom = erfa_astrom.get().apco(altaz_coo)
+
+    # Topocentric CIRS
+    cirs_ra, cirs_dec = erfa.atoiq('A', az, zen, astrom)*u.radian
+    if is_unitspherical:
+        srepr = SphericalRepresentation(cirs_ra*u.deg, cirs_dec*u.deg, 1)
+    else:
+        srepr = SphericalRepresentation(lon=cirs_ra, lat=cirs_dec,
+                                        distance=altaz_coo.distance)
+
+    # BCRS (Astrometric) direction to source
+    bcrs_ra, bcrs_dec = aticq(srepr, astrom)
+
+    # Correct for parallax to get ICRS representation
+    if is_unitspherical:
+        icrs_srepr = SphericalRepresentation(cirs_ra*u.deg, cirs_dec*u.deg, 1)
+    else:
+        icrs_srepr = SphericalRepresentation(lon=bcrs_ra*u.rad, lat=bcrs_dec*u.rad,
+                                             distance=altaz_coo.distance)
+        observer_icrs = CartesianRepresentation(astrom['eb'] * u.au, xyz_axis=-1)
+        newrepr = icrs_srepr.to_cartesian() + observer_icrs
+        icrs_srepr = newrepr.represent_as(SphericalRepresentation)
+
+    return icrs_frame.realize_frame(icrs_srepr)

--- a/astropy/coordinates/builtin_frames/icrs_observed_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_observed_transforms.py
@@ -64,19 +64,19 @@ def altaz_to_icrs(altaz_coo, icrs_frame):
     # Topocentric CIRS
     cirs_ra, cirs_dec = erfa.atoiq('A', az, zen, astrom)*u.radian
     if is_unitspherical:
-        srepr = SphericalRepresentation(cirs_ra*u.deg, cirs_dec*u.deg, 1)
+        srepr = SphericalRepresentation(cirs_ra, cirs_dec, 1)
     else:
         srepr = SphericalRepresentation(lon=cirs_ra, lat=cirs_dec,
                                         distance=altaz_coo.distance)
 
     # BCRS (Astrometric) direction to source
-    bcrs_ra, bcrs_dec = aticq(srepr, astrom)
+    bcrs_ra, bcrs_dec = aticq(srepr, astrom)*u.radian
 
     # Correct for parallax to get ICRS representation
     if is_unitspherical:
-        icrs_srepr = SphericalRepresentation(cirs_ra*u.deg, cirs_dec*u.deg, 1)
+        icrs_srepr = SphericalRepresentation(bcrs_ra, bcrs_dec, 1)
     else:
-        icrs_srepr = SphericalRepresentation(lon=bcrs_ra*u.rad, lat=bcrs_dec*u.rad,
+        icrs_srepr = SphericalRepresentation(lon=bcrs_ra, lat=bcrs_dec,
                                              distance=altaz_coo.distance)
         observer_icrs = CartesianRepresentation(astrom['eb'] * u.au, xyz_axis=-1)
         newrepr = icrs_srepr.to_cartesian() + observer_icrs

--- a/astropy/coordinates/tests/test_icrs_observed_transformations.py
+++ b/astropy/coordinates/tests/test_icrs_observed_transformations.py
@@ -1,0 +1,48 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""Accuracy tests for ICRS transformations, primarily to/from AltAz.
+
+"""
+import pytest
+import numpy as np
+
+from astropy import units as u
+from astropy.tests.helper import assert_quantity_allclose as assert_allclose
+from astropy.time import Time
+from astropy.coordinates import (
+    EarthLocation, ICRS,  CIRS, AltAz, SkyCoord)
+
+from astropy.coordinates.tests.utils import randomly_sample_sphere
+from astropy.coordinates import frame_transform_graph
+
+ra, dec, dist = randomly_sample_sphere(200)
+icrs_coords = SkyCoord(ra=ra, dec=dec, distance=dist*u.km*1e5)
+
+
+@pytest.mark.parametrize('icoo', icrs_coords)
+def test_icrs_consistency(icoo):
+    """
+    Check ICRS<->AltAz for consistency with ICRS<->CIRS<->AltAz
+
+    The latter is extensively tested in test_intermediate_transformations.py
+    """
+    observer = EarthLocation(28*u.deg, 23*u.deg, height=2000.*u.km)
+    obstime = Time('J2010')
+    aa_frame = AltAz(obstime=obstime, location=observer)
+
+    # check we are going direct!
+    trans = frame_transform_graph.get_transform(ICRS, AltAz).transforms
+    assert(len(trans) == 1)
+
+    # check that ICRS-AltAz and ICRS->CIRS->AltAz are consistent
+    aa1 = icoo.transform_to(aa_frame)
+    aa2 = icoo.transform_to(CIRS()).transform_to(aa_frame)
+    assert_allclose(aa1.separation_3d(aa2), 0*u.mm, atol=1*u.mm)
+
+    # check roundtrip
+    roundtrip = icoo.transform_to(aa_frame).transform_to(icoo)
+    assert_allclose(roundtrip.separation_3d(icoo),  0*u.mm, atol=1*u.mm)
+
+    # check there and back via CIRS mish-mash
+    roundtrip = icoo.transform_to(aa_frame).transform_to(
+        CIRS()).transform_to(icoo)
+    assert_allclose(roundtrip.separation_3d(icoo),  0*u.mm, atol=1*u.mm)


### PR DESCRIPTION
This PR fixes #10887 by implementing a 'direct' transformation between ICRS and AltAz. In fact, this transform routes via CIRS, but by doing it in one routine we avoid the overhead of computing the astrometry context twice, and the overhead in creating a SkyCoord object for each step.

This results in a modest speedup. Running @maxnoe's performance profiling from https://github.com/astropy/astropy/pull/10647#issuecomment-673569823, we find:

```
No Interpolation took 8.8879 s
Interpolation with  10.0 s   resolution took 0.9227 s
Interpolation with   5.0 min resolution took 0.2207 s
Interpolation with  30.0 min resolution took 0.1623 s
```

compared to the current master:

```
No Interpolation took 9.7546 s
Interpolation with  10.0 s   resolution took 1.0634 s
Interpolation with   5.0 min resolution took 0.2984 s
Interpolation with  30.0 min resolution took 0.2053 s
```

The only remaining puzzle is that I am unable to reproduce the high precision for GCRS->AltAz introduced in #11073. What is a mystery is that the transforms in that test are unaltered - they still go through the untouched GCRS->CIRS->AltAz chain. So I am submitting this PR to see if tests pass remotely and the local failure is something to do with my setup.  