### PR TITLE
Bugfixes for `SPECIAL_OPERATORS`

### DIFF
--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -947,6 +947,6 @@ def convolve_models_fft(model, kernel, bounding_box, resolution, cache=True, **k
         Convolved model
     """
 
-    SPECIAL_OPERATORS['convolve_fft'] = partial(convolve_fft, **kwargs)
+    operator = SPECIAL_OPERATORS.add('convolve_fft', partial(convolve_fft, **kwargs))
 
-    return Convolution(model, kernel, bounding_box, resolution, cache)
+    return Convolution(operator, model, kernel, bounding_box, resolution, cache)

--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -908,13 +908,13 @@ def convolve_models(model, kernel, mode='convolve_fft', **kwargs):
     """
 
     if mode == 'convolve_fft':
-        SPECIAL_OPERATORS['convolve_fft'] = partial(convolve_fft, **kwargs)
+        operator = SPECIAL_OPERATORS.add('convolve_fft', partial(convolve_fft, **kwargs))
     elif mode == 'convolve':
-        SPECIAL_OPERATORS['convolve'] = partial(convolve, **kwargs)
+        operator = SPECIAL_OPERATORS.add('convolve', partial(convolve, **kwargs))
     else:
         raise ValueError(f'Mode {mode} is not supported.')
 
-    return CompoundModel(mode, model, kernel)
+    return CompoundModel(operator, model, kernel)
 
 
 def convolve_models_fft(model, kernel, bounding_box, resolution, cache=True, **kwargs):

--- a/astropy/modeling/convolution.py
+++ b/astropy/modeling/convolution.py
@@ -13,6 +13,8 @@ class Convolution(CompoundModel):
 
     Parameters
     ----------
+    operator: tuple
+        The SPECIAL_OPERATORS entry for the convolution being used.
     model : Model
         The model for the convolution.
     kernel: Model
@@ -45,8 +47,8 @@ class Convolution(CompoundModel):
     interpolates the results from this cache.
     """
 
-    def __init__(self, model, kernel, bounding_box, resolution, cache=True):
-        super().__init__('convolve_fft', model, kernel)
+    def __init__(self, operator, model, kernel, bounding_box, resolution, cache=True):
+        super().__init__(operator, model, kernel)
 
         self.bounding_box = bounding_box
         self._resolution = resolution

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -39,7 +39,7 @@ from astropy.utils.exceptions import AstropyDeprecationWarning
 from astropy.nddata.utils import add_array, extract_array
 from .utils import (combine_labels, make_binary_operator_eval,
                     get_inputs_and_params, _BoundingBox, _combine_equivalency_dict,
-                    _ConstraintsDict)
+                    _ConstraintsDict, _SpecialOperatorsDict)
 from .parameters import (Parameter, InputParameterError,
                          param_repr_oneline, _tofloat)
 
@@ -2504,11 +2504,11 @@ BINARY_OPERATORS = {
     '&': _join_operator
 }
 
-SPECIAL_OPERATORS = {}
+SPECIAL_OPERATORS = _SpecialOperatorsDict()
 
 
 def _add_special_operator(sop_name, sop):
-    SPECIAL_OPERATORS[sop_name] = sop
+    return SPECIAL_OPERATORS.add(sop_name, sop)
 
 
 class CompoundModel(Model):

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -3070,7 +3070,7 @@ class CompoundModel(Model):
             else:
                 left = f'(({left}),'
                 right = f'({right}))'
-                operands.append(' '.join((node.op, left, right)))
+                operands.append(' '.join((node.op[0], left, right)))
 
         return ''.join(operands)
 

--- a/astropy/modeling/tests/test_utils.py
+++ b/astropy/modeling/tests/test_utils.py
@@ -112,7 +112,8 @@ def test__SpecialOperatorsDict___setitem__():
     special_operators = _SpecialOperatorsDict()
     assert key not in special_operators
 
-    special_operators[key] = val
+    with pytest.raises(DeprecationWarning, match='Setting special operator directly is being deprecated soon.'):
+        special_operators[key] = val
     assert key in special_operators
     assert special_operators[key] == val
 

--- a/astropy/modeling/tests/test_utils.py
+++ b/astropy/modeling/tests/test_utils.py
@@ -105,6 +105,21 @@ def test_ellipse_extent():
         assert diff < 1
 
 
+def test__SpecialOperatorsDict__set_value():
+    key = 'test'
+    val = 'value'
+
+    special_operators = _SpecialOperatorsDict()
+    assert key not in special_operators
+
+    special_operators._set_value(key, val)
+    assert key in special_operators
+    assert special_operators[key] == val
+
+    with pytest.raises(ValueError, match='Special operator "test" already exists'):
+        special_operators._set_value(key, val)
+
+
 def test__SpecialOperatorsDict___setitem__():
     key = 'test'
     val = 'value'
@@ -112,13 +127,10 @@ def test__SpecialOperatorsDict___setitem__():
     special_operators = _SpecialOperatorsDict()
     assert key not in special_operators
 
-    with pytest.raises(DeprecationWarning, match='Setting special operator directly is being deprecated soon.'):
+    with pytest.deprecated_call():
         special_operators[key] = val
     assert key in special_operators
     assert special_operators[key] == val
-
-    with pytest.raises(ValueError, match='Special operator "test" already exists'):
-        special_operators[key] = val
 
 
 def test__SpecialOperatorsDict__get_unique_id():

--- a/astropy/modeling/tests/test_utils.py
+++ b/astropy/modeling/tests/test_utils.py
@@ -9,6 +9,8 @@ from astropy.utils.exceptions import AstropyDeprecationWarning
 from astropy.modeling.utils import ExpressionTree as ET, ellipse_extent
 from astropy.modeling.models import Ellipse2D
 
+from astropy.modeling.utils import _SpecialOperatorsDict
+
 
 def test_traverse_postorder_duplicate_subtrees():
     """
@@ -101,3 +103,51 @@ def test_ellipse_extent():
         s = actual.sum(axis=i)
         diff = np.abs(limits[2 * i] - np.where(s > 0)[0][0])
         assert diff < 1
+
+
+def test__SpecialOperatorsDict___setitem__():
+    key = 'test'
+    val = 'value'
+
+    special_operators = _SpecialOperatorsDict()
+    assert key not in special_operators
+
+    special_operators[key] = val
+    assert key in special_operators
+    assert special_operators[key] == val
+
+    with pytest.raises(ValueError, match='Special operator "test" already exists'):
+        special_operators[key] = val
+
+
+def test__SpecialOperatorsDict__get_unique_id():
+    special_operators = _SpecialOperatorsDict()
+    assert special_operators._unique_id == 0
+
+    assert special_operators._get_unique_id() == 1
+    assert special_operators._unique_id == 1
+
+    assert special_operators._get_unique_id() == 2
+    assert special_operators._unique_id == 2
+
+    assert special_operators._get_unique_id() == 3
+    assert special_operators._unique_id == 3
+
+
+def test__SpecialOperatorsDict_add():
+    special_operators = _SpecialOperatorsDict()
+
+    operator_name = 'test'
+    operator = 'operator'
+
+    key0 = special_operators.add(operator_name, operator)
+    assert key0 == (operator_name, special_operators._unique_id)
+    assert key0 in special_operators
+    assert special_operators[key0] == operator
+
+    key1 = special_operators.add(operator_name, operator)
+    assert key1 == (operator_name, special_operators._unique_id)
+    assert key1 in special_operators
+    assert special_operators[key1] == operator
+
+    assert key0 != key1

--- a/astropy/modeling/utils.py
+++ b/astropy/modeling/utils.py
@@ -785,3 +785,32 @@ class _ConstraintsDict(UserDict):
         super().__setitem__(key, val)
         param = getattr(self._model, key)
         setattr(param, self.constraint_type, val)
+
+
+class _SpecialOperatorsDict(UserDict):
+    """
+    Wrapper around UserDict to allow for better tracking of the Special
+    Operators for CompoundModels
+    """
+
+    def __init__(self, unique_id = 0, special_operators={}):
+        super().__init__(special_operators)
+        self._unique_id = unique_id
+
+    def __setitem__(self, key, val):
+        if key in self:
+            raise ValueError(f'Special operator "{key}" already exists')
+        else:
+            super().__setitem__(key, val)
+
+    def _get_unique_id(self):
+        self._unique_id += 1
+
+        return self._unique_id
+
+    def add(self, operator_name, operator):
+        key = (operator_name, self._get_unique_id())
+
+        self[key] = operator
+
+        return key

--- a/astropy/modeling/utils.py
+++ b/astropy/modeling/utils.py
@@ -791,10 +791,25 @@ class _ConstraintsDict(UserDict):
 class _SpecialOperatorsDict(UserDict):
     """
     Wrapper around UserDict to allow for better tracking of the Special
-    Operators for CompoundModels
+    Operators for CompoundModels. This dictionary is structured so that
+    one cannot inadvertently overwrite an existing special operator.
+
+    Parameters
+    ----------
+    unique_id: int
+        the last used unique_id for a SPECIAL OPERATOR
+    special_operators: dict
+        a dictionary containing the special_operators
+
+    Notes
+    -----
+    Direct setting of operators (`dict[key] = value`) into the
+    dictionary has been deprecated in favor of the `.add(name, value)`
+    method, so that unique dictionary keys can be generated and tracked
+    consistently.
     """
 
-    def __init__(self, unique_id = 0, special_operators={}):
+    def __init__(self, unique_id=0, special_operators={}):
         super().__init__(special_operators)
         self._unique_id = unique_id
 
@@ -806,7 +821,13 @@ class _SpecialOperatorsDict(UserDict):
 
     def __setitem__(self, key, val):
         self._set_value(key, val)
-        warnings.warn(DeprecationWarning("Special operator dictionary assignment has been deprecated."))
+        warnings.warn(DeprecationWarning(
+            """
+            Special operator dictionary assignment has been deprecated.
+            Please use `.add` instead, so that you can capture a unique
+            key for your operator.
+            """
+        ))
 
     def _get_unique_id(self):
         self._unique_id += 1
@@ -814,6 +835,22 @@ class _SpecialOperatorsDict(UserDict):
         return self._unique_id
 
     def add(self, operator_name, operator):
+        """
+        Adds a special operator to the dictionary, and then returns the
+        unique key that the operator is stored under for later reference.
+
+        Parameters
+        ----------
+        operator_name: str
+            the name for the operator
+        operator: function
+            the actual operator function which will be used
+
+        Returns
+        -------
+        the unique operator key for the dictionary
+            `(operator_name, unique_id)`
+        """
         key = (operator_name, self._get_unique_id())
 
         self._set_value(key, operator)

--- a/astropy/modeling/utils.py
+++ b/astropy/modeling/utils.py
@@ -802,6 +802,7 @@ class _SpecialOperatorsDict(UserDict):
             raise ValueError(f'Special operator "{key}" already exists')
         else:
             super().__setitem__(key, val)
+        raise DeprecationWarning('Setting special operator directly is being deprecated soon.')
 
     def _get_unique_id(self):
         self._unique_id += 1
@@ -811,6 +812,9 @@ class _SpecialOperatorsDict(UserDict):
     def add(self, operator_name, operator):
         key = (operator_name, self._get_unique_id())
 
-        self[key] = operator
+        try:
+            self[key] = operator
+        except DeprecationWarning:
+            pass
 
         return key

--- a/astropy/modeling/utils.py
+++ b/astropy/modeling/utils.py
@@ -9,6 +9,7 @@ from collections.abc import MutableMapping
 from inspect import signature
 
 import numpy as np
+import warnings
 from astropy.utils.decorators import deprecated
 from astropy.utils import isiterable, check_broadcast
 
@@ -797,12 +798,15 @@ class _SpecialOperatorsDict(UserDict):
         super().__init__(special_operators)
         self._unique_id = unique_id
 
-    def __setitem__(self, key, val):
+    def _set_value(self, key, val):
         if key in self:
             raise ValueError(f'Special operator "{key}" already exists')
         else:
             super().__setitem__(key, val)
-        raise DeprecationWarning('Setting special operator directly is being deprecated soon.')
+
+    def __setitem__(self, key, val):
+        self._set_value(key, val)
+        warnings.warn(DeprecationWarning("Special operator dictionary assignment has been deprecated."))
 
     def _get_unique_id(self):
         self._unique_id += 1
@@ -812,9 +816,6 @@ class _SpecialOperatorsDict(UserDict):
     def add(self, operator_name, operator):
         key = (operator_name, self._get_unique_id())
 
-        try:
-            self[key] = operator
-        except DeprecationWarning:
-            pass
+        self._set_value(key, operator)
 
         return key

--- a/docs/changes/modeling/11512.bugfix.rst
+++ b/docs/changes/modeling/11512.bugfix.rst
@@ -1,0 +1,1 @@
+Bugfix for how ``SPECIAL_OPERATORS`` are handled.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

When writing tests for PR #11495 I discovered a bug in how `SPECIAL_OPERATORS` where handled. Namely, it is very easy to overwrite an existing special operator with a new one, which then changes the behavior of a previously defined `CompoundModel`.

For example, one could define a `CompoundModel` using `~astropy.convolution.convolve_models` and then change the results of the first `CompoundModel` by defining a second `CompoundModel`. All one has to do is change one of the keyword arguments to the convolution between the two versions (e.g. `normalize_kernel=True` in one and `normalize_kernel=False` in the second). The convolution operator was always performing under the configuration of the last defined convolution operator, not the one that was defined for the `CompoundModel`.

This PR fixes this issue by wrapping a `UserDict` for `SPECIAL_OPERATORS` in such a way that we check that we only allow operators to be added under unique dictionary keys and provide a mechanism to generate new unique operator keys.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->
