### PR TITLE
Outdated warning (?)

### DIFF
--- a/docs/coordinates/representations.rst
+++ b/docs/coordinates/representations.rst
@@ -392,11 +392,6 @@ supply the ``base`` (representation)::
 Attaching ``Differential`` Objects to ``Representation`` Objects
 ================================================================
 
-.. warning::
-
-    The API for this functionality may change in future versions and should be
-    viewed as provisional!
-
 ``Differential`` objects can be attached to ``Representation`` objects as a way
 to encapsulate related information into a single object. ``Differential``
 objects can be passed in to the initializer of any of the built-in


### PR DESCRIPTION
The docs still warn that attaching differentials to representations is a provisional implementation. But it's been this way since at least v2.0.16! Seems official to me.
@adrn @mhvk 
