### PR TITLE
docs: fix simple typo, explcitly -> explicitly

### DIFF
--- a/astropy/io/fits/hdu/compressed.py
+++ b/astropy/io/fits/hdu/compressed.py
@@ -1386,7 +1386,7 @@ class CompImageHDU(BinTableHDU):
             if self._bscale != 1:
                 np.multiply(data, self._bscale, data)
             if self._bzero != 0:
-                # We have to explcitly cast self._bzero to prevent numpy from
+                # We have to explicitly cast self._bzero to prevent numpy from
                 # raising an error when doing self.data += self._bzero, and we
                 # do this instead of self.data = self.data + self._bzero to
                 # avoid doubling memory usage.

--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -522,7 +522,7 @@ class _ImageBaseHDU(_ValidHDU):
                 self.data = self.data - _zero
             else:
                 # 0.9.6.3 to avoid out of range error for BZERO = +32768
-                # We have to explcitly cast _zero to prevent numpy from raising an
+                # We have to explicitly cast _zero to prevent numpy from raising an
                 # error when doing self.data -= zero, and we do this instead of
                 # self.data = self.data - zero to avoid doubling memory usage.
                 np.add(self.data, -_zero, out=self.data, casting='unsafe')


### PR DESCRIPTION
There is a small typo in astropy/io/fits/hdu/compressed.py, astropy/io/fits/hdu/image.py.

Should read `explicitly` rather than `explcitly`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md