### PR TITLE
TST: Skip CI in Action

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -14,23 +14,31 @@ env:
 
 jobs:
   initial_checks:
-    name: Failure means CI is skipped on purpose
+    name: Mandatory checks before CI
     runs-on: ubuntu-latest
+    outputs:
+      run_next: ${{ steps.skip_ci_step.outputs.run_next }}
     steps:
     - name: Check skip CI
       uses: pllim/action-skip-ci@main
+      id: skip_ci_step
       with:
+        NO_FAIL: true
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     # This should only run if we did not skip CI
     - name: Cancel previous runs
       uses: styfle/cancel-workflow-action@ce17749
+      if: steps.skip_ci_step.outputs.run_next == 'true'
       with:
         access_token: ${{ secrets.GITHUB_TOKEN }}
+
+  # The rest only run if above are done
 
   tests:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     needs: initial_checks
+    if: needs.initial_checks.outputs.run_next == 'true'
     strategy:
       fail-fast: true
       matrix:
@@ -106,6 +114,7 @@ jobs:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     needs: initial_checks
+    if: needs.initial_checks.outputs.run_next == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -137,6 +146,7 @@ jobs:
     name: 32-bit and parallel
     runs-on: ubuntu-latest
     needs: initial_checks
+    if: needs.initial_checks.outputs.run_next == 'true'
     container:
       image: quay.io/pypa/manylinux1_i686
     steps:

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -13,9 +13,24 @@ env:
   IS_CRON: "false"
 
 jobs:
+  initial_checks:
+    name: Failure means CI is skipped on purpose
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check skip CI
+      uses: pllim/action-skip-ci@main
+      with:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    # This should only run if we did not skip CI
+    - name: Cancel previous runs
+      uses: styfle/cancel-workflow-action@ce17749
+      with:
+        access_token: ${{ secrets.GITHUB_TOKEN }}
+
   tests:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
+    needs: initial_checks
     strategy:
       fail-fast: true
       matrix:
@@ -90,6 +105,7 @@ jobs:
   allowed_failures:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
+    needs: initial_checks
     strategy:
       fail-fast: false
       matrix:
@@ -120,6 +136,7 @@ jobs:
   parallel_and_32bit:
     name: 32-bit and parallel
     runs-on: ubuntu-latest
+    needs: initial_checks
     container:
       image: quay.io/pypa/manylinux1_i686
     steps:


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to implement a workaround to enable skipping CI in Actions portion of #11038 .

This uses custom Action at [action-skip-ci](https://github.com/pllim/action-skip-ci) and [styfle/cancel-workflow-action](https://github.com/styfle/cancel-workflow-action).

If this works correctly, only one Action job would run and it will ~fail~ set output value, preventing other jobs from running. What is not showcased here is that duplicate runs would also be cancelled if the CI is not skipped (I tested this on my own repo).

![Screenshot 2021-01-07 183342](https://user-images.githubusercontent.com/2090236/103956651-febf1c80-5116-11eb-9305-18b60551ce61.jpg)

If this needs backporting, please re-milestone.