### PR TITLE
Avoid deprecation warning in wcsaxes doc in 4.2.x

### DIFF
--- a/astropy/visualization/wcsaxes/patches.py
+++ b/astropy/visualization/wcsaxes/patches.py
@@ -11,6 +11,17 @@ from astropy.coordinates.matrix_utilities import rotation_matrix, matrix_product
 
 __all__ = ['Quadrangle', 'SphericalCircle']
 
+# monkey-patch the docs to fix CapStyle and JoinStyle subs.
+# TODO! delete when upstream fix matplotlib/matplotlib#19839
+Polygon.__init__.__doc__ = Polygon.__init__.__doc__.replace(
+    "`.CapStyle`", "``matplotlib._enums.CapStyle``")
+Polygon.__init__.__doc__ = Polygon.__init__.__doc__.replace(
+    "`.JoinStyle`", "``matplotlib._enums.JoinStyle``")
+Polygon.set_capstyle.__doc__ = Polygon.set_capstyle.__doc__.replace(
+    "`.CapStyle`", "``matplotlib._enums.CapStyle``")
+Polygon.set_joinstyle.__doc__ = Polygon.set_joinstyle.__doc__.replace(
+    "`.JoinStyle`", "``matplotlib._enums.JoinStyle``")
+
 
 def _rotate_polygon(lon, lat, lon0, lat0):
     """


### PR DESCRIPTION
This is an alternative to #11465 that instead follows the fix on #11466 . If this works on RTD, I think I prefer it for a 4.2.1post1 over #11465 !

EDIT: Close #11465