### PR TITLE
Astropy#2632 multiple fits tables

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,6 +38,7 @@ astropy.io.fits
 - Check that the SIMPLE card is present when opening a file, to ensure that the
   file is a valid FITS file and raise a better error when opening a non FITS
   one. ``ignore_missing_simple`` can be used to skip this verification. [#10895]
+
 - Added ``append`` keyword to append table objects to an existing FITS file [#2632, #11149]
 
 astropy.io.misc

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,7 +38,7 @@ astropy.io.fits
 - Check that the SIMPLE card is present when opening a file, to ensure that the
   file is a valid FITS file and raise a better error when opening a non FITS
   one. ``ignore_missing_simple`` can be used to skip this verification. [#10895]
-- Added ``append`` keyword to append table objects to an existing FITS file [#2632]
+- Added ``append`` keyword to append table objects to an existing FITS file [#2632, #11149]
 
 astropy.io.misc
 ^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,6 +38,7 @@ astropy.io.fits
 - Check that the SIMPLE card is present when opening a file, to ensure that the
   file is a valid FITS file and raise a better error when opening a non FITS
   one. ``ignore_missing_simple`` can be used to skip this verification. [#10895]
+- Added ``append`` keyword to append table objects to an existing FITS file [#2632]
 
 astropy.io.misc
 ^^^^^^^^^^^^^^^

--- a/astropy/io/fits/tests/test_connect.py
+++ b/astropy/io/fits/tests/test_connect.py
@@ -267,6 +267,24 @@ class TestSingleTable:
         assert read['x'].shape == (2, 1)
         assert len(read['x'][0]) == 1
 
+    def test_write_append(self, tmpdir):
+        filename = str(tmpdir.join('test_write_append.fits'))
+        t = Table(self.data)
+        t.write(filename, append=True)
+        t.write(filename, append=True)
+        with fits.open(filename) as hdu_list:
+            assert len(hdu_list) == 3
+
+        t.write(filename, append=True, overwrite=True)
+        t.write(filename, append=True)
+        with fits.open(filename) as hdu_list:
+            assert len(hdu_list) == 3
+
+        t.write(filename, overwrite=True)
+        t.write(filename, overwrite=True)
+        with fits.open(filename) as hdu_list:
+            assert len(hdu_list) == 2
+
 
 class TestMultipleHDU:
 

--- a/docs/io/unified.rst
+++ b/docs/io/unified.rst
@@ -350,9 +350,12 @@ If the file already exists and you want to overwrite it, then set the
 
     >>> t.write('existing_table.fits', overwrite=True)  # doctest: +SKIP
 
-At this time there is no support for appending an HDU to an existing
-file or writing multi-HDU files using the Table interface. Instead, you
-can use the convenience function
+If you want to append a table to an existing file, set the ``append``
+keyword::
+
+    >>> t.write('existing_table.fits', append=True)  # doctest: +SKIP
+
+Alternatively, you can use the convenience function
 :func:`~astropy.io.fits.table_to_hdu` to create a single
 binary table HDU and insert or append that to an existing
 :class:`~astropy.io.fits.HDUList`.

--- a/tox.ini
+++ b/tox.ini
@@ -4,10 +4,10 @@ envlist =
     build_docs
     linkcheck
     codestyle
-requires =
-    setuptools >= 30.3.0
-    pip >= 19.3.1
-    tox-pypi-filter >= 0.12
+#requires =
+#    setuptools >= 30.3.0
+#    pip >= 19.3.1
+#    tox-pypi-filter >= 0.12
 isolated_build = true
 indexserver =
     NIGHTLY = https://pypi.anaconda.org/scipy-wheels-nightly/simple

--- a/tox.ini
+++ b/tox.ini
@@ -4,10 +4,10 @@ envlist =
     build_docs
     linkcheck
     codestyle
-#requires =
-#    setuptools >= 30.3.0
-#    pip >= 19.3.1
-#    tox-pypi-filter >= 0.12
+requires =
+    setuptools >= 30.3.0
+    pip >= 19.3.1
+    tox-pypi-filter >= 0.12
 isolated_build = true
 indexserver =
     NIGHTLY = https://pypi.anaconda.org/scipy-wheels-nightly/simple


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to address feature request #2632 on saving multiple tables to one FITS file. The implementation follows the original suggestion by the submitter of the request. The performance of appending multiple tables is comparable to writing the same table to a file multiple times.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #2632
