### PR TITLE
WIP: Auto-Import User-Defined Cosmology Realizations

### DIFF
--- a/astropy/cosmology/parameters.py
+++ b/astropy/cosmology/parameters.py
@@ -216,7 +216,7 @@ WMAP5 = dict(
 )
 
 # If new parameters are added, this list must be updated
-available = AVAILABLE_BUILTIN = frozenset(
+available = AVAILABLE_BUILTIN_COSMOLOGIES = frozenset(
     ('Planck18', 'Planck18_arXiv_v2', 'Planck15', 'Planck13',
      'WMAP9', 'WMAP7', 'WMAP5'))
 
@@ -224,7 +224,7 @@ available = AVAILABLE_BUILTIN = frozenset(
 # ======================================================
 # User-Defined Paramaters
 
-AVAILABLE_USER = frozenset()
+AVAILABLE_USER_COSMOLOGIES = frozenset()
 
 
 def _load_from_ecsv(fp):
@@ -254,19 +254,7 @@ def _load_from_ecsv(fp):
     all_cosmo_params = dict()
     for name, row in zip(user_available, parameter_table):
         params = dict(row)
-
-        # metadata
-        # TODO! this assumes meta=
-        # params["meta"] = parameter_table.meta.get(name, None)
-        # TODO! the following is assuming **meta
-        meta = parameter_table.meta.get(name, None)
-        if isinstance(meta, Mapping):
-            intersection = set(params.keys()) & meta.keys()
-            if intersection:
-                raise NameError(
-                    f"Cosmology {name} metadata cannot have keys {intersection}"
-                )
-            params.update(meta)
+        params["meta"] = parameter_table.meta.get(name, None)  # metadata
 
         all_cosmo_params[name] = params
 
@@ -274,6 +262,7 @@ def _load_from_ecsv(fp):
 
 
 if HAS_YAML:
+
     # TODO! this is not a robust place to put this
     drct = pathlib.Path(get_config_dir()).parent.joinpath("cosmology")
 
@@ -282,12 +271,12 @@ if HAS_YAML:
         for fp in drct.glob("*.ecsv"):
             _available, _params = _load_from_ecsv(fp)
  
-            AVAILABLE_USER = AVAILABLE_USER | _available
+            AVAILABLE_USER_COSMOLOGIES = AVAILABLE_USER_COSMOLOGIES | _available
             # add parameter dictionary (later added to __all__)
             [setattr(sys.modules[__name__], n, p) for n, p in _params.items()]
 
         # add all user definitions to "available"
-        available = available | AVAILABLE_USER
+        available = available | AVAILABLE_USER_COSMOLOGIES
 
 # TODO! same for JSON
 

--- a/astropy/cosmology/realizations.py
+++ b/astropy/cosmology/realizations.py
@@ -33,7 +33,7 @@ for key in parameters.available:
         )
 
         # set the docs for builtin realizations
-        if key in parameters.AVAILABLE_BUILTIN:
+        if key in parameters.AVAILABLE_BUILTIN_COSMOLOGIES:
             docstr = "{} instance of FlatLambdaCDM cosmology\n\n(from {})"
             cosmo.__doc__ = docstr.format(key, par["reference"])
     else:

--- a/astropy/cosmology/realizations.py
+++ b/astropy/cosmology/realizations.py
@@ -10,7 +10,7 @@ from astropy.utils.state import ScienceState
 from . import parameters
 from .core import Cosmology, FlatLambdaCDM, LambdaCDM
 
-__all__ = ["default_cosmology"] + parameters.available
+__all__ = ["default_cosmology"] + list(parameters.available)
 
 __doctest_requires__ = {"*": ["scipy"]}
 
@@ -31,8 +31,11 @@ for key in parameters.available:
             name=key,
             Ob0=par["Ob0"],
         )
-        docstr = "{} instance of FlatLambdaCDM cosmology\n\n(from {})"
-        cosmo.__doc__ = docstr.format(key, par["reference"])
+
+        # set the docs for builtin realizations
+        if key in parameters.AVAILABLE_BUILTIN:
+            docstr = "{} instance of FlatLambdaCDM cosmology\n\n(from {})"
+            cosmo.__doc__ = docstr.format(key, par["reference"])
     else:
         warnings.warn("Please open a PR for your added cosmology realization.")
         # For a non-flat LCDM realization, the following is the code necessary

