### PR TITLE
Remove metaclasses from astropy.coordinates

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -263,6 +263,9 @@ Other Changes and Additions
   an order of magnitude, which enters as well in getting observed positions of
   planets using ``get_body``. [#11073]
 
+- Refactored the usage of metaclasses in ``astropy.coordinates`` to instead use
+  ``__init_subclass__`` where possible. [#11090]
+
 
 4.2.1 (unreleased)
 ==================

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -275,80 +275,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray,
         if repr_info is None or isinstance(repr_info, property):
             repr_info = getattr(cls, '_frame_specific_representation_info', None)
 
-        # Unless overridden via `frame_specific_representation_info`, velocity
-        # name defaults are (see also docstring for BaseCoordinateFrame):
-        #   * ``pm_{lon}_cos{lat}``, ``pm_{lat}`` for
-        #     `SphericalCosLatDifferential` proper motion components
-        #   * ``pm_{lon}``, ``pm_{lat}`` for `SphericalDifferential` proper
-        #     motion components
-        #   * ``radial_velocity`` for any `d_distance` component
-        #   * ``v_{x,y,z}`` for `CartesianDifferential` velocity components
-        # where `{lon}` and `{lat}` are the frame names of the angular
-        # components.
-        if repr_info is None:
-            repr_info = {}
-
-        # the tuple() call below is necessary because if it is not there,
-        # the iteration proceeds in a difficult-to-predict manner in the
-        # case that one of the class objects hash is such that it gets
-        # revisited by the iteration.  The tuple() call prevents this by
-        # making the items iterated over fixed regardless of how the dict
-        # changes
-        for cls_or_name in tuple(repr_info.keys()):
-            if isinstance(cls_or_name, str):
-                # TODO: this provides a layer of backwards compatibility in
-                # case the key is a string, but now we want explicit classes.
-                _cls = _get_repr_cls(cls_or_name)
-                repr_info[_cls] = repr_info.pop(cls_or_name)
-
-        # The default spherical names are 'lon' and 'lat'
-        repr_info.setdefault(r.SphericalRepresentation,
-                             [RepresentationMapping('lon', 'lon'),
-                              RepresentationMapping('lat', 'lat')])
-
-        sph_component_map = {m.reprname: m.framename
-                             for m in repr_info[r.SphericalRepresentation]}
-
-        repr_info.setdefault(r.SphericalCosLatDifferential, [
-            RepresentationMapping(
-                'd_lon_coslat',
-                'pm_{lon}_cos{lat}'.format(**sph_component_map),
-                u.mas/u.yr),
-            RepresentationMapping('d_lat',
-                                  'pm_{lat}'.format(**sph_component_map),
-                                  u.mas/u.yr),
-            RepresentationMapping('d_distance', 'radial_velocity',
-                                  u.km/u.s)
-        ])
-
-        repr_info.setdefault(r.SphericalDifferential, [
-            RepresentationMapping('d_lon',
-                                  'pm_{lon}'.format(**sph_component_map),
-                                  u.mas/u.yr),
-            RepresentationMapping('d_lat',
-                                  'pm_{lat}'.format(**sph_component_map),
-                                  u.mas/u.yr),
-            RepresentationMapping('d_distance', 'radial_velocity',
-                                  u.km/u.s)
-        ])
-
-        repr_info.setdefault(r.CartesianDifferential, [
-            RepresentationMapping('d_x', 'v_x', u.km/u.s),
-            RepresentationMapping('d_y', 'v_y', u.km/u.s),
-            RepresentationMapping('d_z', 'v_z', u.km/u.s)])
-
-        # Unit* classes should follow the same naming conventions
-        # TODO: this adds some unnecessary mappings for the Unit classes, so
-        # this could be cleaned up, but in practice doesn't seem to have any
-        # negative side effects
-        repr_info.setdefault(r.UnitSphericalRepresentation,
-                             repr_info[r.SphericalRepresentation])
-
-        repr_info.setdefault(r.UnitSphericalCosLatDifferential,
-                             repr_info[r.SphericalCosLatDifferential])
-
-        repr_info.setdefault(r.UnitSphericalDifferential,
-                             repr_info[r.SphericalDifferential])
+        repr_info = cls._infer_repr_info(repr_info)
 
         # Make read-only properties for the frame class attributes that should
         # be read-only to make them immutable after creation.
@@ -620,6 +547,95 @@ class BaseCoordinateFrame(ShapedLikeNDArray,
             representation_data = representation_data.with_differentials({'s': differential_data})
 
         return representation_data
+
+    @classmethod
+    def _infer_repr_info(cls, repr_info):
+        # Unless overridden via `frame_specific_representation_info`, velocity
+        # name defaults are (see also docstring for BaseCoordinateFrame):
+        #   * ``pm_{lon}_cos{lat}``, ``pm_{lat}`` for
+        #     `SphericalCosLatDifferential` proper motion components
+        #   * ``pm_{lon}``, ``pm_{lat}`` for `SphericalDifferential` proper
+        #     motion components
+        #   * ``radial_velocity`` for any `d_distance` component
+        #   * ``v_{x,y,z}`` for `CartesianDifferential` velocity components
+        # where `{lon}` and `{lat}` are the frame names of the angular
+        # components.
+        if repr_info is None:
+            repr_info = {}
+
+        # the tuple() call below is necessary because if it is not there,
+        # the iteration proceeds in a difficult-to-predict manner in the
+        # case that one of the class objects hash is such that it gets
+        # revisited by the iteration.  The tuple() call prevents this by
+        # making the items iterated over fixed regardless of how the dict
+        # changes
+        for cls_or_name in tuple(repr_info.keys()):
+            if isinstance(cls_or_name, str):
+                # TODO: this provides a layer of backwards compatibility in
+                # case the key is a string, but now we want explicit classes.
+                _cls = _get_repr_cls(cls_or_name)
+                repr_info[_cls] = repr_info.pop(cls_or_name)
+
+        # The default spherical names are 'lon' and 'lat'
+        repr_info.setdefault(r.SphericalRepresentation,
+                             [RepresentationMapping('lon', 'lon'),
+                              RepresentationMapping('lat', 'lat')])
+
+        sph_component_map = {m.reprname: m.framename
+                             for m in repr_info[r.SphericalRepresentation]}
+
+        repr_info.setdefault(r.SphericalCosLatDifferential, [
+            RepresentationMapping(
+                'd_lon_coslat',
+                'pm_{lon}_cos{lat}'.format(**sph_component_map),
+                u.mas/u.yr),
+            RepresentationMapping('d_lat',
+                                  'pm_{lat}'.format(**sph_component_map),
+                                  u.mas/u.yr),
+            RepresentationMapping('d_distance', 'radial_velocity',
+                                  u.km/u.s)
+        ])
+
+        repr_info.setdefault(r.SphericalDifferential, [
+            RepresentationMapping('d_lon',
+                                  'pm_{lon}'.format(**sph_component_map),
+                                  u.mas/u.yr),
+            RepresentationMapping('d_lat',
+                                  'pm_{lat}'.format(**sph_component_map),
+                                  u.mas/u.yr),
+            RepresentationMapping('d_distance', 'radial_velocity',
+                                  u.km/u.s)
+        ])
+
+        repr_info.setdefault(r.CartesianDifferential, [
+            RepresentationMapping('d_x', 'v_x', u.km/u.s),
+            RepresentationMapping('d_y', 'v_y', u.km/u.s),
+            RepresentationMapping('d_z', 'v_z', u.km/u.s)])
+
+        # Unit* classes should follow the same naming conventions
+        # TODO: this adds some unnecessary mappings for the Unit classes, so
+        # this could be cleaned up, but in practice doesn't seem to have any
+        # negative side effects
+        repr_info.setdefault(r.UnitSphericalRepresentation,
+                             repr_info[r.SphericalRepresentation])
+
+        repr_info.setdefault(r.UnitSphericalCosLatDifferential,
+                             repr_info[r.SphericalCosLatDifferential])
+
+        repr_info.setdefault(r.UnitSphericalDifferential,
+                             repr_info[r.SphericalDifferential])
+
+        return repr_info
+
+    @classmethod
+    def _create_readonly_property(cls, attr_name, value):
+        private_attr = '_' + attr_name
+
+        def getter(self):
+            return getattr(self, private_attr)
+
+        setattr(cls, private_attr, value)
+        setattr(cls, attr_name, property(getter))
 
     @lazyproperty
     def cache(self):

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -266,7 +266,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray,
     frame_attributes = {}
     # Default empty frame_attributes dict
 
-    def __init_subclass__(cls):
+    def __init_subclass__(cls, **kwargs):
 
         # We first check for explicitly set values for these:
         default_repr = getattr(cls, 'default_representation', None)
@@ -384,7 +384,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray,
         # them in the meta
         cls._frame_class_cache = {}
 
-        super().__init_subclass__()
+        super().__init_subclass__(**kwargs)
 
     def __init__(self, *args, copy=True, representation_type=None,
                  differential_type=None, **kwargs):

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -137,168 +137,14 @@ def _normalize_representation_type(kwargs):
         kwargs['representation_type'] = kwargs.pop('representation')
 
 
-# Need to subclass ABCMeta as well, so that this meta class can be combined
-# with ShapedLikeNDArray below (which is an ABC); without it, one gets
-# "TypeError: metaclass conflict: the metaclass of a derived class must be a
-#  (non-strict) subclass of the metaclasses of all its bases"
-class FrameMeta(OrderedDescriptorContainer, abc.ABCMeta):
-    def __new__(mcls, name, bases, members):
-        if 'default_representation' in members:
-            default_repr = members.pop('default_representation')
-            found_default_repr = True
-        else:
-            default_repr = None
-            found_default_repr = False
+def _readonly_prop_factory(cls, attr_name, value):
+    private_attr = '_' + attr_name
 
-        if 'default_differential' in members:
-            default_diff = members.pop('default_differential')
-            found_default_diff = True
-        else:
-            default_diff = None
-            found_default_diff = False
+    def getter(self):
+        return getattr(self, private_attr)
 
-        if 'frame_specific_representation_info' in members:
-            repr_info = members.pop('frame_specific_representation_info')
-            found_repr_info = True
-        else:
-            repr_info = None
-            found_repr_info = False
-
-        # somewhat hacky, but this is the best way to get the MRO according to
-        # https://mail.python.org/pipermail/python-list/2002-December/167861.html
-        tmp_cls = super().__new__(mcls, name, bases, members)
-
-        # now look through the whole MRO for the class attributes, raw for
-        # frame_attr_names, and leading underscore for others
-        for m in (c.__dict__ for c in tmp_cls.__mro__):
-            if not found_default_repr and '_default_representation' in m:
-                default_repr = m['_default_representation']
-                found_default_repr = True
-
-            if not found_default_diff and '_default_differential' in m:
-                default_diff = m['_default_differential']
-                found_default_diff = True
-
-            if (not found_repr_info
-                    and '_frame_specific_representation_info' in m):
-                # create a copy of the dict so we don't mess with the contents
-                repr_info = m['_frame_specific_representation_info'].copy()
-                found_repr_info = True
-
-            if found_default_repr and found_default_diff and found_repr_info:
-                break
-        else:
-            raise ValueError(
-                'Could not find all expected BaseCoordinateFrame class '
-                'attributes.  Are you mis-using FrameMeta?')
-
-        # Unless overridden via `frame_specific_representation_info`, velocity
-        # name defaults are (see also docstring for BaseCoordinateFrame):
-        #   * ``pm_{lon}_cos{lat}``, ``pm_{lat}`` for
-        #     `SphericalCosLatDifferential` proper motion components
-        #   * ``pm_{lon}``, ``pm_{lat}`` for `SphericalDifferential` proper
-        #     motion components
-        #   * ``radial_velocity`` for any `d_distance` component
-        #   * ``v_{x,y,z}`` for `CartesianDifferential` velocity components
-        # where `{lon}` and `{lat}` are the frame names of the angular
-        # components.
-        if repr_info is None:
-            repr_info = {}
-
-        # the tuple() call below is necessary because if it is not there,
-        # the iteration proceeds in a difficult-to-predict manner in the
-        # case that one of the class objects hash is such that it gets
-        # revisited by the iteration.  The tuple() call prevents this by
-        # making the items iterated over fixed regardless of how the dict
-        # changes
-        for cls_or_name in tuple(repr_info.keys()):
-            if isinstance(cls_or_name, str):
-                # TODO: this provides a layer of backwards compatibility in
-                # case the key is a string, but now we want explicit classes.
-                cls = _get_repr_cls(cls_or_name)
-                repr_info[cls] = repr_info.pop(cls_or_name)
-
-        # The default spherical names are 'lon' and 'lat'
-        repr_info.setdefault(r.SphericalRepresentation,
-                             [RepresentationMapping('lon', 'lon'),
-                              RepresentationMapping('lat', 'lat')])
-
-        sph_component_map = {m.reprname: m.framename
-                             for m in repr_info[r.SphericalRepresentation]}
-
-        repr_info.setdefault(r.SphericalCosLatDifferential, [
-            RepresentationMapping(
-                'd_lon_coslat',
-                'pm_{lon}_cos{lat}'.format(**sph_component_map),
-                u.mas/u.yr),
-            RepresentationMapping('d_lat',
-                                  'pm_{lat}'.format(**sph_component_map),
-                                  u.mas/u.yr),
-            RepresentationMapping('d_distance', 'radial_velocity',
-                                  u.km/u.s)
-        ])
-
-        repr_info.setdefault(r.SphericalDifferential, [
-            RepresentationMapping('d_lon',
-                                  'pm_{lon}'.format(**sph_component_map),
-                                  u.mas/u.yr),
-            RepresentationMapping('d_lat',
-                                  'pm_{lat}'.format(**sph_component_map),
-                                  u.mas/u.yr),
-            RepresentationMapping('d_distance', 'radial_velocity',
-                                  u.km/u.s)
-        ])
-
-        repr_info.setdefault(r.CartesianDifferential, [
-            RepresentationMapping('d_x', 'v_x', u.km/u.s),
-            RepresentationMapping('d_y', 'v_y', u.km/u.s),
-            RepresentationMapping('d_z', 'v_z', u.km/u.s)])
-
-        # Unit* classes should follow the same naming conventions
-        # TODO: this adds some unnecessary mappings for the Unit classes, so
-        # this could be cleaned up, but in practice doesn't seem to have any
-        # negative side effects
-        repr_info.setdefault(r.UnitSphericalRepresentation,
-                             repr_info[r.SphericalRepresentation])
-
-        repr_info.setdefault(r.UnitSphericalCosLatDifferential,
-                             repr_info[r.SphericalCosLatDifferential])
-
-        repr_info.setdefault(r.UnitSphericalDifferential,
-                             repr_info[r.SphericalDifferential])
-
-        # Make read-only properties for the frame class attributes that should
-        # be read-only to make them immutable after creation.
-        # We copy attributes instead of linking to make sure there's no
-        # accidental cross-talk between classes
-        mcls.readonly_prop_factory(members, 'default_representation',
-                                   default_repr)
-        mcls.readonly_prop_factory(members, 'default_differential',
-                                   default_diff)
-        mcls.readonly_prop_factory(members,
-                                   'frame_specific_representation_info',
-                                   copy.deepcopy(repr_info))
-
-        # now set the frame name as lower-case class name, if it isn't explicit
-        if 'name' not in members:
-            members['name'] = name.lower()
-
-        # A cache that *must be unique to each frame class* - it is
-        # insufficient to share them with superclasses, hence the need to put
-        # them in the meta
-        members['_frame_class_cache'] = {}
-
-        return super().__new__(mcls, name, bases, members)
-
-    @staticmethod
-    def readonly_prop_factory(members, attr, value):
-        private_attr = '_' + attr
-
-        def getter(self):
-            return getattr(self, private_attr)
-
-        members[private_attr] = value
-        members[attr] = property(getter)
+    setattr(cls, private_attr, value)
+    setattr(cls, attr_name, property(getter))
 
 
 _RepresentationMappingBase = \
@@ -358,8 +204,16 @@ _components = """
 """
 
 
+# TODO: This is only needed so that BaseCoordinateFrame can have
+# OrderedDescriptorContainer as a metaclass. Trying to use
+# metaclass=OrderedDescriptorContainer directly causes a metaclass conflict.
+class FrameMeta(OrderedDescriptorContainer, abc.ABCMeta):
+    pass
+
+
 @format_doc(base_doc, components=_components, footer="")
-class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
+class BaseCoordinateFrame(ShapedLikeNDArray,
+                          metaclass=FrameMeta):
     """
     The base class for coordinate frames.
 
@@ -411,6 +265,121 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
 
     frame_attributes = {}
     # Default empty frame_attributes dict
+
+    def __init_subclass__(cls, name=None):
+
+        # We first check for explicitly set values for these:
+        default_repr = getattr(cls, 'default_representation', None)
+        default_diff = getattr(cls, 'default_differential', None)
+        repr_info = getattr(cls, 'frame_specific_representation_info', None)
+
+        # Then, to make sure this works for subclasses-of-subclasses, we also
+        # have to check for cases where the attribute names have already been
+        # replaced by underscore-prefaced equivalents by the logic below:
+        if default_repr is None or isinstance(default_repr, property):
+            default_repr = getattr(cls, '_default_representation', None)
+
+        if default_diff is None or isinstance(default_diff, property):
+            default_diff = getattr(cls, '_default_differential', None)
+
+        if repr_info is None or isinstance(repr_info, property):
+            repr_info = getattr(cls, '_frame_specific_representation_info', None)
+
+        # Unless overridden via `frame_specific_representation_info`, velocity
+        # name defaults are (see also docstring for BaseCoordinateFrame):
+        #   * ``pm_{lon}_cos{lat}``, ``pm_{lat}`` for
+        #     `SphericalCosLatDifferential` proper motion components
+        #   * ``pm_{lon}``, ``pm_{lat}`` for `SphericalDifferential` proper
+        #     motion components
+        #   * ``radial_velocity`` for any `d_distance` component
+        #   * ``v_{x,y,z}`` for `CartesianDifferential` velocity components
+        # where `{lon}` and `{lat}` are the frame names of the angular
+        # components.
+        if repr_info is None:
+            repr_info = {}
+
+        # the tuple() call below is necessary because if it is not there,
+        # the iteration proceeds in a difficult-to-predict manner in the
+        # case that one of the class objects hash is such that it gets
+        # revisited by the iteration.  The tuple() call prevents this by
+        # making the items iterated over fixed regardless of how the dict
+        # changes
+        for cls_or_name in tuple(repr_info.keys()):
+            if isinstance(cls_or_name, str):
+                # TODO: this provides a layer of backwards compatibility in
+                # case the key is a string, but now we want explicit classes.
+                _cls = _get_repr_cls(cls_or_name)
+                repr_info[_cls] = repr_info.pop(cls_or_name)
+
+        # The default spherical names are 'lon' and 'lat'
+        repr_info.setdefault(r.SphericalRepresentation,
+                             [RepresentationMapping('lon', 'lon'),
+                              RepresentationMapping('lat', 'lat')])
+
+        sph_component_map = {m.reprname: m.framename
+                             for m in repr_info[r.SphericalRepresentation]}
+
+        repr_info.setdefault(r.SphericalCosLatDifferential, [
+            RepresentationMapping(
+                'd_lon_coslat',
+                'pm_{lon}_cos{lat}'.format(**sph_component_map),
+                u.mas/u.yr),
+            RepresentationMapping('d_lat',
+                                  'pm_{lat}'.format(**sph_component_map),
+                                  u.mas/u.yr),
+            RepresentationMapping('d_distance', 'radial_velocity',
+                                  u.km/u.s)
+        ])
+
+        repr_info.setdefault(r.SphericalDifferential, [
+            RepresentationMapping('d_lon',
+                                  'pm_{lon}'.format(**sph_component_map),
+                                  u.mas/u.yr),
+            RepresentationMapping('d_lat',
+                                  'pm_{lat}'.format(**sph_component_map),
+                                  u.mas/u.yr),
+            RepresentationMapping('d_distance', 'radial_velocity',
+                                  u.km/u.s)
+        ])
+
+        repr_info.setdefault(r.CartesianDifferential, [
+            RepresentationMapping('d_x', 'v_x', u.km/u.s),
+            RepresentationMapping('d_y', 'v_y', u.km/u.s),
+            RepresentationMapping('d_z', 'v_z', u.km/u.s)])
+
+        # Unit* classes should follow the same naming conventions
+        # TODO: this adds some unnecessary mappings for the Unit classes, so
+        # this could be cleaned up, but in practice doesn't seem to have any
+        # negative side effects
+        repr_info.setdefault(r.UnitSphericalRepresentation,
+                             repr_info[r.SphericalRepresentation])
+
+        repr_info.setdefault(r.UnitSphericalCosLatDifferential,
+                             repr_info[r.SphericalCosLatDifferential])
+
+        repr_info.setdefault(r.UnitSphericalDifferential,
+                             repr_info[r.SphericalDifferential])
+
+        # Make read-only properties for the frame class attributes that should
+        # be read-only to make them immutable after creation.
+        # We copy attributes instead of linking to make sure there's no
+        # accidental cross-talk between classes
+        _readonly_prop_factory(cls, 'default_representation', default_repr)
+        _readonly_prop_factory(cls, 'default_differential', default_diff)
+        _readonly_prop_factory(cls, 'frame_specific_representation_info',
+                               copy.deepcopy(repr_info))
+
+        # now set the frame name as lower-case class name, if it isn't explicit
+        if name is None:
+            name = cls.__name__.lower()
+        cls.name = name
+
+        # A cache that *must be unique to each frame class* - it is
+        # insufficient to share them with superclasses, hence the need to put
+        # them in the meta
+        cls._frame_class_cache = {}
+
+        super().__init_subclass__()
 
     def __init__(self, *args, copy=True, representation_type=None,
                  differential_type=None, **kwargs):
@@ -1298,7 +1267,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
     def _frameattr_equiv(left_fattr, right_fattr):
         """
         Determine if two frame attributes are equivalent.  Implemented as a
-        staticmethod mainly as a convenient location, althought conceivable it
+        staticmethod mainly as a convenient location, although conceivable it
         might be desirable for subclasses to override this behavior.
 
         Primary purpose is to check for equality of representations.  This

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -137,16 +137,6 @@ def _normalize_representation_type(kwargs):
         kwargs['representation_type'] = kwargs.pop('representation')
 
 
-def _readonly_prop_factory(cls, attr_name, value):
-    private_attr = '_' + attr_name
-
-    def getter(self):
-        return getattr(self, private_attr)
-
-    setattr(cls, private_attr, value)
-    setattr(cls, attr_name, property(getter))
-
-
 _RepresentationMappingBase = \
     namedtuple('RepresentationMapping',
                ('reprname', 'framename', 'defaultunit'))
@@ -364,10 +354,10 @@ class BaseCoordinateFrame(ShapedLikeNDArray,
         # be read-only to make them immutable after creation.
         # We copy attributes instead of linking to make sure there's no
         # accidental cross-talk between classes
-        _readonly_prop_factory(cls, 'default_representation', default_repr)
-        _readonly_prop_factory(cls, 'default_differential', default_diff)
-        _readonly_prop_factory(cls, 'frame_specific_representation_info',
-                               copy.deepcopy(repr_info))
+        cls._create_readonly_property('default_representation', default_repr)
+        cls._create_readonly_property('default_differential', default_diff)
+        cls._create_readonly_property('frame_specific_representation_info',
+                                      copy.deepcopy(repr_info))
 
         # Deal with setting the name of the frame:
         if not hasattr(cls, 'name'):

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -266,7 +266,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray,
     frame_attributes = {}
     # Default empty frame_attributes dict
 
-    def __init_subclass__(cls, name=None):
+    def __init_subclass__(cls):
 
         # We first check for explicitly set values for these:
         default_repr = getattr(cls, 'default_representation', None)
@@ -369,10 +369,15 @@ class BaseCoordinateFrame(ShapedLikeNDArray,
         _readonly_prop_factory(cls, 'frame_specific_representation_info',
                                copy.deepcopy(repr_info))
 
-        # now set the frame name as lower-case class name, if it isn't explicit
-        if name is None:
-            name = cls.__name__.lower()
-        cls.name = name
+        # Deal with setting the name of the frame:
+        if not hasattr(cls, 'name'):
+            cls.name = cls.__name__.lower()
+        elif (BaseCoordinateFrame not in cls.__bases__ and
+                cls.name in [base.name for base in cls.__bases__]):
+            # This may be a subclass of a subclass of BaseCoordinateFrame,
+            # like ICRS(BaseRADecFrame). In this case, cls.name will have been
+            # set by init_subclass
+            cls.name = cls.__name__.lower()
 
         # A cache that *must be unique to each frame class* - it is
         # insufficient to share them with superclasses, hence the need to put

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -630,7 +630,7 @@ class BaseRepresentation(BaseRepresentationOrDifferential):
 
     info = RepresentationInfo()
 
-    def __init_subclass__(cls):
+    def __init_subclass__(cls, **kwargs):
         # Register representation name (except for BaseRepresentation)
         if cls.__name__ == 'BaseRepresentation':
             return
@@ -682,6 +682,8 @@ class BaseRepresentation(BaseRepresentationOrDifferential):
                 setattr(cls, component,
                         property(_make_getter(component),
                                  doc=f"The '{component}' component of the points(s)."))
+
+        super().__init_subclass__(**kwargs)
 
     def __init__(self, *args, differentials=None, **kwargs):
         # Handle any differentials passed in.
@@ -2242,7 +2244,7 @@ class BaseDifferential(BaseRepresentationOrDifferential):
     those, and a default ``__init__`` for initialization.
     """
 
-    def __init_subclass__(cls):
+    def __init_subclass__(cls, **kwargs):
         """Set default ``attr_classes`` and component getters on a Differential.
         class BaseDifferential(BaseRepresentationOrDifferential):
 
@@ -2278,6 +2280,8 @@ class BaseDifferential(BaseRepresentationOrDifferential):
                 setattr(cls, component,
                         property(_make_getter(component),
                                  doc=f"Component '{component}' of the Differential."))
+
+        super().__init_subclass__(**kwargs)
 
     @classmethod
     def _check_base(cls, base):


### PR DESCRIPTION
This PR partially addresses #7144 (specifically for classes in astropy.coordinates).

I moved the logic from various metaclasses (`FrameMeta`, `MetaBaseRepresentation`, `MetaBaseDifferential`) into the relevant `__init_subclass__` methods. 

Note that I wasn't able to remove `FrameMeta` entirely, because `BaseCoordinateFrame` still requires `OrderedDescriptorContainer` as a metaclass. But when I tried to add `metaclass=OrderedDescriptorContainer` directly, I get a metaclass conflict error. 