### PR TITLE
Fix calls to 'with_observer_stationary_relative_to' in FITSWCSAPIMixin

### DIFF
--- a/astropy/wcs/wcsapi/fitswcs.py
+++ b/astropy/wcs/wcsapi/fitswcs.py
@@ -501,7 +501,7 @@ class FITSWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
                                       'frame change', AstropyUserWarning)
                         return spectralcoord.to_value(u.m) / self.wcs.restwav - 1.
                     else:
-                        return spectralcoord.in_observer_velocity_frame(observer).to_value(u.m) / self.wcs.restwav - 1.
+                        return spectralcoord.with_observer_stationary_relative_to(observer).to_value(u.m) / self.wcs.restwav - 1.
 
                 classes['spectral'] = (u.Quantity, (), {}, spectralcoord_from_redshift)
                 components[self.wcs.spec] = ('spectral', 0, redshift_from_spectralcoord)
@@ -524,7 +524,7 @@ class FITSWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
                                       'frame change', AstropyUserWarning)
                         return spectralcoord.to_value(u.m / u.s, doppler_equiv) / C_SI
                     else:
-                        return spectralcoord.in_observer_velocity_frame(observer).to_value(u.m / u.s, doppler_equiv) / C_SI
+                        return spectralcoord.with_observer_stationary_relative_to(observer).to_value(u.m / u.s, doppler_equiv) / C_SI
 
                 classes['spectral'] = (u.Quantity, (), {}, spectralcoord_from_beta)
                 components[self.wcs.spec] = ('spectral', 0, beta_from_spectralcoord)
@@ -555,7 +555,7 @@ class FITSWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
                                       'frame change', AstropyUserWarning)
                         return spectralcoord.to_value(**kwargs)
                     else:
-                        return spectralcoord.in_observer_velocity_frame(observer).to_value(**kwargs)
+                        return spectralcoord.with_observer_stationary_relative_to(observer).to_value(**kwargs)
 
                 classes['spectral'] = (u.Quantity, (), {}, spectralcoord_from_value)
                 components[self.wcs.spec] = ('spectral', 0, value_from_spectralcoord)


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request updates calls to `SpectralCoord.with_observer_stationary_relative_to` in [`FITSWCSAPIMixin`](https://github.com/astropy/astropy/blob/master/astropy/wcs/wcsapi/fitswcs.py#L504) that were made in https://github.com/astropy/astropy/commit/14fb024578c7f37c463e995403b53e29ae7d7733.

cc: @astrofrog 

This issue came up when reprojecting one spectral cube to match another. Here is the snippet and traceback:

```
from spectral_cube import SpectralCube
cube = SpectralCube.read("Brick2Tile3_M33_14B_17B_HI_contsub_width_1kms.image.pbcor.GBT_feathered_K.fits")
cube_to_match = SpectralCube.read("Brick2Tile3_12CO21_1p3kms.image.pbcor_K_round_downsamp2.fits")

cube_matched = cube.reproject(cube_to_match.header)
```

```
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-3-a7abc261fdaa> in <module>
----> 1 cube_rep = cube.reproject(co_cube.header)

~/ownCloud/code_development/radio_astro_tools/spectral-cube/spectral_cube/utils.py in wrapper(self, *args, **kwargs)
     47                           PossiblySlowWarning
     48                          )
---> 49         return function(self, *args, **kwargs)
     50     return wrapper
     51 

~/ownCloud/code_development/radio_astro_tools/spectral-cube/spectral_cube/spectral_cube.py in reproject(self, header, order, use_memmap, filled)
   2632             outarray = None
   2633 
-> 2634         newcube, newcube_valid = reproject_interp((data,
   2635                                                    self.header),
   2636                                                   newwcs,

~/anaconda3/envs/py38/lib/python3.8/site-packages/astropy/utils/decorators.py in wrapper(*args, **kwargs)
    533                     warnings.warn(message, warning_type, stacklevel=2)
    534 
--> 535             return function(*args, **kwargs)
    536 
    537         return wrapper

~/ownCloud/code_development/reproject/reproject/interpolation/high_level.py in reproject_interp(input_data, output_projection, shape_out, hdu_in, order, independent_celestial_slices, output_array, return_footprint)
     83         order = ORDER[order]
     84 
---> 85     return _reproject_full(array_in, wcs_in, wcs_out, shape_out=shape_out, order=order,
     86                            array_out=output_array, return_footprint=return_footprint)

~/ownCloud/code_development/reproject/reproject/interpolation/core.py in _reproject_full(array, wcs_in, wcs_out, shape_out, order, array_out, return_footprint)
     80                             indexing='ij', sparse=False, copy=False)
     81     pixel_out = [p.ravel() for p in pixel_out]
---> 82     pixel_in = efficient_pixel_to_pixel_with_roundtrip(wcs_out, wcs_in, *pixel_out[::-1])[::-1]
     83     pixel_in = np.array(pixel_in)
     84 

~/ownCloud/code_development/reproject/reproject/wcs_utils.py in efficient_pixel_to_pixel_with_roundtrip(wcs1, wcs2, *inputs)
    216 def efficient_pixel_to_pixel_with_roundtrip(wcs1, wcs2, *inputs):
    217 
--> 218     outputs = efficient_pixel_to_pixel(wcs1, wcs2, *inputs)
    219 
    220     # Now convert back to check that coordinates round-trip, if not then set to NaN

~/ownCloud/code_development/reproject/reproject/wcs_utils.py in efficient_pixel_to_pixel(wcs1, wcs2, *inputs)
    192         if not isinstance(world_outputs, (tuple, list)):
    193             world_outputs = (world_outputs,)
--> 194         pixel_outputs = wcs2.world_to_pixel(*world_outputs)
    195 
    196         for ipix in range(wcs2.pixel_n_dim):

~/anaconda3/envs/py38/lib/python3.8/site-packages/astropy/wcs/wcsapi/high_level_api.py in world_to_pixel(self, *world_objects)
    225         for key, _, attr in components:
    226             if callable(attr):
--> 227                 world.append(attr(objects[key]))
    228             else:
    229                 world.append(rec_getattr(objects[key], attr))

~/anaconda3/envs/py38/lib/python3.8/site-packages/astropy/wcs/wcsapi/fitswcs.py in value_from_spectralcoord(spectralcoord)
    548                         return spectralcoord.to_value(**kwargs)
    549                     else:
--> 550                         return spectralcoord.in_observer_velocity_frame(observer).to_value(**kwargs)
    551 
    552                 classes['spectral'] = (u.Quantity, (), {}, spectralcoord_from_value)

~/anaconda3/envs/py38/lib/python3.8/site-packages/astropy/units/quantity.py in __getattr__(self, attr)
    857 
    858         if value is None:
--> 859             raise AttributeError(
    860                 "{} instance has no attribute '{}'".format(
    861                     self.__class__.__name__, attr))

AttributeError: SpectralCoord instance has no attribute 'in_observer_velocity_frame'
```

It wasn't clear to me where a test should be added to catch this case.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->
