### PR TITLE
TST: Only run cron for PR on labeled/sync

### DIFF
--- a/.github/workflows/ci_cron_daily.yml
+++ b/.github/workflows/ci_cron_daily.yml
@@ -6,10 +6,9 @@ on:
     - cron: '0 3 * * *'
   pull_request:
     # We also want this workflow triggered if the 'Extra CI' label is added
-    # The first two are subset of the defaults
+    # or present when PR is updated
     types:
       - synchronize
-      - reopened
       - labeled
 
 env:

--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -6,10 +6,9 @@ on:
     - cron: '0 6 * * 1'
   pull_request:
     # We also want this workflow triggered if the 'Extra CI' label is added
-    # The first two are subset of the defaults
+    # or present when PR is updated
     types:
       - synchronize
-      - reopened
       - labeled
 env:
   IS_CRON: 'true'


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to avoid duplicate runs when PR is opened and labeled at the same time or in close succession. I noticed duplicate runs. I think instead of sending a composite event, GitHub fired up separate events for "opened" and "labeled". Therefore, I think having "labeled" alone is enough for our purpose.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Follow-up of #11326
