### PR TITLE
'if (c >= 'A' || c <= 'Z')' is always true

### DIFF
--- a/astropy/io/ascii/src/tokenizer.c
+++ b/astropy/io/ascii/src/tokenizer.c
@@ -599,7 +599,7 @@ int tokenize(tokenizer_t *self, int end, int header, int num_cols)
 // Lower-case a single C locale character
 static inline int ascii_tolower(int c)
 {
-    if (c >= 'A' || c <= 'Z')
+    if (c >= 'A' && c <= 'Z')
     {
         return c + ('a' - 'A');
     }


### PR DESCRIPTION
<!-- This comments are hidden when you submit the issue,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- Please have a search on our GitHub repository to see if a similar
issue has already been posted.
If a similar issue is closed, have a quick look to see if you are satisfied
by the resolution.
If not please go ahead and open an issue! -->

<!-- Please check that the development version still produces the same bug.
You can install development version with
pip install git+https://github.com/astropy/astropy
command. -->

### Description
<!-- Provide a general description of the bug. -->
Fixes https://github.com/astropy/astropy/issues/11373

Hi guys,

It seems to me there is a logic bug in tokenizer.c at line 602.
From https://github.com/astropy/astropy/blob/master/astropy/io/ascii/src/tokenizer.c#L602

```C
static inline int ascii_tolower(int c)
{
    if (c >= 'A' || c <= 'Z') /* this conditions is always true */
    {
        return c + ('a' - 'A');
    }

    return c;
}
```

The condition is always true and it seems it should have been logical-and (&&) instead of logical-or (||) ?
I don't think this has much effect, but it may work different from what was originally envisioned, so I wanted to give you a heads up.


By the way, I'm sorry if I did something wrong with the message (since not all tests are passing), I tried carefully :hand_over_mouth: 