### PR TITLE
Simplify Cosmology cloning logic

### DIFF
--- a/astropy/cosmology/tests/test_cosmology.py
+++ b/astropy/cosmology/tests/test_cosmology.py
@@ -10,7 +10,8 @@ from astropy.cosmology.realizations import Planck13
 from astropy.units import allclose
 from astropy import constants as const
 from astropy import units as u
-from astropy.utils.exceptions import AstropyUserWarning
+from astropy.utils.exceptions import (AstropyDeprecationWarning,
+                                      AstropyUserWarning)
 from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa
 
 
@@ -289,7 +290,8 @@ def test_clone():
 
     # Now test exception if user passes non-parameter
     with pytest.raises(AttributeError):
-        newclone = cosmo.clone(not_an_arg=4)
+        with pytest.warns(AstropyDeprecationWarning, match="Astropy v5.0"):
+            newclone = cosmo.clone(not_an_arg=4)
 
 
 def test_xtfuncs():

--- a/docs/changes/cosmology/11515.api.rst
+++ b/docs/changes/cosmology/11515.api.rst
@@ -1,0 +1,5 @@
+Since cosmologies are immutable, the initialization signature and values can
+be stored, greatly simplifying cloning logic and extending it to user-defined
+cosmology classes that do not have attributes with the same name as each
+initialization argument.
+Also, the class abstraction is moved from ``FLRW`` to the base, ``Cosmology``.


### PR DESCRIPTION
### Description

Massively simplify the cloning logic of Cosmology by storing the initialization signature and arguments on the class and instance, respectively. This is fine since Cosmo classes are immutable (expressed in old ``.clone`` docs).
The refactor generalizes the method to work for any subclass, user-defined or not, which was a notable limitation of the former implementation.
This PR will enable the next PR, which will allow for ``Cosmology`` to by useful for instantiating cosmologies that are "perturbations" around the default cosmology (see  #10673)

Part of #10673 

@mhvk @embray : Pretty much purely technical PR.

p.s. Are any new tests needed? this seems a pretty atomic change. The only reason I labelled it API is that it changes the errors that ``clone`` raises.

p.p.s. Can I add a warning that we'll be changing the error from an Attribute to TypeError at some later date? It really shouldn't be an AttributeError.