### PR TITLE
Small performance refactor of sigma clipping

### DIFF
--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -392,8 +392,6 @@ class SigmaClip:
         iteration = 0
         while nchanged != 0 and (iteration < self.maxiters):
             iteration += 1
-            n_nan = np.count_nonzero(np.isnan(filtered_data))
-
             self._compute_bounds(filtered_data, axis=axis)
             if not np.isscalar(self._min_value):
                 self._min_value = self._min_value.reshape(mshape)
@@ -408,9 +406,8 @@ class SigmaClip:
             if self.grow:
                 new_mask = binary_dilation(new_mask, kernel)
             filtered_data[new_mask] = np.nan
+            nchanged = np.count_nonzero(new_mask)
             del new_mask
-
-            nchanged = n_nan - np.count_nonzero(np.isnan(filtered_data))
 
         self._niterations = iteration
 


### PR DESCRIPTION
While looking at the code in the context of #11219, I noticed that the tracking of the number of rejected pixels could be done a bit more efficiently. Since most time is spent in calculating medians, etc., it does not have a very large effect, but even 5-10% is probably worthwhile. Plus the code is a bit simpler.