### PR TITLE
TST: Temporarily xfail test_skyoffset until to_geodetic error is handled properly

### DIFF
--- a/astropy/coordinates/tests/test_skyoffset_transformations.py
+++ b/astropy/coordinates/tests/test_skyoffset_transformations.py
@@ -30,8 +30,15 @@ def test_skyoffset(inradec, expectedlatlon, tolsep, originradec=(45, 45)*u.deg):
 
     assert skycoord_inaf.separation(expected) < tolsep
     # Check we can also transform back (regression test for gh-11254).
-    roundtrip = skycoord_inaf.transform_to(ICRS())
-    assert roundtrip.separation(skycoord) < 1*u.uas
+    try:
+        roundtrip = skycoord_inaf.transform_to(ICRS())
+    except AttributeError as err:
+        if 'to_geodetic' in str(err):
+            pytest.xfail('See Issue 11277')
+        else:
+            raise
+    else:
+        assert roundtrip.separation(skycoord) < 1*u.uas
 
 
 def test_skyoffset_functional_ra():


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to temporarily xfail `test_skyoffset` until #11277 can be handled properly for the "double run" job.

There is no need to cause stress for unrelated PRs.