### PR TITLE
Expand and modify physical types

### DIFF
--- a/astropy/units/physical.py
+++ b/astropy/units/physical.py
@@ -84,7 +84,7 @@ for unit, name in [
     (si.N, 'force'),
     (si.J, 'energy'),
     (si.J * si.m ** -2 * si.s ** -1, 'energy flux'),
-    (si.Pa, 'pressure'),
+    (si.Pa, 'pressure or energy density'),
     (si.W, 'power'),
     (si.W / si.m ** 3, 'power density'),
     (si.kg / si.m ** 3, 'mass density'),

--- a/astropy/units/physical.py
+++ b/astropy/units/physical.py
@@ -86,6 +86,7 @@ for unit, name in [
     (si.J * si.m ** -2 * si.s ** -1, 'energy flux'),
     (si.Pa, 'pressure'),
     (si.W, 'power'),
+    (si.W / si.m ** 3, 'power density'),
     (si.kg / si.m ** 3, 'mass density'),
     (si.m ** 3 / si.kg, 'specific volume'),
     (si.m ** -3 * si.s ** -1, 'volumetric rate'),

--- a/astropy/units/physical.py
+++ b/astropy/units/physical.py
@@ -83,6 +83,7 @@ for unit, name in [
     (imperial.deg_F, 'temperature'),
     (si.N, 'force'),
     (si.J, 'energy'),
+    (si.J * si.m ** -2 * si.s ** -1, 'energy flux'),
     (si.Pa, 'pressure'),
     (si.W, 'power'),
     (si.kg / si.m ** 3, 'mass density'),

--- a/astropy/units/physical.py
+++ b/astropy/units/physical.py
@@ -93,7 +93,7 @@ for unit, name in [
     (si.rad / si.s, 'angular speed'),
     (si.rad / si.s ** 2, 'angular acceleration'),
     (si.g / (si.m * si.s), 'dynamic viscosity'),
-    (si.m ** 2 / si.s, 'kinematic viscosity'),
+    (si.m ** 2 / si.s, 'diffusivity'),
     (si.m ** -1, 'wavenumber'),
     (si.A, 'electrical current'),
     (si.C, 'electrical charge'),

--- a/astropy/units/physical.py
+++ b/astropy/units/physical.py
@@ -88,6 +88,7 @@ for unit, name in [
     (si.W, 'power'),
     (si.kg / si.m ** 3, 'mass density'),
     (si.m ** 3 / si.kg, 'specific volume'),
+    (si.m ** -3 * si.s ** -1, 'volumetric rate'),
     (si.mol / si.m ** 3, 'molar volume'),
     (si.kg * si.m / si.s, 'momentum/impulse'),
     (si.kg * si.m ** 2 / si.s, 'angular momentum'),


### PR DESCRIPTION
### Description

This pull request adds new physical types and generalizes two existing physical types.

The physical types I added are:
 - Power density (W m⁻³; e.g., something like a heating or cooling power per volume)
 - Volumetric rate (m⁻³ s⁻¹; e.g., collisions per cubic meter per second)
 - Energy flux (J m⁻² s⁻¹; e.g., a heat flux)

The physical types changes are:
 - Pascals are described as units of `"pressure and energy density"` instead of just `"pressure"`, since pressure has units of energy per unit volume
 - The physical type of m⁻² s⁻¹ is broadened from `"kinematic viscosity"` to `"diffusivity"`, since those units are used for multiple reasons in addition to kinematic viscosity.
 
I put more detail about these in each commit message, occasionally with analogies involving wombats.  I still need to add some tests and presumably a change log entry.