### PR TITLE
Check structured dtypes separately for byteorder preservation

### DIFF
--- a/astropy/table/tests/conftest.py
+++ b/astropy/table/tests/conftest.py
@@ -146,8 +146,10 @@ MIXIN_COLS = {'quantity': [0, 1, 2, 3] * u.m,
                   10*u.km/u.s),
               'arraywrap': ArrayWrapper([0, 1, 2, 3]),
               'arrayswap': ArrayWrapper(np.arange(4, dtype='i').byteswap().newbyteorder()),
-              'ndarray': np.array([(7, 'a'), (8, 'b'), (9, 'c'), (9, 'c')],
+              'ndarraylil': np.array([(7, 'a'), (8, 'b'), (9, 'c'), (9, 'c')],
                                   dtype='<i4,|S1').view(table.NdarrayMixin),
+              'ndarraybig': np.array([(7, 'a'), (8, 'b'), (9, 'c'), (9, 'c')],
+                                  dtype='>i4,|S1').view(table.NdarrayMixin),
               }
 MIXIN_COLS['earthlocation'] = coordinates.EarthLocation(
     lon=MIXIN_COLS['longitude'], lat=MIXIN_COLS['latitude'],

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -429,8 +429,10 @@ def test_info_preserved_pickle_copy_init(mixin_cols):
         for func in (copy.copy, copy.deepcopy, pickle_roundtrip, init_from_class):
             m2 = func(m)
             for attr in attrs:
+                # non-native byteorder not preserved by last 2 func, _except_ for structured dtype
                 if (attr != 'dtype'
                         or getattr(m.info.dtype, 'isnative', True)
+                        or m.info.dtype.name.startswith('void')
                         or func in (copy.copy, copy.deepcopy)):
                     original = getattr(m.info, attr)
                 else:

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -436,8 +436,8 @@ def test_info_preserved_pickle_copy_init(mixin_cols):
                         or func in (copy.copy, copy.deepcopy)):
                     original = getattr(m.info, attr)
                 else:
-                    # func does not preserve byteorder, check against (native) base type.
-                    original = m.info.dtype.name
+                    # func does not preserve byteorder, check against (native) type.
+                    original = m.info.dtype.newbyteorder('=')
                 assert getattr(m2.info, attr) == original
 
 

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -1865,7 +1865,7 @@ class TestPandas:
     def test_mixin_pandas(self):
         t = table.QTable()
         for name in sorted(MIXIN_COLS):
-            if name != 'ndarray':
+            if not name.startswith('ndarray'):
                 t[name] = MIXIN_COLS[name]
 
         t['dt'] = TimeDelta([0, 2, 4, 6], format='sec')


### PR DESCRIPTION
### Description
Alternative take to fixing #11339. Added both a little- and a big-endian version of `ndarray` in `MIXIN_COLS` so these issues might be spotted earlier.
As the s390 tests for #11543 failed already on collection for a bunch of unrelated reasons (possibly due to an `importlib_metadata` update?), this may take a while to validate.

EDIT: Fix #11339