### PR TITLE
Add Metadata Attribute to Cosmology

### DIFF
--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -151,7 +151,7 @@ class Cosmology(metaclass=ABCMeta):
 
         Parameters
         ----------
-        meta : Mapping or None (optional, keyword-only)
+        meta : mapping or None (optional, keyword-only)
             Metadata that will update the current metadata.
         **kwargs
             Cosmology parameter (and name) modifications.
@@ -252,7 +252,7 @@ class FLRW(Cosmology):
     name : str or None (optional, keyword-only)
         Name for this cosmological object.
 
-    meta : Mapping or None (optional, keyword-only)
+    meta : mapping or None (optional, keyword-only)
         Metadata for the cosmology, e.g. a reference.
 
     Notes
@@ -1696,7 +1696,7 @@ class LambdaCDM(FLRW):
     name : str or None (optional, keyword-only)
         Name for this cosmological object.
 
-    meta : Mapping or None (optional, keyword-only)
+    meta : mapping or None (optional, keyword-only)
         Metadata for the cosmology, e.g. a reference.
 
     Examples
@@ -2228,7 +2228,7 @@ class FlatLambdaCDM(LambdaCDM):
     name : str or None (optional, keyword-only)
         Name for this cosmological object.
 
-    meta : Mapping or None (optional, keyword-only)
+    meta : mapping or None (optional, keyword-only)
         Metadata for the cosmology, e.g. a reference.
 
     Examples
@@ -2391,7 +2391,7 @@ class wCDM(FLRW):
     name : str or None (optional, keyword-only)
         Name for this cosmological object.
 
-    meta : Mapping or None (optional, keyword-only)
+    meta : mapping or None (optional, keyword-only)
         Metadata for the cosmology, e.g. a reference.
 
     Examples
@@ -2604,7 +2604,7 @@ class FlatwCDM(wCDM):
     name : str or None (optional, keyword-only)
         Name for this cosmological object.
 
-    meta : Mapping or None (optional, keyword-only)
+    meta : mapping or None (optional, keyword-only)
         Metadata for the cosmology, e.g. a reference.
 
     Examples
@@ -2769,7 +2769,7 @@ class w0waCDM(FLRW):
     name : str or None (optional, keyword-only)
         Name for this cosmological object.
 
-    meta : Mapping or None (optional, keyword-only)
+    meta : mapping or None (optional, keyword-only)
         Metadata for the cosmology, e.g. a reference.
 
     Examples
@@ -2941,7 +2941,7 @@ class Flatw0waCDM(w0waCDM):
     name : str or None (optional, keyword-only)
         Name for this cosmological object.
 
-    meta : Mapping or None (optional, keyword-only)
+    meta : mapping or None (optional, keyword-only)
         Metadata for the cosmology, e.g. a reference.
 
     Examples
@@ -3053,7 +3053,7 @@ class wpwaCDM(FLRW):
     name : str or None (optional, keyword-only)
         Name for this cosmological object.
 
-    meta : Mapping or None (optional, keyword-only)
+    meta : mapping or None (optional, keyword-only)
         Metadata for the cosmology, e.g. a reference.
 
     Examples
@@ -3241,7 +3241,7 @@ class w0wzCDM(FLRW):
     name : str or None (optional, keyword-only)
         Name for this cosmological object.
 
-    meta : Mapping or None (optional, keyword-only)
+    meta : mapping or None (optional, keyword-only)
         Metadata for the cosmology, e.g. a reference.
 
     Examples

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -173,7 +173,7 @@ class Cosmology(metaclass=ABCMeta):
             >>> from astropy.cosmology import Planck13
             >>> newcosmo = Planck13.clone(name="Modified Planck 2013", Om0=0.35)
 
-        If no name is specified, the new name will note the modification
+        If no name is specified, the new name will note the modification.
             >>> Planck13.clone(Om0=0.35).name
             'Planck13 (modified)'
 

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -13,6 +13,7 @@ from . import scalar_inv_efuncs
 from astropy import constants as const
 from astropy import units as u
 from astropy.utils import isiterable
+from astropy.utils.metadata import MetaData
 from astropy.utils.state import ScienceState
 from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyUserWarning
 
@@ -93,6 +94,8 @@ class Cosmology(metaclass=ABCMeta):
         Arguments into the cosmology; used by subclasses, not this base class.
     name : str or None (optional, keyword-only)
         The name of the cosmology.
+    meta : dict or None (optional, keyword-only)
+        Metadata for the cosmology, e.g. a reference.
     **kwargs
         Arguments into the cosmology; used by subclasses, not this base class.
 
@@ -103,6 +106,8 @@ class Cosmology(metaclass=ABCMeta):
     read only.
 
     """
+
+    meta = MetaData()
 
     def __init_subclass__(cls):
         super().__init_subclass__()
@@ -127,8 +132,9 @@ class Cosmology(metaclass=ABCMeta):
 
         return self
 
-    def __init__(self, *args, name=None, **kwargs):
+    def __init__(self, *args, name=None, meta=None, **kwargs):
         self._name = name
+        self.meta.update(meta or {})
 
     @property
     def name(self):
@@ -229,6 +235,9 @@ class FLRW(Cosmology):
     name : str or None, optional
         Name for this cosmological object.
 
+    **metadata
+        Metadata for the cosmology, e.g. a reference.
+
     Notes
     -----
     Class instances are static -- you cannot change the values
@@ -237,8 +246,9 @@ class FLRW(Cosmology):
     """
 
     def __init__(self, H0, Om0, Ode0, Tcmb0=0, Neff=3.04,
-                 m_nu=u.Quantity(0.0, u.eV), Ob0=None, name=None):
-        super().__init__(name=name)
+                 m_nu=u.Quantity(0.0, u.eV), Ob0=None, name=None,
+                 **metadata):
+        super().__init__(name=name, meta=metadata)
 
         # all densities are in units of the critical density
         self._Om0 = float(Om0)
