### PR TITLE
Improve validation and docs for dstack, vstack, hstack

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1228,6 +1228,11 @@ astropy.table
   triggered swapping when native endianness was stored with explicit
   ``dtype`` code ``'<'`` (or ``'>'``) instead of ``'='``. [#11288, #11294]
 
+- Fixed bug when validating the inputs to ``table.hstack``, ``table.vstack``,
+  and ``table.dstack``. Previously, mistakenly calling ``table.hstack(t1, t2)``
+  (instead of ``table.hstack([t1, t2]))`` would return ``t1`` instead of raising
+  an exception. [#11336]
+
 astropy.tests
 ^^^^^^^^^^^^^
 

--- a/astropy/table/operations.py
+++ b/astropy/table/operations.py
@@ -498,7 +498,7 @@ def dstack(tables, join_type='outer', metadata_conflicts='warn'):
 
     Parameters
     ----------
-    tables : Table or list of Table objects
+    tables : Table or list of Table or Row objects
         Table(s) to stack along depth-wise with the current table
         Table columns should have same shape and name for depth-wise stacking
     join_type : str
@@ -537,6 +537,8 @@ def dstack(tables, join_type='outer', metadata_conflicts='warn'):
       1 .. 5 3 .. 7
       2 .. 6 4 .. 8
     """
+    _check_join_type(join_type, 'dstack')
+
     tables = _get_list_of_tables(tables)
     if len(tables) == 1:
         return tables[0]  # no point in stacking a single table
@@ -589,8 +591,8 @@ def vstack(tables, join_type='outer', metadata_conflicts='warn'):
 
     Parameters
     ----------
-    tables : Table or list of Table objects
-        Table(s) to stack along rows (vertically) with the current table
+    tables : Table or list of Table or Row objects
+        Table(s) to stack along rows (vertically)
     join_type : str
         Join type ('inner' | 'exact' | 'outer'), default is 'outer'
     metadata_conflicts : str
@@ -629,6 +631,8 @@ def vstack(tables, join_type='outer', metadata_conflicts='warn'):
         5   7
         6   8
     """
+    _check_join_type(join_type, 'vstack')
+
     tables = _get_list_of_tables(tables)  # validates input
     if len(tables) == 1:
         return tables[0]  # no point in stacking a single table
@@ -656,8 +660,8 @@ def hstack(tables, join_type='outer',
 
     Parameters
     ----------
-    tables : List of Table objects
-        Tables to stack along columns (horizontally) with the current table
+    tables : Table or list of Table or Row objects
+        Tables to stack along columns (horizontally)
     join_type : str
         Join type ('inner' | 'exact' | 'outer'), default is 'outer'
     uniq_col_name : str or None
@@ -700,6 +704,8 @@ def hstack(tables, join_type='outer',
         1   3   5   7
         2   4   6   8
     """
+    _check_join_type(join_type, 'hstack')
+
     tables = _get_list_of_tables(tables)  # validates input
     if len(tables) == 1:
         return tables[0]  # no point in stacking a single table
@@ -1074,8 +1080,6 @@ def _join(left, right, keys=None, join_type='inner',
     joined_table : `~astropy.table.Table` object
         New table containing the result of the join operation.
     """
-    from astropy.time import Time
-
     # Store user-provided col_name_map until the end
     _col_name_map = col_name_map
 
@@ -1212,6 +1216,25 @@ def _join(left, right, keys=None, join_type='inner',
     return out
 
 
+def _check_join_type(join_type, func_name):
+    """Check join_type arg in hstack and vstack.
+
+    This specifically checks for the common mistake of call vstack(t1, t2)
+    instead of vstack([t1, t2]). The subsequent check of
+    ``join_type in ('inner', ..)`` does not raise in this case.
+    """
+    if not isinstance(join_type, str):
+        msg = '`join_type` arg must be a string'
+        if isinstance(join_type, Table):
+            msg += ('. Did you accidentally '
+                    f'call {func_name}(t1, t2, ..) instead of '
+                    f'{func_name}([t1, t2], ..)?')
+        raise TypeError(msg)
+
+    if join_type not in ('inner', 'exact', 'outer'):
+        raise ValueError("`join_type` arg must be one of 'inner', 'exact' or 'outer'")
+
+
 def _vstack(arrays, join_type='outer', col_name_map=None, metadata_conflicts='warn'):
     """
     Stack Tables vertically (by rows)
@@ -1240,10 +1263,6 @@ def _vstack(arrays, join_type='outer', col_name_map=None, metadata_conflicts='wa
     """
     # Store user-provided col_name_map until the end
     _col_name_map = col_name_map
-
-    # Input validation
-    if join_type not in ('inner', 'exact', 'outer'):
-        raise ValueError("`join_type` arg must be one of 'inner', 'exact' or 'outer'")
 
     # Trivial case of one input array
     if len(arrays) == 1:
@@ -1351,10 +1370,6 @@ def _hstack(arrays, join_type='outer', uniq_col_name='{col_name}_{table_name}',
 
     # Store user-provided col_name_map until the end
     _col_name_map = col_name_map
-
-    # Input validation
-    if join_type not in ('inner', 'exact', 'outer'):
-        raise ValueError("join_type arg must be either 'inner', 'exact' or 'outer'")
 
     if table_names is None:
         table_names = [f'{ii + 1}' for ii in range(len(arrays))]

--- a/astropy/table/tests/test_operations.py
+++ b/astropy/table/tests/test_operations.py
@@ -814,6 +814,11 @@ class TestVStack():
                                        ('a', 1),
                                        ('e', 1)])
 
+    def test_validate_join_type(self):
+        self._setup()
+        with pytest.raises(TypeError, match='Did you accidentally call vstack'):
+            table.vstack(self.t1, self.t2)
+
     def test_stack_rows(self, operation_table_type):
         self._setup(operation_table_type)
         t2 = self.t1.copy()
@@ -1200,6 +1205,11 @@ class TestDStack():
                               ' 4.  sez  6',
                               ' 6.  foo  3'], format='ascii')
 
+    def test_validate_join_type(self):
+        self._setup()
+        with pytest.raises(TypeError, match='Did you accidentally call dstack'):
+            table.dstack(self.t1, self.t2)
+
     @staticmethod
     def compare_dstack(tables, out):
         for ii, tbl in enumerate(tables):
@@ -1340,6 +1350,11 @@ class TestHStack():
                                        ('d', 1),
                                        ('a', 1),
                                        ('e', 1)])
+
+    def test_validate_join_type(self):
+        self._setup()
+        with pytest.raises(TypeError, match='Did you accidentally call hstack'):
+            table.hstack(self.t1, self.t2)
 
     def test_stack_same_table(self, operation_table_type):
         """


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to address some confusion that users had with `vstack` (but would apply to `dstack` and `hstack` as well).

@mhvk - as a side note, the root cause for not raising an exception for `vstack(t1, t2)` (i.e. `vstack(t1, join_type=t2)` is this:
```
In [3]: t in ('inner',)
/Users/aldcroft/git/astropy/astropy/table/table.py:3399: FutureWarning: elementwise == comparison failed and returning scalar instead; this will raise an error or perform elementwise comparison in the future.
  result = self.as_array() == other
Out[3]: False
```
This goes back to the non-ideal legacy behavior of `==` with tables. Should we make this raise now instead of waiting for numpy?

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->
