### PR TITLE
TST: See if bumping Python works

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -46,10 +46,10 @@ jobs:
             python: 3.7
             toxenv: py37-test-oldestdeps
 
-          - name: Python 3.7 with numpy 1.17 and full coverage
+          - name: Python 3.8 with numpy 1.17 and full coverage
             os: ubuntu-latest
-            python: 3.7
-            toxenv: py37-test-alldeps-numpy117-cov-clocale
+            python: 3.8
+            toxenv: py38-test-alldeps-numpy117-cov-clocale
             toxposargs: --remote-data=astropy
 
           - name: Python 3.8 with all optional dependencies (Windows)

--- a/tox.ini
+++ b/tox.ini
@@ -58,6 +58,8 @@ description =
 
 deps =
 
+    py37: importlib-metadata<3.9
+
     numpy117: numpy==1.17.*
     numpy118: numpy==1.18.*
     numpy119: numpy==1.19.*


### PR DESCRIPTION
to get rid of deprecation warning from this job with importlib-metadata 3.9.x.

<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to address is an attempt to fix the failing job with weird deprecation warning that I cannot reproduce locally outside of tox. The only new release I noticed is `importlib-metadata` going from 3.8.1 to 3.9.x (CI fails on both 3.9.0 and 3.9.1.). 

