### PR TITLE
TST: Ignore RuntimeWarning from scipy 1.6.0

### DIFF
--- a/astropy/modeling/tests/test_fitters.py
+++ b/astropy/modeling/tests/test_fitters.py
@@ -16,7 +16,7 @@ from astropy.modeling import models
 from astropy.modeling.core import Fittable2DModel, Parameter
 from astropy.modeling.fitting import (
     SimplexLSQFitter, SLSQPLSQFitter, LinearLSQFitter, LevMarLSQFitter,
-    JointFitter, Fitter, FittingWithOutlierRemoval, Covariance)
+    JointFitter, Fitter, FittingWithOutlierRemoval)
 from astropy.utils import NumpyRNGContext
 from astropy.utils.data import get_pkg_data_filename
 from astropy.stats import sigma_clip
@@ -441,6 +441,7 @@ class TestNonLinearFitters:
         assert_allclose(model.parameters, withw.parameters, rtol=10 ** (-4))
 
     @pytest.mark.filterwarnings(r'ignore:.* Maximum number of iterations reached')
+    @pytest.mark.filterwarnings(r'ignore:Values in x were outside bounds during a minimize step, clipping to bounds')
     @pytest.mark.parametrize('fitter_class', fitters)
     def test_fitter_against_LevMar(self, fitter_class):
         """Tests results from non-linear fitters against `LevMarLSQFitter`."""
@@ -454,6 +455,7 @@ class TestNonLinearFitters:
         assert_allclose(model.parameters, new_model.parameters,
                         rtol=10 ** (-4))
 
