### PR TITLE
TST: Update coordinates doctest result for 4.2.x

### DIFF
--- a/docs/coordinates/frames.rst
+++ b/docs/coordinates/frames.rst
@@ -244,7 +244,7 @@ set of coordinates, you will need to make sure that the shapes allow this::
         [[( 93.09845185, 89.21613128), (126.85789663, 25.4660055 ),
           ( 51.37993234, 37.18532527)],
          [(307.71713698, 37.99437658), (231.3740787 , 26.36768329),
-          ( 85.4218724 , 89.69297998)]]>
+          ( 85.42187241, 89.69297998)]]>
 
 .. Note::
    Frames without data have a ``shape`` that is determined by their frame


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to update coordinates doctest result to fix this failure in dev job.

```
239     >>> coo2.transform_to(lf2)  # doctest:  +REMOTE_DATA +FLOAT_CMP
Differences (unified diff with -expected +actual):
    @@ -6,3 +6,3 @@
           ( 51.37993234, 37.18532527)],
          [(307.71713698, 37.99437658), (231.3740787 , 26.36768329),
    -      ( 85.4218724 , 89.69297998)]]>
    +      ( 85.42187241, 89.69297998)]]>

/home/runner/work/astropy/astropy/docs/coordinates/frames.rst:239: DocTestFailure
```

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

It is mostly FLOAT_CMP being too strict, I think. Though if this fails in other jobs, maybe this is not worth fixing for the dev job, which is "allowed to fail" anyway?