### PR TITLE
Check input to cosmo.angular_diameter_distance_z1z2, that z2>z1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -131,6 +131,10 @@ astropy.coordinates
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 
+- Clarified definition of inputs to ``angular_diameter_distance_z1z2``.
+  The function now emits ``AstropyUserWarning`` when ``z2`` is less than ``z1``.
+  [#11197]
+
 astropy.extern
 ^^^^^^^^^^^^^^
 
@@ -221,7 +225,6 @@ astropy.coordinates
 
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
-- Clarified definition of inputs to `angular_diameter_distance_z1z2` Added warning if z2<z1. [#11197]
 
 astropy.extern
 ^^^^^^^^^^^^^^
@@ -337,7 +340,6 @@ astropy.cosmology
 
 - Fixed an issue where specializations of the comoving distance calculation
   for certain cosmologies could not handle redshift arrays. [#10980]
-
 
 astropy.extern
 ^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -221,6 +221,7 @@ astropy.coordinates
 
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
+- Clarified definition of inputs to `angular_diameter_distance_z1z2` Added warning if z2<z1. [#11197]
 
 astropy.extern
 ^^^^^^^^^^^^^^
@@ -336,6 +337,7 @@ astropy.cosmology
 
 - Fixed an issue where specializations of the comoving distance calculation
   for certain cosmologies could not handle redshift arrays. [#10980]
+
 
 astropy.extern
 ^^^^^^^^^^^^^^

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -1382,7 +1382,7 @@ class FLRW(Cosmology, metaclass=ABCMeta):
         ----------
         z1, z2 : array_like, shape (N,)
           Input redshifts. For most practical applications such as gravitational lensing,
-          z2 should be larger than z1.  The method will work for z2<z1; however, it may
+          z2 should be larger than z1.  The method will work for z2<z1; however, this will
           return negative distances.
 
         Returns

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -14,7 +14,8 @@ from astropy import constants as const
 from astropy import units as u
 from astropy.utils import isiterable
 from astropy.utils.state import ScienceState
-from astropy.utils.exceptions import AstropyDeprecationWarning
+from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyUserWarning
+
 
 from . import parameters
 
@@ -1374,23 +1375,26 @@ class FLRW(Cosmology, metaclass=ABCMeta):
 
     def angular_diameter_distance_z1z2(self, z1, z2):
         """ Angular diameter distance between objects at 2 redshifts.
-        Useful for gravitational lensing.
+        Useful for gravitational lensing, for example computing the angular diameter
+        distance between a lensed galaxy and the foreground lens.
 
         Parameters
         ----------
         z1, z2 : array_like, shape (N,)
-          Input redshifts. z2 must be large than z1.
+          Input redshifts. For most practical applications such as gravitational lensing,
+          z2 should be larger than z1.  The method will work for z2<z1; however, it may
+          return negative distances.
 
         Returns
         -------
         d : `~astropy.units.Quantity`, shape (N,) or single if input scalar
-          The angular diameter distance between each input redshift
-          pair.
+          The angular diameter distance between each input redshift pair.
 
         """
-
         z1 = np.asanyarray(z1)
         z2 = np.asanyarray(z2)
+        if np.any(np.less(z2, z1)) :
+            warnings.warn(f"Second redshift(s) z2 ({z2}) is less than first redshift(s) z1 ({z1}).", AstropyUserWarning)
         return self._comoving_transverse_distance_z1z2(z1, z2) / (1. + z2)
 
     def absorption_distance(self, z):

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -1393,8 +1393,9 @@ class FLRW(Cosmology, metaclass=ABCMeta):
         """
         z1 = np.asanyarray(z1)
         z2 = np.asanyarray(z2)
-        if np.any(np.less(z2, z1)) :
-            warnings.warn(f"Second redshift(s) z2 ({z2}) is less than first redshift(s) z1 ({z1}).", AstropyUserWarning)
+        if np.any(np.less(z2, z1)):
+            warnings.warn(f"Second redshift(s) z2 ({z2}) is less than first "
+                          f"redshift(s) z1 ({z1}).", AstropyUserWarning)
         return self._comoving_transverse_distance_z1z2(z1, z2) / (1. + z2)
 
     def absorption_distance(self, z):

--- a/astropy/cosmology/tests/test_cosmology.py
+++ b/astropy/cosmology/tests/test_cosmology.py
@@ -9,6 +9,7 @@ from astropy.cosmology import core, funcs
 from astropy.units import allclose
 from astropy import constants as const
 from astropy import units as u
+from astropy.utils.exceptions import AstropyUserWarning
 
 try:
     import scipy  # pylint: disable=W0611  # noqa
@@ -1233,11 +1234,16 @@ def test_angular_diameter_distance_z1z2():
     assert allclose(tcos.angular_diameter_distance_z1z2(1, 2),
                     646.22968662822018 * u.Mpc)
 
-    z1 = 0, 0, 2, 0.5, 1
-    z2 = 2, 1, 1, 2.5, 1.1
+    z1 = 2  # Separate test for z2<z1, returns negative value with warning
+    z2 = 1
+    results = -969.34452994 * u.Mpc
+    with pytest.warns(AstropyUserWarning, match='less than first redshift'):
+        assert allclose(tcos.angular_diameter_distance_z1z2(z1, z2), results)
+
+    z1 = 0, 0, 0.5, 1
+    z2 = 2, 1, 2.5, 1.1
     results = (1760.0628637762106,
                1670.7497657219858,
-               -969.34452994,
                1159.0970895962193,
                115.72768186186921) * u.Mpc
 


### PR DESCRIPTION

<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to address a problem in cosmo.angular_diameter_distance_z1z2().  A comment in the function states that of the input redshifts z1, z2, "z2 must be larger than z1".  However, the code itself does not check the input for this.  As such, the code will return a nonsensical negative distance if z2<z1.  I have added one line of error checking of the input values.  I also fixed the typo in "larger" in the comment.   This is only my second contribution to astropy, so I would appreciate polite, constructive feedback on whether I did it right.  I followed the tutorial in https://docs.astropy.org/en/stable/development/workflow/git_edit_workflow_examples.html

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

