### PR TITLE
units: allow return type annotations to contain non-unit types

### DIFF
--- a/astropy/units/decorators.py
+++ b/astropy/units/decorators.py
@@ -12,6 +12,7 @@ import numpy as np
 from astropy.utils.decorators import wraps
 from .core import (Unit, UnitBase, UnitsError, add_enabled_equivalencies,
                    dimensionless_unscaled)
+from .function.core import FunctionUnitBase
 from .physical import _unit_physical_mapping
 
 
@@ -252,7 +253,8 @@ class QuantityInput:
                 return_ = wrapped_function(*func_args, **func_kwargs)
 
             valid_empty = (inspect.Signature.empty, None)
-            if wrapped_signature.return_annotation not in valid_empty:
+            if (wrapped_signature.return_annotation not in valid_empty) and isinstance(
+                wrapped_signature.return_annotation, (str, UnitBase, FunctionUnitBase)):
                 return return_.to(wrapped_signature.return_annotation)
             else:
                 return return_

--- a/astropy/units/tests/test_quantity_annotations.py
+++ b/astropy/units/tests/test_quantity_annotations.py
@@ -224,6 +224,15 @@ def test_return_annotation_none():
     assert solarx is None
 
 
+def test_return_annotation_notUnit():
+    @u.quantity_input
+    def myfunc_args(solarx: u.arcsec) -> int:
+        return 0
+
+    solarx = myfunc_args(1*u.arcsec)
+    assert solarx == 0
+
+
 def test_enum_annotation():
     # Regression test for gh-9932
     from enum import Enum, auto

--- a/docs/changes/units/11506.bugfix.rst
+++ b/docs/changes/units/11506.bugfix.rst
@@ -1,0 +1,2 @@
+Decorator ``astropy.units.decorators.quantity_input`` now only evaluates return type annotations based on ``UnitBase`` or ``FunctionUnitBase`` types.
+Other annotations are skipped over and are not attempted to convert to the correct type.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
This pull request is provides a small, backportable bugfix to allow non-unit types to be used as return type annotations.
These non-unit types are then ignored by `@quantity_input` decorators, such that no conversion is attempted.

Fixes #10156
