### PR TITLE
Add transform method to all representations

### DIFF
--- a/astropy/coordinates/matrix_utilities.py
+++ b/astropy/coordinates/matrix_utilities.py
@@ -131,35 +131,75 @@ def angle_axis(matrix):
     return Angle(angle, u.radian), -axis / r
 
 
-def is_rotation(matrix, allow_improper=False):
-    """Check whether a matrix is a rotation, proper or improper.
+def is_O3(matrix):
+    """Check whether a matrix is in the length-preserving group O(3).
 
     Parameters
     ----------
-    matrix : array-like
+    matrix : (..., N, N) array-like
         Must have attribute ``.shape`` and method ``.swapaxes()`` and not error
-        when using `~numpy.allclose` and `~numpy.linalg.det`.
-    allow_improper : bool, optional
-        Whether to restrict check to the SO(3), the group of proper rotations,
-        or also allow improper rotations (with determinant -1).
-        The default (False) is only SO(3).
+        when using `~numpy.isclose`.
+
+    Returns
+    -------
+    is_o3 : bool or array of bool
+        If the matrix has more than two axes, the O(3) check is performed on
+        slices along the last two axes -- (M, N, N) => (M, ) bool array.
 
     Notes
     -----
-    The orthogonal group O(3) preserves lengths, so encompasses the more
-    restrictive group SO(3), which is the group of rotations, but does not keep
-    orientations, so allows for reflections. Rotations with determinant -1 are
-    both a rotation and a reflection.
+    The orthogonal group O(3) preserves lengths, but is not guaranteed to keep
+    orientations. Rotations and reflections are in this group.
     For more information, see https://en.wikipedia.org/wiki/Orthogonal_group
 
     """
     # matrix is in O(3) (rotations, proper and improper).
     I = np.identity(matrix.shape[-1])
-    is_O3 = np.allclose(matrix @ matrix.swapaxes(-2, -1), I, atol=1e-15)
+    is_o3 = np.all(np.isclose(matrix @ matrix.swapaxes(-2, -1), I, atol=1e-15),
+                   axis=(-2, -1))
 
+    return is_o3
+
+
+def is_rotation(matrix, allow_improper=False):
+    """Check whether a matrix is a rotation, proper or improper.
+
+    Parameters
+    ----------
+    matrix : (..., N, N) array-like
+        Must have attribute ``.shape`` and method ``.swapaxes()`` and not error
+        when using `~numpy.isclose` and `~numpy.linalg.det`.
+    allow_improper : bool, optional
+        Whether to restrict check to the SO(3), the group of proper rotations,
+        or also allow improper rotations (with determinant -1).
+        The default (False) is only SO(3).
+
+    Returns
+    -------
+    isrot : bool or array of bool
+        If the matrix has more than two axes, the checks are performed on
+        slices along the last two axes -- (M, N, N) => (M, ) bool array.
+
+    See Also
+    --------
+    `~astopy.coordinates.matrix_utilities.is_O3`
+        For the less restrictive check that a matrix is in the group O(3).
+
+    Notes
+    -----
+    The group SO(3) is the rotation group. It is O(3), with determinant 1.
+    Rotations with determinant -1 are improper rotations, combining both a
+    rotation and a reflection.
+    For more information, see https://en.wikipedia.org/wiki/Orthogonal_group
+
+    """
+    # matrix is in O(3).
+    is_o3 = is_O3(matrix)
+
+    # determinant checks  for rotation (proper and improper)
     if allow_improper:  # determinant can be +/- 1
-        is_det1 = np.allclose(np.abs(np.linalg.det(matrix)), 1.0)
+        is_det1 = np.isclose(np.abs(np.linalg.det(matrix)), 1.0)
     else:  # restrict to SO(3)
-        is_det1 = np.allclose(np.linalg.det(matrix), 1.0)
+        is_det1 = np.isclose(np.linalg.det(matrix), 1.0)
 
-    return is_O3 & is_det1
+    return is_o3 & is_det1

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -1603,7 +1603,7 @@ class UnitSphericalRepresentation(BaseRepresentation):
 
     def represent_as(self, other_class, differential_class=None):
         # Take a short cut if the other class is a spherical representation
-        # TODO! for differential_class. This cannot (currently) be implement
+        # TODO! for differential_class. This cannot (currently) be implemented
         # like in the other Representations since `_re_represent_differentials`
         # keeps differentials' unit keys, but this can result in a mismatch
         # between the UnitSpherical expected key (e.g. "s") and that expected

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -16,6 +16,7 @@ from erfa import ufunc as erfa_ufunc
 
 from .angles import Angle, Longitude, Latitude
 from .distances import Distance
+from .matrix_utilities import is_rotation
 from astropy.utils import ShapedLikeNDArray, classproperty
 from astropy.utils.data_info import MixinInfo
 from astropy.utils.exceptions import DuplicateRepresentationWarning
@@ -1642,12 +1643,8 @@ class UnitSphericalRepresentation(BaseRepresentation):
         """
         # the transformation matrix does not need to be a rotation matrix,
         # so the unit-distance is not guaranteed. For speed, we check if the
