### PR TITLE
Replace pkg_resources with importlib.metadata

### DIFF
--- a/astropy/io/misc/asdf/tests/__init__.py
+++ b/astropy/io/misc/asdf/tests/__init__.py
@@ -4,7 +4,11 @@
 # Define a constant to know if the entry points are installed, since this impacts
 # whether we can run the tests.
 
-from importlib.metadata import entry_points
+try:
+    from importlib.metadata import entry_points
+except ImportError:
+    from importlib_metadata import entry_points
+
 import pytest
 
 ep = [entry.name for entry in entry_points().get('asdf_extensions', [])]

--- a/astropy/io/misc/asdf/tests/__init__.py
+++ b/astropy/io/misc/asdf/tests/__init__.py
@@ -4,13 +4,13 @@
 # Define a constant to know if the entry points are installed, since this impacts
 # whether we can run the tests.
 
+from importlib.metadata import entry_points
 import pytest
-from pkg_resources import iter_entry_points
 
-entry_points = [entry.name for entry in iter_entry_points('asdf_extensions')]
-ASDF_ENTRY_INSTALLED = 'astropy' in entry_points and 'astropy-asdf' in entry_points
+ep = [entry.name for entry in entry_points().get('asdf_extensions', [])]
+ASDF_ENTRY_INSTALLED = 'astropy' in ep and 'astropy-asdf' in ep
 
-del entry_points, iter_entry_points
+del entry_points, ep
 
 if not ASDF_ENTRY_INSTALLED:
     pytest.skip('The astropy asdf entry points are not installed',

--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -27,7 +27,11 @@ import inspect
 import operator
 import warnings
 
-import importlib.metadata
+try:
+    from importlib.metadata import entry_points
+except ImportError:
+    from importlib_metadata import entry_points
+
 from functools import reduce, wraps
 
 import numpy as np
@@ -1757,5 +1761,4 @@ def populate_entry_points(entry_points):
                         'astropy.modeling.Fitter' .format(name)))
 
 
-entry_points = importlib.metadata.entry_points()
-populate_entry_points(entry_points.get('astropy.modeling', []))
+populate_entry_points(entry_points().get('astropy.modeling', []))

--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -27,6 +27,7 @@ import inspect
 import operator
 import warnings
 
+import importlib.metadata
 from functools import reduce, wraps
 
 import numpy as np
@@ -37,14 +38,6 @@ from .utils import poly_map_domain, _combine_equivalency_dict
 from .optimizers import (SLSQP, Simplex)
 from .statistic import (leastsquare)
 from .optimizers import (DEFAULT_MAXITER, DEFAULT_EPS, DEFAULT_ACC)
-
-# Check pkg_resources exists
-try:
-    from pkg_resources import iter_entry_points
-    HAS_PKG = True
-except ImportError:
-    HAS_PKG = False
-
 
 __all__ = ['LinearLSQFitter', 'LevMarLSQFitter', 'FittingWithOutlierRemoval',
            'SLSQPLSQFitter', 'SimplexLSQFitter', 'JointFitter', 'Fitter']
@@ -1729,12 +1722,13 @@ def populate_entry_points(entry_points):
     This injects entry points into the `astropy.modeling.fitting` namespace.
     This provides a means of inserting a fitting routine without requirement
     of it being merged into astropy's core.
+
     Parameters
     ----------
-    entry_points : a list of `~pkg_resources.EntryPoint`
-                  entry_points are objects which encapsulate
-                  importable objects and are defined on the
-                  installation of a package.
+    entry_points : list of `~importlib.metadata.EntryPoint`
+        entry_points are objects which encapsulate importable objects and
+        are defined on the installation of a package.
+
     Notes
     -----
     An explanation of entry points can be found `here <http://setuptools.readthedocs.io/en/latest/setuptools.html#dynamic-discovery-of-services-and-plugins>`
@@ -1763,6 +1757,5 @@ def populate_entry_points(entry_points):
                         'astropy.modeling.Fitter' .format(name)))
 
 
