### PR TITLE
Ignore errors about invalid headers when extra data are found at EOF

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -49,9 +49,6 @@ astropy.io.fits
 - Expose ``Header.strip`` as a public method, to remove the most common
   structural keywords. [#11174]
 
-- Fix misleading missing END card error when extra data are found at the end
-  of the file. [#11285] 
-
 astropy.io.misc
 ^^^^^^^^^^^^^^^
 
@@ -1191,6 +1188,8 @@ astropy.io.fits
 - Fix parsing of RVKC header card patterns that were not recognised
   where multiple spaces were separating field-specifier and value like
   "DP1.AXIS.1:   1". [#11301]
+- Fix misleading missing END card error when extra data are found at the end
+  of the file. [#11285] 
 
 astropy.io.misc
 ^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -49,6 +49,9 @@ astropy.io.fits
 - Expose ``Header.strip`` as a public method, to remove the most common
   structural keywords. [#11174]
 
+- Fix misleading missing END card error when extra data are found at the end
+  of the file. [#11285] 
+
 astropy.io.misc
 ^^^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1188,6 +1188,7 @@ astropy.io.fits
 - Fix parsing of RVKC header card patterns that were not recognised
   where multiple spaces were separating field-specifier and value like
   "DP1.AXIS.1:   1". [#11301]
+
 - Fix misleading missing END card error when extra data are found at the end
   of the file. [#11285] 
 

--- a/astropy/io/fits/header.py
+++ b/astropy/io/fits/header.py
@@ -34,10 +34,6 @@ HEADER_END_RE = re.compile(encode_ascii(
 VALID_HEADER_CHARS = set(map(chr, range(0x20, 0x7F)))
 END_CARD = 'END' + ' ' * 77
 
-# According to the FITS standard the header should
-# start with the keyword SIMPLE
-SIMPLE_KEY = encode_ascii('SIMPLE  =')
-
 
 __doctest_skip__ = ['Header', 'Header.comments', 'Header.fromtextfile',
                     'Header.totextfile', 'Header.set', 'Header.update']
@@ -579,14 +575,12 @@ class Header:
         read_blocks = []
         is_eof = False
         end_found = False
-        is_header = True
 
-        if SIMPLE_KEY not in block:
-            is_header = False
         # continue reading header blocks until END card or EOF is reached
         while True:
             # find the END card
             end_found, block = cls._find_end_card(block, clen)
+
             read_blocks.append(decode_ascii(block))
 
             if end_found:
@@ -605,14 +599,14 @@ class Header:
             if not is_binary:
                 block = encode_ascii(block)
 
-        if not end_found and is_eof and endcard and is_header:
-            # TODO: Pass this error to validation framework as an ERROR,
-            # rather than raising an exception
-            raise OSError('Header missing END card.')
-
         header_str = ''.join(read_blocks)
         _check_padding(header_str, actual_block_size, is_eof,
                        check_block_size=padding)
+
+        if not end_found and is_eof and endcard:
+            # TODO: Pass this error to validation framework as an ERROR,
+            # rather than raising an exception
+            raise OSError('Header missing END card.')
 
         return header_str, cls.fromstring(header_str, sep=sep)
 

--- a/astropy/io/fits/header.py
+++ b/astropy/io/fits/header.py
@@ -582,7 +582,7 @@ class Header:
         is_header = True
 
         if SIMPLE_KEY not in block:
-            is_header = False 
+            is_header = False
         # continue reading header blocks until END card or EOF is reached
         while True:
             # find the END card
@@ -606,9 +606,9 @@ class Header:
                 block = encode_ascii(block)
 
         if not end_found and is_eof and endcard and is_header:
-                # TODO: Pass this error to validation framework as an ERROR,
-                # rather than raising an exception
-                raise OSError('Header missing END card.')
+            # TODO: Pass this error to validation framework as an ERROR,
+            # rather than raising an exception
+            raise OSError('Header missing END card.')
 
         header_str = ''.join(read_blocks)
         _check_padding(header_str, actual_block_size, is_eof,

--- a/astropy/io/fits/tests/test_hdulist.py
+++ b/astropy/io/fits/tests/test_hdulist.py
@@ -560,12 +560,12 @@ class TestHDUListFunctions(FitsTestCase):
         with pytest.warns(
             AstropyUserWarning,
             match='Unexpected extra padding at the end of the file.'
-            ) as w:
-                fits.open(
-                    'https://dataverse.harvard.edu/api/access/datafile/2439198',
-                    cache=False
-                )
-                assert len(w) == 1
+        ) as w:
+            fits.open(
+                'https://dataverse.harvard.edu/api/access/datafile/2439198',
+                cache=False
+            )
+        assert len(w) == 1
 
     @pytest.mark.filterwarnings('ignore:Unexpected extra padding')
     def test_open_file_with_end_padding(self):

--- a/astropy/io/fits/tests/test_hdulist.py
+++ b/astropy/io/fits/tests/test_hdulist.py
@@ -550,6 +550,23 @@ class TestHDUListFunctions(FitsTestCase):
         with fits.open(self.temp('temp.fits'), memmap=True) as hdul:
             assert ((old_data + 1) == hdul[1].data).all()
 
+    @pytest.mark.remote_data
+    def test_open_file_with_bad_file_padding(self):
+        """
+        Test warning when opening files with extra padding at the end.
+        See https://github.com/astropy/astropy/issues/4351
+        """
+
+        with pytest.warns(
+            AstropyUserWarning,
+            match='Unexpected extra padding at the end of the file.'
+            ) as w:
+                fits.open(
+                    'https://dataverse.harvard.edu/api/access/datafile/2439198',
+                    cache=False
+                )
+                assert len(w) == 1
+
     @pytest.mark.filterwarnings('ignore:Unexpected extra padding')
     def test_open_file_with_end_padding(self):
         """Regression test for https://aeon.stsci.edu/ssb/trac/pyfits/ticket/106

--- a/astropy/io/fits/tests/test_hdulist.py
+++ b/astropy/io/fits/tests/test_hdulist.py
@@ -550,21 +550,23 @@ class TestHDUListFunctions(FitsTestCase):
         with fits.open(self.temp('temp.fits'), memmap=True) as hdul:
             assert ((old_data + 1) == hdul[1].data).all()
 
-    @pytest.mark.remote_data
     def test_open_file_with_bad_file_padding(self):
         """
         Test warning when opening files with extra padding at the end.
         See https://github.com/astropy/astropy/issues/4351
         """
 
+        # write some arbitrary data to a FITS file
+        fits.writeto(self.temp('temp.fits'), np.arange(100))
+        # append some arbitrary number of zeros to the end
+        with open(self.temp('temp.fits'), 'ab') as fobj:
+            fobj.write(b'\x00' * 1234)
         with pytest.warns(
             AstropyUserWarning,
             match='Unexpected extra padding at the end of the file.'
         ) as w:
-            fits.open(
-                'https://dataverse.harvard.edu/api/access/datafile/2439198',
-                cache=False
-            )
+            with fits.open(self.temp('temp.fits')) as fobj:
+                fobj.info()
         assert len(w) == 1
 
     @pytest.mark.filterwarnings('ignore:Unexpected extra padding')


### PR DESCRIPTION
### Description
This pull request checks if extra data at the end of file contain the SIMPLE keyword, following @embray suggestion in the corresponding issue.
If extra data are not an header a warning is thrown
```
WARNING: Unexpected extra padding at the end of the file.  This padding may not be preserved when saving changes. [astropy.io.fits.header]
```

Fixes #4351

### Additional information
I have added a test but:
- producing a small file with the same issue is quite tricky (edited: I thought it was! :)): I have used the file in the issue (`https://dataverse.harvard.edu/api/access/datafile/2439198`) and marked the test as remote_data
- I can't make the test work: the Warning is not thrown. Yet, running locally
```
>>> from astropy.io import fits
>>> fits.open('https://dataverse.harvard.edu/api/access/datafile/2439198', cache=False)
Downloading https://dataverse.harvard.edu/api/access/datafile/2439198
|==========================================| 511M/511M (100.00%)        14s
WARNING: Unexpected extra padding at the end of the file.  This padding may not be preserved when saving changes. [astropy.io.fits.header]
[<astropy.io.fits.hdu.image.PrimaryHDU object at 0x7f9db80c0220>]
```
gives the expected result. I'm clearly missing something about the way test are written or run...