### PR TITLE
Fix bug in Table init of TableAttribute's

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -358,6 +358,10 @@ astropy.stats
 astropy.table
 ^^^^^^^^^^^^^
 
+- Fix bug when initializing a ``Table`` subclass that uses ``TableAttribute``'s.
+  If the data were an instance of the table then attributes provided in the
+  table initialization call could be ignored. [#11217]
+
 astropy.tests
 ^^^^^^^^^^^^^
 

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -817,7 +817,7 @@ class Table:
                         dtype = [dtype[name] for name in names]
                     except Exception:
                         raise ValueError('dtype was specified but could not be '
-                                        'parsed for column names')
+                                         'parsed for column names')
             # names is guaranteed to be set at this point
             init_func = self._init_from_list
             n_cols = len(names)

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -717,13 +717,17 @@ class Table:
         default_names = None
 
         # Handle custom (subclass) table attributes that are stored in meta.
-        # These are defined as class attributes using the MetaAttribute
-        # descriptor.  Any such attributes get removed from kwargs here.
+        # These are defined as class attributes using the TableAttribute
+        # descriptor.  Any such attributes get removed from kwargs here and
+        # stored for use after the table is otherwise initialized. Any values
+        # provided via kwargs will have precedence over existing values from
+        # meta (e.g. from data as a Table or meta via kwargs).
+        meta_table_attrs = {}
         if kwargs:
             for attr in list(kwargs):
                 descr = getattr(self.__class__, attr, None)
                 if isinstance(descr, TableAttribute):
-                    setattr(self, attr, kwargs.pop(attr))
+                    meta_table_attrs[attr] = kwargs.pop(attr)
 
         if hasattr(data, '__astropy_table__'):
             # Data object implements the __astropy_table__ interface method.
@@ -799,18 +803,21 @@ class Table:
         elif data is None:
             if names is None:
                 if dtype is None:
-                    if meta is not None:
-                        self.meta = deepcopy(meta) if copy else meta
-                    return
-                try:
-                    # No data nor names but dtype is available.  This must be
-                    # valid to initialize a structured array.
-                    dtype = np.dtype(dtype)
-                    names = dtype.names
-                    dtype = [dtype[name] for name in names]
-                except Exception:
-                    raise ValueError('dtype was specified but could not be '
-                                     'parsed for column names')
+                    # Table was initialized as `t = Table()`. Set up for empty
+                    # table with names=[], data=[], and n_cols=0.
+                    # self._init_from_list() will simply return, giving the
+                    # expected empty table.
+                    names = []
+                else:
+                    try:
+                        # No data nor names but dtype is available.  This must be
+                        # valid to initialize a structured array.
+                        dtype = np.dtype(dtype)
+                        names = dtype.names
+                        dtype = [dtype[name] for name in names]
+                    except Exception:
+                        raise ValueError('dtype was specified but could not be '
+                                        'parsed for column names')
             # names is guaranteed to be set at this point
             init_func = self._init_from_list
             n_cols = len(names)
@@ -848,6 +855,12 @@ class Table:
         # user-supplied meta directly.
         if meta is not None:
             self.meta = deepcopy(meta) if copy else meta
+
+        # Update meta with TableAttributes supplied as kwargs in Table init.
+        # This takes precedence over previously-defined meta.
+        if meta_table_attrs:
+            for attr, value in meta_table_attrs.items():
+                setattr(self, attr, value)
 
         # Whatever happens above, the masked property should be set to a boolean
         if self.masked not in (None, True, False):
@@ -1163,6 +1176,11 @@ class Table:
         """Initialize table from a list of column data.  A column can be a
         Column object, np.ndarray, mixin, or any other iterable object.
         """
+        # Special case of initializing an empty table like `t = Table()`. No
+        # action required at this point.
+        if n_cols == 0:
+            return
+
         cols = []
         default_names = _auto_names(n_cols)
 

--- a/astropy/table/tests/test_init_table.py
+++ b/astropy/table/tests/test_init_table.py
@@ -557,3 +557,16 @@ def test_init_from_rows_as_generator():
     t = Table(rows=rows)
     assert np.all(t['col0'] == [1, 2])
     assert np.all(t['col1'] == [2, 3])
+
+
+@pytest.mark.parametrize('dtype', ['fail', 'i4'])
+def test_init_bad_dtype_in_empty_table(dtype):
+    with pytest.raises(ValueError,
+                       match='type was specified but could not be parsed for column names'):
+        Table(dtype=dtype)
+
+
+def test_init_data_type_not_allowed_to_init_table():
+    with pytest.raises(ValueError,
+                       match="Data type <class 'str'> not allowed to init Table"):
+        Table('hello')

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -2523,11 +2523,23 @@ def test_table_attribute():
     assert tp.baz == 'baz'
     assert tp.bar == [2.0]
 
-    # Allow initialization of attributes in table creation
-    t2 = MyTable([[1, 2]], foo=3, bar='bar', baz='baz')
-    assert t2.foo == 3
-    assert t2.bar == 'bar'
-    assert t2.baz == 'baz'
+    # Allow initialization of attributes in table creation, with / without data
+    for data in None, [[1, 2]]:
+        t2 = MyTable(data, foo=3, bar='bar', baz='baz')
+        assert t2.foo == 3
+        assert t2.bar == 'bar'
+        assert t2.baz == 'baz'
+
+    # Initializing from an existing MyTable works, with and without kwarg attrs
+    t3 = MyTable(t2)
+    assert t3.foo == 3
+    assert t3.bar == 'bar'
+    assert t3.baz == 'baz'
+
+    t3 = MyTable(t2, foo=5, bar='fubar')
+    assert t3.foo == 5
+    assert t3.bar == 'fubar'
+    assert t3.baz == 'baz'
 
     # Deleting attributes removes it from attributes
     del t.baz


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to fix this bug reported by @Cadair on slack:
```
In [1]: from astropy.table import *                                             
In [2]: class MyTable(Table): 
   ...:     attr = TableAttribute() 
   ...:                                                                         
In [3]: t = MyTable(attr=2)                                                     
In [4]: t2 = MyTable(t, attr=3)                                                 
In [5]: t2.attr  # Should be 3
Out[5]: 2
```

The implementation of the fix got a bigger scope than I'd like, but in a good way. The table initialization code always had an early `return` for the special case of an empty table like `Table()`. I was never happy about it but had not previously seen a nice way to make this case fit in with the others. Today I found a simple way that makes the code processing take the same path for all initialization options. No new tests but the existing testing should be pretty robust.


<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->
