### PR TITLE
Move non-astronomy units to misc.py.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -249,6 +249,8 @@ astropy.uncertainty
 astropy.units
 ^^^^^^^^^^^^^
 
+- Move non-astronomy units from astrophys.py to a new misc.py file. [#11142]
+
 astropy.utils
 ^^^^^^^^^^^^^
 

--- a/astropy/units/__init__.py
+++ b/astropy/units/__init__.py
@@ -20,6 +20,7 @@ from . import si
 from . import cgs
 from . import astrophys
 from . import photometric
+from . import misc
 from .function import units as function_units
 
 from .si import *
@@ -28,6 +29,7 @@ from .photometric import *
 from .cgs import *
 from .physical import *
 from .function.units import *
+from .misc import *
 
 from .equivalencies import *
 
@@ -41,4 +43,4 @@ del bases
 # Enable the set of default units.  This notably does *not* include
 # Imperial units.
 
-set_enabled_units([si, cgs, astrophys, function_units, photometric])
+set_enabled_units([si, cgs, astrophys, function_units, misc, photometric])

--- a/astropy/units/astrophys.py
+++ b/astropy/units/astrophys.py
@@ -120,9 +120,6 @@ def_unit((['ct', 'count'], ['count']),
 
 def_unit(['chan'], namespace=_ns, prefixes=True)
 def_unit(['bin'], namespace=_ns, prefixes=True)
-def_unit((['vox', 'voxel'], ['voxel']),
-         format={'fits': 'voxel', 'ogip': 'voxel', 'vounit': 'voxel'},
-         namespace=_ns, prefixes=True)
 def_unit(['adu'], namespace=_ns, prefixes=True)
 def_unit(['beam'], namespace=_ns, prefixes=True)
 def_unit(['electron'], doc="Number of electrons", namespace=_ns,

--- a/astropy/units/astrophys.py
+++ b/astropy/units/astrophys.py
@@ -46,24 +46,6 @@ def_unit(['lyr', 'lightyear'], (_si.c * si.yr).to(si.m),
 
 
 ###########################################################################
-# AREAS
-
-def_unit(['barn', 'barn'], 10 ** -28 * si.m ** 2, namespace=_ns, prefixes=True,
-         doc="barn: unit of area used in HEP")
-
-
-###########################################################################
-# ANGULAR MEASUREMENTS
-
-def_unit(['cycle', 'cy'], 2.0 * _numpy.pi * si.rad,
-         namespace=_ns, prefixes=False,
-         doc="cycle: angular measurement, a full turn or rotation")
-
-def_unit(['spat', 'sp'], 4.0 * _numpy.pi * si.sr,
-         namespace=_ns, prefixes=False,
-         doc="spat: the solid angle of the sphere, 4pi sr")
-
-###########################################################################
 # MASS
 
 def_unit(['solMass', 'M_sun', 'Msun'], _si.M_sun, namespace=_ns,
@@ -77,14 +59,6 @@ def_unit(['earthMass', 'M_earth', 'Mearth'], _si.M_earth, namespace=_ns,
          prefixes=False, doc="Earth mass",
          # LaTeX earth symbol requires wasysym
          format={'latex': r'M_{\oplus}', 'unicode': 'M⊕'})
-def_unit(['M_p'], _si.m_p, namespace=_ns, doc="Proton mass",
-         format={'latex': r'M_{p}', 'unicode': 'Mₚ'})
-def_unit(['M_e'], _si.m_e, namespace=_ns, doc="Electron mass",
-         format={'latex': r'M_{e}', 'unicode': 'Mₑ'})
-# Unified atomic mass unit
-def_unit(['u', 'Da', 'Dalton'], _si.u, namespace=_ns,
-         prefixes=True, exclude_prefixes=['a', 'da'],
-         doc="Unified atomic mass unit")
 
 ##########################################################################
 # ENERGY
@@ -99,13 +73,6 @@ def_unit(['Ry', 'rydberg'],
          doc="Rydberg: Energy of a photon whose wavenumber is the Rydberg "
          "constant",
          format={'latex': r'R_{\infty}', 'unicode': 'R∞'})
-
-##########################################################################
-# PRESSURE
-
-def_unit(['bar'], 1e5 * si.Pa, namespace=_ns,
-         prefixes=[(['m'], ['milli'], 1.e-3)],
-         doc="bar: pressure")
 
 ###########################################################################
 # ILLUMINATION
@@ -147,10 +114,6 @@ def_unit(['Sun'], namespace=_ns)
 def_unit((['ct', 'count'], ['count']),
          format={'fits': 'count', 'ogip': 'count', 'vounit': 'count'},
          namespace=_ns, prefixes=True, exclude_prefixes=['p'])
-def_unit((['pix', 'pixel'], ['pixel']),
-         format={'ogip': 'pixel', 'vounit': 'pixel'},
-         namespace=_ns, prefixes=True)
-
 
 ###########################################################################
 # MISCELLANEOUS
@@ -160,12 +123,6 @@ def_unit(['bin'], namespace=_ns, prefixes=True)
 def_unit((['vox', 'voxel'], ['voxel']),
          format={'fits': 'voxel', 'ogip': 'voxel', 'vounit': 'voxel'},
          namespace=_ns, prefixes=True)
-def_unit((['bit', 'b'], ['bit']), namespace=_ns,
-         prefixes=si_prefixes + binary_prefixes)
-def_unit((['byte', 'B'], ['byte']), 8 * bit, namespace=_ns,
-         format={'vounit': 'byte'},
-         prefixes=si_prefixes + binary_prefixes,
-         exclude_prefixes=['d'])
 def_unit(['adu'], namespace=_ns, prefixes=True)
 def_unit(['beam'], namespace=_ns, prefixes=True)
 def_unit(['electron'], doc="Number of electrons", namespace=_ns,
@@ -178,15 +135,6 @@ def_unit(['electron'], doc="Number of electrons", namespace=_ns,
 def_unit(['littleh'], namespace=_ns, prefixes=False,
          doc="Reduced/\"dimensionless\" Hubble constant",
          format={'latex': r'h_{100}'})
-
-# The torr is almost the same as mmHg but not quite.
-# See https://en.wikipedia.org/wiki/Torr
-# Define the unit here despite it not being an astrophysical unit.
-# It may be moved if more similar units are created later.
-def_unit(['Torr', 'torr'], _si.atm.value/760. * si.Pa, namespace=_ns,
-         prefixes=[(['m'], ['milli'], 1.e-3)],
-         doc="Unit of pressure based on an absolute scale, now defined as "
-             "exactly 1/760 of a standard atmosphere")
 
 ###########################################################################
 # CLEANUP

--- a/astropy/units/equivalencies.py
+++ b/astropy/units/equivalencies.py
@@ -14,6 +14,7 @@ from astropy.utils.misc import isiterable
 from . import si
 from . import cgs
 from . import astrophys
+from . import misc
 from .function import units as function_units
 from . import dimensionless_unscaled
 from .core import UnitsError, Unit
@@ -512,7 +513,7 @@ def molar_mass_amu():
     Returns the equivalence between amu and molar mass.
     """
     return Equivalency([
-        (si.g/si.mol, astrophys.u)
+        (si.g/si.mol, misc.u)
     ], "molar_mass_amu")
 
 
@@ -755,18 +756,18 @@ def pixel_scale(pixscale):
 
     decomposed = pixscale.unit.decompose()
     dimensions = dict(zip(decomposed.bases, decomposed.powers))
-    pix_power = dimensions.get(astrophys.pix, 0)
+    pix_power = dimensions.get(misc.pix, 0)
 
     if pix_power == -1:
-        physical_unit = Unit(pixscale * astrophys.pix)
+        physical_unit = Unit(pixscale * misc.pix)
     elif pix_power == 1:
-        physical_unit = Unit(astrophys.pix / pixscale)
+        physical_unit = Unit(misc.pix / pixscale)
     else:
         raise UnitsError(
                 "The pixel scale unit must have"
                 " pixel dimensionality of 1 or -1.")
 
-    return Equivalency([(astrophys.pix, physical_unit)],
+    return Equivalency([(misc.pix, physical_unit)],
                        "pixel_scale", {'pixscale': pixscale})
 
 

--- a/astropy/units/misc.py
+++ b/astropy/units/misc.py
@@ -78,6 +78,9 @@ def_unit((['byte', 'B'], ['byte']), 8 * bit, namespace=_ns,
 def_unit((['pix', 'pixel'], ['pixel']),
          format={'ogip': 'pixel', 'vounit': 'pixel'},
          namespace=_ns, prefixes=True)
+def_unit((['vox', 'voxel'], ['voxel']),
+         format={'fits': 'voxel', 'ogip': 'voxel', 'vounit': 'voxel'},
+         namespace=_ns, prefixes=True)
 
 
 ###########################################################################

--- a/astropy/units/misc.py
+++ b/astropy/units/misc.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+"""
+This package defines miscellaneous units.  They are also
+available in the `astropy.units` namespace.
+"""
+
+
+from . import si
+from astropy.constants import si as _si
+from .core import (UnitBase, def_unit, si_prefixes, binary_prefixes,
+                   set_enabled_units)
+
+# To ensure si units of the constants can be interpreted.
+set_enabled_units([si])
+
+import numpy as _numpy
+
+_ns = globals()

--- a/astropy/units/misc.py
+++ b/astropy/units/misc.py
@@ -2,7 +2,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 """
-This package defines miscellaneous units.  They are also
+This package defines miscellaneous units. They are also
 available in the `astropy.units` namespace.
 """
 
@@ -18,3 +18,80 @@ set_enabled_units([si])
 import numpy as _numpy
 
 _ns = globals()
+
+###########################################################################
+# AREAS
+
+def_unit(['barn', 'barn'], 10 ** -28 * si.m ** 2, namespace=_ns, prefixes=True,
+         doc="barn: unit of area used in HEP")
+
+
+###########################################################################
+# ANGULAR MEASUREMENTS
+
+def_unit(['cycle', 'cy'], 2.0 * _numpy.pi * si.rad,
+         namespace=_ns, prefixes=False,
+         doc="cycle: angular measurement, a full turn or rotation")
+
+def_unit(['spat', 'sp'], 4.0 * _numpy.pi * si.sr,
+         namespace=_ns, prefixes=False,
+         doc="spat: the solid angle of the sphere, 4pi sr")
+
+##########################################################################
+# PRESSURE
+
+def_unit(['bar'], 1e5 * si.Pa, namespace=_ns,
+         prefixes=[(['m'], ['milli'], 1.e-3)],
+         doc="bar: pressure")
+
+# The torr is almost the same as mmHg but not quite.
+# See https://en.wikipedia.org/wiki/Torr
+# Define the unit here despite it not being an astrophysical unit.
+# It may be moved if more similar units are created later.
+def_unit(['Torr', 'torr'], _si.atm.value/760. * si.Pa, namespace=_ns,
+         prefixes=[(['m'], ['milli'], 1.e-3)],
+         doc="Unit of pressure based on an absolute scale, now defined as "
+             "exactly 1/760 of a standard atmosphere")
+
+###########################################################################
+# MASS
+
+def_unit(['M_p'], _si.m_p, namespace=_ns, doc="Proton mass",
+         format={'latex': r'M_{p}', 'unicode': 'Mₚ'})
+def_unit(['M_e'], _si.m_e, namespace=_ns, doc="Electron mass",
+         format={'latex': r'M_{e}', 'unicode': 'Mₑ'})
+# Unified atomic mass unit
+def_unit(['u', 'Da', 'Dalton'], _si.u, namespace=_ns,
+         prefixes=True, exclude_prefixes=['a', 'da'],
+         doc="Unified atomic mass unit")
+
+
+###########################################################################
+# COMPUTER
+
+def_unit((['bit', 'b'], ['bit']), namespace=_ns,
+         prefixes=si_prefixes + binary_prefixes)
+def_unit((['byte', 'B'], ['byte']), 8 * bit, namespace=_ns,
+         format={'vounit': 'byte'},
+         prefixes=si_prefixes + binary_prefixes,
+         exclude_prefixes=['d'])
+def_unit((['pix', 'pixel'], ['pixel']),
+         format={'ogip': 'pixel', 'vounit': 'pixel'},
+         namespace=_ns, prefixes=True)
+
+
+###########################################################################
+# CLEANUP
+
+del UnitBase
+del def_unit
+del si
+
+###########################################################################
+# DOCSTRING
+
+# This generates a docstring for this module that describes all of the
+# standard units defined here.
+from .utils import generate_unit_summary as _generate_unit_summary
+if __doc__ is not None:
+    __doc__ += _generate_unit_summary(globals())

--- a/astropy/units/physical.py
+++ b/astropy/units/physical.py
@@ -15,6 +15,7 @@ from . import si
 from . import astrophys
 from . import cgs
 from . import imperial
+from . import misc
 
 
 __all__ = ['def_physical_type', 'get_physical_type']
@@ -122,8 +123,8 @@ for unit, name in [
     (astrophys.photon / si.Hz / si.cm ** 2 / si.s, 'photon flux density'),
     (astrophys.photon / si.AA / si.cm ** 2 / si.s, 'photon flux density wav'),
     (astrophys.R, 'photon flux'),
-    (astrophys.bit, 'data quantity'),
-    (astrophys.bit / si.s, 'bandwidth'),
+    (misc.bit, 'data quantity'),
+    (misc.bit / si.s, 'bandwidth'),
     (cgs.Franklin, 'electrical charge (ESU)'),
     (cgs.statampere, 'electrical current (ESU)'),
     (cgs.Biot, 'electrical current (EMU)'),

--- a/docs/units/index.rst
+++ b/docs/units/index.rst
@@ -238,6 +238,8 @@ Reference/API
 
 .. automodapi:: astropy.units.astrophys
 
+.. automodapi:: astropy.units.misc
+
 .. automodapi:: astropy.units.function.units
 
 .. automodapi:: astropy.units.photometric


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request addresses the pollution of astrophys.py with miscellaneous units. It moves all non-astrophyiscal units to a new misc.py file.

Fixes #10769

This pull request was done during the astropy hackathon in December 2020. Note to the reviewer: My knowledge of python is limited. I will not be surprised if you encounter beginner mistakes.