### PR TITLE
Avoid deprecation warning in wcsaxes doc

### DIFF
--- a/astropy/visualization/wcsaxes/patches.py
+++ b/astropy/visualization/wcsaxes/patches.py
@@ -11,6 +11,17 @@ from astropy.coordinates.matrix_utilities import rotation_matrix, matrix_product
 
 __all__ = ['Quadrangle', 'SphericalCircle']
 
+# Monkey-patch the docs to fix CapStyle and JoinStyle subs.
+# TODO! delete when upstream fix matplotlib/matplotlib#19839
+Polygon.__init__.__doc__ = Polygon.__init__.__doc__.replace(
+    "`.CapStyle`", "``matplotlib._enums.CapStyle``")
+Polygon.__init__.__doc__ = Polygon.__init__.__doc__.replace(
+    "`.JoinStyle`", "``matplotlib._enums.JoinStyle``")
+Polygon.set_capstyle.__doc__ = Polygon.set_capstyle.__doc__.replace(
+    "`.CapStyle`", "``matplotlib._enums.CapStyle``")
+Polygon.set_joinstyle.__doc__ = Polygon.set_joinstyle.__doc__.replace(
+    "`.JoinStyle`", "``matplotlib._enums.JoinStyle``")
+
 
 def _rotate_polygon(lon, lat, lon0, lat0):
     """


### PR DESCRIPTION
### Description

- Temporary fix to https://github.com/matplotlib/matplotlib/issues/19839,
- from https://github.com/astropy/astropy/pull/11118,
- closes https://github.com/astropy/astropy/pull/11464

🤞Address the RTD part of #11458 (EDITED)

Co-authored-by: @pllim
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>
