### PR TITLE
TST: Ignore exception in thread warning from pytest>=6.2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -53,6 +53,7 @@ asdf_extensions =
 
 [options.extras_require]
 test =
+    pytest<6.2
     pytest-astropy>=0.8
     pytest-xdist
     objgraph

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,7 +53,6 @@ asdf_extensions =
 
 [options.extras_require]
 test =
-    pytest<6.2
     pytest-astropy>=0.8
     pytest-xdist
     objgraph
@@ -139,6 +138,8 @@ filterwarnings =
     # Ignore a warning we emit about not supporting the parallel
     # reading option for now, can be removed once the issue is fixed
     ignore:parallel reading does not currently work, so falling back to serial
+    # Ignore thread warning from SAMP, pytest>=6.2
+    ignore:Exception in thread:pytest.PytestUnhandledThreadExceptionWarning
 doctest_norecursedirs =
     */setup_package.py
 doctest_subpackage_requires =

--- a/setup.cfg
+++ b/setup.cfg
@@ -138,8 +138,8 @@ filterwarnings =
     # Ignore a warning we emit about not supporting the parallel
     # reading option for now, can be removed once the issue is fixed
     ignore:parallel reading does not currently work, so falling back to serial
-    # Ignore thread warning from SAMP, pytest>=6.2
-    ignore:Exception in thread:pytest.PytestUnhandledThreadExceptionWarning
+    # Ignore pytest.PytestUnhandledThreadExceptionWarning from SAMP, pytest>=6.2
+    ignore:Exception in thread
 doctest_norecursedirs =
     */setup_package.py
 doctest_subpackage_requires =


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is a stop-gap fix for two SAMP test failures that started appearing around the time `pytest` 6.2.0 was released (about 2 days ago). We should not ~pin~ ignore this forever but I am not sure how to fix this error:

