### PR TITLE
Allow Quantity to be initialized with a Distribution

### DIFF
--- a/astropy/uncertainty/core.py
+++ b/astropy/uncertainty/core.py
@@ -4,6 +4,7 @@
 """
 Distribution class and associated machinery.
 """
+import builtins
 
 import numpy as np
 
@@ -275,14 +276,22 @@ class ArrayDistribution(Distribution, np.ndarray):
     # Override view so that we stay a Distribution version of the new type.
     def view(self, dtype=None, type=None):
         if type is None:
-            if issubclass(dtype, np.ndarray):
-                type = dtype
-                dtype = None
-            else:
-                raise ValueError('Cannot set just dtype for a Distribution.')
+            if not (isinstance(dtype, builtins.type)
+                    and issubclass(dtype, np.ndarray)):
+                raise ValueError('cannot view Distribution with just a new dtype.')
 
-        result = self.distribution.view(dtype, type)
-        return Distribution(result)
+            type = dtype
+            view_args = (type,)
+
+        else:
+            view_args = (dtype, type)
+
+        if issubclass(type, Distribution):
+            return super().view(*view_args)
+
+        else:
+            result = self.distribution.view(*view_args)
+            return Distribution(result)
 
     # Override __getitem__ so that 'samples' is returned as the sample class.
     def __getitem__(self, item):

--- a/astropy/uncertainty/tests/test_distribution.py
+++ b/astropy/uncertainty/tests/test_distribution.py
@@ -1,9 +1,11 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import numpy as np
+from numpy.testing import assert_array_equal
 import pytest
 
 from astropy import units as u
+from astropy.coordinates import Angle
 from astropy.uncertainty.core import Distribution
 from astropy.uncertainty import distributions as ds
 from astropy.utils import NumpyRNGContext
@@ -15,30 +17,42 @@ if HAS_SCIPY:
     SMAD_FACTOR = 1 / norm.ppf(0.75)
 
 
-def test_numpy_init():
-    # Test that we can initialize directly from a Numpy array
-    rates = np.array([1, 5, 30, 400])[:, np.newaxis]
-    parr = np.random.poisson(rates, (4, 1000))
-    Distribution(parr)
+class TestInit:
+    @classmethod
+    def setup_class(self):
+        self.rates = np.array([1, 5, 30, 400])[:, np.newaxis]
+        self.parr = np.random.poisson(self.rates, (4, 1000))
+        self.parr_t = np.random.poisson(self.rates.squeeze(), (1000, 4))
 
+    def test_numpy_init(self):
+        # Test that we can initialize directly from a Numpy array
+        Distribution(self.parr)
 
-def test_numpy_init_T():
-    rates = np.array([1, 5, 30, 400])
-    parr = np.random.poisson(rates, (1000, 4))
-    Distribution(parr.T)
+    def test_numpy_init_T(self):
+        Distribution(self.parr_t.T)
 
+    def test_quantity_init(self):
+        # Test that we can initialize directly from a Quantity
+        pq = self.parr << u.ct
+        pqd = Distribution(pq)
+        assert isinstance(pqd, u.Quantity)
+        assert isinstance(pqd, Distribution)
+        assert isinstance(pqd.value, Distribution)
+        assert_array_equal(pqd.value.distribution, self.parr)
 
-def test_quantity_init():
-    # Test that we can initialize directly from a Quantity
-    pq = np.random.poisson(np.array([1, 5, 30, 400])[:, np.newaxis],
-                           (4, 1000)) * u.ct
-    Distribution(pq)
+    def test_quantity_init_T(self):
+        # Test that we can initialize directly from a Quantity
+        pq = self.parr_t << u.ct
+        Distribution(pq.T)
 
-
-def test_quantity_init_T():
-    # Test that we can initialize directly from a Quantity
-    pq = np.random.poisson(np.array([1, 5, 30, 400]), (1000, 4)) * u.ct
-    Distribution(pq.T)
+    def test_quantity_init_with_distribution(self):
+        # Test that we can initialize a Quantity from a Distribution.
+        pd = Distribution(self.parr)
+        qpd = pd << u.ct
+        assert isinstance(qpd, u.Quantity)
+        assert isinstance(qpd, Distribution)
+        assert qpd.unit == u.ct
+        assert_array_equal(qpd.value.distribution, pd.distribution.astype(float))
 
 
 def test_init_scalar():
@@ -374,3 +388,49 @@ def test_distr_noq_to_value():
     distr = ds.normal(10, n_samples=100, std=1)
     with pytest.raises(AttributeError):
         distr.to_value(u.m)
