### PR TITLE
TST: Add base branch check

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -13,9 +13,32 @@ env:
   IS_CRON: "false"
 
 jobs:
+  initial_checks:
+    name: Mandatory checks before CI
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check base branch
+      uses: actions/github-script@v3
+      if: github.event_name == 'pull_request'
+      with:
+        script: |
+          const skip_label = 'skip-basebranch-check';
+          const { default_branch: allowed_basebranch } = context.payload.repository;
+          const pr = context.payload.pull_request;
+          if (pr.labels.find(lbl => lbl.name === skip_label)) {
+            core.info(`Base branch check is skipped due to the presence of ${skip_label} label`);
+            return;
+          }
+          if (pr.base.ref !== allowed_basebranch) {
+            core.setFailed(`PR opened against ${pr.base.ref}, not ${allowed_basebranch}`);
+          } else {
+            core.info(`PR opened correctly against ${allowed_basebranch}`);
+          }
+
   tests:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
+    needs: initial_checks
     strategy:
       fail-fast: true
       matrix:
@@ -90,6 +113,7 @@ jobs:
   allowed_failures:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
+    needs: initial_checks
     strategy:
       fail-fast: false
       matrix:
@@ -120,6 +144,7 @@ jobs:
   parallel_and_32bit:
     name: 32-bit and parallel
     runs-on: ubuntu-latest
+    needs: initial_checks
     container:
       image: quay.io/pypa/manylinux1_i686
     steps:


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to perform a check when a new PR is opened and fails the check if the PR is not opened against the correct base branch (`master`). This is because occasionally, a contributor would open PR via the "edit on GitHub" link from RTD docs, which results in them editing an older version of the code on the wrong branch. If a PR is opened against a release branch on purpose, then a special label could be applied by maintainer to bypass the check.

**Notes**

- There is no special event for simply changing base branch, so this check might run even when it is not necessary, unless you only want it to run once when PR is opened. (See below.)
- Update: This action now uses Javascript and completes in 2-3s, so having it running when not strictly needed isn't such a big issue anymore. Prior, it took like 20s when running on Docker.

**TODO or Needs Discussions**

- [x] I did not put this in the labeler YAML, as I originally promised, because you probably want this check not just when the PR is opened? But if you only wants to let it run once when opened, then I can move it to labeler YAML. (Looks like people are okay with running this per push event.)
- [ ] When special label is applied, manually re-running the CI will not change the failure to success because the workflow is not watching label/unlabel events and not sure if we want it to. This means, only force pushing existing commit or normal pushing new commits would change the status... ~maintainer needs to manually re-run the CI because labeled/unlabeled does not trigger CI and we don't want it to anyway.~ Is this okay? If not, another option is to move this out to a different YAML. ~This point is moot if we move to labeler YAML.~
- [x] Maybe we can have the rest of CI to only run if base branch check is successful ~but setting up the logic may be tricky because the YAML also handle push and tag events. Tricky logic might not be needed, though, if I modify the Action code to be a successful no-op if event is not from a PR~. (Action modified to no-op when not a PR.) ~But this point is moot if we move to labeler YAML.~
- [x] Add new `skip-basebranch-check` label if we decide to proceed with this. ~But @bsipocz also suggested an alternative approach where the Action slaps a `non-default-basebranch` label instead of failing the check, which is kind of opposite way of using label as it currently is.~ (I added the label but we can remove it if this PR does not get into production.)
- [x] ~Change `pull_request:` to `pull_request_target:` according to best practices from https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#pull_request_target . But we can only do this after approval but before merge, because otherwise the CI won't run properly here.~ (Not needed anymore here because no longer uses token.)
- [x] Squash commits?
- [x] ~Rename actions to something @astrofrog likes. (Or we can defer?)~ Not applicable anymore.
- [x] ~Move actions to `astropy` org. 🐶 (Or we can defer?)~ Not applicable anymore.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->