```
________________ ERROR at teardown of TestWebProfile.test_main _________________

cls = <class '_pytest.runner.CallInfo'>
func = <function call_runtest_hook.<locals>.<lambda> at 0x7fda56d37d30>
when = 'teardown'
reraise = (<class '_pytest.outcomes.Exit'>, <class 'KeyboardInterrupt'>)

>   ???

_pytest/runner.py:311: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
_pytest/runner.py:255: in <lambda>
    ???
pluggy/hooks.py:286: in __call__
    ???
pluggy/manager.py:93: in _hookexec
    ???
pluggy/manager.py:84: in <lambda>
    ???
_pytest/threadexception.py:90: in pytest_runtest_teardown
    ???
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

>   ???
E   pytest.PytestUnhandledThreadExceptionWarning: Exception in thread Thread-141
E   
E   Traceback (most recent call last):
E     File "astropy/samp/utils.py", line 62, in __call__
E     File "xmlrpc/client.py", line 1109, in __call__
E     File "xmlrpc/client.py", line 1450, in __request
E     File "xmlrpc/client.py", line 1153, in request
E     File "xmlrpc/client.py", line 1169, in single_request
E     File "xmlrpc/client.py", line 1341, in parse_response
E     File "xmlrpc/client.py", line 655, in close
E   xmlrpc.client.Fault: <Fault 1: '<class \'Exception\'>:method "server_close" is not supported'>
E   
E   During handling of the above exception, another exception occurred:
E   
E   Traceback (most recent call last):
E     File "threading.py", line 932, in _bootstrap_inner
E     File "threading.py", line 870, in run
E     File "/home/runner/work/astropy/astropy/.pyinstaller/astropy_tests/samp/tests/web_profile_test_helpers.py", line 175, in _serve_forever
E       self.hub.server_close()
E     File "astropy/samp/hub_proxy.py", line 96, in server_close
E     File "astropy/samp/utils.py", line 64, in __call__
E   astropy.samp.errors.SAMPProxyError: <SAMPProxyError 1: '<class \'Exception\'>:method "server_close" is not supported'>

_pytest/threadexception.py:75: PytestUnhandledThreadExceptionWarning
---------------------------- Captured stdout setup -----------------------------
INFO: Hub set to run with Web Profile support enabled. [astropy.samp.hub]
INFO: Hub started [astropy.samp.hub]
------------------------------ Captured log setup ------------------------------
INFO     astropy:hub.py:268 Hub set to run with Web Profile support enabled.
INFO     astropy:hub.py:402 Hub started
--------------------------- Captured stdout teardown ---------------------------
INFO: Hub is stopping... [astropy.samp.hub]
INFO: Hub stopped. [astropy.samp.hub]
---------------------------- Captured log teardown -----------------------------
INFO     astropy:hub.py:471 Hub is stopping...
INFO     astropy:hub.py:497 Hub stopped.
_____________ ERROR at teardown of TestWebProfile.test_web_profile _____________

cls = <class '_pytest.runner.CallInfo'>
func = <function call_runtest_hook.<locals>.<lambda> at 0x7fda75703040>
when = 'teardown'
reraise = (<class '_pytest.outcomes.Exit'>, <class 'KeyboardInterrupt'>)

>   ???

_pytest/runner.py:311: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
_pytest/runner.py:255: in <lambda>
    ???
pluggy/hooks.py:286: in __call__
    ???
pluggy/manager.py:93: in _hookexec
    ???
pluggy/manager.py:84: in <lambda>
    ???
_pytest/threadexception.py:90: in pytest_runtest_teardown
    ???
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

>   ???
E   pytest.PytestUnhandledThreadExceptionWarning: Exception in thread Thread-264
E   
E   Traceback (most recent call last):
E     File "astropy/samp/utils.py", line 62, in __call__
E     File "xmlrpc/client.py", line 1109, in __call__
E     File "xmlrpc/client.py", line 1450, in __request
E     File "xmlrpc/client.py", line 1153, in request
E     File "xmlrpc/client.py", line 1169, in single_request
E     File "xmlrpc/client.py", line 1341, in parse_response
E     File "xmlrpc/client.py", line 655, in close
E   xmlrpc.client.Fault: <Fault 1: '<class \'Exception\'>:method "server_close" is not supported'>
E   
E   During handling of the above exception, another exception occurred:
E   
E   Traceback (most recent call last):
E     File "threading.py", line 932, in _bootstrap_inner
E     File "threading.py", line 870, in run
E     File "/home/runner/work/astropy/astropy/.pyinstaller/astropy_tests/samp/tests/web_profile_test_helpers.py", line 175, in _serve_forever
E       self.hub.server_close()
E     File "astropy/samp/hub_proxy.py", line 96, in server_close
E     File "astropy/samp/utils.py", line 64, in __call__
E   astropy.samp.errors.SAMPProxyError: <SAMPProxyError 1: '<class \'Exception\'>:method "server_close" is not supported'>

_pytest/threadexception.py:75: PytestUnhandledThreadExceptionWarning
---------------------------- Captured stdout setup -----------------------------
INFO: Hub set to run with Web Profile support enabled. [astropy.samp.hub]
INFO: Hub started [astropy.samp.hub]
------------------------------ Captured log setup ------------------------------
INFO     astropy:hub.py:268 Hub set to run with Web Profile support enabled.
INFO     astropy:hub.py:402 Hub started
--------------------------- Captured stdout teardown ---------------------------
INFO: Hub is stopping... [astropy.samp.hub]
INFO: Hub stopped. [astropy.samp.hub]
---------------------------- Captured log teardown -----------------------------
INFO     astropy:hub.py:471 Hub is stopping...
INFO     astropy:hub.py:497 Hub stopped.
=========================== short test summary info ============================
ERROR astropy_tests/samp/tests/test_web_profile.py::TestWebProfile::test_main
ERROR astropy_tests/samp/tests/test_web_profile.py::TestWebProfile::test_web_profile
= 13777 passed, 1000 skipped, 234 deselected, 104 xfailed, 2 errors in 343.12s (0:05:43) =
```

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

This failure is currently blocking unrelated PRs from running CI to completion.