### PR TITLE
Doc update: INFO is the logging default.

### DIFF
--- a/docs/logging.rst
+++ b/docs/logging.rst
@@ -24,7 +24,7 @@ levels:
 
 * ERROR: indicates a more serious issue, including exceptions
 
-By default, only WARNING and ERROR messages are displayed, and are sent to a
+By default, INFO, WARNING and ERROR messages are displayed, and are sent to a
 log file located at ``~/.astropy/astropy.log`` (if the file is writeable).
 
 Configuring the logging system
@@ -36,7 +36,7 @@ First, import the logger::
 
 The threshold level (defined above) for messages can be set with e.g.::
 
-    log.setLevel('INFO')
+    log.setLevel('DEBUG')
 
 Color (enabled by default) can be disabled with::
 


### PR DESCRIPTION
Updated the documentation to reflect that by default, the logging level is set to INFO. Fixes #11348.