### PR TITLE
Ignore runtimewarning about ndarray size change.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -119,6 +119,7 @@ filterwarnings =
     ignore:unclosed <socket:ResourceWarning
     ignore:unclosed <ssl.SSLSocket:ResourceWarning
     ignore:numpy.ufunc size changed:RuntimeWarning
+    ignore:numpy.ndarray size changed:RuntimeWarning
     ignore:Importing from numpy:DeprecationWarning:scipy
     ignore:Conversion of the second argument:FutureWarning:scipy
     ignore:Using a non-tuple sequence:FutureWarning:scipy


### PR DESCRIPTION
I think these warnings, like for the dtype, can be ignored. 

Note: Only merge if the `*dev` job passes again (it does locally, but one never knows...)

EDIT: Fix #11119 