### PR TITLE
Add native to_pandas byteorder conversion for ArrayWrapper Tables

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1208,7 +1208,7 @@ astropy.table
 
 - Fixed byteorder conversion in ``to_pandas()``, which had incorrectly
   triggered swapping when native endianness was stored with explicit
-  ``dtype`` code ``'<'`` (or ``'>'``) instead of ``'='``. [#11288]
+  ``dtype`` code ``'<'`` (or ``'>'``) instead of ``'='``. [#11288, #11294]
 
 astropy.tests
 ^^^^^^^^^^^^^

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -3662,7 +3662,7 @@ class Table:
                     pd_dtype = column.dtype.name
                     if use_nullable_int:
                         # Convert int64 to Int64, uint32 to UInt32, etc for nullable types
-                        pd_dtype = pd_dtype.capitalize().replace('i', 'I')
+                        pd_dtype = pd_dtype.replace('i', 'I').replace('u', 'U')
                     out[name] = Series(out[name], dtype=pd_dtype)
 
                     # If pandas is older than 0.24 the type may have turned to float

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -3652,28 +3652,26 @@ class Table:
         out = OrderedDict()
 
         for name, column in tbl.columns.items():
+            if getattr(column.dtype, 'isnative', True):
+                out[name] = column
+            else:
+                out[name] = column.data.byteswap().newbyteorder('=')
+
             if isinstance(column, MaskedColumn) and np.any(column.mask):
                 if column.dtype.kind in ['i', 'u']:
-                    pd_dtype = str(column.dtype)
+                    pd_dtype = column.dtype.name
                     if use_nullable_int:
                         # Convert int64 to Int64, uint32 to UInt32, etc for nullable types
-                        pd_dtype = pd_dtype.replace('i', 'I').replace('u', 'U')
-                    out[name] = Series(column, dtype=pd_dtype)
+                        pd_dtype = pd_dtype.capitalize().replace('i', 'I')
+                    out[name] = Series(out[name], dtype=pd_dtype)
 
                     # If pandas is older than 0.24 the type may have turned to float
                     if column.dtype.kind != out[name].dtype.kind:
                         warnings.warn(
                             f"converted column '{name}' from {column.dtype} to {out[name].dtype}",
                             TableReplaceWarning, stacklevel=3)
-                elif column.dtype.kind in ['f', 'c']:
-                    out[name] = column
-                else:
+                elif column.dtype.kind not in ['f', 'c']:
                     out[name] = column.astype(object).filled(np.nan)
-            else:
-                out[name] = column
-
-            if not getattr(out[name].dtype, 'isnative', True):
-                out[name] = out[name].byteswap().newbyteorder('=')
 
         kwargs = {'index': out.pop(index)} if index else {}
 

--- a/astropy/table/tests/conftest.py
+++ b/astropy/table/tests/conftest.py
@@ -17,7 +17,8 @@ import pytest
 import numpy as np
 
 from astropy import table
-from astropy.table import table_helpers, Table, QTable
+from astropy.table import Table, QTable
+from astropy.table.table_helpers import ArrayWrapper
 from astropy import time
 from astropy import units as u
 from astropy import coordinates
@@ -143,7 +144,8 @@ MIXIN_COLS = {'quantity': [0, 1, 2, 3] * u.m,
               'sphericaldiff': coordinates.SphericalCosLatDifferential(
                   [0, 1, 2, 3]*u.mas/u.yr, [0, 1, 2, 3]*u.mas/u.yr,
                   10*u.km/u.s),
-              'arraywrap': table_helpers.ArrayWrapper([0, 1, 2, 3]),
+              'arraywrap': ArrayWrapper([0, 1, 2, 3]),
+              'arrayswap': ArrayWrapper(np.arange(4, dtype='i').byteswap().newbyteorder()),
               'ndarray': np.array([(7, 'a'), (8, 'b'), (9, 'c'), (9, 'c')],
                                   dtype='<i4,|S1').view(table.NdarrayMixin),
               }

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -442,8 +442,11 @@ def test_info_preserved_pickle_copy_init(mixin_cols):
             for attr in attrs:
                 if (attr != 'dtype' or getattr(m.info.dtype, 'isnative', True) or
                         func in (copy.copy, copy.deepcopy)):
-                    # !pytest.xfail(f"{func} does not preserve byteorder")
-                    assert getattr(m2.info, attr) == getattr(m.info, attr)
+                    original = getattr(m.info, attr)
+                else:
+                    # func does not preserve byteorder, check against (native) base type.
+                    original = m.info.dtype.name
+                assert getattr(m2.info, attr) == original
 
 
 def test_add_column(mixin_cols):

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -440,7 +440,10 @@ def test_info_preserved_pickle_copy_init(mixin_cols):
         for func in (copy.copy, copy.deepcopy, pickle_roundtrip, init_from_class):
             m2 = func(m)
             for attr in attrs:
-                assert getattr(m2.info, attr) == getattr(m.info, attr)
+                if (attr != 'dtype' or getattr(m.info.dtype, 'isnative', True) or
+                        func in (copy.copy, copy.deepcopy)):
+                    # !pytest.xfail(f"{func} does not preserve byteorder")
+                    assert getattr(m2.info, attr) == getattr(m.info, attr)
 
 
 def test_add_column(mixin_cols):

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -440,8 +440,9 @@ def test_info_preserved_pickle_copy_init(mixin_cols):
         for func in (copy.copy, copy.deepcopy, pickle_roundtrip, init_from_class):
             m2 = func(m)
             for attr in attrs:
-                if (attr != 'dtype' or getattr(m.info.dtype, 'isnative', True) or
-                        func in (copy.copy, copy.deepcopy)):
+                if (attr != 'dtype'
+                        or getattr(m.info.dtype, 'isnative', True)
+                        or func in (copy.copy, copy.deepcopy)):
                     original = getattr(m.info, attr)
                 else:
                     # func does not preserve byteorder, check against (native) base type.

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -1890,6 +1890,7 @@ class TestPandas:
         assert np.allclose(t2['skycoord.ra'], [0, 1, 2, 3])
         assert np.allclose(t2['skycoord.dec'], [0, 1, 2, 3])
         assert np.allclose(t2['arraywrap'], [0, 1, 2, 3])
+        assert np.allclose(t2['arrayswap'], [0, 1, 2, 3])
         assert np.allclose(t2['earthlocation.y'], [0, 110708, 547501, 654527], rtol=0, atol=1)
 
         # For pandas, Time, TimeDelta are the mixins that round-trip the class


### PR DESCRIPTION
### Description
Follow-up to #11288

This handles some additional corner cases for `MixedArray`-like tables, that were exempt from the `byteorder`/`isnative` checks since they were first converted to Pandas `Series` objects.
Now checking and fixing byteorder first before any conversions to Pandas types, added an `ArrayWrapper` with non-native byteorder to `MIXIN_COLS` for testing.
Since `pickle` and `init_from_class` are not preserving byteorder in this case, their tests in `test_info_preserved_pickle_copy_init` are intercepted accordingly.