### PR TITLE
Fix ColDefs.add_col/del_col

### DIFF
--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -1721,6 +1721,9 @@ class ColDefs(NotifierMixin):
         if not isinstance(column, Column):
             raise AssertionError
 
+        # Ask the HDU object to load the data before we modify our columns
+        self._notify('load_data')
+
         self._arrays.append(column.array)
         # Obliterate caches of certain things
         del self.dtype
@@ -1746,6 +1749,9 @@ class ColDefs(NotifierMixin):
         col_name : str or int
             The column's name or index
         """
+
+        # Ask the HDU object to load the data before we modify our columns
+        self._notify('load_data')
 
         indx = _get_index(self.names, col_name)
         col = self.columns[indx]

--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -331,9 +331,6 @@ class FITS_rec(np.recarray):
         data = np.recarray(nrows, dtype=columns.dtype, buf=raw_data).view(cls)
         data._character_as_bytes = character_as_bytes
 
-        # Make sure the data is a listener for changes to the columns
-        columns._add_listener(data)
-
         # Previously this assignment was made from hdu.columns, but that's a
         # bug since if a _TableBaseHDU has a FITS_rec in its .data attribute
         # the _TableBaseHDU.columns property is actually returned from

--- a/astropy/io/fits/hdu/table.py
+++ b/astropy/io/fits/hdu/table.py
@@ -212,12 +212,12 @@ class _TableLikeHDU(_ValidHDU):
         interface.
         """
 
-        # TODO: It's not clear that this actually works--it probably does not.
-        # This is what the code used to do before introduction of the
-        # notifier interface, but I don't believe it actually worked (there are
-        # several bug reports related to this...)
         if self._data_loaded:
-            del self.data
+            # recreate data from the columns
+            self.data = FITS_rec.from_columns(
+                self.columns, nrows=self._nrows, fill=False,
+                character_as_bytes=self._character_as_bytes
+            )
 
     def _update_column_removed(self, columns, col_idx):
         """
@@ -225,12 +225,12 @@ class _TableLikeHDU(_ValidHDU):
         interface.
         """
 
-        # For now this doesn't do anything fancy--it just deletes the data
-        # attribute so that it is forced to be recreated again.  It doesn't
-        # change anything on the existing data recarray (this is also how this
-        # worked before introducing the notifier interface)
         if self._data_loaded:
-            del self.data
+            # recreate data from the columns
+            self.data = FITS_rec.from_columns(
+                self.columns, nrows=self._nrows, fill=False,
+                character_as_bytes=self._character_as_bytes
+            )
 
 
 class _TableBaseHDU(ExtensionHDU, _TableLikeHDU):

--- a/astropy/io/fits/hdu/table.py
+++ b/astropy/io/fits/hdu/table.py
@@ -206,31 +206,32 @@ class _TableLikeHDU(_ValidHDU):
         # new data placed in the column object above
         del columns._arrays
 
+    def _update_load_data(self):
+        """Load the data if asked to."""
+        if not self._data_loaded:
+            self.data
+
     def _update_column_added(self, columns, column):
         """
         Update the data upon addition of a new column through the `ColDefs`
         interface.
         """
-
-        if self._data_loaded:
-            # recreate data from the columns
-            self.data = FITS_rec.from_columns(
-                self.columns, nrows=self._nrows, fill=False,
-                character_as_bytes=self._character_as_bytes
-            )
+        # recreate data from the columns
+        self.data = FITS_rec.from_columns(
+            self.columns, nrows=self._nrows, fill=False,
+            character_as_bytes=self._character_as_bytes
+        )
 
     def _update_column_removed(self, columns, col_idx):
         """
         Update the data upon removal of a column through the `ColDefs`
         interface.
         """
-
-        if self._data_loaded:
-            # recreate data from the columns
-            self.data = FITS_rec.from_columns(
-                self.columns, nrows=self._nrows, fill=False,
-                character_as_bytes=self._character_as_bytes
-            )
+        # recreate data from the columns
+        self.data = FITS_rec.from_columns(
+            self.columns, nrows=self._nrows, fill=False,
+            character_as_bytes=self._character_as_bytes
+        )
 
 
 class _TableBaseHDU(ExtensionHDU, _TableLikeHDU):

--- a/astropy/io/fits/hdu/table.py
+++ b/astropy/io/fits/hdu/table.py
@@ -350,6 +350,7 @@ class _TableBaseHDU(ExtensionHDU, _TableLikeHDU):
                 self._header['TFIELDS'] = len(self.data._coldefs)
 
                 self.columns = self.data._coldefs
+                self.columns._add_listener(self.data)
                 self.update()
 
                 with suppress(TypeError, AttributeError):
@@ -435,9 +436,12 @@ class _TableBaseHDU(ExtensionHDU, _TableLikeHDU):
                 new_columns = self._columns_type(data.columns)
                 data = FITS_rec.from_columns(new_columns)
 
+            if 'data' in self.__dict__:
+                self.columns._remove_listener(self.__dict__['data'])
             self.__dict__['data'] = data
 
             self.columns = self.data.columns
+            self.columns._add_listener(self.data)
             self.update()
 
             with suppress(TypeError, AttributeError):

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -716,6 +716,20 @@ class TestTableFunctions(FitsTestCase):
             formats='a10,u4,a10,5f4,l')
         assert comparerecords(tbhdu.data, array)
 
