### PR TITLE
Bugfixes for `Model` crashes when some inputs are scalars.

### DIFF
--- a/astropy/modeling/polynomial.py
+++ b/astropy/modeling/polynomial.py
@@ -1037,8 +1037,6 @@ class Polynomial2D(PolynomialModel):
         inputs, format_info = super().prepare_inputs(x, y, **kwargs)
 
         x, y = inputs
-        if x.shape != y.shape:
-            raise ValueError("Expected input arrays to have the same shape")
         return (x, y), format_info
 
     def evaluate(self, x, y, *coeffs):

--- a/astropy/modeling/tabular.py
+++ b/astropy/modeling/tabular.py
@@ -206,6 +206,8 @@ class _Tabular(Model):
             Input coordinates. The number of inputs must be equal
             to the dimensions of the lookup table.
         """
+        inputs = np.broadcast_arrays(*inputs)
+
         if isinstance(inputs, u.Quantity):
             inputs = inputs.value
         shape = inputs[0].shape

--- a/astropy/modeling/tests/test_input.py
+++ b/astropy/modeling/tests/test_input.py
@@ -816,6 +816,130 @@ class TestSingleInputDoubleOutputSingleModel:
                                [131.10, 232.11, 333.12]]]])
 
 
+# test broadcasting rules
+broadcast_models = [
+    {
+        'model': models.Identity(2),
+        'inputs': [0, [1, 1]],
+        'outputs': [0, [1, 1]]
+    },
+    {
+        'model': models.Identity(2),
+        'inputs': [[1, 1], 0],
+        'outputs': [[1, 1], 0]
+    },
+    {
+        'model': models.Mapping((0, 1)),
+        'inputs': [0, [1, 1]],
+        'outputs': [0, [1, 1]]
+    },
+    {
+        'model': models.Mapping((1, 0)),
+        'inputs': [0, [1, 1]],
+        'outputs': [[1, 1], 0]
+    },
+    {
+        'model': models.Mapping((1, 0), n_inputs=3),
+        'inputs': [0, [1, 1], 2],
+        'outputs': [[1, 1], 0]
+    },
+    {
+        'model': models.Mapping((0, 1, 0)),
+        'inputs': [0, [1, 1]],
+        'outputs': [0, [1, 1], 0]
+    },
+    {
+        'model': models.Mapping((0, 1, 1)),
+        'inputs': [0, [1, 1]],
+        'outputs': [0, [1, 1], [1, 1]]
+    },
+    {
+        'model': models.Polynomial2D(1, c0_0=1),
+        'inputs': [0, [1, 1]],
+        'outputs': [1, 1]
+    },
+    {
+        'model': models.Polynomial2D(1, c0_0=1),
+        'inputs': [0, 1],
+        'outputs': 1
+    },
+    {
+        'model': models.Gaussian2D(1, 1, 2, 1, 1.2),
+        'inputs': [0, [1, 1]],
+        'outputs': [0.42860385, 0.42860385]
+    },
+    {
+        'model': models.Gaussian2D(1, 1, 2, 1, 1.2),
+        'inputs': [0, 1],
+        'outputs': 0.428603846153
+    },
+    {
+        'model': models.Polynomial2D(1, c0_0=1) & models.Polynomial2D(1, c0_0=2),
+        'inputs': [1, 1, 1, 1],
+        'outputs': (1, 2)
+    },
+    {
+        'model': models.Polynomial2D(1, c0_0=1) & models.Polynomial2D(1, c0_0=2),
+        'inputs': [1, 1, [1, 1], [1, 1]],
+        'outputs': (1, [2, 2])
+    },
+    {
+        'model': models.math.MultiplyUfunc(),
+        'inputs': [np.array([np.linspace(0, 1, 5)]).T, np.arange(2)],
+        'outputs': np.array([[0., 0.],
+                             [0., 0.25],
+                             [0., 0.5],
+                             [0., 0.75],
+                             [0., 1.]])
+    }
+]
+
+
+@pytest.mark.filterwarnings(
+    r'ignore:Models in math_functions are experimental\.')
+@pytest.mark.parametrize('model', broadcast_models)
+def test_mixed_input(model):
+    result = model['model'](*model['inputs'])
+    if np.isscalar(result):
+        assert_allclose(result, model['outputs'])
+    else:
+        for i in range(len(result)):
+            assert_allclose(result[i], model['outputs'][i])
+
+
+def test_more_outputs():
+
+    class M(FittableModel):
+        standard_broadcasting = False
+        n_inputs = 2
+        n_outputs = 3
+
+        a = Parameter()
+
+        def evaluate(self, x, y, a):
+            return a*x, a-x, a+y
+
+        def __call__(self, *args, **kwargs):
+            inputs, format_info = super().prepare_inputs(*args, **kwargs)
+
+            outputs = self.evaluate(*inputs, *self.parameters)
+            output_shapes = [out.shape for out in outputs]
+            output_shapes = [() if shape == (1,) else shape for shape in output_shapes]
+            return self.prepare_outputs((tuple(output_shapes),), *outputs, **kwargs)
+
+    c = M(1)
+    result = c([1, 1], 1)
+    expected = [[1., 1.], [0., 0.], 2.]
+    for r, e in zip(result, expected):
+        assert_allclose(r, e)
+
+    c = M(1)
+    result = c(1, [1, 1])
+    expected = [1., 0., [2., 2.]]
+    for r, e in zip(result, expected):
+        assert_allclose(r, e)
+
+
 class TInputFormatter(Model):
     """
     A toy model to test input/output formatting.

--- a/astropy/modeling/tests/test_models.py
+++ b/astropy/modeling/tests/test_models.py
@@ -93,8 +93,8 @@ def test_inconsistent_input_shapes():
     # but not array broadcasting
     x.shape = (10, 1)
     y.shape = (1, 10)
-    with pytest.raises(ValueError):
-        g(x, y)
+    result = g(x, y)
+    assert result.shape == (10, 10)
 
 
 def test_custom_model_bounding_box():

--- a/docs/changes/modeling/11548.bugfix.rst
+++ b/docs/changes/modeling/11548.bugfix.rst
@@ -1,0 +1,1 @@
+Fixes ``Model`` crashes when some inputs are scalars and during some types of output reshaping.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This provides bugfixes for model crashes when some inputs are scalars (or smaller array which can broadcast to larger array). The main issue occurs when an earlier (in input order) input is a smaller array which must be broadcast to be compatible with a larger array. This issue occurs because the output should be the shape of the larger array, but `_prepare_outputs_single_model` attempts to reshape the array to fit into the first input's shape. In reality, the outputs should be reshaped to the broadcast shape of all the input arrays. This is what has been implemented here, along side tests verifying that the issue has been fixed.

Also adds fixes to allow outputs to be correctly reshaped without crashing in other circumstances.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #10170, Fixes #11360, Fixes #9953, and Fixes #11060.
Closes #10362
