### PR TITLE
Refactor optional dependency checking

### DIFF
--- a/astropy/conftest.py
+++ b/astropy/conftest.py
@@ -20,22 +20,20 @@ import pytest
 
 from astropy import __version__
 from astropy.tests.helper import enable_deprecations_as_exceptions
+from astropy.utils.compat.optional_deps import HAS_MATPLOTLIB
 
-try:
-    # This is needed to silence a warning from matplotlib caused by
-    # PyInstaller's matplotlib runtime hook.  This can be removed once the
-    # issue is fixed upstream in PyInstaller, and only impacts us when running
-    # the tests from a PyInstaller bundle.
-    # See https://github.com/astropy/astropy/issues/10785
-    if getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS'):
-        # The above checks whether we are running in a PyInstaller bundle.
-        warnings.filterwarnings("ignore", "(?s).*MATPLOTLIBDATA.*",
-                                category=UserWarning)
+if HAS_MATPLOTLIB:
     import matplotlib
-except ImportError:
-    HAS_MATPLOTLIB = False
-else:
-    HAS_MATPLOTLIB = True
+
+# This is needed to silence a warning from matplotlib caused by
+# PyInstaller's matplotlib runtime hook.  This can be removed once the
+# issue is fixed upstream in PyInstaller, and only impacts us when running
+# the tests from a PyInstaller bundle.
+# See https://github.com/astropy/astropy/issues/10785
+if getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS'):
+    # The above checks whether we are running in a PyInstaller bundle.
+    warnings.filterwarnings("ignore", "(?s).*MATPLOTLIBDATA.*",
+                            category=UserWarning)
 
 enable_deprecations_as_exceptions(
     include_astropy_deprecations=False,

--- a/astropy/conftest.py
+++ b/astropy/conftest.py
@@ -23,17 +23,17 @@ from astropy.tests.helper import enable_deprecations_as_exceptions
 from astropy.utils.compat.optional_deps import HAS_MATPLOTLIB
 
 if HAS_MATPLOTLIB:
-    import matplotlib
+    # This is needed to silence a warning from matplotlib caused by
+    # PyInstaller's matplotlib runtime hook.  This can be removed once the
+    # issue is fixed upstream in PyInstaller, and only impacts us when running
+    # the tests from a PyInstaller bundle.
+    # See https://github.com/astropy/astropy/issues/10785
+    if getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS'):
+        # The above checks whether we are running in a PyInstaller bundle.
+        warnings.filterwarnings("ignore", "(?s).*MATPLOTLIBDATA.*",
+                                category=UserWarning)
 
-# This is needed to silence a warning from matplotlib caused by
-# PyInstaller's matplotlib runtime hook.  This can be removed once the
-# issue is fixed upstream in PyInstaller, and only impacts us when running
-# the tests from a PyInstaller bundle.
-# See https://github.com/astropy/astropy/issues/10785
-if getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS'):
-    # The above checks whether we are running in a PyInstaller bundle.
-    warnings.filterwarnings("ignore", "(?s).*MATPLOTLIBDATA.*",
-                            category=UserWarning)
+    import matplotlib
 
 enable_deprecations_as_exceptions(
     include_astropy_deprecations=False,

--- a/astropy/conftest.py
+++ b/astropy/conftest.py
@@ -20,19 +20,22 @@ import pytest
 
 from astropy import __version__
 from astropy.tests.helper import enable_deprecations_as_exceptions
+
+# This is needed to silence a warning from matplotlib caused by
+# PyInstaller's matplotlib runtime hook.  This can be removed once the
+# issue is fixed upstream in PyInstaller, and only impacts us when running
+# the tests from a PyInstaller bundle.
+# See https://github.com/astropy/astropy/issues/10785
+if getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS'):
+    # The above checks whether we are running in a PyInstaller bundle.
+    warnings.filterwarnings("ignore", "(?s).*MATPLOTLIBDATA.*",
+                            category=UserWarning)
+
+# Note: while the filterwarnings is required, this import has to come after the
+# filterwarnings above, because this attempts to import matplotlib:
 from astropy.utils.compat.optional_deps import HAS_MATPLOTLIB
 
 if HAS_MATPLOTLIB:
-    # This is needed to silence a warning from matplotlib caused by
-    # PyInstaller's matplotlib runtime hook.  This can be removed once the
-    # issue is fixed upstream in PyInstaller, and only impacts us when running
-    # the tests from a PyInstaller bundle.
-    # See https://github.com/astropy/astropy/issues/10785
-    if getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS'):
-        # The above checks whether we are running in a PyInstaller bundle.
-        warnings.filterwarnings("ignore", "(?s).*MATPLOTLIBDATA.*",
-                                category=UserWarning)
-
     import matplotlib
 
 enable_deprecations_as_exceptions(

--- a/astropy/convolution/tests/test_convolve.py
+++ b/astropy/convolution/tests/test_convolve.py
@@ -9,6 +9,7 @@ from astropy.convolution.kernels import Gaussian2DKernel
 from astropy.utils.exceptions import AstropyUserWarning
 from astropy import units as u
 from astropy.utils.compat.context import nullcontext
+from astropy.utils.compat.optional_deps import HAS_SCIPY, HAS_PANDAS  # noqa
 
 from numpy.testing import (assert_array_almost_equal_nulp,
                            assert_array_almost_equal,
@@ -29,17 +30,6 @@ BOUNDARIES_AND_CONVOLUTIONS = (list(zip(itertools.cycle((convolve,)),
                                                                'wrap'),
                                                               (convolve_fft,
                                                                'fill')])
-HAS_SCIPY = True
-try:
-    import scipy
-except ImportError:
-    HAS_SCIPY = False
-
-HAS_PANDAS = True
-try:
-    import pandas
-except ImportError:
-    HAS_PANDAS = False
 
 
 class TestConvolve1D:
@@ -936,6 +926,8 @@ def test_astropy_convolution_against_scipy():
 
 @pytest.mark.skipif('not HAS_PANDAS')
 def test_regression_6099():
+    import pandas
+
     wave = np.array(np.linspace(5000, 5100, 10))
     boxcar = 3
     nonseries_result = convolve(wave, np.ones((boxcar,))/boxcar)

--- a/astropy/convolution/tests/test_convolve_models.py
+++ b/astropy/convolution/tests/test_convolve_models.py
@@ -7,14 +7,8 @@ import pytest
 from astropy.convolution.convolve import convolve, convolve_fft, convolve_models
 from astropy.modeling import models, fitting
 from astropy.utils.misc import NumpyRNGContext
+from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa
 from numpy.testing import assert_allclose, assert_almost_equal
-
-try:
-    import scipy
-except ImportError:
-    HAS_SCIPY = False
-else:
-    HAS_SCIPY = True
 
 
 class TestConvolve1DModels:

--- a/astropy/convolution/tests/test_discretize.py
+++ b/astropy/convolution/tests/test_discretize.py
@@ -11,12 +11,7 @@ from astropy.modeling.functional_models import (
     Gaussian1D, Box1D, RickerWavelet1D, Gaussian2D, Box2D, RickerWavelet2D)
 from astropy.modeling.tests.example_models import models_1D, models_2D
 from astropy.modeling.tests.test_models import create_model
-
-try:
-    import scipy  # pylint: disable=W0611
-    HAS_SCIPY = True
-except ImportError:
-    HAS_SCIPY = False
+from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa
 
 
 modes = ['center', 'linear_interp', 'oversample']

--- a/astropy/convolution/tests/test_kernel_class.py
+++ b/astropy/convolution/tests/test_kernel_class.py
@@ -16,12 +16,7 @@ from astropy.convolution.kernels import (
 from astropy.convolution.utils import KernelSizeError
 from astropy.modeling.models import Box2D, Gaussian1D, Gaussian2D
 from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyUserWarning
-
-try:
-    from scipy.ndimage import filters
-    HAS_SCIPY = True
-except ImportError:
-    HAS_SCIPY = False
+from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa
 
 WIDTHS_ODD = [3, 5, 7, 9]
 WIDTHS_EVEN = [2, 4, 8, 16]
@@ -58,6 +53,8 @@ class TestKernels:
         """
         Test GaussianKernel against SciPy ndimage gaussian filter.
         """
+        from scipy.ndimage import filters
+
         gauss_kernel_1D = Gaussian1DKernel(width)
         gauss_kernel_1D.normalize()
         gauss_kernel_2D = Gaussian2DKernel(width)
@@ -78,6 +75,8 @@ class TestKernels:
         """
         Test RickerWavelet kernels against SciPy ndimage gaussian laplace filters.
         """
+        from scipy.ndimage import filters
+
         ricker_kernel_1D = RickerWavelet1DKernel(width)
         ricker_kernel_2D = RickerWavelet2DKernel(width)
 

--- a/astropy/coordinates/tests/test_api_ape5.py
+++ b/astropy/coordinates/tests/test_api_ape5.py
@@ -21,13 +21,7 @@ from astropy import units as u
 from astropy import time
 from astropy import coordinates as coords
 from astropy.units import allclose
-
-try:
-    import scipy  # pylint: disable=W0611  # noqa
-except ImportError:
-    HAS_SCIPY = False
-else:
-    HAS_SCIPY = True
+from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa
 
 
 def test_representations_api():

--- a/astropy/coordinates/tests/test_distance.py
+++ b/astropy/coordinates/tests/test_distance.py
@@ -13,13 +13,7 @@ from astropy.units import allclose as quantity_allclose
 from astropy.coordinates import Longitude, Latitude, Distance, CartesianRepresentation
 from astropy.coordinates.builtin_frames import ICRS, Galactic
 from astropy.utils.exceptions import AstropyWarning
-
-try:
-    import scipy  # pylint: disable=W0611  # noqa
-except ImportError:
-    HAS_SCIPY = False
-else:
-    HAS_SCIPY = True
+from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa
 
 
 def test_distances():

--- a/astropy/coordinates/tests/test_intermediate_transformations.py
+++ b/astropy/coordinates/tests/test_intermediate_transformations.py
@@ -19,6 +19,7 @@ from astropy.coordinates import (
 from astropy.coordinates.solar_system import _apparent_position_in_true_coordinates, get_body
 from astropy.utils import iers
 from astropy.utils.exceptions import AstropyWarning, AstropyDeprecationWarning
+from astropy.utils.compat.optional_deps import HAS_JPLEPHEM  # noqa
 
 from astropy.coordinates.tests.utils import randomly_sample_sphere
 from astropy.coordinates.builtin_frames.intermediate_rotation_transforms import (
@@ -28,13 +29,6 @@ from astropy.coordinates import solar_system_ephemeris
 from astropy.units import allclose
 
 CI = os.environ.get('CI', False) == "true"
-
-try:
-    import jplephem  # pylint: disable=W0611  # noqa
-except ImportError:
-    HAS_JPLEPHEM = False
-else:
-    HAS_JPLEPHEM = True
 
 
 def test_icrs_cirs():

--- a/astropy/coordinates/tests/test_matching.py
+++ b/astropy/coordinates/tests/test_matching.py
@@ -11,17 +11,13 @@ from astropy import units as u
 
 from astropy.coordinates import matching
 
+from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa
+
 """
 These are the tests for coordinate matching.
 
 Note that this requires scipy.
 """
-
-try:
-    import scipy  # noqa
-    HAS_SCIPY = True
-except ImportError:
-    HAS_SCIPY = False
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason="Requires scipy.")

--- a/astropy/coordinates/tests/test_pickle.py
+++ b/astropy/coordinates/tests/test_pickle.py
@@ -7,11 +7,7 @@ from astropy import coordinates as coord
 from astropy.tests.helper import pickle_protocol, check_pickling_recovery  # noqa
 
 # Can't test distances without scipy due to cosmology deps
-try:
-    import scipy  # pylint: disable=W0611
-    HAS_SCIPY = True
-except ImportError:
-    HAS_SCIPY = False
+from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa
 
 
 def test_basic():

--- a/astropy/coordinates/tests/test_regression.py
+++ b/astropy/coordinates/tests/test_regression.py
@@ -28,14 +28,8 @@ from astropy.utils import iers
 from astropy.table import Table
 
 from astropy.tests.helper import assert_quantity_allclose
-from .test_matching import HAS_SCIPY
+from astropy.utils.compat.optional_deps import HAS_SCIPY, HAS_YAML  # noqa
 from astropy.units import allclose as quantity_allclose
-
-try:
-    import yaml  # pylint: disable=W0611  # noqa
-    HAS_YAML = True
-except ImportError:
-    HAS_YAML = False
 
 
 def test_regression_5085():

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -30,6 +30,7 @@ from astropy.units import allclose as quantity_allclose
 from astropy.io import fits
 from astropy.wcs import WCS
 from astropy.io.misc.asdf.tags.helpers import skycoord_equal
+from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa
 
 RA = 1.0 * u.deg
 DEC = 2.0 * u.deg
@@ -42,13 +43,6 @@ def allclose(a, b, rtol=0.0, atol=None):
     if atol is None:
         atol = 1.e-8 * getattr(a, 'unit', 1.)
     return quantity_allclose(a, b, rtol, atol)
-
-
-try:
-    import scipy
-    HAS_SCIPY = True
-except ImportError:
-    HAS_SCIPY = False
 
 
 def setup_function(func):

--- a/astropy/coordinates/tests/test_sky_coord_velocities.py
+++ b/astropy/coordinates/tests/test_sky_coord_velocities.py
@@ -21,11 +21,7 @@ from astropy.coordinates import (
     RadialDifferential, CartesianRepresentation,
     CartesianDifferential, Galactic, PrecessedGeocentric)
 
-try:
-    import scipy
-    HAS_SCIPY = True
-except ImportError:
-    HAS_SCIPY = False
+from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa
 
 
 def test_creation_frameobjs():

--- a/astropy/coordinates/tests/test_solar_system.py
+++ b/astropy/coordinates/tests/test_solar_system.py
@@ -18,20 +18,11 @@ from astropy.coordinates.funcs import get_sun
 from astropy.tests.helper import assert_quantity_allclose
 from astropy.units import allclose as quantity_allclose
 from astropy.utils.data import download_file
+from astropy.utils.compat.optional_deps import (HAS_JPLEPHEM,  # noqa
+                                                HAS_SKYFIELD)
 
-try:
-    import jplephem  # pylint: disable=W0611
-except ImportError:
-    HAS_JPLEPHEM = False
-else:
-    HAS_JPLEPHEM = True
-
-try:
-    from skyfield.api import Loader, Topos  # pylint: disable=W0611
-except ImportError:
-    HAS_SKYFIELD = False
-else:
-    HAS_SKYFIELD = True
+if HAS_SKYFIELD:
+    from skyfield.api import Loader, Topos
 
 de432s_separation_tolerance_planets = 5*u.arcsec
 de432s_separation_tolerance_moon = 5*u.arcsec

--- a/astropy/cosmology/tests/test_cosmology.py
+++ b/astropy/cosmology/tests/test_cosmology.py
@@ -10,13 +10,7 @@ from astropy.units import allclose
 from astropy import constants as const
 from astropy import units as u
 from astropy.utils.exceptions import AstropyUserWarning
-
-try:
-    import scipy  # pylint: disable=W0611  # noqa
-except ImportError:
-    HAS_SCIPY = False
-else:
-    HAS_SCIPY = True
+from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa
 
 
 def test_init():

--- a/astropy/io/ascii/tests/test_compressed.py
+++ b/astropy/io/ascii/tests/test_compressed.py
@@ -5,20 +5,8 @@ import numpy as np
 from astropy.io.ascii import read
 from astropy.utils.data import get_pkg_data_filename
 
-# NOTE: Python can be built without bz2 or lzma.
-try:
-    import bz2  # noqa
-except ImportError:
-    HAS_BZ2 = False
-else:
-    HAS_BZ2 = True
-
-try:
-    import lzma  # noqa
-except ImportError:
-    HAS_XZ = False
-else:
-    HAS_XZ = True
+# NOTE: Python can be built without bz2 or lzma
+from astropy.utils.compat.optional_deps import HAS_BZ2, HAS_LZMA  # noqa
 
 
 @pytest.mark.parametrize('filename', ['data/daophot.dat.gz', 'data/latex1.tex.gz',
@@ -39,7 +27,7 @@ def test_bzip2(filename):
     assert np.all(t_comp.as_array() == t_uncomp.as_array())
 
 
-@pytest.mark.xfail('not HAS_XZ')
+@pytest.mark.xfail('not HAS_LZMA')
 @pytest.mark.parametrize('filename', ['data/short.rdb.xz', 'data/ipac.dat.xz'])
 def test_xz(filename):
     t_comp = read(get_pkg_data_filename(filename))

--- a/astropy/io/ascii/tests/test_connect.py
+++ b/astropy/io/ascii/tests/test_connect.py
@@ -1,12 +1,11 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-import os
-
 import pytest
 
 from astropy.table import Table, Column
 
 from astropy.table.table_helpers import simple_table
 from astropy.utils.data import get_pkg_data_filename
+from astropy.utils.compat.optional_deps import HAS_BS4, HAS_YAML  # noqa
 
 import numpy as np
 
@@ -14,21 +13,8 @@ import numpy as np
 files = ['data/cds.dat', 'data/ipac.dat', 'data/daophot.dat', 'data/latex1.tex',
          'data/simple_csv.csv']
 
-# Check to see if the BeautifulSoup dependency is present.
 
-try:
-    from bs4 import BeautifulSoup  # noqa
-    HAS_BEAUTIFUL_SOUP = True
-except ImportError:
-    HAS_BEAUTIFUL_SOUP = False
-
-try:
-    import yaml  # noqa
-    HAS_YAML = True
-except ImportError:
-    HAS_YAML = False
-
-if HAS_BEAUTIFUL_SOUP:
+if HAS_BS4:
     files.append('data/html.html')
 
 
@@ -80,12 +66,12 @@ def test_write_latex_noformat(tmpdir):
     t.write(path)
 
 
-@pytest.mark.skipif('not HAS_BEAUTIFUL_SOUP')
+@pytest.mark.skipif('not HAS_BS4')
 def test_read_html():
     Table.read(get_pkg_data_filename('data/html.html'), format='html')
 
 
-@pytest.mark.skipif('not HAS_BEAUTIFUL_SOUP')
+@pytest.mark.skipif('not HAS_BS4')
 def test_read_html_noformat():
     Table.read(get_pkg_data_filename('data/html.html'))
 

--- a/astropy/io/ascii/tests/test_ecsv.py
+++ b/astropy/io/ascii/tests/test_ecsv.py
@@ -28,12 +28,7 @@ from astropy.utils.exceptions import AstropyWarning
 from astropy.io.ascii.ecsv import DELIMITERS
 from astropy.io import ascii
 from astropy import units as u
-
-try:
-    import yaml  # noqa
-    HAS_YAML = True
-except ImportError:
-    HAS_YAML = False
+from astropy.utils.compat.optional_deps import HAS_YAML  # noqa
 
 DTYPES = ['bool', 'int8', 'int16', 'int32', 'int64', 'uint8', 'uint16', 'uint32',
           'uint64', 'float16', 'float32', 'float64', 'float128',

--- a/astropy/io/ascii/tests/test_html.py
+++ b/astropy/io/ascii/tests/test_html.py
@@ -22,22 +22,13 @@ import numpy as np
 from .common import setup_function, teardown_function  # noqa
 from astropy.io import ascii
 
-try:
-    import bleach  # noqa
-    HAS_BLEACH = True
-except ImportError:
-    HAS_BLEACH = False
+from astropy.utils.compat.optional_deps import HAS_BLEACH, HAS_BS4  # noqa
 
-# Check to see if the BeautifulSoup dependency is present.
-try:
-
+if HAS_BS4:
     from bs4 import BeautifulSoup, FeatureNotFound
-    HAS_BEAUTIFUL_SOUP = True
-except ImportError:
-    HAS_BEAUTIFUL_SOUP = False
 
 
-@pytest.mark.skipif('not HAS_BEAUTIFUL_SOUP')
+@pytest.mark.skipif('not HAS_BS4')
 def test_soupstring():
     """
     Test to make sure the class SoupString behaves properly.
@@ -68,7 +59,7 @@ def test_listwriter():
     assert lst == [0, 1, 2, 3, 4, 'a', 'b', 'c', 'd', 'e']
 
 
-@pytest.mark.skipif('not HAS_BEAUTIFUL_SOUP')
+@pytest.mark.skipif('not HAS_BS4')
 def test_identify_table():
     """
     Test to make sure that identify_table() returns whether the
@@ -94,7 +85,7 @@ def test_identify_table():
     assert html.identify_table(soup, {'table_id': 'foo'}, 1) is True
 
 
-@pytest.mark.skipif('not HAS_BEAUTIFUL_SOUP')
+@pytest.mark.skipif('not HAS_BS4')
 def test_missing_data():
     """
     Test reading a table with missing data
@@ -122,7 +113,7 @@ def test_missing_data():
     assert dat['A'].dtype.kind == 'i'
 
 
-@pytest.mark.skipif('not HAS_BEAUTIFUL_SOUP')
+@pytest.mark.skipif('not HAS_BS4')
 def test_rename_cols():
     """
     Test reading a table and renaming cols
@@ -144,7 +135,7 @@ def test_rename_cols():
     assert np.all(dat['A'] == 2)
 
 
-@pytest.mark.skipif('not HAS_BEAUTIFUL_SOUP')
+@pytest.mark.skipif('not HAS_BS4')
 def test_no_names():
     """
     Test reading a table witn no column header
@@ -162,7 +153,7 @@ def test_no_names():
     assert len(dat) == 2
 
 
-@pytest.mark.skipif('not HAS_BEAUTIFUL_SOUP')
+@pytest.mark.skipif('not HAS_BS4')
 def test_identify_table_fail():
     """
     Raise an exception with an informative error message if table_id
@@ -182,7 +173,7 @@ def test_identify_table_fail():
     assert err.match("ERROR: HTML table number 3 not found$")
 
 
-@pytest.mark.skipif('not HAS_BEAUTIFUL_SOUP')
+@pytest.mark.skipif('not HAS_BS4')
 def test_backend_parsers():
     """
     Make sure the user can specify which back-end parser to use
@@ -203,7 +194,7 @@ def test_backend_parsers():
                    htmldict={'parser': 'foo'}, guess=False)
 
 
-@pytest.mark.skipif('HAS_BEAUTIFUL_SOUP')
+@pytest.mark.skipif('HAS_BS4')
 def test_htmlinputter_no_bs4():
     """
     This should return an OptionalTableImportError if BeautifulSoup
@@ -215,7 +206,7 @@ def test_htmlinputter_no_bs4():
         inputter.process_lines([])
 
 
-@pytest.mark.skipif('not HAS_BEAUTIFUL_SOUP')
+@pytest.mark.skipif('not HAS_BS4')
 def test_htmlinputter():
     """
     Test to ensure that HTMLInputter correctly converts input
@@ -258,7 +249,7 @@ def test_htmlinputter():
     assert [str(x) for x in inputter.get_lines(table)] == expected
 
 
-@pytest.mark.skipif('not HAS_BEAUTIFUL_SOUP')
+@pytest.mark.skipif('not HAS_BS4')
 def test_htmlsplitter():
     """
     Test to make sure that HTMLSplitter correctly inputs lines
@@ -285,7 +276,7 @@ def test_htmlsplitter():
         list(splitter([]))
 
 
-@pytest.mark.skipif('not HAS_BEAUTIFUL_SOUP')
+@pytest.mark.skipif('not HAS_BS4')
 def test_htmlheader_start():
     """
     Test to ensure that the start_line method of HTMLHeader
@@ -325,7 +316,7 @@ def test_htmlheader_start():
         header.start_line(lines)
 
 
-@pytest.mark.skipif('not HAS_BEAUTIFUL_SOUP')
+@pytest.mark.skipif('not HAS_BS4')
 def test_htmldata():
     """
     Test to ensure that the start_line and end_lines methods
@@ -545,7 +536,7 @@ def test_write_no_multicols():
         expected.strip()
 
 
-@pytest.mark.skipif('not HAS_BEAUTIFUL_SOUP')
+@pytest.mark.skipif('not HAS_BS4')
 def test_multicolumn_read():
     """
     Test to make sure that the HTML reader inputs multidimensional
@@ -728,7 +719,7 @@ def test_multi_column_write_table_html_fill_values_masked():
     assert buffer_output.getvalue() == buffer_expected.getvalue()
 
 
-@pytest.mark.skipif('not HAS_BEAUTIFUL_SOUP')
+@pytest.mark.skipif('not HAS_BS4')
 def test_read_html_unicode():
     """
     Test reading an HTML table with unicode values

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -25,16 +25,11 @@ from astropy.io.ascii import core
 from astropy.io.ascii.ui import _probably_html, get_read_trace
 from astropy.utils.exceptions import AstropyWarning
 
+# NOTE: Python can be built without bz2.
+from astropy.utils.compat.optional_deps import HAS_BZ2  # noqa
+
 # setup/teardown function to have the tests run in the correct directory
 from .common import setup_function, teardown_function  # noqa
-
-# NOTE: Python can be built without bz2.
-try:
-    import bz2  # noqa
-except ImportError:
-    HAS_BZ2 = False
-else:
-    HAS_BZ2 = True
 
 
 def asciiIO(x):

--- a/astropy/io/ascii/tests/test_write.py
+++ b/astropy/io/ascii/tests/test_write.py
@@ -13,16 +13,13 @@ from astropy import table
 from astropy.table.table_helpers import simple_table
 from astropy.utils.compat.context import nullcontext
 from astropy.utils.exceptions import AstropyWarning, AstropyDeprecationWarning
+from astropy.utils.compat.optional_deps import HAS_BS4
 from astropy import units as u
 
 from .common import setup_function, teardown_function  # noqa
 
-# Check to see if the BeautifulSoup dependency is present.
-try:
+if HAS_BS4:
     from bs4 import BeautifulSoup, FeatureNotFound  # noqa
-    HAS_BEAUTIFUL_SOUP = True
-except ImportError:
-    HAS_BEAUTIFUL_SOUP = False
 
 test_defs = [
     dict(kwargs=dict(),
@@ -737,7 +734,7 @@ def test_roundtrip_masked(fmt_name_class):
         return
 
     # Skip tests for fixed_width or HTML without bs4
-    if ((fmt_name == 'html' and not HAS_BEAUTIFUL_SOUP)
+    if ((fmt_name == 'html' and not HAS_BS4)
             or fmt_name == 'fixed_width'):
         return
 

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -42,12 +42,6 @@ from astropy.utils.exceptions import AstropyWarning, AstropyDeprecationWarning
 
 _read_trace = []
 
-try:
-    import yaml  # noqa
-    HAS_YAML = True
-except ImportError:
-    HAS_YAML = False
-
 # Default setting for guess parameter in read()
 _GUESS = True
 

--- a/astropy/io/fits/file.py
+++ b/astropy/io/fits/file.py
@@ -26,12 +26,9 @@ from astropy.utils.decorators import classproperty, deprecated_renamed_argument
 from astropy.utils.exceptions import AstropyUserWarning
 
 # NOTE: Python can be built without bz2.
-try:
+from astropy.utils.compat.optional_deps import HAS_BZ2
+if HAS_BZ2:
     import bz2
-except ImportError:
-    HAS_BZ2 = False
-else:
-    HAS_BZ2 = True
 
 
 # Maps astropy.io.fits-specific file mode names to the appropriate file

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -24,12 +24,9 @@ from astropy.utils.exceptions import AstropyUserWarning
 from astropy.utils.decorators import deprecated_renamed_argument
 
 # NOTE: Python can be built without bz2.
-try:
+from astropy.utils.compat.optional_deps import HAS_BZ2
+if HAS_BZ2:
     import bz2
-except ImportError:
-    HAS_BZ2 = False
-else:
-    HAS_BZ2 = True
 
 # FITS file signature as per RFC 4047
 FITS_SIGNATURE = b'SIMPLE  =                    T'

--- a/astropy/io/fits/tests/test_connect.py
+++ b/astropy/io/fits/tests/test_connect.py
@@ -27,12 +27,7 @@ from astropy.coordinates import (SkyCoord, Latitude, Longitude, Angle, EarthLoca
                                  SphericalCosLatDifferential)
 from astropy.time import Time, TimeDelta
 from astropy.units.quantity import QuantityInfo
-
-try:
-    import yaml  # pylint: disable=W0611  # noqa
-    HAS_YAML = True
-except ImportError:
-    HAS_YAML = False
+from astropy.utils.compat.optional_deps import HAS_YAML  # noqa
 
 
 def equal_data(a, b):

--- a/astropy/io/fits/tests/test_core.py
+++ b/astropy/io/fits/tests/test_core.py
@@ -25,12 +25,9 @@ from astropy.utils.exceptions import AstropyUserWarning
 from astropy.utils import data
 
 # NOTE: Python can be built without bz2.
-try:
+from astropy.utils.compat.optional_deps import HAS_BZ2
+if HAS_BZ2:
     import bz2
-except ImportError:
-    HAS_BZ2 = False
-else:
-    HAS_BZ2 = True
 
 
 class TestCore(FitsTestCase):

--- a/astropy/io/fits/tests/test_image.py
+++ b/astropy/io/fits/tests/test_image.py
@@ -13,16 +13,10 @@ from astropy.io import fits
 from astropy.io.fits.hdu.compressed import SUBTRACTIVE_DITHER_1, DITHER_SEED_CHECKSUM
 from astropy.utils.exceptions import AstropyUserWarning
 from astropy.utils.data import get_pkg_data_filename
+from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa
 from .test_table import comparerecords
 
 from . import FitsTestCase
-
-try:
-    import scipy  # noqa
-except ImportError:
-    HAS_SCIPY = False
-else:
-    HAS_SCIPY = True
 
 
 class TestImageFunctions(FitsTestCase):

--- a/astropy/io/fits/tests/test_util.py
+++ b/astropy/io/fits/tests/test_util.py
@@ -8,14 +8,12 @@ import pytest
 import numpy as np
 from numpy.testing import assert_equal
 
-try:
-    from PIL import Image
-    HAS_PIL = True
-except ImportError:
-    HAS_PIL = False
-
 from astropy.io.fits import util
 from astropy.io.fits.util import ignore_sigint, _rstrip_inplace
+from astropy.utils.compat.optional_deps import HAS_PIL
+
+if HAS_PIL:
+    from PIL import Image
 
 from . import FitsTestCase
 

--- a/astropy/io/misc/pandas/connect.py
+++ b/astropy/io/misc/pandas/connect.py
@@ -42,24 +42,12 @@ def import_html_libs():
 
     global _HAS_BS4, _HAS_LXML, _HAS_HTML5LIB
 
-    try:
-        import bs4  # noqa
-        _HAS_BS4 = True
-    except ImportError:
-        pass
-
-    try:
-        import lxml  # noqa
-        _HAS_LXML = True
-    except ImportError:
-        pass
-
-    try:
-        import html5lib  # noqa
-        _HAS_HTML5LIB = True
-    except ImportError:
-        pass
-
+    from astropy.utils.compat.optional_deps import (HAS_BS4,
+                                                    HAS_LXML,
+                                                    HAS_HTML5LIB)
+    _HAS_BS4 = HAS_BS4
+    _HAS_LXML = HAS_LXML
+    _HAS_HTML5LIB = HAS_HTML5LIB
     _IMPORTS = True
 
 

--- a/astropy/io/misc/pandas/connect.py
+++ b/astropy/io/misc/pandas/connect.py
@@ -42,12 +42,11 @@ def import_html_libs():
 
     global _HAS_BS4, _HAS_LXML, _HAS_HTML5LIB
 
-    from astropy.utils.compat.optional_deps import (HAS_BS4,
-                                                    HAS_LXML,
-                                                    HAS_HTML5LIB)
-    _HAS_BS4 = HAS_BS4
-    _HAS_LXML = HAS_LXML
-    _HAS_HTML5LIB = HAS_HTML5LIB
+    from astropy.utils.compat.optional_deps import (
+        HAS_BS4 as _HAS_BS4,
+        HAS_LXML as _HAS_LXML,
+        HAS_HTML5LIB as _HAS_HTML5LIB
+    )
     _IMPORTS = True
 
 

--- a/astropy/io/misc/tests/test_hdf5.py
+++ b/astropy/io/misc/tests/test_hdf5.py
@@ -16,20 +16,9 @@ from astropy.units.quantity import QuantityInfo
 from astropy.utils.exceptions import AstropyUserWarning
 from astropy.utils.data import get_pkg_data_filename
 from astropy.io.misc.hdf5 import meta_path
-
-try:
+from astropy.utils.compat.optional_deps import HAS_H5PY, HAS_YAML  # noqa
+if HAS_H5PY:
     import h5py
-except ImportError:
-    HAS_H5PY = False
-else:
-    HAS_H5PY = True
-
-try:
-    import yaml  # noqa
-except ImportError:
-    HAS_YAML = False
-else:
-    HAS_YAML = True
 
 ALL_DTYPES = [np.uint8, np.uint16, np.uint32, np.uint64, np.int8,
               np.int16, np.int32, np.int64, np.float32, np.float64,

--- a/astropy/io/tests/test_registry.py
+++ b/astropy/io/tests/test_registry.py
@@ -14,6 +14,7 @@ from astropy.table import Table
 from astropy.utils.compat.context import nullcontext
 from astropy.utils.exceptions import AstropyUserWarning
 from astropy import units as u
+from astropy.utils.compat.optional_deps import HAS_YAML
 
 # Since we reset the readers/writers below, we need to also import any
 # sub-package that defines readers/writers first
@@ -26,12 +27,6 @@ from astropy import timeseries  # noqa
 # during test collection but *before* tests (and the final teardown) get run.
 # This leaves the registry corrupted.
 ORIGINAL = {}
-
-try:
-    import yaml  # pylint: disable=W0611 # noqa
-    HAS_YAML = True
-except ImportError:
-    HAS_YAML = False
 
 
 class TestData:

--- a/astropy/modeling/tests/test_compound.py
+++ b/astropy/modeling/tests/test_compound.py
@@ -17,12 +17,7 @@ from astropy.modeling.models import (Const1D, Shift, Scale, Rotation2D, Gaussian
                                      Identity, Mapping,
                                      Tabular1D, fix_inputs)
 import astropy.units as u
-
-try:
-    import scipy
-    HAS_SCIPY = True
-except ImportError:
-    HAS_SCIPY = False
+from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa
 
 
 @pytest.mark.parametrize(('expr', 'result'),

--- a/astropy/modeling/tests/test_constraints.py
+++ b/astropy/modeling/tests/test_constraints.py
@@ -13,12 +13,7 @@ from astropy.modeling.parameters import Parameter
 from astropy.modeling import models
 from astropy.modeling import fitting
 from astropy.utils.exceptions import AstropyUserWarning
-
-try:
-    from scipy import optimize
-    HAS_SCIPY = True
-except ImportError:
-    HAS_SCIPY = False
+from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa
 
 
 class TestNonLinearConstraints:
@@ -56,6 +51,8 @@ class TestNonLinearConstraints:
 
     @pytest.mark.skipif('not HAS_SCIPY')
     def test_joint_fitter(self):
+        from scipy import optimize
+
         g1 = models.Gaussian1D(10, 14.9, stddev=.3)
         g2 = models.Gaussian1D(10, 13, stddev=.4)
         jf = fitting.JointFitter([g1, g2], {g1: ['amplitude'],
@@ -86,6 +83,8 @@ class TestNonLinearConstraints:
 
     @pytest.mark.skipif('not HAS_SCIPY')
     def test_no_constraints(self):
+        from scipy import optimize
+
         g1 = models.Gaussian1D(9.9, 14.5, stddev=.3)
 
         def func(p, x):

--- a/astropy/modeling/tests/test_core.py
+++ b/astropy/modeling/tests/test_core.py
@@ -15,13 +15,7 @@ from astropy.modeling.parameters import Parameter
 from astropy.modeling import models
 import astropy.units as u
 from astropy.tests.helper import assert_quantity_allclose
-
-try:
-    import scipy  # pylint: disable=W0611 # noqa
-except ImportError:
-    HAS_SCIPY = False
-else:
-    HAS_SCIPY = True
+from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa
 
 
 class NonFittableModel(Model):

--- a/astropy/modeling/tests/test_fitters.py
+++ b/astropy/modeling/tests/test_fitters.py
@@ -26,15 +26,14 @@ from astropy.utils import NumpyRNGContext
 from astropy.utils.data import get_pkg_data_filename
 from astropy.stats import sigma_clip
 
+from astropy.utils.compat.optional_deps import HAS_SCIPY
 from astropy.utils.exceptions import AstropyUserWarning
 from astropy.modeling.fitting import populate_entry_points
 from . import irafutil
 
-try:
+if HAS_SCIPY:
     from scipy import optimize
-    HAS_SCIPY = True
-except ImportError:
-    HAS_SCIPY = False
+
 
 fitters = [SimplexLSQFitter, SLSQPLSQFitter]
 

--- a/astropy/modeling/tests/test_functional_models.py
+++ b/astropy/modeling/tests/test_functional_models.py
@@ -9,12 +9,7 @@ from astropy.modeling import models, InputParameterError
 from astropy.coordinates import Angle
 from astropy.modeling import fitting
 from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyUserWarning
-
-try:
-    from scipy.integrate import quad  # pylint: disable=W0611  # noqa
-    HAS_SCIPY = True
-except ImportError:
-    HAS_SCIPY = False
+from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa
 
 
 def test_sigma_constant():
@@ -261,6 +256,8 @@ def test_Voigt1D():
 @pytest.mark.parametrize('algorithm', ('humlicek2', 'wofz'))
 def test_Voigt1D_norm(algorithm):
     """Test integral of normalized Voigt profile."""
+    from scipy.integrate import quad
+
     voi = models.Voigt1D(amplitude_L=1.0/np.pi, x_0=0.0, fwhm_L=2.0, fwhm_G=1.5, method=algorithm)
     if algorithm == 'wofz':
         atol = 1e-14

--- a/astropy/modeling/tests/test_input.py
+++ b/astropy/modeling/tests/test_input.py
@@ -11,12 +11,7 @@ from astropy.modeling import models
 from astropy.modeling import fitting
 from astropy.modeling.core import Model, FittableModel, Fittable1DModel
 from astropy.modeling.parameters import Parameter
-
-try:
-    from scipy import optimize  # pylint: disable=W0611 # noqa
-    HAS_SCIPY = True
-except ImportError:
-    HAS_SCIPY = False
+from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa
 
 
 model1d_params = [

--- a/astropy/modeling/tests/test_mappings.py
+++ b/astropy/modeling/tests/test_mappings.py
@@ -7,12 +7,7 @@ from numpy.testing import assert_allclose, assert_array_equal
 from astropy.modeling.fitting import LevMarLSQFitter
 from astropy.modeling.models import Shift, Rotation2D, Gaussian1D, Identity, Mapping
 from astropy.utils import NumpyRNGContext
-
-try:
-    from scipy import optimize  # pylint: disable=W0611
-    HAS_SCIPY = True
-except ImportError:
-    HAS_SCIPY = False
+from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa
 
 
 def test_swap_axes():

--- a/astropy/modeling/tests/test_models.py
+++ b/astropy/modeling/tests/test_models.py
@@ -20,12 +20,7 @@ from astropy.utils import minversion
 from astropy.tests.helper import assert_quantity_allclose
 from astropy.utils import NumpyRNGContext
 from .example_models import models_1D, models_2D
-
-try:
-    import scipy
-    HAS_SCIPY = True
-except ImportError:
-    HAS_SCIPY = False
+from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa
 
 
 @pytest.mark.skipif('not HAS_SCIPY')

--- a/astropy/modeling/tests/test_models_quantities.py
+++ b/astropy/modeling/tests/test_models_quantities.py
@@ -6,6 +6,7 @@ import numpy as np
 
 from astropy import units as u
 from astropy.tests.helper import assert_quantity_allclose
+from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa
 
 from astropy.modeling.functional_models import (
     Gaussian1D,
@@ -26,12 +27,6 @@ from astropy.modeling.powerlaws import (
 from astropy.modeling.polynomial import Polynomial1D, Polynomial2D
 
 from astropy.modeling.fitting import LevMarLSQFitter
-
-try:
-    from scipy import optimize  # noqa
-    HAS_SCIPY = True
-except ImportError:
-    HAS_SCIPY = False
 
 FUNC_MODELS_1D = [
 {'class': Gaussian1D,

--- a/astropy/modeling/tests/test_physical_models.py
+++ b/astropy/modeling/tests/test_physical_models.py
@@ -11,13 +11,8 @@ from astropy.tests.helper import assert_quantity_allclose
 from astropy import units as u
 from astropy.utils.exceptions import AstropyUserWarning
 from astropy import cosmology
+from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa
 
-try:
-    from scipy import optimize, integrate  # noqa
-
-    HAS_SCIPY = True
-except ImportError:
-    HAS_SCIPY = False
 
 __doctest_skip__ = ["*"]
 

--- a/astropy/modeling/tests/test_polynomial.py
+++ b/astropy/modeling/tests/test_polynomial.py
@@ -23,13 +23,7 @@ from astropy.modeling.functional_models import Linear1D
 from astropy.modeling.mappings import Identity
 from astropy.utils.data import get_pkg_data_filename
 from astropy.utils.exceptions import AstropyUserWarning
-
-try:
-    from scipy import optimize  # pylint: disable=W0611 # noqa
-    HAS_SCIPY = True
-except ImportError:
-    HAS_SCIPY = False
-
+from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa
 
 linear1d = {
     Chebyshev1D: {

--- a/astropy/modeling/tests/test_quantities_fitting.py
+++ b/astropy/modeling/tests/test_quantities_fitting.py
@@ -14,12 +14,7 @@ from astropy.modeling import fitting
 from astropy.modeling import models
 from astropy.modeling.core import Fittable1DModel
 from astropy.modeling.parameters import Parameter
-
-try:
-    from scipy import optimize  # noqa
-    HAS_SCIPY = True
-except ImportError:
-    HAS_SCIPY = False
+from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa
 
 
 # Fitting should be as intuitive as possible to the user. Essentially, models

--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -1274,17 +1274,7 @@ def _kraft_burrows_nousek(N, B, CL):
     <http://mpmath.org/>`_  need to be available. (Scipy only works for
     N < 100).
     '''
-    try:
-        import scipy  # noqa
-        HAS_SCIPY = True
-    except ImportError:
-        HAS_SCIPY = False
-
-    try:
-        import mpmath  # noqa
-        HAS_MPMATH = True
-    except ImportError:
-        HAS_MPMATH = False
+    from astropy.utils.compat.optional_deps import HAS_SCIPY, HAS_MPMATH
 
     if HAS_SCIPY and N <= 100:
         try:

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -4,16 +4,12 @@ import warnings
 
 import numpy as np
 
+from astropy.units import Quantity
 from astropy.utils import isiterable
 from astropy.utils.exceptions import AstropyUserWarning
-
-
-try:
-    import bottleneck  # pylint: disable=W0611
-    HAS_BOTTLENECK = True
-    from astropy.units import Quantity
-except ImportError:
-    HAS_BOTTLENECK = False
+from astropy.utils.compat.optional_deps import HAS_BOTTLENECK
+if HAS_BOTTLENECK:
+    import bottleneck
 
 
 __all__ = ['SigmaClip', 'sigma_clip', 'sigma_clipped_stats']

--- a/astropy/stats/tests/test_circstats.py
+++ b/astropy/stats/tests/test_circstats.py
@@ -5,13 +5,7 @@ import numpy as np
 from numpy.testing import assert_equal, assert_allclose
 
 from astropy import units as u
-
-try:
-    import scipy.stats
-except ImportError:
-    HAS_SCIPY = False
-else:
-    HAS_SCIPY = True
+from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa
 
 from astropy.stats.circstats import _length, circmean, circvar, circmoment, circcorrcoef
 from astropy.stats.circstats import rayleightest, vtest, vonmisesmle
@@ -36,6 +30,8 @@ def test_circmean():
 
 @pytest.mark.skipif('not HAS_SCIPY')
 def test_circmean_against_scipy():
+    import scipy.stats
+
     # testing against scipy.stats.circmean function
     # the data is the same as the test before, but in radians
     data = np.array([0.89011792, 1.1693706, 0.6981317, 1.90240888, 0.54105207,

--- a/astropy/stats/tests/test_funcs.py
+++ b/astropy/stats/tests/test_funcs.py
@@ -5,19 +5,7 @@ import pytest
 import numpy as np
 from numpy.testing import assert_equal, assert_allclose
 
-try:
-    import scipy  # pylint: disable=W0611 # noqa
-except ImportError:
-    HAS_SCIPY = False
-else:
-    HAS_SCIPY = True
-
-try:
-    import mpmath  # pylint: disable=W0611 # noqa
-except ImportError:
-    HAS_MPMATH = False
-else:
-    HAS_MPMATH = True
+from astropy.utils.compat.optional_deps import HAS_SCIPY, HAS_MPMATH  # noqa
 
 from astropy.stats import funcs
 from astropy import units as u
@@ -743,6 +731,8 @@ def test_detect_kuiper_two_different():
                                  (5, 5),
                                  (1000, 100)])
 def test_fpp_kuiper_two(N, M):
+    from scipy.stats import binom
+
     with NumpyRNGContext(12345):
         R = 100
         fpp = 0.05
@@ -751,12 +741,14 @@ def test_fpp_kuiper_two(N, M):
             D, f = funcs.kuiper_two(np.random.random(N), np.random.random(M))
             if f < fpp:
                 fps += 1
-        assert scipy.stats.binom(R, fpp).sf(fps - 1) > 0.005
-        assert scipy.stats.binom(R, fpp).cdf(fps - 1) > 0.005
+        assert binom(R, fpp).sf(fps - 1) > 0.005
+        assert binom(R, fpp).cdf(fps - 1) > 0.005
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
 def test_histogram():
+    from scipy.stats import chi2
+
     with NumpyRNGContext(1234):
         a, b = 0.3, 3.14
         s = np.random.uniform(a, b, 10000) % 1
@@ -771,8 +763,8 @@ def test_histogram():
 
         c2 = np.sum(((nn - 1) / uu)**2)
 
-        assert scipy.stats.chi2(len(h)).cdf(c2) > 0.01
-        assert scipy.stats.chi2(len(h)).sf(c2) > 0.01
+        assert chi2(len(h)).cdf(c2) > 0.01
+        assert chi2(len(h)).sf(c2) > 0.01
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
@@ -805,11 +797,13 @@ def test_uniform_binomial(N, m, p):
     but the longer the runtime.
 
     """
+    from scipy.stats import binom
+
     with NumpyRNGContext(1234):
         fpps = np.array([funcs.kuiper(np.random.random(N))[1]
                          for i in range(m)])
         assert (fpps >= 0).all()
         assert (fpps <= 1).all()
-        low = scipy.stats.binom(n=m, p=p).ppf(0.01)
-        high = scipy.stats.binom(n=m, p=p).ppf(0.99)
+        low = binom(n=m, p=p).ppf(0.01)
+        high = binom(n=m, p=p).ppf(0.99)
         assert (low < sum(fpps < p) < high)

--- a/astropy/stats/tests/test_histogram.py
+++ b/astropy/stats/tests/test_histogram.py
@@ -9,13 +9,7 @@ from numpy.testing import assert_allclose
 from astropy.stats import (histogram, calculate_bin_edges, scott_bin_width,
                            freedman_bin_width, knuth_bin_width)
 from astropy.utils.exceptions import AstropyUserWarning
-
-try:
-    import scipy  # pylint: disable=W0611 # noqa
-except ImportError:
-    HAS_SCIPY = False
-else:
-    HAS_SCIPY = True
+from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa
 
 
 def test_scott_bin_width(N=10000, rseed=0):

--- a/astropy/stats/tests/test_jackknife.py
+++ b/astropy/stats/tests/test_jackknife.py
@@ -4,15 +4,9 @@ import pytest
 import numpy as np
 from numpy.testing import assert_equal, assert_allclose
 
-try:
-    import scipy  # pylint: disable=W0611 # noqa
-except ImportError:
-    HAS_SCIPY = False
-else:
-    HAS_SCIPY = True
-
 from astropy.stats.jackknife import jackknife_resampling, jackknife_stats
 from astropy.utils.exceptions import AstropyDeprecationWarning
+from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa
 
 
 def test_jackknife_resampling():

--- a/astropy/stats/tests/test_sigma_clipping.py
+++ b/astropy/stats/tests/test_sigma_clipping.py
@@ -4,17 +4,11 @@ import pytest
 import numpy as np
 from numpy.testing import assert_equal, assert_allclose
 
-try:
-    from scipy import stats  # used in testing
-except ImportError:
-    HAS_SCIPY = False
-else:
-    HAS_SCIPY = True
-
 from astropy import units as u
 from astropy.stats.sigma_clipping import sigma_clip, SigmaClip, sigma_clipped_stats
 from astropy.utils.exceptions import AstropyUserWarning
 from astropy.utils.misc import NumpyRNGContext
+from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa
 
 
 def test_sigma_clip():
@@ -66,9 +60,10 @@ def test_sigma_clip():
 
 @pytest.mark.skipif('not HAS_SCIPY')
 def test_compare_to_scipy_sigmaclip():
+    from scipy import stats
+
     # need to seed the numpy RNG to make sure we don't get some
     # amazingly flukey random number that breaks one of the tests
-
     with NumpyRNGContext(12345):
 
         randvar = np.random.randn(10000)

--- a/astropy/table/soco.py
+++ b/astropy/table/soco.py
@@ -7,12 +7,10 @@ Index engine for Tables.
 
 from collections import OrderedDict
 from itertools import starmap
+from astropy.utils.compat.optional_deps import HAS_SORTEDCONTAINERS
 
-try:
+if HAS_SORTEDCONTAINERS:
     from sortedcontainers import SortedList
-    HAS_SOCO = True
-except ImportError:
-    HAS_SOCO = False
 
 
 class Node(object):

--- a/astropy/table/tests/test_index.py
+++ b/astropy/table/tests/test_index.py
@@ -8,16 +8,17 @@ import numpy as np
 from .test_table import SetupData
 from astropy.table.bst import BST
 from astropy.table.sorted_array import SortedArray
-from astropy.table.soco import SCEngine, HAS_SOCO
+from astropy.table.soco import SCEngine
 from astropy.table import QTable, Row, Table, Column, hstack
 from astropy import units as u
 from astropy.time import Time
 from astropy.table.column import BaseColumn
 from astropy.table.index import get_index, SlicedIndex
+from astropy.utils.compat.optional_deps import HAS_SORTEDCONTAINERS
 
 available_engines = [BST, SortedArray]
 
-if HAS_SOCO:
+if HAS_SORTEDCONTAINERS:
     available_engines.append(SCEngine)
 
 

--- a/astropy/table/tests/test_jsviewer.py
+++ b/astropy/table/tests/test_jsviewer.py
@@ -9,18 +9,7 @@ from astropy.time import Time
 from astropy.table.table import Table
 from astropy import extern
 
-try:
-    import bleach  # noqa
-    HAS_BLEACH = True
-except ImportError:
-    HAS_BLEACH = False
-
-try:
-    import IPython  # noqa
-except ImportError:
-    HAS_IPYTHON = False
-else:
-    HAS_IPYTHON = True
+from astropy.utils.compat.optional_deps import HAS_BLEACH, HAS_IPYTHON  # noqa
 
 EXTERN_DIR = abspath(join(dirname(extern.__file__), 'jquery', 'data'))
 

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -1,18 +1,6 @@
 # -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-try:
-    import h5py  # pylint: disable=W0611 # noqa
-except ImportError:
-    HAS_H5PY = False
-else:
-    HAS_H5PY = True
-
-try:
-    import yaml  # pylint: disable=W0611 # noqa
-    HAS_YAML = True
-except ImportError:
-    HAS_YAML = False
 
 import copy
 import pickle
@@ -33,6 +21,7 @@ from astropy.utils.exceptions import AstropyUserWarning
 from astropy.utils.metadata import MergeConflictWarning
 from astropy.coordinates.tests.test_representation import representation_equal
 from astropy.io.misc.asdf.tags.helpers import skycoord_equal
+from astropy.utils.compat.optional_deps import HAS_YAML
 
 from .conftest import MIXIN_COLS
 

--- a/astropy/table/tests/test_operations.py
+++ b/astropy/table/tests/test_operations.py
@@ -20,12 +20,7 @@ from astropy.coordinates import (SkyCoord, SphericalRepresentation,
                                  search_around_3d)
 from astropy.coordinates.tests.test_representation import representation_equal
 from astropy.io.misc.asdf.tags.helpers import skycoord_equal
-
-try:
-    import scipy  # noqa
-    HAS_SCIPY = True
-except ImportError:
-    HAS_SCIPY = False
+from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa
 
 
 def sort_eq(list1, list2):

--- a/astropy/table/tests/test_pprint.py
+++ b/astropy/table/tests/test_pprint.py
@@ -12,15 +12,10 @@ from astropy.table import Table, QTable
 from astropy.table.table_helpers import simple_table
 from astropy import units as u
 from astropy.utils import console
+from astropy.utils.compat.optional_deps import HAS_YAML  # noqa
 
 BIG_WIDE_ARR = np.arange(2000, dtype=np.float64).reshape(100, 20)
 SMALL_ARR = np.arange(18, dtype=np.int64).reshape(6, 3)
-
-try:
-    import yaml  # noqa
-    HAS_YAML = True
-except ImportError:
-    HAS_YAML = False
 
 
 @pytest.mark.usefixtures('table_type')

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -25,18 +25,7 @@ from astropy import units as u
 from astropy.time import Time, TimeDelta
 from .conftest import MaskedTable, MIXIN_COLS
 
-try:
-    import pandas  # noqa
-except ImportError:
-    HAS_PANDAS = False
-else:
-    HAS_PANDAS = True
-
-try:
-    import yaml  # noqa
-    HAS_YAML = True
-except ImportError:
-    HAS_YAML = False
+from astropy.utils.compat.optional_deps import HAS_PANDAS, HAS_YAML  # noqa
 
 
 class SetupData:

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -20,12 +20,7 @@ from astropy.time import (Time, TimeDelta, ScaleValueError, STANDARD_TIME_SCALES
 from astropy.coordinates import EarthLocation
 from astropy import units as u
 from astropy.table import Column, Table
-
-try:
-    import pytz
-    HAS_PYTZ = True
-except ImportError:
-    HAS_PYTZ = False
+from astropy.utils.compat.optional_deps import HAS_PYTZ  # noqa
 
 
 allclose_jd = functools.partial(np.allclose, rtol=np.finfo(float).eps, atol=0)
@@ -1550,7 +1545,7 @@ def test_to_datetime():
 
 @pytest.mark.skipif('not HAS_PYTZ')
 def test_to_datetime_pytz():
-
+    import pytz
     tz = pytz.timezone('US/Hawaii')
     time = Time('2010-09-03 00:00:00')
     tz_aware_datetime = time.to_datetime(tz)

--- a/astropy/time/tests/test_corrs.py
+++ b/astropy/time/tests/test_corrs.py
@@ -5,13 +5,7 @@ from astropy import units as u
 from astropy.coordinates import EarthLocation, SkyCoord, solar_system_ephemeris
 from astropy.time import Time, TimeDelta
 from astropy.utils import iers
-
-try:
-    import jplephem  # pylint: disable=W0611  # noqa
-except ImportError:
-    HAS_JPLEPHEM = False
-else:
-    HAS_JPLEPHEM = True
+from astropy.utils.compat.optional_deps import HAS_JPLEPHEM  # noqa
 
 
 class TestHelioBaryCentric:

--- a/astropy/time/tests/test_mask.py
+++ b/astropy/time/tests/test_mask.py
@@ -9,19 +9,7 @@ from astropy import units as u
 from astropy.utils import iers
 from astropy.time import Time
 from astropy.table import Table
-
-try:
-    import h5py  # pylint: disable=W0611  # noqa
-except ImportError:
-    HAS_H5PY = False
-else:
-    HAS_H5PY = True
-
-try:
-    import yaml  # pylint: disable=W0611  # noqa
-    HAS_YAML = True
-except ImportError:
-    HAS_YAML = False
+from astropy.utils.compat.optional_deps import HAS_H5PY, HAS_YAML
 
 allclose_sec = functools.partial(np.allclose, rtol=2. ** -52,
                                  atol=2. ** -52 * 24 * 3600)  # 20 ps atol

--- a/astropy/timeseries/periodograms/lombscargle/tests/test_statistics.py
+++ b/astropy/timeseries/periodograms/lombscargle/tests/test_statistics.py
@@ -2,18 +2,13 @@ import numpy as np
 import pytest
 from numpy.testing import assert_allclose
 
-try:
-    import scipy
-except ImportError:
-    HAS_SCIPY = False
-else:
-    HAS_SCIPY = True
-
 import astropy.units as u
 from astropy.timeseries.periodograms.lombscargle import LombScargle
 from astropy.timeseries.periodograms.lombscargle._statistics import (fap_single, inv_fap_single,
                                                                      METHODS)
 from astropy.timeseries.periodograms.lombscargle.utils import convert_normalization, compute_chi2_ref
+
+from astropy.utils.compat.optional_deps import HAS_SCIPY
 
 METHOD_KWDS = dict(bootstrap={'n_bootstraps': 20, 'random_seed': 42})
 NORMALIZATIONS = ['standard', 'psd', 'log', 'model']

--- a/astropy/uncertainty/tests/test_distribution.py
+++ b/astropy/uncertainty/tests/test_distribution.py
@@ -8,14 +8,11 @@ from astropy.uncertainty.core import Distribution
 from astropy.uncertainty import distributions as ds
 from astropy.utils import NumpyRNGContext
 from astropy.tests.helper import assert_quantity_allclose
+from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa
 
-try:
+if HAS_SCIPY:
     from scipy.stats import norm  # pylint: disable=W0611
     SMAD_FACTOR = 1 / norm.ppf(0.75)
-except ImportError:
-    HAS_SCIPY = False
-else:
-    HAS_SCIPY = True
 
 
 def test_numpy_init():

--- a/astropy/units/tests/test_quantity_ufuncs.py
+++ b/astropy/units/tests/test_quantity_ufuncs.py
@@ -15,14 +15,7 @@ from astropy import units as u
 from astropy.units import quantity_helper as qh
 from astropy.units.quantity_helper.converters import UfuncHelpers
 from astropy.units.quantity_helper.helpers import helper_sqrt
-
-
-try:
-    import scipy  # pylint: disable=W0611 # noqa
-except ImportError:
-    HAS_SCIPY = False
-else:
-    HAS_SCIPY = True
+from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa
 
 
 testcase = namedtuple('testcase', ['f', 'q_in', 'q_out'])

--- a/astropy/utils/compat/optional_deps.py
+++ b/astropy/utils/compat/optional_deps.py
@@ -4,15 +4,20 @@
 """
 import importlib
 
-# TODO: This is a duplicate of the dependencies in setup.cfg "all", but some of
-# the package names are different from the pip-install name (e.g.,
+# First, the top-level packages:
+# TODO: This list is a duplicate of the dependencies in setup.cfg "all", but
+# some of the package names are different from the pip-install name (e.g.,
 # beautifulsoup4 -> bs4).
 _optional_deps = ['bleach', 'bottleneck', 'bs4', 'bz2', 'h5py', 'html5lib',
                   'IPython', 'jplephem', 'lxml', 'matplotlib', 'mpmath',
                   'pandas', 'PIL', 'pkg_resources', 'pytz', 'scipy', 'skyfield',
                   'sortedcontainers', 'lzma', 'yaml']
+_deps = {k: k for k in _optional_deps}
 
-__all__ = [f"HAS_{pkg}" for pkg in _optional_deps]
+# Any subpackages that have different import behavior:
+_deps['plt'] = 'matplotlib.pyplot'
+
+__all__ = [f"HAS_{pkg}" for pkg in _deps]
 
 
 def __getattr__(name):
@@ -20,7 +25,7 @@ def __getattr__(name):
         module_name = name[4:]
 
         try:
-            importlib.import_module(module_name)
+            importlib.import_module(_deps[module_name])
         except (ImportError, ModuleNotFoundError):
             return False
         return True

--- a/astropy/utils/compat/optional_deps.py
+++ b/astropy/utils/compat/optional_deps.py
@@ -1,0 +1,26 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""Checks for optional dependencies using lazy import from
+`PEP 562 <https://www.python.org/dev/peps/pep-0562/>`_.
+"""
+import importlib
+
+
+__all__ = [  # noqa
+    'HAS_bleach', 'HAS_bottleneck', 'HAS_bs4', 'HAS_bz2', 'HAS_h5py',
+    'HAS_html5lib', 'HAS_IPython', 'HAS_jplephem', 'HAS_lxml', 'HAS_matplotlib',
+    'HAS_mpmath', 'HAS_pandas', 'HAS_PIL', 'HAS_pkg_resources', 'HAS_pytz',
+    'HAS_scipy', 'HAS_skyfield', 'HAS_sortedcontainers', 'HAS_lzma', 'HAS_yaml'
+]
+
+
+def __getattr__(name):
+    if name in __all__:
+        module_name = name[4:]
+
+        try:
+            importlib.import_module(module_name)
+        except (ImportError, ModuleNotFoundError):
+            return False
+        return True
+
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/astropy/utils/compat/optional_deps.py
+++ b/astropy/utils/compat/optional_deps.py
@@ -4,13 +4,15 @@
 """
 import importlib
 
+# TODO: This is a duplicate of the dependencies in setup.cfg "all", but some of
+# the package names are different from the pip-install name (e.g.,
+# beautifulsoup4 -> bs4).
+_optional_deps = ['bleach', 'bottleneck', 'bs4', 'bz2', 'h5py', 'html5lib',
+                  'IPython', 'jplephem', 'lxml', 'matplotlib', 'mpmath',
+                  'pandas', 'PIL', 'pkg_resources', 'pytz', 'scipy', 'skyfield',
+                  'sortedcontainers', 'lzma', 'yaml']
 
-__all__ = [  # noqa
-    'HAS_bleach', 'HAS_bottleneck', 'HAS_bs4', 'HAS_bz2', 'HAS_h5py',
-    'HAS_html5lib', 'HAS_IPython', 'HAS_jplephem', 'HAS_lxml', 'HAS_matplotlib',
-    'HAS_mpmath', 'HAS_pandas', 'HAS_PIL', 'HAS_pkg_resources', 'HAS_pytz',
-    'HAS_scipy', 'HAS_skyfield', 'HAS_sortedcontainers', 'HAS_lzma', 'HAS_yaml'
-]
+__all__ = [f"HAS_{pkg}" for pkg in _optional_deps]
 
 
 def __getattr__(name):
@@ -23,4 +25,8 @@ def __getattr__(name):
             return False
         return True
 
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    # I don't think we can ever get here, because if a name doesn't exist, it
+    # should fail to import from this module. But adding this for safety!
+    raise AttributeError(f"Module {__name__!r} has no attribute {name!r}. To "
+                         "add support for checking if a package name is "
+                         "available for import, add the package name")

--- a/astropy/utils/compat/optional_deps.py
+++ b/astropy/utils/compat/optional_deps.py
@@ -10,12 +10,12 @@ import importlib
 # beautifulsoup4 -> bs4).
 _optional_deps = ['bleach', 'bottleneck', 'bs4', 'bz2', 'h5py', 'html5lib',
                   'IPython', 'jplephem', 'lxml', 'matplotlib', 'mpmath',
-                  'pandas', 'PIL', 'pkg_resources', 'pytz', 'scipy', 'skyfield',
+                  'pandas', 'PIL', 'pytz', 'scipy', 'skyfield',
                   'sortedcontainers', 'lzma', 'yaml']
-_deps = {k: k for k in _optional_deps}
+_deps = {k.upper(): k for k in _optional_deps}
 
 # Any subpackages that have different import behavior:
-_deps['plt'] = 'matplotlib.pyplot'
+_deps['PLT'] = 'matplotlib.pyplot'
 
 __all__ = [f"HAS_{pkg}" for pkg in _deps]
 
@@ -30,8 +30,4 @@ def __getattr__(name):
             return False
         return True
 
-    # I don't think we can ever get here, because if a name doesn't exist, it
-    # should fail to import from this module. But adding this for safety!
-    raise AttributeError(f"Module {__name__!r} has no attribute {name!r}. To "
-                         "add support for checking if a package name is "
-                         "available for import, add the package name")
+    raise AttributeError(f"Module {__name__!r} has no attribute {name!r}.")

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -65,19 +65,7 @@ TESTURL2 = "http://www.astropy.org/about.html"
 TESTLOCAL = get_pkg_data_filename(os.path.join("data", "local.dat"))
 
 # NOTE: Python can be built without bz2 or lzma.
-try:
-    import bz2  # noqa
-except ImportError:
-    HAS_BZ2 = False
-else:
-    HAS_BZ2 = True
-
-try:
-    import lzma  # noqa
-except ImportError:
-    HAS_XZ = False
-else:
-    HAS_XZ = True
+from astropy.utils.compat.optional_deps import HAS_BZ2, HAS_LZMA
 
 # For when we need "some" test URLs
 FEW = 5
@@ -917,7 +905,8 @@ def test_get_invalid(package):
     ("filename"), ["local.dat", "local.dat.gz", "local.dat.bz2", "local.dat.xz"]
 )
 def test_local_data_obj(filename):
-    if (not HAS_BZ2 and "bz2" in filename) or (not HAS_XZ and "xz" in filename):
+    if ((not HAS_BZ2 and "bz2" in filename) or
+            (not HAS_LZMA and "xz" in filename)):
         with pytest.raises(ValueError) as e:
             with get_pkg_data_fileobj(
                 os.path.join("data", filename), encoding="binary"
@@ -966,7 +955,7 @@ def test_local_data_obj_invalid(bad_compressed):
     # they're not local anymore: they just live in a temporary directory
     # created by pytest. However, we can still use get_readable_fileobj for the
     # test.
-    if (not HAS_BZ2 and is_bz2) or (not HAS_XZ and is_xz):
+    if (not HAS_BZ2 and is_bz2) or (not HAS_LZMA and is_xz):
         with pytest.raises(ModuleNotFoundError,
                            match=r'does not provide the [lb]z[2m]a? module\.'):
             with get_readable_fileobj(bad_compressed, encoding="binary") as f:
@@ -1124,7 +1113,7 @@ def test_data_noastropy_fallback(monkeypatch):
         ),
         pytest.param(
             "unicode.txt.xz",
-            marks=pytest.mark.xfail(not HAS_XZ, reason="no lzma support"),
+            marks=pytest.mark.xfail(not HAS_LZMA, reason="no lzma support"),
         ),
     ],
 )

--- a/astropy/utils/tests/test_xml.py
+++ b/astropy/utils/tests/test_xml.py
@@ -5,12 +5,7 @@ import io
 import pytest
 
 from astropy.utils.xml import check, unescaper, writer
-
-try:
-    import bleach  # noqa
-    HAS_BLEACH = True
-except ImportError:
-    HAS_BLEACH = False
+from astropy.utils.compat.optional_deps import HAS_BLEACH  # noqa
 
 
 def test_writer():

--- a/astropy/visualization/scripts/tests/test_fits2bitmap.py
+++ b/astropy/visualization/scripts/tests/test_fits2bitmap.py
@@ -4,14 +4,12 @@ import pytest
 import numpy as np
 
 from astropy.io import fits
+from astropy.utils.compat.optional_deps import HAS_MATPLOTLIB
 
-try:
-    import matplotlib  # pylint: disable=W0611
+
+if HAS_MATPLOTLIB:
     import matplotlib.image as mpimg
-    HAS_MATPLOTLIB = True
     from astropy.visualization.scripts.fits2bitmap import fits2bitmap, main
-except ImportError:
-    HAS_MATPLOTLIB = False
 
 
 @pytest.mark.skipif('not HAS_MATPLOTLIB')

--- a/astropy/visualization/tests/test_histogram.py
+++ b/astropy/visualization/tests/test_histogram.py
@@ -3,17 +3,9 @@
 
 from numpy.testing import assert_allclose
 
-try:
+from astropy.utils.compat.optional_deps import HAS_PLT, HAS_SCIPY
+if HAS_PLT:
     import matplotlib.pyplot as plt
-    HAS_PLT = True
-except ImportError:
-    HAS_PLT = False
-
-try:
-    import scipy  # noqa
-    HAS_SCIPY = True
-except ImportError:
-    HAS_SCIPY = False
 
 import pytest
 import numpy as np

--- a/astropy/visualization/tests/test_lupton_rgb.py
+++ b/astropy/visualization/tests/test_lupton_rgb.py
@@ -15,12 +15,7 @@ from numpy.testing import assert_equal
 
 from astropy.convolution import convolve, Gaussian2DKernel
 from astropy.visualization import lupton_rgb
-
-try:
-    import matplotlib  # noqa
-    HAS_MATPLOTLIB = True
-except ImportError:
-    HAS_MATPLOTLIB = False
+from astropy.utils.compat.optional_deps import HAS_MATPLOTLIB  # noqa
 
 # Set display=True to get matplotlib imshow windows to help with debugging.
 display = False

--- a/astropy/visualization/tests/test_norm.py
+++ b/astropy/visualization/tests/test_norm.py
@@ -10,14 +10,11 @@ from astropy.utils.exceptions import AstropyDeprecationWarning
 from astropy.visualization.mpl_normalize import ImageNormalize, simple_norm, imshow_norm
 from astropy.visualization.interval import ManualInterval, PercentileInterval
 from astropy.visualization.stretch import LogStretch, PowerStretch, SqrtStretch
+from astropy.utils.compat.optional_deps import HAS_MATPLOTLIB, HAS_PLT  # noqa
 
-try:
-    import matplotlib    # pylint: disable=W0611
-    from matplotlib import pyplot as plt
-    HAS_MATPLOTLIB = True
+if HAS_MATPLOTLIB:
+    import matplotlib
     MATPLOTLIB_LT_32 = Version(matplotlib.__version__) < Version('3.2')
-except ImportError:
-    HAS_MATPLOTLIB = False
 
 DATA = np.linspace(0., 15., 6)
 DATA2 = np.arange(3)
@@ -263,8 +260,9 @@ class TestImageScaling:
             simple_norm(DATA2, stretch='invalid')
 
 
-@pytest.mark.skipif('not HAS_MATPLOTLIB')
+@pytest.mark.skipif('not HAS_PLT')
 def test_imshow_norm():
+    import matplotlib.pyplot as plt
     image = np.random.randn(10, 10)
 
     ax = plt.subplot(label='test_imshow_norm')

--- a/astropy/visualization/tests/test_units.py
+++ b/astropy/visualization/tests/test_units.py
@@ -5,12 +5,9 @@ import io
 
 import pytest
 
-try:
+from astropy.utils.compat.optional_deps import HAS_PLT
+if HAS_PLT:
     import matplotlib.pyplot as plt
-except ImportError:
-    HAS_PLT = False
-else:
-    HAS_PLT = True
 
 from astropy import units as u
 from astropy.coordinates import Angle

--- a/astropy/wcs/tests/test_utils.py
+++ b/astropy/wcs/tests/test_utils.py
@@ -34,13 +34,7 @@ from astropy.wcs.utils import (proj_plane_pixel_scales,
                                _pixel_to_world_correlation_matrix,
                                local_partial_pixel_derivatives,
                                fit_wcs_from_points)
-
-try:
-    import scipy  # noqa
-except ImportError:
-    HAS_SCIPY = False
-else:
-    HAS_SCIPY = True
+from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa
 
 
 def test_wcs_dropping():

--- a/docs/changes/utils/11490.other.rst
+++ b/docs/changes/utils/11490.other.rst
@@ -1,0 +1,2 @@
+Added a new module at ``astropy.utils.compat.optional_deps`` to consolidate the
+definition of ``HAS_x`` optional dependency flag variables, like ``HAS_SCIPY``.

--- a/docs/development/testguide.rst
+++ b/docs/development/testguide.rst
@@ -646,11 +646,11 @@ Tests requiring optional dependencies
 =====================================
 
 For tests that test functions or methods that require optional dependencies
-(e.g. Scipy), pytest should be instructed to skip the test if the dependencies
-are not present, as the Astropy tests should succeed even if an optional
-dependency is not present. Astropy provides a list of boolean flags that test
-whether optional dependencies are installed (at import time). For example, to
-load the corresponding flag for Scipy and mark a test to skip if Scipy is not
+(e.g., Scipy), pytest should be instructed to skip the test if the dependencies
+are not present, as the ``astropy`` tests should succeed even if an optional
+dependency is not present. ``astropy`` provides a list of boolean flags that
+test whether optional dependencies are installed (at import time). For example,
+to load the corresponding flag for Scipy and mark a test to skip if Scipy is not
 present, use::
 
     import pytest

--- a/docs/development/testguide.rst
+++ b/docs/development/testguide.rst
@@ -645,26 +645,24 @@ failure to be reported.
 Tests requiring optional dependencies
 =====================================
 
-For tests that test functions or methods that require optional
-dependencies (e.g. Scipy), pytest should be instructed to skip the
-test if the dependencies are not present. The following example shows
-how this should be done::
+For tests that test functions or methods that require optional dependencies
+(e.g. Scipy), pytest should be instructed to skip the test if the dependencies
+are not present, as the Astropy tests should succeed even if an optional
+dependency is not present. Astropy provides a list of boolean flags that test
+whether optional dependencies are installed (at import time). For example, to
+load the corresponding flag for Scipy and mark a test to skip if Scipy is not
+present, use::
 
     import pytest
-
-    try:
-        import scipy
-        HAS_SCIPY = True
-    except ImportError:
-        HAS_SCIPY = False
+    from astropy.utils.compat.optional_deps import HAS_SCIPY
 
     @pytest.mark.skipif('not HAS_SCIPY')
     def test_that_uses_scipy():
         ...
 
-In this way, the test is run if Scipy is present, and skipped if
-not. No tests should fail simply because an optional dependency is not
-present.
+These variables should exist for all of Astropy's optional dependencies; a
+complete list of supported flags can be found in
+``astropy.utils.compat.optional_deps``.
 
 Using pytest helper functions
 =============================

--- a/docs/development/testguide.rst
+++ b/docs/development/testguide.rst
@@ -656,7 +656,7 @@ present, use::
     import pytest
     from astropy.utils.compat.optional_deps import HAS_SCIPY
 
-    @pytest.mark.skipif('not HAS_SCIPY')
+    @pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
     def test_that_uses_scipy():
         ...
 


### PR DESCRIPTION
This PR centralizes the definition of `HAS_x` optional dependency package import checking, such as `HAS_matplotlib`. Now that astropy requires Python 3.7+, we can make use of lazy imports as implemented in [PEP 0562](https://www.python.org/dev/peps/pep-0562/) and as demonstrated by @pllim in [this comment](https://github.com/astropy/astropy/issues/4630#issuecomment-627458639). This implementation is similar to what @pllim suggested, but with some extra flexibility to support flags that check subpackage imports that have different behavior than the top-level package import (e.g., `matplotlib.pyplot`). The actual implementation is in the new file `astropy/utils/compat/optional_deps.py` and was added in the first two commits.

I decided to go with using the actual package names in the flag names (e.g., `HAS_matplotlib` not `HAS_MATPLOTLIB`) because there are cases where the case matters for a package name, like `PIL` or `IPython`.

This fixes #4630, and is relevant for a comment in #11361

cc @nstarman 