### PR TITLE
Manual backport of #11391 (BUG: Fix missing "server_close" method on SAMPHubProxy)

### DIFF
--- a/astropy/samp/hub_proxy.py
+++ b/astropy/samp/hub_proxy.py
@@ -89,12 +89,11 @@ class SAMPHubProxy:
         """
         Disconnect from the current SAMP Hub.
         """
-        self.proxy = None
+        if self.proxy is not None:
+            self.proxy.shutdown()
+            self.proxy = None
         self._connected = False
         self.lockfile = {}
-
-    def server_close(self):
-        self.proxy.server_close()
 
     @property
     def _samp_hub(self):

--- a/astropy/samp/tests/web_profile_test_helpers.py
+++ b/astropy/samp/tests/web_profile_test_helpers.py
@@ -172,7 +172,7 @@ class SAMPWebClient(SAMPClient):
                         self.receive_response(self._private_key,
                                               *result['samp.params'])
 
-        self.hub.server_close()
+        self.hub.disconnect()
 
     def register(self):
         """

--- a/astropy/samp/utils.py
+++ b/astropy/samp/utils.py
@@ -82,6 +82,18 @@ class ServerProxyPool:
         # magic method dispatcher
         return _ServerProxyPoolMethod(self._proxies, name)
 
+    def shutdown(self):
+        """Shut down the proxy pool by closing all active conections."""
+
+        while True:
+            try:
+                proxy = self._proxies.get_nowait()
+            except queue.Empty:
+                break
+            # An undocumented but apparently supported way to call methods on
+            # an ServerProxy that are not dispatched to the remote server
+            proxy('close')
+
 
 class SAMPMsgReplierWrapper:
     """

--- a/setup.cfg
+++ b/setup.cfg
@@ -140,7 +140,6 @@ filterwarnings =
     # Ignore a warning we emit about not supporting the parallel
     # reading option for now, can be removed once the issue is fixed
     ignore:parallel reading does not currently work, so falling back to serial
-    ignore:'datfix' made the change:astropy.wcs.wcs.FITSFixedWarning
 doctest_norecursedirs =
     */setup_package.py
 doctest_subpackage_requires =

--- a/setup.cfg
+++ b/setup.cfg
@@ -140,8 +140,7 @@ filterwarnings =
     # Ignore a warning we emit about not supporting the parallel
     # reading option for now, can be removed once the issue is fixed
     ignore:parallel reading does not currently work, so falling back to serial
-    # Ignore pytest.PytestUnhandledThreadExceptionWarning from SAMP, pytest>=6.2
-    ignore:Exception in thread
+    ignore:'datfix' made the change:astropy.wcs.wcs.FITSFixedWarning
 doctest_norecursedirs =
     */setup_package.py
 doctest_subpackage_requires =


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to manually backport #11391 for 4.2.1.