### PR TITLE
xfail test_against_pyephem on v4.2.x

### DIFF
--- a/astropy/coordinates/tests/accuracy/test_altaz_icrs.py
+++ b/astropy/coordinates/tests/accuracy/test_altaz_icrs.py
@@ -91,6 +91,7 @@ def test_against_hor2eq():
     assert distance_noatm < 0.4 * u.arcsec
 
 
+@pytest.mark.skipif(reason="See https://github.com/astropy/astropy/issues/11305")
 def test_against_pyephem():
     """Check that Astropy gives consistent results with one PyEphem example.
 


### PR DESCRIPTION
This PR is a PR specifically to the v4.2.x branch to allow a release without needing to fix the test described more in #11305 . The conclusion in that issue is that this is a testing problem in that newer versions of pyerfa have a *better* algorithm, and the test is a red herring in that it's failing only because the algorithm was *improved*.

So this PR is straight into 4.2.x to xfail that test for now.  We'll probably want to revert this once #11305 is fixed, but since it's purely the test it's not a big deal either way I think.