### PR TITLE
Introduce a special function for unit scale conversion.

### DIFF
--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -886,7 +886,12 @@ class UnitBase:
             f"{unit_str} and {other_str} are not convertible")
 
     def _get_converter(self, other, equivalencies=[]):
-        other = Unit(other)
+        """Get a converter for values in ``self`` to ``other``.
+
+        If no conversion is necessary, returns ``unit_scale_converter``
+        (which is used as a check in quantity helpers).
+
+        """
 
         # First see if it is just a scaling.
         try:
@@ -894,7 +899,10 @@ class UnitBase:
         except UnitsError:
             pass
         else:
-            return lambda val: scale * _condition_arg(val)
+            if scale == 1.:
+                return unit_scale_converter
+            else:
+                return lambda val: scale * _condition_arg(val)
 
         # if that doesn't work, maybe we can do it with equivalencies?
         try:
@@ -982,7 +990,8 @@ class UnitBase:
         if other is self and value is UNITY:
             return UNITY
         else:
-            return self._get_converter(other, equivalencies=equivalencies)(value)
+            return self._get_converter(Unit(other),
+                                       equivalencies=equivalencies)(value)
 
     def in_units(self, other, value=1.0, equivalencies=[]):
         """
@@ -2380,6 +2389,15 @@ def _condition_arg(value):
         raise ValueError("Value not scalar compatible or convertible to "
                          "an int, float, or complex array")
     return avalue
+
+
+def unit_scale_converter(val):
+    """Function that just multiplies the value by unity.
+
+    This is a separate function so it can be recognized and
+    discarded in unit conversion.
+    """
+    return 1. * _condition_arg(val)
 
 
 dimensionless_unscaled = CompositeUnit(1, [], [], _error_check=False)

--- a/astropy/units/quantity_helper/helpers.py
+++ b/astropy/units/quantity_helper/helpers.py
@@ -15,7 +15,8 @@ import numpy as np
 from . import UFUNC_HELPERS, UNSUPPORTED_UFUNCS
 from astropy.units.core import (
     UnitsError, UnitConversionError, UnitTypeError,
-    dimensionless_unscaled, get_current_unit_registry)
+    dimensionless_unscaled, get_current_unit_registry,
+    unit_scale_converter)
 
 
 def _d(unit):
@@ -28,17 +29,8 @@ def _d(unit):
 def get_converter(from_unit, to_unit):
     """Like Unit._get_converter, except returns None if no scaling is needed,
     i.e., if the inferred scale is unity."""
-    try:
-        scale = from_unit._to(to_unit)
-    except UnitsError:
-        return from_unit._apply_equivalencies(
-                from_unit, to_unit, get_current_unit_registry().equivalencies)
-    except AttributeError:
-        raise UnitTypeError(f"Unit '{from_unit}' cannot be converted to '{to_unit}'")
-    if scale == 1.:
-        return None
-    else:
-        return lambda val: scale * val
+    converter = from_unit._get_converter(to_unit)
+    return None if converter is unit_scale_converter else converter
 
 
 def get_converters_and_unit(f, unit1, unit2):

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -13,20 +13,6 @@ from astropy import constants as c
 from astropy.units import utils
 
 
-def test_getting_started():
-    """
-    Corresponds to "Getting Started" section in the docs.
-    """
-    from astropy.units import imperial
-    with imperial.enable():
-        speed_unit = u.cm / u.s
-        x = speed_unit.to(imperial.mile / u.hour, 1)
-        assert_allclose(x, 0.02236936292054402)
-        speed_converter = speed_unit._get_converter("mile hour^-1")
-        x = speed_converter([1., 1000., 5000.])
-        assert_allclose(x, [2.23693629e-02, 2.23693629e+01, 1.11846815e+02])
-
-
 def test_initialisation():
     assert u.Unit(u.m) is u.m
 


### PR DESCRIPTION
This allows one to remove duplication of functionality in `quantity_helpers`.

Note that the commit also removes a test that uses a private method. Contrary to the description of the test, it no longer does anything recommended in the documentation, so I thought it was better to just remove the test.

p.s. This is factored out from a branch introducing structured units and quantities, which are needed to be able to properly deal with ERFA ufuncs. It seemed useful on its own. Note that it is not essential for that branch, so if on balance slightly changing the private method is seen as too disruptive, this can be dropped.