-        # matrix is in O(3) (rotations, proper and improper).
-        # If not, then route through dimensional representation.
-        I = np.identity(matrix.shape[-1])
-        is_O3 = np.allclose(matrix @ matrix.swapaxes(-2, -1), I, atol=1e-15)
-
-        if is_O3:  # remain in unit-representation
+        # matrix is in O(3) (rotations, proper and improper) and keeps lengths.
+        if is_rotation(matrix, allow_improper=True):  # remain in unit-rep
             if self.differentials:
                 # TODO! shortcut if there are differentials.
                 # Currently just super, which uses Cartesian backend.

--- a/astropy/coordinates/tests/test_matrix_utilities.py
+++ b/astropy/coordinates/tests/test_matrix_utilities.py
@@ -5,7 +5,7 @@ from numpy.testing import assert_allclose, assert_array_equal
 
 from astropy import units as u
 from astropy.coordinates.matrix_utilities import (rotation_matrix, angle_axis,
-                                                  is_rotation)
+                                                  is_O3, is_rotation)
 
 
 def test_rotation_matrix():
@@ -48,23 +48,54 @@ def test_angle_axis():
     assert_allclose(ax2, [-2**-0.5, -2**-0.5, 0])
 
 
+def test_is_O3():
+    """Test the matrix checker ``is_O3``."""
+    # Normal rotation matrix
+    m1 = rotation_matrix(35*u.deg, 'x')
+    assert is_O3(m1)
+    # and (M, 3, 3)
+    n1 = np.tile(m1, (2, 1, 1))
+    assert tuple(is_O3(n1)) == (True, True)  # (show the broadcasting)
+
+    # reflection
+    m2 = m1.copy()
+    m2[0,0] *= -1
+    assert is_O3(m2)
+    # and (M, 3, 3)
+    n2 = np.stack((m1, m2))
+    assert tuple(is_O3(n2)) == (True, True)  # (show the broadcasting)
+
+    # Not any sort of O(3)
+    m3 = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+    assert not is_O3(m3)
+    # and (M, 3, 3)
+    n3 = np.stack((m1, m3))
+    assert tuple(is_O3(n3)) == (True, False)  # (show the broadcasting)
+
+
 def test_is_rotation():
     """Test the rotation matrix checker ``is_rotation``."""
     # Normal rotation matrix
     m1 = rotation_matrix(35*u.deg, 'x')
-
     assert is_rotation(m1)
     assert is_rotation(m1, allow_improper=True)  # (a less restrictive test)
+    # and (M, 3, 3)
+    n1 = np.tile(m1, (2, 1, 1))
+    assert tuple(is_rotation(n1)) == (True, True)  # (show the broadcasting)
 
