### PR TITLE
Allow SIP distortions to be used in WCS with more than 2 axes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -349,6 +349,8 @@ astropy.wcs
   the coefficients of the TPD distortion function to not be written to the
   header. [#11260]
 
+- Allow SIP distortions to be used with more than two axes. [#11452]
+
 
 Other Changes and Additions
 ---------------------------

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -499,15 +499,14 @@ class WCS(FITSWCSAPIMixin, WCSBase):
             self.naxis = wcsprm.naxis
 
             if (wcsprm.naxis != 2 and
-                    (det2im[0] or det2im[1] or cpdis[0] or cpdis[1] or sip)):
+                    (det2im[0] or det2im[1] or cpdis[0] or cpdis[1])):
                 raise ValueError(
-                    """
-FITS WCS distortion paper lookup tables and SIP distortions only work
-in 2 dimensions.  However, WCSLIB has detected {} dimensions in the
-core WCS keywords.  To use core WCS in conjunction with FITS WCS
-distortion paper lookup tables or SIP distortion, you must select or
-reduce these to 2 dimensions using the naxis kwarg.
-""".format(wcsprm.naxis))
+                    f"""
+FITS WCS distortion paper lookup tables only work in 2 dimensions. However,
+WCSLIB has detected {wcsprm.naxis} dimensions in the core WCS keywords. To use core WCS
+in conjunction with FITS WCS distortion paper lookup tables or SIP distortion,
+you must select or reduce these to 2 dimensions using the naxis kwarg."""
+                )
 
             header_naxis = header.get('NAXIS', None)
             if header_naxis is not None and header_naxis < wcsprm.naxis:


### PR DESCRIPTION
This PR would allow -SIP distortions to be used in WCS with more than 2 axes. After reviewing the SIP paper and consulting with @stargaser it seems that there is no fundamental restriction in using SIP with 2 celestial axes and, at the same time, allowing other non-celestial axes in the same WCS.

#### TODO:

I need to add tests that would show that adding another axis and swapping of axes produces the same celestial coordinates.
Also, for now, add a limitation that SIP can be used only with _separable_ additional non-celestial axes.