### PR TITLE
Fix test failing after backport of #11285

### DIFF
--- a/astropy/io/fits/tests/test_hdulist.py
+++ b/astropy/io/fits/tests/test_hdulist.py
@@ -995,7 +995,7 @@ class TestHDUListFunctions(FitsTestCase):
 
         # Make sure that files opened by the user are not closed
         with open(filename, mode='rb') as f:
-            with pytest.raises(OSError):
+            with pytest.raises(OSError), pytest.warns(VerifyWarning):
                 fits.open(f, ignore_missing_end=False)
 
             assert not f.closed
@@ -1006,7 +1006,7 @@ class TestHDUListFunctions(FitsTestCase):
 
             assert not f.closed
 
-        with pytest.raises(OSError):
+        with pytest.raises(OSError), pytest.warns(VerifyWarning):
             fits.open(filename, ignore_missing_end=False)
 
         with pytest.raises(OSError), pytest.warns(VerifyWarning):


### PR DESCRIPTION
With the backport of #11285 on v4.2, a new warning is rasied and turned
into an error. This doesn't happen on v4.0 because the way to catch
warning changed (using pytest) and does not happen on master/4.3 because
some new code was added to detect if the file is a valid FITS file.

cc @eteq @pllim 
ref #11415 and #11430