### PR TITLE
Add link to testing dependencies [ci skip]

### DIFF
--- a/docs/development/workflow/get_devel_version.rst
+++ b/docs/development/workflow/get_devel_version.rst
@@ -274,6 +274,9 @@ Testing is an important part of making sure astropy produces reliable,
 reproducible results. Before you try out a new feature or think you have found
 a bug make sure the tests run properly on your system.
 
+before runnig tests, see
+:ref:`testing-dependencies`.
+
 If the test *don't* complete successfully, that is itself a bug--please
 `report it <https://github.com/astropy/astropy/issues>`_.
 

--- a/docs/development/workflow/get_devel_version.rst
+++ b/docs/development/workflow/get_devel_version.rst
@@ -274,8 +274,7 @@ Testing is an important part of making sure astropy produces reliable,
 reproducible results. Before you try out a new feature or think you have found
 a bug make sure the tests run properly on your system.
 
-before runnig tests, see
-:ref:`testing-dependencies`.
+Before running your tests, please see :ref:`testing-dependencies`.
 
 If the test *don't* complete successfully, that is itself a bug--please
 `report it <https://github.com/astropy/astropy/issues>`_.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->


<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #11172

