### PR TITLE
Fix table.to_pandas incorrect behavior with masked data

### DIFF
--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -3661,7 +3661,18 @@ class Table:
                 elif column.dtype.kind not in ['f', 'c']:
                     out[name] = column.astype(object).filled(np.nan)
 
-        kwargs = {'index': out.pop(index)} if index else {}
+        kwargs = {}
+
+        if index:
+            idx = out.pop(index)
+
+            kwargs['index'] = idx
+
+            # We add the table index to Series inputs (MaskedColumn with int values) to override
+            # its default RangeIndex, see #11432
+            for v in out.values():
+                if isinstance(v, Series):
+                    v.index = idx
 
         return DataFrame(out, **kwargs)
 

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -2042,6 +2042,17 @@ class TestPandas:
         assert len(record) == 1
         assert "{'y'}" in record[0].message.args[0]
 
+    def test_to_pandas_masked_int_data_with__index(self):
+        data = {"data": [0, 1, 2], "index": [10, 11, 12]}
+        t = table.Table(data=data, masked=True)
+
+        t.add_index("index")
+        t["data"].mask = [1, 1, 0]
+
+        df = t.to_pandas()
+
+        assert df["data"].iloc[-1] == 2
+
 
 @pytest.mark.usefixtures('table_types')
 class TestReplaceColumn(SetupData):

--- a/docs/changes/table/11432.bugfix.rst
+++ b/docs/changes/table/11432.bugfix.rst
@@ -1,0 +1,2 @@
+Using ``Table.to_pandas()`` on an indexed ``Table`` with masked integer values
+now correctly construct the ``pandas.DataFrame``.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

Hello,

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

I stumbled upon a weird interaction using `Table.to_pandas()` when the table has an index and some values are masked.

```python
data = {"data": [0, 1, 2], "index": [10, 11, 12]}
t = table.Table(data=data, masked=True)
t.add_index("index")
t["data"].mask = [0, 1, 0]

t.to_pandas()
```
```
	data
index	
10	<NA>
11	<NA>
12	<NA>
```

To compare the expected result, we can just use `float` values instead of `int` because it only occurs for integer dtypes.
```python
data = {"data": [0., 1., 2.], "index": [10, 11, 12]}
t = table.Table(data=data, masked=True)
t.add_index("index")
t["data"].mask = [0, 1, 0]

t.to_pandas()
```
```
	data
index	
10	0.0
11	NaN
12	2.0
```

The problem arises when creating `Series` object to contain integer columns. These `Series` do not have an index and so when building the DataFrame with a specified index it will try to map these values onto the `Series` index.

