### PR TITLE
Wrap Table repr in <div> for horizontal scrolling in Jupyter notebook in VS code

### DIFF
--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -1515,8 +1515,12 @@ class Table:
         return out
 
     def _repr_html_(self):
-        return self._base_repr_(html=True, max_width=-1,
-                                tableclass=conf.default_notebook_table_class)
+        out = self._base_repr_(html=True, max_width=-1,
+                               tableclass=conf.default_notebook_table_class)
+        # Wrap <table> in <div>. This follows the pattern in pandas and allows
+        # table to be scrollable horizontally in VS Code notebook display.
+        out = f'<div>{out}</div>'
+        return out
 
     def __repr__(self):
         return self._base_repr_(html=False, max_width=None)

--- a/astropy/table/tests/test_pprint.py
+++ b/astropy/table/tests/test_pprint.py
@@ -51,13 +51,13 @@ class TestMultiD():
         nbclass = table.conf.default_notebook_table_class
         masked = 'masked=True ' if t.masked else ''
         assert t._repr_html_().splitlines() == [
-            f'<i>{table_type.__name__} {masked}length=2</i>',
+            f'<div><i>{table_type.__name__} {masked}length=2</i>',
             f'<table id="table{id(t)}" class="{nbclass}">',
             '<thead><tr><th>col0 [2]</th><th>col1 [2]</th><th>col2 [2]</th></tr></thead>',
             '<thead><tr><th>int64</th><th>int64</th><th>int64</th></tr></thead>',
             '<tr><td>1 .. 2</td><td>3 .. 4</td><td>5 .. 6</td></tr>',
             '<tr><td>10 .. 20</td><td>30 .. 40</td><td>50 .. 60</td></tr>',
-            '</table>']
+            '</table></div>']
 
         t = table_type([arr])
         lines = t.pformat()
@@ -92,12 +92,12 @@ class TestMultiD():
         nbclass = table.conf.default_notebook_table_class
         masked = 'masked=True ' if t.masked else ''
         assert t._repr_html_().splitlines() == [
-            f'<i>{table_type.__name__} {masked}length=2</i>',
+            f'<div><i>{table_type.__name__} {masked}length=2</i>',
             f'<table id="table{id(t)}" class="{nbclass}">',
             '<thead><tr><th>col0 [1,1]</th><th>col1 [1,1]</th><th>col2 [1,1]</th></tr></thead>',
             '<thead><tr><th>int64</th><th>int64</th><th>int64</th></tr></thead>',
             '<tr><td>1</td><td>3</td><td>5</td></tr>', '<tr><td>10</td><td>30</td><td>50</td></tr>',
-            '</table>']
+            '</table></div>']
 
         t = table_type([arr])
         lines = t.pformat()
@@ -112,14 +112,14 @@ def test_html_escaping():
     t = table.Table([('<script>alert("gotcha");</script>', 2, 3)])
     nbclass = table.conf.default_notebook_table_class
     assert t._repr_html_().splitlines() == [
-        '<i>Table length=3</i>',
+        '<div><i>Table length=3</i>',
         f'<table id="table{id(t)}" class="{nbclass}">',
         '<thead><tr><th>col0</th></tr></thead>',
         '<thead><tr><th>str33</th></tr></thead>',
         '<tr><td>&lt;script&gt;alert(&quot;gotcha&quot;);&lt;/script&gt;</td></tr>',
         '<tr><td>2</td></tr>',
         '<tr><td>3</td></tr>',
-        '</table>']
+        '</table></div>']
 
 
 @pytest.mark.usefixtures('table_type')

--- a/docs/changes/table/11476.bugfix.rst
+++ b/docs/changes/table/11476.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed ``Table`` HTML representation in Jupyter notebooks so that it is
+horizontally scrollable within Visual Studio Code. This was done by wrapping
+the ``<table>`` in a ``<div>`` element.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This PR fixes the `Table` HTML representation in Jupyter notebooks so that it is horizontally scrollable within Visual Studio Code. This was done by wrapping the `<table>` in a `<div>` element. This is the same as how the pandas `DataFrame` is represented in HTML.

Testing:

- [x] VS code (March 2021 release) Jupyter notebook
- [x] VS code Insiders (dev release) Native notebook
- [x] Jupyter notebook (`jupyter notebook`)

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->
