### PR TITLE
Invalid combination of arguments to BinnedTimeSeries raises an exception

### DIFF
--- a/astropy/timeseries/binned.py
+++ b/astropy/timeseries/binned.py
@@ -119,6 +119,11 @@ class BinnedTimeSeries(BaseTimeSeries):
         if isinstance(time_bin_size, TimeDelta):
             time_bin_size = time_bin_size.sec * u.s
 
+        if n_bins is not None and time_bin_size is not None:
+            if not (time_bin_start.isscalar and time_bin_size.isscalar):
+                raise TypeError("'n_bins' cannot be specified if 'time_bin_start' or "
+                                "'time_bin_size' are not scalar'")
+
         if time_bin_start.isscalar:
 
             # We interpret this as meaning that this is the start of the
@@ -326,8 +331,14 @@ class BinnedTimeSeries(BaseTimeSeries):
 
                 time_bin_end = None
 
-            return BinnedTimeSeries(data=table,
+            if time_bin_start.isscalar and time_bin_size.isscalar:
+                return BinnedTimeSeries(data=table,
                                     time_bin_start=time_bin_start,
                                     time_bin_end=time_bin_end,
                                     time_bin_size=time_bin_size,
                                     n_bins=len(table))
+            else:
+                return BinnedTimeSeries(data=table,
+                                    time_bin_start=time_bin_start,
+                                    time_bin_end=time_bin_end,
+                                    time_bin_size=time_bin_size)

--- a/astropy/timeseries/tests/test_binned.py
+++ b/astropy/timeseries/tests/test_binned.py
@@ -89,6 +89,19 @@ def test_initialization_time_bin_start_scalar():
     assert exc.value.args[0] == ("'time_bin_start' is scalar, so 'time_bin_size' is required")
 
 
+def test_initialization_n_bins_invalid_arguments():
+
+    # Make sure an exception is raised when n_bins is passed as an argument while
+    # any of the parameters 'time_bin_start' or 'time_bin_end' is not scalar.
+
+    with pytest.raises(TypeError) as exc:
+        BinnedTimeSeries(time_bin_start=Time([1, 2, 3], format='cxcsec'),
+                         time_bin_size=1*u.s,
+                         n_bins=10)
+    assert exc.value.args[0] == ("'n_bins' cannot be specified if 'time_bin_start' or "
+                                 "'time_bin_size' are not scalar'")
+
+
 def test_initialization_n_bins():
 
     # Make sure things crash with incorrect n_bins

--- a/docs/changes/timeseries/11463.feature.rst
+++ b/docs/changes/timeseries/11463.feature.rst
@@ -1,0 +1,3 @@
+An exception is raised when ``n_bins`` is passed as an argument while 
+any of the parameters ``time_bin_start`` or ``time_bin_size`` is not 
+scalar.


### PR DESCRIPTION
A warning is raised when n_bins is passed as an argument while any of the parameters 'time_bin_start' or 'time_bin_end' is not scalar.

Fixes #11262 