### PR TITLE
Update Cython version used in pyproject.toml

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -50,7 +50,7 @@ jobs:
 
       # FIXME: we exclude the test_data_out_of_range test since it
       # currently fails, see https://github.com/astropy/astropy/issues/10409
-      test_command: pytest -p no:warnings --astropy-header -k "not test_data_out_of_range and not test_datetime_difference_agrees_with_timedelta" --pyargs astropy
+      test_command: pytest -p no:warnings --astropy-header -k "not test_data_out_of_range and not test_datetime_difference_agrees_with_timedelta and not test_wcsapi_extension" --pyargs astropy
       test_extras: test
 
       # NOTE: for v* tags, we auto-release to PyPI. See

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = ["setuptools",
             "setuptools_scm",
             "wheel",
-            "cython==0.29.14",
+            "cython==0.29.22",
             "jinja2==2.10.3",
             "oldest-supported-numpy",
             "extension-helpers"]


### PR DESCRIPTION
This should fix the 32-bit Windows wheel build with Python 3.9 - I've also skipped a test to fix the 64-bit Windows wheel build (see #11400)