-    # Improper rotation
+    # Improper rotation (unit rotation + reflection)
     m2 = np.identity(3)
     m2[0,0] = -1
-
     assert not is_rotation(m2)
     assert is_rotation(m2, allow_improper=True)
+    # and (M, 3, 3)
+    n2 = np.stack((m1, m2))
+    assert tuple(is_rotation(n2)) == (True, False)  # (show the broadcasting)
 
     # Not any sort of rotation
     m3 = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
-
     assert not is_rotation(m3)
     assert not is_rotation(m3, allow_improper=True)
+    # and (M, 3, 3)
+    n3 = np.stack((m1, m3))
+    assert tuple(is_rotation(n3)) == (True, False)  # (show the broadcasting)

--- a/astropy/coordinates/tests/test_matrix_utilities.py
+++ b/astropy/coordinates/tests/test_matrix_utilities.py
@@ -4,7 +4,8 @@ import numpy as np
 from numpy.testing import assert_allclose, assert_array_equal
 
 from astropy import units as u
-from astropy.coordinates.matrix_utilities import rotation_matrix, angle_axis
+from astropy.coordinates.matrix_utilities import (rotation_matrix, angle_axis,
+                                                  is_rotation)
 
 
 def test_rotation_matrix():
@@ -45,3 +46,25 @@ def test_angle_axis():
 
     assert an2 - 89*u.deg < 1e-10*u.deg
     assert_allclose(ax2, [-2**-0.5, -2**-0.5, 0])
+
+
+def test_is_rotation():
+    """Test the rotation matrix checker ``is_rotation``."""
+    # Normal rotation matrix
+    m1 = rotation_matrix(35*u.deg, 'x')
+
+    assert is_rotation(m1)
+    assert is_rotation(m1, allow_improper=True)  # (a less restrictive test)
+
+    # Improper rotation
+    m2 = np.identity(3)
+    m2[0,0] = -1
+
+    assert not is_rotation(m2)
+    assert is_rotation(m2, allow_improper=True)
+
+    # Not any sort of rotation
+    m3 = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+
+    assert not is_rotation(m3)
+    assert not is_rotation(m3, allow_improper=True)

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -15,23 +15,14 @@ from astropy.utils.exceptions import DuplicateRepresentationWarning
 from astropy.coordinates.angles import Longitude, Latitude, Angle
 from astropy.coordinates.distances import Distance
 from astropy.coordinates.matrix_utilities import rotation_matrix
-from astropy.coordinates.representation import (REPRESENTATION_CLASSES,
-                                                DIFFERENTIAL_CLASSES,
-                                                DUPLICATE_REPRESENTATIONS,
-                                                BaseRepresentation,
-                                                SphericalRepresentation,
-                                                UnitSphericalRepresentation,
-                                                SphericalCosLatDifferential,
-                                                CartesianRepresentation,
-                                                CylindricalRepresentation,
-                                                PhysicsSphericalRepresentation,
-                                                CartesianDifferential,
-                                                SphericalDifferential,
-                                                RadialDifferential,
-                                                CylindricalDifferential,
-                                                PhysicsSphericalDifferential,
-                                                UnitSphericalDifferential,
-                                                UnitSphericalCosLatDifferential)
+from astropy.coordinates.representation import (
+    REPRESENTATION_CLASSES, DIFFERENTIAL_CLASSES, DUPLICATE_REPRESENTATIONS,
+    BaseRepresentation, SphericalRepresentation, UnitSphericalRepresentation,
+    SphericalCosLatDifferential, CartesianRepresentation, RadialDifferential,
+    CylindricalRepresentation, PhysicsSphericalRepresentation,
+    CartesianDifferential, SphericalDifferential, CylindricalDifferential,
+    PhysicsSphericalDifferential, UnitSphericalDifferential,
+    UnitSphericalCosLatDifferential)
 
 
 # Preserve the original REPRESENTATION_CLASSES dict so that importing

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -331,19 +331,20 @@ class TestSphericalRepresentation:
 
         s2 = s1.transform(matrix)
 
