### PR TITLE
Extend description of fits scripts

### DIFF
--- a/astropy/io/fits/scripts/fitscheck.py
+++ b/astropy/io/fits/scripts/fitscheck.py
@@ -46,15 +46,19 @@ import argparse
 import warnings
 
 from astropy.io import fits
+from astropy import version
 
 log = logging.getLogger('fitscheck')
 
-_DESCRIPTION = """
+_DESCRIPTION = f"""
 e.g. fitscheck example.fits
 
 Verifies and optionally re-writes the CHECKSUM and DATASUM keywords
 for a .fits file.
 Optionally detects and fixes FITS standard compliance problems.
+
+This script is part of the Astropy package, version {version.major}.{version.minor}.{version.bugfix}. See
+https://docs.astropy.org/en/latest/io/fits/usage/scripts.html#module-astropy.io.fits.scripts.fitscheck for further documentation.
 """
 
 

--- a/astropy/io/fits/scripts/fitscheck.py
+++ b/astropy/io/fits/scripts/fitscheck.py
@@ -46,7 +46,7 @@ import argparse
 import warnings
 
 from astropy.io import fits
-from astropy import version
+from astropy import __version__
 
 log = logging.getLogger('fitscheck')
 
@@ -57,7 +57,7 @@ Verifies and optionally re-writes the CHECKSUM and DATASUM keywords
 for a .fits file.
 Optionally detects and fixes FITS standard compliance problems.
 
-This script is part of the Astropy package, version {version.major}.{version.minor}.{version.bugfix}. See
+This script is part of the Astropy package, version {__version__}. See
 https://docs.astropy.org/en/latest/io/fits/usage/scripts.html#module-astropy.io.fits.scripts.fitscheck for further documentation.
 """
 

--- a/astropy/io/fits/scripts/fitscheck.py
+++ b/astropy/io/fits/scripts/fitscheck.py
@@ -50,16 +50,17 @@ from astropy import __version__
 
 log = logging.getLogger('fitscheck')
 
-_DESCRIPTION = f"""
+DESCRIPTION = """
 e.g. fitscheck example.fits
 
 Verifies and optionally re-writes the CHECKSUM and DATASUM keywords
 for a .fits file.
 Optionally detects and fixes FITS standard compliance problems.
 
-This script is part of the Astropy package, version {__version__}. See
-https://docs.astropy.org/en/latest/io/fits/usage/scripts.html#module-astropy.io.fits.scripts.fitscheck for further documentation.
-"""
+This script is part of the Astropy package. See
+https://docs.astropy.org/en/latest/io/fits/usage/scripts.html#module-astropy.io.fits.scripts.fitscheck
+for further documentation.
+""".strip()
 
 
 def handle_options(args):
@@ -67,8 +68,12 @@ def handle_options(args):
         args = ['-h']
 
     parser = argparse.ArgumentParser(
-        description=_DESCRIPTION,
+        description=DESCRIPTION,
         formatter_class=argparse.RawDescriptionHelpFormatter)
