### PR TITLE
Correct docs for number of terms in 2D Polynomials

### DIFF
--- a/astropy/modeling/polynomial.py
+++ b/astropy/modeling/polynomial.py
@@ -969,7 +969,7 @@ class Polynomial1D(_PolyDomainWindow1D):
 
 
 class Polynomial2D(PolynomialModel):
-    """
+    r"""
     2D Polynomial  model.
 
     Represents a general polynomial of degree n:
@@ -985,8 +985,10 @@ class Polynomial2D(PolynomialModel):
     Parameters
     ----------
     degree : int
-        highest power of the polynomial,
-        the number of terms is degree+1
+        Polynomial degree: largest sum of exponents (:math:`i + j`) of
+        variables in each monomial term of the form :math:`x^i y^j`. The
+        number of terms in a 2D polynomial of degree ``n`` is given by binomial
+        coefficient :math:`C(n + 2, 2) = (n + 2)! / (2!\,n!) = (n + 1)(n + 2) / 2`.
     x_domain : tuple or None, optional
         domain of the x independent variable
         If None, it is set to (-1, 1)


### PR DESCRIPTION
Docstring for `Polynomial2D` says that number of coefficients is:
```
degree: int
    highest power of the polynomial, the number of terms is degree+1
```
which is wrong. This PR corrects documentation for `degree`.