### PR TITLE
Make UfuncHelpers thread-safe

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -282,6 +282,8 @@ astropy.units
 
 - Make ``Unit`` string parsing (as well as ``Angle`` parsing) thread-safe. [#11227]
 
+- Make ufunc helper lookup thread-safe. [#11226]
+
 astropy.utils
 ^^^^^^^^^^^^^
 

--- a/astropy/units/quantity_helper/converters.py
+++ b/astropy/units/quantity_helper/converters.py
@@ -2,6 +2,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Converters for Quantity."""
 
+import threading
+
 import numpy as np
 
 from astropy.units.core import (UnitsError, UnitConversionError, UnitTypeError,
@@ -21,6 +23,11 @@ class UfuncHelpers(dict):
     """
     UNSUPPORTED = set()
 
+    def __init__(self, *args, **kwargs):
+        self.modules = {}
+        self._lock = threading.RLock()
+        super().__init__(*args, **kwargs)
+
     def register_module(self, module, names, importer):
         """Register (but do not import) a set of ufunc helpers.
 
@@ -35,15 +42,9 @@ class UfuncHelpers(dict):
             keyed by those ufuncs.  If the value is `None`, the ufunc is
             explicitly *not* supported.
         """
-        self.modules[module] = {'names': names,
-                                'importer': importer}
-
-    @property
-    def modules(self):
-        """Modules for which helpers are available (but not yet loaded)."""
-        if not hasattr(self, '_modules'):
-            self._modules = {}
-        return self._modules
+        with self._lock:
+            self.modules[module] = {'names': names,
+                                    'importer': importer}
 
     def import_module(self, module):
         """Import the helpers from the given module using its helper function.
@@ -53,8 +54,9 @@ class UfuncHelpers(dict):
         module : str
             Name of the module. Has to have been registered beforehand.
         """
-        module_info = self.modules.pop(module)
-        self.update(module_info['importer']())
+        with self._lock:
+            module_info = self.modules.pop(module)
+            self.update(module_info['importer']())
 
     def __missing__(self, ufunc):
         """Called if a ufunc is not found.
@@ -62,25 +64,30 @@ class UfuncHelpers(dict):
         Check if the ufunc is in any of the available modules, and, if so,
         import the helpers for that module.
         """
-        if ufunc in self.UNSUPPORTED:
-            raise TypeError(f"Cannot use ufunc '{ufunc.__name__}' with quantities")
+        with self._lock:
+            # Check if it was loaded while we waited for the lock
+            if ufunc in self:
+                return self[ufunc]
 
-        for module, module_info in list(self.modules.items()):
-            if ufunc.__name__ in module_info['names']:
-                # A ufunc with the same name is supported by this module.
-                # Of course, this doesn't necessarily mean it is the
-                # right module. So, we try let the importer do its work.
-                # If it fails (e.g., for `scipy.special`), then that's
-                # fine, just raise the TypeError.  If it succeeds, but
-                # the ufunc is not found, that is also fine: we will
-                # enter __missing__ again and either find another
-                # module or get the TypeError there.
-                try:
-                    self.import_module(module)
-                except ImportError:
-                    pass
-                else:
-                    return self[ufunc]
+            if ufunc in self.UNSUPPORTED:
+                raise TypeError(f"Cannot use ufunc '{ufunc.__name__}' with quantities")
+
+            for module, module_info in list(self.modules.items()):
+                if ufunc.__name__ in module_info['names']:
+                    # A ufunc with the same name is supported by this module.
+                    # Of course, this doesn't necessarily mean it is the
+                    # right module. So, we try let the importer do its work.
+                    # If it fails (e.g., for `scipy.special`), then that's
+                    # fine, just raise the TypeError.  If it succeeds, but
+                    # the ufunc is not found, that is also fine: we will
+                    # enter __missing__ again and either find another
+                    # module or get the TypeError there.
+                    try:
+                        self.import_module(module)
+                    except ImportError:
+                        pass
+                    else:
+                        return self[ufunc]
 
         raise TypeError("unknown ufunc {}.  If you believe this ufunc "
                         "should be supported, please raise an issue on "
@@ -92,12 +99,13 @@ class UfuncHelpers(dict):
         # mean that something is not implemented, but this means an
         # extra if clause for the output, slowing down the common
         # path where a ufunc is supported.
-        if value is None:
-            self.UNSUPPORTED |= {key}
-            self.pop(key, None)
-        else:
-            super().__setitem__(key, value)
-            self.UNSUPPORTED -= {key}
+        with self._lock:
+            if value is None:
+                self.UNSUPPORTED |= {key}
+                self.pop(key, None)
+            else:
+                super().__setitem__(key, value)
+                self.UNSUPPORTED -= {key}
 
 
 UFUNC_HELPERS = UfuncHelpers()

--- a/astropy/units/quantity_helper/converters.py
+++ b/astropy/units/quantity_helper/converters.py
@@ -21,10 +21,10 @@ class UfuncHelpers(dict):
 
     Such modules should be registered using ``register_module``.
     """
-    UNSUPPORTED = set()
 
     def __init__(self, *args, **kwargs):
         self.modules = {}
+        self.UNSUPPORTED = set()   # Upper-case for backwards compatibility
         self._lock = threading.RLock()
         super().__init__(*args, **kwargs)
 

--- a/astropy/units/quantity_helper/converters.py
+++ b/astropy/units/quantity_helper/converters.py
@@ -84,7 +84,7 @@ class UfuncHelpers(dict):
                     # module or get the TypeError there.
                     try:
                         self.import_module(module)
-                    except ImportError:
+                    except ImportError:  # pragma: no cover
                         pass
                     else:
                         return self[ufunc]

--- a/astropy/units/tests/test_quantity_ufuncs.py
+++ b/astropy/units/tests/test_quantity_ufuncs.py
@@ -1,6 +1,8 @@
 # The purpose of these tests are to ensure that calling ufuncs with quantities
 # returns quantities with the right units, or raises exceptions.
 
+import concurrent.futures
+import sys
 import warnings
 from collections import namedtuple
 
@@ -11,6 +13,8 @@ from erfa import ufunc as erfa_ufunc
 
 from astropy import units as u
 from astropy.units import quantity_helper as qh
+from astropy.units.quantity_helper.converters import UfuncHelpers
+from astropy.units.quantity_helper.helpers import helper_sqrt
 
 
 try:
@@ -87,6 +91,30 @@ class TestUfuncHelpers:
         qh.UFUNC_HELPERS[np.add] = qh.UFUNC_HELPERS[np.subtract]
         assert np.add in qh.UFUNC_HELPERS
         assert np.add not in qh.UNSUPPORTED_UFUNCS
+
+    def test_thread_safety(self, fast_thread_switching):
+        def dummy_ufunc(*args, **kwargs):
+            return np.sqrt(*args, **kwargs)
+
+        def register():
+            return {dummy_ufunc: helper_sqrt}
+
+        workers = 8
+        with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
+            for p in range(10000):
+                helpers = UfuncHelpers()
+                # UNSUPPORTED is (for some reason) a class attribute rather than an
+                # instance attribute. Make it an instance attribute so that the test
+                # doesn't affect the class attribute.
+                helpers.UNSUPPORTED = set(helpers.UNSUPPORTED)
+                helpers.register_module(
+                    'astropy.units.tests.test_quantity_ufuncs',
+                    ['dummy_ufunc'],
+                    register
+                )
+                futures = [executor.submit(lambda: helpers[dummy_ufunc]) for i in range(workers)]
+                values = [future.result() for future in futures]
+                assert values == [helper_sqrt] * workers
 
 
 class TestQuantityTrigonometricFuncs:

--- a/astropy/units/tests/test_quantity_ufuncs.py
+++ b/astropy/units/tests/test_quantity_ufuncs.py
@@ -103,10 +103,6 @@ class TestUfuncHelpers:
         with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
             for p in range(10000):
                 helpers = UfuncHelpers()
-                # UNSUPPORTED is (for some reason) a class attribute rather than an
-                # instance attribute. Make it an instance attribute so that the test
-                # doesn't affect the class attribute.
-                helpers.UNSUPPORTED = set(helpers.UNSUPPORTED)
                 helpers.register_module(
                     'astropy.units.tests.test_quantity_ufuncs',
                     ['dummy_ufunc'],


### PR DESCRIPTION
### Description

- Remove `modules` property that lazily creates the underlying
  `_modules` attribute, in favour of an `__init__` that creates
  `modules` as an attribute.
- Add a lock that is held for all mutations of the object.
- Moved UNSUPPORTED from a class attribute to an instance attribute,
  for consistency. This is a singleton class and it's accessed via
  the `UNSUPPORTED_UFUNCS` global so this shouldn't make any difference
  other than making it easier to isolate unit tests.

Fixes #11220.