### PR TITLE
Fixed bug where allowing dimensionless input broke unit checking

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -417,6 +417,10 @@ astropy.uncertainty
 astropy.units
 ^^^^^^^^^^^^^
 
+- Fixed a bug with the ``quantity_input`` decorator where allowing
+  dimensionless inputs for an argument inadvertently disabled any checking of
+  compatible units for that argument. [#11283]
+
 astropy.utils
 ^^^^^^^^^^^^^
 

--- a/astropy/units/decorators.py
+++ b/astropy/units/decorators.py
@@ -55,9 +55,10 @@ def _validate_arg_value(param_name, func_name, arg, targets, equivalencies,
 
     allowed_units = _get_allowed_units(targets)
 
-    # If dimensionless is an allowed unit, allow numbers or numpy arrays with
-    #  numeric dtypes:
-    if dimensionless_unscaled in allowed_units and not strict_dimensionless:
+    # If dimensionless is an allowed unit and the argument is unit-less,
+    #   allow numbers or numpy arrays with numeric dtypes
+    if (dimensionless_unscaled in allowed_units and not strict_dimensionless
+            and not hasattr(arg, "unit")):
         if isinstance(arg, Number):
             return
 

--- a/astropy/units/tests/test_quantity_decorator.py
+++ b/astropy/units/tests/test_quantity_decorator.py
@@ -407,3 +407,18 @@ def test_allow_dimensionless_numeric_strict(val):
 
     with pytest.raises(TypeError):
         assert myfunc(val)
+
+
+@pytest.mark.parametrize('val', [1*u.deg, [1, 2, 3]*u.m])
+def test_dimensionless_with_nondimensionless_input(val):
+    """
+    When dimensionless_unscaled is the only allowed unit, don't let input with
+    non-dimensionless units through
+    """
+
+    @u.quantity_input(x=u.dimensionless_unscaled)
+    def myfunc(x):
+        return x
+
+    with pytest.raises(u.UnitsError):
+        myfunc(val)


### PR DESCRIPTION
#10232 contained a bug where the `quantity_input` decorator no longer properly checked units for arguments where dimensionless input is allowed.  For example:
```python
@u.quantity_input(x=u.dimensionless_unscaled)
def test(x):
    return x
```
would not properly raise an error for `test(1*u.deg)` because `Quantity` inputs automatically pass this check due to subclassing:
https://github.com/astropy/astropy/blob/4d31e6ce66719cf3a180ebcc45ff64d027a9413c/astropy/units/decorators.py#L64-L65
which then aborted unit checking.

This PR fixes the bug.