### PR TITLE
[#5408] Don't re-verify invalid FITS cards after their values have been replaced

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1121,6 +1121,9 @@ astropy.io.ascii
 astropy.io.fits
 ^^^^^^^^^^^^^^^
 
+- Fix bug where manual fixes to invalid header cards were not preserved when
+  saving a FITS file. [#11108]
+
 astropy.io.misc
 ^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
Fixes #5408.

Fixing this was not so easy because it once again ran up against the huge mess that is FITS card parsing and verification.  If I could I would rewrite the whole thing from scratch.
