### PR TITLE
New convolve operator wrapper for models

### DIFF
--- a/astropy/convolution/__init__.py
+++ b/astropy/convolution/__init__.py
@@ -5,7 +5,7 @@ from .core import *  # noqa
 from .kernels import *  # noqa
 from .utils import discretize_model  # noqa
 
-from .convolve import convolve, convolve_fft, interpolate_replace_nans, convolve_models  # noqa
+from .convolve import convolve, convolve_fft, interpolate_replace_nans, convolve_models, convolve_models_fft  # noqa
 
 # Deprecated kernels that are not defined in __all__
 from .kernels import MexicanHat1DKernel, MexicanHat2DKernel

--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -16,6 +16,7 @@ from astropy import units as u
 from astropy.nddata import support_nddata
 from astropy.modeling.core import CompoundModel
 from astropy.modeling.core import SPECIAL_OPERATORS
+from astropy.modeling.convolution import Convolution
 from .utils import KernelSizeError, has_even_axis, raise_even_kernel_exception
 
 LIBRARY_PATH = os.path.dirname(__file__)
@@ -869,3 +870,28 @@ def convolve_models(model, kernel, mode='convolve_fft', **kwargs):
         raise ValueError(f'Mode {mode} is not supported.')
 
     return CompoundModel(mode, model, kernel)
+
+
+def convolve_models_fft(model, kernel, bounding_box, resolution, cache=True, **kwargs):
+    """
+    Convolve two models using `~astropy.convolution.convolve_fft`.
+
+    Parameters
+    ----------
+    model : `~astropy.modeling.core.Model`
+        Functional model
+    kernel : `~astropy.modeling.core.Model`
+        Convolution kernel
+    kwargs : dict
+        Keyword arguments to be passed either to `~astropy.convolution.convolve`
+        or `~astropy.convolution.convolve_fft` depending on ``mode``.
+
+    Returns
+    -------
+    default : `~astropy.modeling.core.CompoundModel`
+        Convolved model
+    """
+
+    SPECIAL_OPERATORS['convolve_fft'] = partial(convolve_fft, **kwargs)
+
+    return Convolution(model, kernel, bounding_box, resolution, cache)