-        assert_allclose(s2.lon.deg, s1.lon.deg + 10)
-        assert_allclose(s2.lat.deg, s1.lat.deg)
-        assert_allclose(s2.distance.value, s1.distance.value)
+        assert_allclose_quantity(s2.lon, s1.lon + 10 * u.deg)
+        assert_allclose_quantity(s2.lat, s1.lat)
+        assert_allclose_quantity(s2.distance, s1.distance)
 
         # now with a non rotation matrix
         matrix = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
 
         s3 = s1.transform(matrix)
-        expected = s1.to_cartesian().transform(matrix).represent_as(SphericalRepresentation)
+        expected = (s1.to_cartesian().transform(matrix)
+                      .represent_as(SphericalRepresentation))
 
-        assert_allclose(s3.lon.deg, expected.lon.deg)
-        assert_allclose(s3.lat.deg, expected.lat.deg)
-        assert_allclose(s3.distance.value, expected.distance.value)
+        assert_allclose_quantity(s3.lon, expected.lon)
+        assert_allclose_quantity(s3.lat, expected.lat)
+        assert_allclose_quantity(s3.distance, expected.distance)
 
     def test_transform_with_NaN(self):
         # all over again, but with a NaN in the distance
@@ -355,9 +356,9 @@ class TestSphericalRepresentation:
 
         s2 = s1.transform(matrix)
 
-        assert_allclose(s2.lon.deg, s1.lon.deg + 10)
-        assert_allclose(s2.lat.deg, s1.lat.deg)
-        assert_allclose(s2.distance.value, s1.distance.value)
+        assert_allclose_quantity(s2.lon, s1.lon + 10 * u.deg)
+        assert_allclose_quantity(s2.lat, s1.lat)
+        assert_allclose_quantity(s2.distance, s1.distance)
 
         # now with a non rotation matrix
         matrix = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
@@ -375,8 +376,8 @@ class TestSphericalRepresentation:
         assert tuple(np.isnan(thruC.lat.deg)) == (False, True)
         assert tuple(np.isnan(thruC.distance.value)) == (False, True)
         # test that they are close on the first value
-        assert_allclose(s3.lon.deg[0], thruC.lon.deg[0])
-        assert_allclose(s3.lat.deg[0], thruC.lat.deg[0])
+        assert_allclose_quantity(s3.lon[0], thruC.lon[0])
+        assert_allclose_quantity(s3.lat[0], thruC.lat[0])
 
 
 class TestUnitSphericalRepresentation:
@@ -524,8 +525,8 @@ class TestUnitSphericalRepresentation:
 
         s2 = s1.transform(matrix)
 
-        assert_allclose(s2.lon.deg, s1.lon.deg + 10)
-        assert_allclose(s2.lat.deg, s1.lat.deg)
+        assert_allclose_quantity(s2.lon, s1.lon + 10 * u.deg)
+        assert_allclose_quantity(s2.lat, s1.lat)
 
         # now with a non rotation matrix
         # note that the result will be a Spherical, not UnitSpherical
@@ -534,9 +535,9 @@ class TestUnitSphericalRepresentation:
         s3 = s1.transform(matrix)
         expected = s1.to_cartesian().transform(matrix).represent_as(SphericalRepresentation)
 
-        assert_allclose(s3.lon.deg, expected.lon.deg)
-        assert_allclose(s3.lat.deg, expected.lat.deg)
-        assert_allclose(s3.distance.value, expected.distance.value)
+        assert_allclose_quantity(s3.lon, expected.lon)
+        assert_allclose_quantity(s3.lat, expected.lat)
+        assert_allclose_quantity(s3.distance, expected.distance)
 
 
 class TestPhysicsSphericalRepresentation:
@@ -710,9 +711,9 @@ class TestPhysicsSphericalRepresentation:
 
         s2 = s1.transform(matrix)
 
