### PR TITLE
Allow table indices and the primary key to be pickled

### DIFF
--- a/astropy/io/fits/connect.py
+++ b/astropy/io/fits/connect.py
@@ -97,6 +97,11 @@ def _decode_mixins(tbl):
     # Add serialized column information to table meta for use in constructing mixins
     tbl.meta['__serialized_columns__'] = info['meta']['__serialized_columns__']
 
+    # Add back the special __attributes__ key in the table meta. This handles
+    # TableAttributes such as `primary_key` or `pprint_exclude_names`.
+    if '__attributes__' in info['meta']:
+        tbl.meta['__attributes__'] = info['meta']['__attributes__']
+
     # Use the `datatype` attribute info to update column attributes that are
     # NOT already handled via standard FITS column keys (name, dtype, unit).
     for col in info['datatype']:
@@ -307,13 +312,29 @@ def _encode_mixins(tbl):
     """Encode a Table ``tbl`` that may have mixin columns to a Table with only
     astropy Columns + appropriate meta-data to allow subsequent decoding.
     """
-    # Determine if information will be lost without serializing meta.  This is hardcoded
-    # to the set difference between column info attributes and what FITS can store
-    # natively (name, dtype, unit).  See _get_col_attributes() in table/meta.py for where
-    # this comes from.
-    info_lost = any(any(getattr(col.info, attr, None) not in (None, {})
-                        for attr in ('description', 'meta'))
-                    for col in tbl.itercols())
+    # If PyYAML is not available then check to see if there are any mixin cols
+    # that *require* YAML serialization.  FITS already has support for Time,
+    # Quantity, so if those are the only mixins the proceed without doing the
+    # YAML bit, for backward compatibility (i.e. not requiring YAML to write
+    # Time or Quantity).  In this case other mixin column meta (e.g.
+    # description or meta) will be silently dropped, consistent with astropy <=
+    # 2.0 behavior.
+    info_lost = serialize._get_info_lost(tbl, ('description', 'meta'))
+    try:
+        import yaml  # noqa
+    except ImportError:
+        for col in tbl.itercols():
+            if (has_info_class(col, MixinInfo)
+                    and col.__class__ not in (u.Quantity, Time)):
+                raise TypeError("cannot write type {} column '{}' "
+                                "to FITS without PyYAML installed."
+                                .format(col.__class__.__name__, col.info.name))
+        else:
+            if info_lost:
+                warnings.warn(f"table contains {info_lost}. This meta-data"
+                              " will be dropped unless you install PyYAML.",
+                              AstropyUserWarning)
+            return tbl
 
     # Convert the table to one with no mixins, only Column objects.  This adds
     # meta data which is extracted with meta.get_yaml_from_table.  This ignores
@@ -349,8 +370,17 @@ def _encode_mixins(tbl):
     encode_tbl.meta.setdefault(ser_col, {})
 
     tbl_meta_copy = encode_tbl.meta.copy()
+
+    # Any TableAttributes like `primary_key` or `pprint_include_names` will
+    # result in meta having '__attribues__'. These cannot be handled with the
+    # native FITS keywords so pop them off of tbl_meta_copy here (which is what
+    # gets sent to FITS keywords later) and put the __attributes__ into the
+    # temporary encode_tbl.meta which gets used to generate `meta_yaml_lines`.
+    attributes = tbl_meta_copy.pop('__attributes__', None)
     try:
         encode_tbl.meta = {ser_col: encode_tbl.meta[ser_col]}
+        if attributes:
+            encode_tbl.meta['__attributes__'] = attributes
         meta_yaml_lines = meta.get_yaml_from_table(encode_tbl)
     finally:
         encode_tbl.meta = tbl_meta_copy

--- a/astropy/table/serialize.py
+++ b/astropy/table/serialize.py
@@ -375,3 +375,31 @@ def _construct_mixins_from_columns(tbl):
     out_cls = QTable if has_quantities else Table
 
     return out_cls(list(out.values()), names=out.colnames, copy=False, meta=meta)
+
+
+def _get_info_lost(tbl, attrs):
+    """Determine if information will be lost without serializing meta.
+
+    This is an internal function used in astropy/io/fits/connect.py and
+    astropy/io/misc/hdf5.py to check the Table ``tbl`` for meta['__attributes__']
+    or any columns with ``attrs`` attributes.
+    """
+    # Check for column attributes that cannot be serialized natively.
+    info_lost = ''
+    for col in tbl.itercols():
+        for attr in attrs:
+            if getattr(col.info, attr, None) not in (None, {}):
+                info_lost = f"column {col.info.name!r} with defined {attr!r} info attribute"
+                break
+        if info_lost:
+            break
+
+    # Check for any defined TableAttributes such as `primary_key` or
+    # `pprint_exclude_names` that are stored in tbl.meta['__attributes__'].
+    if '__attributes__' in tbl.meta:
+        if info_lost:
+            info_lost = info_lost + ', and '
+        lost_attrs = ', '.join(repr(key) for key in tbl.meta['__attributes__'])
+        info_lost = info_lost + f'defined table attribute(s) {lost_attrs}'
+
+    return info_lost

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -540,6 +540,22 @@ class PprintIncludeExclude(TableAttribute):
         return ctx
 
 
+class PrimaryKeyAttribute(TableAttribute):
+    """Table attribute to store the index primary_key in table.meta.
+
+    This allows the primary_key to round-trip through pickling.
+    """
+    def __set__(self, instance, value):
+        # Like normal MetaAttribute set but if setting to None (the default)
+        # then delete the attribute. This allows code like below to run without
+        # making a ``meta`` entry if ``old_table.primary_key`` is None.
+        #   new_table.primary_key = old_table.primary_key
+        if value is None:
+            delattr(instance, self.name)
+        else:
+            super().__set__(instance, value)
+
+
 class Table:
     """A class to represent tables of heterogeneous data.
 
@@ -600,6 +616,8 @@ class Table:
 
     pprint_exclude_names = PprintIncludeExclude()
     pprint_include_names = PprintIncludeExclude()
+
+    primary_key = PrimaryKeyAttribute()
 
     def as_array(self, keep_byteorder=False, names=None):
         """
@@ -668,7 +686,6 @@ class Table:
         self.formatter = self.TableFormatter()
         self._copy_indices = True  # copy indices from this Table by default
         self._init_indices = copy_indices  # whether to copy indices in init
-        self.primary_key = None
 
         # Must copy if dtype are changing
         if not copy and dtype is not None:

--- a/docs/changes/table/11337.feature.rst
+++ b/docs/changes/table/11337.feature.rst
@@ -1,0 +1,4 @@
+Allow table indices and the primary key to be pickled. Also allow any
+``TableAttribute`` to be serialized to FITS and HDF5, including ``primary_key``
+and ``pprint_include/exclude_names``.
+


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to allow table indices and the primary key to be pickled. This is done by turning the `primary_key` Table attribute into a custom `TableAttribute` so it gets stored in meta and hence round-trips through pickling.

It also allows any `TableAttribute` to be serialized to FITS, including `primary_key` and `pprint_include/exclude_names`, and adds tests for FITS and HDF5. This could have been a separate PR but I was in the code.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #11332
