### PR TITLE
DOC: Temporarily pin matplotlib max version for RTD

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -19,6 +19,7 @@ python:
       extra_requirements:
         - docs
         - all
+    - requirements: docs/requirements.txt
 
 # Don't build any extra formats
 formats: []

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,1 @@
+matplotlib<3.4


### PR DESCRIPTION
Temporarily pin matplotlib max version for RTD until we know what is issuing the deprecation warning.

Hacky patch for the RTD warning reported in #11458,