### PR TITLE
Fix deprecation warning about default h5py file mode

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -46,10 +46,10 @@ jobs:
             python: 3.7
             toxenv: py37-test-oldestdeps
 
-          - name: Python 3.7 with numpy 1.17 and full coverage
+          - name: Python 3.8 with numpy 1.17 and full coverage
             os: ubuntu-latest
-            python: 3.7
-            toxenv: py37-test-alldeps-numpy117-cov-clocale
+            python: 3.8
+            toxenv: py38-test-alldeps-numpy117-cov-clocale
             toxposargs: --remote-data=astropy
 
           - name: Python 3.8 with all optional dependencies (Windows)

--- a/astropy/io/misc/tests/test_hdf5.py
+++ b/astropy/io/misc/tests/test_hdf5.py
@@ -464,7 +464,7 @@ def test_preserve_serialized(tmpdir):
     assert t1.meta == t2.meta
 
     # Check that the meta table is fixed-width bytes (see #11299)
-    h5 = h5py.File(test_file)
+    h5 = h5py.File(test_file, 'r')
     meta_lines = h5[meta_path('the_table')]
     assert meta_lines.dtype.kind == 'S'
 

--- a/tox.ini
+++ b/tox.ini
@@ -58,6 +58,8 @@ description =
 
 deps =
 
+    py37: importlib-metadata<3.9
+
     numpy117: numpy==1.17.*
     numpy118: numpy==1.18.*
     numpy119: numpy==1.19.*


### PR DESCRIPTION
As reported by @pllim in Slack:

> While running tests locally, I also saw this... astropy/io/misc/tests/test_hdf5.py::test_preserve_serialized - h5py.h5py_warnings.H5pyDeprecationWarning: The default file mode will change to 'r' (read-only) in h5py 3.0.

I believe this is because there is one instance of `h5py.File()` that does not specify the file mode (fixed in this PR).