### PR TITLE
Make leap-second initialisation thread-safe

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -264,6 +264,9 @@ astropy.tests
 astropy.time
 ^^^^^^^^^^^^
 
+- Fix a thread-safety issue with initialization of the leap-second table
+  (which is only an issue when ERFA's built-in table is out of date).
+
 astropy.timeseries
 ^^^^^^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -265,7 +265,7 @@ astropy.time
 ^^^^^^^^^^^^
 
 - Fix a thread-safety issue with initialization of the leap-second table
-  (which is only an issue when ERFA's built-in table is out of date).
+  (which is only an issue when ERFA's built-in table is out of date). [#11234]
 
 astropy.timeseries
 ^^^^^^^^^^^^^^^^^^

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -9,6 +9,7 @@ astronomy.
 
 import os
 import copy
+import enum
 import operator
 import threading
 from datetime import datetime, date, timedelta
@@ -97,8 +98,13 @@ SIDEREAL_TIME_MODELS = {
         'IAU1994': {'function': erfa.gst94, 'scales': ('ut1',)}}}
 
 
-_LEAP_SECONDS_CHECKED = False
-_LEAP_SECONDS_CHECK_STARTED = False         # See comments where it is used
+class _LeapSecondsCheck(enum.Enum):
+    NOT_STARTED = 0     # No thread has reached the check
+    RUNNING = 1         # A thread is running update_leap_seconds (_LEAP_SECONDS_LOCK is held)
+    DONE = 2            # update_leap_seconds has completed
+
+
+_LEAP_SECONDS_CHECK = _LeapSecondsCheck.NOT_STARTED
 _LEAP_SECONDS_LOCK = threading.RLock()
 
 
@@ -1484,21 +1490,20 @@ class Time(TimeBase):
         # In principle, this may cause wrong leap seconds in
         # update_leap_seconds itself, but since expiration is in
         # units of days, that is fine.
-        global _LEAP_SECONDS_CHECKED, _LEAP_SECONDS_CHECK_STARTED
-        if not _LEAP_SECONDS_CHECKED:
+        global _LEAP_SECONDS_CHECK
+        if _LEAP_SECONDS_CHECK != _LeapSecondsCheck.DONE:
             with _LEAP_SECONDS_LOCK:
                 # There are three ways we can get here:
-                # 1. First call.
-                # 2. Re-entrant call. Then _LEAP_SECONDS_CHECK_STARTED will
-                #    already be true, and we skip the initialisation and
-                #    don't worry about leap second errors.
-                # 3. Another thread which raced with the first call. The
-                #    first thread has relinquished the lock to us, so
-                #    initialization is complete.
-                if not _LEAP_SECONDS_CHECK_STARTED:
-                    _LEAP_SECONDS_CHECK_STARTED = True
+                # 1. First call (NOT_STARTED).
+                # 2. Re-entrant call (RUNNING). We skip the initialisation
+                #    and don't worry about leap second errors.
+                # 3. Another thread which raced with the first call
+                #    (RUNNING). The first thread has relinquished the
+                #    lock to us, so initialization is complete.
+                if _LEAP_SECONDS_CHECK == _LeapSecondsCheck.NOT_STARTED:
+                    _LEAP_SECONDS_CHECK = _LeapSecondsCheck.RUNNING
                     update_leap_seconds()
-                    _LEAP_SECONDS_CHECKED = True
+                    _LEAP_SECONDS_CHECK = _LeapSecondsCheck.DONE
 
         if isinstance(val, Time):
             self = val.replicate(format=format, copy=copy, cls=cls)

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -10,8 +10,8 @@ astronomy.
 import os
 import copy
 import operator
-from datetime import datetime, date, timedelta
 import threading
+from datetime import datetime, date, timedelta
 from time import strftime
 from warnings import warn
 

--- a/astropy/time/tests/test_update_leap_seconds.py
+++ b/astropy/time/tests/test_update_leap_seconds.py
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta
 
 import pytest
@@ -7,7 +8,8 @@ import erfa
 from astropy.utils import iers
 from astropy.utils.exceptions import AstropyWarning
 
-from astropy.time import update_leap_seconds
+import astropy.time.core
+from astropy.time import update_leap_seconds, Time
 
 
 class TestUpdateLeapSeconds:
@@ -81,3 +83,20 @@ class TestUpdateLeapSeconds:
 
         with pytest.warns(iers.IERSStaleWarning):
             update_leap_seconds(['erfa', expired_file])
+
+    def test_init_thread_safety(self):
+        # Set up expired ERFA leap seconds.
+        expired = self.erfa_ls[self.erfa_ls['year'] < 2017]
+        expired.update_erfa_leap_seconds(initialize_erfa='empty')
+        # Force re-initialization, even if another test already did it
+        # (assert isinstance just to check that they haven't moved)
+        assert isinstance(astropy.time.core._LEAP_SECONDS_CHECKED, bool)
+        assert isinstance(astropy.time.core._LEAP_SECONDS_CHECK_STARTED, bool)
+        astropy.time.core._LEAP_SECONDS_CHECKED = False
+        astropy.time.core._LEAP_SECONDS_CHECK_STARTED = False
+        workers = 4
+        with ThreadPoolExecutor(max_workers=workers) as executor:
+            futures = [executor.submit(lambda: str(Time('2019-01-01 00:00:00.000').tai))
+                       for i in range(workers)]
+            results = [future.result() for future in futures]
+            assert results == ['2019-01-01 00:00:37.000'] * workers

--- a/astropy/time/tests/test_update_leap_seconds.py
+++ b/astropy/time/tests/test_update_leap_seconds.py
@@ -89,11 +89,10 @@ class TestUpdateLeapSeconds:
         expired = self.erfa_ls[self.erfa_ls['year'] < 2017]
         expired.update_erfa_leap_seconds(initialize_erfa='empty')
         # Force re-initialization, even if another test already did it
-        # (assert isinstance just to check that they haven't moved)
-        assert isinstance(astropy.time.core._LEAP_SECONDS_CHECKED, bool)
-        assert isinstance(astropy.time.core._LEAP_SECONDS_CHECK_STARTED, bool)
-        astropy.time.core._LEAP_SECONDS_CHECKED = False
-        astropy.time.core._LEAP_SECONDS_CHECK_STARTED = False
+        # (assert isinstance just to check that it hasn't moved)
+        assert isinstance(astropy.time.core._LEAP_SECONDS_CHECK,
+                          astropy.time.core._LeapSecondsCheck)
+        astropy.time.core._LEAP_SECONDS_CHECK = astropy.time.core._LeapSecondsCheck.NOT_STARTED
         workers = 4
         with ThreadPoolExecutor(max_workers=workers) as executor:
             futures = [executor.submit(lambda: str(Time('2019-01-01 00:00:00.000').tai))

--- a/astropy/time/tests/test_update_leap_seconds.py
+++ b/astropy/time/tests/test_update_leap_seconds.py
@@ -84,15 +84,13 @@ class TestUpdateLeapSeconds:
         with pytest.warns(iers.IERSStaleWarning):
             update_leap_seconds(['erfa', expired_file])
 
-    def test_init_thread_safety(self):
+    def test_init_thread_safety(self, monkeypatch):
         # Set up expired ERFA leap seconds.
         expired = self.erfa_ls[self.erfa_ls['year'] < 2017]
         expired.update_erfa_leap_seconds(initialize_erfa='empty')
         # Force re-initialization, even if another test already did it
-        # (assert isinstance just to check that it hasn't moved)
-        assert isinstance(astropy.time.core._LEAP_SECONDS_CHECK,
-                          astropy.time.core._LeapSecondsCheck)
-        astropy.time.core._LEAP_SECONDS_CHECK = astropy.time.core._LeapSecondsCheck.NOT_STARTED
+        monkeypatch.setattr(astropy.time.core, '_LEAP_SECONDS_CHECK',
+                            astropy.time.core._LeapSecondsCheck.NOT_STARTED)
         workers = 4
         with ThreadPoolExecutor(max_workers=workers) as executor:
             futures = [executor.submit(lambda: str(Time('2019-01-01 00:00:00.000').tai))


### PR DESCRIPTION
### Description
Add a lock and some extra logic so that if multiple threads race to
construct `Time`s, the first will do the leap-second update check and
the rest will wait for it.

Fixes #11233.