```
2021-03-29T11:31:17.1293785Z py37-test-alldeps-numpy117-cov-clocale run-test: commands[1] | pytest --pyargs astropy /home/runner/work/astropy/astropy/docs --cov astropy --cov-config=/home/runner/work/astropy/astropy/setup.cfg --remote-data=astropy
2021-03-29T11:31:19.3498083Z Traceback (most recent call last):
2021-03-29T11:31:19.3502179Z   File "/home/runner/work/astropy/astropy/.tox/py37-test-alldeps-numpy117-cov-clocale/bin/pytest", line 8, in <module>
2021-03-29T11:31:19.3503964Z     sys.exit(console_main())
2021-03-29T11:31:19.3506345Z   File "/home/runner/work/astropy/astropy/.tox/py37-test-alldeps-numpy117-cov-clocale/lib/python3.7/site-packages/_pytest/config/__init__.py", line 185, in console_main
2021-03-29T11:31:19.3508238Z     code = main()
2021-03-29T11:31:19.3510075Z   File "/home/runner/work/astropy/astropy/.tox/py37-test-alldeps-numpy117-cov-clocale/lib/python3.7/site-packages/_pytest/config/__init__.py", line 143, in main
2021-03-29T11:31:19.3511796Z     config = _prepareconfig(args, plugins)
2021-03-29T11:31:19.3515412Z   File "/home/runner/work/astropy/astropy/.tox/py37-test-alldeps-numpy117-cov-clocale/lib/python3.7/site-packages/_pytest/config/__init__.py", line 319, in _prepareconfig
2021-03-29T11:31:19.3516884Z     pluginmanager=pluginmanager, args=args
2021-03-29T11:31:19.3519150Z   File "/home/runner/work/astropy/astropy/.tox/py37-test-alldeps-numpy117-cov-clocale/lib/python3.7/site-packages/pluggy/hooks.py", line 286, in __call__
2021-03-29T11:31:19.3520437Z     return self._hookexec(self, self.get_hookimpls(), kwargs)
2021-03-29T11:31:19.3522093Z   File "/home/runner/work/astropy/astropy/.tox/py37-test-alldeps-numpy117-cov-clocale/lib/python3.7/site-packages/pluggy/manager.py", line 93, in _hookexec
2021-03-29T11:31:19.3523543Z     return self._inner_hookexec(hook, methods, kwargs)
2021-03-29T11:31:19.3525218Z   File "/home/runner/work/astropy/astropy/.tox/py37-test-alldeps-numpy117-cov-clocale/lib/python3.7/site-packages/pluggy/manager.py", line 87, in <lambda>
2021-03-29T11:31:19.3526620Z     firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
2021-03-29T11:31:19.3528661Z   File "/home/runner/work/astropy/astropy/.tox/py37-test-alldeps-numpy117-cov-clocale/lib/python3.7/site-packages/pluggy/callers.py", line 203, in _multicall
2021-03-29T11:31:19.3529893Z     gen.send(outcome)
2021-03-29T11:31:19.3531579Z   File "/home/runner/work/astropy/astropy/.tox/py37-test-alldeps-numpy117-cov-clocale/lib/python3.7/site-packages/_pytest/helpconfig.py", line 100, in pytest_cmdline_parse
2021-03-29T11:31:19.3532920Z     config: Config = outcome.get_result()
2021-03-29T11:31:19.3534553Z   File "/home/runner/work/astropy/astropy/.tox/py37-test-alldeps-numpy117-cov-clocale/lib/python3.7/site-packages/pluggy/callers.py", line 80, in get_result
2021-03-29T11:31:19.3536112Z     raise ex[1].with_traceback(ex[2])
2021-03-29T11:31:19.3537726Z   File "/home/runner/work/astropy/astropy/.tox/py37-test-alldeps-numpy117-cov-clocale/lib/python3.7/site-packages/pluggy/callers.py", line 187, in _multicall
2021-03-29T11:31:19.3539024Z     res = hook_impl.function(*args)
2021-03-29T11:31:19.3540822Z   File "/home/runner/work/astropy/astropy/.tox/py37-test-alldeps-numpy117-cov-clocale/lib/python3.7/site-packages/_pytest/config/__init__.py", line 1003, in pytest_cmdline_parse
2021-03-29T11:31:19.3542259Z     self.parse(args)
2021-03-29T11:31:19.3543784Z   File "/home/runner/work/astropy/astropy/.tox/py37-test-alldeps-numpy117-cov-clocale/lib/python3.7/site-packages/_pytest/config/__init__.py", line 1283, in parse
2021-03-29T11:31:19.3545155Z     self._preparse(args, addopts=addopts)
2021-03-29T11:31:19.3546909Z   File "/home/runner/work/astropy/astropy/.tox/py37-test-alldeps-numpy117-cov-clocale/lib/python3.7/site-packages/_pytest/config/__init__.py", line 1192, in _preparse
2021-03-29T11:31:19.3548243Z     early_config=self, args=args, parser=self._parser
2021-03-29T11:31:19.3549789Z   File "/home/runner/work/astropy/astropy/.tox/py37-test-alldeps-numpy117-cov-clocale/lib/python3.7/site-packages/pluggy/hooks.py", line 286, in __call__
2021-03-29T11:31:19.3551133Z     return self._hookexec(self, self.get_hookimpls(), kwargs)
2021-03-29T11:31:19.3552985Z   File "/home/runner/work/astropy/astropy/.tox/py37-test-alldeps-numpy117-cov-clocale/lib/python3.7/site-packages/pluggy/manager.py", line 93, in _hookexec
2021-03-29T11:31:19.3554385Z     return self._inner_hookexec(hook, methods, kwargs)
2021-03-29T11:31:19.3556031Z   File "/home/runner/work/astropy/astropy/.tox/py37-test-alldeps-numpy117-cov-clocale/lib/python3.7/site-packages/pluggy/manager.py", line 87, in <lambda>
2021-03-29T11:31:19.3557384Z     firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
2021-03-29T11:31:19.3559134Z   File "/home/runner/work/astropy/astropy/.tox/py37-test-alldeps-numpy117-cov-clocale/lib/python3.7/site-packages/pluggy/callers.py", line 208, in _multicall
2021-03-29T11:31:19.3560327Z     return outcome.get_result()
2021-03-29T11:31:19.3562065Z   File "/home/runner/work/astropy/astropy/.tox/py37-test-alldeps-numpy117-cov-clocale/lib/python3.7/site-packages/pluggy/callers.py", line 80, in get_result
2021-03-29T11:31:19.3563572Z     raise ex[1].with_traceback(ex[2])
2021-03-29T11:31:19.3565368Z   File "/home/runner/work/astropy/astropy/.tox/py37-test-alldeps-numpy117-cov-clocale/lib/python3.7/site-packages/pluggy/callers.py", line 182, in _multicall
2021-03-29T11:31:19.3566521Z     next(gen)  # first yield
2021-03-29T11:31:19.3568343Z   File "/home/runner/work/astropy/astropy/.tox/py37-test-alldeps-numpy117-cov-clocale/lib/python3.7/site-packages/_pytest/warnings.py", line 137, in pytest_load_initial_conftests
2021-03-29T11:31:19.3569894Z     config=early_config, ihook=early_config.hook, when="config", item=None
2021-03-29T11:31:19.3570874Z   File "/opt/hostedtoolcache/Python/3.7.10/x64/lib/python3.7/contextlib.py", line 112, in __enter__
2021-03-29T11:31:19.3571658Z     return next(self.gen)
2021-03-29T11:31:19.3573175Z   File "/home/runner/work/astropy/astropy/.tox/py37-test-alldeps-numpy117-cov-clocale/lib/python3.7/site-packages/_pytest/warnings.py", line 52, in catch_warnings_for_item
2021-03-29T11:31:19.3574543Z     apply_warning_filters(config_filters, cmdline_filters)
2021-03-29T11:31:19.3576172Z   File "/home/runner/work/astropy/astropy/.tox/py37-test-alldeps-numpy117-cov-clocale/lib/python3.7/site-packages/_pytest/config/__init__.py", line 1603, in apply_warning_filters
2021-03-29T11:31:19.3577804Z     warnings.filterwarnings(*parse_warning_filter(arg, escape=False))
2021-03-29T11:31:19.3579831Z   File "/home/runner/work/astropy/astropy/.tox/py37-test-alldeps-numpy117-cov-clocale/lib/python3.7/site-packages/_pytest/config/__init__.py", line 1579, in parse_warning_filter
2021-03-29T11:31:19.3581971Z     category: Type[Warning] = warnings._getcategory(category_)  # type: ignore[attr-defined]
2021-03-29T11:31:19.3583034Z   File "/opt/hostedtoolcache/Python/3.7.10/x64/lib/python3.7/warnings.py", line 260, in _getcategory
2021-03-29T11:31:19.3583931Z     m = __import__(module, None, None, [klass])
2021-03-29T11:31:19.3585492Z   File "/home/runner/work/astropy/astropy/.tox/py37-test-alldeps-numpy117-cov-clocale/lib/python3.7/site-packages/astropy/wcs/__init__.py", line 26, in <module>
2021-03-29T11:31:19.3586696Z     from .wcs import *
2021-03-29T11:31:19.3588186Z   File "/home/runner/work/astropy/astropy/.tox/py37-test-alldeps-numpy117-cov-clocale/lib/python3.7/site-packages/astropy/wcs/wcs.py", line 46, in <module>
2021-03-29T11:31:19.3589345Z     from astropy.io import fits
2021-03-29T11:31:19.3590936Z   File "/home/runner/work/astropy/astropy/.tox/py37-test-alldeps-numpy117-cov-clocale/lib/python3.7/site-packages/astropy/io/fits/__init__.py", line 70, in <module>
2021-03-29T11:31:19.3592121Z     from . import convenience
2021-03-29T11:31:19.3594092Z   File "/home/runner/work/astropy/astropy/.tox/py37-test-alldeps-numpy117-cov-clocale/lib/python3.7/site-packages/astropy/io/fits/convenience.py", line 64, in <module>
2021-03-29T11:31:19.3595331Z     from .diff import FITSDiff, HDUDiff
2021-03-29T11:31:19.3596895Z   File "/home/runner/work/astropy/astropy/.tox/py37-test-alldeps-numpy117-cov-clocale/lib/python3.7/site-packages/astropy/io/fits/diff.py", line 28, in <module>
2021-03-29T11:31:19.3598225Z     from .hdu.hdulist import fitsopen, HDUList  # pylint: disable=W0611
2021-03-29T11:31:19.3599878Z   File "/home/runner/work/astropy/astropy/.tox/py37-test-alldeps-numpy117-cov-clocale/lib/python3.7/site-packages/astropy/io/fits/hdu/__init__.py", line 5, in <module>
2021-03-29T11:31:19.3601101Z     from .compressed import CompImageHDU
2021-03-29T11:31:19.3602720Z   File "/home/runner/work/astropy/astropy/.tox/py37-test-alldeps-numpy117-cov-clocale/lib/python3.7/site-packages/astropy/io/fits/hdu/compressed.py", line 15, in <module>
2021-03-29T11:31:19.3603973Z     from .image import ImageHDU
2021-03-29T11:31:19.3605473Z   File "/home/runner/work/astropy/astropy/.tox/py37-test-alldeps-numpy117-cov-clocale/lib/python3.7/site-packages/astropy/io/fits/hdu/image.py", line 17, in <module>
2021-03-29T11:31:19.3606751Z     from dask.array import Array as DaskArray
2021-03-29T11:31:19.3608343Z   File "/home/runner/work/astropy/astropy/.tox/py37-test-alldeps-numpy117-cov-clocale/lib/python3.7/site-packages/dask/array/__init__.py", line 2, in <module>
2021-03-29T11:31:19.3609584Z     from .blockwise import blockwise, atop
2021-03-29T11:31:19.3611129Z   File "/home/runner/work/astropy/astropy/.tox/py37-test-alldeps-numpy117-cov-clocale/lib/python3.7/site-packages/dask/array/blockwise.py", line 288, in <module>
2021-03-29T11:31:19.3612514Z     from .core import new_da_object
2021-03-29T11:31:19.3613963Z   File "/home/runner/work/astropy/astropy/.tox/py37-test-alldeps-numpy117-cov-clocale/lib/python3.7/site-packages/dask/array/core.py", line 21, in <module>
2021-03-29T11:31:19.3615173Z     from fsspec import get_mapper
2021-03-29T11:31:19.3616557Z   File "/home/runner/work/astropy/astropy/.tox/py37-test-alldeps-numpy117-cov-clocale/lib/python3.7/site-packages/fsspec/__init__.py", line 43, in <module>
2021-03-29T11:31:19.3617759Z     for spec in entry_points.get("fsspec.specs", []):
2021-03-29T11:31:19.3619554Z   File "/home/runner/work/astropy/astropy/.tox/py37-test-alldeps-numpy117-cov-clocale/lib/python3.7/site-packages/importlib_metadata/__init__.py", line 302, in get
2021-03-29T11:31:19.3620706Z     flake8_bypass(self._warn)()
2021-03-29T11:31:19.3621536Z DeprecationWarning: SelectableGroups dict interface is deprecated. Use select.
2021-03-29T11:31:19.4568043Z ERROR: InvocationError for command /home/runner/work/astropy/astropy/.tox/py37-test-alldeps-numpy117-cov-clocale/bin/pytest --pyargs astropy /home/runner/work/astropy/astropy/docs --cov astropy --cov-config=/home/runner/work/astropy/astropy/setup.cfg --remote-data=astropy (exited with code 1)
```

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Tentatively milestoning to LTS but feel free to re-milestone as needed.

xref python/importlib_metadata#289