### PR TITLE
Fix for erfa 1.7.2

### DIFF
--- a/astropy/coordinates/tests/test_icrs_observed_transformations.py
+++ b/astropy/coordinates/tests/test_icrs_observed_transformations.py
@@ -2,8 +2,6 @@
 """Accuracy tests for ICRS transformations, primarily to/from AltAz.
 
 """
-import pytest
-import numpy as np
 
 from astropy import units as u
 from astropy.tests.helper import assert_quantity_allclose as assert_allclose
@@ -14,17 +12,16 @@ from astropy.coordinates import (
 from astropy.coordinates.tests.utils import randomly_sample_sphere
 from astropy.coordinates import frame_transform_graph
 
-ra, dec, dist = randomly_sample_sphere(200)
-icrs_coords = SkyCoord(ra=ra, dec=dec, distance=dist*u.km*1e5)
 
-
-@pytest.mark.parametrize('icoo', icrs_coords)
-def test_icrs_consistency(icoo):
+def test_icrs_consistency():
     """
     Check ICRS<->AltAz for consistency with ICRS<->CIRS<->AltAz
 
     The latter is extensively tested in test_intermediate_transformations.py
     """
+    ra, dec, dist = randomly_sample_sphere(200)
+    icoo = SkyCoord(ra=ra, dec=dec, distance=dist*u.km*1e5)
+
     observer = EarthLocation(28*u.deg, 23*u.deg, height=2000.*u.km)
     obstime = Time('J2010')
     aa_frame = AltAz(obstime=obstime, location=observer)

--- a/docs/changes/coordinates/11485.other.rst
+++ b/docs/changes/coordinates/11485.other.rst
@@ -1,0 +1,1 @@
+The minimum version of ERFA is now 1.7.2.

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ tests_require = pytest-astropy
 setup_requires = setuptools_scm
 install_requires =
     numpy>=1.17
-    pyerfa>=1.7,<1.7.2
+    pyerfa>=1.7.2
 python_requires = >=3.7
 
 [options.packages.find]


### PR DESCRIPTION
This fixes most of the problems with ERFA 1.7.2, following the suggestion of @mkbrewer to adjust `erfa_astrom.apio` to follow the update in ERFA itself. With that, we're internally consistent.

~I'm a bit puzzled, though, by the remaining failure, which is a comparison against pyephem. Note that the actual failure is against an earlier astropy result, but why is it off by so much? Also comparing directly to the pyephem result, we're also off by a large amount (490"), much larger than used to be the case.~

~Now I noticed one strange thing with that particular test, which is that the height is 30000 m. However, a quick check with 30 m did not help.  (link to test below)~

EDIT: as noted by @StuartLittlefair below, the really strange number is the input altitude of -60 degrees! With that more reasonable, things pass.

Also a question: should I make `apio` ERFA-version dependent, or can we simply insist on a recent ERFA version (I think definitely OK for 4.3, but what about LTS?).

See  https://github.com/astropy/astropy/blob/fff5ccf460280432c303c59550ba869bc350899b/astropy/coordinates/tests/accuracy/test_altaz_icrs.py#L94-L127