### PR TITLE
Adding custom bins to aggregate_downsample

### DIFF
--- a/astropy/timeseries/tests/test_downsample.py
+++ b/astropy/timeseries/tests/test_downsample.py
@@ -11,9 +11,10 @@ from astropy.timeseries.sampled import TimeSeries
 from astropy.timeseries.downsample import aggregate_downsample, reduceat
 
 INPUT_TIME = Time(['2016-03-22T12:30:31', '2016-03-22T12:30:32',
-                   '2016-03-22T12:30:33', '2016-03-22T12:30:34'])
-ts = TimeSeries(time=INPUT_TIME, data=[[1, 2, 3, 4]], names=['a'])
-ts_units = TimeSeries(time=INPUT_TIME, data=[[1, 2, 3, 4] * u.count], names=['a'])
+                   '2016-03-22T12:30:33', '2016-03-22T12:30:34',
+                   '2016-03-22T12:30:35'])
+ts = TimeSeries(time=INPUT_TIME, data=[[1, 2, 3, 4, 5]], names=['a'])
+ts_units = TimeSeries(time=INPUT_TIME, data=[[1, 2, 3, 4, 5] * u.count], names=['a'])
 
 
 def test_reduceat():
@@ -36,34 +37,54 @@ def test_timeseries_invalid():
     assert exc.value.args[0] == ("time_series should be a TimeSeries")
 
     with pytest.raises(TypeError) as exc:
-        aggregate_downsample(TimeSeries())
+        aggregate_downsample(TimeSeries(), time_bin_size=1)
     assert exc.value.args[0] == ("time_bin_size should be a astropy.unit quantity")
 
 
 def test_downsample():
     down_1 = aggregate_downsample(ts, time_bin_size=1*u.second)
-    u.isclose(down_1.time_bin_size, [1, 1, 1, 1]*u.second)
+    u.isclose(down_1.time_bin_size, [1, 1, 1, 1, 1]*u.second)
     assert_equal(down_1.time_bin_start.isot, Time(['2016-03-22T12:30:31.000', '2016-03-22T12:30:32.000',
-                                                   '2016-03-22T12:30:33.000', '2016-03-22T12:30:34.000']))
-    assert_equal(down_1["a"].data, np.array([1, 2, 3, 4]))
+                                                   '2016-03-22T12:30:33.000', '2016-03-22T12:30:34.000',
+                                                   '2016-03-22T12:30:35.000']))
+    assert_equal(down_1["a"].data, np.array([1, 2, 3, 4, 5]))
 
     down_2 = aggregate_downsample(ts, time_bin_size=2*u.second)
-    u.isclose(down_2.time_bin_size, [2, 2]*u.second)
-    assert_equal(down_2.time_bin_start.isot, Time(['2016-03-22T12:30:31.000', '2016-03-22T12:30:33.000']))
-    assert_equal(down_2["a"].data, np.array([1, 3]))
+    u.isclose(down_2.time_bin_size, [2, 2, 2]*u.second)
+    assert_equal(down_2.time_bin_start.isot, Time(['2016-03-22T12:30:31.000', '2016-03-22T12:30:33.000',
+                                                   '2016-03-22T12:30:35.000']))
+    assert_equal(down_2["a"].data, np.array([1, 3, 5]))
 
     down_3 = aggregate_downsample(ts, time_bin_size=3*u.second)
     u.isclose(down_3.time_bin_size, [3, 3]*u.second)
     assert_equal(down_3.time_bin_start.isot, Time(['2016-03-22T12:30:31.000', '2016-03-22T12:30:34.000']))
-    assert_equal(down_3["a"].data, np.array([2, 4]))
+    assert_equal(down_3["a"].data, np.array([2, 5]))
 
     down_4 = aggregate_downsample(ts, time_bin_size=4*u.second)
-    u.isclose(down_4.time_bin_size, [4]*u.second)
-    assert_equal(down_4.time_bin_start.isot, Time(['2016-03-22T12:30:31.000']))
-    assert_equal(down_4["a"].data, np.array([2]))
+    u.isclose(down_4.time_bin_size, [4, 4]*u.second)
+    assert_equal(down_4.time_bin_start.isot, Time(['2016-03-22T12:30:31.000', '2016-03-22T12:30:35.000']))
+    assert_equal(down_4["a"].data, np.array([2, 5]))
 
     down_units = aggregate_downsample(ts_units, time_bin_size=4*u.second)
-    u.isclose(down_units.time_bin_size, [4]*u.second)
-    assert_equal(down_units.time_bin_start.isot, Time(['2016-03-22T12:30:31.000']))
+    u.isclose(down_units.time_bin_size, [4, 4]*u.second)
+    assert_equal(down_units.time_bin_start.isot, Time(['2016-03-22T12:30:31.000', '2016-03-22T12:30:35.000']))
     assert down_units["a"].unit.name == 'ct'
-    assert_equal(down_units["a"].data, np.array([2.5]))
+    assert_equal(down_units["a"].data, np.array([2.5, 5.0]))
+
+    # Uneven bin sizes
+    down_uneven_bins = aggregate_downsample(ts, time_bin_size=[2, 1, 1]*u.second)
+    u.isclose(down_uneven_bins.time_bin_size, [2, 1, 1]*u.second)
+    assert_equal(down_uneven_bins.time_bin_start.isot, Time(['2016-03-22T12:30:31.000',
+                                                             '2016-03-22T12:30:33.000',
+                                                             '2016-03-22T12:30:34.000']))
+    assert_equal(down_uneven_bins["a"].data, np.array([1, 3, 4]))
+
+    # Uneven bins
+    down_time_array = aggregate_downsample(ts, time_bin_start=Time(['2016-03-22T12:30:31.000',
+                                                                    '2016-03-22T12:30:33.000']),
+                                           time_bin_end=Time(['2016-03-22T12:30:32.000',
+                                                              '2016-03-22T12:30:35.000']))
+    u.isclose(down_time_array.time_bin_size, [1, 2]*u.second)
+    assert_equal(down_time_array.time_bin_start.isot, Time(['2016-03-22T12:30:31.000',
+                                                            '2016-03-22T12:30:33.000']))
+    assert_equal(down_time_array["a"].data, np.array([1, 4]))


### PR DESCRIPTION
### Description
This pull request adds custom binning to `aggregate_downsample` by allowing `time_bin_start` and `time_bin_end` to be arrays. In addition, there is now an optional  `time_bin_end` argument which can be an array as well.

Fixes #8584