-# this is so fitting doesn't choke if pkg_resources doesn't exist
-if HAS_PKG:
-    populate_entry_points(iter_entry_points(group='astropy.modeling', name=None))
+entry_points = importlib.metadata.entry_points()
+populate_entry_points(entry_points.get('astropy.modeling', []))

--- a/astropy/modeling/tests/test_fitters.py
+++ b/astropy/modeling/tests/test_fitters.py
@@ -5,8 +5,12 @@ Module to test fitting routines
 # pylint: disable=invalid-name
 import os.path
 import warnings
-from importlib.metadata import EntryPoint
 from unittest import mock
+
+try:
+    from importlib.metadata import EntryPoint
+except ImportError:
+    from importlib_metadata import EntryPoint
 
 import pytest
 import numpy as np

--- a/astropy/modeling/tests/test_fitters.py
+++ b/astropy/modeling/tests/test_fitters.py
@@ -5,6 +5,7 @@ Module to test fitting routines
 # pylint: disable=invalid-name
 import os.path
 import warnings
+from importlib.metadata import EntryPoint
 from unittest import mock
 
 import pytest
@@ -30,13 +31,6 @@ try:
     HAS_SCIPY = True
 except ImportError:
     HAS_SCIPY = False
-
-try:
-    from pkg_resources import EntryPoint
-    HAS_PKG = True
-except ImportError:
-    HAS_PKG = False
-
 
 fitters = [SimplexLSQFitter, SLSQPLSQFitter]
 
@@ -526,7 +520,6 @@ class TestNonLinearFitters:
         assert_allclose(olscov, fitter.fit_info['param_cov'])
 
 
-@pytest.mark.skipif('not HAS_PKG')
 class TestEntryPoint:
     """Tests population of fitting with entry point fitters"""
 

--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -12,14 +12,6 @@ import functools
 
 import pytest
 
-try:
-    # Import pkg_resources to prevent it from issuing warnings upon being
-    # imported from within pytest.  See
-    # https://github.com/astropy/astropy/pull/537 for a detailed explanation.
-    import pkg_resources  # pylint: disable=W0611  # noqa
-except ImportError:
-    pass
-
 from astropy.units import allclose as quantity_allclose  # noqa
 from astropy.utils.exceptions import (AstropyDeprecationWarning,
                                       AstropyPendingDeprecationWarning)

--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -199,11 +199,6 @@ class TestRunnerBase:
             for egg in glob.glob(os.path.join('.eggs', '*.egg')):
                 sys.path.insert(0, egg)
 
-            # We now need to force reload pkg_resources in case any pytest
-            # plugins were added above, so that their entry points are picked up
-            import pkg_resources
-            importlib.reload(pkg_resources)
-
         self._has_test_dependencies()  # pragma: no cover
 
         # The docstring for this method is defined as a class variable.

--- a/docs/changes/11091.other.rst
+++ b/docs/changes/11091.other.rst
@@ -1,0 +1,3 @@
+Replace ``pkg_resources`` (from setuptools) with ``importlib.metadata`` which
+comes from the stdlib, except for Python 3.7 where the backport package is added
+as a new dependency.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -111,7 +111,7 @@ for line in importlib_metadata.requires('astropy'):
 # be used globally.
 rst_epilog += "\n".join(
     f".. |minimum_{name}_version| replace:: {min_versions[name]}"
-    for name in ('numpy', 'erfa', 'scipy', 'yaml', 'asdf', 'matplotlib', 'ipython')) + f"""
+    for name in ('numpy', 'pyerfa', 'scipy', 'yaml', 'asdf', 'matplotlib', 'ipython')) + f"""
 .. |minimum_python_version| replace:: {__minimum_python_version__}
 
 .. Astropy

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,9 +27,9 @@
 
 import os
 import sys
-
 import configparser
 from datetime import datetime
+
 from packaging.requirements import Requirement
 
 try:
@@ -239,6 +239,7 @@ for line in open('nitpick-exceptions'):
 
 try:
     import warnings
