### PR TITLE
Add _repr_latex_ method to table.Table and test for it, fix for #3972

### DIFF
--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -1521,6 +1521,31 @@ class Table:
     def __repr__(self):
         return self._base_repr_(html=False, max_width=None)
 
+    def _repr_latex_(self):
+        """
+        Format a Table object into the LaTeX format, and return it as a string.
+
+        Notes
+        -----
+        Uses `astropy.io.ascii.latex.Latex.write()` function to change
+        the Table format to LaTeX. The default LaTeX formatting options defined
+        in ``latex.Latex`` are assumed if the ``table.Table.meta`` dictionary
+        doesn't already contain a ``latexdict`` keyword.
+        See: `astropy.io.ascii.Latex`
+
+        A new key ``latexdict`` corresponding to ``Latex.latex`` dictionary of
+        ``astropy.io.ascii.latex`` object is added to ``table.Table.meta``.
+        It contains the LaTeX formatting options for the table used.
+        """
+        from astropy.io import ascii
+
+        latexdict = self.meta.get('latexdict', {})
+        lTable = ascii.latex.Latex(latexdict=latexdict)
+        lines = lTable.write(table=self)
+        self.meta['latexdict'] = lTable.latex
+
+        return '\n'.join(lines)
+
     def __str__(self):
         return '\n'.join(self.pformat())
 

--- a/astropy/table/tests/test_pprint.py
+++ b/astropy/table/tests/test_pprint.py
@@ -917,3 +917,42 @@ class TestColumnsShowHide:
         with t.pprint_exclude_names.set('a??'):
             out = t.pformat_all()
         assert out == exp
+
+
+def test_repr_latex():
+    """
+    Tests the _repr_latex_ method of astropy.table.Table class.
+    Output should be a latex formatted table returned as a string.
+    Test for PR related to issue #3972.
+    """
+    a = [1, 2, 3, 5]
+    b = np.array([4, 5, 6, 5])
+    c = ['hello', 'konichiwa', 'namaskar', 'guten morgen']
+    d = [2, 3, 5, 10] * u.m/u.s**2
+    t = Table([a, b, c, d], names=('val', 'val1', 'greeting', 'speed'))
+
+    lTable1 = [r'\begin{table}',
+               r'\begin{tabular}{cccc}',
+               r'val & val1 & greeting & speed \\',
+               r' &  &  & $\mathrm{m\,s^{-2}}$ \\',
+               r'1 & 4 & hello & 2.0 \\',
+               r'2 & 5 & konichiwa & 3.0 \\',
+               r'3 & 6 & namaskar & 5.0 \\',
+               r'5 & 5 & guten morgen & 10.0 \\',
+               r'\end{tabular}',
+               r'\end{table}']
+    assert t._repr_latex_().splitlines() == lTable1
+
+    lTable2 = [r'\begin{table}',
+               r'\caption{this is a table}',
+               r'\begin{tabular}{cccc}',
+               r'val & val1 & greeting & speed \\',
+               r' &  &  & $\mathrm{m\,s^{-2}}$ \\',
+               r'1 & 4 & hello & 2.0 \\',
+               r'2 & 5 & konichiwa & 3.0 \\',
+               r'3 & 6 & namaskar & 5.0 \\',
+               r'5 & 5 & guten morgen & 10.0 \\',
+               r'\end{tabular}',
+               r'\end{table}']
+    t.meta['latexdict'] = {'caption':'this is a table'}
+    assert t._repr_latex_().splitlines() == lTable2

--- a/docs/changes/table/11508.feature.rst
+++ b/docs/changes/table/11508.feature.rst
@@ -1,0 +1,2 @@
+A new feature, the ``_repr_latex_`` method, is now available for  ``table.Table``.
+This displays a LaTeX formatted table on the screen and can be called using ``Table._repr_latex_()``.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request created as part of my application for GSoC 2021, is to add a ``_repr_latex_`` method for ``table.Table`` object.

@aaryapatil and @hamogu, please have a look.

The ``_repr_latex_`` method can be called using ``Table()._repr_latex_()``. 
It uses ``latex.Latex.write()`` function from ``astropy.io.ascii`` to change the table format to latex. The default LaTeX formatting options defined in ``latex.Latex`` are assumed if no ``latexdict`` argument is passed.
See: https://docs.astropy.org/en/latest/api/astropy.io.ascii.Latex.html#astropy.io.ascii.Latex

A new key ``latexdict`` corresponding to ``Latex.latex`` dictionary of ``astropy.io.ascii.latex`` object is added to ``table.Table.meta``. It contains the LaTeX formatting options for the table used.

Fixes #3972 
