### PR TITLE
DOC: Update milestone/label policy 

### DIFF
--- a/docs/development/workflow/maintainer_workflow.rst
+++ b/docs/development/workflow/maintainer_workflow.rst
@@ -109,27 +109,19 @@ branch in the ``upstream-rw`` repository.
 Using Milestones and Labels
 ===========================
 
-These guidelines are adapted from `similar guidelines <https://github.com/ipython/ipython/wiki/Dev:-GitHub-workflow>`_
-followed by IPython:
+General guidelines for milestones:
 
-* 100% of confirmed issues and new features should have a milestone
+* 100% of pull requests should have a milestone
 
-* Only the following criteria should result in an issue being closed without a milestone:
+* Issues are not milestoned unless they block a given release
 
-  * Not actually an issue (user error, etc.)
+* Only the following criteria should result in a pull request being closed without a milestone:
 
-  * Duplicate of an existing issue
+  * Invalid (user error, etc.)
+
+  * Duplicate of an existing pull request
 
   * A pull request superseded by a new pull request providing an alternate implementation
-
-* Open issues should only lack a milestone if:
-
-  * More clarification is required
-
-  * Which milestone it belongs in requires some discussion
-
-* Corollary: When an issue is closed without a milestone that means that the issue will not be fixed, or that it was
-  not a real issue at all.
 
 * In general there should be the following open milestones:
 
@@ -142,25 +134,20 @@ followed by IPython:
   * The next X.Y release +1; for example if 0.3 is the next release, there should also be a milestone for 0.4 for
     issues that are important, but that we know won't be resolved in the next release.
 
-  * Future--this is for all issues that require attention at some point but for which no immediate solution is in
-    sight.
-
-* Bug fix release milestones should only be used for deferring issues that won't be fixed in the next minor release,
-  or for issues is previous releases that no longer apply to the mainline.
-
-* When in doubt about which milestone to use for an issue, use the next minor release--it can always be moved once
-  it's been more closely reviewed prior to release.
-
 * Active milestones associated with a specific release (eg. v0.3.0) should contain at least one issue with the
   release label representing the actual task for releasing that version (this also works around the GitHub annoyance
   that milestones without any open issues are automatically closed).
+  For example, we have `Rolling reminder: update wcslib and cfitsio and leap second/IERS B table to the latest version <https://github.com/astropy/astropy/issues/9018>`_.
 
-* Issues that require fixing in the mainline, but that also are confirmed to apply to supported stable version lines
-  should be marked with one or more ``'backport-*'`` labels for each v0.X.Y branch that has the issue.
+General guidelines for labels:
 
-  * In some cases it may require extra work beyond a simple merge to port bug fixes to older lines of development; if
-    such additional work is required it is not a bad idea to open a "Backport #nnn to v0.X.Y" issue in the appropriate
-    v0.X.Y milestone.
+* Issues: Maintainer should be proactive in labeling issues as they come in.
+  At the very least, label the subpackage(s) involved and whether the issue
+  is a bug.
+
+* Pull requests: We have GitHub Actions to automatically apply labels using
+  some simple rules when a pull request is opened. Once that is done, a
+  maintainer can then manually apply any other labels that apply.
 
 
 .. _changelog-format:

--- a/docs/development/workflow/maintainer_workflow.rst
+++ b/docs/development/workflow/maintainer_workflow.rst
@@ -134,10 +134,9 @@ General guidelines for milestones:
   * The next X.Y release +1; for example if 0.3 is the next release, there should also be a milestone for 0.4 for
     issues that are important, but that we know won't be resolved in the next release.
 
-* Active milestones associated with a specific release (eg. v0.3.0) should contain at least one issue with the
-  release label representing the actual task for releasing that version (this also works around the GitHub annoyance
-  that milestones without any open issues are automatically closed).
-  For example, we have `Rolling reminder: update wcslib and cfitsio and leap second/IERS B table to the latest version <https://github.com/astropy/astropy/issues/9018>`_.
+* We have `Rolling reminder: update wcslib and cfitsio and leap second/IERS B table to the latest version <https://github.com/astropy/astropy/issues/9018>`_.
+  The milestone for this issue should be updated as part of the release
+  procedures.
 
 General guidelines for labels:
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

I came across this section and noticed that none of the words reflect how we actually use milestone and label. 😅 

Hopefully now it is more accurate.

Given now we don't render dev docs in "stable," we don't have to backport this.