### PR TITLE
Expand SkyCoord.guess_from_table

### DIFF
--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -1842,10 +1842,10 @@ class SkyCoord(ShapedLikeNDArray):
         in an astropy Table.
 
         This method matches table columns that start with the case-insensitive
-        names of the the components of the requested frames, if they are also
-        followed by a non-alphanumeric character. It will also match columns
-        that *end* with the component name if a non-alphanumeric character is
-        *before* it.
+        names of the the components of the requested frames (including
+        differentials), if they are also followed by a non-alphanumeric
+        character. It will also match columns that *end* with the component name
+        if a non-alphanumeric character is *before* it.
 
         For example, the first rule means columns with names like
         ``'RA[J2000]'`` or ``'ra'`` will be interpreted as ``ra`` attributes for
@@ -1872,13 +1872,26 @@ class SkyCoord(ShapedLikeNDArray):
         -------
         newsc : same as this class
             The new `SkyCoord` (or subclass) object.
+
+        Raises
+        ------
+        ValueError
+            If more than one match is found in the table for a component,
+            unless the additional matches are also valid frame component names.
+            If a "coord_kwargs" is provided for a value also found in the table.
+
         """
         _frame_cls, _frame_kwargs = _get_frame_without_data([], coord_kwargs)
         frame = _frame_cls(**_frame_kwargs)
         coord_kwargs['frame'] = coord_kwargs.get('frame', frame)
 
+        representation_component_names = (
+            set(frame.get_representation_component_names())
+            .union(set(frame.get_representation_component_names("s")))
+        )
+
         comp_kwargs = {}
-        for comp_name in frame.representation_component_names:
+        for comp_name in representation_component_names:
             # this matches things like 'ra[...]'' but *not* 'rad'.
             # note that the "_" must be in there explicitly, because
             # "alphanumeric" usually includes underscores.
@@ -1887,18 +1900,32 @@ class SkyCoord(ShapedLikeNDArray):
             # 'aura'
             ends_with_comp = r'.*(\W|\b|_)' + comp_name + r'\b'
             # the final regex ORs together the two patterns
-            rex = re.compile('(' + starts_with_comp + ')|(' + ends_with_comp + ')',
+            rex = re.compile(rf"({starts_with_comp})|({ends_with_comp})",
                              re.IGNORECASE | re.UNICODE)
 
-            for col_name in table.colnames:
-                if rex.match(col_name):
-                    if comp_name in comp_kwargs:
-                        oldname = comp_kwargs[comp_name].name
-                        msg = ('Found at least two matches for  component "{0}"'
-                               ': "{1}" and "{2}". Cannot continue with this '
-                               'ambiguity.')
-                        raise ValueError(msg.format(comp_name, oldname, col_name))
-                    comp_kwargs[comp_name] = table[col_name]
+            # find all matches
+            matches = {col_name for col_name in table.colnames
+                       if rex.match(col_name)}
+
+            # now need to select among matches, also making sure we don't have
+            # an exact match with another component
+            if len(matches) == 0:  # no matches
+                continue
+            elif len(matches) == 1:  # only one match
+                col_name = matches.pop()
+            else:  # more than 1 match
+                # try to sieve out other components
+                matches -= representation_component_names - {comp_name}
+                # if there's only one remaining match, it worked.
+                if len(matches) == 1:
+                    col_name = matches.pop()
+                else:
+                    raise ValueError(
+                        'Found at least two matches for component '
+                        f'"{comp_name}": "{matches}". Cannot guess coordinates '
+                        'from a table with this ambiguity.')
+
+            comp_kwargs[comp_name] = table[col_name]
 
         for k, v in comp_kwargs.items():
             if k in coord_kwargs:

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -1270,8 +1270,8 @@ def test_guess_from_table():
 
     tab = Table()
     with NumpyRNGContext(987654321):
-        tab.add_column(Column(data=np.random.rand(1000), unit='deg', name='RA[J2000]'))
-        tab.add_column(Column(data=np.random.rand(1000), unit='deg', name='DEC[J2000]'))
+        tab.add_column(Column(data=np.random.rand(10), unit='deg', name='RA[J2000]'))
+        tab.add_column(Column(data=np.random.rand(10), unit='deg', name='DEC[J2000]'))
 
     sc = SkyCoord.guess_from_table(tab)
     npt.assert_array_equal(sc.ra.deg, tab['RA[J2000]'])
@@ -1286,20 +1286,44 @@ def test_guess_from_table():
 
     # but should work if provided
     sc2 = SkyCoord.guess_from_table(tab, unit=u.deg)
-    npt.assert_array_equal(sc.ra.deg, tab['RA[J2000]'])
-    npt.assert_array_equal(sc.dec.deg, tab['DEC[J2000]'])
+    npt.assert_array_equal(sc2.ra.deg, tab['RA[J2000]'])
+    npt.assert_array_equal(sc2.dec.deg, tab['DEC[J2000]'])
 
     # should fail if two options are available - ambiguity bad!
-    tab.add_column(Column(data=np.random.rand(1000), name='RA_J1900'))
+    tab.add_column(Column(data=np.random.rand(10), name='RA_J1900'))
     with pytest.raises(ValueError) as excinfo:
-        sc3 = SkyCoord.guess_from_table(tab, unit=u.deg)
+        SkyCoord.guess_from_table(tab, unit=u.deg)
     assert 'J1900' in excinfo.value.args[0] and 'J2000' in excinfo.value.args[0]
+
+    tab.remove_column('RA_J1900')
+    tab['RA[J2000]'].unit = u.deg
+    tab['DEC[J2000]'].unit = u.deg
+
+    # but should succeed if the ambiguity can be broken b/c one of the matches
+    # is the name of a different component
+    tab.add_column(Column(data=np.random.rand(10)*u.mas/u.yr,
+                          name='pm_ra_cosdec'))
+    tab.add_column(Column(data=np.random.rand(10)*u.mas/u.yr,
+                          name='pm_dec'))
+    sc3 = SkyCoord.guess_from_table(tab)
+    assert u.allclose(sc3.ra, tab['RA[J2000]'])
+    assert u.allclose(sc3.dec, tab['DEC[J2000]'])
+    assert u.allclose(sc3.pm_ra_cosdec, tab['pm_ra_cosdec'])
+    assert u.allclose(sc3.pm_dec, tab['pm_dec'])
+
+    # should fail if stuff doesn't have proper units
+    tab['RA[J2000]'].unit = None
+    tab['DEC[J2000]'].unit = None
+    with pytest.raises(u.UnitTypeError, match="no unit was given."):
+        SkyCoord.guess_from_table(tab)
+
+    tab.remove_column('pm_ra_cosdec')
+    tab.remove_column('pm_dec')
 
     # should also fail if user specifies something already in the table, but
     # should succeed even if the user has to give one of the components
-    tab.remove_column('RA_J1900')
     with pytest.raises(ValueError):
-        sc3 = SkyCoord.guess_from_table(tab, ra=tab['RA[J2000]'], unit=u.deg)
+        SkyCoord.guess_from_table(tab, ra=tab['RA[J2000]'], unit=u.deg)
 
     oldra = tab['RA[J2000]']
     tab.remove_column('RA[J2000]')

--- a/docs/changes/coordinates/11417.feature.rst
+++ b/docs/changes/coordinates/11417.feature.rst
@@ -1,0 +1,4 @@
+``SkyCoord.guess_from_table`` now also searches for differentials in the table.
+In addition, multiple regex matches can be resolved when they are exact
+component names, e.g. having both columns “dec” and “pm_dec” no longer errors
+and will be included in the SkyCoord.


### PR DESCRIPTION
### Description

1) Allow for multiple regex matches when they are exact component names.
   eg: allow for column “dec” and “pm_dec” to work
2) allow for differential component names
  eg:  "pm_ra_cosdec", “pm_dec”
3) improve error message to show all matches, if there are more than one.


- [x] write tests
- [x] changelog
- [x] docstring
- [ ] docs (?)

Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>