### PR TITLE
Cosmology base class

### DIFF
--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -26,8 +26,8 @@ from . import parameters
 # Many of these adapted from Hogg 1999, astro-ph/9905116
 # and Linder 2003, PRL 90, 91301
 
-__all__ = ["FLRW", "LambdaCDM", "FlatLambdaCDM", "wCDM", "FlatwCDM",
-           "Flatw0waCDM", "w0waCDM", "wpwaCDM", "w0wzCDM"]
+__all__ = ["Cosmology", "FLRW", "LambdaCDM", "FlatLambdaCDM", "wCDM",
+           "FlatwCDM", "Flatw0waCDM", "w0waCDM", "wpwaCDM", "w0wzCDM"]
 
 __doctest_requires__ = {'*': ['scipy']}
 
@@ -83,8 +83,29 @@ kB_evK = const.k_B.to(u.eV / u.K)
 class CosmologyError(Exception):
     pass
 
+class CosmologyMeta(ABCMeta):
+    def __call__(cls, *args, **kwargs):
+        """
+        Create Cosmology instance. If class is Cosmology,
+        create from `default_cosmology`, else create as normal.
 
-class Cosmology(metaclass=ABCMeta):
+        Returns
+        -------
+        `~astropy.cosmology.Cosmology`
+
+        """
+        if cls is Cosmology:
+            from .realizations import default_cosmology
+
+            base = default_cosmology.get()
+            cosmo = base.clone(*args, **kwargs)
+            return cosmo
+
+        # else, proceed normally
+        return super().__call__(*args, **kwargs)
+
+
+class Cosmology(metaclass=CosmologyMeta):
     """Base-class for all Cosmologies.
 
     Parameters

--- a/astropy/cosmology/tests/test_cosmology.py
+++ b/astropy/cosmology/tests/test_cosmology.py
@@ -10,7 +10,8 @@ from astropy.cosmology.realizations import Planck13
 from astropy.units import allclose
 from astropy import constants as const
 from astropy import units as u
-from astropy.utils.exceptions import AstropyUserWarning
+from astropy.utils.exceptions import (AstropyDeprecationWarning,
+                                      AstropyUserWarning)
 from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa
 
 
@@ -289,7 +290,8 @@ def test_clone():
 
     # Now test exception if user passes non-parameter
     with pytest.raises(AttributeError):
-        newclone = cosmo.clone(not_an_arg=4)
+        with pytest.warns(AstropyDeprecationWarning, match="Astropy v5.0"):
+            newclone = cosmo.clone(not_an_arg=4)
 
 
 def test_xtfuncs():

--- a/docs/changes/cosmology/11515.api.rst
+++ b/docs/changes/cosmology/11515.api.rst
@@ -1,0 +1,5 @@
+Since cosmologies are immutable, the initialization signature and values can
+be stored, greatly simplifying cloning logic and extending it to user-defined
+cosmology classes that do not have attributes with the same name as each
+initialization argument.
+Also, the class abstraction is moved from ``FLRW`` to the base, ``Cosmology``.

--- a/docs/changes/cosmology/rename_me.api.rst
+++ b/docs/changes/cosmology/rename_me.api.rst
@@ -1,0 +1,14 @@
+Directly instantiating the ``Cosmology`` base class now clones the current
+default cosmology (controlled by ``default_cosmology``), updating parameters,
+as specified. This allows for:
+
+>>> from astropy.cosmology import Cosmology, default_cosmology
+>>> print(Cosmology())  # the default cosmology
+FlatLambdaCDM(name="Planck18", H0=67.7 km / (Mpc s), ...)
+
+>>> with default_cosmology.set("WMAP5"):
+>>>      print(Cosmology())  # gets the new default
+FlatLambdaCDM(name="WMAP5", H0=70.2 km / (Mpc s), ...)
+
+>>> Cosmology(name="modified", H0=70)  # perturb around the default
+FlatLambdaCDM(name="modified", H0=70 km / (Mpc s), ...)

--- a/docs/cosmology/index.rst
+++ b/docs/cosmology/index.rst
@@ -248,6 +248,28 @@ To make a copy of a cosmological instance using the ``clone`` operation:
 ..
   EXAMPLE END
 
+Directly instantiating the `~astropy.cosmology.Cosmology`` base class clones the
+current default cosmology (set by `~astropy.cosmology.default_cosmology`),
+updating parameters as specified. This allows for:
+
+..
+  EXAMPLE START
+  Making New Cosmology Instances with the Base Class.
+
+  >>> from astropy.cosmology import Cosmology, default_cosmology
+  >>> Cosmology()  # the default cosmology
+  FlatLambdaCDM(name="Planck18", H0=67.7 km / (Mpc s), ...)
+
+  >>> with default_cosmology.set("WMAP5"):
+  >>>      print(Cosmology())  # gets the new default
+  FlatLambdaCDM(name="WMAP5", H0=70.2 km / (Mpc s), ...)
+
+  >>> Cosmology(name="modified", H0=70)  # perturb around the default
+  FlatLambdaCDM(name="modified", H0=70 km / (Mpc s), ...)
+  
+..
+  EXAMPLE END
+
 Finding the Redshift at a Given Value of a Cosmological Quantity
 ----------------------------------------------------------------
 


### PR DESCRIPTION
### Description

Directly instantiating the ``Cosmology`` base class now clones the current
default cosmology (controlled by ``default_cosmology``), updating parameters
as specified. This allows for:

```python
>>> from astropy.cosmology import Cosmology, default_cosmology
>>> print(Cosmology())  # the default cosmology
FlatLambdaCDM(name="Planck18", H0=67.7 km / (Mpc s), ...)

>>> with default_cosmology.set("WMAP5"):
>>>      print(Cosmology())  # gets the new default
FlatLambdaCDM(name="WMAP5", H0=70.2 km / (Mpc s), ...)

>>> Cosmology(name="modified", H0=70)  # perturb around the default
FlatLambdaCDM(name="modified", H0=70 km / (Mpc s), ...)
```

Some things this does: 
- Make instantiating non built-in cosmos slightly easier.
- Simplifies programmatic creation of cosmology classes, perturbing some values, e.g.

```
for name in cosmology.parameters.available:
    with default_cosmology.set(name):
        Cosmology(H0=77)
```

While this is convenient, I think this is the least consequential / necessary change outlined in #10673. I'm totally fine if we don't merge this in, I just thought I should suggest it.

Requires #11515
Part of #10673 
