### PR TITLE
Fix #11140 Angle.to_string(precision=None) does not produce the expected number of decimal places

### DIFF
--- a/astropy/coordinates/angle_utilities.py
+++ b/astropy/coordinates/angle_utilities.py
@@ -603,7 +603,7 @@ def sexagesimal_to_string(values, precision=None, pad=False, sep=(':',),
     # it to 0 and carry upwards.  If the field is hidden (by the
     # fields kwarg) we round up around the middle, 30.0.
     if precision is None:
-        rounding_thresh = 60.0 - (10.0 ** -4)
+        rounding_thresh = 60.0 - (10.0 ** -8)
     else:
         rounding_thresh = 60.0 - (10.0 ** -precision)
 
@@ -626,7 +626,7 @@ def sexagesimal_to_string(values, precision=None, pad=False, sep=(':',),
         literal.append('{1:02d}{sep[1]}')
     if fields == 3:
         if precision is None:
-            last_value = f'{abs(values[2]):.4f}'
+            last_value = f'{abs(values[2]):.8f}'
             last_value = last_value.rstrip('0').rstrip('.')
         else:
             last_value = '{0:.{precision}f}'.format(

--- a/astropy/coordinates/tests/test_angles.py
+++ b/astropy/coordinates/tests/test_angles.py
@@ -871,6 +871,13 @@ def test_regression_formatting_negative():
     assert Angle(-1., unit='hour').to_string() == '-1h00m00s'
 
 
+def test_regression_formatting_default_precision():
+    # Regression test for issue #11140
+    assert Angle('10:20:30.12345678d').to_string() == '10d20m30.12345678s'
+    assert Angle('10h20m30.123456784564s').to_string() == '10d20m30.12345678s'
+    assert Angle('10d20m30.123s').to_string() == '10d20m30.123s'
+
+
 def test_empty_sep():
     a = Angle('05h04m31.93830s')
 

--- a/astropy/coordinates/tests/test_angles.py
+++ b/astropy/coordinates/tests/test_angles.py
@@ -347,18 +347,18 @@ def test_angle_formatting():
     angle = Angle(-1.23456789, unit=u.degree)
     angle2 = Angle(-1.23456789, unit=u.hour)
 
-    assert angle.to_string() == '-1d14m04.4444s'
-    assert angle.to_string(pad=True) == '-01d14m04.4444s'
-    assert angle.to_string(unit=u.hour) == '-0h04m56.2963s'
-    assert angle2.to_string(unit=u.hour, pad=True) == '-01h14m04.4444s'
+    assert angle.to_string() == '-1d14m04.444404s'
+    assert angle.to_string(pad=True) == '-01d14m04.444404s'
+    assert angle.to_string(unit=u.hour) == '-0h04m56.2962936s'
+    assert angle2.to_string(unit=u.hour, pad=True) == '-01h14m04.444404s'
     assert angle.to_string(unit=u.radian, decimal=True) == '-0.0215473'
 
 
 def test_to_string_vector():
     # Regression test for the fact that vectorize doesn't work with Numpy 1.6
-    assert Angle([1./7., 1./7.], unit='deg').to_string()[0] == "0d08m34.2857s"
-    assert Angle([1./7.], unit='deg').to_string()[0] == "0d08m34.2857s"
-    assert Angle(1./7., unit='deg').to_string() == "0d08m34.2857s"
+    assert Angle([1./7., 1./7.], unit='deg').to_string()[0] == "0d08m34.28571429s"
+    assert Angle([1./7.], unit='deg').to_string()[0] == "0d08m34.28571429s"
+    assert Angle(1./7., unit='deg').to_string() == "0d08m34.28571429s"
 
 
 def test_angle_format_roundtripping():
@@ -874,7 +874,7 @@ def test_regression_formatting_negative():
 def test_regression_formatting_default_precision():
     # Regression test for issue #11140
     assert Angle('10:20:30.12345678d').to_string() == '10d20m30.12345678s'
-    assert Angle('10h20m30.123456784564s').to_string() == '10d20m30.12345678s'
+    assert Angle('10d20m30.123456784564s').to_string() == '10d20m30.12345678s'
     assert Angle('10d20m30.123s').to_string() == '10d20m30.123s'
 
 

--- a/astropy/coordinates/tests/test_formatting.py
+++ b/astropy/coordinates/tests/test_formatting.py
@@ -90,13 +90,15 @@ def test_to_string_padding():
 
 
 def test_sexagesimal_rounding_up():
-    a = Angle(359.9999999999, unit=u.deg)
+    a = Angle(359.999999999999, unit=u.deg)
 
     assert a.to_string(precision=None) == '360d00m00s'
     assert a.to_string(precision=4) == '360d00m00.0000s'
     assert a.to_string(precision=5) == '360d00m00.00000s'
     assert a.to_string(precision=6) == '360d00m00.000000s'
-    assert a.to_string(precision=7) == '359d59m59.9999996s'
+    assert a.to_string(precision=7) == '360d00m00.0000000s'
+    assert a.to_string(precision=8) == '360d00m00.00000000s'
+    assert a.to_string(precision=9) == '359d59m59.999999996s'
 
     a = Angle(3.999999, unit=u.deg)
     assert a.to_string(fields=2, precision=None) == '4d00m'

--- a/docs/changes/coordinates/11153.bugfix.rst
+++ b/docs/changes/coordinates/11153.bugfix.rst
@@ -1,0 +1,2 @@
+Makes the ``Angle.to_string`` method to follow the format described in the
+docstring with up to 8 significant decimals instead of 4.

--- a/docs/coordinates/angles.rst
+++ b/docs/coordinates/angles.rst
@@ -105,13 +105,13 @@ There are many ways to represent the value of an |Angle|::
     >>> a.to_string()
     '1rad'
     >>> a.to_string(unit=u.degree)
-    '57d17m44.8062s'
+    '57d17m44.8062471s'
     >>> a.to_string(unit=u.degree, sep=':')
-    '57:17:44.8062'
+    '57:17:44.8062471'
     >>> a.to_string(unit=u.degree, sep=('deg', 'm', 's'))
-    '57deg17m44.8062s'
+    '57deg17m44.8062471s'
     >>> a.to_string(unit=u.hour)
-    '3h49m10.9871s'
+    '3h49m10.98708314s'
     >>> a.to_string(unit=u.hour, decimal=True)
     '3.81972'
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to address issue #11140. Calling Angle.to_string(precision=None) did not produce the number of decimals described in the docstring. Now, when the precission is not defined, the output is the same as the one used in the input. For angles based of values with more than 8 decimal places this is truncated at 8 decimal places now instead of 4, as described.



<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #11140
