### PR TITLE
Transform radial rep when multiplication

### DIFF
--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -1847,17 +1847,16 @@ class RadialRepresentation(BaseRepresentation):
 
         Raises
         ------
-        NotImplementedError
+        ValueError
             If the matrix is not a multiplication.
 
         """
         scl = matrix[..., 0, 0]
         # check that the matrix is a scaled identity matrix on the last 2 axes.
         if np.any(matrix != scl[..., np.newaxis, np.newaxis] * np.identity(3)):
-            raise NotImplementedError("Radial representations can only be "
-                                      "transformed by a scaled identity matrix")
+            raise ValueError("Radial representations can only be "
+                             "transformed by a scaled identity matrix")
 
-        # route through __mul__
         return self * scl
 
 

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -1836,15 +1836,29 @@ class RadialRepresentation(BaseRepresentation):
     def transform(self, matrix):
         """Radial representations cannot be transformed by a Cartesian matrix.
 
+        Parameters
+        ----------
+        matrix : array-like
+            The transformation matrix in a Cartesian basis.
+            Must be a multiplication: a diagonal matrix with identical elements.
+            Must have shape (..., 3, 3), where the last 2 indices are for the
+            matrix on each other axis. Make sure that the matrix shape is
+            compatible with the shape of this representation.
+
         Raises
         ------
         NotImplementedError
+            If the matrix is not a multiplication.
 
         """
-        raise NotImplementedError(
-            "Radial representations cannot be transformed "
-            "by a Cartesian matrix."
-        )
+        scl = matrix[..., 0, 0]
+        # check that the matrix is a scaled identity matrix on the last 2 axes.
+        if np.any(matrix != scl[..., np.newaxis, np.newaxis] * np.identity(3)):
+            raise NotImplementedError("Radial representations can only be "
+                                      "transformed by a scaled identity matrix")
+
+        # route through __mul__
+        return self * scl
 
 
 def _spherical_op_funcs(op, *args):

--- a/docs/changes/coordinates/11576.feature.rst
+++ b/docs/changes/coordinates/11576.feature.rst
@@ -1,0 +1,2 @@
+``RadialRepresentation.transform`` can work with a multiplication matrix only.
+All other matrices still raise an exception.


### PR DESCRIPTION
### Description

RadialRepresentation.transform can work with a multiplication matrix only. All other matrices raise an exception.

Requires ~#11444~ ~#11470~
@mhvk 