### PR TITLE
pin matplotlib to <3.4 in 4.2.x

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -84,7 +84,7 @@ docs =
     pytest
     PyYAML>=3.13
     scipy>=1.1
-    matplotlib>=3.1
+    matplotlib>=3.1, <3.4.0
 
 [options.package_data]
 * = data/*, data/*/*, data/*/*/*, data/*/*/*/*, data/*/*/*/*/*, data/*/*/*/*/*/*


### PR DESCRIPTION
This is for the 4.2.x branch, as a potential change for a 4.2.1post1 just to get the RTD build working.