### PR TITLE
Set time default location to geocenter for scale changes to/from TDB

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1123,6 +1123,9 @@ astropy.time
 
 - Fix leap second update when using a non english locale. [#11062]
 
+- Fix default assumed location to be the geocenter when transforming times
+  to and from solar-system barycenter scales. [#11134]
+
 astropy.timeseries
 ^^^^^^^^^^^^^^^^^^
 

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -1460,6 +1460,8 @@ class Time(TimeBase):
         length for geocentric coordinates, or contain a longitude, latitude,
         and an optional height for geodetic coordinates.
         Can be a single location, or one for each input time.
+        If not given, assumed to be the center of the Earth for time scale
+        transformations to and from the solar-system barycenter.
     copy : bool, optional
         Make a copy of the input values
     """
@@ -1971,17 +1973,17 @@ class Time(TimeBase):
             ut = day_frac(njd1 - 0.5, njd2)[1]
 
             if self.location is None:
-                from astropy.coordinates import EarthLocation
-                location = EarthLocation.from_geodetic(0., 0., 0.)
+                # Assume geocentric.
+                self._delta_tdb_tt = erfa.dtdb(jd1, jd2, ut, 0., 0., 0.)
             else:
                 location = self.location
-            # Geodetic params needed for d_tdb_tt()
-            lon = location.lon
-            rxy = np.hypot(location.x, location.y)
-            z = location.z
-            self._delta_tdb_tt = erfa.dtdb(
-                jd1, jd2, ut, lon.to_value(u.radian),
-                rxy.to_value(u.km), z.to_value(u.km))
+                # Geodetic params needed for d_tdb_tt()
+                lon = location.lon
+                rxy = np.hypot(location.x, location.y)
+                z = location.z
+                self._delta_tdb_tt = erfa.dtdb(
+                    jd1, jd2, ut, lon.to_value(u.radian),
+                    rxy.to_value(u.km), z.to_value(u.km))
 
         return self._delta_tdb_tt
 

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -271,15 +271,33 @@ class TestBasic:
         lat = 19.48125
         lon = -155.933222
         t = Time('2006-01-15 21:24:37.5', format='iso', scale='utc',
-                 precision=6, location=(lon, lat))
+                 precision=7, location=(lon, lat))
         t.delta_ut1_utc = 0.3341  # Explicitly set one part of the xform
-        assert t.utc.iso == '2006-01-15 21:24:37.500000'
-        assert t.ut1.iso == '2006-01-15 21:24:37.834100'
-        assert t.tai.iso == '2006-01-15 21:25:10.500000'
-        assert t.tt.iso == '2006-01-15 21:25:42.684000'
-        assert t.tcg.iso == '2006-01-15 21:25:43.322690'
-        assert t.tdb.iso == '2006-01-15 21:25:42.684373'
-        assert t.tcb.iso == '2006-01-15 21:25:56.893952'
+        assert t.utc.iso == '2006-01-15 21:24:37.5000000'
+        assert t.ut1.iso == '2006-01-15 21:24:37.8341000'
+        assert t.tai.iso == '2006-01-15 21:25:10.5000000'
+        assert t.tt.iso == '2006-01-15 21:25:42.6840000'
+        assert t.tcg.iso == '2006-01-15 21:25:43.3226905'
+        assert t.tdb.iso == '2006-01-15 21:25:42.6843728'
+        assert t.tcb.iso == '2006-01-15 21:25:56.8939523'
+
+    def test_transforms_no_location(self):
+        """Location should default to geocenter (relevant for TDB, TCB)."""
+        t = Time('2006-01-15 21:24:37.5', format='iso', scale='utc',
+                 precision=7)
+        t.delta_ut1_utc = 0.3341  # Explicitly set one part of the xform
+        assert t.utc.iso == '2006-01-15 21:24:37.5000000'
+        assert t.ut1.iso == '2006-01-15 21:24:37.8341000'
+        assert t.tai.iso == '2006-01-15 21:25:10.5000000'
+        assert t.tt.iso == '2006-01-15 21:25:42.6840000'
+        assert t.tcg.iso == '2006-01-15 21:25:43.3226905'
+        assert t.tdb.iso == '2006-01-15 21:25:42.6843725'
+        assert t.tcb.iso == '2006-01-15 21:25:56.8939519'
+        # Check we get the same result
+        t2 = Time('2006-01-15 21:24:37.5', format='iso', scale='utc',
+                  location=(0*u.m, 0*u.m, 0*u.m))
+        assert t == t2
+        assert t.tdb == t2.tdb
 
     def test_location(self):
         """Check that location creates an EarthLocation object, and that


### PR DESCRIPTION
Fixes #11132 

The existing default seems just a mistake (or I didn't think about this hard enough when I implemented `location` back in 2013...). The only logical choice for no location would seem to be to ignore it and thus assume geocenter, and from #11132 it is clear that this was thought to be the case in PINT, which is probably the only group that really cares at the ~1 us level (and caused what I'm sure was a difficult-to-track discrepancy, sorry!). I think back-porting is the right thing to do here...