+
+    parser.add_argument(
+        '--version', action='version',
+        version=f'%(prog)s {__version__}')
 
     parser.add_argument(
         'fits_files', metavar='file', nargs='+',

--- a/astropy/io/fits/scripts/fitsdiff.py
+++ b/astropy/io/fits/scripts/fitsdiff.py
@@ -7,14 +7,14 @@ import sys
 
 from astropy.io import fits
 from astropy.io.fits.util import fill
-from astropy import version
+from astropy import __version__
 
 
 log = logging.getLogger('fitsdiff')
 
 
 USAGE = f"""
-This script is part of the Astropy package, version {version.major}.{version.minor}.{version.bugfix}. See
+This script is part of the Astropy package, version {__version__}. See
 https://docs.astropy.org/en/latest/io/fits/usage/scripts.html#fitsdiff for further documentation.
 
 Compare two FITS image files and report the differences in header keywords and

--- a/astropy/io/fits/scripts/fitsdiff.py
+++ b/astropy/io/fits/scripts/fitsdiff.py
@@ -7,12 +7,16 @@ import sys
 
 from astropy.io import fits
 from astropy.io.fits.util import fill
+from astropy import version
 
 
 log = logging.getLogger('fitsdiff')
 
 
-USAGE = """
+USAGE = f"""
+This script is part of the Astropy package, version {version.major}.{version.minor}.{version.bugfix}. See
+https://docs.astropy.org/en/latest/io/fits/usage/scripts.html#fitsdiff for further documentation.
+
 Compare two FITS image files and report the differences in header keywords and
 data.
 

--- a/astropy/io/fits/scripts/fitsdiff.py
+++ b/astropy/io/fits/scripts/fitsdiff.py
@@ -13,10 +13,7 @@ from astropy import __version__
 log = logging.getLogger('fitsdiff')
 
 
-USAGE = f"""
-This script is part of the Astropy package, version {__version__}. See
-https://docs.astropy.org/en/latest/io/fits/usage/scripts.html#fitsdiff for further documentation.
-
+DESCRIPTION = """
 Compare two FITS image files and report the differences in header keywords and
 data.
 
@@ -33,6 +30,10 @@ argument.  for example::
 
 will compare all FITS files in the current directory to the corresponding files
 in the directory /machine/data1.
+
+This script is part of the Astropy package. See
+https://docs.astropy.org/en/latest/io/fits/usage/scripts.html#fitsdiff
+for further documentation.
 """.strip()
 
 
@@ -90,8 +91,12 @@ class StoreListAction(argparse.Action):
 
 def handle_options(argv=None):
     parser = argparse.ArgumentParser(
-        description=USAGE, epilog=EPILOG,
+        description=DESCRIPTION, epilog=EPILOG,
         formatter_class=argparse.RawDescriptionHelpFormatter)
+
+    parser.add_argument(
+        '--version', action='version',
+        version=f'%(prog)s {__version__}')
 
     parser.add_argument(
         'fits_files', metavar='file', nargs='+',

--- a/astropy/io/fits/scripts/fitsheader.py
+++ b/astropy/io/fits/scripts/fitsheader.py
@@ -66,6 +66,18 @@ from astropy.io import fits
 from astropy import log, __version__
 
 
+DESCRIPTION = """
+Print the header(s) of a FITS file. Optional arguments allow the desired
+extension(s), keyword(s), and output format to be specified.
+Note that in the case of a compressed image, the decompressed header is
+shown by default.
+
+This script is part of the Astropy package. See
+https://docs.astropy.org/en/latest/io/fits/usage/scripts.html#module-astropy.io.fits.scripts.fitsheader
+for further documentation.
+""".strip()
+
+
 class ExtensionNotFoundException(Exception):
     """Raised if an HDU extension requested by the user does not exist."""
     pass
@@ -397,14 +409,13 @@ def main(args=None):
     """This is the main function called by the `fitsheader` script."""
 
     parser = argparse.ArgumentParser(
-        description=('Print the header(s) of a FITS file. '
-                     'Optional arguments allow the desired extension(s), '
-                     'keyword(s), and output format to be specified. '
-                     'Note that in the case of a compressed image, '
-                     'the decompressed header is shown by default. \n\n'
-                     f'This script is part of the Astropy package, version {__version__}. '
-                     'See https://docs.astropy.org/en/latest/io/fits/usage/scripts.html#module-astropy.io.fits.scripts.fitsheader for further documentation.'),
-                     formatter_class=argparse.RawDescriptionHelpFormatter)
+        description=DESCRIPTION,
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+
+    parser.add_argument(
+        '--version', action='version',
+        version=f'%(prog)s {__version__}')
+
     parser.add_argument('-e', '--extension', metavar='HDU',
                         action='append', dest='extensions',
                         help='specify the extension by name or number; '

--- a/astropy/io/fits/scripts/fitsheader.py
+++ b/astropy/io/fits/scripts/fitsheader.py
@@ -63,7 +63,7 @@ import argparse
 import numpy as np
 
 from astropy.io import fits
-from astropy import log
+from astropy import log, version
 
 
 class ExtensionNotFoundException(Exception):
@@ -401,7 +401,10 @@ def main(args=None):
                      'Optional arguments allow the desired extension(s), '
                      'keyword(s), and output format to be specified. '
                      'Note that in the case of a compressed image, '
-                     'the decompressed header is shown by default.'))
+                     'the decompressed header is shown by default. \n\n'
+                     f'This script is part of the Astropy package, version {version.major}.{version.minor}.{version.bugfix}. '
+                     'See https://docs.astropy.org/en/latest/io/fits/usage/scripts.html#module-astropy.io.fits.scripts.fitsheader for further documentation.'),
+                     formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument('-e', '--extension', metavar='HDU',
                         action='append', dest='extensions',
                         help='specify the extension by name or number; '

--- a/astropy/io/fits/scripts/fitsheader.py
+++ b/astropy/io/fits/scripts/fitsheader.py
@@ -63,7 +63,7 @@ import argparse
 import numpy as np
 
 from astropy.io import fits
-from astropy import log, version
+from astropy import log, __version__
 
 
 class ExtensionNotFoundException(Exception):
@@ -402,7 +402,7 @@ def main(args=None):
                      'keyword(s), and output format to be specified. '
                      'Note that in the case of a compressed image, '
                      'the decompressed header is shown by default. \n\n'
-                     f'This script is part of the Astropy package, version {version.major}.{version.minor}.{version.bugfix}. '
+                     f'This script is part of the Astropy package, version {__version__}. '
                      'See https://docs.astropy.org/en/latest/io/fits/usage/scripts.html#module-astropy.io.fits.scripts.fitsheader for further documentation.'),
                      formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument('-e', '--extension', metavar='HDU',

--- a/astropy/io/fits/scripts/fitsinfo.py
+++ b/astropy/io/fits/scripts/fitsinfo.py
@@ -28,6 +28,15 @@ import astropy.io.fits as fits
 from astropy import log, __version__
 
 
+DESCRIPTION = """
+Print a summary of the HDUs in a FITS file(s).
+
+This script is part of the Astropy package. See
+https://docs.astropy.org/en/latest/io/fits/usage/scripts.html#module-astropy.io.fits.scripts.fitsinfo
+for further documentation.
+""".strip()
+
+
 def fitsinfo(filename):
     """
     Print a summary of the HDUs in a FITS file.
@@ -48,10 +57,11 @@ def fitsinfo(filename):
 def main(args=None):
     """The main function called by the `fitsinfo` script."""
     parser = argparse.ArgumentParser(
-        description=('Print a summary of the HDUs in a FITS file(s). \n\n'
-                     f'This script is part of the Astropy package, version {__version__}. '
-                     'See https://docs.astropy.org/en/latest/io/fits/usage/scripts.html#module-astropy.io.fits.scripts.fitsinfo for further documentation.'),
-                     formatter_class=argparse.RawDescriptionHelpFormatter)
+        description=DESCRIPTION,
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        '--version', action='version',
+        version=f'%(prog)s {__version__}')
     parser.add_argument('filename', nargs='+',
                         help='Path to one or more FITS files. '
                              'Wildcards are supported.')

--- a/astropy/io/fits/scripts/fitsinfo.py
+++ b/astropy/io/fits/scripts/fitsinfo.py
@@ -25,7 +25,7 @@ Example usage of ``fitsinfo``:
 
 import argparse
 import astropy.io.fits as fits
-from astropy import log, version
+from astropy import log, __version__
 
 
 def fitsinfo(filename):
@@ -49,7 +49,7 @@ def main(args=None):
     """The main function called by the `fitsinfo` script."""
     parser = argparse.ArgumentParser(
         description=('Print a summary of the HDUs in a FITS file(s). \n\n'
-                     f'This script is part of the Astropy package, version {version.major}.{version.minor}.{version.bugfix}. '
+                     f'This script is part of the Astropy package, version {__version__}. '
                      'See https://docs.astropy.org/en/latest/io/fits/usage/scripts.html#module-astropy.io.fits.scripts.fitsinfo for further documentation.'),
                      formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument('filename', nargs='+',

--- a/astropy/io/fits/scripts/fitsinfo.py
+++ b/astropy/io/fits/scripts/fitsinfo.py
@@ -25,7 +25,7 @@ Example usage of ``fitsinfo``:
 
 import argparse
 import astropy.io.fits as fits
-from astropy import log
+from astropy import log, version
 
 
 def fitsinfo(filename):
@@ -48,7 +48,10 @@ def fitsinfo(filename):
 def main(args=None):
     """The main function called by the `fitsinfo` script."""
     parser = argparse.ArgumentParser(
-        description=('Print a summary of the HDUs in a FITS file(s).'))
+        description=('Print a summary of the HDUs in a FITS file(s). \n\n'
+                     f'This script is part of the Astropy package, version {version.major}.{version.minor}.{version.bugfix}. '
+                     'See https://docs.astropy.org/en/latest/io/fits/usage/scripts.html#module-astropy.io.fits.scripts.fitsinfo for further documentation.'),
+                     formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument('filename', nargs='+',
                         help='Path to one or more FITS files. '
                              'Wildcards are supported.')

--- a/astropy/io/fits/tests/test_fitscheck.py
+++ b/astropy/io/fits/tests/test_fitscheck.py
@@ -6,12 +6,20 @@ from . import FitsTestCase
 from astropy.io.fits.scripts import fitscheck
 from astropy.io import fits
 from astropy.utils.exceptions import AstropyUserWarning
+from astropy import __version__ as version
 
 
 class TestFitscheck(FitsTestCase):
-    def test_noargs(self):
+    def test_help(self):
         with pytest.raises(SystemExit) as e:
             fitscheck.main(['-h'])
+        assert e.value.code == 0
+
+    def test_version(self, capsys):
+        with pytest.raises(SystemExit) as e:
+            fitscheck.main(['--version'])
+            out = capsys.readouterr()[0]
+            assert out == f'fitscheck {version}'
         assert e.value.code == 0
 
     def test_missing_file(self, capsys):

--- a/astropy/io/fits/tests/test_fitsdiff.py
+++ b/astropy/io/fits/tests/test_fitsdiff.py
@@ -18,6 +18,13 @@ class TestFITSDiff_script(FitsTestCase):
             fitsdiff.main(['-h'])
         assert e.value.code == 0
 
+    def test_version(self, capsys):
+        with pytest.raises(SystemExit) as e:
+            fitsdiff.main(['--version'])
+            out = capsys.readouterr()[0]
+            assert out == f'fitsdiff {version}'
+        assert e.value.code == 0
+
     def test_noargs(self):
         with pytest.raises(SystemExit) as e:
             fitsdiff.main([""])

--- a/astropy/io/fits/tests/test_fitsheader.py
+++ b/astropy/io/fits/tests/test_fitsheader.py
@@ -4,13 +4,21 @@ import pytest
 
 from . import FitsTestCase
 from astropy.io.fits.scripts import fitsheader
+from astropy import __version__ as version
 
 
 class TestFITSheader_script(FitsTestCase):
 
-    def test_noargs(self):
+    def test_help(self):
         with pytest.raises(SystemExit) as e:
             fitsheader.main(['-h'])
+        assert e.value.code == 0
+
+    def test_version(self, capsys):
+        with pytest.raises(SystemExit) as e:
+            fitsheader.main(['--version'])
+            out = capsys.readouterr()[0]
+            assert out == f'fitsheader {version}'
         assert e.value.code == 0
 
     def test_file_exists(self, capsys):

--- a/astropy/io/fits/tests/test_fitsinfo.py
+++ b/astropy/io/fits/tests/test_fitsinfo.py
@@ -1,10 +1,25 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+import pytest
+
 from . import FitsTestCase
 from astropy.io.fits.scripts import fitsinfo
+from astropy import __version__ as version
 
 
 class TestFitsinfo(FitsTestCase):
+
+    def test_help(self):
+        with pytest.raises(SystemExit) as e:
+            fitsinfo.main(['-h'])
+        assert e.value.code == 0
+
+    def test_version(self, capsys):
+        with pytest.raises(SystemExit) as e:
+            fitsinfo.main(['--version'])
+            out = capsys.readouterr()[0]
+            assert out == f'fitsinfo {version}'
+        assert e.value.code == 0
 
     def test_onefile(self, capsys):
         fitsinfo.main([self.data('arange.fits')])


### PR DESCRIPTION
### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

When invoking `fits[check/diff/header/info] --help` from the command line, the Astropy version is printed as well as a link to the documentation.

Let me know if there are any other executable scripts in Astropy that might benefit from these changes, I am really fresh to Astropy.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

fixes #3009
