### PR TITLE
MNT: matplotlib 3.4.0 broke plot_obs-planning.py

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -72,7 +72,7 @@ all =
     sortedcontainers
     pytz
     jplephem
-    matplotlib>=3.0
+    matplotlib>=3.0,!=3.4.0
     mpmath
     asdf>=2.6
     bottleneck
@@ -84,7 +84,7 @@ docs =
     pytest
     PyYAML>=3.13
     scipy>=1.1
-    matplotlib>=3.1
+    matplotlib>=3.1,!=3.4.0
 
 [options.package_data]
 * = data/*, data/*/*, data/*/*/*, data/*/*/*/*, data/*/*/*/*/*, data/*/*/*/*/*/*


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to address broken RTD builds caused by `matplotlib` 3.4.0 release last night.

```
WARNING: .../examples/coordinates/plot_obs-planning.py failed to execute correctly: Traceback (most recent call last):
  File ".../sphinx_gallery/scrapers.py", line 333, in save_figures
    rst = scraper(block, block_vars, gallery_conf)
  File ".../sphinx_gallery/scrapers.py", line 149, in matplotlib_scraper
    fig.savefig(image_path, **these_kwargs)
  File ".../matplotlib/figure.py", line 2959, in savefig
    self.canvas.print_figure(fname, **kwargs)
  File ".../matplotlib/backend_bases.py", line 2255, in print_figure
    result = print_method(
  File ".../matplotlib/backend_bases.py", line 1669, in wrapper
    return func(*args, **kwargs)
  File ".../matplotlib/backends/backend_agg.py", line 508, in print_png
    FigureCanvasAgg.draw(self)
  File ".../matplotlib/backends/backend_agg.py", line 406, in draw
    self.figure.draw(self.renderer)
  File ".../matplotlib/artist.py", line 74, in draw_wrapper
    result = draw(artist, renderer, *args, **kwargs)
  File ".../matplotlib/artist.py", line 51, in draw_wrapper
    return draw(artist, renderer, *args, **kwargs)
  File ".../matplotlib/figure.py", line 2734, in draw
    mimage._draw_list_compositing_images(
  File ".../matplotlib/image.py", line 132, in _draw_list_compositing_images
    a.draw(renderer)
  File ".../matplotlib/artist.py", line 51, in draw_wrapper
    return draw(artist, renderer, *args, **kwargs)
  File ".../matplotlib/_api/deprecation.py", line 431, in wrapper
    return func(*inner_args, **inner_kwargs)
  File ".../matplotlib/axes/_base.py", line 2925, in draw
    mimage._draw_list_compositing_images(renderer, self, artists)
  File ".../matplotlib/image.py", line 132, in _draw_list_compositing_images
    a.draw(renderer)
  File ".../matplotlib/artist.py", line 51, in draw_wrapper
    return draw(artist, renderer, *args, **kwargs)
  File ".../matplotlib/legend.py", line 614, in draw
    self._legend_box.draw(renderer)
  File ".../matplotlib/offsetbox.py", line 368, in draw
    c.draw(renderer)
  File ".../matplotlib/offsetbox.py", line 368, in draw
    c.draw(renderer)
  File ".../matplotlib/offsetbox.py", line 368, in draw
    c.draw(renderer)
  [Previous line repeated 1 more time]
  File ".../matplotlib/offsetbox.py", line 694, in draw
    c.draw(renderer)
  File ".../matplotlib/artist.py", line 51, in draw_wrapper
    return draw(artist, renderer, *args, **kwargs)
  File ".../matplotlib/collections.py", line 1009, in draw
    super().draw(renderer)
  File ".../matplotlib/artist.py", line 51, in draw_wrapper
    return draw(artist, renderer, *args, **kwargs)
  File ".../matplotlib/collections.py", line 380, in draw
    len(facecolors) == 1 and len(edgecolors) == 1 and
TypeError: object of type 'NoneType' has no len()
```

I opened bug report upstream at matplotlib/matplotlib#19779 . @eteq , pretty sure 4.2.1 release will be affected and probably 4.0.5 too. I tentatively milestoning to 4.0.6 for now, but feel free to move milestone as needed.