### PR TITLE
adding fix for performance issues in fitting

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -66,6 +66,15 @@ astropy.io.votable
 astropy.modeling
 ^^^^^^^^^^^^^^^^
 
+- Added a state attribute to models to allow preventing the synching of 
+  constraint values from the constituent models. This synching can
+  greatly slow down fitting if there are large numbers of fit parameters.
+  model.sync_constraints = True means check constituent model constraints
+  for compound models every time the constraint is accessed, False, do not.
+  Fitters that support constraints will set this to False on the model copy
+  and then set back to True when the fit is complete before returning.
+  [#xxxx].
+  
 astropy.nddata
 ^^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -73,8 +73,8 @@ astropy.modeling
   for compound models every time the constraint is accessed, False, do not.
   Fitters that support constraints will set this to False on the model copy
   and then set back to True when the fit is complete before returning.
-  [#xxxx].
-  
+  [#11365].
+
 astropy.nddata
 ^^^^^^^^^^^^^^
 

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -1057,13 +1057,13 @@ class Model(metaclass=_ModelMeta):
         '''
         This is a boolean property that indicates whether or not accessing constraints
         automatically check the constituent models current values. It defaults to True
-        on creation of a model, but for fitting purposes it should be set to False 
+        on creation of a model, but for fitting purposes it should be set to False
         for performance reasons.
         '''
         if not hasattr(self, '_sync_constraints'):
             self._sync_constraints = True
         return self._sync_constraints
-    
+
     @sync_constraints.setter
     def sync_constraints(self, value):
         if not isinstance(value, bool):

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -1053,12 +1053,31 @@ class Model(metaclass=_ModelMeta):
         self._array_to_parameters()
 
     @property
+    def sync_constraints(self):
+        '''
+        This is a boolean property that indicates whether or not accessing constraints
+        automatically check the constituent models current values. It defaults to True
+        on creation of a model, but for fitting purposes it should be set to False 
+        for performance reasons.
+        '''
+        if not hasattr(self, '_sync_constraints'):
+            self._sync_constraints = True
+        return self._sync_constraints
+    
+    @sync_constraints.setter
+    def sync_constraints(self, value):
+        if not isinstance(value, bool):
+            raise ValueError('sync_constraints only accepts True or False as values')
+        self._sync_constraints = value
+
+    @property
     def fixed(self):
         """
         A ``dict`` mapping parameter names to their fixed constraint.
         """
-
-        return _ConstraintsDict(self, 'fixed')
+        if not hasattr(self, '_fixed') or self.sync_constraints:
+            self._fixed = _ConstraintsDict(self, 'fixed')
+        return self._fixed
 
     @property
     def bounds(self):
@@ -1066,15 +1085,18 @@ class Model(metaclass=_ModelMeta):
         A ``dict`` mapping parameter names to their upper and lower bounds as
         ``(min, max)`` tuples or ``[min, max]`` lists.
         """
-        return _ConstraintsDict(self, 'bounds')
+        if not hasattr(self, '_bounds') or self.sync_constraints:
+            self._bounds = _ConstraintsDict(self, 'bounds')
+        return self._bounds
 
     @property
     def tied(self):
         """
         A ``dict`` mapping parameter names to their tied constraint.
         """
-
-        return _ConstraintsDict(self, 'tied')
+        if not hasattr(self, '_tied') or self.sync_constraints:
+            self._tied = _ConstraintsDict(self, 'tied')
+        return self._tied
 
     @property
     def eqcons(self):

--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -535,6 +535,7 @@ class LinearLSQFitter(metaclass=_FitterMeta):
         _validate_constraints(self.supported_constraints, model)
 
         model_copy = model.copy()
+        model_copy.sync_constraints = False
         _, fitparam_indices = _model_to_fit_params(model_copy)
 
         if model_copy.n_inputs == 2 and z is None:
@@ -785,7 +786,7 @@ class LinearLSQFitter(metaclass=_FitterMeta):
             if len(y) > len(lacoef):
                 self._add_fitting_uncertainties(model_copy, a*scl,
                                                len(lacoef), x, y, z, resids)
-
+        model_copy.sync_constraints = True
         return model_copy
 
 
@@ -1147,6 +1148,7 @@ class LevMarLSQFitter(metaclass=_FitterMeta):
         from scipy import optimize
 
         model_copy = _validate_model(model, self.supported_constraints)
+        model_copy.sync_constraints = False
         farg = (model_copy, weights, ) + _convert_input(x, y, z)
         if model_copy.fit_deriv is None or estimate_jacobian:
             dfunc = None
@@ -1180,6 +1182,7 @@ class LevMarLSQFitter(metaclass=_FitterMeta):
                 self._add_fitting_uncertainties(model_copy,
                                                self.fit_info['param_cov'])
 
+        model_copy.sync_constraints = True
         return model_copy
 
     @staticmethod
@@ -1302,6 +1305,7 @@ class SLSQPLSQFitter(Fitter):
         """
 
         model_copy = _validate_model(model, self._opt_method.supported_constraints)
+        model_copy.sync_constraints = False
         farg = _convert_input(x, y, z)
         farg = (model_copy, weights, ) + farg
         init_values, _ = _model_to_fit_params(model_copy)
@@ -1309,6 +1313,7 @@ class SLSQPLSQFitter(Fitter):
             self.objective_function, init_values, farg, **kwargs)
         _fitter_to_model_params(model_copy, fitparams)
 
+        model_copy.sync_constraints = True
         return model_copy
 
 
@@ -1367,6 +1372,7 @@ class SimplexLSQFitter(Fitter):
 
         model_copy = _validate_model(model,
                                      self._opt_method.supported_constraints)
+        model_copy.sync_constraints = False
         farg = _convert_input(x, y, z)
         farg = (model_copy, weights, ) + farg
 
@@ -1375,6 +1381,7 @@ class SimplexLSQFitter(Fitter):
         fitparams, self.fit_info = self._opt_method(
             self.objective_function, init_values, farg, **kwargs)
         _fitter_to_model_params(model_copy, fitparams)
+        model_copy.sync_constraints = True
         return model_copy
 
 

--- a/astropy/modeling/tests/test_compound.py
+++ b/astropy/modeling/tests/test_compound.py
@@ -474,6 +474,13 @@ def test_inherit_constraints():
     assert model.mean_1.fixed is False
     assert model[1].mean.fixed is False
 
+    # Now turn off syncing of constraints
+    assert model.bounds['stddev_0']  == (0.1, 0.5)
+    model.sync_constraints = False
+    model[0].stddev.bounds = (0, 0.2)
+    assert model.bounds['stddev_0'] == (0.1, 0.5)
+    model.sync_constraints = True
+    assert model.bounds['stddev_0'] == (0, 0.2)
 
 def test_compound_custom_inverse():
     """

--- a/astropy/modeling/tests/test_compound.py
+++ b/astropy/modeling/tests/test_compound.py
@@ -482,6 +482,7 @@ def test_inherit_constraints():
     model.sync_constraints = True
     assert model.bounds['stddev_0'] == (0, 0.2)
 
+
 def test_compound_custom_inverse():
     """
     Test that a compound model with a custom inverse has that inverse applied


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This PR addresses #11314 
<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

That issue highlighted that fitting with many parameters takes very long because the access of constraint attributes scales as the square of the number of parameters. The solution was to add state to the model allowing fitting to stop the syncing of constraint parameters with the constituent models during fitting. This is done by using the property sync_constraints. Setting it to False disables the costly syncing.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #11314
