### PR TITLE
Fix issue #11486

### DIFF
--- a/docs/changes/io.fits/11487.bugfix.rst
+++ b/docs/changes/io.fits/11487.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed regression introduced in Astropy 4.0.5 and 4.2.1 with verification of
+FITS headers with HISTORY or COMMENT cards with long (> 72 characters)
+values.


### PR DESCRIPTION
Fixes #11486.

As usual, FITS card parsing/verification is a mess that should be cleaned up thoroughly, but this provides a quick fix to the regression.
