### PR TITLE
Fix inability to write masked times with ``formatted_value``.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1140,6 +1140,8 @@ astropy.time
 - Fix default assumed location to be the geocenter when transforming times
   to and from solar-system barycenter scales. [#11134]
 
+- Fix inability to write masked times with ``formatted_value``. [#11195]
+
 astropy.timeseries
 ^^^^^^^^^^^^^^^^^^
 

--- a/astropy/table/serialize.py
+++ b/astropy/table/serialize.py
@@ -1,10 +1,13 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 from importlib import import_module
 import re
 from copy import deepcopy
 from collections import OrderedDict
 
+import numpy as np
+
 from astropy.utils.data_info import MixinInfo
-from .column import Column
+from .column import Column, MaskedColumn
 from .table import Table, QTable, has_info_class
 from astropy.units.quantity import QuantityInfo
 
@@ -128,7 +131,9 @@ def _represent_mixin_as_column(col, name, new_cols, mixin_cols,
             new_name = name + '.' + data_attr
 
         if not has_info_class(data, MixinInfo):
-            new_cols.append(Column(data, name=new_name, **info))
+            col_cls = MaskedColumn if (hasattr(data, 'mask')
+                                       and np.any(data.mask)) else Column
+            new_cols.append(col_cls(data, name=new_name, **info))
             obj_attrs[data_attr] = SerializedColumn({'name': new_name})
         else:
             # recurse. This will define obj_attrs[new_name].

--- a/astropy/time/tests/test_mask.py
+++ b/astropy/time/tests/test_mask.py
@@ -5,6 +5,7 @@ import functools
 import numpy as np
 import pytest
 
+from astropy import units as u
 from astropy.utils import iers
 from astropy.time import Time
 from astropy.table import Table
@@ -196,14 +197,12 @@ def test_serialize_hdf5_masked(tmpdir):
 # Ignore warning in MIPS https://github.com/astropy/astropy/issues/9750
 @pytest.mark.skipif('not HAS_YAML')
 @pytest.mark.filterwarnings('ignore:invalid value encountered')
-def test_serialize_ecsv_masked(tmpdir):
+@pytest.mark.parametrize('serialize_method', ['jd1_jd2', 'formatted_value'])
+def test_serialize_ecsv_masked(serialize_method, tmpdir):
     tm = Time([1, 2, 3], format='cxcsec')
     tm[1] = np.ma.masked
 
-    # Serializing in the default way for ECSV fails to round-trip
-    # because it writes out a "nan" instead of "".  But for jd1/jd2
-    # this works OK.
-    tm.info.serialize_method['ecsv'] = 'jd1_jd2'
+    tm.info.serialize_method['ecsv'] = serialize_method
 
     fn = str(tmpdir.join('tempfile.ecsv'))
     t = Table([tm])
@@ -212,6 +211,6 @@ def test_serialize_ecsv_masked(tmpdir):
 
     assert t2['col0'].masked
     assert np.all(t2['col0'].mask == [False, True, False])
-    # Serializing floats to ASCII loses some precision so use allclose
-    # and 1e-7 seconds tolerance.
-    assert np.allclose(t2['col0'].value, t['col0'].value, rtol=0, atol=1e-7)
+    # Serializing formatted_value loses some precision.
+    atol = 0.1*u.us if serialize_method == 'formatted_value' else 1*u.ps
+    assert np.all(abs(t2['col0'] - t['col0']) <= atol)


### PR DESCRIPTION
The very simple solution is to use `MaskedColumn` for serialization rather than `Column` - this propagates any mask wherever `MaskedColumn` knows how to do it.

fixes #11193