### PR TITLE
Extend astropy.cosmology.z_at_value to accept array of values

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,10 @@ astropy.coordinates
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 
+- Adds the ability to pass an array of function values to ``z_at_value``,
+  rather than just a single value. This uses a cubic spline to interpolate
+  over a grid of ``(z, func(z))`` values.
+
 astropy.extern
 ^^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,7 +33,7 @@ astropy.cosmology
 
 - Adds the ability to pass an array of function values to ``z_at_value``,
   rather than just a single value. This uses a cubic spline to interpolate
-  over a grid of ``(z, func(z))`` values.
+  over a grid of ``(z, func(z))`` values. [#11361]
 
 astropy.extern
 ^^^^^^^^^^^^^^

--- a/astropy/cosmology/funcs.py
+++ b/astropy/cosmology/funcs.py
@@ -84,7 +84,7 @@ def z_at_value(func, fval, zmin=1e-8, zmax=1000, ztol=1e-8, maxfun=500,
 
     Parameters
     ----------
-    func : function or method
+    func : callable
        A function that takes a redshift as input.
     fval : astropy.Quantity instance or array_like
        The value of ``func(z)``.
@@ -147,8 +147,7 @@ def z_at_value(func, fval, zmin=1e-8, zmax=1000, ztol=1e-8, maxfun=500,
            (not isinstance(fval, Quantity) and isinstance(fval, np.ndarray))
            )
     if is_array:
-        fvals = fval
-        return _z_at_array(func, fvals,
+        return _z_at_array(func, fval,
                            zmin=zmin, zmax=zmax,
                            nbins=nbins, logspace=logspace,
                            interpolation=interpolation)

--- a/astropy/cosmology/funcs.py
+++ b/astropy/cosmology/funcs.py
@@ -5,7 +5,13 @@ Convenience functions for `astropy.cosmology`.
 
 import warnings
 import numpy as np
-from scipy.interpolate import CubicSpline
+
+try:
+    from scipy.interpolate import CubicSpline
+except ImportError:
+    HAS_SCIPY = False
+else:
+    HAS_SCIPY = True
 
 from .core import CosmologyError
 from astropy.units import Quantity
@@ -27,8 +33,15 @@ def _z_at_array(func, fvals, zmin, zmax, nbins=1000, logspace=True):
     fvals_val = fvals.value
     fgrid_val = fgrid.value
 
-    interpolator = CubicSpline(fgrid_val, zgrid)
-    zvals = interpolator(fvals_val)
+    if HAS_SCIPY:
+        interpolator = CubicSpline(fgrid_val, zgrid)
+        zvals = interpolator(fvals_val)
+    else:
+        warnings.warn("""\
+SciPy not found, so falling back to linear numpy interpolation scheme
+for array z_at_value, instead of the normal cubic spline.""")
+        zvals = np.interp(fvals_val, fgrid_val, zgrid)
+
     return zvals
 
 

--- a/astropy/cosmology/funcs.py
+++ b/astropy/cosmology/funcs.py
@@ -76,7 +76,7 @@ def z_at_value(func, fval, zmin=1e-8, zmax=1000, ztol=1e-8, maxfun=500,
 
     Returns
     -------
-    z : float
+    z : float or array_like
       The redshift ``z`` satisfying ``zmin < z < zmax`` and ``func(z) =
       fval`` within ``ztol``.
 

--- a/astropy/cosmology/funcs.py
+++ b/astropy/cosmology/funcs.py
@@ -5,6 +5,7 @@ Convenience functions for `astropy.cosmology`.
 
 import warnings
 import numpy as np
+from scipy.interpolate import CubicSpline
 
 from .core import CosmologyError
 from astropy.units import Quantity
@@ -27,12 +28,8 @@ def _z_at_array(func, fvals, fmin, fmax, nbins=1000, logspace=True):
     fgrid_val = fgrid.value
 
     func_is_monotonic = np.all(np.diff(fgrid_val) > 0)
-    if func_is_monotonic:
-        zvals = np.interp(fvals_val, fgrid_val, zgrid)
-    else:
-        from scipy.interpolate import CubicSpline
-        interpolator = CubicSpline(fgrid_val, zgrid)
-        zvals = interpolator(fvals_val)
+    interpolator = CubicSpline(fgrid_val, zgrid)
+    zvals = interpolator(fvals_val)
     return zvals
 
 

--- a/astropy/cosmology/funcs.py
+++ b/astropy/cosmology/funcs.py
@@ -71,6 +71,16 @@ def z_at_value(func, fval, zmin=1e-8, zmax=1000, ztol=1e-8, maxfun=500,
       ``zmin`` and ``zmax`` keywords to limit the search range (see the
       example below).
 
+    .. warning::
+      The results of this function will likely differ depending on whether
+      you input a single value for ``fval``, or an array of values.
+      In the single value case, this function will attempt to find
+      something close to the exact value using ``fminbound`` (proximity
+      depending on ``ztol``), but in the array case, this function
+      will use a cubic spline interpolation scheme, which will give
+      approximate answers which increase in accuracy as ``nbins``
+      is increased.
+
     Parameters
     ----------
     func : function or method

--- a/astropy/cosmology/funcs.py
+++ b/astropy/cosmology/funcs.py
@@ -31,7 +31,7 @@ def _z_at_array(func, fvals, zmin, zmax, nbins=1000, logspace=True):
     fgrid = func(zgrid)
 
     fvals_val = fvals.value
-    fgrid_val = fgrid.value
+    fgrid_val = fgrid.to_value(fvals.unit)
 
     if HAS_SCIPY:
         interpolator = CubicSpline(fgrid_val, zgrid)

--- a/astropy/cosmology/funcs.py
+++ b/astropy/cosmology/funcs.py
@@ -9,9 +9,9 @@ import numpy as np
 try:
     from scipy.interpolate import CubicSpline
 except ImportError:
-    USE_SCIPY = False
+    HAS_SCIPY = False
 else:
-    USE_SCIPY = True
+    HAS_SCIPY = True
 
 from .core import CosmologyError
 from astropy.units import Quantity
@@ -35,7 +35,7 @@ def _z_at_array(func, fvals, zmin, zmax, nbins=10000,
     fgrid_val = fgrid.to_value(fvals.unit)
 
     if interpolation is None:
-        if USE_SCIPY:
+        if HAS_SCIPY:
             interpolation = 'cubic'
         else:
             warnings.warn("""\

--- a/astropy/cosmology/funcs.py
+++ b/astropy/cosmology/funcs.py
@@ -20,6 +20,8 @@ __all__ = ['z_at_value']
 
 __doctest_requires__ = {'*': ['scipy']}
 
+_interpolation_choices = ['cubic', 'linear']
+
 
 def _z_at_array(func, fvals, zmin, zmax, nbins=10000,
                 logspace=True, interpolation=None):
@@ -44,7 +46,11 @@ def _z_at_array(func, fvals, zmin, zmax, nbins=10000,
                 " spline."))
             interpolation = 'linear'
 
-    assert interpolation in ['cubic', 'linear']
+    if interpolation not in _interpolation_choices:
+        raise ValueError(
+                f"{interpolation} is an invalid interpolation method."
+                f" Please use an option from {_interpolation_choices}."
+            )
 
     if interpolation == 'cubic':
         interpolator = CubicSpline(fgrid_val, zgrid)

--- a/astropy/cosmology/funcs.py
+++ b/astropy/cosmology/funcs.py
@@ -9,9 +9,9 @@ import numpy as np
 try:
     from scipy.interpolate import CubicSpline
 except ImportError:
-    HAS_SCIPY = False
+    USE_SCIPY = False
 else:
-    HAS_SCIPY = True
+    USE_SCIPY = True
 
 from .core import CosmologyError
 from astropy.units import Quantity
@@ -35,7 +35,7 @@ def _z_at_array(func, fvals, zmin, zmax, nbins=10000,
     fgrid_val = fgrid.to_value(fvals.unit)
 
     if interpolation is None:
-        if HAS_SCIPY:
+        if USE_SCIPY:
             interpolation = 'cubic'
         else:
             warnings.warn("""\
@@ -43,14 +43,13 @@ SciPy not found, so falling back to linear numpy interpolation scheme
 for array z_at_value, instead of the normal cubic spline.""")
             interpolation = 'linear'
 
+    assert interpolation in ['cubic', 'linear']
+
     if interpolation == 'cubic':
         interpolator = CubicSpline(fgrid_val, zgrid)
         zvals = interpolator(fvals_val)
-    elif interpolation == 'linear':
-        zvals = np.interp(fvals_val, fgrid_val, zgrid)
     else:
-        raise NotImplementedError(f"Interpolation method '{interpolation}'"
-                                   " is not implemented.")
+        zvals = np.interp(fvals_val, fgrid_val, zgrid)
 
     return zvals
 

--- a/astropy/cosmology/funcs.py
+++ b/astropy/cosmology/funcs.py
@@ -21,7 +21,7 @@ __all__ = ['z_at_value']
 __doctest_requires__ = {'*': ['scipy']}
 
 
-def _z_at_array(func, fvals, zmin, zmax, nbins=1000,
+def _z_at_array(func, fvals, zmin, zmax, nbins=10000,
                 logspace=True, interpolation=None):
     """Helper function to interpolate (func, z) over a grid for array input"""
     if logspace:
@@ -56,7 +56,7 @@ for array z_at_value, instead of the normal cubic spline.""")
 
 
 def z_at_value(func, fval, zmin=1e-8, zmax=1000, ztol=1e-8, maxfun=500,
-               nbins=1000, logspace=True, interpolation=None):
+               nbins=10000, logspace=True, interpolation=None):
     """ Find the redshift ``z`` at which ``func(z) = fval``.
 
     This finds the redshift at which one of the cosmology functions or

--- a/astropy/cosmology/funcs.py
+++ b/astropy/cosmology/funcs.py
@@ -13,6 +13,7 @@ __all__ = ['z_at_value']
 
 __doctest_requires__ = {'*': ['scipy']}
 
+
 def _z_at_array(func, fvals, fmin, fmax, nbins=1000, logspace=True):
     """Helper function to interpolate (func, z) over a grid for array input"""
     if logspace:

--- a/astropy/cosmology/funcs.py
+++ b/astropy/cosmology/funcs.py
@@ -118,7 +118,11 @@ def z_at_value(func, fval, zmin=1e-8, zmax=1000, ztol=1e-8, maxfun=500,
     other commonly inverted quantities) are monotonic in flat and open
     universes, but not in closed universes.
     """
-    if not fval.isscalar:
+    is_array = (
+           (isinstance(fval, Quantity) and not fval.isscalar) or
+           (not isinstance(fval, Quantity) and isinstance(fval, np.ndarray))
+           )
+    if is_array:
         fvals = fval
         return _z_at_array(func, fvals,
                            zmin=zmin, zmax=zmax,

--- a/astropy/cosmology/funcs.py
+++ b/astropy/cosmology/funcs.py
@@ -105,6 +105,12 @@ def z_at_value(func, fval, zmin=1e-8, zmax=1000, ztol=1e-8, maxfun=500,
     other commonly inverted quantities) are monotonic in flat and open
     universes, but not in closed universes.
     """
+    if isinstance(fval, np.ndarray):
+        fvals = fval
+        return _z_at_array(func, fvals,
+                           zmin=zmin, zmax=zmax,
+                           nbins=nbins, logspace=logspace)
+
     from scipy.optimize import fminbound
 
     fval_zmin = func(zmin)
@@ -114,12 +120,6 @@ def z_at_value(func, fval, zmin=1e-8, zmax=1000, ztol=1e-8, maxfun=500,
 fval is not bracketed by func(zmin) and func(zmax). This means either
 there is no solution, or that there is more than one solution between
 zmin and zmax satisfying fval = func(z).""")
-
-    if isinstance(fval, np.ndarray):
-        fvals = fval
-        return _z_at_array(func, fvals,
-                           zmin=zmin, zmax=zmax,
-                           nbins=nbins, logspace=logspace)
 
     if isinstance(fval_zmin, Quantity):
         val = fval.to_value(fval_zmin.unit)

--- a/astropy/cosmology/funcs.py
+++ b/astropy/cosmology/funcs.py
@@ -118,7 +118,7 @@ def z_at_value(func, fval, zmin=1e-8, zmax=1000, ztol=1e-8, maxfun=500,
     other commonly inverted quantities) are monotonic in flat and open
     universes, but not in closed universes.
     """
-    if isinstance(fval, np.ndarray):
+    if not fval.isscalar:
         fvals = fval
         return _z_at_array(func, fvals,
                            zmin=zmin, zmax=zmax,

--- a/astropy/cosmology/funcs.py
+++ b/astropy/cosmology/funcs.py
@@ -15,7 +15,7 @@ __all__ = ['z_at_value']
 __doctest_requires__ = {'*': ['scipy']}
 
 
-def _z_at_array(func, fvals, fmin, fmax, nbins=1000, logspace=True):
+def _z_at_array(func, fvals, zmin, zmax, nbins=1000, logspace=True):
     """Helper function to interpolate (func, z) over a grid for array input"""
     if logspace:
         zgrid = np.logspace(np.log10(zmin), np.log10(zmax), nbins)
@@ -27,7 +27,6 @@ def _z_at_array(func, fvals, fmin, fmax, nbins=1000, logspace=True):
     fvals_val = fvals.value
     fgrid_val = fgrid.value
 
-    func_is_monotonic = np.all(np.diff(fgrid_val) > 0)
     interpolator = CubicSpline(fgrid_val, zgrid)
     zvals = interpolator(fvals_val)
     return zvals
@@ -119,7 +118,7 @@ zmin and zmax satisfying fval = func(z).""")
     if isinstance(fval, np.ndarray):
         fvals = fval
         return _z_at_array(func, fvals,
-                           fmin=fval_zmin, fmax=fval_zmax,
+                           zmin=zmin, zmax=zmax,
                            nbins=nbins, logspace=logspace)
 
     if isinstance(fval_zmin, Quantity):

--- a/astropy/cosmology/funcs.py
+++ b/astropy/cosmology/funcs.py
@@ -38,9 +38,10 @@ def _z_at_array(func, fvals, zmin, zmax, nbins=10000,
         if HAS_SCIPY:
             interpolation = 'cubic'
         else:
-            warnings.warn("""\
-SciPy not found, so falling back to linear numpy interpolation scheme
-for array z_at_value, instead of the normal cubic spline.""")
+            warnings.warn((
+                "SciPy not found, so falling back to linear numpy interpolation"
+                " scheme for array z_at_value, instead of the normal cubic"
+                " spline."))
             interpolation = 'linear'
 
     assert interpolation in ['cubic', 'linear']

--- a/astropy/cosmology/funcs.py
+++ b/astropy/cosmology/funcs.py
@@ -68,25 +68,25 @@ def z_at_value(func, fval, zmin=1e-8, zmax=1000, ztol=1e-8, maxfun=500,
     This finds the redshift at which one of the cosmology functions or
     methods (for example Planck13.distmod) is equal to a known value.
 
-    .. warning::
-      Make sure you understand the behavior of the function that you
-      are trying to invert! Depending on the cosmology, there may not
-      be a unique solution. For example, in the standard Lambda CDM
-      cosmology, there are two redshifts which give an angular
-      diameter distance of 1500 Mpc, z ~ 0.7 and z ~ 3.8. To force
-      ``z_at_value`` to find the solution you are interested in, use the
-      ``zmin`` and ``zmax`` keywords to limit the search range (see the
-      example below).
+    Warnings
+    --------
+       * **Uniqueness**. Make sure you understand the behavior of the
+       function that you are trying to invert! Depending on the cosmology,
+       there may not be a unique solution. For example, in the standard
+       Lambda CDM cosmology, there are two redshifts which give an angular
+       diameter distance of 1500 Mpc, z ~ 0.7 and z ~ 3.8. To force
+       ``z_at_value`` to find the solution you are interested in, use the
+       ``zmin`` and ``zmax`` keywords to limit the search range (see the
+       example below).
 
-    .. warning::
-      The results of this function will likely differ depending on whether
-      you input a single value for ``fval``, or an array of values.
-      In the single value case, this function will attempt to find
-      something close to the exact value using ``fminbound`` (proximity
-      depending on ``ztol``), but in the array case, this function
-      will use a cubic spline interpolation scheme, which will give
-      approximate answers which increase in accuracy as ``nbins``
-      is increased.
+       * **Arrays**. The results of this function will differ depending
+       on whether you input a scalar for ``fval``, or an array.
+       In the single value case, this function will attempt to find
+       something close to the exact value using ``fminbound`` (proximity
+       depending on ``ztol``), but in the array case, this function
+       will use a cubic spline interpolation scheme, which will give
+       approximate answers which increase in accuracy as ``nbins``
+       is increased.
 
     Parameters
     ----------
@@ -115,8 +115,9 @@ def z_at_value(func, fval, zmin=1e-8, zmax=1000, ztol=1e-8, maxfun=500,
         to create the gridpoints in logarithmic space
     interpolation: {'cubic', 'linear'} or None, optional
         If passing an array for ``fval``, this specifies the
-        interpolation method. Default is ``'cubic''' if
-        scipy is installed, or ``'linear''' otherwise.
+        interpolation method. Default is ``'cubic'`` (a cubic
+        spline interpolation scheme) if
+        scipy is installed, or ``'linear'`` interpolation otherwise.
 
     Returns
     -------

--- a/astropy/cosmology/funcs.py
+++ b/astropy/cosmology/funcs.py
@@ -35,15 +35,18 @@ def _z_at_array(func, fvals, zmin, zmax, nbins=1000,
     fgrid_val = fgrid.to_value(fvals.unit)
 
     if interpolation is None:
-        interpolation = 'cubic' if HAS_SCIPY else 'linear'
+        if HAS_SCIPY:
+            interpolation = 'cubic'
+        else:
+            warnings.warn("""\
+SciPy not found, so falling back to linear numpy interpolation scheme
+for array z_at_value, instead of the normal cubic spline.""")
+            interpolation = 'linear'
 
     if interpolation == 'cubic':
         interpolator = CubicSpline(fgrid_val, zgrid)
         zvals = interpolator(fvals_val)
     elif interpolation == 'linear':
-        warnings.warn("""\
-SciPy not found, so falling back to linear numpy interpolation scheme
-for array z_at_value, instead of the normal cubic spline.""")
         zvals = np.interp(fvals_val, fgrid_val, zgrid)
     else:
         raise NotImplementedError(f"Interpolation method '{interpolation}'"

--- a/astropy/cosmology/funcs.py
+++ b/astropy/cosmology/funcs.py
@@ -14,7 +14,9 @@ __all__ = ['z_at_value']
 __doctest_requires__ = {'*': ['scipy']}
 
 
-def z_at_value(func, fval, zmin=1e-8, zmax=1000, ztol=1e-8, maxfun=500):
+
+def z_at_value(func, fval, zmin=1e-8, zmax=1000, ztol=1e-8, maxfun=500,
+               nbins=10000):
     """ Find the redshift ``z`` at which ``func(z) = fval``.
 
     This finds the redshift at which one of the cosmology functions or
@@ -34,7 +36,7 @@ def z_at_value(func, fval, zmin=1e-8, zmax=1000, ztol=1e-8, maxfun=500):
     ----------
     func : function or method
        A function that takes a redshift as input.
-    fval : astropy.Quantity instance
+    fval : astropy.Quantity instance or array_like
        The value of ``func(z)``.
     zmin : float, optional
        The lower search limit for ``z``.  Beware of divergences
@@ -47,45 +49,15 @@ def z_at_value(func, fval, zmin=1e-8, zmax=1000, ztol=1e-8, maxfun=500):
     maxfun : int, optional
        The maximum number of function evaluations allowed in the
        optimization routine (default 500).
+    nbins : float, optional
+        If passing an array of ``fval``, this specifies the number
+        of gridpoints to fit.
 
     Returns
     -------
     z : float
       The redshift ``z`` satisfying ``zmin < z < zmax`` and ``func(z) =
       fval`` within ``ztol``.
-
-    Notes
-    -----
-    This works for any arbitrary input cosmology, but is inefficient
-    if you want to invert a large number of values for the same
-    cosmology. In this case, it is faster to instead generate an array
-    of values at many closely-spaced redshifts that cover the relevant
-    redshift range, and then use interpolation to find the redshift at
-    each value you're interested in. For example, to efficiently find
-    the redshifts corresponding to 10^6 values of the distance modulus
-    in a Planck13 cosmology, you could do the following:
-
-    >>> import astropy.units as u
-    >>> from astropy.cosmology import Planck13, z_at_value
-
-    Generate 10^6 distance moduli between 24 and 43 for which we
-    want to find the corresponding redshifts:
-
-    >>> Dvals = (24 + np.random.rand(1000000) * 20) * u.mag
-
-    Make a grid of distance moduli covering the redshift range we
-    need using 50 equally log-spaced values between zmin and
-    zmax. We use log spacing to adequately sample the steep part of
-    the curve at low distance moduli:
-
-    >>> zmin = z_at_value(Planck13.distmod, Dvals.min())
-    >>> zmax = z_at_value(Planck13.distmod, Dvals.max())
-    >>> zgrid = np.logspace(np.log10(zmin), np.log10(zmax), 50)
-    >>> Dgrid = Planck13.distmod(zgrid)
-
-    Finally interpolate to find the redshift at each distance modulus:
-
-    >>> zvals = np.interp(Dvals.value, Dgrid.value, zgrid)
 
     Examples
     --------

--- a/astropy/cosmology/funcs.py
+++ b/astropy/cosmology/funcs.py
@@ -101,20 +101,22 @@ def z_at_value(func, fval, zmin=1e-8, zmax=1000, ztol=1e-8, maxfun=500,
     zmax : float, optional
        The upper search limit for ``z`` (default 1000).
     ztol : float, optional
-       The relative error in ``z`` acceptable for convergence.
+       If passing a scalar for ``fval``, the relative error
+       in ``z`` acceptable for convergence.
     maxfun : int, optional
-       The maximum number of function evaluations allowed in the
+       If passing a scalar for ``fval``,
+       the maximum number of function evaluations allowed in the
        optimization routine (default 500).
     nbins : float, optional
-        If passing an array of ``fval``, this specifies the number
+        If passing an array for ``fval``, this specifies the number
         of gridpoints to use for interpolation.
     logspace: bool, optional
-        If passing an array of ``fval``, this specifies whether
+        If passing an array for ``fval``, this specifies whether
         to create the gridpoints in logarithmic space
-    interpolation: None or string, optional
-        To force linear interpolation, use ``'linear'``. Otherwise,
-        the choice depends on whether scipy is installed (cubic) or not
-        (linear).
+    interpolation: {'cubic', 'linear'} or None, optional
+        If passing an array for ``fval``, this specifies the
+        interpolation method. Default is ``'cubic''' if
+        scipy is installed, or ``'linear''' otherwise.
 
     Returns
     -------

--- a/astropy/cosmology/tests/test_cosmology.py
+++ b/astropy/cosmology/tests/test_cosmology.py
@@ -1583,7 +1583,7 @@ def test_z_at_value():
                     1.9913891680278133, rtol=1e-3)
     assert allclose(z_at_value(cosmo.distmod, np.array([46]*4) * u.mag,
                                zmin=1.5, zmax=2.5, nbins=10000,
-                               logspace=False),
+                               logspace=False, interpolation='linear'),
                     1.9913891680278133, rtol=1e-3)
     c = core.WMAP9
     assert allclose(z_at_value(c.distmod, np.linspace(46, 47, num=5)*u.mag,

--- a/astropy/cosmology/tests/test_cosmology.py
+++ b/astropy/cosmology/tests/test_cosmology.py
@@ -1577,6 +1577,11 @@ def test_z_at_value():
     assert allclose(z_at_value(cosmo.distmod, 46 * u.mag),
                     1.9913891680278133, rtol=1e-6)
 
+    # Test array:
+    assert allclose(z_at_value(cosmo.distmod, np.array([46]*4) * u.mag,
+                               zmin=1.5, zmax=2.5, nbins=10000),
+                    [1.9913891680278133]*4, rtol=1e-3)
+
     # test behavior when the solution is outside z limits (should
     # raise a CosmologyError)
     with pytest.raises(core.CosmologyError):

--- a/astropy/cosmology/tests/test_cosmology.py
+++ b/astropy/cosmology/tests/test_cosmology.py
@@ -1580,7 +1580,7 @@ def test_z_at_value():
     # Test array:
     assert allclose(z_at_value(cosmo.distmod, np.array([46]*4) * u.mag,
                                zmin=1.5, zmax=2.5, nbins=10000),
-                    [1.9913891680278133]*4, rtol=1e-3)
+                    1.9913891680278133, rtol=1e-3)
 
     # test behavior when the solution is outside z limits (should
     # raise a CosmologyError)

--- a/astropy/cosmology/tests/test_cosmology.py
+++ b/astropy/cosmology/tests/test_cosmology.py
@@ -1581,6 +1581,16 @@ def test_z_at_value():
     assert allclose(z_at_value(cosmo.distmod, np.array([46]*4) * u.mag,
                                zmin=1.5, zmax=2.5, nbins=10000),
                     1.9913891680278133, rtol=1e-3)
+    assert allclose(z_at_value(cosmo.distmod, np.array([46]*4) * u.mag,
+                               zmin=1.5, zmax=2.5, nbins=10000,
+                               logspace=False),
+                    1.9913891680278133, rtol=1e-3)
+    c = core.WMAP9
+    assert allclose(z_at_value(c.distmod, np.linspace(46, 47, num=5)*u.mag,
+                               nbins=10000),
+                    np.array([z_at_value(c.distmod, m*u.mag)
+                              for m in np.linspace(46, 47, num=5)])
+                   )
 
     # test behavior when the solution is outside z limits (should
     # raise a CosmologyError)


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This PR extends `astropy.cosmology.z_at_value` to accept an array of function values, rather than a single value. The implementation follows the suggested advice in the docstring of using interpolation over a grid of z values and inverting. However, I use a cubic spline instead of `np.interp` (which uses linear interpolation), though the fallback method is `np.interp` if scipy is not found.

Two new arguments are added: `nbins` which sets the number of gridpoints to evaluate the function at to build up a dataset of `(z, func(z))` tuples, and `logspace`, a bool which determines whether to generate the grid with logarithmic spacing. `zmin` and `zmax` are used for the boundaries.

### Example

```python
In [1]: import numpy as np

In [2]: from astropy.cosmology import *

In [3]: from astropy import units as u

In [4]: c = WMAP9

In [5]: z_at_value(c.distmod, np.linspace(46, 47, num=5)*u.mag, nbins=100000)
Out[5]: array([1.99730735, 2.19385919, 2.41063801, 2.64988939, 2.91411485])

In [6]: [z_at_value(c.distmod, m*u.mag) for m in np.linspace(46, 47, num=5)]
Out[6]:
[1.9973073517900408,
 2.1938592046349723,
 2.4106380062724306,
 2.649889378441432,
 2.914114859113246]
```

^(The array-based scheme in `In [5]` is much faster)