### PR TITLE
TST: Patch table test failures in numpy-dev

### DIFF
--- a/astropy/table/tests/test_masked.py
+++ b/astropy/table/tests/test_masked.py
@@ -4,11 +4,14 @@
 import pytest
 import numpy as np
 import numpy.ma as ma
+from packaging.version import Version
 
 from astropy.table import Column, MaskedColumn, Table, QTable
 from astropy.table.column import BaseColumn
 from astropy.time import Time
 import astropy.units as u
+
+NUMPY_DEV = Version(np.__version__).is_devrelease
 
 
 class SetupData:
@@ -238,8 +241,10 @@ class TestTableInit(SetupData):
         t = Table([np_data_list])
         col = t['col0']
 
-        # Confirm dtype is same as for untype list input w/ no mask
-        assert col.dtype == dtype_expected
+        # Confirm dtype is same as for untype list input w/ no mask.
+        # dtype maybe 'O' for numpy-dev and S/U combo, see Issue 11291
+        if not NUMPY_DEV or type_str not in ('S', 'U') or col.dtype != 'O':
+            assert col.dtype == dtype_expected
         assert np.all(col == np_data)
         assert col.mask[last_idx]
         assert type(col) is MaskedColumn

--- a/astropy/table/tests/test_pprint.py
+++ b/astropy/table/tests/test_pprint.py
@@ -10,6 +10,7 @@ from astropy import table
 from astropy.io import ascii
 from astropy.table import Table, QTable
 from astropy.table.table_helpers import simple_table
+from astropy.table.tests.test_masked import NUMPY_DEV
 from astropy import units as u
 from astropy.utils import console
 
@@ -108,6 +109,8 @@ class TestMultiD():
                          '     5 .. 50']
 
 
+# Remove xfail when this is no longer an issue
+@pytest.mark.xfail(NUMPY_DEV, reason="Issue 11291")
 def test_html_escaping():
     t = table.Table([('<script>alert("gotcha");</script>', 2, 3)])
     nbclass = table.conf.default_notebook_table_class

--- a/docs/table/masking.rst
+++ b/docs/table/masking.rst
@@ -76,14 +76,14 @@ Notice that masked entries in the table output are shown as ``--``.
 You can use the `numpy.ma.masked` constant to indicate masked or invalid data::
 
   >>> a = [1.0, np.ma.masked]
-  >>> b = [np.ma.masked, 'val']
-  >>> Table([a, b], names=('a', 'b'))
+  >>> b = [np.ma.masked, 'value1']
+  >>> Table([a, b], names=('a', 'b'))  # doctest: +ELLIPSIS
   <Table length=2>
     a     b
-  float64 str3
-  ------- ----
-      1.0   --
-      --  val
+  float64 ...
+  ------- ------
+      1.0     --
+      --  value1
 
 Initializing from lists with embedded `numpy.ma.masked` elements is considerably
 slower than using `numpy.ma.array` or |MaskedColumn| directly, so if performance


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to address dtype "S" and "U" turning into "object" in numpy-dev job. Probably a non-issue due to the moving target of numpy-dev and how Cython didn't compile against it, and we can just deal with it as long as we don't see this behavior in stable numpy?

Fix #11291 

NOTE TO REVIEWERS: Make sure tests really pass now in the numpy-dev job!