@@ -1669,6 +1679,9 @@ class LambdaCDM(FLRW):
     name : str or None, optional
         Name for this cosmological object.
 
+    **metadata
+        Metadata for the cosmology, e.g. a reference.
+
     Examples
     --------
     >>> from astropy.cosmology import LambdaCDM
@@ -1681,9 +1694,10 @@ class LambdaCDM(FLRW):
     """
 
     def __init__(self, H0, Om0, Ode0, Tcmb0=0, Neff=3.04,
-                 m_nu=u.Quantity(0.0, u.eV), Ob0=None, name=None):
+                 m_nu=u.Quantity(0.0, u.eV), Ob0=None, name=None, **metadata):
 
-        super().__init__(H0, Om0, Ode0, Tcmb0, Neff, m_nu, Ob0=Ob0, name=name)
+        super().__init__(H0, Om0, Ode0, Tcmb0, Neff, m_nu, Ob0=Ob0,
+                         name=name, **metadata)
 
         # Please see "Notes about speeding up integrals" for discussion
         # about what is being done here.
@@ -2197,6 +2211,9 @@ class FlatLambdaCDM(LambdaCDM):
     name : str or None, optional
         Name for this cosmological object.
 
+    **metadata
+        Metadata for the cosmology, e.g. a reference.
+
     Examples
     --------
     >>> from astropy.cosmology import FlatLambdaCDM
@@ -2209,9 +2226,10 @@ class FlatLambdaCDM(LambdaCDM):
     """
 
     def __init__(self, H0, Om0, Tcmb0=0, Neff=3.04,
-                 m_nu=u.Quantity(0.0, u.eV), Ob0=None, name=None):
+                 m_nu=u.Quantity(0.0, u.eV), Ob0=None, name=None, **metadata):
 
-        super().__init__(H0, Om0, 0.0, Tcmb0, Neff, m_nu, Ob0=Ob0, name=name)
+        super().__init__(H0, Om0, 0.0, Tcmb0, Neff, m_nu, Ob0=Ob0,
+			 name=name, **metadata)
         # Do some twiddling after the fact to get flatness
         self._Ode0 = 1.0 - self._Om0 - self._Ogamma0 - self._Onu0
         self._Ok0 = 0.0
@@ -2356,6 +2374,9 @@ class wCDM(FLRW):
     name : str or None, optional
         Name for this cosmological object.
 
+    **metadata
+        Metadata for the cosmology, e.g. a reference.
+
     Examples
     --------
     >>> from astropy.cosmology import wCDM
@@ -2368,7 +2389,8 @@ class wCDM(FLRW):
     """
 
     def __init__(self, H0, Om0, Ode0, w0=-1., Tcmb0=0,
-                 Neff=3.04, m_nu=u.Quantity(0.0, u.eV), Ob0=None, name=None):
+                 Neff=3.04, m_nu=u.Quantity(0.0, u.eV), Ob0=None,
+                 name=None, **metadata):
 
         super().__init__(H0, Om0, Ode0, Tcmb0, Neff, m_nu, Ob0=Ob0, name=name)
         self._w0 = float(w0)
@@ -2565,6 +2587,9 @@ class FlatwCDM(wCDM):
     name : str or None, optional
         Name for this cosmological object.
 
+    **metadata
+        Metadata for the cosmology, e.g. a reference.
+
     Examples
     --------
     >>> from astropy.cosmology import FlatwCDM
@@ -2577,9 +2602,11 @@ class FlatwCDM(wCDM):
     """
 
     def __init__(self, H0, Om0, w0=-1., Tcmb0=0,
-                 Neff=3.04, m_nu=u.Quantity(0.0, u.eV), Ob0=None, name=None):
+                 Neff=3.04, m_nu=u.Quantity(0.0, u.eV), Ob0=None,
+                 name=None, **metadata):
 
-        super().__init__(H0, Om0, 0., w0, Tcmb0, Neff, m_nu, Ob0=Ob0, name=name)
+        super().__init__(H0, Om0, 0., w0, Tcmb0, Neff, m_nu, Ob0=Ob0,
+                         name=name, **metdata)
         # Do some twiddling after the fact to get flatness
         self._Ode0 = 1.0 - self._Om0 - self._Ogamma0 - self._Onu0
         self._Ok0 = 0.0
@@ -2726,6 +2753,9 @@ class w0waCDM(FLRW):
     name : str or None, optional
         Name for this cosmological object.
 
+    **metadata
+        Metadata for the cosmology, e.g. a reference.
+
     Examples
     --------
     >>> from astropy.cosmology import w0waCDM
