### PR TITLE
Add packaging as dependency for tests and doc

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -61,6 +61,7 @@ test =
     coverage
     skyfield>=1.20
     sgp4>=2.3
+    packaging
 all =
     scipy>=1.1
     dask[array]
@@ -87,6 +88,7 @@ docs =
     scipy>=1.1
     matplotlib>=3.1,!=3.4.0
     sphinx-changelog
+    packaging
 
 [options.package_data]
 * = data/*, data/*/*, data/*/*/*, data/*/*/*/*, data/*/*/*/*/*, data/*/*/*/*/*/*


### PR DESCRIPTION
Ref https://github.com/astropy/astropy/pull/11091#pullrequestreview-630266621
packaging is used in tests and the Sphinx config so we should list it
explicitly as a dependency, even if it's already a dependency for pytest
and Sphinx.
