### PR TITLE
Allow explicit negative distances in SphericalRepresentation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -102,6 +102,9 @@ astropy.convolution
 astropy.coordinates
 ^^^^^^^^^^^^^^^^^^^
 
+- For input to representations, subclasses of the class required for a
+  given attribute will now be allowed in. [#11113]
+
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 
@@ -187,6 +190,11 @@ astropy.convolution
 
 astropy.coordinates
 ^^^^^^^^^^^^^^^^^^^
+
+- Allow ``Distance`` instances with negative distance values as input for
+  ``SphericalRepresentation``.  This was always noted as allowed in an
+  exception message when a negative ``Quantity`` with length units was
+  passed in, but was not actually possible to do. [#11113]
 
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^

--- a/astropy/coordinates/angles.py
+++ b/astropy/coordinates/angles.py
@@ -108,7 +108,7 @@ class Angle(u.SpecificTypeQuantity):
     _equivalent_unit = u.radian
     _include_easy_conversion_members = True
 
-    def __new__(cls, angle, unit=None, dtype=None, copy=True):
+    def __new__(cls, angle, unit=None, dtype=None, copy=True, **kwargs):
 
         if not isinstance(angle, u.Quantity):
             if unit is not None:
@@ -134,7 +134,8 @@ class Angle(u.SpecificTypeQuantity):
                        angle.dtype.kind not in 'SUVO')):
                 angle = [Angle(x, unit, copy=False) for x in angle]
 
-        return super().__new__(cls, angle, unit, dtype=dtype, copy=copy)
+        return super().__new__(cls, angle, unit, dtype=dtype, copy=copy,
+                               **kwargs)
 
     @staticmethod
     def _tuple_to_float(angle, unit):

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -226,7 +226,7 @@ class BaseRepresentationOrDifferential(ShapedLikeNDArray):
                 raise TypeError(f'unexpected keyword arguments: {kwargs}')
 
         # Pass attributes through the required initializing classes.
-        attrs = [self.attr_classes[component](attr, copy=False)
+        attrs = [self.attr_classes[component](attr, copy=False, subok=True)
                  for component, attr in zip(components, attrs)]
         try:
             attrs = np.broadcast_arrays(*attrs, subok=True)
@@ -1805,7 +1805,8 @@ class SphericalRepresentation(BaseRepresentation):
                  copy=True):
         super().__init__(lon, lat, distance, copy=copy,
                          differentials=differentials)
-        if self._distance.unit.physical_type == 'length':
+        if (not isinstance(self._distance, Distance)
+                and self._distance.unit.physical_type == 'length'):
             try:
                 self._distance = Distance(self._distance, copy=False)
             except ValueError as e:

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -75,36 +75,6 @@ def _array2string(values, prefix=''):
     return np.array2string(values, **kwargs)
 
 