+    def test_adding_a_column_to_file(self):
+        hdul = fits.open(self.data('table.fits'))
+        tbhdu = hdul[1]
+        col = fits.Column(name='a', array=np.array([1, 2]), format='K')
+        tbhdu.columns.add_col(col)
+        assert tbhdu.columns.names == ['target', 'V_mag', 'a']
+        array = np.rec.array(
+            [('NGC1001', 11.1, 1),
+             ('NGC1002', 12.3, 2),
+             ('NGC1003', 15.2, 0)],
+            formats='a20,f4,i8')
+        assert comparerecords(tbhdu.data, array)
+        hdul.close()
+
     def test_removing_a_column_inplace(self):
         # Tests adding a column to a table.
         counts = np.array([312, 334, 308, 317])
@@ -754,6 +768,19 @@ class TestTableFunctions(FitsTestCase):
              ('NCG4', z)],
             formats='a10,5f4')
         assert comparerecords(tbhdu.data, array)
+
+    def test_removing_a_column_from_file(self):
+        hdul = fits.open(self.data('table.fits'))
+        tbhdu = hdul[1]
+        tbhdu.columns.del_col('V_mag')
+        assert tbhdu.columns.names == ['target']
+        array = np.rec.array(
+            [('NGC1001', ),
+             ('NGC1002', ),
+             ('NGC1003', )],
+            formats='a20')
+        assert comparerecords(tbhdu.data, array)
+        hdul.close()
 
     def test_merge_tables(self):
         counts = np.array([312, 334, 308, 317])

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -689,6 +689,72 @@ class TestTableFunctions(FitsTestCase):
             formats='a10,u4,a10,5f4,l')
         assert comparerecords(tbhdu1.data, array)
 
+    def test_adding_a_column_inplace(self):
+        # Tests adding a column to a table.
+        counts = np.array([312, 334, 308, 317])
+        names = np.array(['NGC1', 'NGC2', 'NGC3', 'NCG4'])
+        c1 = fits.Column(name='target', format='10A', array=names)
+        c2 = fits.Column(name='counts', format='J', unit='DN', array=counts)
+        c3 = fits.Column(name='notes', format='A10')
+        c4 = fits.Column(name='spectrum', format='5E')
+        c5 = fits.Column(name='flag', format='L', array=[1, 0, 1, 1])
+        coldefs = fits.ColDefs([c1, c2, c3, c4])
+        tbhdu = fits.BinTableHDU.from_columns(coldefs)
+
+        assert tbhdu.columns.names == ['target', 'counts', 'notes', 'spectrum']
+
+        tbhdu.columns.add_col(c5)
+        assert tbhdu.columns.names == ['target', 'counts', 'notes',
+                                       'spectrum', 'flag']
+
+        z = np.array([0., 0., 0., 0., 0.], dtype=np.float32)
+        array = np.rec.array(
+            [('NGC1', 312, '', z, True),
+             ('NGC2', 334, '', z, False),
+             ('NGC3', 308, '', z, True),
+             ('NCG4', 317, '', z, True)],
+            formats='a10,u4,a10,5f4,l')
+        assert comparerecords(tbhdu.data, array)
+
+    def test_removing_a_column_inplace(self):
+        # Tests adding a column to a table.
+        counts = np.array([312, 334, 308, 317])
+        names = np.array(['NGC1', 'NGC2', 'NGC3', 'NCG4'])
+        c1 = fits.Column(name='target', format='10A', array=names)
+        c2 = fits.Column(name='counts', format='J', unit='DN', array=counts)
+        c3 = fits.Column(name='notes', format='A10')
+        c4 = fits.Column(name='spectrum', format='5E')
+        c5 = fits.Column(name='flag', format='L', array=[1, 0, 1, 1])
+        coldefs = fits.ColDefs([c1, c2, c3, c4, c5])
+        tbhdu = fits.BinTableHDU.from_columns(coldefs)
+
+        assert tbhdu.columns.names == ['target', 'counts', 'notes',
+                                       'spectrum', 'flag']
+
+        tbhdu.columns.del_col('flag')
+
+        assert tbhdu.columns.names == ['target', 'counts', 'notes', 'spectrum']
+        z = np.array([0., 0., 0., 0., 0.], dtype=np.float32)
+        array = np.rec.array(
+            [('NGC1', 312, '', z),
+             ('NGC2', 334, '', z),
+             ('NGC3', 308, '', z),
+             ('NCG4', 317, '', z)],
+            formats='a10,u4,a10,5f4')
+        assert comparerecords(tbhdu.data, array)
+
+        tbhdu.columns.del_col('counts')
+        tbhdu.columns.del_col('notes')
+
+        assert tbhdu.columns.names == ['target', 'spectrum']
+        array = np.rec.array(
+            [('NGC1', z),
+             ('NGC2', z),
+             ('NGC3', z),
+             ('NCG4', z)],
+            formats='a10,5f4')
+        assert comparerecords(tbhdu.data, array)
+
     def test_merge_tables(self):
         counts = np.array([312, 334, 308, 317])
         names = np.array(['NGC1', 'NGC2', 'NGC3', 'NCG4'])

--- a/docs/changes/io.fits/11338.bugfix.rst
+++ b/docs/changes/io.fits/11338.bugfix.rst
@@ -1,0 +1,2 @@
+Fix ``ColDefs.add_col/del_col`` to allow in-place addition or removal of
+a column.


### PR DESCRIPTION
This seems to fix #3647, recreating the data array with `FITS_rec.from_columns` when a column has been added or removed.

I also had to make some changes for listeners, because after the fitsrec object was added to listeners a new `.data` object was created in `__init__` so it was not possible to remove the old one from listeners.