### PR TITLE
Fix issue with serialized meta with h5py version >= 3.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1213,6 +1213,11 @@ astropy.io.fits
 astropy.io.misc
 ^^^^^^^^^^^^^^^
 
+- Fixed problem when writing serialized metadata to HDF5 using h5py >= 3.0.
+  With the newer h5py this was writing the metadata table as a variable-length
+  string array instead of the previous fixed-length bytes array. Fixed astropy
+  to force using a fixed-length bytes array. [#11359]
+
 astropy.io.registry
 ^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/io/misc/hdf5.py
+++ b/astropy/io/misc/hdf5.py
@@ -360,8 +360,7 @@ def write_table_hdf5(table, output, path=None, compression=False,
 
     if serialize_meta:
         header_yaml = meta.get_yaml_from_table(table)
-
-        header_encoded = [h.encode('utf-8') for h in header_yaml]
+        header_encoded = np.array([h.encode('utf-8') for h in header_yaml])
         output_group.create_dataset(meta_path(name),
                                     data=header_encoded)
 

--- a/astropy/io/misc/tests/test_hdf5.py
+++ b/astropy/io/misc/tests/test_hdf5.py
@@ -15,6 +15,7 @@ from astropy.time import Time, TimeDelta
 from astropy.units.quantity import QuantityInfo
 from astropy.utils.exceptions import AstropyUserWarning
 from astropy.utils.data import get_pkg_data_filename
+from astropy.io.misc.hdf5 import meta_path
 
 try:
     import h5py
@@ -461,6 +462,11 @@ def test_preserve_serialized(tmpdir):
     assert t1['a'].description == t2['a'].description
     assert t1['a'].meta == t2['a'].meta
     assert t1.meta == t2.meta
+
+    # Check that the meta table is fixed-width bytes (see #11299)
+    h5 = h5py.File(test_file)
+    meta_lines = h5[meta_path('the_table')]
+    assert meta_lines.dtype.kind == 'S'
 
 
 @pytest.mark.skipif('not HAS_H5PY or not HAS_YAML')


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to fix a compatibility issue introduced by h5py version 3.0.  In previous versions, creating a dataset from a list of bytes objects would choose a fixed length string datatype to fit the biggest item. It will now use a variable length string datatype. 

Thus h5py is now writing out as variable-length strings but the current version of PyTables can't handle that.

This fix forces use of fixed-length `bytes` by turning the metadata lines into a fixed-length numpy array before storing with h5py.

In addition to the new test, I independently verified that the table can be read with PyTables. I also verified that the new test fails without the patch.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #11299
