### PR TITLE
Ensure angle wrapping of NaN does not raise a warning.

### DIFF
--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -1972,16 +1972,16 @@ class PhysicsSphericalRepresentation(BaseRepresentation):
         super().__init__(phi, theta, r, copy=copy, differentials=differentials)
 
         # Wrap/validate phi/theta
-        if copy:
-            self._phi = self._phi.wrap_at(360 * u.deg)
-        else:
-            # necessary because the above version of `wrap_at` has to be a copy
-            self._phi.wrap_at(360 * u.deg, inplace=True)
+        # Note that _phi already holds our own copy if copy=True.
+        self._phi.wrap_at(360 * u.deg, inplace=True)
 
-        if np.any(self._theta < 0.*u.deg) or np.any(self._theta > 180.*u.deg):
-            raise ValueError('Inclination angle(s) must be within '
-                             '0 deg <= angle <= 180 deg, '
-                             'got {}'.format(theta.to(u.degree)))
+        # This invalid catch block can be removed when the minimum numpy
+        # version is >= 1.19 (NUMPY_LT_1_19)
+        with np.errstate(invalid='ignore'):
+            if np.any(self._theta < 0.*u.deg) or np.any(self._theta > 180.*u.deg):
+                raise ValueError('Inclination angle(s) must be within '
+                                 '0 deg <= angle <= 180 deg, '
+                                 'got {}'.format(theta.to(u.degree)))
 
         if self._r.unit.physical_type == 'length':
             self._r = self._r.view(Distance)

--- a/astropy/coordinates/tests/test_angles.py
+++ b/astropy/coordinates/tests/test_angles.py
@@ -1009,6 +1009,11 @@ def test_latitude_nan():
     Latitude([0, np.nan, 1] * u.deg)
 
 
+def test_angle_wrap_at_nan():
+    # Check that passing a NaN to Latitude doesn't raise a warning
+    Angle([0, np.nan, 1] * u.deg).wrap_at(180*u.deg)
+
+
 def test_angle_multithreading():
     """
     Regression test for issue #7168

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -623,6 +623,14 @@ class TestPhysicsSphericalRepresentation:
             sph, UnitSphericalRepresentation, UnitSphericalDifferential)
         assert representation_equal_up_to_angular_type(got, expected)
 
+    def test_initialize_with_nan(self):
+        # Regression test for gh-11558: initialization used to fail.
+        psr = PhysicsSphericalRepresentation([1., np.nan]*u.deg, [np.nan, 2.]*u.deg,
+                                             [3., np.nan]*u.m)
+        assert_array_equal(np.isnan(psr.phi), [False, True])
+        assert_array_equal(np.isnan(psr.theta), [True, False])
+        assert_array_equal(np.isnan(psr.r), [False, True])
+
 
 class TestCartesianRepresentation:
 

--- a/docs/changes/coordinates/11568.bugfix.rst
+++ b/docs/changes/coordinates/11568.bugfix.rst
@@ -1,0 +1,3 @@
+Ensure that wrapping of ``Angle`` does not raise a warning even if ``nan`` are
+present.  Also try to make sure that the result is within the wrapped range
+even in the presence of rounding errors.


### PR DESCRIPTION
Also fix some small rounding problems. But consolidates routines between `Angle` and `Longitude`.

fixes #11558