### PR TITLE
Fix bug writing 'csv' format when table has comments

### DIFF
--- a/astropy/io/ascii/basic.py
+++ b/astropy/io/ascii/basic.py
@@ -258,6 +258,12 @@ class Csv(Basic):
     from the typical default for `astropy.io.ascii` in which missing values are
     indicated by ``--``.
 
+    Since the `CSV format <https://tools.ietf.org/html/rfc4180t>`_ does not
+    formally support comments, any comments defined for the table via
+    ``tbl.meta['comments']`` are ignored by default. If you would still like to
+    write those comments then include a keyword ``comment='#'`` to the
+    ``write()`` call.
+
     Example::
 
       num,ra,dec,radius,mag

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -613,7 +613,7 @@ class BaseHeader:
                 yield line
 
     def write_comments(self, lines, meta):
-        if self.write_comment is not False:
+        if self.write_comment not in (False, None):
             for comment in meta.get('comments', []):
                 lines.append(self.write_comment + comment)
 

--- a/astropy/io/ascii/cparser.pyx
+++ b/astropy/io/ascii/cparser.pyx
@@ -1053,7 +1053,7 @@ cdef class FastWriter:
                       for name in self.use_names]
 
     cdef _write_comments(self, output):
-        if self.comment is not False:
+        if self.comment not in (False, None):
             for comment_line in self.line_comments:
                 output.write(self.comment + comment_line + '\n')
 

--- a/astropy/io/ascii/tests/test_write.py
+++ b/astropy/io/ascii/tests/test_write.py
@@ -780,6 +780,24 @@ def test_write_newlines(fast_writer, tmpdir):
 
 
 @pytest.mark.parametrize("fast_writer", [True, False])
+def test_write_csv_with_comments(fast_writer):
+    """
+    Test fix for #7357 where writing a Table with comments to 'csv' fails with
+    a cryptic message. The comments are dropped by default, but when comment='#'
+    is supplied they are still written.
+    """
+    out = StringIO()
+    t = table.Table([[1, 2], [3, 4]], names=['a', 'b'])
+    t.meta['comments'] = ['hello']
+    ascii.write(t, out, format='csv', fast_writer=fast_writer)
+    assert out.getvalue().splitlines() == ['a,b', '1,3', '2,4']
+
+    out = StringIO()
+    ascii.write(t, out, format='csv', fast_writer=fast_writer, comment='#')
+    assert out.getvalue().splitlines() == ['#hello', 'a,b', '1,3', '2,4']
+
+
+@pytest.mark.parametrize("fast_writer", [True, False])
 def test_write_formatted_mixin(fast_writer):
     """
     Test fix for #8680 where writing a QTable with a quantity mixin generates

--- a/docs/changes/io.ascii/11475.bugfix.rst
+++ b/docs/changes/io.ascii/11475.bugfix.rst
@@ -1,0 +1,4 @@
+Fixed bug where writing a table that has comments defined (via
+``tbl.meta['comments']``) with the 'csv' format was failing. Since the formally
+defined CSV format does not support comments, the comments are now just ignored
+unless ``comment=<comment prefix>`` is supplied to the ``write()`` call.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to fix a bug writing 'csv' format when the table has comments.

The comments are ignored by default the formal CSV format does not support comments, but documentation is added that informs the user how to override this if they desire.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #7357
