### PR TITLE
Fix Unit construction with no arguments

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -200,6 +200,9 @@ astropy.uncertainty
 astropy.units
 ^^^^^^^^^^^^^
 
+- Calling ``Unit()`` with no argument now returns a dimensionless unit, 
+  as was documented but not implemented. [#11295]
+
 astropy.utils
 ^^^^^^^^^^^^^
 

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -1794,7 +1794,7 @@ class _UnitMetaClass(type):
     can return an existing one.
     """
 
-    def __call__(self, s, represents=None, format=None, namespace=None,
+    def __call__(self, s="", represents=None, format=None, namespace=None,
                  doc=None, parse_strict='raise'):
 
         # Short-circuit if we're already a unit
@@ -1926,11 +1926,11 @@ class Unit(NamedUnit, metaclass=_UnitMetaClass):
 
       Returns the given unit unchanged.
 
-    - From `None`::
+    - From no arguments::
 
         Unit()
 
-      Returns the null unit.
+      Returns the dimensionless unit.
 
     - The last form, which creates a new `Unit` is described in detail
       below.

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -45,6 +45,8 @@ def test_initialisation():
     assert u.Unit('10 m') == ten_meter
     assert u.Unit(10.) == u.CompositeUnit(10., [], [])
 
+    assert u.Unit() == u.dimensionless_unscaled
+
 
 def test_invalid_power():
     x = u.m ** Fraction(1, 3)
@@ -230,11 +232,6 @@ def test_null_unit():
 def test_unrecognized_equivalency():
     assert u.m.is_equivalent('foo') is False
     assert u.m.is_equivalent('pc') is True
-
-
-def test_unit_noarg():
-    with pytest.raises(TypeError):
-        u.Unit()
 
 
 def test_convertible_exception():


### PR DESCRIPTION
Hi,
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

Within `Unit` docstring, it is listed that one can construct the null Unit from an argumentless call of Unit.
https://github.com/astropy/astropy/blob/783be4f00819ac959dfb899e05b46e3ec72431c8/astropy/units/core.py#L1929-L1933

There is currently no implementation of this and there is even a test to ensure `Unit()` throws an error.

This PR makes `Unit` behave as the docstring tells it should.
