### PR TITLE
Allow table columns to be hidden from print output

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -64,6 +64,10 @@ astropy.stats
 astropy.table
 ^^^^^^^^^^^^^
 
+- Add table attributes to include or exclude columns from the output when
+  printing a table. This functionality includes a context manager to
+  include/exclude columns temporarily. [#11190]
+
 astropy.tests
 ^^^^^^^^^^^^^
 

--- a/astropy/table/__init__.py
+++ b/astropy/table/__init__.py
@@ -10,7 +10,7 @@ __all__ = ['BST', 'Column', 'ColumnGroups', 'ColumnInfo', 'Conf',
            'TableGroups', 'TableMergeError', 'TableReplaceWarning', 'conf',
            'connect', 'hstack', 'join', 'registry', 'represent_mixins_as_columns',
            'setdiff', 'unique', 'vstack', 'dstack', 'conf', 'join_skycoord',
-           'join_distance']
+           'join_distance', 'PprintIncludeExclude']
 
 
 class Conf(_config.ConfigNamespace):  # noqa
@@ -47,8 +47,9 @@ conf = Conf()  # noqa
 
 from . import connect  # noqa: E402
 from .groups import TableGroups, ColumnGroups  # noqa: E402
-from .table import (Table, QTable, TableColumns, Row, TableFormatter,  # noqa: E402
-                    NdarrayMixin, TableReplaceWarning, TableAttribute)  # noqa: E402
+from .table import (Table, QTable, TableColumns, Row, TableFormatter,
+                    NdarrayMixin, TableReplaceWarning, TableAttribute,
+                    PprintIncludeExclude)  # noqa: E402
 from .operations import (join, setdiff, hstack, dstack, vstack, unique,  # noqa: E402
                          TableMergeError, join_skycoord, join_distance)  # noqa: E402
 from .bst import BST  # noqa: E402

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -2504,8 +2504,11 @@ def test_table_attribute():
 
     t = MyTable([[1, 2]])
     # __attributes__ created on the fly on the first access of an attribute
+    # that has a non-None default.
     assert '__attributes__' not in t.meta
     assert t.foo is None
+    assert '__attributes__' not in t.meta
+    assert t.baz == 1
     assert '__attributes__' in t.meta
     t.bar.append(2.0)
     assert t.bar == [2.0]
@@ -2525,6 +2528,12 @@ def test_table_attribute():
     assert t2.foo == 3
     assert t2.bar == 'bar'
     assert t2.baz == 'baz'
+
+    # Deleting attributes removes it from attributes
+    del t.baz
+    assert 'baz' not in t.meta['__attributes__']
+    del t.bar
+    assert '__attributes__' not in t.meta
 
 
 @pytest.mark.skipif('not HAS_YAML')


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is another try at #2466 to allow table columns to be hidden during normal print functions.

This now stores the hidden column information on the table, not on columns, thus addressing one original concern from @mhvk in #2466.

It adds a handy context manager to allow unhiding all columns in the context block.

This implementation stores  the hidden column set as a Table MetaAttribute, i.e. in `t.meta['__attributes__']`. This allows all the usual machinery like slicing and serialization to work since `meta` is guaranteed to propagate.

The API is intentionally similar to `ConfigItem`, with methods `__call__` (to get the value), and `set` for setting, `set_temp` (context manager).

## Demonstration code
```
import astropy
from astropy.table.table_helpers import simple_table
from io import StringIO
from astropy.io import ascii
print(astropy.__version__)

t = simple_table(cols=6)
print(t.hidden_columns)
# <HiddenColumns name=hidden_columns value=None>

print(t)

t.hidden_columns = ('c', 'd', 'f')

# Same thing with the `set` method ala ConfigItem
t.hidden_columns.set(('c', 'd', 'f', 'does-not-exist'))  # Can set non-existent col

# __call__ provides the actual value as a tuple (ala ConfigItem)
cols = t.hidden_columns()

print(t.hidden_columns)
# <HiddenColumns name=hidden_columns value=('c', 'd', 'f', 'does-not-exist')>

print(t)

# Serialization works
out = StringIO()
ascii.write(t, out, format='ecsv')
print(out.getvalue())
t2 = ascii.read(out.getvalue(), format='ecsv')
print(t2)

# Context manager ala ConfigItem
with t2.hidden_columns.set_temp(None):
    print(t2)

with t2.hidden_columns.set_temp('b'):
    print(t2)

t2.hidden_columns.remove('c')
```
