### PR TITLE
Fixes for bounding box inverse

### DIFF
--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -668,6 +668,8 @@ class Model(metaclass=_ModelMeta):
     _bounding_box = None
     _user_bounding_box = None
 
+    _has_inverse_bounding_box = False
+
     # Default n_models attribute, so that __len__ is still defined even when a
     # model hasn't completed initialization yet
     _n_models = 1
@@ -1149,6 +1151,8 @@ class Model(metaclass=_ModelMeta):
         elif self._inverse is not None:
             result = self._inverse()
             if result is not NotImplemented:
+                if not self._has_inverse_bounding_box:
+                    result.bounding_box = None
                 return result
 
         raise NotImplementedError("No analytical or user-supplied inverse transform "

--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -461,6 +461,8 @@ class Shift(Fittable1DModel):
     offset = Parameter(default=0)
     linear = True
 
+    _has_inverse_bounding_box = True
+
     @property
     def input_units(self):
         if self.offset.unit is None:
@@ -470,8 +472,17 @@ class Shift(Fittable1DModel):
     @property
     def inverse(self):
         """One dimensional inverse Shift model function"""
+
         inv = self.copy()
         inv.offset *= -1
+
+        try:
+            self.bounding_box
+        except NotImplementedError:
+            pass
+        else:
+            inv.bounding_box = tuple(self.evaluate(x, self.offset) for x in self.bounding_box)
+
         return inv
 
     @staticmethod
@@ -519,6 +530,8 @@ class Scale(Fittable1DModel):
     _input_units_strict = True
     _input_units_allow_dimensionless = True
 
+    _has_inverse_bounding_box = True
+
     @property
     def input_units(self):
         if self.factor.unit is None:
@@ -530,6 +543,14 @@ class Scale(Fittable1DModel):
         """One dimensional inverse Scale model function"""
         inv = self.copy()
         inv.factor = 1 / self.factor
+
+        try:
+            self.bounding_box
+        except NotImplementedError:
+            pass
+        else:
+            inv.bounding_box = tuple(self.evaluate(x, self.factor) for x in self.bounding_box)
+
         return inv
 
     @staticmethod
@@ -565,11 +586,21 @@ class Multiply(Fittable1DModel):
     linear = True
     fittable = True
 
+    _has_inverse_bounding_box = True
+
     @property
     def inverse(self):
         """One dimensional inverse multiply model function"""
         inv = self.copy()
         inv.factor = 1 / self.factor
+
+        try:
+            self.bounding_box
+        except NotImplementedError:
+            pass
+        else:
+            inv.bounding_box = tuple(self.evaluate(x, self.factor) for x in self.bounding_box)
+
         return inv
 
     @staticmethod
@@ -606,6 +637,8 @@ class RedshiftScaleFactor(Fittable1DModel):
 
     z = Parameter(description='redshift', default=0)
 
+    _has_inverse_bounding_box = True
+
     @staticmethod
     def evaluate(x, z):
         """One dimensional RedshiftScaleFactor model function"""
@@ -625,6 +658,14 @@ class RedshiftScaleFactor(Fittable1DModel):
 
         inv = self.copy()
         inv.z = 1.0 / (1.0 + self.z) - 1.0
+
+        try:
+            self.bounding_box
+        except NotImplementedError:
+            pass
+        else:
+            inv.bounding_box = tuple(self.evaluate(x, self.z) for x in self.bounding_box)
+
         return inv
 
 

--- a/astropy/modeling/tests/test_core.py
+++ b/astropy/modeling/tests/test_core.py
@@ -532,3 +532,17 @@ def test_coerce_units():
 
     with pytest.raises(ValueError, match=r"return_units length does not match n_outputs"):
         model.coerce_units(return_units=(u.m, u.s))
+
+
+def test_bounding_box_general_inverse():
+    model = NonFittableModel(42.5)
+
+    with pytest.raises(NotImplementedError):
+        model.bounding_box
+    model.bounding_box = ()
+    assert model.bounding_box == ()
+
+    model.inverse = NonFittableModel(3.14)
+    inverse_model = model.inverse
+    with pytest.raises(NotImplementedError):
+        inverse_model.bounding_box

--- a/astropy/modeling/tests/test_functional_models.py
+++ b/astropy/modeling/tests/test_functional_models.py
@@ -141,6 +141,21 @@ def test_RedshiftScaleFactor():
                     [[1, 2], [1, 2], [1, 2]])
 
 
+def test_RedshiftScaleFactor_inverse():
+    m = models.RedshiftScaleFactor(1.2345)
+    assert_allclose(m.inverse(m(6.789)), 6.789)
+
+
+def test_RedshiftScaleFactor_inverse_bounding_box():
+    model = models.RedshiftScaleFactor(2)
+    model.bounding_box = (1, 5)
+    assert model.bounding_box == (1, 5)
+
+    inverse_model = model.inverse
+    assert inverse_model.bounding_box == (3, 15)
+    assert_allclose(inverse_model(model(4, with_bounding_box=True), with_bounding_box=True), 4)
+
+
 def test_Ellipse2D():
     """Test Ellipse2D model."""
     amplitude = 7.5
@@ -179,14 +194,44 @@ def test_Scale_inverse():
     assert_allclose(m.inverse(m(6.789)), 6.789)
 
 
+def test_Scale_inverse_bounding_box():
+    model = models.Scale(2)
+    model.bounding_box = (1, 5)
+    assert model.bounding_box == (1, 5)
+
+    inverse_model = model.inverse
+    assert inverse_model.bounding_box == (2, 10)
+    assert inverse_model(model(4, with_bounding_box=True), with_bounding_box=True) == 4.0
+
+
 def test_Multiply_inverse():
     m = models.Multiply(1.2345)
     assert_allclose(m.inverse(m(6.789)), 6.789)
 
 
+def test_Multiply_inverse_bounding_box():
+    model = models.Multiply(2)
+    model.bounding_box = (1, 5)
+    assert model.bounding_box == (1, 5)
+
+    inverse_model = model.inverse
+    assert inverse_model.bounding_box == (2, 10)
+    assert inverse_model(model(4, with_bounding_box=True), with_bounding_box=True) == 4.0
+
+
 def test_Shift_inverse():
     m = models.Shift(1.2345)
     assert_allclose(m.inverse(m(6.789)), 6.789)
+
+
+def test_Shift_inverse_bounding_box():
+    model = models.Shift(10)
+    model.bounding_box = (1, 5)
+    assert model.bounding_box == (1, 5)
+
+    inverse_model = model.inverse
+    assert inverse_model.bounding_box == (11, 15)
+    assert inverse_model(model(4, with_bounding_box=True), with_bounding_box=True) == 4.0
 
 
 @pytest.mark.skipif('not HAS_SCIPY')

--- a/docs/changes/modeling/11414.bugfix.rst
+++ b/docs/changes/modeling/11414.bugfix.rst
@@ -1,0 +1,1 @@
+Fixes the improper propagation of ``bounding_box`` from ``astropy.modeling.models`` to their inverses. For cases in which the inverses ``bounding_box`` can be determined, the proper calculation has been implemented.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request attempts to fix issues surrounding the `bounding_box` of the `inverse` of a model. The main issue was that in some cases the `bounding_box` of the original model was propagating without modification into the `inverse`. In many cases this is incorrect. 

Limits have been imposed to prevent the propagation of a `bounding_box` to the inverse, unless specifically allowed. Moreover, in the cases that one can automatically generate the `bounding_box` for an inverse, that computation has been implemented.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #10712
