### PR TITLE
Make coord_wrap input a quantity instead of a scalar

### DIFF
--- a/astropy/visualization/wcsaxes/coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/coordinate_helpers.py
@@ -73,8 +73,8 @@ class CoordinateHelper:
         The unit that this coordinate is in given the output of transform.
     format_unit : `~astropy.units.Unit`, optional
         The unit to use to display the coordinates.
-    coord_wrap : float
-        The angle at which the longitude wraps (defaults to 360)
+    coord_wrap : Quantity
+        The angle at which the longitude wraps (defaults to 360 degrees).
     frame : `~astropy.visualization.wcsaxes.frame.BaseFrame`
         The frame of the :class:`~astropy.visualization.wcsaxes.WCSAxes`.
     """
@@ -182,9 +182,9 @@ class CoordinateHelper:
         Parameters
         ----------
         coord_type : str
-            One of 'longitude', 'latitude' or 'scalar'
-        coord_wrap : float, optional
-            The value to wrap at for angular coordinates
+            One of 'longitude', 'latitude' or 'scalar'.
+        coord_wrap : Quantity, optional
+            The value to wrap at for angular coordinates.
         """
 
         self.coord_type = coord_type
@@ -195,6 +195,13 @@ class CoordinateHelper:
             raise NotImplementedError('coord_wrap is not yet supported '
                                       'for non-longitude coordinates')
         else:
+            if isinstance(coord_wrap, u.Quantity):
+                coord_wrap = coord_wrap.to_value(u.deg)
+            elif coord_wrap is not None:
+                warnings.warn('Passing coord_wrap as a scalar is deprecated, '
+                              'pass a Quantity instead.',
+                              AstropyDeprecationWarning)
+
             self.coord_wrap = coord_wrap
 
         # Initialize tick formatter/locator

--- a/astropy/visualization/wcsaxes/tests/test_images.py
+++ b/astropy/visualization/wcsaxes/tests/test_images.py
@@ -611,7 +611,7 @@ class TestBasic(BaseImageTests):
 
         ax.imshow(np.zeros([1024, 1024]), origin='lower')
 
-        ax.coords[0].set_coord_type('longitude', coord_wrap=180)
+        ax.coords[0].set_coord_type('longitude', coord_wrap=180 * u.deg)
         ax.coords[1].set_coord_type('latitude')
 
         ax.coords[0].set_major_formatter('s.s')

--- a/astropy/visualization/wcsaxes/tests/test_transform_coord_meta.py
+++ b/astropy/visualization/wcsaxes/tests/test_transform_coord_meta.py
@@ -83,7 +83,7 @@ class TestTransformCoordMeta(BaseImageTests):
 
         coord_meta = {}
         coord_meta['type'] = ('longitude', 'latitude')
-        coord_meta['wrap'] = (360., None)
+        coord_meta['wrap'] = (360 * u.deg, None)
         coord_meta['unit'] = (u.deg, u.deg)
         coord_meta['name'] = 'lon', 'lat'
 
@@ -140,7 +140,7 @@ class TestTransformCoordMeta(BaseImageTests):
 
         coord_meta = {}
         coord_meta['type'] = ('longitude', 'latitude')
-        coord_meta['wrap'] = (360., None)
+        coord_meta['wrap'] = (360 * u.deg, None)
         coord_meta['unit'] = (u.deg, u.deg)
         coord_meta['name'] = 'lon', 'lat'
         fig = plt.figure(figsize=(4, 4))

--- a/astropy/visualization/wcsaxes/tests/test_wcsapi.py
+++ b/astropy/visualization/wcsaxes/tests/test_wcsapi.py
@@ -177,7 +177,7 @@ def test_coord_type_from_ctype(cube_wcs):
 
     assert coord_meta['type'] == ['longitude', 'latitude']
     assert coord_meta['format_unit'] == [u.arcsec, u.arcsec]
-    assert coord_meta['wrap'] == [180., None]
+    assert coord_meta['wrap'] == [180 * u.deg, None]
 
     _, coord_meta = transform_coord_meta_from_wcs(wcs, RectangularFrame,
                                                   slices=('y', 'x'))
@@ -202,7 +202,7 @@ def test_coord_type_from_ctype(cube_wcs):
 
     assert coord_meta['type'] == ['longitude', 'latitude']
     assert coord_meta['format_unit'] == [u.deg, u.deg]
-    assert coord_meta['wrap'] == [180., None]
+    assert coord_meta['wrap'] == [180 * u.deg, None]
 
     wcs = WCS(naxis=2)
     wcs.wcs.ctype = ['CRLN-TAN', 'CRLT-TAN']
@@ -215,7 +215,7 @@ def test_coord_type_from_ctype(cube_wcs):
 
     assert coord_meta['type'] == ['longitude', 'latitude']
     assert coord_meta['format_unit'] == [u.deg, u.deg]
-    assert coord_meta['wrap'] == [360., None]
+    assert coord_meta['wrap'] == [360 * u.deg, None]
 
     wcs = WCS(naxis=2)
     wcs.wcs.ctype = ['RA---TAN', 'DEC--TAN']
@@ -358,7 +358,7 @@ def test_sliced_ND_input(wcs_4d, sub_wcs, wcs_slice, plt_close):
                                       ('custom:pos.helioprojective.lat', 'hplt-tan', 'hplt'),
                                       ('custom:pos.helioprojective.lon', 'hpln-tan', 'hpln')]
         assert coord_meta['type'] == ['scalar', 'latitude', 'longitude']
-        assert coord_meta['wrap'] == [None, None, 180.0]
+        assert coord_meta['wrap'] == [None, None, 180 * u.deg]
         assert coord_meta['unit'] == [u.Unit("min"), u.Unit("deg"), u.Unit("deg")]
         assert coord_meta['visible'] == [False, True, True]
         assert coord_meta['format_unit'] == [u.Unit("min"), u.Unit("arcsec"), u.Unit("arcsec")]

--- a/astropy/visualization/wcsaxes/wcsapi.py
+++ b/astropy/visualization/wcsaxes/wcsapi.py
@@ -59,21 +59,21 @@ def transform_coord_meta_from_wcs(wcs, frame_class, slices=None):
             axis_type_split = axis_type.split('.')
 
             if "pos.helioprojective.lon" in axis_type:
-                coord_wrap = 180.
+                coord_wrap = 180 * u.deg
                 format_unit = u.arcsec
                 coord_type = "longitude"
             elif "pos.helioprojective.lat" in axis_type:
                 format_unit = u.arcsec
                 coord_type = "latitude"
             elif "pos.heliographic.stonyhurst.lon" in axis_type:
-                coord_wrap = 180.
+                coord_wrap = 180 * u.deg
                 format_unit = u.deg
                 coord_type = "longitude"
             elif "pos.heliographic.stonyhurst.lat" in axis_type:
                 format_unit = u.deg
                 coord_type = "latitude"
             elif "pos.heliographic.carrington.lon" in axis_type:
-                coord_wrap = 360.
+                coord_wrap = 360 * u.deg
                 format_unit = u.deg
                 coord_type = "longitude"
             elif "pos.heliographic.carrington.lat" in axis_type:


### PR DESCRIPTION
I noticed this slight oddity whilst looking through WCSAxes code. Since `coord_wrap` is an angle, it should probably be a `Quantity` instead of a just a number. This PR deprecates passing it as a plain number.