-        assert_allclose(s2.phi.deg, s1.phi.deg + 10)
-        assert_allclose(s2.theta.deg, s1.theta.deg)
-        assert_allclose(s2.r.value, s1.r.value)
+        assert_allclose_quantity(s2.phi, s1.phi + 10 * u.deg)
+        assert_allclose_quantity(s2.theta, s1.theta)
+        assert_allclose_quantity(s2.r, s1.r)
 
         # now with a non rotation matrix
         matrix = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
@@ -721,9 +722,9 @@ class TestPhysicsSphericalRepresentation:
         expected = (s1.to_cartesian().transform(matrix)
                       .represent_as(PhysicsSphericalRepresentation))
 
-        assert_allclose(s3.phi.deg, expected.phi.deg)
-        assert_allclose(s3.theta.deg, expected.theta.deg)
-        assert_allclose(s3.r.value, expected.r.value)
+        assert_allclose_quantity(s3.phi, expected.phi)
+        assert_allclose_quantity(s3.theta, expected.theta)
+        assert_allclose_quantity(s3.r, expected.r)
 
     def test_transform_with_NaN(self):
         # all over again, but with a NaN in the distance
@@ -735,13 +736,13 @@ class TestPhysicsSphericalRepresentation:
 
         s2 = s1.transform(matrix)
 
-        assert_allclose(s2.phi.deg, s1.phi.deg + 10)
-        assert_allclose(s2.theta.deg, s1.theta.deg)
-        assert_allclose(s2.r.value, s1.r.value)
+        assert_allclose_quantity(s2.phi, s1.phi + 10 * u.deg)
+        assert_allclose_quantity(s2.theta, s1.theta)
+        assert_allclose_quantity(s2.r, s1.r)
 
         # TODO! implement these checks. First requires solving the problem that
         # expected = (s1.to_cartesian().transform(matrix).represent_as(PhysicsSphericalRepresentation))
-        # raises an error. Once fixed, this should just work.
+        # raises a warning. Once fixed, this should just work.
         # # now with a non rotation matrix
         # matrix = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
 
@@ -758,8 +759,8 @@ class TestPhysicsSphericalRepresentation:
         # assert tuple(np.isnan(thruC.theta.deg)) == (False, True)
         # assert tuple(np.isnan(thruC.r.value)) == (False, True)
         # so only test on the first value
-        # assert_allclose(s3.phi.deg[0], thruC.phi.deg[0])
-        # assert_allclose(s3.theta.deg[0], thruC.theta.deg[0])
+        # assert_allclose_quantity(s3.phi[0], thruC.phi[0])
+        # assert_allclose_quantity(s3.theta[0], thruC.theta[0])
 
 
 class TestCartesianRepresentation:
@@ -1156,9 +1157,9 @@ class TestCylindricalRepresentation:
 
         s2 = s1.transform(matrix)
 
-        assert_allclose(s2.phi.deg, s1.phi.deg + 10)
-        assert_allclose(s2.z.to_value(u.pc), s1.z.value)
-        assert_allclose(s2.rho.value, s1.rho.value)
+        assert_allclose_quantity(s2.phi, s1.phi + 10 * u.deg)
+        assert_allclose_quantity(s2.z, s1.z)
+        assert_allclose_quantity(s2.rho, s1.rho)
 
         assert s2.phi.unit is u.rad
         assert s2.z.unit is u.kpc
@@ -1170,9 +1171,9 @@ class TestCylindricalRepresentation:
         s3 = s1.transform(matrix)
         expected = s1.to_cartesian().transform(matrix).represent_as(CylindricalRepresentation)
 
