### PR TITLE
Table indices tidying: class structure and repr's

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -82,6 +82,9 @@ astropy.table
   printing a table. This functionality includes a context manager to
   include/exclude columns temporarily. [#11190]
 
+- Improved the string representation of objects related to ``Table.indices`` so
+  they now indicate the object type and relevant attributes. [#11333]
+
 astropy.tests
 ^^^^^^^^^^^^^
 
@@ -190,6 +193,10 @@ astropy.table
 - In reading from a FITS tables, the standard mask values of ``NaN`` for float
   and null string for string are properly recognized, leading to a
   ``MaskedColumn`` with appropriately set mask. [#11222]
+
+- Changed the implementation of the ``table.index.Index`` class so instantiating
+  from this class now returns an ``Index`` object as expected instead of a
+  ``SlicedIndex`` object. [#11333]
 
 astropy.tests
 ^^^^^^^^^^^^^

--- a/astropy/table/bst.py
+++ b/astropy/table/bst.py
@@ -443,12 +443,10 @@ class BST:
         return lst
 
     def __str__(self):
-        if self.root is None:
-            return 'Empty'
-        return self._print(self.root, 0)
+        return repr(self)
 
     def __repr__(self):
-        return str(self)
+        return f'<{self.__class__.__name__}>'
 
     def _print(self, node, level):
         line = '\t' * level + str(node) + '\n'

--- a/astropy/table/bst.py
+++ b/astropy/table/bst.py
@@ -442,9 +442,6 @@ class BST:
             self._same_prefix(val, node.left, lst)
         return lst
 
-    def __str__(self):
-        return repr(self)
-
     def __repr__(self):
         return f'<{self.__class__.__name__}>'
 

--- a/astropy/table/index.py
+++ b/astropy/table/index.py
@@ -370,11 +370,9 @@ class Index:
         '''
         return SlicedIndex(self, item)
 
-    def __str__(self):
-        return repr(self)
-
     def __repr__(self):
-        return f'<{self.__class__.__name__} data={self.data}>'
+        col_names = tuple(col.info.name for col in self.columns)
+        return f'<{self.__class__.__name__} columns={col_names} data={self.data}>'
 
     def __deepcopy__(self, memo):
         '''
@@ -553,17 +551,9 @@ class SlicedIndex:
             self.get_index_or_copy().sort()
 
     def __repr__(self):
-        col_names = tuple(col.info.name for col in self.index.columns)
-        if len(col_names) == 1:
-            name_str = f'column={col_names[0]!r}'
-        else:
-            name_str = f'columns={col_names}'
         slice_str = '' if self.original else f' slice={self.start}:{self.stop}:{self.step}'
-        return (f'<{self.__class__.__name__} {name_str} original={self.original}{slice_str}'
+        return (f'<{self.__class__.__name__} original={self.original}{slice_str}'
                 f' index={self.index}>')
-
-    def __str__(self):
-        return repr(self)
 
     def replace_col(self, prev_col, new_col):
         self.index.replace_col(prev_col, new_col)
@@ -588,13 +578,13 @@ class SlicedIndex:
         from .table import Table
         if len(self.columns) == 1:
             index = Index([col_slice], engine=self.data.__class__)
-            return SlicedIndex(index, slice(0, 0, None), original=True)
+            return self.__class__(index, slice(0, 0, None), original=True)
 
         t = Table(self.columns, copy_indices=False)
         with t.index_mode('discard_on_copy'):
             new_cols = t[item].columns.values()
         index = Index(new_cols, engine=self.data.__class__)
-        return SlicedIndex(index, slice(0, 0, None), original=True)
+        return self.__class__(index, slice(0, 0, None), original=True)
 
     @property
     def columns(self):

--- a/astropy/table/index.py
+++ b/astropy/table/index.py
@@ -524,7 +524,7 @@ class SlicedIndex:
         if not self._frozen:
             self.index.replace(self.orig_coords(row), col, val)
 
-    def copy(self):
+    def get_index_or_copy(self):
         if not self.original:
             # replace self.index with a new object reference
             self.index = deepcopy(self.index)
@@ -532,8 +532,7 @@ class SlicedIndex:
 
     def insert_row(self, pos, vals, columns):
         if not self._frozen:
-            self.copy().insert_row(self.orig_coords(pos), vals,
-                                   columns)
+            self.get_index_or_copy().insert_row(self.orig_coords(pos), vals, columns)
 
     def get_row_specifier(self, row_specifier):
         return [self.orig_coords(x) for x in
@@ -541,7 +540,7 @@ class SlicedIndex:
 
     def remove_rows(self, row_specifier):
         if not self._frozen:
-            self.copy().remove_rows(row_specifier)
+            self.get_index_or_copy().remove_rows(row_specifier)
 
     def replace_rows(self, col_slice):
         if not self._frozen:
@@ -549,7 +548,7 @@ class SlicedIndex:
 
     def sort(self):
         if not self._frozen:
-            self.copy().sort()
+            self.get_index_or_copy().sort()
 
     def __repr__(self):
         col_names = tuple(col.info.name for col in self.index.columns)

--- a/astropy/table/index.py
+++ b/astropy/table/index.py
@@ -371,10 +371,10 @@ class Index:
         return SlicedIndex(self, item)
 
     def __str__(self):
-        return str(self.data)
+        return repr(self)
 
     def __repr__(self):
-        return str(self)
+        return f'<{self.__class__.__name__} data={self.data}>'
 
     def __deepcopy__(self, memo):
         '''
@@ -552,9 +552,14 @@ class SlicedIndex:
             self.copy().sort()
 
     def __repr__(self):
-        if self.original:
-            return repr(self.index)
-        return f'Index slice {self.start, self.stop, self.step} of\n{self.index}'
+        col_names = tuple(col.info.name for col in self.index.columns)
+        if len(col_names) == 1:
+            name_str = f'column={col_names[0]!r}'
+        else:
+            name_str = f'columns={col_names}'
+        slice_str = '' if self.original else f' slice={self.start}:{self.stop}:{self.step}'
+        return (f'<{self.__class__.__name__} {name_str} original={self.original}{slice_str}'
+                f' index={self.index}>')
 
     def __str__(self):
         return repr(self)

--- a/astropy/table/index.py
+++ b/astropy/table/index.py
@@ -410,7 +410,7 @@ class SlicedIndex:
     ----------
     index : Index
         The original Index reference
-    index_slice : slice
+    index_slice : tuple, slice
         The slice to which this SlicedIndex corresponds
     original : bool
         Whether this SlicedIndex represents the original index itself.
@@ -426,9 +426,11 @@ class SlicedIndex:
 
         if isinstance(index_slice, tuple):
             self.start, self._stop, self.step = index_slice
-        else:  # index_slice is an actual slice
+        elif isinstance(index_slice, slice):  # index_slice is an actual slice
             num_rows = len(index.columns[0])
             self.start, self._stop, self.step = index_slice.indices(num_rows)
+        else:
+            raise TypeError('index_slice must be tuple or slice')
 
     @property
     def length(self):

--- a/astropy/table/soco.py
+++ b/astropy/table/soco.py
@@ -168,4 +168,9 @@ class SCEngine:
         self._nodes.update(nodes)
 
     def __repr__(self):
-        return f'{list(self._nodes)!r}'
+        if len(self._nodes) > 6:
+            nodes = list(self._nodes[:3]) + ['...'] + list(self._nodes[-3:])
+        else:
+            nodes = self._nodes
+        nodes_str = ', '.join(str(node) for node in nodes)
+        return f'<{self.__class__.__name__} nodes={nodes_str}>'

--- a/astropy/table/sorted_array.py
+++ b/astropy/table/sorted_array.py
@@ -307,7 +307,7 @@ class SortedArray:
     def __repr__(self):
         t = self.data.copy()
         t['rows'] = self.row_index
-        return str(t)
+        return f'<{self.__class__.__name__} length={len(t)}>\n{t}'
 
     def __str__(self):
         return repr(self)

--- a/astropy/table/sorted_array.py
+++ b/astropy/table/sorted_array.py
@@ -308,6 +308,3 @@ class SortedArray:
         t = self.data.copy()
         t['rows'] = self.row_index
         return f'<{self.__class__.__name__} length={len(t)}>\n{t}'
-
-    def __str__(self):
-        return repr(self)

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from .index import TableIndices, TableLoc, TableILoc, TableLocIndices
+from .index import SlicedIndex, TableIndices, TableLoc, TableILoc, TableLocIndices
 
 import sys
 from collections import OrderedDict, defaultdict
@@ -1011,11 +1011,13 @@ class Table:
                 raise ValueError('Cannot create an index on column "{}", of '
                                  'type "{}"'.format(col.info.name, type(col)))
 
+        is_primary = not self.indices
         index = Index(columns, engine=engine, unique=unique)
-        if not self.indices:
+        sliced_index = SlicedIndex(index, slice(0, 0, None), original=True)
+        if is_primary:
             self.primary_key = colnames
         for col in columns:
-            col.info.indices.append(index)
+            col.info.indices.append(sliced_index)
 
     def remove_indices(self, colname):
         '''

--- a/astropy/table/tests/test_index.py
+++ b/astropy/table/tests/test_index.py
@@ -579,3 +579,8 @@ def test_hstack_qtable_table():
     qstack = hstack([qtab, tab])
     assert qstack['t'].info.indices == []
     assert qstack.indices == []
+
+
+def test_index_slice_exception():
+    with pytest.raises(TypeError, match='index_slice must be tuple or slice'):
+        SlicedIndex(None, None)

--- a/docs/table/indexing.rst
+++ b/docs/table/indexing.rst
@@ -37,19 +37,21 @@ retrieve an index from a table, use the `~astropy.table.Table.indices`
 property::
 
    >>> t.indices['a']
+   <SlicedIndex original=True index=<Index columns=('a',) data=<SortedArray length=4>
     a  rows
    --- ----
      1    3
      2    0
      2    2
-     3    1
+     3    1>>
    >>> t.indices['a', 'b']
+   <SlicedIndex original=True index=<Index columns=('a', 'b') data=<SortedArray length=4>
     a   b  rows
    --- --- ----
      1   5    3
      2   6    2
      2   8    0
-     3   7    1
+     3   7    1>>
 
 .. EXAMPLE END
 
@@ -168,19 +170,21 @@ index is modified, and all indices refresh themselves after the context ends::
   >>> with t.index_mode('freeze'):
   ...    t['a'][0] = 0
   ...    print(t.indices['a']) # unmodified
+  <SlicedIndex original=True index=<Index columns=('a',) data=<SortedArray length=4>
    a  rows
   --- ----
     1    0
     2    1
     3    2
-    4    3
+    4    3>>
   >>> print(t.indices['a']) # modified
+  <SlicedIndex original=True index=<Index columns=('a',) data=<SortedArray length=4>
    a  rows
   --- ----
     0    0
     2    1
     3    2
-    4    3
+    4    3>>
 
 .. EXAMPLE END
 
@@ -196,11 +200,12 @@ indices while column slices will not::
   >>> with t.index_mode('copy_on_getitem'):
   ...     ca = t['a'][[1, 3]]
   ...     print(ca.info.indices)
-  [ a  rows
+  [<SlicedIndex original=True index=<Index columns=('a',) data=<SortedArray length=2>
+   a  rows
   --- ----
     2    0
-    4    1]
-
+    4    1>>]
+    
 .. EXAMPLE END
 
 .. EXAMPLE START: Table Indexing with the "discard_on_copy" Index Mode
@@ -210,19 +215,13 @@ column or table is copied::
 
   >>> t2 = Table(t)
   >>> t2.indices['a']
+  <SlicedIndex original=True index=<Index columns=('a',) data=<SortedArray length=4>
    a  rows
   --- ----
     0    0
     2    1
     3    2
-    4    3
-  >>> t2.indices['b']
-   b  rows
-  --- ----
-    1    1
-    9    2
-    9    3
-   10    0
+    4    3>>
   >>> with t.index_mode('discard_on_copy'):
   ...    t2 = Table(t)
   ...    print(t2.indices)
@@ -303,9 +302,13 @@ specified to use a particular indexing engine. The available engines are:
   sorted ``Table``.
 * `~astropy.table.SCEngine`, a sorted list engine using the `Sorted Containers
   <https://pypi.org/project/sortedcontainers/>`_ package.
-* `~astropy.table.BST`, a Python-based binary search tree engine.
+* `~astropy.table.BST`, a Python-based binary search tree engine (not recommended).
 
 The SCEngine depends on the ``sortedcontainers`` dependency. The most important takeaway is that
 `~astropy.table.SortedArray` (the default engine) is usually best, although
 `~astropy.table.SCEngine` may be more appropriate for an index created on an
 empty column since adding new values is quicker.
+
+The `~astropy.table.BST` engine demonstrates a simple pure Python implementation
+of a search tree engine, but the performance is poor for larger tables. This
+is available in the code largely as an implementation reference.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request was the start of a fix for #11332, but I found that I needed to clean up the basic code structure to try making sense of things. In particular there was a pretty weird construct where the `Index` class initializer was actually returning an instance of `SlicedIndex`. Combining this with the entirely inscrutable `repr()` of various bits has always made table indices really confusing to me.

## Example repr outputs
```
from astropy import table
from astropy.table.table_helpers import simple_table

for engine in table.BST, table.SortedArray, table.SCEngine:
    t = simple_table(size=100)
    t.add_index('a', engine=engine)
    print()
    print(engine)
    print(t.indices)
```
gives:
```
<class 'astropy.table.bst.BST'>
[<SlicedIndex original=True index=<Index columns=('a',) data=<BST>>>]

<class 'astropy.table.sorted_array.SortedArray'>
[<SlicedIndex original=True index=<Index columns=('a',) data=<SortedArray length=100>
 a  rows
--- ----
  1    0
  2    1
  3    2
  4    3
  5    4
...  ...
 95   94
 96   95
 97   96
 98   97
 99   98
100   99
Length = 100 rows>>]

<class 'astropy.table.soco.SCEngine'>
[<SlicedIndex original=True index=<Index columns=('a',) data=<SCEngine nodes=Node((1,), 0), Node((2,), 1), Node((3,), 2), ..., Node((98,), 97), Node((99,), 98), Node((100,), 99)>>>]
```


<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->
