### PR TITLE
TST: Skip CI natively, DOC: Update license year

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -16,19 +16,10 @@ jobs:
   initial_checks:
     name: Mandatory checks before CI
     runs-on: ubuntu-latest
-    outputs:
-      run_next: ${{ steps.skip_ci_step.outputs.run_next }}
     steps:
-    - name: Check skip CI
-      uses: OpenAstronomy/action-skip-ci@main
-      id: skip_ci_step
-      with:
-        NO_FAIL: true
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    # This should only run if we did not skip CI
+    # TODO: Make this work for PRs
     - name: Cancel previous runs
       uses: styfle/cancel-workflow-action@ce177499ccf9fd2aded3b0426c97e5434c2e8a73
-      if: steps.skip_ci_step.outputs.run_next == 'true'
       with:
         access_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -38,7 +29,6 @@ jobs:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     needs: initial_checks
-    if: needs.initial_checks.outputs.run_next == 'true'
     strategy:
       fail-fast: true
       matrix:
@@ -114,7 +104,6 @@ jobs:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     needs: initial_checks
-    if: needs.initial_checks.outputs.run_next == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -146,7 +135,6 @@ jobs:
     name: 32-bit and parallel
     runs-on: ubuntu-latest
     needs: initial_checks
-    if: needs.initial_checks.outputs.run_next == 'true'
     container:
       image: quay.io/pypa/manylinux1_i686
     steps:

--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -1,4 +1,4 @@
-Copyright (c) 2011-2020, Astropy Developers
+Copyright (c) 2011-2021, Astropy Developers
 
 All rights reserved.
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

Supposedly, this should Just Work ™️ now...

https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/

Direct follow-up of #11168 and #11274 . Also see #11038 

Also updated license year, because I needed a second commit to make sure it doesn't skip when second commit doesn't have the directive. Might as well put in a real change, right? Seems to work!

## Pros

* Uses built-in functionality, hence reducing our maintenance burden.
* Does not even start any jobs, hence appears to be more eco-friendly (not quantified).

## Cons

* There is no way to disable this.
* Skips *everything* inside `.github/workflows`, including labeler and triage actions, which is undesirable.
* Might also skip a merge commit in `master` when PR is merged if the merge commit message collates all PR commit messages into one, and one or more of the PR commits had the trigger in it (unproven).
* Might also skip a cron job run if the last commit in `master` is a message with the trigger (unproven).

For the first two points in Cons, let's see how actions/runner#976 goes. For the last two points, we might just have to live with it or have a way to scrub out trigger directive from the merge commit message before merge (is that even possible without much pain?).