@@ -2738,9 +2768,11 @@ class w0waCDM(FLRW):
     """
 
     def __init__(self, H0, Om0, Ode0, w0=-1., wa=0., Tcmb0=0,
-                 Neff=3.04, m_nu=u.Quantity(0.0, u.eV), Ob0=None, name=None):
+                 Neff=3.04, m_nu=u.Quantity(0.0, u.eV), Ob0=None,
+                 name=None, **metadata):
 
-        super().__init__(H0, Om0, Ode0, Tcmb0, Neff, m_nu, Ob0=Ob0, name=name)
+        super().__init__(H0, Om0, Ode0, Tcmb0, Neff, m_nu, Ob0=Ob0,
+                         name=name, **metadata)
         self._w0 = float(w0)
         self._wa = float(wa)
 
@@ -2894,6 +2926,9 @@ class Flatw0waCDM(w0waCDM):
     name : str or None, optional
         Name for this cosmological object.
 
+    **metadata
+        Metadata for the cosmology, e.g. a reference.
+
     Examples
     --------
     >>> from astropy.cosmology import Flatw0waCDM
@@ -2906,10 +2941,11 @@ class Flatw0waCDM(w0waCDM):
     """
 
     def __init__(self, H0, Om0, w0=-1., wa=0., Tcmb0=0,
-                 Neff=3.04, m_nu=u.Quantity(0.0, u.eV), Ob0=None, name=None):
+                 Neff=3.04, m_nu=u.Quantity(0.0, u.eV), Ob0=None, name=None,
+                 **metadata):
 
         super().__init__(H0, Om0, 0.0, w0=w0, wa=wa, Tcmb0=Tcmb0,
-                         Neff=Neff, m_nu=m_nu, Ob0=Ob0, name=name)
+                         Neff=Neff, m_nu=m_nu, Ob0=Ob0, name=name, **metadata)
         # Do some twiddling after the fact to get flatness
         self._Ode0 = 1.0 - self._Om0 - self._Ogamma0 - self._Onu0
         self._Ok0 = 0.0
@@ -3003,6 +3039,9 @@ class wpwaCDM(FLRW):
     name : str or None, optional
         Name for this cosmological object.
 
+    **metadata
+        Metadata for the cosmology, e.g. a reference.
+
     Examples
     --------
     >>> from astropy.cosmology import wpwaCDM
@@ -3016,9 +3055,10 @@ class wpwaCDM(FLRW):
 
     def __init__(self, H0, Om0, Ode0, wp=-1., wa=0., zp=0,
                  Tcmb0=0, Neff=3.04, m_nu=u.Quantity(0.0, u.eV),
-                 Ob0=None, name=None):
+                 Ob0=None, name=None, **metadata):
 
-        super().__init__(H0, Om0, Ode0, Tcmb0, Neff, m_nu, Ob0=Ob0, name=name)
+        super().__init__(H0, Om0, Ode0, Tcmb0, Neff, m_nu, Ob0=Ob0,
+			 name=name, **metadata)
         self._wp = float(wp)
         self._wa = float(wa)
         self._zp = float(zp)
@@ -3187,6 +3227,9 @@ class w0wzCDM(FLRW):
     name : str or None, optional
         Name for this cosmological object.
 
+    **metadata
+        Metadata for the cosmology, e.g. a reference.
+
     Examples
     --------
     >>> from astropy.cosmology import w0wzCDM
@@ -3200,9 +3243,10 @@ class w0wzCDM(FLRW):
 
     def __init__(self, H0, Om0, Ode0, w0=-1., wz=0., Tcmb0=0,
                  Neff=3.04, m_nu=u.Quantity(0.0, u.eV), Ob0=None,
-                 name=None):
+                 name=None, **metadata):
 
-        super().__init__(H0, Om0, Ode0, Tcmb0, Neff, m_nu, Ob0=Ob0, name=name)
+        super().__init__(H0, Om0, Ode0, Tcmb0, Neff, m_nu, Ob0=Ob0,
+                         name=name, **metadata)
         self._w0 = float(w0)
         self._wz = float(wz)
 

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -102,7 +102,7 @@ class Cosmology(metaclass=ABCMeta):
     Notes
     -----
     Class instances are static -- you cannot (and should not) change the values
-    of the parameters.  That is, all of the attributes above are
+    of the parameters.  That is, all of the above attributes (except meta) are
     read only.
 
     """
@@ -118,14 +118,10 @@ class Cosmology(metaclass=ABCMeta):
 
     def __new__(cls, *args, **kwargs):
         # bundle initialization argument
-        if not args:
-            parameters = kwargs
-        else:  # have to merge args and kwargs.
-            # bind any arguments passed
-            ba = cls._init_signature.bind_partial(*args, **kwargs)
-            ba.apply_defaults()  # and fill in the defaults
-            # get dictionary of arguments
-            parameters = ba.arguments
+        ba = cls._init_signature.bind_partial(*args, **kwargs)
+        ba.apply_defaults()  # and fill in the defaults
+        # get dictionary of arguments
+        parameters = ba.arguments
 
         self = super().__new__(cls)
         self._init_arguments = parameters  # store arguments from initialization
@@ -173,7 +169,7 @@ class Cosmology(metaclass=ABCMeta):
                                    if self.name is not None else None))
 
         # Mix kwargs into initial arguments, preferring the former.
-        full_kwargs = {**self._init_arguments, **kwargs}
+        full_kwargs = {**self._init_arguments, "meta": self.meta, **kwargs}
         # Create BoundArgument to handle args versus kwargs.
         # This also handles all errors from mismatched arguments
         try:
@@ -232,23 +228,23 @@ class FLRW(Cosmology):
         density at z=0.  If this is set to None (the default), any
         computation that requires its value will raise an exception.
 
-    name : str or None, optional
+    name : str or None (optional, keyword-only)
         Name for this cosmological object.
 
-    **metadata
+    meta : Mapping or None (optional, keyword-only)
         Metadata for the cosmology, e.g. a reference.
 
     Notes
     -----
     Class instances are static -- you cannot change the values
-    of the parameters.  That is, all of the attributes above are
+    of the parameters.  That is, all of the above attributes (except meta) are
     read only.
     """
 
     def __init__(self, H0, Om0, Ode0, Tcmb0=0, Neff=3.04,
-                 m_nu=u.Quantity(0.0, u.eV), Ob0=None, name=None,
-                 **metadata):
-        super().__init__(name=name, meta=metadata)
+                 m_nu=u.Quantity(0.0, u.eV), Ob0=None, *,
+                 name=None, meta=None):
+        super().__init__(name=name, meta=meta)
 
         # all densities are in units of the critical density
         self._Om0 = float(Om0)
