### PR TITLE
Expose Header.strip as a public method

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -41,6 +41,9 @@ astropy.io.fits
 
 - Added ``append`` keyword to append table objects to an existing FITS file [#2632, #11149]
 
+- Expose ``Header.strip`` as a public method, to remove the most common
+  structural keywords. [#11174]
+
 astropy.io.misc
 ^^^^^^^^^^^^^^^
 
@@ -70,7 +73,7 @@ astropy.tests
 astropy.time
 ^^^^^^^^^^^^
 
-- Add new time format ``unix_ptp`` (Precision Time Protocol) which provides 
+- Add new time format ``unix_ptp`` (Precision Time Protocol) which provides
   the number of SI seconds since ``1970-01-01T00:00:00 TAI``. [#11143]
 
 astropy.timeseries

--- a/astropy/io/fits/header.py
+++ b/astropy/io/fits/header.py
@@ -830,7 +830,7 @@ class Header:
 
         tmp = self.__class__((copy.copy(card) for card in self._cards))
         if strip:
-            tmp._strip()
+            tmp.strip()
         return tmp
 
     def __copy__(self):
@@ -1299,7 +1299,7 @@ class Header:
 
         temp = self.__class__(cards)
         if strip:
-            temp._strip()
+            temp.strip()
 
         if len(self):
             first = self._cards[0].keyword
@@ -1624,6 +1624,38 @@ class Header:
 
         self._add_commentary('', value, before=before, after=after)
 
+    def strip(self):
+        """
+        Strip cards specific to a certain kind of header.
+
+        Strip cards like ``SIMPLE``, ``BITPIX``, etc. so the rest of
+        the header can be used to reconstruct another kind of header.
+        """
+
+        # TODO: Previously this only deleted some cards specific to an HDU if
+        # _hdutype matched that type.  But it seemed simple enough to just
+        # delete all desired cards anyways, and just ignore the KeyErrors if
+        # they don't exist.
+        # However, it might be desirable to make this extendable somehow--have
+        # a way for HDU classes to specify some headers that are specific only
+        # to that type, and should be removed otherwise.
+
+        naxis = self.get('NAXIS', 0)
+        tfields = self.get('TFIELDS', 0)
+
+        for idx in range(naxis):
+            self.remove('NAXIS' + str(idx + 1), ignore_missing=True)
+
+        for name in ('TFORM', 'TSCAL', 'TZERO', 'TNULL', 'TTYPE',
+                     'TUNIT', 'TDISP', 'TDIM', 'THEAP', 'TBCOL'):
+            for idx in range(tfields):
+                self.remove(name + str(idx + 1), ignore_missing=True)
+
+        for name in ('SIMPLE', 'XTENSION', 'BITPIX', 'NAXIS', 'EXTEND',
+                     'PCOUNT', 'GCOUNT', 'GROUPS', 'BSCALE', 'BZERO',
+                     'TFIELDS'):
+            self.remove(name, ignore_missing=True)
+
     def _update(self, card):
         """
         The real update code.  If keyword already exists, its value and/or
@@ -1898,38 +1930,6 @@ class Header:
                 cards.append(Card(keyword, valuestr[idx:idx + maxlen]))
                 idx += maxlen
         return cards
-
-    def _strip(self):
-        """
-        Strip cards specific to a certain kind of header.
-
-        Strip cards like ``SIMPLE``, ``BITPIX``, etc. so the rest of
-        the header can be used to reconstruct another kind of header.
-        """
-
-        # TODO: Previously this only deleted some cards specific to an HDU if
-        # _hdutype matched that type.  But it seemed simple enough to just
-        # delete all desired cards anyways, and just ignore the KeyErrors if
-        # they don't exist.
-        # However, it might be desirable to make this extendable somehow--have
-        # a way for HDU classes to specify some headers that are specific only
-        # to that type, and should be removed otherwise.
-
-        naxis = self.get('NAXIS', 0)
-        tfields = self.get('TFIELDS', 0)
-
-        for idx in range(naxis):
-            self.remove('NAXIS' + str(idx + 1), ignore_missing=True)
-
-        for name in ('TFORM', 'TSCAL', 'TZERO', 'TNULL', 'TTYPE',
-                     'TUNIT', 'TDISP', 'TDIM', 'THEAP', 'TBCOL'):
-            for idx in range(tfields):
-                self.remove(name + str(idx + 1), ignore_missing=True)
-
-        for name in ('SIMPLE', 'XTENSION', 'BITPIX', 'NAXIS', 'EXTEND',
-                     'PCOUNT', 'GCOUNT', 'GROUPS', 'BSCALE', 'BZERO',
-                     'TFIELDS'):
-            self.remove(name, ignore_missing=True)
 
     def _add_commentary(self, key, value, before=None, after=None):
         """

--- a/astropy/io/fits/header.py
+++ b/astropy/io/fits/header.py
@@ -1915,37 +1915,21 @@ class Header:
         # a way for HDU classes to specify some headers that are specific only
         # to that type, and should be removed otherwise.
 
-        if 'NAXIS' in self:
-            naxis = self['NAXIS']
-        else:
-            naxis = 0
-
-        if 'TFIELDS' in self:
-            tfields = self['TFIELDS']
-        else:
-            tfields = 0
+        naxis = self.get('NAXIS', 0)
+        tfields = self.get('TFIELDS', 0)
 
         for idx in range(naxis):
-            try:
-                del self['NAXIS' + str(idx + 1)]
-            except KeyError:
-                pass
+            self.remove('NAXIS' + str(idx + 1), ignore_missing=True)
 
         for name in ('TFORM', 'TSCAL', 'TZERO', 'TNULL', 'TTYPE',
                      'TUNIT', 'TDISP', 'TDIM', 'THEAP', 'TBCOL'):
             for idx in range(tfields):
-                try:
-                    del self[name + str(idx + 1)]
-                except KeyError:
-                    pass
+                self.remove(name + str(idx + 1), ignore_missing=True)
 
         for name in ('SIMPLE', 'XTENSION', 'BITPIX', 'NAXIS', 'EXTEND',
                      'PCOUNT', 'GCOUNT', 'GROUPS', 'BSCALE', 'BZERO',
                      'TFIELDS'):
-            try:
-                del self[name]
-            except KeyError:
-                pass
+            self.remove(name, ignore_missing=True)
 
     def _add_commentary(self, key, value, before=None, after=None):
         """

--- a/astropy/io/fits/tests/test_header.py
+++ b/astropy/io/fits/tests/test_header.py
@@ -2387,6 +2387,17 @@ class TestHeaderFunctions(FitsTestCase):
         assert hdr['KEY2'] == 4
         assert hdr['KEY2 '] == 4
 
+    def test_strip(self):
+        hdr = fits.getheader(self.data('tb.fits'), ext=1)
+        hdr['FOO'] = 'bar'
+        hdr.strip()
+        assert set(hdr) == {'HISTORY', 'FOO'}
+
+        hdr = fits.getheader(self.data('tb.fits'), ext=1)
+        hdr['FOO'] = 'bar'
+        hdr = hdr.copy(strip=True)
+        assert set(hdr) == {'HISTORY', 'FOO'}
+
 
 class TestRecordValuedKeywordCards(FitsTestCase):
     """


### PR DESCRIPTION
This method is currently private though it can be useful to remove the most common structural keywords.