### PR TITLE
Fix isort config

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -164,7 +164,6 @@ known_numpy = numpy
 multi_line_output = 0
 balanced_wrapping = True
 include_trailing_comma = false
-length_sort_stdlib = true
 
 [coverage:run]
 omit =


### PR DESCRIPTION
Fix #11496. `length_sort_stdlib` no more works with a recent version of isort.
