### PR TITLE
Fix for #11407

### DIFF
--- a/astropy/samp/tests/test_web_profile.py
+++ b/astropy/samp/tests/test_web_profile.py
@@ -10,8 +10,6 @@ import threading
 import tempfile
 from urllib.request import Request, urlopen
 
-import pytest
-
 from astropy.utils.data import get_readable_fileobj
 
 from astropy.samp import SAMPIntegratedClient, SAMPHubServer
@@ -23,14 +21,11 @@ from astropy.samp import conf
 
 from .test_standard_profile import TestStandardProfile as BaseTestStandardProfile
 
-CI = os.environ.get('CI', False) == "true"
-
 
 def setup_module(module):
     conf.use_internet = False
 
 
-@pytest.mark.skipif(CI, reason="Flaky on CI")
 class TestWebProfile(BaseTestStandardProfile):
 
     def setup_method(self, method):


### PR DESCRIPTION
This reverts the workaround for #11407 and provides a fix that addresses the underlying bug (which can be reproduced locally under the right conditions).

The bug was a race condition whereby the `SAMPWebClient` (which makes [`pullCallbacks`](https://www.ivoa.net/documents/SAMP/20120411/REC-SAMP-1.3-20120411.html#tth_sEc5.2.5) calls to the hub, which is how SAMP web clients perform long polling) unregisters itself from the hub, but then immediately makes a `pullCallbacks` request (since the unregistration happened between `if self._is_registered` and the `pullCallbacks` call [here](https://github.com/astropy/astropy/blob/7811614f8b9b08eb3f7bcb1705ad53b186ca8187/astropy/samp/tests/web_profile_test_helpers.py#L163)).

In normal practice this would be a rare race condition, though on busy CI servers it's probably more common as there can be more delay between context switches.

This bug probably has existed for a while but was merely masked by the bug fixed by #11391.