-        assert_allclose(s3.phi.deg, expected.phi.deg)
-        assert_allclose(s3.z.value, expected.z.value)
-        assert_allclose(s3.rho.value, expected.rho.value)
+        assert_allclose_quantity(s3.phi, expected.phi)
+        assert_allclose_quantity(s3.z, expected.z)
+        assert_allclose_quantity(s3.rho, expected.rho)
 
 
 def test_cartesian_spherical_roundtrip():

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -365,16 +365,16 @@ class TestSphericalRepresentation:
 
         s3 = s1.transform(matrix)
         # s3 should not propagate Nan.
-        assert tuple(np.isnan(s3.lon.deg)) == (False, False)
-        assert tuple(np.isnan(s3.lat.deg)) == (False, False)
-        assert tuple(np.isnan(s3.distance.value)) == (False, True)
+        assert_array_equal(np.isnan(s3.lon.deg), (False, False))
+        assert_array_equal(np.isnan(s3.lat.deg), (False, False))
+        assert_array_equal(np.isnan(s3.distance.value), (False, True))
 
         # through Cartesian should
         thruC = (s1.to_cartesian().transform(matrix)
                    .represent_as(SphericalRepresentation))
-        assert tuple(np.isnan(thruC.lon.deg)) == (False, True)
-        assert tuple(np.isnan(thruC.lat.deg)) == (False, True)
-        assert tuple(np.isnan(thruC.distance.value)) == (False, True)
+        assert_array_equal(np.isnan(thruC.lon.deg), (False, True))
+        assert_array_equal(np.isnan(thruC.lat.deg), (False, True))
+        assert_array_equal(np.isnan(thruC.distance.value), (False, True))
         # test that they are close on the first value
         assert_allclose_quantity(s3.lon[0], thruC.lon[0])
         assert_allclose_quantity(s3.lat[0], thruC.lat[0])
@@ -745,16 +745,16 @@ class TestPhysicsSphericalRepresentation:
 
         s3 = s1.transform(matrix)
         # s3 should not propagate Nan.
-        assert tuple(np.isnan(s3.phi.deg)) == (False, False)
-        assert tuple(np.isnan(s3.theta.deg)) == (False, False)
-        assert tuple(np.isnan(s3.r.value)) == (False, True)
+        assert_array_equal(np.isnan(s3.phi.deg), (False, False))
+        assert_array_equal(np.isnan(s3.theta.deg), (False, False))
+        assert_array_equal(np.isnan(s3.r.value), (False, True))
 
         # through Cartesian does
         thruC = (s1.to_cartesian().transform(matrix)
                  .represent_as(PhysicsSphericalRepresentation))
-        assert tuple(np.isnan(thruC.phi.deg)) == (False, True)
-        assert tuple(np.isnan(thruC.theta.deg)) == (False, True)
-        assert tuple(np.isnan(thruC.r.value)) == (False, True)
+        assert_array_equal(np.isnan(thruC.phi.deg), (False, True))
+        assert_array_equal(np.isnan(thruC.theta.deg), (False, True))
+        assert_array_equal(np.isnan(thruC.r.value), (False, True))
         # so only test on the first value
         assert_allclose_quantity(s3.phi[0], thruC.phi[0])
         assert_allclose_quantity(s3.theta[0], thruC.theta[0])

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -740,27 +740,24 @@ class TestPhysicsSphericalRepresentation:
         assert_allclose_quantity(s2.theta, s1.theta)
         assert_allclose_quantity(s2.r, s1.r)
 
-        # TODO! implement these checks. First requires solving the problem that
-        # expected = (s1.to_cartesian().transform(matrix).represent_as(PhysicsSphericalRepresentation))
-        # raises a warning. Once fixed, this should just work.
-        # # now with a non rotation matrix
-        # matrix = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+        # now with a non rotation matrix
+        matrix = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
 
