### PR TITLE
Proper format parsing when attempting mask creation on fits load

### DIFF
--- a/astropy/io/fits/connect.py
+++ b/astropy/io/fits/connect.py
@@ -241,12 +241,12 @@ def read_table_fits(input, hdu=None, astropy_native=False, memmap=False,
         # string, empty strings.
         masked = mask = False
         if col.null is not None:
-            mask = col.array == col.null
+            mask = data[col.name] == col.null
             # Return a MaskedColumn even if no elements are masked so
             # we roundtrip better.
             masked = True
         elif issubclass(col.dtype.type, np.inexact):
-            mask = np.isnan(col.array)
+            mask = np.isnan(data[col.name])
         elif issubclass(col.dtype.type, np.character):
             mask = col.array == b''
 

--- a/astropy/io/fits/tests/test_connect.py
+++ b/astropy/io/fits/tests/test_connect.py
@@ -304,6 +304,26 @@ class TestSingleTable:
         check_equal(filename, 3, start_from=2)
         assert equal_data(t2, Table.read(filename, hdu=1))
 
+    def test_mask_nans_on_read(self, tmpdir):
+        filename = str(tmpdir.join('test_inexact_format_parse_on_read.fits'))
+        c1 = fits.Column(name='a', array=np.array([1, 2, np.nan]), format='E')
+        table_hdu = fits.TableHDU.from_columns([c1])
+        table_hdu.writeto(filename)
+
+        tab = Table.read(filename)
+        assert any(tab.mask)
+        assert tab.mask[2]
+
+    def test_mask_null_on_read(self, tmpdir):
+        filename = str(tmpdir.join('test_null_format_parse_on_read.fits'))
+        col = fits.Column(name='a', array=np.array([1, 2, 99, 60000], dtype='u2'), format='I', null=99, bzero=32768)
+        bin_table_hdu = fits.BinTableHDU.from_columns([col])
+        bin_table_hdu.writeto(filename, overwrite=True)
+
+        tab = Table.read(filename)
+        assert any(tab.mask)
+        assert tab.mask[2]
+
 
 class TestMultipleHDU:
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to address an issue where the input types of a fits `HDUList` loaded from file cannot be coerced when attempting to generate a mask. The `col.array` may have an improper data type _when loaded from file_ (note that it _does_ have the proper data type if the `HDUList` is constructed ad-hoc) when used in the `np.isnan` function introduced in the #11222 `read_table_fits` [changes](https://github.com/astropy/astropy/commit/eabbc1ecdc414a18d715b29ecf8eed5c70f4e95f#diff-2b263cbbb7d9b3215b1a7180dcd1b909c7ee9f78cf1e2e53834ee3b4d6b837b3R249).

This PR simply uses the data parsed through the FITS record array object (`data[col.name]`) instead to ensure the proper data column-defined data type is used.

The failure in the current behavior:

```python
In [2]: primary_hdu = fits.PrimaryHDU()
   ...: c1 = fits.Column(name='a', array=np.array([b'1', b'2']), format='E')
   ...: 
   ...: table_hdu = fits.TableHDU.from_columns([c1])
   ...: hdulist = fits.HDUList([primary_hdu, table_hdu])
   ...: hdulist.writeto(filename, overwrite=True)
   ...: 
   ...: with fits.open(filename) as hdulist:
   ...:     data = hdulist[1].data
   ...: 
   ...:     for col in data.columns:
   ...:         assert np.isnan(col.array)
   ...:
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-12-869aab13a63d> in <module>
     12 
     13     for col in data.columns:
---> 14         assert np.isnan(col.array)

TypeError: ufunc 'isnan' not supported for the input types, and the inputs could not be safely coerced to any supported types according to the casting rule ''safe''
```

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->
