### PR TITLE
FITS: Allow multiple leading spaces in value field for RVKC input format

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1182,6 +1182,10 @@ astropy.io.fits
 - Fix bug where manual fixes to invalid header cards were not preserved when
   saving a FITS file. [#11108]
 
+- Fix parsing of RVKC header card patterns that were not recognised
+  where multiple spaces were separating field-specifier and value like
+  "DP1.AXIS.1:   1". [#11301]
+
 astropy.io.misc
 ^^^^^^^^^^^^^^^
 

--- a/astropy/io/fits/card.py
+++ b/astropy/io/fits/card.py
@@ -127,7 +127,7 @@ class Card(_Verify):
     _rvkc_identifier = r'[a-zA-Z_]\w*'
     _rvkc_field = _rvkc_identifier + r'(\.\d+)?'
     _rvkc_field_specifier_s = fr'{_rvkc_field}(\.{_rvkc_field})*'
-    _rvkc_field_specifier_val = (r'(?P<keyword>{}): (?P<val>{})'.format(
+    _rvkc_field_specifier_val = (r'(?P<keyword>{}): +(?P<val>{})'.format(
             _rvkc_field_specifier_s, _numr_FSC))
     _rvkc_keyword_val = fr'\'(?P<rawval>{_rvkc_field_specifier_val})\''
     _rvkc_keyword_val_comm = (r' *{} *(/ *(?P<comm>[ -~]*))?$'.format(

--- a/astropy/io/fits/tests/test_header.py
+++ b/astropy/io/fits/tests/test_header.py
@@ -2439,6 +2439,8 @@ class TestRecordValuedKeywordCards(FitsTestCase):
 
     These tests are derived primarily from the release notes for PyFITS 1.4 (in
     which this feature was first introduced.
+    Note that extra leading spaces in the `value` fields should be parsed on input,
+    but will be stripped in the cards.
     """
 
     def setup(self):
@@ -2447,11 +2449,11 @@ class TestRecordValuedKeywordCards(FitsTestCase):
         self._test_header.set('DP1', 'NAXIS: 2')
         self._test_header.set('DP1', 'AXIS.1: 1')
         self._test_header.set('DP1', 'AXIS.2: 2')
-        self._test_header.set('DP1', 'NAUX: 2')
+        self._test_header.set('DP1', 'NAUX:   2')
         self._test_header.set('DP1', 'AUX.1.COEFF.0: 0')
         self._test_header.set('DP1', 'AUX.1.POWER.0: 1')
         self._test_header.set('DP1', 'AUX.1.COEFF.1: 0.00048828125')
-        self._test_header.set('DP1', 'AUX.1.POWER.1: 1')
+        self._test_header.set('DP1', 'AUX.1.POWER.1:  1')
 
     def test_initialize_rvkc(self):
         """
@@ -2465,7 +2467,7 @@ class TestRecordValuedKeywordCards(FitsTestCase):
         assert c.field_specifier == 'NAXIS'
         assert c.comment == 'A comment'
 
-        c = fits.Card.fromstring("DP1     = 'NAXIS: 2.1'")
+        c = fits.Card.fromstring("DP1     = 'NAXIS:  2.1'")
         assert c.keyword == 'DP1.NAXIS'
         assert c.value == 2.1
         assert c.field_specifier == 'NAXIS'
@@ -2480,7 +2482,7 @@ class TestRecordValuedKeywordCards(FitsTestCase):
         assert c.value == 2.0
         assert c.field_specifier == 'NAXIS'
 
-        c = fits.Card('DP1', 'NAXIS: 2.0')
+        c = fits.Card('DP1', 'NAXIS:  2.0')
         assert c.keyword == 'DP1.NAXIS'
         assert c.value == 2.0
         assert c.field_specifier == 'NAXIS'


### PR DESCRIPTION
### Description
This is a bug fix or enhancement for a minor issue that arose in relation to #11260:

The `io.fits.Card` filters for identifying record-valued key cards were rejecting multiple spaces in the value field after the `: `, therefore not recognising header cards written by WCSLIB like
```
DQ1     = 'NAXES:  2'          / Two independent variables
DQ1     = 'AUX.1.COEFF.0:   -0.030369554325293' / TPD: x = c0 + c1*u + c2*v
```
as RVKC and thus not making them accessible as e.g. `header['DQ1.AUX.1.COEFF...']`.
Since the syntax does not seem to forbid extra space, and anyway WCSLIB is using it gratuitously in writing its headers, I have extended the `re` accordingly and modified a few tests for this format.