### PR TITLE
Add TimeUnixPTP to time formats

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -68,6 +68,9 @@ astropy.tests
 astropy.time
 ^^^^^^^^^^^^
 
+- Add new time format ``unix_ptp`` (Precision Time Protocol) which provides 
+  the number of SI seconds since ``1970-01-01T00:00:00 TAI``. [#11143]
+
 astropy.timeseries
 ^^^^^^^^^^^^^^^^^^
 

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -467,9 +467,9 @@ class TimeBase(ShapedLikeNDArray):
         that could be used for initialization.  These can be listed with::
 
           >>> list(Time.FORMATS)
-          ['jd', 'mjd', 'decimalyear', 'unix', 'unix_tai', 'cxcsec', 'gps', 'plot_date',
-           'stardate', 'datetime', 'ymdhms', 'iso', 'isot', 'yday', 'datetime64',
-           'fits', 'byear', 'jyear', 'byear_str', 'jyear_str']
+          ['jd', 'mjd', 'decimalyear', 'unix', 'unix_tai', 'unix_ptp', 'cxcsec',
+           'gps', 'plot_date', 'stardate', 'datetime', 'ymdhms', 'iso', 'isot',
+           'yday', 'datetime64', 'fits', 'byear', 'jyear', 'byear_str', 'jyear_str']
         """
         return self._format
 
@@ -1430,9 +1430,9 @@ class Time(TimeBase):
     The allowed values for ``format`` can be listed with::
 
       >>> list(Time.FORMATS)
-      ['jd', 'mjd', 'decimalyear', 'unix', 'unix_tai', 'cxcsec', 'gps', 'plot_date',
-       'stardate', 'datetime', 'ymdhms', 'iso', 'isot', 'yday', 'datetime64',
-       'fits', 'byear', 'jyear', 'byear_str', 'jyear_str']
+      ['jd', 'mjd', 'decimalyear', 'unix', 'unix_tai', 'unix_ptp', 'cxcsec',
+       'gps', 'plot_date', 'stardate', 'datetime', 'ymdhms', 'iso', 'isot',
+       'yday', 'datetime64', 'fits', 'byear', 'jyear', 'byear_str', 'jyear_str']
 
     See also: http://docs.astropy.org/en/stable/time/
 

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -745,6 +745,52 @@ class TimeUnixTai(TimeUnix):
     epoch_scale = 'tai'
 
 
+class TimeUnixPTP(TimeUnix):
+    """
+    Precision Time Protocol: SI seconds elapsed from 1970-01-01 00:00:00 TAI.
+
+    This convention matches the definition of the Precision Time Protocol,
+    https://en.wikipedia.org/wiki/Precision_Time_Protocol and
+    is also used by the White Rabbit protocol in High Energy Physics:
+    https://white-rabbit.web.cern.ch/
+
+    For more information on this time format definition, see:
+    https://www-acc.gsi.de/wiki/Timing/TimingSystemButisInterface#Time
+
+    This format is basically the same as the ``unix_tai`` with an offset of
+    8 seconds due to the different epoch (1970-01-01 00:00:00 UTC vs. TAI).
+
+    This will generally differ from Unix time by the cumulative integral number
+    of leap seconds since 1970-01-01 UTC plus the initial offset of 8 seconds.
+
+    Caveats:
+    - Before 1972, fractional adjustments to UTC were made, so the difference
+      between ``unix`` and ``unix_ptp`` time is no longer an integer.
+    - Because of the fractional adjustments, to be very precise, ``unix_ptp``
+      is the number of seconds since ``1970-01-01 00:00:00 TAI`` or equivalently
+      ``1969-12-31 23:59:51.999918 UTC``.  The difference between TAI and UTC
+      at that epoch was 8.000082 sec.
+    - On the day of a leap second the difference between ``unix`` and ``unix_ptp``
+      times increases linearly through the day by 1.0.  See also the
+      documentation for the `~astropy.time.TimeUnix` class.
+
+    Examples
+    --------
+
+      >>> from astropy.time import Time
+      >>> t = Time('2020-01-01', scale='utc')
+      >>> t.unix_ptp - t.unix
+      37.0
+
+      >>> t = Time('1970-01-01', scale='utc')
+      >>> t.unix_ptp - t.unix  # doctest: +FLOAT_CMP
+      8.000082
+    """
+    name = 'unix_ptp'
+    epoch_val = '1970-01-01 00:00:00'
+    epoch_scale = 'tai'
+
+
 class TimeCxcSec(TimeFromEpoch):
     """
     Chandra X-ray Center seconds from 1998-01-01 00:00:00 TT.

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -1435,6 +1435,13 @@ def test_unix_tai_format():
     assert allclose_sec(t.unix_tai - t.unix, 8.2e-05)
 
 
+def test_unix_ptp_format():
+    t = Time('2020-01-01', scale='utc')
+    assert allclose_sec(t.unix_ptp - t.unix_tai, 8)
+    t = Time('1970-01-01', scale='utc')
+    assert allclose_sec(t.unix_ptp - t.unix_tai, 8)
+
+
 def test_set_format_shares_subfmt():
     """
     Set format and round trip through a format that shares out_subfmt


### PR DESCRIPTION
### Description

This adds a new time format `TimeUnixPTP` that has epoch `1970-01-01T00:00:00 TAI` as apposed to `1970-01-01T00:00:08 TAI` of the `TimeUnixTAI` format.

This format is used by the Precision Time Protocol IEEE standard and by extension the White Rabbit hardware / software in high energy physics.