### PR TITLE
Keep SkyCoord differentials the same in represent_as if possible

### DIFF
--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -1055,7 +1055,15 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
         representation_cls = repr_classes['base']
         # We only keep velocity information
         if 's' in self.data.differentials:
-            differential_cls = repr_classes['s']
+            # For the default 'base' option in which _get_repr_classes has
+            # given us a best guess based on the representation class, we only
+            # use it if the class we had already is incompatible.
+            if (s == 'base'
+                and (self.data.differentials['s'].__class__
+                     in representation_cls._compatible_differentials)):
+                differential_cls = self.data.differentials['s'].__class__
+            else:
+                differential_cls = repr_classes['s']
         elif s is None or s == 'base':
             differential_cls = None
         else:

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -734,9 +734,9 @@ class BaseRepresentation(BaseRepresentationOrDifferential):
                             "differentials are attached to a {}."
                             .format(op_name, self.__class__.__name__))
 
-    @property
-    def _compatible_differentials(self):
-        return [DIFFERENTIAL_CLASSES[self.get_name()]]
+    @classproperty
+    def _compatible_differentials(cls):
+        return [DIFFERENTIAL_CLASSES[cls.get_name()]]
 
     @property
     def differentials(self):
@@ -1521,8 +1521,8 @@ class UnitSphericalRepresentation(BaseRepresentation):
     def __init__(self, lon, lat=None, differentials=None, copy=True):
         super().__init__(lon, lat, differentials=differentials, copy=copy)
 
-    @property
-    def _compatible_differentials(self):
+    @classproperty
+    def _compatible_differentials(cls):
         return [UnitSphericalDifferential, UnitSphericalCosLatDifferential,
                 SphericalDifferential, SphericalCosLatDifferential,
                 RadialDifferential]
@@ -1816,8 +1816,8 @@ class SphericalRepresentation(BaseRepresentation):
                 else:
                     raise
 
-    @property
-    def _compatible_differentials(self):
+    @classproperty
+    def _compatible_differentials(cls):
         return [UnitSphericalDifferential, UnitSphericalCosLatDifferential,
                 SphericalDifferential, SphericalCosLatDifferential,
                 RadialDifferential]

--- a/docs/changes/coordinates/11482.bugfix.rst
+++ b/docs/changes/coordinates/11482.bugfix.rst
@@ -1,0 +1,4 @@
+When re-representing coordinates from spherical to unit-spherical and vice
+versa, the type of differential will now be preserved. For instance, if only a
+radial velocity was present, that will remain the case (previously, a zero
+proper motion component was added).

--- a/docs/coordinates/spectralcoord.rst
+++ b/docs/coordinates/spectralcoord.rst
@@ -277,11 +277,11 @@ have been measured (for the purposes of the example here we will assume we have 
                       (0., 0., 0.)>
         target: <ICRS Coordinate: (ra, dec, distance) in (deg, deg, pc)
                     (65.497625, 19.53511111, 144.321)
-                 (pm_ra_cosdec, pm_dec, radial_velocity) in (mas / yr, mas / yr, km / s)
-                    (1.37949782e-15, 1.46375638e-15, 23.9)>
+                 (radial_velocity) in km / s
+                    (23.9,)>
         observer to target (computed from above):
-          radial_velocity=41.03594947739035 km / s
-          redshift=0.00013689056309340586)
+          radial_velocity=41.03594953774002 km / s
+          redshift=0.00013689056329480032)
       [200., 210., 220., 230., 240., 250., 260., 270., 280., 290., 300.] GHz>
 
 We can already see above that |SpectralCoord| has computed the difference in
@@ -324,8 +324,8 @@ the effect of the Earth's rotation), we can use the ``'gcrs'`` which stands for
                       (4.33251262e-09, 8.96175625e-08, -1.49258412e-08)>
         target: <ICRS Coordinate: (ra, dec, distance) in (deg, deg, pc)
                     (65.497625, 19.53511111, 144.321)
-                 (pm_ra_cosdec, pm_dec, radial_velocity) in (mas / yr, mas / yr, km / s)
-                    (1.37949782e-15, 1.46375638e-15, 23.9)>
+                 (radial_velocity) in km / s
+                    (23.9,)>
         observer to target (computed from above):
           radial_velocity=40.674086368345165 km / s
           redshift=0.00013568335316072044)
@@ -347,8 +347,8 @@ origin of the *International Celestial Reference System* (ICRS) system, we can u
                       (0., 0., 0.)>
         target: <ICRS Coordinate: (ra, dec, distance) in (deg, deg, pc)
                     (65.497625, 19.53511111, 144.321)
-                 (pm_ra_cosdec, pm_dec, radial_velocity) in (mas / yr, mas / yr, km / s)
-                    (1.37949782e-15, 1.46375638e-15, 23.9)>
+                 (radial_velocity) in km / s
+                    (23.9,)>
         observer to target (computed from above):
           radial_velocity=23.9 km / s
           redshift=7.97249967898761e-05)
