### PR TITLE
Avoid copies in NDArithmeticMixin

### DIFF
--- a/astropy/nddata/mixins/ndarithmetic.py
+++ b/astropy/nddata/mixins/ndarithmetic.py
@@ -311,14 +311,14 @@ class NDArithmeticMixin:
         if self.unit is None and operand.unit is None:
             result = operation(self.data, operand.data)
         elif self.unit is None:
-            result = operation(self.data * dimensionless_unscaled,
-                               operand.data * operand.unit)
+            result = operation(self.data << dimensionless_unscaled,
+                               operand.data << operand.unit)
         elif operand.unit is None:
-            result = operation(self.data * self.unit,
-                               operand.data * dimensionless_unscaled)
+            result = operation(self.data << self.unit,
+                               operand.data << dimensionless_unscaled)
         else:
-            result = operation(self.data * self.unit,
-                               operand.data * operand.unit)
+            result = operation(self.data << self.unit,
+                               operand.data << operand.unit)
 
         return result
 

--- a/astropy/nddata/nduncertainty.py
+++ b/astropy/nddata/nduncertainty.py
@@ -1,8 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-
-from .nddata_base import NDDataBase
-
 import numpy as np
 from abc import ABCMeta, abstractmethod
 from copy import deepcopy
@@ -505,10 +502,10 @@ class _VariancePropagationMixin:
         if other_uncert.array is not None:
             # Formula: sigma**2 = dB
             if (other_uncert.unit is not None and
-                result_unit_sq != to_variance(other_uncert.unit)):
+                    result_unit_sq != to_variance(other_uncert.unit)):
                 # If the other uncertainty has a unit and this unit differs
                 # from the unit of the result convert it to the results unit
-                other = to_variance(other_uncert.array *
+                other = to_variance(other_uncert.array <<
                                     other_uncert.unit).to(result_unit_sq).value
             else:
                 other = to_variance(other_uncert.array)
@@ -521,7 +518,7 @@ class _VariancePropagationMixin:
             if self.unit is not None and to_variance(self.unit) != self.parent_nddata.unit**2:
                 # If the uncertainty has a different unit than the result we
                 # need to convert it to the results unit.
-                this = to_variance(self.array * self.unit).to(result_unit_sq).value
+                this = to_variance(self.array << self.unit).to(result_unit_sq).value
             else:
                 this = to_variance(self.array)
         else:
@@ -591,7 +588,7 @@ class _VariancePropagationMixin:
             if (other_uncert.unit and
                 to_variance(1 * other_uncert.unit) !=
                     ((1 * other_uncert.parent_nddata.unit)**2).unit):
-                d_b = to_variance(other_uncert.array * other_uncert.unit).to(
+                d_b = to_variance(other_uncert.array << other_uncert.unit).to(
                     (1 * other_uncert.parent_nddata.unit)**2).value
             else:
                 d_b = to_variance(other_uncert.array)
@@ -605,7 +602,7 @@ class _VariancePropagationMixin:
             if (self.unit and
                 to_variance(1 * self.unit) !=
                     ((1 * self.parent_nddata.unit)**2).unit):
-                d_a = to_variance(self.array * self.unit).to(
+                d_a = to_variance(self.array << self.unit).to(
                     (1 * self.parent_nddata.unit)**2).value
             else:
                 d_a = to_variance(self.array)

--- a/docs/changes/nddata/11107.other.rst
+++ b/docs/changes/nddata/11107.other.rst
@@ -1,0 +1,2 @@
+Prevent unnecessary copies of the data during ``NDData`` arithmetic when units
+need to be added.


### PR DESCRIPTION
`NDArithmeticMixin` is currently using `data * unit` which does a copy of the data to create the `Quantity` object:

https://github.com/astropy/astropy/blob/d351a99320002317e5abfe954e36e433eed4a3dd/astropy/nddata/mixins/ndarithmetic.py#L313-L321

We can avoid that copy with the `data << unit` syntax.

Before:
```
In [1]: import astropy.units as u
   ...: import numpy as np
   ...: from astropy.nddata import CCDData, NDDataArray
   ...: nd1 = CCDData(np.zeros((2000, 2000)), unit='adu')
   ...: nd2 = CCDData(np.ones((2000, 2000)), unit='adu')
   ...: nd1_nounit = NDDataArray(np.zeros((2000, 2000)))
   ...: nd2_nounit = NDDataArray(np.ones((2000, 2000)))

In [2]: %timeit nd1.add(nd2)
22.2 ms ± 104 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)

In [3]: %timeit nd1_nounit.add(nd2_nounit)
4.53 ms ± 97.7 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```

After:
```
In [1]: import astropy.units as u
   ...: import numpy as np
   ...: from astropy.nddata import CCDData, NDDataArray
   ...: nd1 = CCDData(np.zeros((2000, 2000)), unit='adu')
   ...: nd2 = CCDData(np.ones((2000, 2000)), unit='adu')

In [2]: %timeit nd1.add(nd2)
4.53 ms ± 17.4 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```