### PR TITLE
Fix bug in Table init from list of Quantity

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -206,7 +206,7 @@ astropy.uncertainty
 astropy.units
 ^^^^^^^^^^^^^
 
-- Calling ``Unit()`` with no argument now returns a dimensionless unit, 
+- Calling ``Unit()`` with no argument now returns a dimensionless unit,
   as was documented but not implemented. [#11295]
 
 astropy.utils
@@ -1218,6 +1218,11 @@ astropy.stats
 
 astropy.table
 ^^^^^^^^^^^^^
+
+- Fixed bug when initializing a ``Table`` with a column as list of ``Quantity``,
+  for example ``Table({'x': [1*u.m, 2*u.m]})``. Previously this resulted in an
+  ``object`` dtype with no column ``unit`` set, but now gives a float array with
+  the correct unit. [#11329]
 
 - Fixed byteorder conversion in ``to_pandas()``, which had incorrectly
   triggered swapping when native endianness was stored with explicit

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -203,9 +203,14 @@ def _convert_sequence_data_to_array(data, dtype=None):
             # convert to float
             np_data = np.array(data)
         except Exception:
-            # Conversion failed for some reason, e.g. [2, 1*u.m] gives TypeError in Quantity
-            dtype = object
-            np_data = np.array(data, dtype=dtype)
+            # Conversion failed for some reason, e.g. [2, 1*u.m] gives TypeError in Quantity.
+            # First try to interpret the data as Quantity. If that still fails then fall
+            # through to object
+            try:
+                np_data = Quantity(data, dtype)
+            except Exception:
+                dtype = object
+                np_data = np.array(data, dtype=dtype)
 
     if np_data.ndim == 0 or (np_data.ndim > 0 and len(np_data) == 0):
         # Implies input was a scalar or an empty list (e.g. initializing an

--- a/astropy/table/tests/test_init_table.py
+++ b/astropy/table/tests/test_init_table.py
@@ -7,6 +7,7 @@ import pytest
 import numpy as np
 
 from astropy.table import Column, TableColumns, Table, MaskedColumn
+import astropy.units as u
 
 
 class TestTableColumnsInit():
@@ -570,3 +571,17 @@ def test_init_data_type_not_allowed_to_init_table():
     with pytest.raises(ValueError,
                        match="Data type <class 'str'> not allowed to init Table"):
         Table('hello')
+
+
+def test_init_Table_from_list_of_quantity():
+    """Test fix for #11327"""
+    # Variation on original example in #11327 at the Table level
+    data = [{'x': 5 * u.m, 'y': 1 * u.m}, {'x': 10 * u.m, 'y': 3}]
+    t = Table(data)
+    assert t['x'].unit is u.m
+    assert t['y'].unit is None
+    assert t['x'].dtype.kind == 'f'
+    assert t['y'].dtype.kind == 'O'
+    assert np.all(t['x'] == [5, 10])
+    assert t['y'][0] == 1 * u.m
+    assert t['y'][1] == 3


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to fix a bug when when initializing a ``Table`` with a column as list of 
``Quantity``,  for example ``Table({'x': [1*u.m, 2*u.m]})``. Previously this resulted in an
 ``object`` dtype with no column ``unit`` set, but now gives a float array with
  the correct unit. 

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #11327