@@ -375,8 +375,8 @@ branches of astronomy (such as radio astronomy)::
                       (0., 0., 0.)>
         target: <ICRS Coordinate: (ra, dec, distance) in (deg, deg, pc)
                     (65.497625, 19.53511111, 144.321)
-                 (pm_ra_cosdec, pm_dec, radial_velocity) in (mas / yr, mas / yr, km / s)
-                    (1.37949782e-15, 1.46375638e-15, 23.9)>
+                 (radial_velocity) in km / s
+                    (23.9,)>
         observer to target (computed from above):
           radial_velocity=12.50698856018455 km / s
           redshift=4.171969349386906e-05)
@@ -402,8 +402,8 @@ rest frame of the target::
                       (9.34149908, 20.49579745, 7.99178839)>
         target: <ICRS Coordinate: (ra, dec, distance) in (deg, deg, pc)
                     (65.497625, 19.53511111, 144.321)
-                 (pm_ra_cosdec, pm_dec, radial_velocity) in (mas / yr, mas / yr, km / s)
-                    (1.37949782e-15, 1.46375638e-15, 23.9)>
+                 (radial_velocity) in km / s
+                    (23.9,)>
         observer to target (computed from above):
           radial_velocity=0.0 km / s
           redshift=0.0)
@@ -434,8 +434,8 @@ We can convert these to the rest frame of the target using::
                       (9.34149908, 20.49579745, 7.99178839)>
         target: <ICRS Coordinate: (ra, dec, distance) in (deg, deg, pc)
                     (65.497625, 19.53511111, 144.321)
-                 (pm_ra_cosdec, pm_dec, radial_velocity) in (mas / yr, mas / yr, km / s)
-                    (1.37949782e-15, 1.46375638e-15, 23.9)>
+                 (radial_velocity) in km / s
+                    (23.9,)>
         observer to target (computed from above):
           radial_velocity=0.0 km / s
           redshift=0.0)
@@ -455,8 +455,8 @@ T Tau. We can convert these frequencies to velocities assuming the Doppler shift
                       (9.34149908, 20.49579745, 7.99178839)>
         target: <ICRS Coordinate: (ra, dec, distance) in (deg, deg, pc)
                     (65.497625, 19.53511111, 144.321)
-                 (pm_ra_cosdec, pm_dec, radial_velocity) in (mas / yr, mas / yr, km / s)
-                    (1.37949782e-15, 1.46375638e-15, 23.9)>
+                 (radial_velocity) in km / s
+                    (23.9,)>
         observer to target (computed from above):
           radial_velocity=0.0 km / s
           redshift=0.0
@@ -537,8 +537,8 @@ in that frame of reference::
                       (-1.42108547e-14, -300., 2.84217094e-14)>
         target: <ICRS Coordinate: (ra, dec, distance) in (deg, deg, pc)
                     (65.497625, 19.53511111, 144.321)
-                 (pm_ra_cosdec, pm_dec, radial_velocity) in (mas / yr, mas / yr, km / s)
-                    (1.37949782e-15, 1.46375638e-15, 23.9)>
+                 (radial_velocity) in km / s
+                    (23.9,)>
         observer to target (computed from above):
           radial_velocity=42.33062895275233 km / s
           redshift=0.00014120974955456056)


### PR DESCRIPTION
Fixes #11477 - a small annoyance. Milestoned 4.3 since I think this relies on other changes to the representations.

Before:
```
from astropy.coordinates import SkyCoord
from astropy import units as u

sc = SkyCoord(10*u.deg, 10*u.deg, radial_velocity=-10*u.km/u.s)
sc
<SkyCoord (ICRS): (ra, dec) in deg
    (10., 10.)
 (radial_velocity) in km / s
    (-10.,)>

sc.data.differentials
{'s': <RadialDifferential (d_distance) in km / s
     (-10.,)>}

sc.represent_as('spherical')
<SphericalRepresentation (lon, lat, distance) in (rad, rad, )
    (0.17453293, 0.17453293, 1.)
 (has differentials w.r.t.: 's')>

sc.represent_as('spherical').differentials
{'s': <SphericalDifferential (d_lon, d_lat, d_distance) in (km rad / s, km rad / s, km / s)
     (2.22044605e-16, -2.22044605e-16, -10.)>}
```

Now:
```
sc.represent_as('spherical')
<SphericalRepresentation (lon, lat, distance) in (rad, rad, )
    (0.17453293, 0.17453293, 1.)
 (has differentials w.r.t.: 's')>

c.represent_as('spherical').differentials
Out[3]: 
{'s': <RadialDifferential (d_distance) in km / s
     (-10.,)>}
```