### PR TITLE
Clarify changelog entry for CDS dimensionless unit change [skip ci]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1230,8 +1230,9 @@ astropy.units
 - For ``Quantity.to_string()``, ensure that the precision argument is also
   used when the format is not latex. [#11145]
 
-- For CDS units and tables, recognize ``-`` as indicating dimensionless and
-  ``[-]`` as indicating base 10 logarithm of dimensionless. [#11250]
+- For CDS units and tables, recognize ``---`` and ``-`` as indicating
+  dimensionless and ``[-]`` as indicating base 10 logarithm of dimensionless.
+  [#11250]
 
 astropy.utils
 ^^^^^^^^^^^^^


### PR DESCRIPTION
To avoid anyone else having to go through git bisect to find out why Vizier tables are not quite read the same way as before... See 
https://github.com/astropy/astropy/pull/11250#issuecomment-768493492