--- a/astropy/cosmology/tests/realizations.ecsv
+++ b/astropy/cosmology/tests/realizations.ecsv
@@ -1,0 +1,64 @@
+# %ECSV 0.9
+# ---
+# datatype:
+# - {name: name, datatype: string}
+# - {name: cosmology, datatype: string}
+# - {name: Oc0, datatype: float64}
+# - {name: Ob0, datatype: float64}
+# - {name: Om0, datatype: float64}
+# - {name: H0, unit: km / (Mpc s), datatype: float64}
+# - {name: n, datatype: float64}
+# - {name: sigma8, datatype: float64}
+# - {name: tau, datatype: float64}
+# - {name: z_reion, datatype: float64}
+# - {name: t0, unit: Gyr, datatype: float64}
+# - {name: Tcmb0, unit: K, datatype: float64}
+# - {name: Neff, datatype: float64}
+# - {name: flat, datatype: bool}
+# - {name: m_nu_1, unit: eV, datatype: float64}
+# - {name: m_nu_2, unit: eV, datatype: float64}
+# - {name: m_nu_3, unit: eV, datatype: float64}
+# meta: !!omap
+# - TestPlanck13: {reference: 'Planck Collaboration 2014, A&A, 571, A16 (Paper XVI), Table 5 (Planck + WP + highL + BAO)'}
+# - TestPlanck15: {reference: 'Planck Collaboration 2016, A&A, 594, A13 (Paper XIII), Table 4 (TT, TE, EE + lowP + lensing + ext)'}
+# - TestPlanck18: {reference: 'Planck Collaboration 2018, 2020, A&A, 641, A6  (Paper VI), Table 2 (TT, TE, EE + lowE + lensing + BAO)'}
+# - TestPlanck18_arXiv_v2: {reference: 'DEPRECATED: Planck Collaboration 2018, arXiv:1807.06209 v2 (Paper VI), Table 2 (TT, TE, EE + lowE
+#       + lensing + BAO)'}
+# - TestWMAP5: {reference: 'Komatsu et al. 2009, ApJS, 180, 330, doi: 10.1088/0067-0049/180/2/330. Table 1 (WMAP + BAO + SN ML).'}
+# - TestWMAP7: {reference: 'Komatsu et al. 2011, ApJS, 192, 18, doi: 10.1088/0067-0049/192/2/18. Table 1 (WMAP + BAO + H0 ML).'}
+# - TestWMAP9: {reference: 'Hinshaw et al. 2013, ApJS, 208, 19, doi: 10.1088/0067-0049/208/2/19. Table 4 (WMAP9 + eCMB + BAO + H0, last
+#       column)'}
+# - __serialized_columns__:
+#     H0:
+#       __class__: astropy.units.quantity.Quantity
+#       unit: !astropy.units.Unit {unit: km / (Mpc s)}
+#       value: !astropy.table.SerializedColumn {name: H0}
+#     Tcmb0:
+#       __class__: astropy.units.quantity.Quantity
+#       unit: !astropy.units.Unit {unit: K}
+#       value: !astropy.table.SerializedColumn {name: Tcmb0}
+#     m_nu_1:
+#       __class__: astropy.units.quantity.Quantity
+#       unit: &id001 !astropy.units.Unit {unit: eV}
+#       value: !astropy.table.SerializedColumn {name: m_nu_1}
+#     m_nu_2:
+#       __class__: astropy.units.quantity.Quantity
+#       unit: *id001
+#       value: !astropy.table.SerializedColumn {name: m_nu_2}
+#     m_nu_3:
+#       __class__: astropy.units.quantity.Quantity
+#       unit: *id001
+#       value: !astropy.table.SerializedColumn {name: m_nu_3}
+#     t0:
+#       __class__: astropy.units.quantity.Quantity
+#       unit: !astropy.units.Unit {unit: Gyr}
+#       value: !astropy.table.SerializedColumn {name: t0}
+# schema: astropy-2.0
+name cosmology Oc0 Ob0 Om0 H0 n sigma8 tau z_reion t0 Tcmb0 Neff flat m_nu_1 m_nu_2 m_nu_3
+TestPlanck18 FlatLambdaCDM 0.2607 0.04897 0.30966 67.66 0.9665 0.8102 0.0561 7.82 13.787 2.7255 3.046 True 0.0 0.0 0.06
+TestPlanck18_arXiv_v2 FlatLambdaCDM 0.2607 0.04897 0.30966 67.66 0.9665 0.8102 0.0561 7.82 13.787 2.7255 3.046 True 0.0 0.0 0.06
+TestPlanck15 FlatLambdaCDM 0.2589 0.0486 0.3075 67.74 0.9667 0.8159 0.066 8.8 13.799 2.7255 3.046 True 0.0 0.0 0.06
+TestPlanck13 FlatLambdaCDM 0.25886 0.048252 0.30712 67.77 0.9611 0.8288 0.0952 11.52 13.7965 2.7255 3.046 True 0.0 0.0 0.06
+TestWMAP9 FlatLambdaCDM 0.2402 0.04628 0.2865 69.32 0.9608 0.82 0.081 10.1 13.772 2.725 3.04 True 0.0 0.0 0.0
+TestWMAP7 FlatLambdaCDM 0.226 0.0455 0.272 70.4 0.967 0.81 0.085 10.3 13.76 2.725 3.04 True 0.0 0.0 0.0
+TestWMAP5 FlatLambdaCDM 0.231 0.0459 0.277 70.2 0.962 0.817 0.088 11.3 13.72 2.725 3.04 True 0.0 0.0 0.0

--- a/astropy/cosmology/tests/test_parameters.py
+++ b/astropy/cosmology/tests/test_parameters.py
@@ -1,0 +1,10 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+import tempfile
+
+import pytest
+
+from astropy.cosmology import parameters
+
+def test_user_parameters():
+    pass

--- a/docs/changes/cosmology/11517.other.rst
+++ b/docs/changes/cosmology/11517.other.rst
@@ -1,0 +1,1 @@
+Users can add ECSV files of cosmologies... describe more.


### PR DESCRIPTION
### Description

Allow the user to add an ECSV file of custom realizations to a config directory (default in `~/.astropy/cosmologies/`) and have them be created at import.  Also, I think using the ECSV format will eventually enable cool things like working through an MCMC chain of cosmologies.

For backward compatibility, the file is read and dicts of each row added into ``parameters.py``.

Part of #10673 
Blocked by ~#11530~ #11570 ~#11542~  #11559

@embray, this PR relates to our convo on non-entrypoint custom realizations.

- - -
OLD Description

> Instead of storing parameters as dictionaries in the file ``parameters``, the parameters for built-in realizations are kept in an ECSV. This enables easy comparison of realizations and, more importantly, lays the foundation for the next PR, which is allow the user to add an ECSV file of custom realizations to the astropy config directory and have them be created at import. 
Also, I think using the ECSV format will eventually enable cool things like working through an MCMC chain of cosmologies.
> For backward compatibility, the file is read and dicts of each row added into ``parameters.py``.