### PR TITLE
Fix compatibility issue with Table masked init and numpy 1.21

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1251,6 +1251,10 @@ astropy.table
   triggered swapping when native endianness was stored with explicit
   ``dtype`` code ``'<'`` (or ``'>'``) instead of ``'='``. [#11288, #11294]
 
+- Fixed a compatibility issue with numpy 1.21. Initializing a Table with a
+  column like ``['str', np.ma.masked]`` was failing in tests due to a change in
+  numpy. [#11364]
+
 - Fixed bug when validating the inputs to ``table.hstack``, ``table.vstack``,
   and ``table.dstack``. Previously, mistakenly calling ``table.hstack(t1, t2)``
   (instead of ``table.hstack([t1, t2]))`` would return ``t1`` instead of raising

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -196,6 +196,10 @@ def _convert_sequence_data_to_array(data, dtype=None):
         # converted to an error (which can happen during pytest).
         warnings.filterwarnings('always', category=UserWarning,
                                 message='.*converting a masked element.*')
+        # FutureWarning in numpy 1.21. See https://github.com/astropy/astropy/issues/11291
+        # and https://github.com/numpy/numpy/issues/18425.
+        warnings.filterwarnings('always', category=FutureWarning,
+                                message='.*Promotion of numbers and bools to strings.*')
         try:
             np_data = np.array(data, dtype=dtype)
         except np.ma.MaskError:


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

See #11291 and https://github.com/numpy/numpy/issues/18425 for the full story, but in short numpy 1.21 is introducing a new FutureWarning that was causing tests to fail, but without impact to normal usage. This is due to pytest turning warnings into errors, which numpy was catching and causing the array dtype to become `object`.

This code specifies that the new `FutureWarning` is always issued as a warning, which overrides (for this warning) the generic pytest directive to convert warnings to errors. In local testing at least this does the right thing.

This patch is a band-aid for now to get tests passing again. It would be good to get this out in a bug-fix release before numpy 1.21 is released.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #11291
