### PR TITLE
Converting a zero-length Time object from UTC to UT1 when an empty array is passed

### DIFF
--- a/astropy/time/tests/test_ut1.py
+++ b/astropy/time/tests/test_ut1.py
@@ -93,6 +93,17 @@ class TestTimeUT1:
             t_back = t.utc.ut1
             assert allclose_jd(t.jd, t_back.jd)
 
+    def test_empty_ut1(self):
+        """Testing for a zero-length Time object from UTC to UT1
+        when an empty array is passed"""
+        from astropy import units as u
+        with iers_conf.set_temp('auto_download', False):
+            t = Time(['2012-06-30 12:00:00']) + np.arange(24) * u.hour
+            t_empty = t[[]].ut1
+            assert isinstance(t_empty, Time)
+            assert t_empty.scale == 'ut1'
+            assert t_empty.size == 0
+
     def test_delta_ut1_utc(self):
         """Accessing delta_ut1_utc should try to get it from IERS
         (closes #1924 partially)"""

--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -356,6 +356,9 @@ class IERS(QTable):
         if is_scalar:
             mjd = np.array([mjd])
             utc = np.array([utc])
+        elif mjd.size == 0:
+            # Short-cut empty input.
+            return np.array([])
 
         self._refresh_table_as_needed(mjd)
 

--- a/docs/changes/time/11516.bugfix.rst
+++ b/docs/changes/time/11516.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed converting a zero-length time object from UTC to 
+UT1 when an empty array is passed.


### PR DESCRIPTION
 Fixes #11454