@@ -1676,10 +1672,10 @@ class LambdaCDM(FLRW):
         density at z=0.  If this is set to None (the default), any
         computation that requires its value will raise an exception.
 
-    name : str or None, optional
+    name : str or None (optional, keyword-only)
         Name for this cosmological object.
 
-    **metadata
+    meta : Mapping or None (optional, keyword-only)
         Metadata for the cosmology, e.g. a reference.
 
     Examples
@@ -1694,10 +1690,10 @@ class LambdaCDM(FLRW):
     """
 
     def __init__(self, H0, Om0, Ode0, Tcmb0=0, Neff=3.04,
-                 m_nu=u.Quantity(0.0, u.eV), Ob0=None, name=None, **metadata):
-
-        super().__init__(H0, Om0, Ode0, Tcmb0, Neff, m_nu, Ob0=Ob0,
-                         name=name, **metadata)
+                 m_nu=u.Quantity(0.0, u.eV), Ob0=None, *,
+                 name=None, meta=None):
+        super().__init__(H0=H0, Om0=Om0, Ode0=Ode0, Tcmb0=Tcmb0, Neff=Neff,
+                         m_nu=m_nu, Ob0=Ob0, name=name, meta=meta)
 
         # Please see "Notes about speeding up integrals" for discussion
         # about what is being done here.
@@ -2208,10 +2204,10 @@ class FlatLambdaCDM(LambdaCDM):
         density at z=0.  If this is set to None (the default), any
         computation that requires its value will raise an exception.
 
-    name : str or None, optional
+    name : str or None (optional, keyword-only)
         Name for this cosmological object.
 
-    **metadata
+    meta : Mapping or None (optional, keyword-only)
         Metadata for the cosmology, e.g. a reference.
 
     Examples
@@ -2226,10 +2222,10 @@ class FlatLambdaCDM(LambdaCDM):
     """
 
     def __init__(self, H0, Om0, Tcmb0=0, Neff=3.04,
-                 m_nu=u.Quantity(0.0, u.eV), Ob0=None, name=None, **metadata):
-
-        super().__init__(H0, Om0, 0.0, Tcmb0, Neff, m_nu, Ob0=Ob0,
-			 name=name, **metadata)
+                 m_nu=u.Quantity(0.0, u.eV), Ob0=None, *,
+                 name=None, meta=None):
+        super().__init__(H0=H0, Om0=Om0, Ode0=0.0, Tcmb0=Tcmb0, Neff=Neff,
+                         m_nu=m_nu, Ob0=Ob0, name=name, meta=meta)
         # Do some twiddling after the fact to get flatness
         self._Ode0 = 1.0 - self._Om0 - self._Ogamma0 - self._Onu0
         self._Ok0 = 0.0
@@ -2371,10 +2367,10 @@ class wCDM(FLRW):
         density at z=0.  If this is set to None (the default), any
         computation that requires its value will raise an exception.
 
-    name : str or None, optional
+    name : str or None (optional, keyword-only)
         Name for this cosmological object.
 
-    **metadata
+    meta : Mapping or None (optional, keyword-only)
         Metadata for the cosmology, e.g. a reference.
 
     Examples
@@ -2389,10 +2385,10 @@ class wCDM(FLRW):
     """
 
     def __init__(self, H0, Om0, Ode0, w0=-1., Tcmb0=0,
-                 Neff=3.04, m_nu=u.Quantity(0.0, u.eV), Ob0=None,
-                 name=None, **metadata):
-
-        super().__init__(H0, Om0, Ode0, Tcmb0, Neff, m_nu, Ob0=Ob0, name=name)
+                 Neff=3.04, m_nu=u.Quantity(0.0, u.eV), Ob0=None, *,
+                 name=None, meta=None):
+        super().__init__(H0=H0, Om0=Om0, Ode0=Ode0, Tcmb0=Tcmb0, Neff=Neff,
+                         m_nu=m_nu, Ob0=Ob0, name=name, meta=meta)
         self._w0 = float(w0)
 
         # Please see "Notes about speeding up integrals" for discussion
@@ -2584,10 +2580,10 @@ class FlatwCDM(wCDM):
         density at z=0.  If this is set to None (the default), any
         computation that requires its value will raise an exception.
 
-    name : str or None, optional
+    name : str or None (optional, keyword-only)
         Name for this cosmological object.
 
-    **metadata
+    meta : Mapping or None (optional, keyword-only)
         Metadata for the cosmology, e.g. a reference.
 
     Examples
@@ -2602,11 +2598,10 @@ class FlatwCDM(wCDM):
     """
 
     def __init__(self, H0, Om0, w0=-1., Tcmb0=0,
-                 Neff=3.04, m_nu=u.Quantity(0.0, u.eV), Ob0=None,
-                 name=None, **metadata):
-
-        super().__init__(H0, Om0, 0., w0, Tcmb0, Neff, m_nu, Ob0=Ob0,
-                         name=name, **metdata)
+                 Neff=3.04, m_nu=u.Quantity(0.0, u.eV), Ob0=None, *,
+                 name=None, meta=None):
+        super().__init__(H0=H0, Om0=Om0, Ode0=0.0, w0=w0, Tcmb0=Tcmb0,
+                         Neff=Neff, m_nu=m_nu, Ob0=Ob0, name=name, meta=meta)
         # Do some twiddling after the fact to get flatness
         self._Ode0 = 1.0 - self._Om0 - self._Ogamma0 - self._Onu0
         self._Ok0 = 0.0
