### PR TITLE
Define TESTED_VERSIONS for the next version of pytest_astropy_header

### DIFF
--- a/astropy/conftest.py
+++ b/astropy/conftest.py
@@ -11,12 +11,14 @@ import tempfile
 import warnings
 
 try:
-    from pytest_astropy_header.display import PYTEST_HEADER_MODULES
+    from pytest_astropy_header.display import PYTEST_HEADER_MODULES, TESTED_VERSIONS
 except ImportError:
     PYTEST_HEADER_MODULES = {}
+    TESTED_VERSIONS = {}
 
 import pytest
 
+from astropy import __version__
 from astropy.tests.helper import enable_deprecations_as_exceptions
 
 try:
@@ -100,6 +102,7 @@ def pytest_configure(config):
     PYTEST_HEADER_MODULES['Cython'] = 'cython'
     PYTEST_HEADER_MODULES['Scikit-image'] = 'skimage'
     PYTEST_HEADER_MODULES['asdf'] = 'asdf'
+    TESTED_VERSIONS['Astropy'] = __version__
 
 
 def pytest_unconfigure(config):

--- a/conftest.py
+++ b/conftest.py
@@ -8,10 +8,13 @@ import tempfile
 
 import hypothesis
 
+from astropy import __version__
+
 try:
-    from pytest_astropy_header.display import PYTEST_HEADER_MODULES
+    from pytest_astropy_header.display import PYTEST_HEADER_MODULES, TESTED_VERSIONS
 except ImportError:
     PYTEST_HEADER_MODULES = {}
+    TESTED_VERSIONS = {}
 
 
 # This has to be in the root dir or it will not display in CI.
@@ -20,6 +23,7 @@ def pytest_configure(config):
     PYTEST_HEADER_MODULES['Cython'] = 'cython'
     PYTEST_HEADER_MODULES['Scikit-image'] = 'skimage'
     PYTEST_HEADER_MODULES['asdf'] = 'asdf'
+    TESTED_VERSIONS['Astropy'] = __version__
 
 
 # This has to be in the root dir or it will not display in CI.


### PR DESCRIPTION
pytest_astropy_header will no more define Astropy by default in TESTED_VERSIONS, so let's add it here. This is compatible with the current version of pytest_astropy_header.