### PR TITLE
Follow-up to #11090 to address #11096

### DIFF
--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -338,7 +338,8 @@ class BaseCoordinateFrame(ShapedLikeNDArray,
 
         if kwargs:
             raise TypeError(
-                f'Coordinate frame got unexpected keywords: {list(kwargs)}')
+                f'Coordinate frame {self.__class__.__name__} got unexpected '
+                f'keywords: {list(kwargs)}')
 
         # We do ``is None`` because self._data might evaluate to false for
         # empty arrays or data == 0

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -290,7 +290,8 @@ class BaseCoordinateFrame(ShapedLikeNDArray,
         if not hasattr(cls, 'name'):
             cls.name = cls.__name__.lower()
         elif (BaseCoordinateFrame not in cls.__bases__ and
-                cls.name in [base.name for base in cls.__bases__]):
+                cls.name in [getattr(base, 'name', None)
+                             for base in cls.__bases__]):
             # This may be a subclass of a subclass of BaseCoordinateFrame,
             # like ICRS(BaseRADecFrame). In this case, cls.name will have been
             # set by init_subclass

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -1510,3 +1510,15 @@ def test_realize_frame_accepts_kwargs():
 
     assert c2.representation_type == r.CartesianRepresentation
     assert c3.representation_type == r.CylindricalRepresentation
+
+
+def test_nameless_frame_subclass():
+    """Note: this is a regression test for #11096"""
+
+    class Test:
+        pass
+
+    # Subclass from a frame class and a non-frame class.
+    # This subclassing is the test!
+    class NewFrame(ICRS, Test):
+        pass


### PR DESCRIPTION
Soon after merging #11090, @ayshih noticed that sunpy tests were failing, as reported in #11096, because the new `BaseCoordinateFrame.__init_subclass__` expected any coordinate frame parent class to have a `.name` attribute. This is a simple follow-up to use `getattr()` instead.