### PR TITLE
Improve the performance of bayesian_blocks (binned or unbinned events)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -352,6 +352,9 @@ Other Changes and Additions
 - Refactored the usage of metaclasses in ``astropy.coordinates`` to instead use
   ``__init_subclass__`` where possible. [#11090]
 
+- Improved performance of ``bayesian_blocks()`` by removing one ``np.log()``
+  call [#11356]
+
 
 4.2.1 (unreleased)
 ==================

--- a/astropy/stats/bayesian_blocks.py
+++ b/astropy/stats/bayesian_blocks.py
@@ -426,7 +426,7 @@ class Events(FitnessFunc):
 
     def fitness(self, N_k, T_k):
         # eq. 19 from Scargle 2012
-        return N_k * (np.log(N_k) - np.log(T_k))
+        return N_k * (np.log(N_k / T_k))
 
     def validate_input(self, t, x, sigma):
         t, x, sigma = super().validate_input(t, x, sigma)


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

A very small change to improve the performance of `bayesian_blocks()`. In my tests it runs ~1.4x faster, between 30-40% of time saved.

```
In [2]: %timeit -n 5 -r 5 bayesian_block(x)
10.7 s ± 39.9 ms per loop (mean ± std. dev. of 5 runs, 5 loops each)

In [3]: %timeit -n 5 -r 5 bayesian_block_new(x)
6.34 s ± 668 ms per loop (mean ± std. dev. of 5 runs, 5 loops each)
```

Could somebody confirm this?