+    @pytest.mark.filterwarnings(r'ignore:Values in x were outside bounds during a minimize step, clipping to bounds')
     def test_LSQ_SLSQP_with_constraints(self):
         """
         Runs `LevMarLSQFitter` and `SLSQPLSQFitter` on a model with
@@ -624,6 +626,7 @@ class Test1DFittingWithOutlierRemoval:
         self.y = func(self.model_params, self.x)
 
     @pytest.mark.filterwarnings('ignore:The fit may be unsuccessful')
+    @pytest.mark.filterwarnings(r'ignore:Values in x were outside bounds during a minimize step, clipping to bounds')
     def test_with_fitters_and_sigma_clip(self):
         import scipy.stats as stats
 
@@ -685,6 +688,7 @@ class Test2DFittingWithOutlierRemoval:
         return amplitude, x_mean, y_mean
 
     @pytest.mark.filterwarnings('ignore:The fit may be unsuccessful')
+    @pytest.mark.filterwarnings(r'ignore:Values in x were outside bounds during a minimize step, clipping to bounds')
     def test_with_fitters_and_sigma_clip(self):
         import scipy.stats as stats
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to ignore a new warning that appears in some fitter tests with the release of Scipy 1.6.0. I am ignoring them because they are blocking CI for unrelated PRs.

```
================================== FAILURES ===================================
_______ TestNonLinearFitters.test_fitter_against_LevMar[SLSQPLSQFitter] _______

self = <astropy.modeling.tests.test_fitters.TestNonLinearFitters object at 0x00000214A13BFC40>
fitter_class = <class 'astropy.modeling.fitting.SLSQPLSQFitter'>

    @pytest.mark.filterwarnings(r'ignore:.* Maximum number of iterations reached')
    @pytest.mark.parametrize('fitter_class', fitters)
    def test_fitter_against_LevMar(self, fitter_class):
        """Tests results from non-linear fitters against `LevMarLSQFitter`."""
    
        levmar = LevMarLSQFitter()
        fitter = fitter_class()
        # This emits a warning from fitter that we need to ignore with
        # pytest.mark.filterwarnings above.
>       new_model = fitter(self.gauss, self.xdata, self.ydata)

..\..\.tox\py38-test-alldeps\lib\site-packages\astropy\modeling\tests\test_fitters.py:452: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
..\..\.tox\py38-test-alldeps\lib\site-packages\astropy\modeling\fitting.py:263: in wrapper
    return func(self, model, x, y, z=z, **kwargs)
..\..\.tox\py38-test-alldeps\lib\site-packages\astropy\modeling\fitting.py:1308: in __call__
    fitparams, self.fit_info = self._opt_method(
..\..\.tox\py38-test-alldeps\lib\site-packages\astropy\modeling\optimizers.py:159: in __call__
    fitparams, final_func_val, numiter, exit_mode, mess = self.opt_method(
..\..\.tox\py38-test-alldeps\lib\site-packages\scipy\optimize\slsqp.py:207: in fmin_slsqp
    res = _minimize_slsqp(func, x0, args, jac=fprime, bounds=bounds,
..\..\.tox\py38-test-alldeps\lib\site-packages\scipy\optimize\slsqp.py:433: in _minimize_slsqp
    fx = wrapped_fun(x)
..\..\.tox\py38-test-alldeps\lib\site-packages\scipy\optimize\optimize.py:274: in eval
    x = _check_clip_x(x, bounds)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

x = array([243.15297506,   4.9492131 ,   0.        ])
bounds = (array([-1.00000000e+12, -1.00000000e+12,  1.17549435e-38]), array([1.e+12, 1.e+12, 1.e+12]))

    def _check_clip_x(x, bounds):
        if (x < bounds[0]).any() or (x > bounds[1]).any():
>           warnings.warn("Values in x were outside bounds during a "
                          "minimize step, clipping to bounds", RuntimeWarning)
E           RuntimeWarning: Values in x were outside bounds during a minimize step, clipping to bounds

..\..\.tox\py38-test-alldeps\lib\site-packages\scipy\optimize\optimize.py:282: RuntimeWarning
____________ TestNonLinearFitters.test_LSQ_SLSQP_with_constraints _____________

self = <astropy.modeling.tests.test_fitters.TestNonLinearFitters object at 0x00000214A0E79340>

    def test_LSQ_SLSQP_with_constraints(self):
        """
        Runs `LevMarLSQFitter` and `SLSQPLSQFitter` on a model with
        constraints.
        """
    
        g1 = models.Gaussian1D(100, 5, stddev=1)
        g1.mean.fixed = True
        fitter = LevMarLSQFitter()
        fslsqp = SLSQPLSQFitter()
>       slsqp_model = fslsqp(g1, self.xdata, self.ydata)

..\..\.tox\py38-test-alldeps\lib\site-packages\astropy\modeling\tests\test_fitters.py:467: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
..\..\.tox\py38-test-alldeps\lib\site-packages\astropy\modeling\fitting.py:263: in wrapper
    return func(self, model, x, y, z=z, **kwargs)
..\..\.tox\py38-test-alldeps\lib\site-packages\astropy\modeling\fitting.py:1308: in __call__
    fitparams, self.fit_info = self._opt_method(
..\..\.tox\py38-test-alldeps\lib\site-packages\astropy\modeling\optimizers.py:159: in __call__
    fitparams, final_func_val, numiter, exit_mode, mess = self.opt_method(
..\..\.tox\py38-test-alldeps\lib\site-packages\scipy\optimize\slsqp.py:207: in fmin_slsqp
    res = _minimize_slsqp(func, x0, args, jac=fprime, bounds=bounds,
..\..\.tox\py38-test-alldeps\lib\site-packages\scipy\optimize\slsqp.py:433: in _minimize_slsqp
    fx = wrapped_fun(x)
..\..\.tox\py38-test-alldeps\lib\site-packages\scipy\optimize\optimize.py:274: in eval
    x = _check_clip_x(x, bounds)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

x = array([242.40174527,   0.        ])
bounds = (array([-1.00000000e+12,  1.17549435e-38]), array([1.e+12, 1.e+12]))

    def _check_clip_x(x, bounds):
        if (x < bounds[0]).any() or (x > bounds[1]).any():
>           warnings.warn("Values in x were outside bounds during a "
                          "minimize step, clipping to bounds", RuntimeWarning)
E           RuntimeWarning: Values in x were outside bounds during a minimize step, clipping to bounds

..\..\.tox\py38-test-alldeps\lib\site-packages\scipy\optimize\optimize.py:282: RuntimeWarning
______ Test1DFittingWithOutlierRemoval.test_with_fitters_and_sigma_clip _______

self = <astropy.modeling.tests.test_fitters.Test1DFittingWithOutlierRemoval object at 0x00000214A0A10D00>

    @pytest.mark.filterwarnings('ignore:The fit may be unsuccessful')
    def test_with_fitters_and_sigma_clip(self):
        import scipy.stats as stats
    
        np.random.seed(0)
        c = stats.bernoulli.rvs(0.25, size=self.x.shape)
        self.y += (np.random.normal(0., 0.2, self.x.shape) +
                   c*np.random.normal(3.0, 5.0, self.x.shape))
    
        g_init = models.Gaussian1D(amplitude=1., mean=0, stddev=1.)
        # test with Levenberg-Marquardt Least Squares fitter
        fit = FittingWithOutlierRemoval(LevMarLSQFitter(), sigma_clip,
                                        niter=3, sigma=3.0)
        fitted_model, _ = fit(g_init, self.x, self.y)
        assert_allclose(fitted_model.parameters, self.model_params, rtol=1e-1)
        # test with Sequential Least Squares Programming fitter
        fit = FittingWithOutlierRemoval(SLSQPLSQFitter(), sigma_clip,
                                        niter=3, sigma=3.0)
>       fitted_model, _ = fit(g_init, self.x, self.y)

..\..\.tox\py38-test-alldeps\lib\site-packages\astropy\modeling\tests\test_fitters.py:644: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
..\..\.tox\py38-test-alldeps\lib\site-packages\astropy\modeling\fitting.py:923: in __call__
    fitted_model = self.fitter(model, x, y, z, weights=weights, **kwargs)
..\..\.tox\py38-test-alldeps\lib\site-packages\astropy\modeling\fitting.py:263: in wrapper
    return func(self, model, x, y, z=z, **kwargs)
..\..\.tox\py38-test-alldeps\lib\site-packages\astropy\modeling\fitting.py:1308: in __call__
    fitparams, self.fit_info = self._opt_method(
..\..\.tox\py38-test-alldeps\lib\site-packages\astropy\modeling\optimizers.py:159: in __call__
    fitparams, final_func_val, numiter, exit_mode, mess = self.opt_method(
..\..\.tox\py38-test-alldeps\lib\site-packages\scipy\optimize\slsqp.py:207: in fmin_slsqp
    res = _minimize_slsqp(func, x0, args, jac=fprime, bounds=bounds,
..\..\.tox\py38-test-alldeps\lib\site-packages\scipy\optimize\slsqp.py:433: in _minimize_slsqp
    fx = wrapped_fun(x)
..\..\.tox\py38-test-alldeps\lib\site-packages\scipy\optimize\optimize.py:274: in eval
    x = _check_clip_x(x, bounds)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

x = array([ 4.15448194, -2.8654803 ,  0.        ])
bounds = (array([-1.00000000e+12, -1.00000000e+12,  1.17549435e-38]), array([1.e+12, 1.e+12, 1.e+12]))

    def _check_clip_x(x, bounds):
        if (x < bounds[0]).any() or (x > bounds[1]).any():
>           warnings.warn("Values in x were outside bounds during a "
                          "minimize step, clipping to bounds", RuntimeWarning)
E           RuntimeWarning: Values in x were outside bounds during a minimize step, clipping to bounds

..\..\.tox\py38-test-alldeps\lib\site-packages\scipy\optimize\optimize.py:282: RuntimeWarning
______ Test2DFittingWithOutlierRemoval.test_with_fitters_and_sigma_clip _______

self = <astropy.modeling.tests.test_fitters.Test2DFittingWithOutlierRemoval object at 0x00000214A0F4A820>

    @pytest.mark.filterwarnings('ignore:The fit may be unsuccessful')
    def test_with_fitters_and_sigma_clip(self):
        import scipy.stats as stats
    
        np.random.seed(0)
        c = stats.bernoulli.rvs(0.25, size=self.z.shape)
        self.z += (np.random.normal(0., 0.2, self.z.shape) +
                   c*np.random.normal(self.z, 2.0, self.z.shape))
    
        guess = self.initial_guess(self.z, np.array([self.y, self.x]))
        g2_init = models.Gaussian2D(amplitude=guess[0], x_mean=guess[1],
                                    y_mean=guess[2], x_stddev=0.75,
                                    y_stddev=1.25)
    
        # test with Levenberg-Marquardt Least Squares fitter
        fit = FittingWithOutlierRemoval(LevMarLSQFitter(), sigma_clip,
                                        niter=3, sigma=3.)
        fitted_model, _ = fit(g2_init, self.x, self.y, self.z)
        assert_allclose(fitted_model.parameters[0:5], self.model_params,
                        atol=1e-1)
        # test with Sequential Least Squares Programming fitter
        fit = FittingWithOutlierRemoval(SLSQPLSQFitter(), sigma_clip, niter=3,
                                        sigma=3.)
>       fitted_model, _ = fit(g2_init, self.x, self.y, self.z)

..\..\.tox\py38-test-alldeps\lib\site-packages\astropy\modeling\tests\test_fitters.py:710: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
..\..\.tox\py38-test-alldeps\lib\site-packages\astropy\modeling\fitting.py:923: in __call__
    fitted_model = self.fitter(model, x, y, z, weights=weights, **kwargs)
..\..\.tox\py38-test-alldeps\lib\site-packages\astropy\modeling\fitting.py:263: in wrapper
    return func(self, model, x, y, z=z, **kwargs)
..\..\.tox\py38-test-alldeps\lib\site-packages\astropy\modeling\fitting.py:1308: in __call__
    fitparams, self.fit_info = self._opt_method(
..\..\.tox\py38-test-alldeps\lib\site-packages\astropy\modeling\optimizers.py:159: in __call__
    fitparams, final_func_val, numiter, exit_mode, mess = self.opt_method(
..\..\.tox\py38-test-alldeps\lib\site-packages\scipy\optimize\slsqp.py:207: in fmin_slsqp
    res = _minimize_slsqp(func, x0, args, jac=fprime, bounds=bounds,
..\..\.tox\py38-test-alldeps\lib\site-packages\scipy\optimize\slsqp.py:433: in _minimize_slsqp
    fx = wrapped_fun(x)
..\..\.tox\py38-test-alldeps\lib\site-packages\scipy\optimize\optimize.py:274: in eval
    x = _check_clip_x(x, bounds)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

x = array([-565.15362854, -915.72898196, -285.2617742 ,    0.        ,
          0.        ,  201.04907227])
bounds = (array([-1.00000000e+12, -1.00000000e+12, -1.00000000e+12,  1.17549435e-38,
        1.17549435e-38, -1.00000000e+12]), array([1.e+12, 1.e+12, 1.e+12, 1.e+12, 1.e+12, 1.e+12]))

    def _check_clip_x(x, bounds):
        if (x < bounds[0]).any() or (x > bounds[1]).any():
>           warnings.warn("Values in x were outside bounds during a "
                          "minimize step, clipping to bounds", RuntimeWarning)
E           RuntimeWarning: Values in x were outside bounds during a minimize step, clipping to bounds

..\..\.tox\py38-test-alldeps\lib\site-packages\scipy\optimize\optimize.py:282: RuntimeWarning
```

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->