-def _combine_xyz(x, y, z, xyz_axis=0):
-    """
-    Combine components ``x``, ``y``, ``z`` into a single Quantity array.
-
-    Parameters
-    ----------
-    x, y, z : `~astropy.units.Quantity`
-        The individual x, y, and z components.
-    xyz_axis : int, optional
-        The axis in the final array along which the x, y, z components
-        should be stored (default: 0).
-
-    Returns
-    -------
-    xyz : `~astropy.units.Quantity`
-        With dimension 3 along ``xyz_axis``, i.e., using the default of ``0``,
-        the shape will be ``(3,) + x.shape``.
-    """
-    # Get x, y, z to the same units (this is very fast for identical units)
-    # since np.stack cannot deal with quantity.
-    cls = x.__class__
-    unit = x.unit
-    x = x.value
-    y = y.to_value(unit)
-    z = z.to_value(unit)
-
-    xyz = np.stack([x, y, z], axis=xyz_axis)
-    return cls(xyz, unit=unit, copy=False)
-
-
 class BaseRepresentationOrDifferentialInfo(MixinInfo):
     """
     Container for meta information like name, description, format.  This is
@@ -1340,7 +1310,7 @@ class CartesianRepresentation(BaseRepresentation):
         # Create combined array.  TO DO: keep it in _xyz for repeated use?
         # But then in-place changes have to cancel it. Likely best to
         # also update components.
-        return _combine_xyz(self._x, self._y, self._z, xyz_axis=xyz_axis)
+        return np.stack([self._x, self._y, self._z], axis=xyz_axis)
 
     xyz = property(get_xyz)
 
@@ -2604,7 +2574,7 @@ class CartesianDifferential(BaseDifferential):
         # Create combined array.  TO DO: keep it in _d_xyz for repeated use?
         # But then in-place changes have to cancel it. Likely best to
         # also update components.
-        return _combine_xyz(self._d_x, self._d_y, self._d_z, xyz_axis=xyz_axis)
+        return np.stack([self._d_x, self._d_y, self._d_z], axis=xyz_axis)
 
     d_xyz = property(get_d_xyz)
 

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -114,6 +114,17 @@ class TestSphericalRepresentation:
         assert s3.lon == -90. * u.degree
         assert s3.lon.wrap_angle == 180 * u.degree
 
+    def test_init_subclass(self):
+        class Longitude180(Longitude):
+            _default_wrap_angle = 180*u.degree
+
+        s = SphericalRepresentation(Longitude180(-90, u.degree),
+                                    Latitude(-45, u.degree),
+                                    Distance(1., u.Rsun))
+        assert isinstance(s.lon, Longitude180)
+        assert s.lon == -90. * u.degree
+        assert s.lon.wrap_angle == 180 * u.degree
+
     def test_init_array(self):
 
         s1 = SphericalRepresentation(lon=[8, 9] * u.hourangle,
@@ -237,6 +248,16 @@ class TestSphericalRepresentation:
         assert_allclose_quantity(s.lon, [10, 10, 2, 3, 4] * u.deg)
         assert_allclose_quantity(s.lat, [2, 2, -2, -3, -4] * u.deg)
         assert_allclose_quantity(s.distance, [5, 5, 1, 1, 1] * u.kpc)
+
+    def test_negative_distance(self):
+        """Only allowed if explicitly passed on."""
+        with pytest.raises(ValueError, match='allow_negative'):
+            SphericalRepresentation(10*u.deg, 20*u.deg, -10*u.m)
+
+        s1 = SphericalRepresentation(10*u.deg, 20*u.deg,
+                                     Distance(-10*u.m, allow_negative=True))
+
+        assert s1.distance == -10.*u.m
 
     def test_nan_distance(self):
         """ This is a regression test: calling represent_as() and passing in the

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -30,8 +30,7 @@ from astropy.coordinates.representation import (REPRESENTATION_CLASSES,
                                                 CylindricalDifferential,
                                                 PhysicsSphericalDifferential,
                                                 UnitSphericalDifferential,
-                                                UnitSphericalCosLatDifferential,
-                                                _combine_xyz)
+                                                UnitSphericalCosLatDifferential)
 
 
 # Preserve the original REPRESENTATION_CLASSES dict so that importing
@@ -1179,35 +1178,6 @@ def test_duplicate_warning():
     assert 'unitspherical' not in REPRESENTATION_CLASSES
     assert 'astropy.coordinates.representation.UnitSphericalRepresentation' in REPRESENTATION_CLASSES
     assert __name__ + '.test_duplicate_warning.<locals>.UnitSphericalRepresentation' in REPRESENTATION_CLASSES
-
-
-def test_combine_xyz():
-
-    x, y, z = np.arange(27).reshape(3, 9) * u.kpc
-    xyz = _combine_xyz(x, y, z, xyz_axis=0)
-    assert xyz.shape == (3, 9)
-    assert np.all(xyz[0] == x)
-    assert np.all(xyz[1] == y)
-    assert np.all(xyz[2] == z)
-
-    x, y, z = np.arange(27).reshape(3, 3, 3) * u.kpc
-    xyz = _combine_xyz(x, y, z, xyz_axis=0)
-    assert xyz.ndim == 3
-    assert np.all(xyz[0] == x)
-    assert np.all(xyz[1] == y)
-    assert np.all(xyz[2] == z)
-
-    xyz = _combine_xyz(x, y, z, xyz_axis=1)
-    assert xyz.ndim == 3
-    assert np.all(xyz[:, 0] == x)
-    assert np.all(xyz[:, 1] == y)
-    assert np.all(xyz[:, 2] == z)
-
-    xyz = _combine_xyz(x, y, z, xyz_axis=-1)
-    assert xyz.ndim == 3
-    assert np.all(xyz[..., 0] == x)
-    assert np.all(xyz[..., 1] == y)
-    assert np.all(xyz[..., 2] == z)
 
 
 class TestCartesianRepresentationWithDifferential:


### PR DESCRIPTION
Fixes #11104, #8091

The problem was that any input `Distance` was turned into a `Quantity` instead of just passed through. It really should pass it through, as it is a subclass, so this PR allows it (which is what makes it an API change). But to fix that, a small change had to be made to `Angle.__new__` to allow it to pass on keyword arguments like `subok=True` to `Quantity.__new__`.

Also, it turned out `_combine_xyz` was not safe for some operations with this change, but since that private function that was no longer needed anyway now our minimum numpy version is 1.17, so the first commit just turns that into a simple `np.stack`.