### PR TITLE
split cosmology classes from realizations

### DIFF
--- a/astropy/cosmology/__init__.py
+++ b/astropy/cosmology/__init__.py
@@ -5,7 +5,12 @@ distance measures and other cosmology-related calculations.
 See the `Astropy documentation
 <https://docs.astropy.org/en/latest/cosmology/index.html>`_ for more
 detailed usage examples and references.
+
 """
 
+from . import core, funcs, realizations
 from .core import *
 from .funcs import *
+from .realizations import *
+
+__all__ = core.__all__ + realizations.__all__ + funcs.__all__

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -27,8 +27,7 @@ from . import parameters
 # and Linder 2003, PRL 90, 91301
 
 __all__ = ["FLRW", "LambdaCDM", "FlatLambdaCDM", "wCDM", "FlatwCDM",
-           "Flatw0waCDM", "w0waCDM", "wpwaCDM", "w0wzCDM",
-           "default_cosmology"] + parameters.available
+           "Flatw0waCDM", "w0waCDM", "wpwaCDM", "w0wzCDM"]
 
 __doctest_requires__ = {'*': ['scipy']}
 
@@ -3279,83 +3278,3 @@ def inf_like(x):
         return np.inf
     else:
         return np.full_like(x, np.inf, dtype='float')
-
-
-# Pre-defined cosmologies. This loops over the parameter sets in the
-# parameters module and creates a LambdaCDM or FlatLambdaCDM instance
-# with the same name as the parameter set in the current module's namespace.
-# Note this assumes all the cosmologies in parameters are LambdaCDM,
-# which is true at least as of this writing.
-
-for key in parameters.available:
-    par = getattr(parameters, key)
-    if par['flat']:
-        cosmo = FlatLambdaCDM(par['H0'], par['Om0'], Tcmb0=par['Tcmb0'],
-                              Neff=par['Neff'],
-                              m_nu=u.Quantity(par['m_nu'], u.eV),
-                              name=key,
-                              Ob0=par['Ob0'])
-        docstr = "{} instance of FlatLambdaCDM cosmology\n\n(from {})"
-        cosmo.__doc__ = docstr.format(key, par['reference'])
-    else:
-        cosmo = LambdaCDM(par['H0'], par['Om0'], par['Ode0'],
-                          Tcmb0=par['Tcmb0'], Neff=par['Neff'],
-                          m_nu=u.Quantity(par['m_nu'], u.eV), name=key,
-                          Ob0=par['Ob0'])
-        docstr = "{} instance of LambdaCDM cosmology\n\n(from {})"
-        cosmo.__doc__ = docstr.format(key, par['reference'])
-    setattr(sys.modules[__name__], key, cosmo)
-
-# don't leave these variables floating around in the namespace
-del key, par, cosmo
-
-#########################################################################
-# The science state below contains the current cosmology.
-#########################################################################
-
-
-class default_cosmology(ScienceState):
-    """
-    The default cosmology to use.  To change it::
-
-        >>> from astropy.cosmology import default_cosmology, WMAP7
-        >>> with default_cosmology.set(WMAP7):
-        ...     # WMAP7 cosmology in effect
-        ...     pass
-
-    Or, you may use a string::
-
-        >>> with default_cosmology.set('WMAP7'):
-        ...     # WMAP7 cosmology in effect
-        ...     pass
-    """
-    _value = 'Planck18'
-
-    @staticmethod
-    def get_cosmology_from_string(arg):
-        """ Return a cosmology instance from a string.
-        """
-        if arg == 'no_default':
-            cosmo = None
-        else:
-            try:
-                cosmo = getattr(sys.modules[__name__], arg)
-            except AttributeError:
-                s = "Unknown cosmology '{}'. Valid cosmologies:\n{}".format(
-                    arg, parameters.available)
-                raise ValueError(s)
-        return cosmo
-
-    @classmethod
-    def validate(cls, value):
-        if value is None:
-            value = 'Planck18'
-        if isinstance(value, str):
-            if value == 'Planck18_arXiv_v2':
-                warnings.warn(f"{value} is deprecated in astropy 4.2, use Planck18 instead",
-                              AstropyDeprecationWarning)
-            return cls.get_cosmology_from_string(value)
-        elif isinstance(value, Cosmology):
-            return value
-        else:
-            raise TypeError("default_cosmology must be a string or Cosmology instance.")

--- a/astropy/cosmology/parameters.py
+++ b/astropy/cosmology/parameters.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-""" This module contains dictionaries with sets of parameters for a
+"""This module contains dictionaries with sets of parameters for a
 given cosmology.
 
 Each cosmology has the following parameters defined:

--- a/astropy/cosmology/realizations.py
+++ b/astropy/cosmology/realizations.py
@@ -1,0 +1,115 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+import sys
+import warnings
+
+from astropy import units as u
+from astropy.utils.exceptions import AstropyDeprecationWarning
+from astropy.utils.state import ScienceState
+
+from . import parameters
+from .core import Cosmology, FlatLambdaCDM, LambdaCDM
+
+__all__ = ["default_cosmology"] + parameters.available
+
+__doctest_requires__ = {"*": ["scipy"]}
+
+# Pre-defined cosmologies. This loops over the parameter sets in the
+# parameters module and creates a LambdaCDM or FlatLambdaCDM instance
+# with the same name as the parameter set in the current module's namespace.
+# Note this assumes all the cosmologies in parameters are LambdaCDM,
+# which is true at least as of this writing.
+
+for key in parameters.available:
+    par = getattr(parameters, key)
+    if par["flat"]:
+        cosmo = FlatLambdaCDM(
+            par["H0"],
+            par["Om0"],
+            Tcmb0=par["Tcmb0"],
+            Neff=par["Neff"],
+            m_nu=u.Quantity(par["m_nu"], u.eV),
+            name=key,
+            Ob0=par["Ob0"],
+        )
+        docstr = "{} instance of FlatLambdaCDM cosmology\n\n(from {})"
+        cosmo.__doc__ = docstr.format(key, par["reference"])
+    else:
+        warnings.warn("Please open a PR for your added cosmology realization.")
+        # For a non-flat LCDM realization, the following is the code necessary
+        # to create the realization, given the parameters. We comment this out
+        # as there are not currently any such built-in realizations.
+        # cosmo = LambdaCDM(
+        #     par["H0"],
+        #     par["Om0"],
+        #     par["Ode0"],
+        #     Tcmb0=par["Tcmb0"],
+        #     Neff=par["Neff"],
+        #     m_nu=u.Quantity(par["m_nu"], u.eV),
+        #     name=key,
+        #     Ob0=par["Ob0"],
+        # )
+        # docstr = "{} instance of LambdaCDM cosmology\n\n(from {})"
+        # cosmo.__doc__ = docstr.format(key, par["reference"])
+
+    setattr(sys.modules[__name__], key, cosmo)
+
+# don't leave these variables floating around in the namespace
+del key, par, cosmo
+
+#########################################################################
+# The science state below contains the current cosmology.
+#########################################################################
+
+
+class default_cosmology(ScienceState):
+    """
+    The default cosmology to use.  To change it::
+
+        >>> from astropy.cosmology import default_cosmology, WMAP7
+        >>> with default_cosmology.set(WMAP7):
+        ...     # WMAP7 cosmology in effect
+        ...     pass
+
+    Or, you may use a string::
+
+        >>> with default_cosmology.set('WMAP7'):
+        ...     # WMAP7 cosmology in effect
+        ...     pass
+    """
+
+    _value = "Planck18"
+
+    @staticmethod
+    def get_cosmology_from_string(arg):
+        """ Return a cosmology instance from a string.
+        """
+        if arg == "no_default":
+            cosmo = None
+        else:
+            try:
+                cosmo = getattr(sys.modules[__name__], arg)
+            except AttributeError:
+                s = "Unknown cosmology '{}'. Valid cosmologies:\n{}".format(
+                    arg, parameters.available
+                )
+                raise ValueError(s)
+        return cosmo
+
+    @classmethod
+    def validate(cls, value):
+        if value is None:
+            value = "Planck18"
+        if isinstance(value, str):
+            if value == "Planck18_arXiv_v2":
+                warnings.warn(
+                    f"{value} is deprecated in astropy 4.2, use Planck18 instead",
+                    AstropyDeprecationWarning,
+                )
+            return cls.get_cosmology_from_string(value)
+        elif isinstance(value, Cosmology):
+            return value
+        else:
+            raise TypeError(
+                "default_cosmology must be a string or Cosmology instance."
+            )

--- a/astropy/cosmology/tests/test_cosmology.py
+++ b/astropy/cosmology/tests/test_cosmology.py
@@ -5,7 +5,8 @@ from io import StringIO
 import pytest
 import numpy as np
 
-from astropy.cosmology import core, funcs
+from astropy.cosmology import core, funcs, realizations
+from astropy.cosmology.realizations import Planck13
 from astropy.units import allclose
 from astropy import constants as const
 from astropy import units as u
@@ -47,7 +48,7 @@ def test_init():
         cosmo = core.FlatLambdaCDM(H0=70, Om0=0.27)
         cosmo.Odm(1)
     with pytest.raises(TypeError):
-        core.default_cosmology.validate(4)
+        realizations.default_cosmology.validate(4)
 
 
 def test_basic():
@@ -1554,7 +1555,7 @@ def test_z_at_value():
     # there we are checking internal consistency on the same architecture
     # and so can be more demanding
     z_at_value = funcs.z_at_value
-    cosmo = core.Planck13
+    cosmo = Planck13
     d = cosmo.luminosity_distance(3)
     assert allclose(z_at_value(cosmo.luminosity_distance, d), 3,
                     rtol=1e-8)
@@ -1601,7 +1602,7 @@ def test_z_at_value_roundtrip():
             'de_density_scale', 'w')
 
     import inspect
-    methods = inspect.getmembers(core.Planck13, predicate=inspect.ismethod)
+    methods = inspect.getmembers(Planck13, predicate=inspect.ismethod)
 
     for name, func in methods:
         if name.startswith('_') or name in skip:
@@ -1617,11 +1618,11 @@ def test_z_at_value_roundtrip():
 
     # Test distance functions between two redshifts
     z2 = 2.0
-    func_z1z2 = [lambda z1: core.Planck13._comoving_distance_z1z2(z1, z2),
-                 lambda z1:
-                 core.Planck13._comoving_transverse_distance_z1z2(z1, z2),
-                 lambda z1:
-                 core.Planck13.angular_diameter_distance_z1z2(z1, z2)]
+    func_z1z2 = [
+        lambda z1: Planck13._comoving_distance_z1z2(z1, z2),
+        lambda z1: Planck13._comoving_transverse_distance_z1z2(z1, z2),
+        lambda z1: Planck13.angular_diameter_distance_z1z2(z1, z2)
+    ]
     for func in func_z1z2:
         fval = func(z)
         assert allclose(z, funcs.z_at_value(func, fval, zmax=1.5),

--- a/astropy/cosmology/tests/test_realizations.py
+++ b/astropy/cosmology/tests/test_realizations.py
@@ -1,0 +1,53 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+import pytest
+
+from astropy.cosmology import parameters, realizations
+from astropy.cosmology.realizations import Planck13, default_cosmology
+from astropy.utils.exceptions import AstropyDeprecationWarning
+
+cosmo_realz = [s for s in parameters.available if s != "Planck18_arXiv_v2"]
+
+
+class Test_default_cosmology(object):
+    """Tests for :class:`~astropy.cosmology.realizations.default_cosmology`."""
+
+    @staticmethod
+    def test_get_cosmology_from_string():
+        """Test method ``get_cosmology_from_string``."""
+        cosmo = default_cosmology.get_cosmology_from_string("no_default")
+        assert cosmo is None
+
+        cosmo = default_cosmology.get_cosmology_from_string("Planck13")
+        assert cosmo is Planck13
+
+        with pytest.raises(ValueError):
+            cosmo = default_cosmology.get_cosmology_from_string("fail!")
+
+    @staticmethod
+    def test_validate_specific():
+        """Test method ``validate`` for specific values."""
+        value = default_cosmology.validate(None)
+        assert value is realizations.Planck18
+
+        with pytest.warns(AstropyDeprecationWarning) as e:
+            value = default_cosmology.validate("Planck18_arXiv_v2")
+        assert "use Planck18 instead" in str(e.list[0].message)
+        assert value is realizations.Planck18_arXiv_v2
+
+        with pytest.raises(TypeError) as e:
+            default_cosmology.validate(TypeError)
+        assert "string or Cosmology instance" in str(e.value)
+
+    @pytest.mark.parametrize("name", cosmo_realz)
+    def test_validate_str(self, name):
+        """Test method ``validate`` for string input."""
+        value = default_cosmology.validate(name)
+        assert value is getattr(realizations, name)
+
+    @pytest.mark.parametrize("name", cosmo_realz)
+    def test_validate_cosmo(self, name):
+        """Test method ``validate`` for cosmology instance input."""
+        cosmo = getattr(realizations, name)
+        value = default_cosmology.validate(cosmo)
+        assert value is cosmo

--- a/docs/changes/cosmology/11345.api.rst
+++ b/docs/changes/cosmology/11345.api.rst
@@ -1,0 +1,2 @@
+Split cosmology realizations from core classes, moving the former to new file
+``realizations``.


### PR DESCRIPTION
### Description

Part of #10673

All this PR does is separate the class definitions of a cosmology with its realization(s).
As both the classes and realizations are intended to be accessed from the top-level namespace of the ``cosmology`` package, this PR should have no/minimal/very-easily-fixed impact on users.
Looking forward, this separation will make it easier to add separate entry points for both the classes and realizations so that 3rd party packages can augment``cosmology``'s offerings.
