### PR TITLE
More careful handling of masked values in FITS tables

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -138,6 +138,10 @@ astropy.io.ascii
 astropy.io.fits
 ^^^^^^^^^^^^^^^
 
+- For FITS tables, the standard mask values of ``NaN`` for float and null string
+  for string are now properly recognized, leading to a ``MaskedColumn`` with
+  appropriately set mask instead of a ``Column`` with those values exposed. [#11222]
+
 astropy.io.misc
 ^^^^^^^^^^^^^^^
 
@@ -164,6 +168,10 @@ astropy.table
 - Added ``Column.value`` as an alias for the existing ``Column.data`` attribute.
   This makes accessing a column's underlying data array consistent with the
   ``.value`` attribute available for ``Time`` and ``Quantity`` objects. [#10962]
+
+- In reading from a FITS tables, the standard mask values of ``NaN`` for float
+  and null string for string are properly recognized, leading to a
+  ``MaskedColumn`` with appropriately set mask. [#11222]
 
 astropy.tests
 ^^^^^^^^^^^^^
@@ -257,6 +265,10 @@ astropy.table
   does not have side effects, such as creating an associated ``info``
   instance (which would lead to slow-down of, e.g., slicing afterwards).
   [#11077]
+
+- When writing to a FITS tables, masked values are again always converted to
+  the standard FITS mask values of ``NaN`` for float and null string
+  for string, not just for table with ``masked=True``. [#11222]
 
 astropy.tests
 ^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -138,9 +138,14 @@ astropy.io.ascii
 astropy.io.fits
 ^^^^^^^^^^^^^^^
 
-- For FITS tables, the standard mask values of ``NaN`` for float and null string
-  for string are now properly recognized, leading to a ``MaskedColumn`` with
-  appropriately set mask instead of a ``Column`` with those values exposed. [#11222]
+- For conversion between FITS tables and astropy ``Table``, the standard mask
+  values of ``NaN`` for float and null string for string are now properly
+  recognized, leading to a ``MaskedColumn`` with appropriately set mask
+  instead of a ``Column`` with those values exposed. Conversely, when writing
+  an astropy ``Table`` to a FITS tables, masked values are now consistently
+  converted to the standard FITS mask values of ``NaN`` for float and null
+  string for string (i.e., not just for tables with ``masked=True``, which no
+  longer is guaranteed to signal the presence of ``MaskedColumn``). [#11222]
 
 astropy.io.misc
 ^^^^^^^^^^^^^^^

--- a/astropy/timeseries/io/kepler.py
+++ b/astropy/timeseries/io/kepler.py
@@ -4,7 +4,7 @@ import warnings
 import numpy as np
 
 from astropy.io import registry, fits
-from astropy.table import Table
+from astropy.table import Table, MaskedColumn
 from astropy.time import Time, TimeDelta
 
 from astropy.timeseries.sampled import TimeSeries
@@ -62,10 +62,15 @@ def kepler_fits_reader(filename):
         tab.rename_column("T", "TIME")
 
     for colname in tab.colnames:
+        unit = tab[colname].unit
+        # Make masks nan for any column which will turn into a Quantity
+        # later. TODO: remove once we support Masked Quantities properly?
+        if unit and isinstance(tab[colname], MaskedColumn):
+            tab[colname] = tab[colname].filled(np.nan)
         # Fix units
-        if tab[colname].unit == 'e-/s':
+        if unit == 'e-/s':
             tab[colname].unit = 'electron/s'
-        if tab[colname].unit == 'pixels':
+        if unit == 'pixels':
             tab[colname].unit = 'pixel'
 
         # Rename columns to lowercase


### PR DESCRIPTION
As noted in #11194, writing masked float and string columns should be possible, by using `np.nan` and null string as null values, respectively, but this was broken in the transition of masked tables to tables able to contain `MaskedColumn`. This is fixed here (and improved, also fixing complex).

Furthermore, upon reading tables, those FITS null values are properly recognized and used to initialize a `MaskedColumn`. 

I wasn't quite clear whether the latter should be labelled a bug or API change, but as I worried about breaking code in a bug-fix release, conservatively decided on API change, hence the 4.3 milestone. Obviously, happy to change this.

fixes #11194.