@@ -2750,10 +2745,10 @@ class w0waCDM(FLRW):
         density at z=0.  If this is set to None (the default), any
         computation that requires its value will raise an exception.
 
-    name : str or None, optional
+    name : str or None (optional, keyword-only)
         Name for this cosmological object.
 
-    **metadata
+    meta : Mapping or None (optional, keyword-only)
         Metadata for the cosmology, e.g. a reference.
 
     Examples
@@ -2768,11 +2763,10 @@ class w0waCDM(FLRW):
     """
 
     def __init__(self, H0, Om0, Ode0, w0=-1., wa=0., Tcmb0=0,
-                 Neff=3.04, m_nu=u.Quantity(0.0, u.eV), Ob0=None,
-                 name=None, **metadata):
-
-        super().__init__(H0, Om0, Ode0, Tcmb0, Neff, m_nu, Ob0=Ob0,
-                         name=name, **metadata)
+                 Neff=3.04, m_nu=u.Quantity(0.0, u.eV), Ob0=None, *,
+                 name=None, meta=None):
+        super().__init__(H0=H0, Om0=Om0, Ode0=Ode0, Tcmb0=Tcmb0, Neff=Neff,
+                         m_nu=m_nu, Ob0=Ob0, name=name, meta=meta)
         self._w0 = float(w0)
         self._wa = float(wa)
 
@@ -2923,10 +2917,10 @@ class Flatw0waCDM(w0waCDM):
         density at z=0.  If this is set to None (the default), any
         computation that requires its value will raise an exception.
 
-    name : str or None, optional
+    name : str or None (optional, keyword-only)
         Name for this cosmological object.
 
-    **metadata
+    meta : Mapping or None (optional, keyword-only)
         Metadata for the cosmology, e.g. a reference.
 
     Examples
@@ -2941,11 +2935,10 @@ class Flatw0waCDM(w0waCDM):
     """
 
     def __init__(self, H0, Om0, w0=-1., wa=0., Tcmb0=0,
-                 Neff=3.04, m_nu=u.Quantity(0.0, u.eV), Ob0=None, name=None,
-                 **metadata):
-
-        super().__init__(H0, Om0, 0.0, w0=w0, wa=wa, Tcmb0=Tcmb0,
-                         Neff=Neff, m_nu=m_nu, Ob0=Ob0, name=name, **metadata)
+                 Neff=3.04, m_nu=u.Quantity(0.0, u.eV), Ob0=None, *,
+                 name=None, meta=None):
+        super().__init__(H0=H0, Om0=Om0, Ode0=0.0, w0=w0, wa=wa, Tcmb0=Tcmb0,
+                         Neff=Neff, m_nu=m_nu, Ob0=Ob0, name=name, meta=meta)
         # Do some twiddling after the fact to get flatness
         self._Ode0 = 1.0 - self._Om0 - self._Ogamma0 - self._Onu0
         self._Ok0 = 0.0
@@ -3036,10 +3029,10 @@ class wpwaCDM(FLRW):
         density at z=0.  If this is set to None (the default), any
         computation that requires its value will raise an exception.
 
-    name : str or None, optional
+    name : str or None (optional, keyword-only)
         Name for this cosmological object.
 
-    **metadata
+    meta : Mapping or None (optional, keyword-only)
         Metadata for the cosmology, e.g. a reference.
 
     Examples
@@ -3053,12 +3046,11 @@ class wpwaCDM(FLRW):
     >>> dc = cosmo.comoving_distance(z)
     """
 
-    def __init__(self, H0, Om0, Ode0, wp=-1., wa=0., zp=0,
-                 Tcmb0=0, Neff=3.04, m_nu=u.Quantity(0.0, u.eV),
-                 Ob0=None, name=None, **metadata):
-
-        super().__init__(H0, Om0, Ode0, Tcmb0, Neff, m_nu, Ob0=Ob0,
-			 name=name, **metadata)
+    def __init__(self, H0, Om0, Ode0, wp=-1., wa=0., zp=0, Tcmb0=0,
+                 Neff=3.04, m_nu=u.Quantity(0.0, u.eV), Ob0=None, *, 
+                 name=None, meta=None):
+        super().__init__(H0=H0, Om0=Om0, Ode0=Ode0, Tcmb0=Tcmb0, Neff=Neff,
+                         m_nu=m_nu, Ob0=Ob0, name=name, meta=meta)
         self._wp = float(wp)
         self._wa = float(wa)
         self._zp = float(zp)
@@ -3224,10 +3216,10 @@ class w0wzCDM(FLRW):
         density at z=0.  If this is set to None (the default), any
         computation that requires its value will raise an exception.
 
-    name : str or None, optional
+    name : str or None (optional, keyword-only)
         Name for this cosmological object.
 
-    **metadata
+    meta : Mapping or None (optional, keyword-only)
         Metadata for the cosmology, e.g. a reference.
 
     Examples
@@ -3242,11 +3234,10 @@ class w0wzCDM(FLRW):
     """
 
     def __init__(self, H0, Om0, Ode0, w0=-1., wz=0., Tcmb0=0,
-                 Neff=3.04, m_nu=u.Quantity(0.0, u.eV), Ob0=None,
-                 name=None, **metadata):
-
-        super().__init__(H0, Om0, Ode0, Tcmb0, Neff, m_nu, Ob0=Ob0,
-                         name=name, **metadata)
+                 Neff=3.04, m_nu=u.Quantity(0.0, u.eV), Ob0=None, *,
+                 name=None, meta=None):
+        super().__init__(H0=H0, Om0=Om0, Ode0=Ode0, Tcmb0=Tcmb0, Neff=Neff,
+                         m_nu=m_nu, Ob0=Ob0, name=name, meta=meta)
         self._w0 = float(w0)
         self._wz = float(wz)
 