+
+
+def test_distr_angle():
+    # Check that Quantity subclasses decay to Quantity appropriately.
+    distr = Distribution([2., 3., 4.])
+    ad = Angle(distr, 'deg')
+    ad_plus_ad = ad + ad
+    assert isinstance(ad_plus_ad, Angle)
+    assert isinstance(ad_plus_ad, Distribution)
+
+    ad_times_ad = ad * ad
+    assert not isinstance(ad_times_ad, Angle)
+    assert isinstance(ad_times_ad, u.Quantity)
+    assert isinstance(ad_times_ad, Distribution)
+
+    ad += ad
+    assert isinstance(ad, Angle)
+    assert isinstance(ad, Distribution)
+    assert_array_equal(ad.distribution, ad_plus_ad.distribution)
+
+    with pytest.raises(u.UnitTypeError):
+        ad *= ad
+
+
+def test_distr_angle_view_as_quantity():
+    # Check that Quantity subclasses decay to Quantity appropriately.
+    distr = Distribution([2., 3., 4.])
+    ad = Angle(distr, 'deg')
+    qd = ad.view(u.Quantity)
+    assert not isinstance(qd, Angle)
+    assert isinstance(qd, u.Quantity)
+    assert isinstance(qd, Distribution)
+    # View directly as DistributionQuantity class.
+    qd2 = ad.view(qd.__class__)
+    assert not isinstance(qd2, Angle)
+    assert isinstance(qd2, u.Quantity)
+    assert isinstance(qd2, Distribution)
+    assert_array_equal(qd2.distribution, qd.distribution)
+    qd3 = ad.view(qd.dtype, qd.__class__)
+    assert not isinstance(qd3, Angle)
+    assert isinstance(qd3, u.Quantity)
+    assert isinstance(qd3, Distribution)
+    assert_array_equal(qd3.distribution, qd.distribution)
+
+    with pytest.raises(ValueError, match='just a new dtype'):
+        ad.view(np.dtype('f8'))

--- a/astropy/uncertainty/tests/test_distribution.py
+++ b/astropy/uncertainty/tests/test_distribution.py
@@ -432,5 +432,20 @@ def test_distr_angle_view_as_quantity():
     assert isinstance(qd3, Distribution)
     assert_array_equal(qd3.distribution, qd.distribution)
 
-    with pytest.raises(ValueError, match='just a new dtype'):
+
+def test_distr_cannot_view_new_dtype():
+    # A Distribution has a very specific structured dtype with just one
+    # element that holds the array of samples.  As it is not clear what
+    # to do with a view as a new dtype, we just error on it.
+    # TODO: with a lot of thought, this restriction can likely be relaxed.
+    distr = Distribution([2., 3., 4.])
+    with pytest.raises(ValueError, match='with a new dtype'):
+        distr.view(np.dtype('f8'))
+
+    # Check subclass just in case.
+    ad = Angle(distr, 'deg')
+    with pytest.raises(ValueError, match='with a new dtype'):
         ad.view(np.dtype('f8'))
+
+    with pytest.raises(ValueError, match='with a new dtype'):
+        ad.view(np.dtype('f8'), Distribution)

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -375,7 +375,7 @@ class Quantity(np.ndarray):
                     copy = False  # copy will be made in conversion at end
 
         value = np.array(value, dtype=dtype, copy=copy, order=order,
-                         subok=False, ndmin=ndmin)
+                         subok=True, ndmin=ndmin)
 
         # check that array contains numbers or long int objects
         if (value.dtype.kind in 'OSU' and
@@ -404,6 +404,13 @@ class Quantity(np.ndarray):
             return value.to(unit)
 
     def __array_finalize__(self, obj):
+        # Check whether super().__array_finalize should be called
+        # (sadly, ndarray.__array_finalize__ is None; we cannot be sure
+        # what is above us).
+        super_array_finalize = super().__array_finalize__
+        if super_array_finalize is not None:
+            super_array_finalize(obj)
+
         # If we're a new object or viewing an ndarray, nothing has to be done.
         if obj is None or obj.__class__ is np.ndarray:
             return
@@ -602,7 +609,7 @@ class Quantity(np.ndarray):
         if obj is None:
             obj = self.view(np.ndarray)
         else:
-            obj = np.array(obj, copy=False)
+            obj = np.array(obj, copy=False, subok=True)
 
         # Take the view, set the unit, and update possible other properties
         # such as ``info``, ``wrap_angle`` in `Longitude`, etc.
@@ -1370,9 +1377,9 @@ class Quantity(np.ndarray):
         if check_precision:
             # If, e.g., we are casting double to float, we want to fail if
             # precision is lost, but let things pass if it works.
-            _value = np.array(_value, copy=False)
+            _value = np.array(_value, copy=False, subok=True)
             if not np.can_cast(_value.dtype, self.dtype):
-                self_dtype_array = np.array(_value, self.dtype)
+                self_dtype_array = np.array(_value, self.dtype, subok=True)
                 if not np.all(np.logical_or(self_dtype_array == _value,
                                             np.isnan(_value))):
                     raise TypeError("cannot convert value type to array type "

--- a/docs/changes/uncertainty/11210.bugfix.rst
+++ b/docs/changes/uncertainty/11210.bugfix.rst
@@ -1,0 +1,3 @@
+``Distribution`` instances can now be used as input to ``Quantity`` to
+initialize ``QuantityDistribution``.  Hence, ``distribution * unit``
+and ``distribution << unit`` will work too.


### PR DESCRIPTION
This is really a spin-off from trying to get a general `Masked` class to work in #11127, where I wanted to ensuring that `Quantity(masked, unit)` gave a `MaskedQuantity`. But the changes I made suggested  `Quantity(distribution, unit)` should also give a `QuantityDistribution` - which indeed worked! I split the required changes out of #11127, since it is likely much easier to review here (and being able to do `distribution * unit` is nice!).