### PR TITLE
BUG: Fix missing "server_close" method on SAMPHubProxy

### DIFF
--- a/astropy/samp/hub_proxy.py
+++ b/astropy/samp/hub_proxy.py
@@ -88,12 +88,11 @@ class SAMPHubProxy:
         """
         Disconnect from the current SAMP Hub.
         """
-        self.proxy = None
+        if self.proxy is not None:
+            self.proxy.shutdown()
+            self.proxy = None
         self._connected = False
         self.lockfile = {}
-
-    def server_close(self):
-        self.proxy.server_close()
 
     @property
     def _samp_hub(self):

--- a/astropy/samp/tests/web_profile_test_helpers.py
+++ b/astropy/samp/tests/web_profile_test_helpers.py
@@ -172,7 +172,7 @@ class SAMPWebClient(SAMPClient):
                         self.receive_response(self._private_key,
                                               *result['samp.params'])
 
-        self.hub.server_close()
+        self.hub.disconnect()
 
     def register(self):
         """

--- a/astropy/samp/utils.py
+++ b/astropy/samp/utils.py
@@ -82,6 +82,18 @@ class ServerProxyPool:
         # magic method dispatcher
         return _ServerProxyPoolMethod(self._proxies, name)
 
+    def shutdown(self):
+        """Shut down the proxy pool but closing all active conections."""
+
+        while True:
+            try:
+                proxy = self._proxies.get_nowait()
+            except queue.Empty:
+                break
+            # An undocumented but apparently supported way to call methods on
+            # an ServerProxy that are not dispatched to the remote server
+            proxy('close')
+
 
 class SAMPMsgReplierWrapper:
     """

--- a/astropy/samp/utils.py
+++ b/astropy/samp/utils.py
@@ -83,7 +83,7 @@ class ServerProxyPool:
         return _ServerProxyPoolMethod(self._proxies, name)
 
     def shutdown(self):
-        """Shut down the proxy pool but closing all active conections."""
+        """Shut down the proxy pool by closing all active conections."""
 
         while True:
             try:

--- a/setup.cfg
+++ b/setup.cfg
@@ -138,8 +138,6 @@ filterwarnings =
     # Ignore a warning we emit about not supporting the parallel
     # reading option for now, can be removed once the issue is fixed
     ignore:parallel reading does not currently work, so falling back to serial
-    # Ignore pytest.PytestUnhandledThreadExceptionWarning from SAMP, pytest>=6.2
-    ignore:Exception in thread
     ignore:'datfix' made the change:astropy.wcs.wcs.FITSFixedWarning
 doctest_norecursedirs =
     */setup_package.py


### PR DESCRIPTION
Follow-up to #11167 to try to fix the underlying bug in the `astropy.samp` tests.

This is affecting the CI on the 4.0.x branch too so it would be helpful to backport it.

I marked this "affects-dev" since it's not really a user-facing bug, but I can still add a changelog if someone thinks it's necessary.

(As an aside, after going through this code, I wonder, now that we're on Python 3.6+ and even dropping 3.6 on the horizon, if it wouldn't make sense to rewrite this code on asyncio, which might make it clearer.  Or maybe not, since wrapping one's head around asyncio is not easy either...)

### Description

It's possible this bug has existed for a long time and was just hidden.
Another possibility is it appeared at some point during refactoring, but
as far as I can tell it's been around a long time.

The `SAMPWebClient.hub` attribute is still just a `SAMPHubProxy`; it
does not make sense for it to have a `server_close` method because it
does not itself run or wrap a server.

It does however manage a pool of XML-RPC client connections which is
deleted when calling `SAMPHubProxy.disconnect()`.  To be on the safe
side I added a `ServerProxyPool.shutdown()` method to the proxy pool
class which closes the client connections.  This is called when shutting
down the `SAMPWebClient` server loop.  Unlike the normal `SAMPClient`
class, the `SAMPWebClient` used only in tests never runs a TCP server
of its own, so calling `server_close` anywhere in here does not make
sense.