@@ -3382,3 +3373,11 @@ def inf_like(x):
         return np.inf
     else:
         return np.full_like(x, np.inf, dtype='float')
+
+
+# modified from https://stackoverflow.com/a/33607093
+def _get_subclasses(cls):
+    for subclass in cls.__subclasses__():
+        yield from _get_subclasses(subclass)
+        yield subclass.__qualname__, subclass
+    yield cls.__qualname__, cls

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -3395,11 +3395,3 @@ def inf_like(x):
         return np.inf
     else:
         return np.full_like(x, np.inf, dtype='float')
-
-
-# modified from https://stackoverflow.com/a/33607093
-def _get_subclasses(cls):
-    for subclass in cls.__subclasses__():
-        yield from _get_subclasses(subclass)
-        yield subclass.__qualname__, subclass
-    yield cls.__qualname__, cls

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -95,7 +95,7 @@ class Cosmology(metaclass=ABCMeta):
     name : str or None (optional, keyword-only)
         The name of the cosmology.
     meta : dict or None (optional, keyword-only)
-        Metadata for the cosmology, e.g. a reference.
+        Metadata for the cosmology, e.g., a reference.
     **kwargs
         Arguments into the cosmology; used by subclasses, not this base class.
 
@@ -253,7 +253,7 @@ class FLRW(Cosmology):
         Name for this cosmological object.
 
     meta : mapping or None (optional, keyword-only)
-        Metadata for the cosmology, e.g. a reference.
+        Metadata for the cosmology, e.g., a reference.
 
     Notes
     -----
@@ -1697,7 +1697,7 @@ class LambdaCDM(FLRW):
         Name for this cosmological object.
 
     meta : mapping or None (optional, keyword-only)
-        Metadata for the cosmology, e.g. a reference.
+        Metadata for the cosmology, e.g., a reference.
 
     Examples
     --------
@@ -2229,7 +2229,7 @@ class FlatLambdaCDM(LambdaCDM):
         Name for this cosmological object.
 
     meta : mapping or None (optional, keyword-only)
-        Metadata for the cosmology, e.g. a reference.
+        Metadata for the cosmology, e.g., a reference.
 
     Examples
     --------
@@ -2392,7 +2392,7 @@ class wCDM(FLRW):
         Name for this cosmological object.
 
     meta : mapping or None (optional, keyword-only)
-        Metadata for the cosmology, e.g. a reference.
+        Metadata for the cosmology, e.g., a reference.
 
     Examples
     --------
@@ -2605,7 +2605,7 @@ class FlatwCDM(wCDM):
         Name for this cosmological object.
 
     meta : mapping or None (optional, keyword-only)
-        Metadata for the cosmology, e.g. a reference.
+        Metadata for the cosmology, e.g., a reference.
 
     Examples
     --------
@@ -2770,7 +2770,7 @@ class w0waCDM(FLRW):
         Name for this cosmological object.
 
     meta : mapping or None (optional, keyword-only)
-        Metadata for the cosmology, e.g. a reference.
+        Metadata for the cosmology, e.g., a reference.
 
     Examples
     --------
@@ -2942,7 +2942,7 @@ class Flatw0waCDM(w0waCDM):
         Name for this cosmological object.
 
     meta : mapping or None (optional, keyword-only)
-        Metadata for the cosmology, e.g. a reference.
+        Metadata for the cosmology, e.g., a reference.
 
     Examples
     --------
@@ -3054,7 +3054,7 @@ class wpwaCDM(FLRW):
         Name for this cosmological object.
 
     meta : mapping or None (optional, keyword-only)
-        Metadata for the cosmology, e.g. a reference.
+        Metadata for the cosmology, e.g., a reference.
 
     Examples
     --------
@@ -3242,7 +3242,7 @@ class w0wzCDM(FLRW):
         Name for this cosmological object.
 
     meta : mapping or None (optional, keyword-only)
-        Metadata for the cosmology, e.g. a reference.
+        Metadata for the cosmology, e.g., a reference.
 
     Examples
     --------

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -131,6 +131,11 @@ class Cosmology(metaclass=ABCMeta):
         self._name = name
         self.meta.update(meta or {})
 
+    # make initial signature of cosmology. overwritten in subclasses
+    _init_signature = signature(__init__)
+    _init_signature = _init_signature.replace(
+        parameters=list(_init_signature.parameters.values())[1:])
+
     @property
     def name(self):
         return self._name

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -13,12 +13,11 @@ from . import scalar_inv_efuncs
 from astropy import constants as const
 from astropy import units as u
 from astropy.utils import isiterable
+from astropy.utils.exceptions import (AstropyDeprecationWarning,
+                                      AstropyUserWarning)
 from astropy.utils.metadata import MetaData
 from astropy.utils.state import ScienceState
-from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyUserWarning
 
