### PR TITLE
DOC: Changed one line in reprasentation.py file.

### DIFF
--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -836,7 +836,7 @@ class BaseRepresentation(BaseRepresentationOrDifferential):
         By default, conversion is done via Cartesian coordinates.
         Also note that orientation information at the origin is *not* preserved by
         conversions through Cartesian coordinates. See the docstring for
-        `~astropy.coordinates.BaseRepresentation.represent_as()` for an example.
+        `astropy.coordinates.BaseRepresentationOrDifferential.to_cartesian()` for an example.
 
         Parameters
         ----------

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -836,7 +836,8 @@ class BaseRepresentation(BaseRepresentationOrDifferential):
         By default, conversion is done via Cartesian coordinates.
         Also note that orientation information at the origin is *not* preserved by
         conversions through Cartesian coordinates. See the docstring for
-        `astropy.coordinates.BaseRepresentationOrDifferential.to_cartesian()` for an example.
+        :meth:`~astropy.coordinates.BaseRepresentationOrDifferential.to_cartesian`
+        for an example.
 
         Parameters
         ----------

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -1796,10 +1796,11 @@ class TimeSys(SimpleElement):
         The timeorigin attribute MUST be given unless the
         time’s representation contains a year of a calendar
         era, in which case it MUST NOT be present. In VOTables,
-        these representations currently are Gregorian calendar
-        years with xtype="timestamp", or years in the Julian
-        or Besselian calendar when a column has yr, a, or Ba as
-        its unit and no time origin is given.
+        these representations are currently Gregorian calendar
+        years with xtype="timestamp", but when a column has
+        yr, a, or Ba as its unit and no time origin is given,
+        years in the Julian or Besselian calendar are
+        represented.
         """
         return self._timeorigin
 

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -1796,11 +1796,10 @@ class TimeSys(SimpleElement):
         The timeorigin attribute MUST be given unless the
         time’s representation contains a year of a calendar
         era, in which case it MUST NOT be present. In VOTables,
-        these representations are currently Gregorian calendar
-        years with xtype="timestamp", but when a column has
-        yr, a, or Ba as its unit and no time origin is given,
-        years in the Julian or Besselian calendar are
-        represented.
+        these representations currently are Gregorian calendar
+        years with xtype="timestamp", or years in the Julian
+        or Besselian calendar when a column has yr, a, or Ba as
+        its unit and no time origin is given.
         """
         return self._timeorigin
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
Former line was recursive, which arose confusion since the docstring belonged exclusively to "astropy.coordinates.BaseRepresentation.represent_as " adding to_cartesian makes it clearer.
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to address ...
"BaseRepresentation.represent_as mentions example that is not there" issue
<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #11106

<Issue Number>
