### PR TITLE
adding `STOKES` polarisation to map the CTYPE  axis name to UCD1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -120,6 +120,8 @@ astropy.wcs
 ^^^^^^^^^^^
 - Add IVOA UCD mappings for some FITS WCS keywords commonly used in solar physics. [#10965]
 
+- Add ``STOKES`` FITS WCS keyword to the IVOA UCD mapping. [#11236]
+
 API Changes
 -----------
 

--- a/astropy/wcs/wcsapi/fitswcs.py
+++ b/astropy/wcs/wcsapi/fitswcs.py
@@ -118,6 +118,7 @@ CTYPE_TO_UCD1 = {
     'AWAV': 'em.wl',  # Air wavelength
     'VELO': 'spect.dopplerVeloc',  # Apparent radial velocity
     'BETA': 'custom:spect.doplerVeloc.beta',  # Beta factor (v/c)
+    'STOKES': 'phys.polarization.stokes',  # STOKES parameters
 
     # Time coordinates (https://www.aanda.org/articles/aa/pdf/2015/02/aa24653-14.pdf)
     'TIME': 'time',

--- a/astropy/wcs/wcsapi/tests/test_fitswcs.py
+++ b/astropy/wcs/wcsapi/tests/test_fitswcs.py
@@ -929,6 +929,23 @@ def test_sub_wcsapi_attributes():
     assert wcs_sub4.world_axis_names == ['', '']
 
 
+HEADER_POLARIZED = """
+CTYPE1  = 'HPLT-TAN'
+CTYPE2  = 'HPLN-TAN'
+CTYPE3  = 'STOKES'
+"""
+
+
+@pytest.fixture
+def header_polarized():
+    return Header.fromstring(HEADER_POLARIZED, sep='\n')
+
+
+def test_phys_type_polarization(header_polarized):
+    w = WCS(header_polarized)
+    assert w.world_axis_physical_types[2] == 'phys.polarization.stokes'
+
+
 ###############################################################################
 # Spectral transformations
 ###############################################################################


### PR DESCRIPTION
### Description
This PR is to address the fact that when `STOKES` is given as a `CTYPE` to a WCS object it doesn't map to a physical type. 
For example:

```python
>>> data = np.random.rand(4, 5, 5)
>>> wcs = astropy.wcs.WCS(naxis=3)
>>> wcs.wcs.ctype = 'HPLT-TAN', 'HPLN-TAN', 'STOKES'
>>> wcs.wcs.cunit = 'deg', 'deg', ''
>>> wcs.wcs.cdelt =  0.5, 0.4, 1
>>> wcs.wcs.crpix =  2, 2, 0
>>> wcs.wcs.crval =  0.5, 1, 1
```

when you look at this it returns None for STOKES. 
```python
>>> wcs.world_axis_physical_types
['custom:pos.helioprojective.lat',
 'custom:pos.helioprojective.lon',
None]
```

This PR now includes STOKES in the mapping dictionary and hence now returns
```python
>>> wcs.world_axis_physical_types
['custom:pos.helioprojective.lat',
 'custom:pos.helioprojective.lon',
 'phys.polarization.stokes']
```


