### PR TITLE
Fix check for byteorder swap in Table.to_pandas()

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1202,6 +1202,10 @@ astropy.stats
 astropy.table
 ^^^^^^^^^^^^^
 
+- Fixed byteorder conversion in ``to_pandas()``, which had incorrectly
+  triggered swapping when native endianness was stored with explicit
+  ``dtype`` code ``'<'`` (or ``'>'``) instead of ``'='``. [#11288]
+
 astropy.tests
 ^^^^^^^^^^^^^
 

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -638,9 +638,6 @@ class Table:
         if len(self.columns) == 0:
             return empty_init(0, dtype=None)
 
-        sys_byteorder = ('>', '<')[sys.byteorder == 'little']
-        native_order = ('=', sys_byteorder)
-
         dtype = []
 
         cols = self.columns.values()
@@ -650,9 +647,8 @@ class Table:
 
         for col in cols:
             col_descr = descr(col)
-            byteorder = col.info.dtype.byteorder
 
-            if not keep_byteorder and byteorder not in native_order:
+            if not (col.info.dtype.isnative or keep_byteorder):
                 new_dt = np.dtype(col_descr[1]).newbyteorder('=')
                 col_descr = (col_descr[0], new_dt, col_descr[2])
 
@@ -3676,9 +3672,8 @@ class Table:
             else:
                 out[name] = column
 
-            if (hasattr(out[name].dtype, 'byteorder')
-                    and out[name].dtype.byteorder not in ('=', '|')):
-                out[name] = out[name].byteswap().newbyteorder()
+            if not getattr(out[name].dtype, 'isnative', True):
+                out[name] = out[name].byteswap().newbyteorder('=')
 
         kwargs = {'index': out.pop(index)} if index else {}
 

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -1801,12 +1801,12 @@ class TestPandas:
 
         t = table.Table()
 
-        for endian in ['<', '>']:
+        for endian in ['<', '>', '=']:
             for kind in ['f', 'i']:
                 for byte in ['2', '4', '8']:
                     dtype = np.dtype(endian + kind + byte)
                     x = np.array([1, 2, 3], dtype=dtype)
-                    t[endian + kind + byte] = x
+                    t[endian + kind + byte] = x.newbyteorder(endian)
 
         t['u'] = ['a', 'b', 'c']
         t['s'] = ['a', 'b', 'c']
@@ -1823,7 +1823,7 @@ class TestPandas:
             else:
                 # We should be able to compare exact values here
                 assert np.all(t[column] == d[column])
-                if t[column].dtype.byteorder in ('=', '|'):
+                if t[column].dtype.isnative:
                     assert d[column].dtype == t[column].dtype
                 else:
                     assert d[column].dtype == t[column].byteswap().newbyteorder().dtype
@@ -1832,6 +1832,8 @@ class TestPandas:
         # ValueError: Big-endian buffer not supported on little-endian
         # compiler. We now automatically swap the endian-ness to native order
         # upon adding the arrays to the data frame.
+        # Explicitly testing little/big/native endian separately -
+        # regression for a case in astropy/astropy#11286 not caught by #3729.
         d[['<i4', '>i4']]
         d[['<f4', '>f4']]
 
@@ -1842,7 +1844,7 @@ class TestPandas:
                 assert np.all(t[column] == t2[column])
             else:
                 assert_allclose(t[column], t2[column])
-            if t[column].dtype.byteorder in ('=', '|'):
+            if t[column].dtype.isnative:
                 assert t[column].dtype == t2[column].dtype
             else:
                 assert t[column].byteswap().newbyteorder().dtype == t2[column].dtype


### PR DESCRIPTION
### Description
Fix #11286 – `Table.to_pandas()` is supposed to export columns always in native byteorder, i.e. swap if, and only if, `dtype.byteorder` is non-native. This failed in some cases with data identifying e.g. as `byteorder='<'` on a little-endian system, which was not recognised as `'='` and thus incorrectly swap.

This PR attempts to improve identification of non-native byteorder and extends the tests to probe '<', '>', '=' independently.

EDIT: Corrected auto-close syntax