### PR TITLE
Improve AltAz documentation

### DIFF
--- a/astropy/coordinates/builtin_frames/altaz.py
+++ b/astropy/coordinates/builtin_frames/altaz.py
@@ -67,9 +67,9 @@ doc_footer = """
     but becomes inaccurate for altitudes below about 5 degrees.  Near and below
     altitudes of 0, it can even give meaningless answers, and in this case
     transforming to AltAz and back to another frame can give highly discrepant
-    results.  For much better numerical stability, leaving the ``pressure`` at
-    ``0`` (the default), disabling the refraction correction (yielding
-    "topocentric" horizontal coordinates).
+    results.  For much better numerical stability, leave the ``pressure`` at
+    ``0`` (the default), thereby disabling the refraction correction and
+    yielding "topocentric" horizontal coordinates.
     """
 
 
@@ -77,7 +77,9 @@ doc_footer = """
 class AltAz(BaseCoordinateFrame):
     """
     A coordinate or frame in the Altitude-Azimuth system (Horizontal
-    coordinates).  Azimuth is oriented East of North (i.e., N=0, E=90 degrees).
+    coordinates) with respect to the WGS84 ellipsoid.  Azimuth is oriented
+    East of North (i.e., N=0, E=90 degrees).  Altitude is also known as
+    elevation angle, so this frame is also in the Azimuth-Elevation system.
 
     This frame is assumed to *include* refraction effects if the ``pressure``
     frame attribute is non-zero.
@@ -109,15 +111,15 @@ class AltAz(BaseCoordinateFrame):
     @property
     def secz(self):
         """
-        Secant if the zenith angle for this coordinate, a common estimate of the
-        airmass.
+        Secant of the zenith angle for this coordinate, a common estimate of
+        the airmass.
         """
         return 1/np.sin(self.alt)
 
     @property
     def zen(self):
         """
-        The zenith angle for this coordinate
+        The zenith angle (or zenith distance / co-altitude) for this coordinate.
         """
         return _90DEG.to(self.alt.unit) - self.alt
 


### PR DESCRIPTION
### Description

This pull request is to address the `astropy.coordinates.AltAz` documentation.

Mention that the local horizon is defined with respect to the WGS84 reference ellipsoid, since that is what ERFA does underneath (see `astropy.coordinates.erfa_astrom` for more details). This is useful to know because other libraries might make different choices. For example, GSFC Calc uses the IERS 2003 ellipsoid.

Mention that altitude == elevation angle, AltAz == AzEl and zenith angle == zenith distance, as those terms are in common use in astronomy.

Also improve grammar and fix a typo.