-
-from . import parameters
 
 # Originally authored by Andrew Becker (becker@astro.washington.edu),
 # and modified by Neil Crighton (neilcrighton@gmail.com) and Roban
@@ -3047,7 +3046,7 @@ class wpwaCDM(FLRW):
     """
 
     def __init__(self, H0, Om0, Ode0, wp=-1., wa=0., zp=0, Tcmb0=0,
-                 Neff=3.04, m_nu=u.Quantity(0.0, u.eV), Ob0=None, *, 
+                 Neff=3.04, m_nu=u.Quantity(0.0, u.eV), Ob0=None, *,
                  name=None, meta=None):
         super().__init__(H0=H0, Om0=Om0, Ode0=Ode0, Tcmb0=Tcmb0, Neff=Neff,
                          m_nu=m_nu, Ob0=Ob0, name=name, meta=meta)

--- a/astropy/cosmology/realizations.py
+++ b/astropy/cosmology/realizations.py
@@ -39,7 +39,7 @@ for key in parameters.available:
             else:
                 par[k] = v
 
-        ba = cosmo_cls._init_signature.bind_partial(**par, meta=meta)
+        ba = cosmo_cls._init_signature.bind_partial(**par, name=key, meta=meta)
         cosmo = cosmo_cls(*ba.args, **ba.kwargs)
         cosmo.__doc__ = (f"{key} instance of {cosmo_cls} cosmology\n"
                          f"(from {meta['reference']})")

--- a/astropy/cosmology/realizations.py
+++ b/astropy/cosmology/realizations.py
@@ -14,12 +14,14 @@ __all__ = ["default_cosmology"] + parameters.available
 
 __doctest_requires__ = {"*": ["scipy"]}
 
+
 def _all_subclasses(cls):
     """Yield a (qualname, cls) of all subclasses (inclusive)."""
     # modified from https://stackoverflow.com/a/33607093
     yield cls.__qualname__, cls
     for subclass in cls.__subclasses__():
         yield from _all_subclasses(subclass)  # recursion in subclass
+
 
 # Pre-defined cosmologies. This loops over the parameter sets in the
 # parameters module and creates a cosmology instance with the same name as the

--- a/astropy/cosmology/realizations.py
+++ b/astropy/cosmology/realizations.py
@@ -8,16 +8,23 @@ from astropy.utils.exceptions import AstropyDeprecationWarning
 from astropy.utils.state import ScienceState
 
 from . import parameters
-from .core import Cosmology, _get_subclasses
+from .core import Cosmology
 
 __all__ = ["default_cosmology"] + parameters.available
 
 __doctest_requires__ = {"*": ["scipy"]}
 
+def _all_subclasses(cls):
+    """Yield a (qualname, cls) of all subclasses (inclusive)."""
+    # modified from https://stackoverflow.com/a/33607093
+    yield cls.__qualname__, cls
+    for subclass in cls.__subclasses__():
+        yield from _all_subclasses(subclass)  # recursion in subclass
+
 # Pre-defined cosmologies. This loops over the parameter sets in the
 # parameters module and creates a cosmology instance with the same name as the
 # parameter set in the current module's namespace.
-_subclasses = dict(_get_subclasses(Cosmology))
+_subclasses = dict(_all_subclasses(Cosmology))
 for key in parameters.available:
     params = getattr(parameters, key)
 

--- a/astropy/cosmology/realizations.py
+++ b/astropy/cosmology/realizations.py
@@ -41,7 +41,7 @@ for key in parameters.available:
 
         ba = cosmo_cls._init_signature.bind_partial(**par, name=key, meta=meta)
         cosmo = cosmo_cls(*ba.args, **ba.kwargs)
-        cosmo.__doc__ = (f"{key} instance of {cosmo_cls} cosmology\n"
+        cosmo.__doc__ = (f"{key} instance of {cosmo_cls.__name__} cosmology\n"
                          f"(from {meta['reference']})")
 
         setattr(sys.modules[__name__], key, cosmo)

--- a/astropy/cosmology/realizations.py
+++ b/astropy/cosmology/realizations.py
@@ -41,7 +41,7 @@ for key in parameters.available:
 
         ba = cosmo_cls._init_signature.bind_partial(**par, meta=meta)
         cosmo = cosmo_cls(*ba.args, **ba.kwargs)
-        cosmo.__doc__ = (f"{key} instance of {cosmo_cls} cosmology\n\n"
+        cosmo.__doc__ = (f"{key} instance of {cosmo_cls} cosmology\n"
                          f"(from {meta['reference']})")
 
         setattr(sys.modules[__name__], key, cosmo)

--- a/astropy/cosmology/tests/test_cosmology.py
+++ b/astropy/cosmology/tests/test_cosmology.py
@@ -56,6 +56,11 @@ def test_immutability():
     with pytest.raises(AttributeError):
         cosmo.name = "new name"
 
+    # The metadata is NOT immutable
+    assert "a" not in cosmo.meta
+    cosmo.meta["a"] = 1
+    assert "a" in cosmo.meta
+
 
 def test_basic():
     cosmo = core.FlatLambdaCDM(H0=70, Om0=0.27, Tcmb0=2.0, Neff=3.04,

--- a/astropy/cosmology/tests/test_cosmology.py
+++ b/astropy/cosmology/tests/test_cosmology.py
@@ -59,7 +59,7 @@ def test_immutability():
 
 def test_basic():
     cosmo = core.FlatLambdaCDM(H0=70, Om0=0.27, Tcmb0=2.0, Neff=3.04,
-                               Ob0=0.05)
+                               Ob0=0.05, name="test", meta={"a": "b"})
     assert allclose(cosmo.Om0, 0.27)
     assert allclose(cosmo.Ode0, 0.729975, rtol=1e-4)
     assert allclose(cosmo.Ob0, 0.05)
@@ -78,6 +78,8 @@ def test_basic():
     assert allclose(cosmo.Neff, 3.04)
     assert allclose(cosmo.h, 0.7)
     assert allclose(cosmo.H0, 70.0 * u.km / u.s / u.Mpc)
+    assert cosmo.name == "test"
+    assert cosmo.meta == {"a": "b"}
 
     # Make sure setting them as quantities gives the same results
     H0 = u.Quantity(70, u.km / (u.s * u.Mpc))
@@ -201,7 +203,7 @@ def test_clone():
     """ Test clone operation"""
 
     cosmo = core.FlatLambdaCDM(H0=70 * u.km / u.s / u.Mpc, Om0=0.27,
-                               Tcmb0=3.0 * u.K)
+                               Tcmb0=3.0 * u.K, name="test", meta={"a":"b"})
     z = np.linspace(0.1, 3, 15)
 
     # First, test with no changes, which should return same object
@@ -213,7 +215,7 @@ def test_clone():
     newclone = cosmo.clone(H0=60 * u.km / u.s / u.Mpc)
     assert newclone is not cosmo
     assert newclone.__class__ == cosmo.__class__
-    assert newclone.name == cosmo.name
+    assert newclone.name == cosmo.name + " (modified)"
     assert not allclose(newclone.H0.value, cosmo.H0.value)
     assert allclose(newclone.H0, 60.0 * u.km / u.s / u.Mpc)
     assert allclose(newclone.Om0, cosmo.Om0)
@@ -228,7 +230,7 @@ def test_clone():
     cmp = core.FlatLambdaCDM(H0=60 * u.km / u.s / u.Mpc, Om0=0.27,
                              Tcmb0=3.0 * u.K)
     assert newclone.__class__ == cmp.__class__
-    assert newclone.name == cmp.name
+    assert cmp.name is None
     assert allclose(newclone.H0, cmp.H0)
     assert allclose(newclone.Om0, cmp.Om0)
     assert allclose(newclone.Ode0, cmp.Ode0)

--- a/astropy/cosmology/tests/test_cosmology.py
+++ b/astropy/cosmology/tests/test_cosmology.py
@@ -205,8 +205,7 @@ def test_distance_broadcast():
 
 @pytest.mark.skipif('not HAS_SCIPY')
 def test_clone():
-    """ Test clone operation"""
-
+    """Test clone operation."""
     cosmo = core.FlatLambdaCDM(H0=70 * u.km / u.s / u.Mpc, Om0=0.27,
                                Tcmb0=3.0 * u.K, name="test", meta={"a":"b"})
     z = np.linspace(0.1, 3, 15)
@@ -252,7 +251,7 @@ def test_clone():
 
     # Now try changing multiple things
     newclone = cosmo.clone(name="New name", H0=65 * u.km / u.s / u.Mpc,
-                           Tcmb0=2.8 * u.K)
+                           Tcmb0=2.8 * u.K, meta=dict(zz="tops"))
     assert newclone.__class__ == cosmo.__class__
     assert not newclone.name == cosmo.name
     assert not allclose(newclone.H0.value, cosmo.H0.value)
@@ -265,6 +264,7 @@ def test_clone():
     assert allclose(newclone.Tcmb0, 2.8 * u.K)
     assert allclose(newclone.m_nu, cosmo.m_nu)
     assert allclose(newclone.Neff, cosmo.Neff)
+    assert newclone.meta == dict(a="b", zz="tops")
 
     # And direct comparison
     cmp = core.FlatLambdaCDM(name="New name", H0=65 * u.km / u.s / u.Mpc,

--- a/docs/changes/cosmology/11542.feature.rst
+++ b/docs/changes/cosmology/11542.feature.rst
@@ -1,0 +1,2 @@
+Cosmologies now store metadata in a mutable parameter ``meta``.
+The initialization arguments ``name`` and ``meta`` are keyword-only.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -147,6 +147,7 @@ numpydoc_xref_aliases = {
     "module": ":term:`python:module`",
     "buffer-like": ":term:buffer-like",
     "function": ":term:`python:function`",
+    "mapping": ":term:`python:mapping`",
     # for matplotlib
     "color": ":term:`color`",
     # for numpy

--- a/docs/cosmology/index.rst
+++ b/docs/cosmology/index.rst
@@ -321,7 +321,7 @@ are available in the docstring for each object::
   >>> print(WMAP7.__doc__)
   WMAP7 instance of FlatLambdaCDM cosmology
   (from Komatsu et al. 2011, ApJS, 192, 18, doi: 10.1088/0067-0049/192/2/18.
-  Table 1 (WMAP + BAO + H0 ML).)
+   Table 1 (WMAP + BAO + H0 ML).)
 
 
 Specifying a Dark Energy Model


### PR DESCRIPTION
### Description

Adds metadata to cosmologies. The original motivation was that all the parameter dictionaries for built-in realizations have all this extra info that isn't being used. Let's just stick the extra info in metadata! Seems generically useful for e.g. adding references to user-defined cosmologies.

Should  the metadata be mutable? yes, I think this should be the one mutable thing on a cosmology. It is never used by the cosmology.

Ready for review!  ~But plz merge #11540 first. Then I can rebase this since there's some overlap.~ 🎉 
request review: @adrn @mhvk @embray @dhomeier 