### PR TITLE
Reenable shape-getting functions on ShapedLikeNDArray (subclasses)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -359,6 +359,10 @@ astropy.units
 astropy.utils
 ^^^^^^^^^^^^^
 
+- Fix a bug so that ``np.shape``, ``np.ndim`` and ``np.size`` again work on
+  classes that use ``ShapedLikeNDArray``, like representations, frames,
+  sky coordinates, and times. [#11133]
+
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/coordinates/tests/test_representation_methods.py
+++ b/astropy/coordinates/tests/test_representation_methods.py
@@ -396,3 +396,9 @@ class TestShapeFunctions(ShapeSetup):
         s0d = np.delete(self.s0, [2, 3], axis=0)
         assert np.all(representation_equal(s0d[:2], self.s0[:2]))
         assert np.all(representation_equal(s0d[2:], self.s0[4:]))
+
+    @pytest.mark.parametrize('attribute', ['shape', 'ndim', 'size'])
+    def test_shape_attribute_functions(self, attribute):
+        function = getattr(np, attribute)
+        result = function(self.s0)
+        assert result == getattr(self.s0, attribute)

--- a/astropy/utils/shapes.py
+++ b/astropy/utils/shapes.py
@@ -210,6 +210,18 @@ class ShapedLikeNDArray(metaclass=abc.ABCMeta):
         np.roll, np.delete,
         }
 
+    # Functions that themselves defer to a method. Those are all
+    # defined in np.core.fromnumeric, but exclude alen as well as
+    # sort and partition, which make copies before calling the method.
+    _METHOD_FUNCTIONS = {getattr(np, name):
+                         {'amax': 'max', 'amin': 'min', 'around': 'round',
+                          'round_': 'round', 'alltrue': 'all',
+                          'sometrue': 'any'}.get(name, name)
+                         for name in np.core.fromnumeric.__all__
+                         if name not in ['alen', 'sort', 'partition']}
+    # Add np.copy, which we may as well let defer to our method.
+    _METHOD_FUNCTIONS[np.copy] = 'copy'
+
     # Could be made to work with a bit of effort:
     # np.where, np.compress, np.extract,
     # np.diag_indices_from, np.triu_indices_from, np.tril_indices_from
@@ -236,19 +248,15 @@ class ShapedLikeNDArray(metaclass=abc.ABCMeta):
 
             return self._apply(function, *args[1:], **kwargs)
 
-        if self is args[0]:
-            # Call the method rather than _apply(function.__name__),
-            # since classes could override the method.
-            name = {np.amax: 'max',
-                    np.amin: 'min'}.get(function, function.__name__)
-
-            method = getattr(self, name, None)
+        # For functions that defer to methods, use the corresponding
+        # method/attribute if we have it.  Otherwise, fall through.
+        if self is args[0] and function in self._METHOD_FUNCTIONS:
+            method = getattr(self, self._METHOD_FUNCTIONS[function], None)
             if method is not None:
                 if callable(method):
                     return method(*args[1:], **kwargs)
-                elif (len(args) == 1 and hasattr(
-                        getattr(self.__class__, name, None), '__get__')):
-                    # Descriptor/property; assume it holds the result.
+                else:
+                    # For np.shape, etc., just return the attribute.
                     return method
 
         # Fall-back, just pass the arguments on since perhaps the function

--- a/astropy/utils/shapes.py
+++ b/astropy/utils/shapes.py
@@ -241,9 +241,15 @@ class ShapedLikeNDArray(metaclass=abc.ABCMeta):
             # since classes could override the method.
             name = {np.amax: 'max',
                     np.amin: 'min'}.get(function, function.__name__)
+
             method = getattr(self, name, None)
             if method is not None:
-                return method(*args[1:], **kwargs)
+                if callable(method):
+                    return method(*args[1:], **kwargs)
+                elif (len(args) == 1 and hasattr(
+                        getattr(self.__class__, name, None), '__get__')):
+                    # Descriptor/property; assume it holds the result.
+                    return method
 
         # Fall-back, just pass the arguments on since perhaps the function
         # works already (see above).


### PR DESCRIPTION
As noted in https://github.com/astropy/astropy/issues/8610#issuecomment-736855217, things like `np.shape(time)` have stopped working in 4.2. This fixes it by ensuring we check that if a given function name exist on the class, we not just call it, but check if it is a property and if so just return the value.

(Adding time and coordinate labels just because those are affected - the bug is in utils).