### PR TITLE
Add warning about integer casting in Quantity

### DIFF
--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -272,6 +272,8 @@ class Quantity(np.ndarray):
     Quantities can also be created by multiplying a number or array with a
     :class:`~astropy.units.Unit`. See https://docs.astropy.org/en/latest/units/
 
+    Unless the ``dtype`` argument is explicitly specified, integer
+    or (non-Quantity) object inputs are converted to `float` by default.
     """
     # Need to set a class-level default for _equivalencies, or
     # Constants can not initialize properly


### PR DESCRIPTION
Personally I think this is surprising enough behaviour that is warrants a prominent warning. xref https://github.com/astropy/astropy/issues/10079