### PR TITLE
Fix string formatting for minimum_python_version

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -110,7 +110,7 @@ def minvers(name):
 # be used globally.
 rst_epilog += "\n".join(
     f".. |minimum_{name}_version| replace:: {minvers(name)}"
-    for name in ('numpy', 'erfa', 'scipy', 'yaml', 'asdf', 'matplotlib', 'ipython')) + """
+    for name in ('numpy', 'erfa', 'scipy', 'yaml', 'asdf', 'matplotlib', 'ipython')) + f"""
 .. |minimum_python_version| replace:: {__minimum_python_version__}
 
 .. Astropy


### PR DESCRIPTION
Fixes installation docs, which currently look like this:

<img width="322" alt="astropydocs" src="https://user-images.githubusercontent.com/4992897/104383678-33a7e680-54fe-11eb-933a-448fe09c7f2e.png">
