### PR TITLE
Allow string input to `SkyCoord.is_transformable_to`

### DIFF
--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -1264,11 +1264,12 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
         trans = frame_transform_graph.get_transform(self.__class__, new_frame_cls)
 
         if trans is None:
-            transformable = 'same' if new_frame_cls is self.__class__ else False
+            if new_frame_cls is self.__class__:
+                return 'same'
+            else:
+                return False
         else:
-            transformable = True
-
-        return transformable
+            return True
 
     def is_frame_attr_default(self, attrnm):
         """

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -1260,17 +1260,15 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
         transformation between two objects of the same frame class but with
         different attributes.
         """
-
         new_frame_cls = new_frame if inspect.isclass(new_frame) else new_frame.__class__
         trans = frame_transform_graph.get_transform(self.__class__, new_frame_cls)
 
         if trans is None:
-            if new_frame_cls is self.__class__:
-                return 'same'
-            else:
-                return False
+            transformable = 'same' if new_frame_cls is self.__class__ else False
         else:
-            return True
+            transformable = True
+
+        return transformable
 
     def is_frame_attr_default(self, attrnm):
         """

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -531,6 +531,43 @@ class SkyCoord(ShapedLikeNDArray):
         out[idx0 + n_values:] = self[idx0:]
 
         return out
+    
+    def is_transformable_to(self, new_frame):
+        """
+        Determines if this coordinate frame can be transformed to another
+        given frame.
+
+        Parameters
+        ----------
+        new_frame : frame class, frame object, or str
+            The proposed frame to transform into.
+
+        Returns
+        -------
+        transformable : bool or str
+            `True` if this can be transformed to ``new_frame``, `False` if
+            not, or the string 'same' if ``new_frame`` is the same system as
+            this object but no transformation is defined.
+
+        Notes
+        -----
+        A return value of 'same' means the transformation will work, but it will
+        just give back a copy of this object.  The intended usage is::
+
+            if coord.is_transformable_to(some_unknown_frame):
+                coord2 = coord.transform_to(some_unknown_frame)
+
+        This will work even if ``some_unknown_frame``  turns out to be the same
+        frame class as ``coord``.  This is intended for cases where the frame
+        is the same regardless of the frame attributes (e.g. ICRS), but be
+        aware that it *might* also indicate that someone forgot to define the
+        transformation between two objects of the same frame class but with
+        different attributes.
+        """
+        # TODO! like matplotlib, do string overrides for modified methods
+        new_frame = (_get_frame_class(new_frame) if isinstance(new_frame, str)
+                     else new_frame)
+        return self.frame.is_transformable_to(new_frame)
 
     def transform_to(self, frame, merge_attributes=True):
         """Transform this coordinate to a new frame.

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -531,7 +531,7 @@ class SkyCoord(ShapedLikeNDArray):
         out[idx0 + n_values:] = self[idx0:]
 
         return out
-    
+
     def is_transformable_to(self, new_frame):
         """
         Determines if this coordinate frame can be transformed to another

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -57,6 +57,24 @@ def teardown_function(func):
     DUPLICATE_REPRESENTATIONS.update(func.DUPLICATE_REPRESENTATIONS_ORIG)
 
 
+def test_is_transformable_to_str_input():
+    """Test method ``is_transformable_to`` with string input.
+
+    The only difference from the frame method of the same name is that
+    strings are allowed. As the frame tests cover ``is_transform_to``, here
+    we only test the added string option.
+
+    """
+    # make example SkyCoord
+    c = SkyCoord(90*u.deg, -11*u.deg)
+
+    # iterate through some frames, checking consistency
+    names = frame_transform_graph.get_names()
+    for name in names:
+        frame = frame_transform_graph.lookup_name(name)()
+        assert c.is_transformable_to(name) == c.is_transformable_to(frame)
+
+
 def test_transform_to():
     for frame in (FK5(), FK5(equinox=Time('J1975.0')),
                   FK4(), FK4(equinox=Time('J1975.0')),

--- a/docs/changes/coordinates/11552.api.rst
+++ b/docs/changes/coordinates/11552.api.rst
@@ -1,0 +1,1 @@
+Allow coordinate name strings as input to ``SkyCoord.is_transformable_to``


### PR DESCRIPTION
### Description

@adrn @srirajshukla @pllim 

Allows string input to ``SkyCoord.is_transformable_to``.

Fixes #11472
