### PR TITLE
Fix #11298 (CONTINUE keyword in header)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1203,7 +1203,10 @@ astropy.io.fits
   "DP1.AXIS.1:   1". [#11301]
 
 - Fix misleading missing END card error when extra data are found at the end
-  of the file. [#11285] 
+  of the file. [#11285]
+
+- Fix incorrect wrapping of long card values as CONTINUE cards when some
+  words in the value are longer than a single card. [#11304]
 
 astropy.io.misc
 ^^^^^^^^^^^^^^^

--- a/astropy/io/fits/tests/test_header.py
+++ b/astropy/io/fits/tests/test_header.py
@@ -406,6 +406,20 @@ class TestHeaderFunctions(FitsTestCase):
                 "CONTINUE  '&' / comment long comment long comment long comment long comment     "
                 "CONTINUE  '' / long comment                                                     ")
 
+    def test_long_string_value_with_multiple_long_words(self):
+        """
+        Regression test for https://github.com/astropy/astropy/issues/11298
+        """
+        c = fits.Card('WHATEVER',
+                      'SuperCalibrationParameters_XXXX_YYYY_ZZZZZ_KK_01_02_'
+                      '03)-AAABBBCCC.n.h5 SuperNavigationParameters_XXXX_YYYY'
+                      '_ZZZZZ_KK_01_02_03)-AAABBBCCC.n.xml')
+        assert (str(c) ==
+                "WHATEVER= 'SuperCalibrationParameters_XXXX_YYYY_ZZZZZ_KK_01_02_03)-AAABBBCCC.n&'"
+                "CONTINUE  '.h5 &'                                                               "
+                "CONTINUE  'SuperNavigationParameters_XXXX_YYYY_ZZZZZ_KK_01_02_03)-AAABBBCCC.n.&'"
+                "CONTINUE  'xml'                                                                 ")
+
     def test_long_unicode_string(self):
         """Regression test for
         https://github.com/spacetelescope/PyFITS/issues/1

--- a/astropy/io/fits/util.py
+++ b/astropy/io/fits/util.py
@@ -761,7 +761,7 @@ def _words_group(s, width):
     """
     Split a long string into parts where each part is no longer than ``strlen``
     and no word is cut into two pieces.  But if there are any single words
-    which are longer than ``strlen``, then then will be split in the middle of
+    which are longer than ``strlen``, then they will be split in the middle of
     the word.
     """
 

--- a/astropy/io/fits/util.py
+++ b/astropy/io/fits/util.py
@@ -757,39 +757,44 @@ def _str_to_num(val):
     return num
 
 
-def _words_group(input, strlen):
+def _words_group(s, width):
     """
-    Split a long string into parts where each part is no longer
-    than ``strlen`` and no word is cut into two pieces.  But if
-    there is one single word which is longer than ``strlen``, then
-    it will be split in the middle of the word.
+    Split a long string into parts where each part is no longer than ``strlen``
+    and no word is cut into two pieces.  But if there are any single words
+    which are longer than ``strlen``, then then will be split in the middle of
+    the word.
     """
 
     words = []
-    nblanks = input.count(' ')
-    nmax = max(nblanks, len(input) // strlen + 1)
-    arr = np.frombuffer((input + ' ').encode('utf8'), dtype='S1')
+    slen = len(s)
+
+    # appending one blank at the end always ensures that the "last" blank
+    # is beyond the end of the string
+    arr = np.frombuffer(s.encode('utf8') + b' ', dtype='S1')
 
     # locations of the blanks
     blank_loc = np.nonzero(arr == b' ')[0]
     offset = 0
     xoffset = 0
-    for idx in range(nmax):
+
+    while True:
         try:
-            loc = np.nonzero(blank_loc >= strlen + offset)[0][0]
+            loc = np.nonzero(blank_loc >= width + offset)[0][0]
+        except IndexError:
+            loc = len(blank_loc)
+
+        if loc > 0:
             offset = blank_loc[loc - 1] + 1
-            if loc == 0:
-                offset = -1
-        except Exception:
-            offset = len(input)
+        else:
+            offset = -1
 
         # check for one word longer than strlen, break in the middle
         if offset <= xoffset:
-            offset = xoffset + strlen
+            offset = min(xoffset + width, slen)
 
         # collect the pieces in a list
-        words.append(input[xoffset:offset])
-        if len(input) == offset:
+        words.append(s[xoffset:offset])
+        if offset >= slen:
             break
         xoffset = offset
 


### PR DESCRIPTION
The original code made the mistake of assuming that the number of
groups the string will be split into is directly related to the length
of the input or the number of spaces, but this is false if the input
is made up of multiple long words that need to be split across lines as
in the regression test.

In this case, if a long word follows another long word we want to keep
the existing semantics of breaking after a space, and then beginning
the next word on a new line.

Backport to 4.2.x and 4.0.x.

EDIT: Fix #11298