### PR TITLE
Fix cextern/wcslib build to compile original WCSLIB source in C99 mode

### DIFF
--- a/astropy/wcs/setup_package.py
+++ b/astropy/wcs/setup_package.py
@@ -228,7 +228,7 @@ def get_wcslib_cfg(cfg, wcslib_files, include_paths):
         cfg['define_macros'].append(('HAVE_SINCOS', None))
 
     # For 4.7+ enable C99 syntax in older compilers
-    cfg['extra_compile_args'].extend(['-std=c99'])
+    cfg['extra_compile_args'].extend(['-std=gnu99'])
 
     # Squelch a few compilation warnings in WCSLIB
     if get_compiler() in ('unix', 'mingw32'):

--- a/astropy/wcs/setup_package.py
+++ b/astropy/wcs/setup_package.py
@@ -227,6 +227,9 @@ def get_wcslib_cfg(cfg, wcslib_files, include_paths):
     if sys.platform.startswith('linux'):
         cfg['define_macros'].append(('HAVE_SINCOS', None))
 
+    # For 4.7+ enable C99 syntax in older compilers
+    cfg['extra_compile_args'].extend(['-std=c99'])
+
     # Squelch a few compilation warnings in WCSLIB
     if get_compiler() in ('unix', 'mingw32'):
         if not debug:

--- a/cextern/wcslib/C/wcshdr.c
+++ b/cextern/wcslib/C/wcshdr.c
@@ -1946,8 +1946,7 @@ void wcshdo_format(
   int emax = -999;
   int emin = +999;
   int precision = 0;
-  int i;
-  for (i = 0; i < nval; i++) {
+  for (int i = 0; i < nval; i++) {
     // Double precision has at least 15 significant digits, and up to 17:
     // http://en.wikipedia.org/wiki/Double-precision_floating-point_format
     char cval[24];


### PR DESCRIPTION
### Description
Follow-up to #11260, replacing the source patch in the bundled WCSLIB 7.4 with a fix to the build script.
This should enable C99-compliant builds with all supported compilers for future WCSLIB updates as well.