### PR TITLE
[#11094] Deprecate and remove use of OrderedDescriptor

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -100,6 +100,10 @@ astropy.utils
 
 - Add new ``utils.parsing`` module to with helper wrappers around ``ply``. [#11227]
 
+- Deprecated ``astropy.utils.OrderedDescriptor`` and
+  ``astropy.utils.OrderedDescriptorContainer``, as new features in Python 3
+  make their use less compelling. [#11094, #11099]
+
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/coordinates/attributes.py
+++ b/astropy/coordinates/attributes.py
@@ -7,7 +7,7 @@ import numpy as np
 
 # Project
 from astropy import units as u
-from astropy.utils import OrderedDescriptor, ShapedLikeNDArray
+from astropy.utils import ShapedLikeNDArray
 
 __all__ = ['Attribute', 'TimeAttribute', 'QuantityAttribute',
            'EarthLocationAttribute', 'CoordinateAttribute',
@@ -15,7 +15,7 @@ __all__ = ['Attribute', 'TimeAttribute', 'QuantityAttribute',
            'DifferentialAttribute']
 
 
-class Attribute(OrderedDescriptor):
+class Attribute:
     """A non-mutable data descriptor to hold a frame attribute.
 
     This class must be used to define frame attributes (e.g. ``equinox`` or
@@ -50,14 +50,15 @@ class Attribute(OrderedDescriptor):
         ``default is None`` and no value was supplied during initialization.
     """
 
-    _class_attribute_ = 'frame_attributes'
-    _name_attribute_ = 'name'
     name = '<unbound>'
 
     def __init__(self, default=None, secondary_attribute=''):
         self.default = default
         self.secondary_attribute = secondary_attribute
         super().__init__()
+
+    def __set_name__(self, owner, name):
+        self.name = name
 
     def convert_input(self, value):
         """

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -21,8 +21,7 @@ from astropy.utils.compat.misc import override__dir__
 from astropy.utils.decorators import lazyproperty, format_doc
 from astropy.utils.exceptions import AstropyWarning, AstropyDeprecationWarning
 from astropy import units as u
-from astropy.utils import (OrderedDescriptorContainer, ShapedLikeNDArray,
-                           check_broadcast)
+from astropy.utils import ShapedLikeNDArray, check_broadcast
 from .transformations import TransformGraph
 from . import representation as r
 from .angles import Angle
@@ -197,13 +196,12 @@ _components = """
 # TODO: This is only needed so that BaseCoordinateFrame can have
 # OrderedDescriptorContainer as a metaclass. Trying to use
 # metaclass=OrderedDescriptorContainer directly causes a metaclass conflict.
-class FrameMeta(OrderedDescriptorContainer, abc.ABCMeta):
+class FrameMeta(abc.ABCMeta):
     pass
 
 
 @format_doc(base_doc, components=_components, footer="")
-class BaseCoordinateFrame(ShapedLikeNDArray,
-                          metaclass=FrameMeta):
+class BaseCoordinateFrame(ShapedLikeNDArray):
     """
     The base class for coordinate frames.
 
@@ -251,8 +249,6 @@ class BaseCoordinateFrame(ShapedLikeNDArray,
     # attributes.
     frame_specific_representation_info = {}
 
-    _inherit_descriptors_ = (Attribute,)
-
     frame_attributes = {}
     # Default empty frame_attributes dict
 
@@ -262,6 +258,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray,
         default_repr = getattr(cls, 'default_representation', None)
         default_diff = getattr(cls, 'default_differential', None)
         repr_info = getattr(cls, 'frame_specific_representation_info', None)
+        frame_attrs = getattr(cls, 'frame_attributes', None)
 
         # Then, to make sure this works for subclasses-of-subclasses, we also
         # have to check for cases where the attribute names have already been
@@ -285,6 +282,19 @@ class BaseCoordinateFrame(ShapedLikeNDArray,
         cls._create_readonly_property('default_differential', default_diff)
         cls._create_readonly_property('frame_specific_representation_info',
                                       copy.deepcopy(repr_info))
+
+        # Set the frame attributes
+        # TODO: Should this be made to use readonly_prop_factory as well or
+        # would it be inconvenient for getting the frame_attributes from
+        # classes?
+        if frame_attrs is None:
+            frame_attrs = {}
+        else:
+            frame_attrs = frame_attrs.copy()
+
+        frame_attrs.update({k: v for k, v in cls.__dict__.items()
+                            if isinstance(v, Attribute)})
+        cls.frame_attributes = frame_attrs
 
         # Deal with setting the name of the frame:
         if not hasattr(cls, 'name'):

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -284,8 +284,14 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
         else:
             frame_attrs = frame_attrs.copy()
 
-        frame_attrs.update({k: v for k, v in cls.__dict__.items()
-                            if isinstance(v, Attribute)})
+        for basecls in (cls,) + cls.__bases__:
+            if not issubclass(basecls, BaseCoordinateFrame):
+                continue
+
+            for k, v in basecls.__dict__.items():
+                if isinstance(v, Attribute):
+                    frame_attrs.setdefault(k, v)
+
         cls.frame_attributes = frame_attrs
 
         # Deal with setting the name of the frame:

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -7,7 +7,6 @@ classes.
 
 
 # Standard library
-import abc
 import copy
 import inspect
 from collections import namedtuple, defaultdict
@@ -191,13 +190,6 @@ _components = """
     *args, **kwargs
         Coordinate components, with names that depend on the subclass.
 """
-
-
-# TODO: This is only needed so that BaseCoordinateFrame can have
-# OrderedDescriptorContainer as a metaclass. Trying to use
-# metaclass=OrderedDescriptorContainer directly causes a metaclass conflict.
-class FrameMeta(abc.ABCMeta):
-    pass
 
 
 @format_doc(base_doc, components=_components, footer="")

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -121,6 +121,39 @@ def test_frame_subclass_attribute_descriptor():
     assert mfk4.newattr == 'world'
 
 
+def test_frame_multiple_inheritance_attribute_descriptor():
+    """
+    Ensure that all attributes are accumulated in case of inheritance from
+    multiple BaseCoordinateFrames.  See
+    https://github.com/astropy/astropy/pull/11099#issuecomment-735829157
+    """
+
+    class Frame1(BaseCoordinateFrame):
+        attr1 = Attribute()
+
+    class Frame2(BaseCoordinateFrame):
+        attr2 = Attribute()
+
+    class Frame3(Frame1, Frame2):
+        pass
+
+    assert len(Frame3.frame_attributes) == 2
+    assert 'attr1' in Frame3.frame_attributes
+    assert 'attr2' in Frame3.frame_attributes
+
+    # In case the same attribute exists in both frames, the one from the
+    # left-most class in the MRO should take precedence
+    class Frame4(BaseCoordinateFrame):
+        attr1 = Attribute()
+        attr2 = Attribute()
+
+    class Frame5(Frame1, Frame4):
+        pass
+
+    assert Frame5.frame_attributes['attr1'] is Frame1.frame_attributes['attr1']
+    assert Frame5.frame_attributes['attr2'] is Frame4.frame_attributes['attr2']
+
+
 def test_differentialattribute():
 
     # Test logic of passing input through to allowed class

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -9,7 +9,6 @@ import re
 from astropy import units as u
 from astropy.units import allclose
 from astropy.tests.helper import assert_quantity_allclose as assert_allclose
-from astropy.utils import OrderedDescriptorContainer
 from astropy.utils.exceptions import AstropyWarning
 from astropy.time import Time
 
@@ -63,7 +62,7 @@ def teardown_function(func):
 
 def test_frame_attribute_descriptor():
     """Unit tests of the Attribute descriptor."""
-    class TestAttributes(metaclass=OrderedDescriptorContainer):
+    class TestAttributes:
         attr_none = Attribute()
         attr_2 = Attribute(default=2)
         attr_3_attr2 = Attribute(default=3, secondary_attribute='attr_2')

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -36,7 +36,6 @@ from astropy.utils import (sharedmethod, find_current_module,
                            check_broadcast, IncompatibleShapeError, isiterable)
 from astropy.utils.codegen import make_function_with_signature
 from astropy.utils.exceptions import AstropyDeprecationWarning
-from astropy.utils.misc import get_parameters
 from astropy.nddata.utils import add_array, extract_array
 from .utils import (combine_labels, make_binary_operator_eval,
                     get_inputs_and_params, _BoundingBox, _combine_equivalency_dict,
@@ -90,7 +89,6 @@ class _ModelMeta(abc.ABCMeta):
         # See the docstring for _is_dynamic above
         if '_is_dynamic' not in members:
             members['_is_dynamic'] = mcls._is_dynamic
-        get_parameters(members)
         opermethods = [
             ('__add__', _model_oper('+')),
             ('__sub__', _model_oper('-')),
@@ -101,6 +99,9 @@ class _ModelMeta(abc.ABCMeta):
             ('__and__', _model_oper('&')),
             ('_fix_inputs', _model_oper('fix_inputs'))
         ]
+
+        members['_parameters_'] = {k: v for k, v in members.items()
+                                   if isinstance(v, Parameter)}
 
         for opermethod, opercall in opermethods:
             members[opermethod] = opercall

--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -16,7 +16,7 @@ import operator
 import numpy as np
 
 from astropy.units import Quantity
-from astropy.utils import isiterable, OrderedDescriptor
+from astropy.utils import isiterable
 from .utils import array_repr_oneline
 from .utils import get_inputs_and_params
 
@@ -111,14 +111,13 @@ def _unary_arithmetic_operation(op):
     return wrapper
 
 
-class Parameter(OrderedDescriptor):
+class Parameter:
     """
     Wraps individual parameters.
 
-    Since 4.0 Parameters are no longer descriptors (despite the fact that
-    it inherits from OrderedDescriptor) and are based on a new implementation
-    of the Parameter class. Parameters now  (as of 4.0) store values locally
-    (as instead previously in the associated model)
+    Since 4.0 Parameters are no longer descriptors and are based on a new
+    implementation of the Parameter class. Parameters now  (as of 4.0) store
+    values locally (as instead previously in the associated model)
 
     This class represents a model's parameter (in a somewhat broad sense). It
     serves a number of purposes:
@@ -191,10 +190,6 @@ class Parameter(OrderedDescriptor):
     fitters as of this writing.
     """
 
-    # Settings for OrderedDescriptor
-    _class_attribute_ = '_parameters_'
-    _name_attribute_ = '_name'
-
     def __init__(self, name='', description='', default=None, unit=None,
                  getter=None, setter=None, fixed=False, tied=False, min=None,
                  max=None, bounds=None):
@@ -250,6 +245,9 @@ class Parameter(OrderedDescriptor):
         self._posterior = None
 
         self._std = None
+
+    def __set_name__(self, owner, name):
+        self._name = name
 
     def __len__(self):
         val = self.value

--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -31,6 +31,10 @@ __all__ = ['isiterable', 'silence', 'format_exception', 'NumpyRNGContext',
            'OrderedDescriptor', 'OrderedDescriptorContainer']
 
 
+# Because they are deprecated.
+__doctest_skip__ = ['OrderedDescriptor', 'OrderedDescriptorContainer']
+
+
 def isiterable(obj):
     """Returns `True` if the given object is iterable."""
 

--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -494,6 +494,17 @@ def did_you_mean(s, candidates, n=3, cutoff=0.8, fix=None):
     return ''
 
 
+_ordered_descriptor_deprecation_message = """\
+The {func} {obj_type} is deprecated and may be removed in a future version.
+
+    You can replace its functionality with a combination of the
+    __init_subclass__ and __set_name__ magic methods introduced in Python 3.6.
+    See https://github.com/astropy/astropy/issues/11094 for recipes on how to
+    replicate their functionality.
+"""
+
+
+@deprecated('4.3', _ordered_descriptor_deprecation_message)
 class OrderedDescriptor(metaclass=abc.ABCMeta):
     """
     Base class for descriptors whose order in the class body should be
@@ -578,6 +589,7 @@ class OrderedDescriptor(metaclass=abc.ABCMeta):
             return NotImplemented
 
 
+@deprecated('4.3', _ordered_descriptor_deprecation_message)
 class OrderedDescriptorContainer(type):
     """
     Classes should use this metaclass if they wish to use `OrderedDescriptor`

--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -778,26 +778,6 @@ class OrderedDescriptorContainer(type):
                                                         members)
 
 
-def get_parameters(members):
-    """
-    Looks for ordered descriptors in a class definition and
-    copies such definitions in two new class attributes,
-    one being a dictionary of these objects keyed by their
-    attribute names, and the other a simple list of those names.
-
-    """
-    pdict = OrderedDict()
-    for name, obj in members.items():
-        if (not isinstance(obj, OrderedDescriptor)):
-            continue
-        if obj._name_attribute_ is not None:
-            setattr(obj, '_name', name)
-        pdict[name] = obj
-
-    # members['_parameter_vals_'] = pdict
-    members['_parameters_'] = pdict
-
-
 LOCALE_LOCK = threading.Lock()
 
 


### PR DESCRIPTION
Fixes #11094.  Builds on top of #11098 but they could be separated I think.

~~Note, this does not attempt to remove any metaclasses in favor of `__init_subclass__` as discussed somewhat in #11090.  That should be handled elsewhere for coordinates~~

Completes the work of #11090 to remove `FrameMeta` since it is no longer used.

* [x] Should probably have a changelog entry.
* [x] Fix the case brought up by @ayshih https://github.com/astropy/astropy/pull/11099#issuecomment-735829157