### PR TITLE
Change Cosmology name when parameters change in `clone`

### DIFF
--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -157,6 +157,11 @@ class Cosmology(metaclass=ABCMeta):
         if len(kwargs) == 0:
             return self
 
+        # There are changed parameter values.
+        # The name needs to be changed accordingly, if it wasn't already.
+        kwargs.setdefault("name", (self.name + " (modified)"
+                                   if self.name is not None else None))
+
         # Mix kwargs into initial arguments, preferring the former.
         full_kwargs = {**self._init_arguments, **kwargs}
         # Create BoundArgument to handle args versus kwargs.

--- a/astropy/cosmology/tests/test_cosmology.py
+++ b/astropy/cosmology/tests/test_cosmology.py
@@ -278,7 +278,7 @@ def test_clone():
                          Om0=0.27, Ode0=0.5, wa=0.1, Tcmb0=4.0 * u.K)
     newclone = cosmo.clone(w0=-1.1, wa=0.2)
     assert newclone.__class__ == cosmo.__class__
-    assert newclone.name == cosmo.name
+    assert newclone.name == cosmo.name + " (modified)"
     assert allclose(newclone.H0, cosmo.H0)
     assert allclose(newclone.Om0, cosmo.Om0)
     assert allclose(newclone.Ode0, cosmo.Ode0)

--- a/docs/changes/cosmology/11536.api.rst
+++ b/docs/changes/cosmology/11536.api.rst
@@ -1,2 +1,2 @@
 Cloning a cosmology with changed parameter(s) now appends "(modified)" to the
-new instance's name, unless a name is explicitly passed to clone.
+new instance's name, unless a name is explicitly passed to ``clone``.

--- a/docs/changes/cosmology/rename.api.rst
+++ b/docs/changes/cosmology/rename.api.rst
@@ -1,0 +1,2 @@
+Cloning a cosmology with changed parameter(s) now appends "(modified)" to the
+new instance's name, unless a name is explicitly passed to clone.


### PR DESCRIPTION
### Description

Cloning a cosmology with changed parameters now appends "(modified)" to the
new instance's name, unless a name is explicitly passed to ``clone``.

The problem can be seen when cloning a built-in cosmology and changing a parameter — eg ``Planck18.clone(H0=10)``. This should NOT have the same name because it is not the same thing.