--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -884,7 +884,7 @@ def convolve_models_fft(model, kernel, bounding_box, resolution, cache=True, **k
         Convolution kernel
     bounding_box: tuple
         The bounding box which encompasses enough of the support of both
-        the `model` and `kernel` so that an accurate convolution can be
+        the ``model`` and ``kernel`` so that an accurate convolution can be
         computed.
     resolution: float
         The resolution that one wishes to approximate the convolution

--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -882,6 +882,16 @@ def convolve_models_fft(model, kernel, bounding_box, resolution, cache=True, **k
         Functional model
     kernel : `~astropy.modeling.core.Model`
         Convolution kernel
+    bounding_box: tuple
+        The bounding box which encompasses enough of the support of both
+        the `model` and `kernel` so that an accurate convolution can be
+        computed.
+    resolution: float
+        The resolution that one wishes to approximate the convolution
+        integral at.
+    cache: optional, bool
+        Default value True. Allow for the storage of the convolution
+        computation for later reuse.
     kwargs : dict
         Keyword arguments to be passed either to `~astropy.convolution.convolve`
         or `~astropy.convolution.convolve_fft` depending on ``mode``.

--- a/astropy/modeling/convolution.py
+++ b/astropy/modeling/convolution.py
@@ -45,8 +45,8 @@ class Convolution(CompoundModel):
     interpolates the results from this cache.
     """
 
-    def __init__(self, model, kernal, bounding_box, resolution, cache=True):
-        super().__init__('convolve_fft', model, kernal)
+    def __init__(self, model, kernel, bounding_box, resolution, cache=True):
+        super().__init__('convolve_fft', model, kernel)
 
         self.bounding_box = bounding_box
         self._resolution = resolution

--- a/astropy/modeling/convolution.py
+++ b/astropy/modeling/convolution.py
@@ -9,7 +9,7 @@ from .core import CompoundModel, SPECIAL_OPERATORS
 
 class Convolution(CompoundModel):
     """
-    Wrapper class for a convolution model:
+    Wrapper class for a convolution model.
 
     Parameters
     ----------

--- a/astropy/modeling/convolution.py
+++ b/astropy/modeling/convolution.py
@@ -1,0 +1,116 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+"""Convolution Model"""
+# pylint: disable=line-too-long, too-many-lines, too-many-arguments, invalid-name
+import numpy as np
+
+from .core import CompoundModel, SPECIAL_OPERATORS
+
+
+class Convolution(CompoundModel):
+    """
+    Wrapper class for a Convolution model:
+
+    Parameters
+    ----------
+    model : Model
+        the model for the convolution.
+    kernal: Model
+        the kernal model for the convolution.
+    bounding_box : tuple
+        a bounding box to define the limits of the integration
+        approximation for the convolution.
+    resolution : float
+        the resolution for the approximation of the convolution.
+    cache : bool, optional
+        Allow convolution computation to be cached for reuse. This is
+        enabled by default.
+
+    Notes
+    -----
+    This is wrapper is necessary to handle the limitations of the
+    pseudospectral convolution binary operator implemented in
+    astropy.convolution under `convolve_fft`. In this `convolve_fft` it
+    is assumed that the inputs `array` and `kernel` span a sufficient
+    portion of the support of the functions of the convolution.
+    Consequently, the ``Compound`` created by the `convolve_models` function
+    makes the assumption that one should pass an input array that
+    sufficiently spans this space. This means that slightly different
+    input arrays to this model will result in different outputs, even
+    on points of intersection between these arrays.
+
+    This issue is solved by requiring a bounding_box together with a
+    resolution so that one can pre-calculate the entire domain and then
+    (by default) cache the convolution values. The function then just
+    interpolates the results from this cache.
+    """
+
+    def __init__(self, model, kernal, bounding_box, resolution, cache=True):
+        super().__init__('convolve_fft', model, kernal)
+
+        self.bounding_box = bounding_box
+        self._resolution = resolution
+
+        self._cache_convolution = cache
+        self._kwargs = None
+        self._convolution = None
+
+    def clear_cache(self):
+        """
+        Clears the cached convolution
+        """
+
+        self._kwargs = None
+        self._convolution = None
+
+    def _get_convolution(self, **kwargs):
+        if (self._convolution is None) or (self._kwargs != kwargs):
+            domain = self.bounding_box.domain(self._resolution)
+            mesh = np.meshgrid(*domain)
+            data = super().__call__(*mesh, **kwargs)
+
+            try:
+                from scipy.interpolate import RegularGridInterpolator
+                convolution = RegularGridInterpolator(domain, data)
+            except ValueError:
+                raise ImportError('Convolution model requires scipy.')
+
+            if self._cache_convolution:
+                self._kwargs = kwargs
+                self._convolution = convolution
+
+        else:
+            convolution = self._convolution
+
+        return convolution
+
+    @staticmethod
+    def _convolution_inputs(*args):
+        not_scalar = np.where([not np.isscalar(arg) for arg in args])[0]
+
+        if len(not_scalar) == 0:
+            return np.array(args), (1,)
+        else:
+            output_shape = args[not_scalar[0]].shape
+            if not all(args[index].shape == output_shape for index in not_scalar):
+                raise ValueError('Values have differing Shapes')
+
+            inputs = []
+            for arg in args:
+                if np.isscalar(arg):
+                    inputs.append(np.full(output_shape, arg))
+                else:
+                    inputs.append(arg)
+
+            return np.reshape(inputs, (len(inputs), -1)).T, output_shape
+
+    @staticmethod
+    def _convolution_outputs(outputs, output_shape):
+        return outputs.reshape(output_shape)
+
+    def __call__(self, *args, **kw):
+        inputs, output_shape = self._convolution_inputs(*args)
+        convolution = self._get_convolution(**kw)
+        outputs = convolution(inputs)
+
+        return self._convolution_outputs(outputs, output_shape)

--- a/astropy/modeling/convolution.py
+++ b/astropy/modeling/convolution.py
@@ -9,19 +9,19 @@ from .core import CompoundModel, SPECIAL_OPERATORS
 
 class Convolution(CompoundModel):
     """
-    Wrapper class for a Convolution model:
+    Wrapper class for a convolution model:
 
     Parameters
     ----------
     model : Model
-        the model for the convolution.
-    kernal: Model
-        the kernal model for the convolution.
+        The model for the convolution.
+    kernel: Model
+        The kernel model for the convolution.
     bounding_box : tuple
-        a bounding box to define the limits of the integration
+        A bounding box to define the limits of the integration
         approximation for the convolution.
     resolution : float
-        the resolution for the approximation of the convolution.
+        The resolution for the approximation of the convolution.
     cache : bool, optional
         Allow convolution computation to be cached for reuse. This is
         enabled by default.
@@ -30,16 +30,16 @@ class Convolution(CompoundModel):
     -----
     This is wrapper is necessary to handle the limitations of the
     pseudospectral convolution binary operator implemented in
-    astropy.convolution under `convolve_fft`. In this `convolve_fft` it
-    is assumed that the inputs `array` and `kernel` span a sufficient
+    astropy.convolution under `~astropy.convolution.convolve_fft`. In this `~astropy.convolution.convolve_fft` it
+    is assumed that the inputs ``array`` and ``kernel`` span a sufficient
     portion of the support of the functions of the convolution.
-    Consequently, the ``Compound`` created by the `convolve_models` function
+    Consequently, the ``Compound`` created by the `~astropy.convolution.convolve_models` function
     makes the assumption that one should pass an input array that
     sufficiently spans this space. This means that slightly different
     input arrays to this model will result in different outputs, even
     on points of intersection between these arrays.
 
-    This issue is solved by requiring a bounding_box together with a
+    This issue is solved by requiring a ``bounding_box`` together with a
     resolution so that one can pre-calculate the entire domain and then
     (by default) cache the convolution values. The function then just
     interpolates the results from this cache.

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -3049,19 +3049,25 @@ class CompoundModel(Model):
                 operands.append(format_leaf(leaf_idx, node))
                 leaf_idx += 1
                 continue
-            oper_order = OPERATOR_PRECEDENCE[node.op]
+
             right = operands.pop()
             left = operands.pop()
+            if node.op in OPERATOR_PRECEDENCE:
+                oper_order = OPERATOR_PRECEDENCE[node.op]
 
-            if isinstance(node, CompoundModel):
-                if (isinstance(node.left, CompoundModel) and
-                        OPERATOR_PRECEDENCE[node.left.op] < oper_order):
-                    left = f'({left})'
-                if (isinstance(node.right, CompoundModel) and
-                        OPERATOR_PRECEDENCE[node.right.op] < oper_order):
-                    right = f'({right})'
+                if isinstance(node, CompoundModel):
+                    if (isinstance(node.left, CompoundModel) and
+                            OPERATOR_PRECEDENCE[node.left.op] < oper_order):
+                        left = f'({left})'
+                    if (isinstance(node.right, CompoundModel) and
+                            OPERATOR_PRECEDENCE[node.right.op] < oper_order):
+                        right = f'({right})'
 
-            operands.append(' '.join((left, node.op, right)))
+                operands.append(' '.join((left, node.op, right)))
+            else:
+                left = f'(({left}),'
+                right = f'({right}))'
+                operands.append(' '.join((node.op, left, right)))
 
         return ''.join(operands)
 

--- a/astropy/modeling/tests/test_convolution.py
+++ b/astropy/modeling/tests/test_convolution.py
@@ -1,0 +1,70 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# pylint: disable=invalid-name
+import pytest
+import numpy as np
+
+from astropy.convolution import convolve_models_fft
+from astropy.modeling.models import Const1D, Const2D
+
+try:
+    import scipy  # pylint: disable=W0611 # noqa
+except ImportError:
+    HAS_SCIPY = False
+else:
+    HAS_SCIPY = True
+
+
+@pytest.mark.skipif('not HAS_SCIPY')
+def test_clear_cache():
+    m1 = Const1D()
+    m2 = Const1D()
+
+    model = convolve_models_fft(m1, m2, (-1, 1), 0.01)
+    assert model._kwargs is None
+    assert model._convolution is None
+
+    results = model(0)
+    assert results.all() == np.array([1.]).all()
+    assert model._kwargs is not None
+    assert model._convolution is not None
+
+    model.clear_cache()
+    assert model._kwargs is None
+    assert model._convolution is None
+
+
+@pytest.mark.skipif('not HAS_SCIPY')
+def test_input_shape_1d():
+    m1 = Const1D()
+    m2 = Const1D()
+
+    model = convolve_models_fft(m1, m2, (-1, 1), 0.01)
+
+    results = model(0)
+    assert results.shape == (1,)
+
+    x = np.arange(-1, 1, 0.1)
+    results = model(x)
+    assert results.shape == x.shape
+
+
+@pytest.mark.skipif('not HAS_SCIPY')
+def test_input_shape_2d():
+    m1 = Const2D()
+    m2 = Const2D()
+
+    model = convolve_models_fft(m1, m2, ((-1, 1), (-1, 1)), 0.01)
+
+    results = model(0, 0)
+    assert results.shape == (1,)
+
+    x = np.arange(-1, 1, 0.1)
+    results = model(x, 0)
+    assert results.shape == x.shape
+    results = model(0, x)
+    assert results.shape == x.shape
+
+    grid = np.meshgrid(x, x)
+    results = model(*grid)
+    assert results.shape == grid[0].shape
+    assert results.shape == grid[1].shape

--- a/astropy/modeling/utils.py
+++ b/astropy/modeling/utils.py
@@ -517,11 +517,12 @@ class _BoundingBox(tuple):
 
     def domain(self, resolution):
         """
-        Given a resolution find the meshgrid approximation of the bounding box
+        Given a resolution find the meshgrid approximation of the bounding box.
 
         Parameters
         ----------
-        resolution: the resolution of the grid
+        resolution: float
+            The resolution of the grid.
         """
 
         if self.dimension == 1:

--- a/astropy/modeling/utils.py
+++ b/astropy/modeling/utils.py
@@ -508,6 +508,29 @@ class _BoundingBox(tuple):
 
             return cls(tuple(bounds) for bounds in bounding_box)
 
+    @property
+    def dimension(self):
+        if isinstance(self[0], tuple):
+            return len(self)
+        else:
+            return 1
+
+    def domain(self, resolution):
+        """
+        Given a resolution find the meshgrid approximation of the bounding box
+
+        Parameters
+        ----------
+        resolution: the resolution of the grid
+        """
+
+        if self.dimension == 1:
+            return [np.arange(self[0], self[1] + resolution, resolution)]
+        elif self.dimension > 1:
+            return [np.arange(self[i][0], self[i][1] + resolution, resolution) for i in range(self.dimension)]
+        else:
+            raise ValueError('Bounding box must have positive dimension')
+
 
 def make_binary_operator_eval(oper, f, g):
     """

--- a/docs/changes/modeling/11456.feature.rst
+++ b/docs/changes/modeling/11456.feature.rst
@@ -1,0 +1,1 @@
+The ``convolve_models_fft`` function implements model convolution so that one insures that the convolution remains consistent across multiple different inputs.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This addresses two issues: prints being broken for `CompoundModel` involving convolutions (indeed any "non-standard" binary operator) and incorrect behavior surrounding models built using convolutions. Prints are just a minor fix, where the model can now be expressed using function notation.

The incorrect behavior when using convolutions (issue #11311) is primarily the result of the fact that the pseudospectral convolution implemented in `convolve_fft` relying on the user's input points to include a sufficient portion of the support for the functions being convolved. This explains the majority of the issues detailed.
- The different starting values are a result of different domains of integration specified by the user.
-  The sudden smoothness issue is the result of aliasing errors that one would normally see near the tails of the domain (this can also be corrected for using other techniques).
- The error listed for when one passes a single input is the result of it needing an array of values to pass to the fft, not a scalar.

All of this behavior can be avoided by extending the `CompoundModel` class to a special child class which uses the bounding box and a resolution to define a reasonable domain to compute the convolution over. We then cache that result and interpolate the user's requested values using the cache and domain. 

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #11311 and fixes #11310
