### PR TITLE
Add keepdims argument to mean, std, var methods.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1158,6 +1158,9 @@ astropy.uncertainty
 astropy.units
 ^^^^^^^^^^^^^
 
+- Ensure ``keepdims`` works for taking ``mean``, ``std``, and ``var`` of
+  ``Quantity``. [#11198]
+
 astropy.utils
 ^^^^^^^^^^^^^
 

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -1607,15 +1607,18 @@ class Quantity(np.ndarray):
         return self._wrap_function(np.trace, offset, axis1, axis2, dtype,
                                    out=out)
 
-    def var(self, axis=None, dtype=None, out=None, ddof=0):
+    def var(self, axis=None, dtype=None, out=None, ddof=0, keepdims=False):
         return self._wrap_function(np.var, axis, dtype,
-                                   out=out, ddof=ddof, unit=self.unit**2)
+                                   out=out, ddof=ddof, keepdims=keepdims,
+                                   unit=self.unit**2)
 
-    def std(self, axis=None, dtype=None, out=None, ddof=0):
-        return self._wrap_function(np.std, axis, dtype, out=out, ddof=ddof)
+    def std(self, axis=None, dtype=None, out=None, ddof=0, keepdims=False):
+        return self._wrap_function(np.std, axis, dtype, out=out, ddof=ddof,
+                                   keepdims=keepdims)
 
-    def mean(self, axis=None, dtype=None, out=None):
-        return self._wrap_function(np.mean, axis, dtype, out=out)
+    def mean(self, axis=None, dtype=None, out=None, keepdims=False):
+        return self._wrap_function(np.mean, axis, dtype, out=out,
+                                   keepdims=keepdims)
 
     def round(self, decimals=0, out=None):
         return self._wrap_function(np.round, decimals, out=out)

--- a/astropy/units/tests/test_quantity_array_methods.py
+++ b/astropy/units/tests/test_quantity_array_methods.py
@@ -3,6 +3,7 @@
 
 import pytest
 import numpy as np
+from numpy.testing import assert_array_equal
 
 from astropy import units as u
 
@@ -129,7 +130,8 @@ class TestQuantityStatsFuncs:
 
     def test_mean(self):
         q1 = np.array([1., 2., 4., 5., 6.]) * u.m
-        assert np.mean(q1) == 3.6 * u.m
+        assert_array_equal(np.mean(q1), 3.6 * u.m)
+        assert_array_equal(np.mean(q1, keepdims=True), [3.6] * u.m)
 
     def test_mean_inplace(self):
         q1 = np.array([1., 2., 4., 5., 6.]) * u.m
@@ -140,7 +142,8 @@ class TestQuantityStatsFuncs:
 
     def test_std(self):
         q1 = np.array([1., 2.]) * u.m
-        assert np.std(q1) == 0.5 * u.m
+        assert_array_equal(np.std(q1), 0.5 * u.m)
+        assert_array_equal(q1.std(axis=-1, keepdims=True), [0.5] * u.m)
 
     def test_std_inplace(self):
         q1 = np.array([1., 2.]) * u.m
@@ -150,7 +153,8 @@ class TestQuantityStatsFuncs:
 
     def test_var(self):
         q1 = np.array([1., 2.]) * u.m
-        assert np.var(q1) == 0.25 * u.m ** 2
+        assert_array_equal(np.var(q1), 0.25 * u.m ** 2)
+        assert_array_equal(q1.var(axis=0, keepdims=True), [0.25] * u.m ** 2)
 
     def test_var_inplace(self):
         q1 = np.array([1., 2.]) * u.m


### PR DESCRIPTION
Somehow these had been missing.

Separated out from the `MaskedQuantity` work at #11127 (f3f82f4b9e46ed227286cf73c102080ac71d45b5)

cc @astrojuanlu, @adrn - should be very simple review.