### PR TITLE
Make classproperty and lazyproperty thread-safe

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -101,9 +101,6 @@ astropy.utils
   function ``_find_pkg_data_path``) for obtaining file paths without checking if the
   file/directory exists, as long as the package and module do. [#11006]
 
-- Make ``lazyproperty`` and ``classdecorator`` thread-safe. This should fix a
-  number of thread safety issues. [#11224]
-
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 
@@ -280,6 +277,9 @@ astropy.units
 
 astropy.utils
 ^^^^^^^^^^^^^
+
+- Make ``lazyproperty`` and ``classdecorator`` thread-safe. This should fix a
+  number of thread safety issues. [#11224]
 
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -101,6 +101,9 @@ astropy.utils
   function ``_find_pkg_data_path``) for obtaining file paths without checking if the
   file/directory exists, as long as the package and module do. [#11006]
 
+- Make ``lazyproperty`` and ``classdecorator`` thread-safe. This should fix a
+  number of thread safety issues. [#11221]
+
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -102,7 +102,7 @@ astropy.utils
   file/directory exists, as long as the package and module do. [#11006]
 
 - Make ``lazyproperty`` and ``classdecorator`` thread-safe. This should fix a
-  number of thread safety issues. [#11221]
+  number of thread safety issues. [#11224]
 
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^

--- a/astropy/conftest.py
+++ b/astropy/conftest.py
@@ -54,6 +54,18 @@ def ignore_matplotlibrc():
         yield
 
 
+@pytest.fixture
+def fast_thread_switching():
+    """Fixture that reduces thread switching interval.
+
+    This makes it easier to provoke race conditions.
+    """
+    old = sys.getswitchinterval()
+    sys.setswitchinterval(1e-6)
+    yield
+    sys.setswitchinterval(old)
+
+
 def pytest_configure(config):
     from astropy.utils.iers import conf as iers_conf
 

--- a/astropy/utils/decorators.py
+++ b/astropy/utils/decorators.py
@@ -774,22 +774,21 @@ class lazyproperty(property):
 
     def __set__(self, obj, val):
         obj_dict = obj.__dict__
-        with self._lock:
-            if self.fset:
-                ret = self.fset(obj, val)
-                if ret is not None and obj_dict.get(self._key) is ret:
-                    # By returning the value set the setter signals that it
-                    # took over setting the value in obj.__dict__; this
-                    # mechanism allows it to override the input value
-                    return
-            obj_dict[self._key] = val
+        if self.fset:
+            ret = self.fset(obj, val)
+            if ret is not None and obj_dict.get(self._key) is ret:
+                # By returning the value set the setter signals that it
+                # took over setting the value in obj.__dict__; this
+                # mechanism allows it to override the input value
+                return
+        obj_dict[self._key] = val
 
     def __delete__(self, obj):
-        with self._lock:
-            if self.fdel:
-                self.fdel(obj)
-            if self._key in obj.__dict__:
-                del obj.__dict__[self._key]
+        if self.fdel:
+            self.fdel(obj)
+        obj.__dict__.pop(self._key, None)    # Delete if present
+        if self._key in obj.__dict__:
+            del obj.__dict__[self._key]
 
 
 class sharedmethod(classmethod):

--- a/astropy/utils/decorators.py
+++ b/astropy/utils/decorators.py
@@ -787,8 +787,6 @@ class lazyproperty(property):
         if self.fdel:
             self.fdel(obj)
         obj.__dict__.pop(self._key, None)    # Delete if present
-        if self._key in obj.__dict__:
-            del obj.__dict__[self._key]
 
 
 class sharedmethod(classmethod):

--- a/astropy/utils/tests/test_decorators.py
+++ b/astropy/utils/tests/test_decorators.py
@@ -3,7 +3,6 @@
 import concurrent.futures
 import inspect
 import pickle
-import sys
 
 import pytest
 
@@ -528,18 +527,6 @@ def test_classproperty_docstring():
         foo = classproperty(_get_foo, doc="The foo.")
 
     assert B.__dict__['foo'].__doc__ == "The foo."
-
-
-@pytest.fixture
-def fast_thread_switching():
-    """Fixture that reduces thread switching interval.
-
-    This makes it easier to provoke race conditions.
-    """
-    old = sys.getswitchinterval()
-    sys.setswitchinterval(1e-6)
-    yield
-    sys.setswitchinterval(old)
 
 
 def test_classproperty_lazy_threadsafe(fast_thread_switching):


### PR DESCRIPTION
### Description
This pull request is to address thread safety in the decorator utilities.

Fixes #11221.

I've also added unit tests. Testing race conditions is notoriously tricky, so I've made it try 10000 times each. That adds about 1s (for each), which is my attempt at a compromise between not slowing down the tests and trying enough times to trigger the bug. Without the fix it is still not enough to reliably fail, but it should be enough that if someone breaks it in future it will fail sooner or later in CI and prompt someone to look closer.
