### PR TITLE
Representation arithmetic with differentials

### DIFF
--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -1064,10 +1064,9 @@ class BaseRepresentation(BaseRepresentationOrDifferential):
         except Exception:
             return NotImplemented
 
-        if self.differentials:
-            for key, differential in self.differentials.items():
-                diff_result = differential._scale_operation(op, *args, scaled_base=True)
-                result.differentials[key] = diff_result
+        for key, differential in self.differentials.items():
+            diff_result = differential._scale_operation(op, *args, scaled_base=True)
+            result.differentials[key] = diff_result
 
         return result
 
@@ -1661,8 +1660,8 @@ class UnitSphericalRepresentation(BaseRepresentation):
 
     def _scale_operation(self, op, *args):
         return self._dimensional_representation(
-            lon=self.lon, lat=self.lat,
-            distance=1., differentials=self.differentials)._scale_operation(op, *args)
+            lon=self.lon, lat=self.lat, distance=1.,
+            differentials=self.differentials)._scale_operation(op, *args)
 
     def __neg__(self):
         if any(differential.base_representation is not self.__class__
@@ -1819,14 +1818,6 @@ class RadialRepresentation(BaseRepresentation):
         else:
             return super().__mul__(other)
 
-    def _scale_operation(self, op, *args):
-        result = self.__class__(op(self.distance, *args), copy=False)
-        if self.differentials:
-            for key, differential in self.differentials.items():
-                result.differentials[key] = op(differential, *args)
-
-        return result
-
     def norm(self):
         """Vector norm.
 
@@ -1861,7 +1852,6 @@ def _spherical_op_funcs(op, *args):
     if op is operator.neg:
         return lambda x: x+180*u.deg, operator.neg, operator.pos
 
-    assert len(args) == 1
     try:
         scale_sign = np.sign(args[0])
     except Exception:

--- a/astropy/coordinates/tests/test_representation_arithmetic.py
+++ b/astropy/coordinates/tests/test_representation_arithmetic.py
@@ -1241,6 +1241,21 @@ class TestArithmeticWithDifferentials:
         assert_differential_allclose(result_c.differentials['s'],
                                      expected_c.differentials['s'])
 
+    @pytest.mark.parametrize('rep_cls', [
+        SphericalRepresentation,
+        PhysicsSphericalRepresentation,
+        CylindricalRepresentation])
+    def test_operation_cartesian_differential(self, rep_cls, op, args):
+        rep = self.c.represent_as(rep_cls, {'s': CartesianDifferential})
+        result = op(rep, *args)
+
+        expected_c = op(self.c, *args)
+        expected = expected_c.represent_as(rep_cls, {'s': CartesianDifferential})
+        # Check that we match in the representation itself.
+        assert_representation_allclose(result, expected)
+        assert_differential_allclose(result.differentials['s'],
+                                     expected.differentials['s'])
+
     @pytest.mark.parametrize('diff_cls', [
         UnitSphericalDifferential,
         UnitSphericalCosLatDifferential])
@@ -1287,6 +1302,16 @@ class TestArithmeticWithDifferentials:
         assert_representation_allclose(result_c, expected_c)
         assert_differential_allclose(result_c.differentials['s'],
                                      expected_c.differentials['s'])
+
+
+@pytest.mark.parametrize('op,args', [
+    (operator.neg, ()),
+    (operator.mul, (10.,))])
+def test_operation_unitspherical_with_rv_fails(op, args):
+    rep = UnitSphericalRepresentation(
+        0*u.deg, 0*u.deg, differentials={'s': RadialDifferential(10*u.km/u.s)})
+    with pytest.raises(ValueError, match='unit key'):
+        op(rep, *args)
 
 
 @pytest.mark.parametrize('rep,dif', [

--- a/astropy/coordinates/tests/test_representation_arithmetic.py
+++ b/astropy/coordinates/tests/test_representation_arithmetic.py
@@ -6,13 +6,14 @@ import pytest
 import numpy as np
 
 from astropy import units as u
-from astropy.coordinates import (PhysicsSphericalRepresentation, CartesianRepresentation,
-                CylindricalRepresentation, SphericalRepresentation,
-                UnitSphericalRepresentation, SphericalDifferential,
-                CartesianDifferential, UnitSphericalDifferential,
-                SphericalCosLatDifferential, UnitSphericalCosLatDifferential,
-                PhysicsSphericalDifferential, CylindricalDifferential,
-                RadialRepresentation, RadialDifferential, Longitude, Latitude)
+from astropy.coordinates import (
+    PhysicsSphericalRepresentation, CartesianRepresentation,
+    CylindricalRepresentation, SphericalRepresentation,
+    UnitSphericalRepresentation, SphericalDifferential,
+    CartesianDifferential, UnitSphericalDifferential,
+    SphericalCosLatDifferential, UnitSphericalCosLatDifferential,
+    PhysicsSphericalDifferential, CylindricalDifferential,
+    RadialRepresentation, RadialDifferential, Longitude, Latitude)
 from astropy.coordinates.representation import DIFFERENTIAL_CLASSES
 from astropy.coordinates.angle_utilities import angular_separation
 from astropy.tests.helper import assert_quantity_allclose, quantity_allclose
@@ -669,16 +670,16 @@ class TestSphericalDifferential():
             self.SD_cls(1.*u.arcsec, 0., 0.)
         with pytest.raises(TypeError):
             self.SD_cls(1.*u.arcsec, 0.*u.arcsec, 0.*u.kpc,
-                                  False, False)
+                        False, False)
         with pytest.raises(TypeError):
             self.SD_cls(1.*u.arcsec, 0.*u.arcsec, 0.*u.kpc,
-                            copy=False, d_lat=0.*u.arcsec)
+                        copy=False, d_lat=0.*u.arcsec)
         with pytest.raises(TypeError):
             self.SD_cls(1.*u.arcsec, 0.*u.arcsec, 0.*u.kpc,
-                            copy=False, flying='circus')
+                        copy=False, flying='circus')
         with pytest.raises(ValueError):
             self.SD_cls(np.ones(2)*u.arcsec,
-                            np.zeros(3)*u.arcsec, np.zeros(2)*u.kpc)
+                        np.zeros(3)*u.arcsec, np.zeros(2)*u.kpc)
         with pytest.raises(u.UnitsError):
             self.SD_cls(1.*u.arcsec, 1.*u.s, 0.*u.kpc)
         with pytest.raises(u.UnitsError):

--- a/docs/changes/coordinates/11470.feature.rst
+++ b/docs/changes/coordinates/11470.feature.rst
@@ -1,0 +1,7 @@
+Allow negation, multiplication and division also of representations that
+include a differential (e.g., ``SphericalRepresentation`` with a
+``SphericalCosLatDifferential``).  For all operations, the outcome is
+equivalent to transforming the representation and differential to cartesian,
+then operating on those, and transforming back to the original representation
+(except for ``UnitSphericalRepresentation``, which will return a
+``SphericalRepresentation`` if there is a scale change).


### PR DESCRIPTION
~Note: built on top of #11469, so that should be dealt with first! (Hence making this a draft, even though it is ready otherwise.)~ (edit: #11469 is merged and this is rebased)

With this PR, differentials are taken along for multiplication, division, and negation:
```
In [3]: c = CartesianRepresentation([1.,2.,3]*u.kpc, differentials={'s': CartesianDiffer
   ...: ential([-2., 3., 4.]*u.km/u.s)})

In [4]: c2 = c * 10

In [5]: c2
Out[5]: 
<CartesianRepresentation (x, y, z) in kpc
    (10., 20., 30.)
 (has differentials w.r.t.: 's')>

In [6]: c2.differentials
Out[6]: 
{'s': <CartesianDifferential (d_x, d_y, d_z) in km / s
     (-20., 30., 40.)>}
```
For all other representations, the operations will continue to be equivalent to transforming to cartesian, applying the operation, and transforming back.

fixes #10987

p.s. No problem if this does not get in 4.3.