### PR TITLE
Remove useless logging call

### DIFF
--- a/astropy/__init__.py
+++ b/astropy/__init__.py
@@ -182,11 +182,6 @@ def _get_bibtex():
 
 __citation__ = __bibtex__ = _get_bibtex()
 
-import logging  # noqa: E402
-
-# Use the root logger as a dummy log before initilizing Astropy's logger
-log = logging.getLogger()
-
 from .logger import _init_log, _teardown_log  # noqa: E402, F401
 
 log = _init_log()


### PR DESCRIPTION
Leftover from 0a84063ba5c093f93de1992094343c09ae96a247, previously `_init_log` was called only if not in the setup execution.