### PR TITLE
Run cron CI on pull requests with a label added

### DIFF
--- a/.github/workflows/ci_cron_daily.yml
+++ b/.github/workflows/ci_cron_daily.yml
@@ -4,6 +4,13 @@ on:
   schedule:
     # run every day at 3am UTC
     - cron: '0 3 * * *'
+  pull_request:
+    # We also want this workflow triggered if the 'Extra CI' label is added
+    # The first two are subset of the defaults
+    types:
+      - synchronize
+      - reopened
+      - labeled
 
 env:
   ARCH_ON_CI: "normal"
@@ -11,9 +18,8 @@ env:
 
 jobs:
   tests:
-    name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
-    if: github.repository == 'astropy/astropy'
+    if: (github.repository == 'astropy/astropy' && (github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'Extra CI')))
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -4,14 +4,20 @@ on:
   schedule:
     # run every Monday at 6am UTC
     - cron: '0 6 * * 1'
+  pull_request:
+    # We also want this workflow triggered if the 'Extra CI' label is added
+    # The first two are subset of the defaults
+    types:
+      - synchronize
+      - reopened
+      - labeled
 env:
-  IS_CRON: "true"
+  IS_CRON: 'true'
 
 jobs:
   tests:
-    name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
-    if: github.repository == 'astropy/astropy'
+    if: (github.repository == 'astropy/astropy' && (github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'Extra CI')))
     env:
       ARCH_ON_CI: "normal"
     strategy:
@@ -69,8 +75,8 @@ jobs:
     # of using system libraries and using pytest directly.
 
     runs-on: ubuntu-18.04
-    name: Python 3.7 on ${{ matrix.arch }}
-    if: github.repository == 'astropy/astropy'
+    name: Python 3.7
+    if: (github.repository == 'astropy/astropy' && (github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'Extra CI')))
     env:
       ARCH_ON_CI: ${{ matrix.arch }}
 


### PR DESCRIPTION
This is an idea I came up with for sunpy and thought it would be useful. The idea is that when you are trying to debug or fix a cron build it would be useful if you could have those jobs run on a PR. So this modifies the cron workflows so that they trigger when the 'Extra CI' label is added (name can be changed).

I haven't actually tested the trigger logic here, because the sunpy workflow is a little different.

Another thing to consider is if we want a label for the weekly and for the daily separately.