### PR TITLE
Fixed bug with WCSAxes grid-line visibility

### DIFF
--- a/astropy/visualization/wcsaxes/grid_paths.py
+++ b/astropy/visualization/wcsaxes/grid_paths.py
@@ -7,8 +7,8 @@ from matplotlib.lines import Path
 
 from astropy.coordinates.angle_utilities import angular_separation
 
-# Tolerance for WCS round-tripping
-ROUND_TRIP_TOL = 1e-1
+# Tolerance for WCS round-tripping, relative to the scale size
+ROUND_TRIP_RTOL = 1.
 
 # Tolerance for discontinuities relative to the median
 DISCONT_FACTOR = 10.
@@ -39,11 +39,14 @@ def get_lon_lat_path(lon_lat, pixel, lon_lat_check):
                              np.radians(lon_lat_check[:, 0]),
                              np.radians(lon_lat_check[:, 1]))
 
+    # Define the relevant scale size using the separation between the first two points
+    scale_size = angular_separation(*np.radians(lon_lat[0, :]), *np.radians(lon_lat[1, :]))
+
     with np.errstate(invalid='ignore'):
 
         sep[sep > np.pi] -= 2. * np.pi
 
-        mask = np.abs(sep > ROUND_TRIP_TOL)
+        mask = np.abs(sep > ROUND_TRIP_RTOL * scale_size)
 
     # Mask values with invalid pixel positions
     mask = mask | np.isnan(pixel[:, 0]) | np.isnan(pixel[:, 1])

--- a/astropy/visualization/wcsaxes/tests/test_grid_paths.py
+++ b/astropy/visualization/wcsaxes/tests/test_grid_paths.py
@@ -1,0 +1,28 @@
+import numpy as np
+import pytest
+from matplotlib.lines import Path
+
+from astropy.visualization.wcsaxes.grid_paths import get_lon_lat_path
+
+
+@pytest.mark.parametrize('step_in_degrees', [10, 1, 0.01])
+def test_round_trip_visibility(step_in_degrees):
+    zero = np.zeros(100)
+
+    # The pixel values are irrelevant for this test
+    pixel = np.stack([zero, zero]).T
+
+    # Create a grid line of constant latitude with a point every step
+    line = np.stack([np.arange(100), zero]).T * step_in_degrees
+
+    # Create a modified grid line where the point spacing is larger by 5%
+    # Starting with point 20, the discrepancy between `line` and `line_round` is greater than `step`
+    line_round = line * 1.05
+
+    # Perform the round-trip check
+    path = get_lon_lat_path(line, pixel, line_round)
+
+    # The grid line should be visible for only the initial part line (19 points)
+    codes_check = np.full(100, Path.MOVETO)
+    codes_check[line_round[:, 0] - line[:, 0] < step_in_degrees] = Path.LINETO
+    assert np.all(path.codes[1:] == codes_check[1:])

--- a/docs/changes/visualization/11380.bugfix.rst
+++ b/docs/changes/visualization/11380.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug that resulted in some parts of grid lines being visible when they should have been hidden.


### PR DESCRIPTION
WCSAxes uses round-trip consistency to determine whether grid-line points should be visible.  However, the tolerance for this check is hard-coded to be 0.1 ~degrees~ radians(!), which is far too tolerant when the natural scale of the coordinate frame is something other than degrees (e.g., arcmin).  This PR makes the tolerance a relative tolerance instead.

To showcase the bug, here's an example using SunPy:
![download (4)](https://user-images.githubusercontent.com/991759/110516388-830e2b80-80d7-11eb-86b8-7f0ca05b3a4d.png)

And after this PR:
![download (5)](https://user-images.githubusercontent.com/991759/110516379-80abd180-80d7-11eb-8fc4-7649085c0011.png)