### PR TITLE
Manual backport of #11145 (Use proper precision when format not specified)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1152,6 +1152,9 @@ astropy.units
 - Ensure ``keepdims`` works for taking ``mean``, ``std``, and ``var`` of
   ``Quantity``. [#11198]
 
+- For ``Quantity.to_string()``, ensure that the precision argument is also
+  used when the format is not latex. [#11145]
+
 astropy.utils
 ^^^^^^^^^^^^^
 

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -1172,14 +1172,20 @@ class Quantity(np.ndarray):
         if format not in formats:
             raise ValueError(f"Unknown format '{format}'")
         elif format is None:
-            return f'{self.value}{self._unitstr:s}'
+            if precision is None:
+                # Use default formatting settings
+                return f'{self.value}{self._unitstr:s}'
+            else:
+                # np.array2string properly formats arrays as well as scalars
+                return np.array2string(self.value, precision=precision, floatmode="fixed") + self._unitstr
 
         # else, for the moment we assume format="latex"
 
         # need to do try/finally because "threshold" cannot be overridden
         # with array2string
-        pops = np.get_printoptions()
 
+        # Set the precision if set, otherwise use numpy default
+        pops = np.get_printoptions()
         format_spec = '.{}g'.format(
             precision if precision is not None else pops['precision'])
 

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -913,6 +913,10 @@ class TestQuantityDisplay:
         res = 'Quantity as KMS: 150000000000.0 km / s'
         assert "Quantity as KMS: {}".format(qscalar.to_string(unit=u.km / u.s)) == res
 
+        # With precision set
+        res = 'Quantity as KMS: 1.500e+11 km / s'
+        assert f"Quantity as KMS: {qscalar.to_string(precision=3, unit=u.km / u.s)}" == res
+
         res = r'$1.5 \times 10^{14} \; \mathrm{\frac{m}{s}}$'
         assert qscalar.to_string(format="latex") == res
 


### PR DESCRIPTION
Use proper precision when format not specified

<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to manually backport #11145 for 4.2.1.