### PR TITLE
MNT: Replace master with main

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,9 +7,9 @@ about: Create a report describing unexpected or incorrect behavior in astropy.
 so you do not need to remove them! -->
 
 <!-- Please be sure to check out our contributing guidelines,
-https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
+https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
 Please be sure to check out our code of conduct,
-https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->
+https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->
 
 <!-- Please have a search on our GitHub repository to see if a similar
 issue has already been posted.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,9 +7,9 @@ about: Suggest an idea to improve astropy
 so you do not need to remove them! -->
 
 <!-- Please be sure to check out our contributing guidelines,
-https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
+https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
 Please be sure to check out our code of conduct,
-https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->
+https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->
 
 <!-- Please have a search on our GitHub repository to see if a similar
 issue has already been posted.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,9 +2,9 @@
 so you do not need to remove them! -->
 
 <!-- Please be sure to check out our contributing guidelines,
-https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
+https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
 Please be sure to check out our code of conduct,
-https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->
+https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->
 
 <!-- If you are new or need to be re-acquainted with Astropy
 contributing workflow, please see

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-    - master
+    - main
     tags:
     - '*'
   pull_request:

--- a/.github/workflows/open_actions.yml
+++ b/.github/workflows/open_actions.yml
@@ -27,7 +27,7 @@ jobs:
 
             A project member will respond to you as soon as possible; in
             the meantime, please double-check the [guidelines for submitting
-            issues](https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md#reporting-issues)
+            issues](https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md#reporting-issues)
             and make sure you've provided the requested details.
 
 
@@ -45,7 +45,7 @@ jobs:
 
             A project member will respond to you as soon as possible; in the
             meantime, please have a look over the [Checklist for Contributed
-            Code](https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md#checklist-for-contributed-code)
+            Code](https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md#checklist-for-contributed-code)
             and make sure you've addressed as many of the questions there as
             possible.
 

--- a/CITATION
+++ b/CITATION
@@ -1,1 +1,1 @@
-See https://github.com/astropy/astropy/blob/master/astropy/CITATION
+See https://github.com/astropy/astropy/blob/main/astropy/CITATION

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ and follow the Astropy guidelines for reuse, interoperability, and interfacing.
 Each affiliated package has its own developers/maintainers and its own specific
 guidelines for contributions, so be sure to read their docs.
 
-Once you open a pull request (which should be opened against the ``master``
+Once you open a pull request (which should be opened against the ``main``
 branch, not against any of the other branches), please make sure to
 include the following:
 

--- a/README.rst
+++ b/README.rst
@@ -52,15 +52,15 @@ Astropy is licensed under a 3-clause BSD style license - see the
     :target: https://github.com/astropy/astropy/actions
     :alt: Astropy's GitHub Actions CI Status
 
-.. |CircleCI Status| image::  https://img.shields.io/circleci/build/github/astropy/astropy/master?logo=circleci&label=CircleCI
+.. |CircleCI Status| image::  https://img.shields.io/circleci/build/github/astropy/astropy/main?logo=circleci&label=CircleCI
     :target: https://circleci.com/gh/astropy/astropy
     :alt: Astropy's CircleCI Status
 
-.. |Azure Status| image:: https://dev.azure.com/astropy-project/astropy/_apis/build/status/astropy.astropy?repoName=astropy%2Fastropy&branchName=master
+.. |Azure Status| image:: https://dev.azure.com/astropy-project/astropy/_apis/build/status/astropy.astropy?repoName=astropy%2Fastropy&branchName=main
     :target: https://dev.azure.com/astropy-project/astropy
     :alt: Astropy's Azure Pipelines Status
 
-.. |Coverage Status| image:: https://codecov.io/gh/astropy/astropy/branch/master/graph/badge.svg
+.. |Coverage Status| image:: https://codecov.io/gh/astropy/astropy/branch/main/graph/badge.svg
     :target: https://codecov.io/gh/astropy/astropy
     :alt: Astropy's Coverage Status
 

--- a/README.rst
+++ b/README.rst
@@ -78,3 +78,21 @@ Astropy is licensed under a 3-clause BSD style license - see the
 
 .. |Donate| image:: https://img.shields.io/badge/Donate-to%20Astropy-brightgreen.svg
     :target: https://numfocus.salsalabs.org/donate-to-astropy/index.html
+
+
+If you locally cloned this repo before 2 Apr 2021
+-------------------------------------------------
+
+The primary branch for this repo has been transitioned from ``master`` to
+``main``.  If you have a local clone of this repository and want to keep your
+local branch in sync with this repo, you'll need to do the following in your
+local clone from your terminal::
+
+   git fetch --all --prune
+   # you can stop here if you don't use your local "master"/"main" branch
+   git branch -m master main
+   git branch -u origin/main main
+
+If you are using a GUI to manage your repos you'll have to find the equivalent
+commands as it's different for different programs. Alternatively, you can just
+delete your local clone and re-clone!

--- a/astropy/config/configuration.py
+++ b/astropy/config/configuration.py
@@ -483,7 +483,7 @@ class ConfigItem:
         return self._validator.check(self.cfgtype, val)
 
 
-# this dictionary stores the master copy of the ConfigObj's for each
+# this dictionary stores the primary copy of the ConfigObj's for each
 # root package
 _cfgobjs = {}
 

--- a/astropy/config/tests/data/astropy.0.3.cfg
+++ b/astropy/config/tests/data/astropy.0.3.cfg
@@ -139,7 +139,7 @@ conesearch_dbname = conesearch_good
 
 [vo.validator.validate]
 
-# Cone Search services master list for validation.
+# Cone Search services default list for validation.
 cs_mstr_list = http://vao.stsci.edu/directory/NVORegInt.asmx/VOTCapabilityPredOpt?predicate=1%3D1&capability=conesearch&VOTStyleOption=2
 
 # Only check these Cone Search URLs.

--- a/astropy/config/tests/data/astropy.0.3.windows.cfg
+++ b/astropy/config/tests/data/astropy.0.3.windows.cfg
@@ -139,7 +139,7 @@ conesearch_dbname = conesearch_good
 
 [vo.validator.validate]
 
-# Cone Search services master list for validation.
+# Cone Search services default list for validation.
 cs_mstr_list = http://vao.stsci.edu/directory/NVORegInt.asmx/VOTCapabilityPredOpt?predicate=1%3D1&capability=conesearch&VOTStyleOption=2
 
 # Only check these Cone Search URLs.

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -760,7 +760,7 @@ class SkyCoord(ShapedLikeNDArray):
     def __getattr__(self, attr):
         """
         Overrides getattr to return coordinates that this can be transformed
-        to, based on the alias attr in the master transform graph.
+        to, based on the alias attr in the primary transform graph.
         """
         if '_sky_coord_frame' in self.__dict__:
             if self._is_name(attr):

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -1360,7 +1360,7 @@ class TestCartesianRepresentationWithDifferential:
         for name in REPRESENTATION_CLASSES:
             if name == 'radial':
                 # TODO: Converting a CartesianDifferential to a
-                #       RadialDifferential fails, even on `master`
+                #       RadialDifferential fails, even on `main`
                 continue
             elif name.endswith("geodetic"):
                 # TODO: Geodetic representations do not have differentials yet

--- a/astropy/io/ascii/ecsv.py
+++ b/astropy/io/ascii/ecsv.py
@@ -241,7 +241,7 @@ class Ecsv(basic.Basic):
     Th ECSV format allows for specification of key table and column meta-data, in
     particular the data type and unit.
 
-    See: https://github.com/astropy/astropy-APEs/blob/master/APE6.rst
+    See: https://github.com/astropy/astropy-APEs/blob/main/APE6.rst
 
     Examples
     --------

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,7 +10,7 @@ resources:
     name: OpenAstronomy/azure-pipelines-templates
     ref: master
 
-# NOTE: for now we only use Azure Pipelines on v* branches, tags, and master
+# NOTE: for now we only use Azure Pipelines on v* branches, tags, and main
 # only on a cron for building the source and wheel distributions. If you want to
 # make changes to this configuration via a pull request, you can *temporarily*
 # change the pr branches include trigger to just '*'
@@ -18,7 +18,7 @@ trigger:
   branches:
     include:
     - 'v*'
-    - master
+    - main
   tags:
     include:
     - 'v*'
@@ -32,7 +32,7 @@ schedules:
     displayName: Daily Build for Nightly Wheels
     branches:
       include:
-        - master
+        - main
     always: true
 
 # Build Linux wheels using manylinux1 for compatibility with old versions
@@ -43,8 +43,8 @@ variables:
   CI: true
 
 jobs:
-# Run this job on non-master branches (when triggered) or if we are on master and on the cron, or if manually triggered through the web ui.
-- ${{ if or(ne(variables['Build.SourceBranchName'], 'master'), eq(variables['Build.Reason'], 'Schedule'), eq(variables['Build.Reason'], 'Manual')) }}:
+# Run this job on non-main branches (when triggered) or if we are on main and on the cron, or if manually triggered through the web ui.
+- ${{ if or(ne(variables['Build.SourceBranchName'], 'main'), eq(variables['Build.Reason'], 'Schedule'), eq(variables['Build.Reason'], 'Manual')) }}:
   - template: publish.yml@OpenAstronomy
     parameters:
 
@@ -59,8 +59,8 @@ jobs:
       ${{ if startsWith(variables['Build.SourceBranch'], 'refs/tags/v') }}:
         pypi_connection_name : 'pypi_endpoint'
 
-      # If the build has run on master then upload the artifacts to the nightly feed
-      ${{ if eq(variables['Build.SourceBranchName'], 'master') }}:
+      # If the build has run on main then upload the artifacts to the nightly feed
+      ${{ if eq(variables['Build.SourceBranchName'], 'main') }}:
         artifact_project : 'astropy'
         artifact_feed : 'nightly'
         remove_local_scheme: true

--- a/docs/changes/11379.other.rst
+++ b/docs/changes/11379.other.rst
@@ -1,0 +1,1 @@
+The name of the default branch for the astropy git repository has been renamed to ``main``, and the documentation and tooling has been updated accordingly. If you have made a local clone you may wish to update it following the instructions in the repository's README.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -222,7 +222,7 @@ man_pages = [('index', project.lower(), project + u' Documentation',
 
 # Setting this URL is requited by sphinx-astropy
 github_issues_url = 'https://github.com/astropy/astropy/issues/'
-edit_on_github_branch = 'master'
+edit_on_github_branch = 'main'
 
 # Enable nitpicky mode - which ensures that all references in the docs
 # resolve.

--- a/docs/coordinates/index.rst
+++ b/docs/coordinates/index.rst
@@ -416,7 +416,7 @@ Overview of `astropy.coordinates` Concepts
 .. note ::
     The `~astropy.coordinates` package from v0.4 onward builds from
     previous versions of  the package, and more detailed information and
-    justification of the design is available in `APE (Astropy Proposal for Enhancement) 5 <https://github.com/astropy/astropy- APEs/blob/master/APE5.rst>`_.
+    justification of the design is available in `APE (Astropy Proposal for Enhancement) 5 <https://github.com/astropy/astropy-APEs/blob/main/APE5.rst>`_.
 
 Here we provide an overview of the package and associated framework.
 This background information is not necessary for using `~astropy.coordinates`,

--- a/docs/credits.rst
+++ b/docs/credits.rst
@@ -421,7 +421,7 @@ Other Credits
 
 (If you have contributed to the ``astropy`` core package and your name is missing,
 please send an email to the coordinators, or
-`open a pull request for this page <https://github.com/astropy/astropy/edit/master/docs/credits.rst>`_
+`open a pull request for this page <https://github.com/astropy/astropy/edit/main/docs/credits.rst>`_
 in the `astropy repository <https://github.com/astropy/astropy>`_)
 
 For how to acknowledge Astropy, please see `the Acknowledging or Citing Astropy page <https://www.astropy.org/acknowledging.html>`_.

--- a/docs/development/astropy-package-template.rst
+++ b/docs/development/astropy-package-template.rst
@@ -138,10 +138,10 @@ by ``CHANGES.md`` in the instructions.
    instructions. Check that the entry on PyPI is correct, and that
    the tarfile is present.
 
-#. Go back to the master branch and push your changes to github::
+#. Go back to the main branch and push your changes to github::
 
-        git checkout master
-        git push --tags origin master
+        git checkout main
+        git push --tags origin main
 
    Once you have done this, if you use Read the Docs, trigger a ``latest`` build
    then go to the project settings, and under **Versions** you should see the

--- a/docs/development/codeguide.rst
+++ b/docs/development/codeguide.rst
@@ -14,7 +14,7 @@ Interface and Dependencies
 
 * All code must be compatible with the versions of Python indicated by the
   ``python_requires`` key in the `setup.cfg
-  <https://github.com/astropy/astropy/blob/master/setup.cfg>`_ file of the
+  <https://github.com/astropy/astropy/blob/main/setup.cfg>`_ file of the
   core package.
 
 * Usage of ``six``, ``__future__``, and ``2to3`` is no longer acceptable.

--- a/docs/development/releasing.rst
+++ b/docs/development/releasing.rst
@@ -189,7 +189,7 @@ Post-Release procedures
    list on the web site if you updated the ``docs/credits.rst`` at the outset.
 
 #. Cherry-pick the commit rendering the changelog and deleting the fragments and
-   open a PR to the astropy *master* branch. Note: updating this when doing the
+   open a PR to the astropy *main* branch. Note: updating this when doing the
    next release with towncrier.
    In the same PR, you also have to update ``docs/whatsnew/index.rst`` and
    ``docs/whatsnew/X.Y.rst`` to link to "what's new" documentation in the
@@ -265,21 +265,21 @@ Performing a Feature Freeze/Branching new Major Versions
 ========================================================
 
 As outlined in
-`APE2 <https://github.com/astropy/astropy-APEs/blob/master/APE2.rst>`_, astropy
+`APE2 <https://github.com/astropy/astropy-APEs/blob/main/APE2.rst>`_, astropy
 releases occur at regular intervals, but feature freezes occur well before the
-actual release.  Feature freezes are also the time when the master branch's
+actual release.  Feature freezes are also the time when the main branch's
 development separates from the new major version's maintenance branch.  This
 allows new development for the next major version to continue while the
 soon-to-be-released version can focus on bug fixes and documentation updates.
 
 The procedure for this is straightforward:
 
-#. Update your local master branch to use to the latest version from github::
+#. Update your local main branch to use to the latest version from github::
 
       $ git fetch upstream --tags
-      $ git checkout -B master upstream/master
+      $ git checkout -B main upstream/main
 
-#. Create a new branch from master at the point you want the feature freeze to
+#. Create a new branch from main at the point you want the feature freeze to
    occur::
 
       $ git branch v<version>.x
@@ -312,7 +312,7 @@ The procedure for this is straightforward:
 #. Push all of these changes up to github::
 
       $ git push upstream v<version>.x:v<version>.x
-      $ git push upstream master:master
+      $ git push upstream main:main
 
    .. note::
 
@@ -343,9 +343,9 @@ that enhance clarity but do not describe new features (e.g., more examples,
 typo fixes, etc).
 
 Bug fix releases are typically managed by maintaining one or more bug fix
-branches separate from the master branch (the release procedure below discusses
+branches separate from the main branch (the release procedure below discusses
 creating these branches).  Typically, whenever an issue is fixed on the Astropy
-master branch a decision must be made whether this is a fix that should be
+main branch a decision must be made whether this is a fix that should be
 included in the Astropy bug fix release.  Usually the answer to this question
 is "yes", though there are some issues that may not apply to the bug fix
 branch.  For example, it is not necessary to backport a fix to a new feature
@@ -353,7 +353,7 @@ that did not exist when the bug fix branch was first created.  New features
 are never merged into the bug fix branch--only bug fixes; hence the name.
 
 In rare cases a bug fix may be made directly into the bug fix branch without
-going into the master branch first.  This may occur if a fix is made to a
+going into the main branch first.  This may occur if a fix is made to a
 feature that has been removed or rewritten in the development version and no
 longer has the issue being fixed.  However, depending on how critical the bug
 is it may be worth including in a bug fix release, as some users can be slow to
@@ -366,23 +366,23 @@ For example, at the time of writing there are two release milestones open:
 v1.2.2 and v0.3.0.  In this case, v1.2.2 is the next bug fix release and all
 issues that should include fixes in that release should be assigned that
 milestone.  Any issues that implement new features would go into the v0.3.0
-milestone--this is any work that goes in the master branch that should not
+milestone--this is any work that goes in the main branch that should not
 be backported.  For a more detailed set of guidelines on using milestones, see
 :ref:`milestones-and-labels`.
 
 
 .. _release-procedure-bug-fix-backport:
 
-Backporting fixes from master
------------------------------
+Backporting fixes from main
+---------------------------
 
 .. note::
 
     The changelog script in ``astropy-procedures`` (``pr_consistency`` scripts
     in particular) does not know about minor releases, thus please be careful.
-    For example, let's say we have two branches (``master`` and ``v1.2.x``).
+    For example, let's say we have two branches (``main`` and ``v1.2.x``).
     Both 1.2.0 and 1.2.1 releases will come out of the same v1.2.x branch.
-    If a PR for 1.2.1 is merged into ``master`` before 1.2.0 is released,
+    If a PR for 1.2.1 is merged into ``main`` before 1.2.0 is released,
     it should not be backported into v1.2.x branch until after 1.2.0 is
     released, despite complaining from the aforementioned script.
     This situation only arises in a very narrow time frame after 1.2.0
@@ -390,7 +390,7 @@ Backporting fixes from master
 
 Most fixes are backported using the ``git cherry-pick`` command, which applies
 the diff from a single commit like a patch.  For the sake of example, say the
-current bug fix branch is 'v1.2.x', and that a bug was fixed in master in a
+current bug fix branch is 'v1.2.x', and that a bug was fixed in main in a
 commit ``abcd1234``.  In order to backport the fix, checkout the v1.2.x
 branch (it's also good to make sure it's in sync with the
 `astropy core repository`_) and cherry-pick the appropriate commit::
@@ -408,8 +408,8 @@ sure to backport that as well.
 
 What if the issue required more than one commit to fix?  There are a few
 possibilities for this.  The easiest is if the fix came in the form of a
-pull request that was merged into the master branch.  Whenever GitHub merges
-a pull request it generates a merge commit in the master branch.  This merge
+pull request that was merged into the main branch.  Whenever GitHub merges
+a pull request it generates a merge commit in the main branch.  This merge
 commit represents the *full* difference of all the commits in the pull request
 combined.  What this means is that it is only necessary to cherry-pick the
 merge commit (this requires adding the ``-m 1`` option to the cherry-pick
@@ -457,11 +457,11 @@ there are two choices:
    check out the bug fix branch and commit and push your fix directly.
 
 2. **Preferable**: You may also make a pull request through GitHub against the
-   bug fix branch rather than against master.  Normally when making a pull
+   bug fix branch rather than against main.  Normally when making a pull
    request from a branch on your fork to the `astropy core repository`_, GitHub
-   compares your branch to Astropy's master.  If you look on the left-hand
+   compares your branch to Astropy's main.  If you look on the left-hand
    side of the pull request page, under "base repo: astropy/astropy" there is
-   a drop-down list labeled "base branch: master".  You can click on this
+   a drop-down list labeled "base branch: main".  You can click on this
    drop-down and instead select the bug fix branch ("v1.2.x" for example). Then
    GitHub will instead compare your fix against that branch, and merge into
    that branch when the PR is accepted.
@@ -483,7 +483,7 @@ right version number).
 
 2. The Astropy changelog must be updated to list all issues--especially
    user-visible issues--fixed for the current release.  The changelog should
-   be updated in the master branch, and then merged into the bug fix branch.
+   be updated in the main branch, and then merged into the bug fix branch.
    Most issues *should* already have changelog entries for them. But
    occasionally these are forgotten, so if doesn't exist yet please add one in
    the process of backporting.  See :ref:`changelog-format` for more details.
@@ -504,7 +504,7 @@ The script to actually check consistency should be run like::
     $ python 4.check_consistency.py > consistency.html
 
 Which will generate a simple web page that shows all of the areas where either
-a pull request was merged into master but is *not* in the relevant release that
+a pull request was merged into main but is *not* in the relevant release that
 it has been milestoned for, as well as any changelog irregularities (i.e., PRs
 that are in the wrong section for what the github milestone indicates).  You'll
 want to correct those irregularities *first* before starting the backport

--- a/docs/development/style-guide.rst
+++ b/docs/development/style-guide.rst
@@ -163,7 +163,7 @@ material is included within another sentence.
 Examples
 --------
 * (For full contributor guidelines, see our documentation.)
-* Once you open a pull request (which should be opened against the ``master``
+* Once you open a pull request (which should be opened against the ``main``
   branch), please make sure to include the following.
 * In some cases, most of the required functionality is contained in a single
   class (or a few classes).

--- a/docs/development/testguide.rst
+++ b/docs/development/testguide.rst
@@ -1086,7 +1086,7 @@ The 32-bit tests on CircleCI use the
 `quay.io/pypa/manylinux1_i686 <https://quay.io/pypa/manylinux1_i686>`_
 docker image which includes a 32-bit Python environment for each major Python
 version. See the CircleCI
-`configuration file <https://github.com/astropy/astropy/blob/master/.circleci/config.yml>`_
+`configuration file <https://github.com/astropy/astropy/blob/main/.circleci/config.yml>`_
 for the core package for how to access the different Python versions.
 
 In some cases, you may see failures on continuous integration services that

--- a/docs/development/when_to_rebase.rst
+++ b/docs/development/when_to_rebase.rst
@@ -47,8 +47,8 @@ When to rebase
 Pull requests **must** be rebased (but not necessarily squashed to a single
 commit) if at least one of the following conditions is met:
 
-* There are conflicts with master
-* There are merge commits from upstream/master in the PR commit history (merge
+* There are conflicts with main
+* There are merge commits from upstream/main in the PR commit history (merge
   commits from PRs to the user's fork are fine)
 * There are commit messages include offensive language or violate the code of
   conduct (in this case the rebase must also edit the commit messages)

--- a/docs/development/workflow/additional_git_topics.rst
+++ b/docs/development/workflow/additional_git_topics.rst
@@ -20,9 +20,9 @@ You can do these independent of each other.
 To delete both your local copy AND the GitHub copy from the command line follow
 these instructions::
 
-   # change to the master branch (if you still have one, otherwise change to
+   # change to the main branch (if you still have one, otherwise change to
    # another branch)
-   git checkout master
+   git checkout main
 
    # delete branch locally
    # Note: -d tells git to check whether your branch has been merged somewhere
@@ -67,7 +67,7 @@ Your collaborators can then commit directly into that repo with the
 usual::
 
      git commit -am 'ENH - much better code'
-     git push origin master # pushes directly into your repo
+     git push origin main # pushes directly into your repo
 
 Explore your repository
 =======================
@@ -130,12 +130,12 @@ To do a rebase on trunk::
     git branch tmp cool-feature
 
     # Rebase cool-feature onto trunk
-    git rebase --onto upstream/master upstream/master cool-feature
+    git rebase --onto upstream/main upstream/main cool-feature
 
 In this situation, where you are already on branch ``cool-feature``, the last
 command can be written more succinctly as::
 
-    git rebase upstream/master
+    git rebase upstream/main
 
 When all looks good you can delete your backup branch::
 
@@ -285,18 +285,18 @@ Merge commits and cherry picks
 ==============================
 
 Let's say that you have a fork (origin) on GitHub of the main Astropy
-repository (upstream).  Your fork is up to date with upstream's master branch
+repository (upstream).  Your fork is up to date with upstream's main branch
 and you've made some commits branching off from it on your own branch::
 
     upstream:
 
-       master
+       main
           |
     A--B--C
 
     origin:
 
-     upstream/master
+     upstream/main
           |
     A--B--C
            \
@@ -304,11 +304,11 @@ and you've made some commits branching off from it on your own branch::
                |
            issue-branch
 
-Then say you make a pull request of issue-branch against Astroy's master, and
+Then say you make a pull request of issue-branch against Astroy's main, and
 the pull request is accepted and merged.  When GitHub merges the pull request
 it's basically doing the following in the upstream repository::
 
-    $ git checkout master
+    $ git checkout main
     $ git remote add yourfork file:///path/to/your/fork/astropy
     $ git fetch yourfork
     $ git merge --no-ff yourfork/issue-branch
@@ -321,7 +321,7 @@ that).  Now the main Astropy repository looks like this::
 
     upstream:
 
-              master
+              main
                  |
     A--B--C------F
            \    /
@@ -338,11 +338,11 @@ this case "C") and applies that diff as a patch to whatever your HEAD is.
 The problem with a merge commit, such as "F", is that "F" has two parents: "C"
 and "E".  It doesn't know whether to apply the diff of "F" with "C" or the diff
 of "F" with "E".  Clearly in this case of backporting a pull request to a bug
-fix branch we want to apply everything that changed on master from the merge,
+fix branch we want to apply everything that changed on main from the merge,
 so we want the diff of "F" with "C".
 
-Since GitHub was on ``master`` when it did ``git merge yourfork/issue-branch``, the
-last commit in ``master`` is the first parent.  Basically whatever HEAD you're on
+Since GitHub was on ``main`` when it did ``git merge yourfork/issue-branch``, the
+last commit in ``main`` is the first parent.  Basically whatever HEAD you're on
 when you do the merge is the first parent, and the tip you're merging from is
 the second parent (octopus merge gets more complicated but only a little, and
 that doesn't apply to pull requests).  Since parents are numbered starting from
@@ -355,7 +355,7 @@ upstream we also have a backport branch that we want to cherry pick "F" onto::
 
       backport
          |
-         G       master
+         G       main
         /          |
     A--B----C------F
              \    /

--- a/docs/development/workflow/development_workflow.rst
+++ b/docs/development/workflow/development_workflow.rst
@@ -76,23 +76,23 @@ About names in `git`_
 
 `git`_ is designed to be a *distributed* version control system. Each clone of
 a repository is, itself, a repository. That can lead to some confusion,
-especially for the branch called ``master``. If you list all of the branches
+especially for the branch called ``main``. If you list all of the branches
 your clone of git knows about with ``git branch -a`` you will see there are
-*three* different branches called ``master``::
+*three* different branches called ``main``::
 
-    * master                              # this is master in your local repo
-    remotes/your-github-username/master   # master on your fork of Astropy on GitHub
-    remotes/astropy/master                # the official development branch of Astropy
+    * main                              # this is main in your local repo
+    remotes/your-github-username/main   # main on your fork of Astropy on GitHub
+    remotes/astropy/main                # the official development branch of Astropy
 
 The naming scheme used by `git`_ will also be used here. A plain branch name,
-like ``master`` means a branch in your local copy of Astropy. A branch on a
-remote, like ``astropy`` , is labeled by that remote, ``astropy/master``.
+like ``main`` means a branch in your local copy of Astropy. A branch on a
+remote, like ``astropy`` , is labeled by that remote, ``astropy/main``.
 
 This duplication of names can get very confusing when working with pull
-requests, especially when the official master branch, ``astropy/master``,
+requests, especially when the official main branch, ``astropy/main``,
 changes due to other contributions before your contributions are merged in.
-As a result, you should never do any work in your master
-branch, ``master``. Always work on a branch instead.
+As a result, you should never do any work in your main
+branch, ``main``. Always work on a branch instead.
 
 Essential `git`_ commands
 =========================
@@ -127,7 +127,7 @@ walks you through recovering from `git`_ mistakes is the
 Astropy Guidelines for `git`_
 *****************************
 
-* Don't use your ``master`` branch for anything. Consider :ref:`delete-master`.
+* Don't use your ``main`` branch for anything. Consider :ref:`delete-main`.
 * Make a new branch, called a *feature branch*, for each separable set of
   changes: "one task, one branch" (`ipython git workflow`_).
 * Start that new *feature branch* from the most current development version
@@ -137,7 +137,7 @@ Astropy Guidelines for `git`_
 * Make frequent commits, and always include a commit message. Each commit
   should represent one logical set of changes.
 * Ask on the `astropy-dev mailing list`_ if you get stuck.
-* Never merge changes from ``astropy/master`` into your feature branch. If
+* Never merge changes from ``astropy/main`` into your feature branch. If
   changes in the development version require changes to our code you can
   :ref:`rebase`.
 
@@ -176,13 +176,13 @@ A worked example that follows these steps for fixing an Astropy issue is at
 
 Some additional topics related to `git`_ are in :ref:`additional-git`.
 
-.. _delete-master:
+.. _delete-main:
 
-Deleting your master branch
-===========================
+Deleting your main branch
+=========================
 
-It may sound strange, but deleting your own ``master`` branch can help reduce
-confusion about which branch you are on.  See `deleting master on github`_ for
+It may sound strange, but deleting your own ``main`` branch can help reduce
+confusion about which branch you are on.  See `deleting main on github`_ for
 details.
 
 .. _fetch-latest:
@@ -191,14 +191,14 @@ Fetch the latest Astropy
 ************************
 
 From time to time you should fetch the development version (i.e. Astropy
-``astropy/master``) changes from GitHub::
+``astropy/main``) changes from GitHub::
 
    git fetch astropy --tags
 
 This will pull down any commits you don't have, and set the remote branches to
 point to the latest commit. For example, 'trunk' is the branch referred to by
-``astropy/master``, and if there have been commits since
-you last checked, ``astropy/master`` will change after you do the fetch.
+``astropy/main``, and if there have been commits since
+you last checked, ``astropy/main`` will change after you do the fetch.
 
 .. _make-feature-branch:
 
@@ -219,14 +219,14 @@ Choose an informative name for the branch to remind yourself and the rest of us
 what the changes in the branch are for. Branch names like ``add-ability-to-fly``
 or ``buxfix-for-issue-42`` clearly describe the purpose of the branch.
 
-Always make your branch from ``astropy/master`` so that you are basing your
+Always make your branch from ``astropy/main`` so that you are basing your
 changes on the latest version of Astropy::
 
     # Update the mirror of trunk
     git fetch astropy --tags
 
-    # Make new feature branch starting at astropy/master
-    git branch my-new-feature astropy/master
+    # Make new feature branch starting at astropy/main
+    git branch my-new-feature astropy/main
     git checkout my-new-feature
 
 Connect the branch to GitHub
@@ -452,7 +452,7 @@ to GitHub. GitHub will automatically update your pull request.
 Do Not Create a Merge Commit
 ****************************
 
-If your branch associated with the pull request falls behind the ``master``
+If your branch associated with the pull request falls behind the ``main``
 branch of https://github.com/astropy/astropy, GitHub might offer you the option
 to catch up or resolve conflicts via its web interface, but do not use this. Using
 the web interface might create a "merge commit" in your commit history, which is
@@ -470,7 +470,7 @@ Rebase, but only if asked
 
 Sometimes the maintainers of Astropy may ask a pull request to be *rebased*
 or *squashed* in the process of reviewing a pull request for merging into
-the main Astropy *master* repository.
+the main Astropy *main* repository.
 
 The decisions of when to request a *squash* or *rebase* are left to
 individual maintainers.  These may be requested to reduce the number of
@@ -506,8 +506,8 @@ branch from the development branch and applying your changes to your branch.
 
 The actual rebasing is usually easy::
 
-    git fetch astropy master # get the latest development astropy
-    git rebase astropy/master my-new-feature
+    git fetch astropy main # get the latest development astropy
+    git rebase astropy/main my-new-feature
 
 You are more likely to run into *conflicts* here — places where the changes you
 made conflict with changes that someone else made — than anywhere else. Ask for
@@ -532,7 +532,7 @@ Many of us find that is it actually easiest to squash using rebase. In particula
 you can rebase and squash within the existing branch using::
 
   git fetch astropy
-  git rebase -i astropy/master
+  git rebase -i astropy/main
 
 The last command will open an editor with all your commits, allowing you to
 squash several commits together, rename them, etc. Helpfully, the file you are

--- a/docs/development/workflow/get_devel_version.rst
+++ b/docs/development/workflow/get_devel_version.rst
@@ -36,7 +36,7 @@ version of astropy on your computer:
    account on `github`_ yet, go there now and make one).
 #. :ref:`check_git_install`
 #. :ref:`clone_your_fork`; this is called making a *clone* of the repository.
-#. :ref:`set_upstream_master`
+#. :ref:`set_upstream_main`
 #. :ref:`make_a_branch`; this is called making a *branch*.
 #. :ref:`activate_development_astropy`
 #. :ref:`test_installation`
@@ -136,7 +136,7 @@ on what kind of authentication you set up in the previous step::
 If there is an error at this stage it is probably an error in setting up
 authentication.
 
-.. _set_upstream_master:
+.. _set_upstream_main:
 
 Tell git where to look for changes in the development version of Astropy
 ------------------------------------------------------------------------
@@ -184,11 +184,11 @@ Your repository already has several branches; see them if you want by running
 ``git branch -a``. Most of them are on ``remotes/origin``; in other words,
 they exist on your remote copy of astropy on GitHub.
 
-There is one special branch, called *master*. Right now it is the one you are
+There is one special branch, called *main*. Right now it is the one you are
 working on; you can tell because it has a marker next to it in your list of
-branches: ``* master``.
+branches: ``* main``.
 
-To make a long story short, you never want to work on master. Always work on a branch.
+To make a long story short, you never want to work on main. Always work on a branch.
 
 To avoid potential confusion down the road, make your own branch now; this
 one you can call anything you like (when making contributions you should use
@@ -199,10 +199,10 @@ a meaningful more name)::
 You are *not quite* done yet. Git knows about this new branch; run
 ``git branch`` and you get::
 
-    * master
+    * main
       my-own-astropy
 
-The ``*`` indicates you are still working on master. To work on your branch
+The ``*`` indicates you are still working on main. To work on your branch
 instead you need to *check out* the branch ``my-own-astropy``. Do that with::
 
     git checkout my-own-astropy

--- a/docs/development/workflow/git_edit_workflow_examples.rst
+++ b/docs/development/workflow/git_edit_workflow_examples.rst
@@ -53,7 +53,7 @@ Set up an isolated workspace
 
 + Make a new `git`_ branch for fixing this issue and switch to the branch::
 
-    git checkout astropy/master -b fix-1761
+    git checkout astropy/main -b fix-1761
 
 + Make a Python environment just for this fix and switch to that environment.
   The example below shows the necessary steps in the Miniconda/Anaconda Python
@@ -171,7 +171,7 @@ We can see what has changed with ``git status``::
 
     $ git status
     On branch fix-1761
-    Your branch is up-to-date with 'astropy/master'.
+    Your branch is up-to-date with 'astropy/main'.
 
     Changes not staged for commit:
       (use "git add <file>..." to update what will be committed)
@@ -243,7 +243,7 @@ You get no notice at the command line that anything has changed, but
 
     $ git status
     On branch fix-1761
-    Your branch is up-to-date with 'astropy/master'.
+    Your branch is up-to-date with 'astropy/main'.
 
     Changes to be committed:
       (use "git reset HEAD <file>..." to unstage)
@@ -269,7 +269,7 @@ Use ``git status`` to get a recap of where we are so far::
 
     $ git status
     On branch fix-1761
-    Your branch is ahead of 'astropy/master' by 1 commit.
+    Your branch is ahead of 'astropy/main' by 1 commit.
       (use "git push" to publish your local commits)
 
     nothing to commit, working directory clean
@@ -325,7 +325,7 @@ are still in the top level directory and check the ``git status``::
 
     $ git status
     On branch fix-1761
-    Your branch is ahead of 'astropy/master' by 1 commit.
+    Your branch is ahead of 'astropy/main' by 1 commit.
       (use "git push" to publish your local commits)
 
     Changes not staged for commit:

--- a/docs/development/workflow/git_links.inc
+++ b/docs/development/workflow/git_links.inc
@@ -47,7 +47,7 @@
 .. _linux git workflow: http://www.mail-archive.com/dri-devel@lists.sourceforge.net/msg39091.html
 .. _git parable: https://tom.preston-werner.com/2009/05/19/the-git-parable.html
 .. _git foundation: http://matthew-brett.github.io/pydagogue/foundation.html
-.. _deleting master on github: http://matthew-brett.github.io/pydagogue/gh_delete_master.html
+.. _deleting main on github: http://matthew-brett.github.io/pydagogue/gh_delete_master.html
 .. _rebase without tears: http://matthew-brett.github.io/pydagogue/rebase_without_tears.html
 .. _resolving a merge: http://schacon.github.io/git/user-manual.html#resolving-a-merge
 .. _ipython git workflow: https://mail.python.org/pipermail/ipython-dev/2010-October/005632.html

--- a/docs/development/workflow/maintainer_workflow.rst
+++ b/docs/development/workflow/maintainer_workflow.rst
@@ -22,7 +22,7 @@ Make sure that pull requests do not contain a messy history with merges, etc. If
 Integrating changes manually
 ============================
 
-First, check out the ``astropy`` repository. The instructions in :ref:`set_upstream_master` add a remote that has read-only
+First, check out the ``astropy`` repository. The instructions in :ref:`set_upstream_main` add a remote that has read-only
 access to the upstream repo.  Being a maintainer, you've got read-write access.
 
 It's good to have your upstream remote have a scary name, to remind you that
@@ -32,7 +32,7 @@ it's a read-write remote::
     git fetch upstream-rw --tags
 
 Let's say you have some changes that need to go into trunk
-(``upstream-rw/master``).
+(``upstream-rw/main``).
 
 The changes are in some branch that you are currently on. For example, you are
 looking at someone's changes like this::
@@ -54,7 +54,7 @@ If there are only a few commits, consider rebasing to upstream::
     git fetch upstream-rw
 
     # Rebase
-    git rebase upstream-rw/master
+    git rebase upstream-rw/main
 
 Remember that, if you do a rebase, and push that, you'll have to close any
 github pull requests manually, because github will not be able to detect the
@@ -66,7 +66,7 @@ A long series of commits
 If there are a longer series of related commits, consider a merge instead::
 
     git fetch upstream-rw
-    git merge --no-ff upstream-rw/master
+    git merge --no-ff upstream-rw/main
 
 The merge will be detected by github, and should close any related pull
 requests automatically.
@@ -83,11 +83,11 @@ Now, in either case, you should check that the history is sensible and you
 have the right commits::
 
     git log --oneline --graph
-    git log -p upstream-rw/master..
+    git log -p upstream-rw/main..
 
 The first line above just shows the history in a compact way, with a text
 representation of the history graph. The second line shows the log of commits
-excluding those that can be reached from trunk (``upstream-rw/master``), and
+excluding those that can be reached from trunk (``upstream-rw/main``), and
 including those that can be reached from current HEAD (implied with the ``..``
 at the end). So, it shows the commits unique to this branch compared to trunk.
 The ``-p`` option shows the diff for these commits in patch form.
@@ -97,9 +97,9 @@ Push to trunk
 
 ::
 
-    git push upstream-rw my-new-feature:master
+    git push upstream-rw my-new-feature:main
 
-This pushes the ``my-new-feature`` branch in this repository to the ``master``
+This pushes the ``my-new-feature`` branch in this repository to the ``main``
 branch in the ``upstream-rw`` repository.
 
 
@@ -137,7 +137,7 @@ followed by IPython:
     0.2.x and 0.3.x are still supported there should be milestones for the next 0.2.x and 0.3.x releases.
 
   * The next X.Y release, i.e. the next minor release; this is generally the next release that all development in
-    master is aimed toward.
+    main is aimed toward.
 
   * The next X.Y release +1; for example if 0.3 is the next release, there should also be a milestone for 0.4 for
     issues that are important, but that we know won't be resolved in the next release.
@@ -187,7 +187,7 @@ Adding to the changelog
 There are two approaches one may take to adding a new entry to the changelog,
 each with certain pros and cons.  Before describing the two specific approaches
 it should be said that *all* additions to the changelog should be made first
-in the 'master' branch.  This is because every release of Astropy includes a
+in the 'main' branch.  This is because every release of Astropy includes a
 copy of the changelog, and it should list all the changes in every prior
 version of Astropy.  For example, when Astropy v0.3.0 is released, in addition
 to the changes new to that version the changelog should have all the changes
@@ -202,14 +202,14 @@ are:
 
   Pro: An addition to the changelog is just like any other documentation
   update, and should be part of any atomic change to the software.  It can
-  be pulled into master along with the rest of the change.
+  be pulled into main along with the rest of the change.
 
   Con: If many pull requests also include changelog updates, they can quickly
   conflict with each other and require rebasing.  This is not difficult to
   resolve if the only conflict is in the changelog, but it can still be trouble
   especially for new contributors.
 
-* Add to the changelog after a change has been merged to master, whether by
+* Add to the changelog after a change has been merged to main, whether by
   pull request or otherwise.
 
   Pro: Largely escapes the merge conflict issue.

--- a/docs/development/workflow/patches.rst
+++ b/docs/development/workflow/patches.rst
@@ -38,7 +38,7 @@ Then, the workflow is the following::
    git commit -am 'BF - added fix for Funny bug'
 
    # Make the patch files
-   git format-patch -M -C master
+   git format-patch -M -C main
 
 Then, send the generated patch files to the `astropy-dev mailing list`_ |emdash|
 where we will thank you warmly.
@@ -93,9 +93,9 @@ In detail
       git status
 
 #. Finally, make your commits into patches. You want all the commits since you
-   branched from the ``master`` branch::
+   branched from the ``main`` branch::
 
-      git format-patch -M -C master
+      git format-patch -M -C main
 
    You will now have several files named for the commits::
 
@@ -105,8 +105,8 @@ In detail
    Send these files to the `astropy-dev mailing list`_.
 
 When you are done, to switch back to the main copy of the
-code, just return to the ``master`` branch::
+code, just return to the ``main`` branch::
 
-   git checkout master
+   git checkout main
 
 .. include:: links.inc

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,4 +1,4 @@
-.. Astropy documentation master file, created by
+.. Astropy documentation index file, created by
    sphinx-quickstart on Tue Jul 26 02:59:34 2011.
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.

--- a/docs/io/ascii/fast_ascii_io.rst
+++ b/docs/io/ascii/fast_ascii_io.rst
@@ -143,18 +143,12 @@ data has less than about fifteen significant figures, or if accuracy is
 relatively unimportant, this converter might be the best option in
 performance-critical scenarios.
 
-`Here
-<https://nbviewer.jupyter.org/github/astropy/astropy-notebooks/blob/master/io/ascii/conversion_profile.ipynb>`__
-is an IPython notebook analyzing the error of the fast converter, both in
-decimal values and in ULP. For values with a reasonably small number of
+For values with a reasonably small number of
 significant figures, the fast converter is guaranteed to produce an optimal
 conversion (within 0.5 ULP). Once the number of significant figures exceeds
 the precision of 64-bit floating-point values, the fast converter is no
 longer guaranteed to be within 0.5 ULP, but about 60% of values end up
-within 0.5 ULP and about 90% within 1.0 ULP. Another notebook analyzing
-the fast converter's behavior with extreme values (such as subnormals
-and values out of the range of floats) is available `here
-<https://nbviewer.jupyter.org/github/astropy/astropy-notebooks/blob/master/io/ascii/test_converter.ipynb>`__.
+within 0.5 ULP and about 90% within 1.0 ULP.
 
 Reading Large Tables
 --------------------
@@ -166,10 +160,7 @@ Writing
 =======
 
 The fast engine supports the same functionality as the ordinary writing engine
-and is generally about two to four times faster than the ordinary engine. An
-IPython notebook testing the relative performance of the fast writer against the
-ordinary writing system and the data analysis library `Pandas
-<https://pandas.pydata.org/>`__ is available `here <https://nbviewer.ipython.org/github/astropy/astropy-notebooks/blob/master/io/ascii/ascii_write_bench.ipynb>`__.
+and is generally about two to four times faster than the ordinary engine.
 The speed advantage of the faster engine is greatest for integer data and least
 for floating-point data; the fast engine is around 3.6 times faster for a
 sample file including a mixture of floating-point, integer, and text data.
@@ -183,14 +174,8 @@ The fast ASCII engine was designed based on the general parsing strategy
 used in the `Pandas <https://pandas.pydata.org/>`__ data analysis library, so
 its performance is generally comparable (although slightly slower by
 default) to the Pandas ``read_csv`` method.
-`Here
-<https://nbviewer.jupyter.org/github/astropy/astropy-notebooks/blob/master/io/ascii/ascii_read_bench.ipynb>`__
-is an IPython notebook comparing the performance of the ordinary
-:mod:`astropy.io.ascii` reader, the fast reader, the fast reader with the
-fast converter enabled, NumPy's ``genfromtxt``, and Pandas' ``read_csv``
-for different kinds of table data in a basic space-delimited file.
 
-In summary, ``genfromtxt`` and the ordinary :mod:`astropy.io.ascii` reader
+The ``genfromtxt`` and the ordinary :mod:`astropy.io.ascii` reader
 are very similar in terms of speed, while ``read_csv`` is slightly faster
 than the fast engine for integer and floating-point data; for pure
 floating-point data, enabling the fast converter yields a speedup of about

--- a/docs/io/ascii/write.rst
+++ b/docs/io/ascii/write.rst
@@ -312,7 +312,7 @@ ECSV Format
 -----------
 
 The `Enhanced Character-Separated Values (ECSV) format
-<https://github.com/astropy/astropy-APEs/blob/master/APE6.rst>`_ can be used to
+<https://github.com/astropy/astropy-APEs/blob/main/APE6.rst>`_ can be used to
 write ``astropy`` `~astropy.table.Table` or `~astropy.table.QTable` datasets to
 a text-only data file and then read the table back without loss of information.
 The format handles the key issue of serializing column specifications and table

--- a/docs/io/unified.rst
+++ b/docs/io/unified.rst
@@ -5,7 +5,7 @@ Unified File Read/Write Interface
 
 ``astropy`` provides a unified interface for reading and writing data in
 different formats. For many common cases this will streamline the process of
-file I/O and reduce the need to master the separate details of all of the I/O
+file I/O and reduce the need to learn the separate details of all of the I/O
 packages within ``astropy``. For details on the implementation see
 :ref:`io_registry`.
 
@@ -992,7 +992,7 @@ the call to ``write()``::
 
 The table metadata are stored as a dataset of strings by serializing the
 metadata in YAML following the `ECSV header format
-<https://github.com/astropy/astropy-APEs/blob/master/APE6.rst#header-details>`_
+<https://github.com/astropy/astropy-APEs/blob/main/APE6.rst#header-details>`_
 definition. Since there are YAML parsers for most common languages, one can
 easily access and use the table metadata if reading the HDF5 in a non-astropy
 application.

--- a/docs/nddata/index.rst
+++ b/docs/nddata/index.rst
@@ -505,4 +505,4 @@ Reference/API
 .. automodapi:: astropy.nddata.utils
     :no-inheritance-diagram:
 
-.. _APE 7: https://github.com/astropy/astropy-APEs/blob/master/APE7.rst
+.. _APE 7: https://github.com/astropy/astropy-APEs/blob/main/APE7.rst

--- a/docs/stability.rst
+++ b/docs/stability.rst
@@ -126,7 +126,7 @@ The current planned and existing sub-packages are:
             </td>
             <td>
                 New in v0.2, major changes in v0.4.  Subsequent versions should
-                maintain a stable/backwards-compatible API, following the plan of <a href="https://github.com/astropy/astropy-APEs/blob/master/APE5.rst">APE 5</a>.  Further major additions/enhancements likely, but with basic framework unchanged.
+                maintain a stable/backwards-compatible API, following the plan of <a href="https://github.com/astropy/astropy-APEs/blob/main/APE5.rst">APE 5</a>.  Further major additions/enhancements likely, but with basic framework unchanged.
             </td>
         </tr>
         <tr>
@@ -203,7 +203,7 @@ The current planned and existing sub-packages are:
                 <span class="dev"></span>
             </td>
             <td>
-                Significantly revised in v1.0 to implement <a href="https://github.com/astropy/astropy-APEs/blob/master/APE7.rst">APE 7</a>. Major changes in the API are not anticipated, broader use may reveal flaws that require API changes.
+                Significantly revised in v1.0 to implement <a href="https://github.com/astropy/astropy-APEs/blob/main/APE7.rst">APE 7</a>. Major changes in the API are not anticipated, broader use may reveal flaws that require API changes.
             </td>
         </tr>
         <tr>

--- a/docs/table/io.rst
+++ b/docs/table/io.rst
@@ -7,7 +7,7 @@ Reading and Writing Table Objects
 
 ``astropy`` provides a unified interface for reading and writing data in
 different formats. For many common cases this will streamline the process of
-file I/O and reduce the need to master the separate details of all of the I/O
+file I/O and reduce the need to learn the separate details of all of the I/O
 packages within ``astropy``. For details and examples of using this interface
 see the :ref:`table_io` section.
 

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ indexserver =
 # project-wide pinning of dependencies, e.g. if new versions of pytest do not
 # work correctly with pytest-astropy plugins. Most of the time the pinnings file
 # should be empty.
-pypi_filter = https://raw.githubusercontent.com/astropy/ci-helpers/master/pip_pinnings.txt
+pypi_filter = https://raw.githubusercontent.com/astropy/ci-helpers/main/pip_pinnings.txt
 
 # Pass through the following environemnt variables which are needed for the CI
 passenv = HOME WINDIR LC_ALL LC_CTYPE CC CI IS_CRON ARCH_ON_CI TEST_READ_HUGE_FILE


### PR DESCRIPTION
This PR attempts to replace all mention of `master` to `main` in this repository. This should be reviewed and merged right after the maintainer has renamed the default branch.

This is an automated update made by the `batchpr` tool :robot: - feel free to close if it doesn't look good! You can report issues to @pllim.

This is part of #11378

Fix #11381

# TODO

- [x] @eteq to update README with instructions, see https://github.com/astropy/astropy/pull/11379#issuecomment-802302358
- [x] Do we need a change log? See https://github.com/astropy/astropy/pull/11379#issuecomment-812694911