-        # s3 = s1.transform(matrix)
-        # # s3 should not propagate Nan.
-        # assert tuple(np.isnan(s3.phi.deg)) == (False, False)
-        # assert tuple(np.isnan(s3.theta.deg)) == (False, False)
-        # assert tuple(np.isnan(s3.r.value)) == (False, True)
+        s3 = s1.transform(matrix)
+        # s3 should not propagate Nan.
+        assert tuple(np.isnan(s3.phi.deg)) == (False, False)
+        assert tuple(np.isnan(s3.theta.deg)) == (False, False)
+        assert tuple(np.isnan(s3.r.value)) == (False, True)
 
         # through Cartesian does
-        # expected = (s1.to_cartesian().transform(matrix)
-        #               .represent_as(PhysicsSphericalRepresentation))
-        # assert tuple(np.isnan(thruC.phi.deg)) == (False, True)
-        # assert tuple(np.isnan(thruC.theta.deg)) == (False, True)
-        # assert tuple(np.isnan(thruC.r.value)) == (False, True)
+        thruC = (s1.to_cartesian().transform(matrix)
+                 .represent_as(PhysicsSphericalRepresentation))
+        assert tuple(np.isnan(thruC.phi.deg)) == (False, True)
+        assert tuple(np.isnan(thruC.theta.deg)) == (False, True)
+        assert tuple(np.isnan(thruC.r.value)) == (False, True)
         # so only test on the first value
-        # assert_allclose_quantity(s3.phi[0], thruC.phi[0])
-        # assert_allclose_quantity(s3.theta[0], thruC.theta[0])
+        assert_allclose_quantity(s3.phi[0], thruC.phi[0])
+        assert_allclose_quantity(s3.theta[0], thruC.theta[0])
 
 
 class TestCartesianRepresentation:

--- a/docs/changes/coordinates/11444.feature.rst
+++ b/docs/changes/coordinates/11444.feature.rst
@@ -1,0 +1,5 @@
+All representations now have a ``transform`` method, which allows them to be
+transformed by a 3x3 matrix in a Cartesian basis. By default, transformations
+are routed through ``CartesianRepresentation``. ``SphericalRepresentation`` and
+``PhysicssphericalRepresentation`` override this for speed and to prevent NaN
+leakage from the distance to the angular components.

--- a/docs/changes/coordinates/11444.feature.rst
+++ b/docs/changes/coordinates/11444.feature.rst
@@ -3,5 +3,6 @@ transformed by a 3x3 matrix in a Cartesian basis. By default, transformations
 are routed through ``CartesianRepresentation``. ``SphericalRepresentation`` and
 ``PhysicssphericalRepresentation`` override this for speed and to prevent NaN
 leakage from the distance to the angular components.
-Also, add a utility function in ``matrix_utities`` to check whether a matrix is
-a rotation  (proper or improper).
+Also, the functions ``is_O3`` and ``is_rotation`` have been added to
+``matrix_utities`` for checking whether a matrix is in the O(3) group or is a
+rotation (proper or improper), respectively.

--- a/docs/changes/coordinates/11444.feature.rst
+++ b/docs/changes/coordinates/11444.feature.rst
@@ -3,3 +3,5 @@ transformed by a 3x3 matrix in a Cartesian basis. By default, transformations
 are routed through ``CartesianRepresentation``. ``SphericalRepresentation`` and
 ``PhysicssphericalRepresentation`` override this for speed and to prevent NaN
 leakage from the distance to the angular components.
+Also, add a utility function in ``matrix_utities`` to check whether a matrix is
+a rotation  (proper or improper).


### PR DESCRIPTION
### Description (edited)

All representations now have a ``transform`` method, which allows them to be
 transformed by a 3x3 matrix in a Cartesian basis. By default, transformations
 are routed through ``CartesianRepresentation``. ``SphericalRepresentation`` and
 ``PhysicssphericalRepresentation`` override this for speed and to prevent NaN
 leakage from the distance to the angular components.
 Also, add a utility function in ``matrix_utities`` to check whether a matrix is
 a rotation  (proper or improper).

@mhvk @adrn 
closes #11423
Blocked by #11568 

Signed-off-by: Nathaniel Starkman (@nstarman)