+
     import sphinx_gallery  # noqa: F401
     extensions += ["sphinx_gallery.gen_gallery"]  # noqa: F405
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -104,14 +104,14 @@ project = u'Astropy'
 min_versions = {}
 for line in importlib_metadata.requires('astropy'):
     req = Requirement(line.split(';')[0])
-    min_versions[req.name] = str(req.specifier)
+    min_versions[req.name.lower()] = str(req.specifier)
 
 
 # This is added to the end of RST files - a good place to put substitutions to
 # be used globally.
 rst_epilog += "\n".join(
     f".. |minimum_{name}_version| replace:: {min_versions[name]}"
-    for name in ('numpy', 'pyerfa', 'scipy', 'yaml', 'asdf', 'matplotlib', 'ipython')) + f"""
+    for name in ('numpy', 'pyerfa', 'scipy', 'pyyaml', 'asdf', 'matplotlib', 'ipython')) + f"""
 .. |minimum_python_version| replace:: {__minimum_python_version__}
 
 .. Astropy

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,10 +29,13 @@ import os
 import sys
 
 import configparser
-import importlib.metadata
 from datetime import datetime
 from packaging.requirements import Requirement
 
+try:
+    import importlib.metadata as importlib_metadata
+except ImportError:
+    import importlib_metadata
 
 try:
     from sphinx_astropy.conf.v1 import *  # noqa
@@ -99,7 +102,7 @@ __minimum_python_version__ = setup_cfg['options']['python_requires'].replace('>=
 project = u'Astropy'
 
 min_versions = {}
-for line in importlib.metadata.requires('astropy'):
+for line in importlib_metadata.requires('astropy'):
     req = Requirement(line.split(';')[0])
     min_versions[req.name] = str(req.specifier)
 
@@ -126,7 +129,7 @@ copyright = f'2011–{datetime.utcnow().year}, ' + author
 # built documents.
 
 # The full version, including alpha/beta/rc tags.
-release = importlib.metadata.version(project)
+release = importlib_metadata.version(project)
 # The short X.Y version.
 version = '.'.join(release.split('.')[:2])
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -13,7 +13,7 @@ Requirements
 
 - `Numpy`_ |minimum_numpy_version| or later
 
-- `PyERFA`_ |minimum_erfa_version| or later
+- `PyERFA`_ |minimum_pyerfa_version| or later
 
 ``astropy`` also depends on other packages for optional features:
 
@@ -33,7 +33,7 @@ Requirements
 - `bleach <https://bleach.readthedocs.io/>`_: Used to sanitize text when
   disabling HTML escaping in the :class:`~astropy.table.Table` HTML writer.
 
-- `PyYAML <https://pyyaml.org>`_ |minimum_yaml_version| or later: To read/write
+- `PyYAML <https://pyyaml.org>`_ |minimum_pyyaml_version| or later: To read/write
   :class:`~astropy.table.Table` objects from/to the Enhanced CSV ASCII table
   format and to serialize mixins for various formats.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,7 @@ packages = find:
 requires =
     numpy
     pyerfa
+    importlib-metadata ; python_version == '3.7'
 zip_safe = False
 tests_require = pytest-astropy
 setup_requires = setuptools_scm


### PR DESCRIPTION
Following discussions on `pkg_resources` vs `importlib.metadata`: `pkg_resources` is slow ([1](https://github.com/astropy/astropy/issues/4598#issuecomment-404657295), [2](https://github.com/astropy/astropy/pull/7647), [3](https://github.com/astropy/astropy/issues/6623#issuecomment-626183284)), which is the reason why [importlib.metadata](https://docs.python.org/3/library/importlib.metadata.html) was added to the stdlib in Python 3.8 (with a backport for 3.7).

For instance, importing `astropy.modeling`:
![image](https://user-images.githubusercontent.com/311639/100290576-70be1680-2f5a-11eb-9cef-bfdaa41b98fc.png)

There is a better alternative, so let's use it ?