### PR TITLE
Ensure SkyOffsetFrame can again be transformed back to base frame

### DIFF
--- a/astropy/coordinates/builtin_frames/skyoffset.py
+++ b/astropy/coordinates/builtin_frames/skyoffset.py
@@ -52,9 +52,6 @@ def make_skyoffset_cls(framecls):
          # defaults of SkyOffsetFrame set by BaseCoordinateFrame.
          '_default_representation': framecls._default_representation,
          '_default_differential': framecls._default_differential,
-         # Similarly, we need to ensure the frame attributes are recalculated,
-         # otherwise the default from SkyOffsetFrame will be used.
-         'frame_attributes': None,
          '__doc__': SkyOffsetFrame.__doc__,
          })
 

--- a/astropy/coordinates/tests/test_skyoffset_transformations.py
+++ b/astropy/coordinates/tests/test_skyoffset_transformations.py
@@ -29,6 +29,9 @@ def test_skyoffset(inradec, expectedlatlon, tolsep, originradec=(45, 45)*u.deg):
     expected = SkyCoord(*expectedlatlon, frame=skyoffset_frame)
 
     assert skycoord_inaf.separation(expected) < tolsep
+    # Check we can also transform back (regression test for gh-11254).
+    roundtrip = skycoord_inaf.transform_to(ICRS())
+    assert roundtrip.separation(skycoord) < 1*u.uas
 
 
 def test_skyoffset_functional_ra():


### PR DESCRIPTION
This Meta-class creation was missed in #11099 because there was no test that showed it was a problem. Now got rid of the whole meta-class and added an appropriate test.

Fixes #11254 