### PR TITLE
Added fallback_unit to fits_ccddata_reader

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -63,6 +63,17 @@ astropy.modeling
 astropy.nddata
 ^^^^^^^^^^^^^^
 
+- Improved unit handling of ``astropy.nddata.fits_ccddata_reader``
+  with (1) new ``astropy.nddata.conf.default_ccddata_unit``
+  configuration item that enables errorless reading of FITS files that
+  have no BUNIT value.  Default unit is ``adu``.  (2) When BUNIT is
+  found in the FITS header, compare it to the ``unit`` keyword
+  argument of ``astropy.nddata.fits_ccddata_reader`` (if provided) and
+  only generate an informational message if the the units are
+  different [#11325]
+
+
+
 astropy.samp
 ^^^^^^^^^^^^
 

--- a/astropy/nddata/__init__.py
+++ b/astropy/nddata/__init__.py
@@ -48,5 +48,10 @@ class Conf(_config.ConfigNamespace):
         'that data values/uncertainties are not scaled with the unit change.'
     )
 
+    default_ccddata_unit = _config.ConfigItem(
+        'adu',
+        'Default CCDData unit when no BUNIT is specified in the FITS header'
+    )
+
 
 conf = Conf()

--- a/astropy/nddata/ccddata.py
+++ b/astropy/nddata/ccddata.py
@@ -524,8 +524,7 @@ def _generate_wcs_and_update_header(hdr):
     return (new_hdr, wcs)
 
 
-def fits_ccddata_reader(filename, hdu=0, unit=None, fallback_unit=None,
-                        hdu_uncertainty='UNCERT',
+def fits_ccddata_reader(filename, hdu=0, unit=None, hdu_uncertainty='UNCERT',
                         hdu_mask='MASK', hdu_flags=None,
                         key_uncertainty_type='UTYPE', **kwd):
     """
@@ -546,12 +545,9 @@ def fits_ccddata_reader(filename, hdu=0, unit=None, fallback_unit=None,
         Units of the image data. If this argument is provided and there is a
         unit for the image in the FITS header (the keyword ``BUNIT`` is used
         as the unit, if present), this argument is used in for the
-        unit.  See also `fallback_unit.`
-        Default is ``None``.
-
-    fallback_unit : `~astropy.units.Unit`, optional
-        Units to be used for the image data if `unit` is not provided
-        and no unit is found in the FITS header.
+        unit.  If ``None`` and no unit is found in the FITS header,
+        the value of the ``astropy.nddata.conf.default_ccddata_unit``
+        configuration item is used.
         Default is ``None``.
 
     hdu_uncertainty : str or None, optional

--- a/astropy/nddata/ccddata.py
+++ b/astropy/nddata/ccddata.py
@@ -658,12 +658,16 @@ def fits_ccddata_reader(filename, hdu=0, unit=None, fallback_unit=None,
                         'argument explicitly or change the header of the FITS '
                         'file before reading it.'
                         .format(fits_unit_string))
-            else:
+
+            elif u.Unit(unit) != u.Unit(fits_unit_string):
                 log.info("using the unit {} passed to the FITS reader instead "
                          "of the unit {} in the FITS file."
                          .format(unit, fits_unit_string))
 
-        use_unit = unit or fits_unit_string or fallback_unit
+        from . import conf
+        use_unit = (unit
+                    or fits_unit_string
+                    or conf.default_ccddata_unit)
         hdr, wcs = _generate_wcs_and_update_header(hdr)
         ccd_data = CCDData(hdus[hdu].data, meta=hdr, unit=use_unit,
                            mask=mask, uncertainty=uncertainty, wcs=wcs)

--- a/astropy/nddata/ccddata.py
+++ b/astropy/nddata/ccddata.py
@@ -524,7 +524,8 @@ def _generate_wcs_and_update_header(hdr):
     return (new_hdr, wcs)
 
 
-def fits_ccddata_reader(filename, hdu=0, unit=None, hdu_uncertainty='UNCERT',
+def fits_ccddata_reader(filename, hdu=0, unit=None, fallback_unit=None,
+                        hdu_uncertainty='UNCERT',
                         hdu_mask='MASK', hdu_flags=None,
                         key_uncertainty_type='UTYPE', **kwd):
     """
@@ -544,7 +545,13 @@ def fits_ccddata_reader(filename, hdu=0, unit=None, hdu_uncertainty='UNCERT',
     unit : `~astropy.units.Unit`, optional
         Units of the image data. If this argument is provided and there is a
         unit for the image in the FITS header (the keyword ``BUNIT`` is used
-        as the unit, if present), this argument is used for the unit.
+        as the unit, if present), this argument is used in for the
+        unit.  See also `fallback_unit.`
+        Default is ``None``.
+
+    fallback_unit : `~astropy.units.Unit`, optional
+        Units to be used for the image data if `unit` is not provided
+        and no unit is found in the FITS header.
         Default is ``None``.
 
     hdu_uncertainty : str or None, optional
@@ -656,7 +663,7 @@ def fits_ccddata_reader(filename, hdu=0, unit=None, hdu_uncertainty='UNCERT',
                          "of the unit {} in the FITS file."
                          .format(unit, fits_unit_string))
 
-        use_unit = unit or fits_unit_string
+        use_unit = unit or fits_unit_string or fallback_unit
         hdr, wcs = _generate_wcs_and_update_header(hdr)
         ccd_data = CCDData(hdus[hdu].data, meta=hdr, unit=use_unit,
                            mask=mask, uncertainty=uncertainty, wcs=wcs)


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request adds better granularity to the control of assigning the CCDData unit when a file is read from disk (astropy.nddata.fits_ccddata_reader).  The current behavior either clobbers the unit in the header or requires there to be a unit in the header (via the BUNIT keyword).  This adds a keyword, fallback_unit that enables errorless reading of FITS files written by systems that do not record a BUNIT keyword and provides the user the ability to decide what that unit should be.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #10977

PS I have not  edited the changelog, since I don't know what version this would go under, but the entry might look something like:
```rst
astropy.nddata
^^^^^^^^^^^^^^

- Added ``fallback_unit`` keyword to fits_ccddata_reader.  Unlike the
  existing keyword ``unit``, which sets the CCDData unit in preference
  to that found in the FITS file, ``fallback_unit`` sets the
  ``CCDData`` unit if no unit is found in the FITS header
```