### PR TITLE
Bump wheels to manylinux2010 now we are python 3.7+

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,8 +38,8 @@ schedules:
 # Build Linux wheels using manylinux1 for compatibility with old versions
 # of pip and old platforms.
 variables:
-  CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
-  CIBW_MANYLINUX_I686_IMAGE: manylinux1
+  CIBW_MANYLINUX_X86_64_IMAGE: manylinux2010
+  CIBW_MANYLINUX_I686_IMAGE: manylinux2010
   CI: true
 
 jobs:

--- a/docs/changes/11377.other.rst
+++ b/docs/changes/11377.other.rst
@@ -1,0 +1,2 @@
+Binary wheels are now built to the manylinux2010 specification. These wheels
+should be supported on all versions of pip shipped with Python 3.7+.


### PR DESCRIPTION
As discussed in #11376 we can do this safely from 4.2+ as the required version of pip (19) to support manylinux2010 was shipped by default with Python 3.7+ so these wheels should install even if pip has never ever been upgraded.