### PR TITLE
Replace next powers of 2 in convolve_fft's fft_pad size with scipy.fft.next_fast_len

### DIFF
--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -47,11 +47,57 @@ _convolveNd_c.argtypes = [ndpointer(ctypes.c_double, flags={"C_CONTIGUOUS", "WRI
                           ctypes.c_bool,  # embed_result_within_padded_region
                           ctypes.c_uint]  # n_threads
 
+# np.unique([scipy.fft.next_fast_len(i, real=True) for i in range(10000)])
+_good_sizes = [   0,    1,    2,    3,    4,    5,    6,    8,    9,   10,   12,  # noqa E201
+                 15,   16,   18,   20,   24,   25,   27,   30,   32,   36,   40,
+                 45,   48,   50,   54,   60,   64,   72,   75,   80,   81,   90,
+                 96,  100,  108,  120,  125,  128,  135,  144,  150,  160,  162,
+                180,  192,  200,  216,  225,  240,  243,  250,  256,  270,  288,
+                300,  320,  324,  360,  375,  384,  400,  405,  432,  450,  480,
+                486,  500,  512,  540,  576,  600,  625,  640,  648,  675,  720,
+                729,  750,  768,  800,  810,  864,  900,  960,  972, 1000, 1024,
+               1080, 1125, 1152, 1200, 1215, 1250, 1280, 1296, 1350, 1440, 1458,
+               1500, 1536, 1600, 1620, 1728, 1800, 1875, 1920, 1944, 2000, 2025,
+               2048, 2160, 2187, 2250, 2304, 2400, 2430, 2500, 2560, 2592, 2700,
+               2880, 2916, 3000, 3072, 3125, 3200, 3240, 3375, 3456, 3600, 3645,
+               3750, 3840, 3888, 4000, 4050, 4096, 4320, 4374, 4500, 4608, 4800,
+               4860, 5000, 5120, 5184, 5400, 5625, 5760, 5832, 6000, 6075, 6144,
+               6250, 6400, 6480, 6561, 6750, 6912, 7200, 7290, 7500, 7680, 7776,
+               8000, 8100, 8192, 8640, 8748, 9000, 9216, 9375, 9600, 9720, 10000]
+_good_range = int(np.log10(_good_sizes[-1]))
+
 # Disabling all doctests in this module until a better way of handling warnings
 # in doctests can be determined
 __doctest_skip__ = ['*']
 
 BOUNDARY_OPTIONS = [None, 'fill', 'wrap', 'extend']
+
+
+def _next_fast_lengths(shape):
+    """
+    Find optimal or good sizes to pad an array of ``shape`` to for better
+    performance with `numpy.fft.*fft` and `scipy.fft.*fft`.
+    Calculated directly with `scipy.fft.next_fast_len`, if available; otherwise
+    looked up from list and scaled by powers of 10, if necessary.
+    """
+
+    try:
+        import scipy.fft
+        return np.array([scipy.fft.next_fast_len(j, real=False) for j in shape])
+    except ImportError:
+        pass
+
+    newshape = np.empty(len(np.atleast_1d(shape)), dtype=int)
+    for i, j in enumerate(shape):
+        scale = 10 ** max(int(np.ceil(np.log10(j))) - _good_range, 0)
+        for n in _good_sizes:
+            if n * scale >= j:
+                newshape[i] = n * scale
+                break
+        else:
+            raise ValueError(f'No next fast length for {j} found in list of _good_sizes '
+                             f'<= {_good_sizes[-1] * scale}.')
+    return newshape
 
 
 def _copy_input_if_needed(input, dtype=float, order='C', nan_treatment=None,
@@ -489,7 +535,7 @@ def convolve_fft(array, kernel, boundary='fill', fill_value=0.,
         array or kernel size is >1 GB.
     fftn : functions, optional
         The fft function.  Can be overridden to use your own ffts,
-        e.g. an fftw3 wrapper or scipy's fftn, ``fft=scipy.fftpack.fftn``.
+        e.g. an fftw3 wrapper or scipy's fftn, ``fft=scipy.fft.fftn``.
     ifftn : functions, optional
         The inverse fft function. Can be overridden the same way ``fttn``.
     complex_dtype : numpy.complex, optional
@@ -550,10 +596,10 @@ def convolve_fft(array, kernel, boundary='fill', fill_value=0.,
     ...               normalize_kernel=True)
     array([ 1.,  2.,  3.])
 
-    >>> import scipy.fftpack  # optional - requires scipy
+    >>> import scipy.fft  # optional - requires scipy
     >>> convolve_fft([1, np.nan, 3], [1, 1, 1], nan_treatment='interpolate',
     ...               normalize_kernel=True,
-    ...               fftn=scipy.fftpack.fft, ifftn=scipy.fftpack.ifft)
+    ...               fftn=scipy.fft.fft, ifftn=scipy.fft.ifft)
     array([ 1.,  2.,  3.])
 
     """
@@ -666,25 +712,24 @@ def convolve_fft(array, kernel, boundary='fill', fill_value=0.,
         raise NotImplementedError("The 'extend' option is not implemented "
                                   "for fft-based convolution")
 
-    # find ideal size (power of 2) for fft.
-    # Can add shapes because they are tuples
+    # Find ideal size for fft (was power of 2, now any powers of prime factors 2, 3, 5).
+    # Add shapes elementwise for psf_pad.
     if fft_pad:  # default=True
         if psf_pad:  # default=False
-            # add the dimensions and then take the max (bigger)
-            fsize = 2 ** np.ceil(np.log2(
-                np.max(np.array(arrayshape) + np.array(kernshape))))
+            # add the sizes along each dimension (bigger)
+            fsize = np.array(arrayshape) + np.array(kernshape)
         else:
-            # add the shape lists (max of a list of length 4) (smaller)
-            # also makes the shapes square
-            fsize = 2 ** np.ceil(np.log2(np.max(arrayshape + kernshape)))
-        newshape = np.full((array.ndim, ), fsize, dtype=int)
+            # take the larger shape in each dimension (smaller)
+            fsize = np.maximum(arrayshape, kernshape)
+        # newshape = np.array([2 ** np.ceil(np.log2(i)).astype(int) for i in fsize])
+        # Get optimized sizes from scipy.
+        newshape = _next_fast_lengths(fsize)
     else:
         if psf_pad:
             # just add the biggest dimensions
             newshape = np.array(arrayshape) + np.array(kernshape)
         else:
-            newshape = np.array([np.max([imsh, kernsh])
-                                 for imsh, kernsh in zip(arrayshape, kernshape)])
+            newshape = np.maximum(arrayshape, kernshape)
 
     # perform a second check after padding
     array_size_C = (np.product(newshape, dtype=np.int64) *

--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -708,24 +708,18 @@ def convolve_fft(array, kernel, boundary='fill', fill_value=0.,
         raise NotImplementedError("The 'extend' option is not implemented "
                                   "for fft-based convolution")
 
-    # Find ideal size for fft (was power of 2, now any powers of prime factors 2, 3, 5).
     # Add shapes elementwise for psf_pad.
-    if fft_pad:  # default=True
-        if psf_pad:  # default=False
-            # add the sizes along each dimension (bigger)
-            fsize = np.array(arrayshape) + np.array(kernshape)
-        else:
-            # take the larger shape in each dimension (smaller)
-            fsize = np.maximum(arrayshape, kernshape)
-        # newshape = np.array([2 ** np.ceil(np.log2(i)).astype(int) for i in fsize])
-        # Get optimized sizes from scipy.
-        newshape = _next_fast_lengths(fsize)
+    if psf_pad:  # default=False
+        # add the sizes along each dimension (bigger)
+        newshape = np.array(arrayshape) + np.array(kernshape)
     else:
-        if psf_pad:
-            # just add the biggest dimensions
-            newshape = np.array(arrayshape) + np.array(kernshape)
-        else:
-            newshape = np.maximum(arrayshape, kernshape)
+        # take the larger shape in each dimension (smaller)
+        newshape = np.maximum(arrayshape, kernshape)
+
+    # Find ideal size for fft (was power of 2, now any powers of prime factors 2, 3, 5).
+    if fft_pad:  # default=True
+        # Get optimized sizes from scipy.
+        newshape = _next_fast_lengths(newshape)
 
     # perform a second check after padding
     array_size_C = (np.product(newshape, dtype=np.int64) *

--- a/astropy/convolution/tests/test_convolve_fft.py
+++ b/astropy/convolution/tests/test_convolve_fft.py
@@ -675,12 +675,12 @@ class TestConvolve2D:
         to length of longest side (#11242/#10047).
         """
 
-        # old implementation expanded this to up to 2048**2
-        shape = (1226, 518)
+        # old implementation expanded this to up to 2048**3
+        shape = (1, 1226, 518)
         img = np.zeros(shape, dtype='float64')
-        img[600:610, 300:304] = 1.0
-        kernel = np.zeros((7, 7), dtype='float64')
-        kernel[3, 3] = 1.0
+        img[0, 600:610, 300:304] = 1.0
+        kernel = np.zeros((1, 7, 7), dtype='float64')
+        kernel[0, 3, 3] = 1.0
 
         with pytest.warns(AstropyUserWarning,
                           match="psf_pad was set to False, which overrides the boundary='fill'"):
@@ -688,12 +688,12 @@ class TestConvolve2D:
             assert_array_equal(img_fft.shape, shape)
             img_fft = convolve_fft(img, kernel, return_fft=True, psf_pad=False, fft_pad=True)
             # should be from either hardcoded _good_sizes[] or scipy.fft.next_fast_len()
-            assert img_fft.shape in ((1250, 540), (1232, 525))
+            assert img_fft.shape in ((1, 1250, 540), (1, 1232, 525))
 
         img_fft = convolve_fft(img, kernel, return_fft=True, psf_pad=True, fft_pad=False)
         assert_array_equal(img_fft.shape, np.array(shape) + np.array(kernel.shape))
         img_fft = convolve_fft(img, kernel, return_fft=True, psf_pad=True, fft_pad=True)
-        assert img_fft.shape in ((1250, 540), (1250, 525))
+        assert img_fft.shape in ((2, 1250, 540), (2, 1250, 525))
 
     @pytest.mark.parametrize(('boundary'), BOUNDARY_OPTIONS)
     def test_non_normalized_kernel(self, boundary):

--- a/astropy/convolution/tests/test_convolve_fft.py
+++ b/astropy/convolution/tests/test_convolve_fft.py
@@ -4,7 +4,7 @@ import itertools
 
 import pytest
 import numpy as np
-from numpy.testing import assert_allclose, assert_array_almost_equal_nulp
+from numpy.testing import assert_allclose, assert_array_equal, assert_array_almost_equal_nulp
 
 from astropy.convolution.convolve import convolve_fft, convolve
 from astropy.utils.exceptions import AstropyUserWarning
@@ -659,7 +659,7 @@ class TestConvolve2D:
         assert_floatclose(z[posns], z[posns])
 
     def test_big_fail(self):
-        """ Test that convolve_fft raises an exception if a too-large array is passed in """
+        """ Test that convolve_fft raises an exception if a too-large array is passed in."""
 
         with pytest.raises((ValueError, MemoryError)):
             # while a good idea, this approach did not work; it actually writes to disk
@@ -668,6 +668,32 @@ class TestConvolve2D:
             arr = np.empty([512, 512, 512], dtype=complex)
             # note 512**3 * 16 bytes = 2.0 GB
             convolve_fft(arr, arr)
+
+    def test_padding(self):
+        """
+        Test that convolve_fft pads to _next_fast_lengths and does not expand all dimensions
+        to length of longest side (#11242/#10047).
+        """
+
+        # old implementation expanded this to up to 2048**2
+        shape = (1226, 518)
+        img = np.zeros(shape, dtype='float64')
+        img[600:610, 300:304] = 1.0
+        kernel = np.zeros((7, 7), dtype='float64')
+        kernel[3, 3] = 1.0
+
+        with pytest.warns(AstropyUserWarning,
+                          match="psf_pad was set to False, which overrides the boundary='fill'"):
+            img_fft = convolve_fft(img, kernel, return_fft=True, psf_pad=False, fft_pad=False)
+            assert_array_equal(img_fft.shape, shape)
+            img_fft = convolve_fft(img, kernel, return_fft=True, psf_pad=False, fft_pad=True)
+            # should be from either hardcoded _good_sizes[] or scipy.fft.next_fast_len()
+            assert img_fft.shape in ((1250, 540), (1232, 525))
+
+        img_fft = convolve_fft(img, kernel, return_fft=True, psf_pad=True, fft_pad=False)
+        assert_array_equal(img_fft.shape, np.array(shape) + np.array(kernel.shape))
+        img_fft = convolve_fft(img, kernel, return_fft=True, psf_pad=True, fft_pad=True)
+        assert img_fft.shape in ((1250, 540), (1250, 525))
 
     @pytest.mark.parametrize(('boundary'), BOUNDARY_OPTIONS)
     def test_non_normalized_kernel(self, boundary):

--- a/docs/changes/convolution/11533.feature.rst
+++ b/docs/changes/convolution/11533.feature.rst
@@ -1,0 +1,4 @@
+Change padding sizes for ``fft_pad`` in ``convolve_fft`` from powers of
+2 only to scipy-optimized numbers, applied separately to each dimension;
+yielding some performance gains and avoiding potential large memory
+impact for certain multi-dimensional inputs.

--- a/docs/convolution/performance.inc.rst
+++ b/docs/convolution/performance.inc.rst
@@ -11,4 +11,4 @@ Performance Tips
 The :func:`~astropy.convolution.convolve` function is best suited to small
 kernels, and can become very slow for larger kernels. In this case, consider
 using :func:`~astropy.convolution.convolve_fft` (though note that this function
-uses more memory).
+uses more memory, and consider the different padding options).


### PR DESCRIPTION
### Description
Addressing https://github.com/astropy/astropy/issues/11242#issuecomment-818017906.

Benchmarks indicate that padding the input to fft to the next integer power of 2 often increases array size to the point where it actually degrades performance. In addition there is no solid foundation for blowing up each dimension to the size of the longest one, possibly also contributing to the memory issues in #10047.
The `scipy.fft.next_fast_len` function should produce better substitutes by using any combination of power of small primes, only slightly increasing the input size. This seems to be the most efficient method both for scipy's `fft` (and its older `fftpack`) and the default `np.fft`.

With this PR the padding is applied separately for each dimension, and using numbers as prescribed by scipy.
An obvious problem was how to find those numbers if scipy is not available, but since the number of `good_sizes` is relatively modest for the `real=True` option, they are now simply stored for sizes up to 10000; for larger sizes these are simply scaled by multiples of 2*5. This may only find the 2nd or 3rd-best value for these large numbers, but those should still be close enough to the optimum. For complex input, additional prime factors of 7 and 11 seem to be included, but the impact on performance is not very obvious.

In some thoughts on further tuning, all the numpy and scipy ffts support `n`, `s` or `shape` options to directly specify the padding size, so one could avoid the prior creation of a larger array in `convolve_fft`; but since in theory any external fft and inverse fft could be provided, it would be complicated to account for all of these cases (and of course we cannot know if all these implementations will have similar performance characteristics...).
Also as already noted in https://github.com/astropy/astropy/issues/11242#issuecomment-760169792 the automatic casting to `complex` might be removed to allow using the yet a bit faster `scipy.fft.[i]rfft` implementations, but the [scipy tutorial entry](https://docs.scipy.org/doc/scipy/reference/tutorial/fft.html#d-discrete-fourier-transforms) indicates that the real versions would need to be applied slightly differently.

Tests to come later as well.