### PR TITLE
Document Longitude wrap_angle angle-like

### DIFF
--- a/astropy/coordinates/angles.py
+++ b/astropy/coordinates/angles.py
@@ -638,7 +638,7 @@ class Longitude(Angle):
         better to give an actual unit object.  Must be an angular
         unit.
 
-    wrap_angle : :class:`~astropy.coordinates.Angle` or None, optional
+    wrap_angle : angle-like or None, optional
         Angle at which to wrap back to ``wrap_angle - 360 deg``.
         If ``None`` (default), it will be taken to be 360 deg unless ``angle``
         has a ``wrap_angle`` attribute already (i.e., is a ``Longitude``),
@@ -664,7 +664,7 @@ class Longitude(Angle):
         self = super().__new__(cls, angle, unit=unit, **kwargs)
         if wrap_angle is None:
             wrap_angle = getattr(angle, 'wrap_angle', self._default_wrap_angle)
-        self.wrap_angle = wrap_angle
+        self.wrap_angle = wrap_angle  # angle-like b/c property setter
         return self
 
     def __setitem__(self, item, value):

--- a/astropy/coordinates/tests/test_angles.py
+++ b/astropy/coordinates/tests/test_angles.py
@@ -2,15 +2,19 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Test initalization and other aspects of Angle and subclasses"""
 
-import pytest
-import numpy as np
-from numpy.testing import assert_allclose, assert_array_equal
 import threading
+import warnings
 
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose, assert_array_equal
+
+import astropy.units as u
 from astropy.coordinates.angles import Longitude, Latitude, Angle
-from astropy import units as u
-from astropy.coordinates.errors import (IllegalSecondError, IllegalMinuteError, IllegalHourError,
-                      IllegalSecondWarning, IllegalMinuteWarning)
+from astropy.coordinates.errors import (
+    IllegalSecondError, IllegalMinuteError, IllegalHourError,
+    IllegalSecondWarning, IllegalMinuteWarning)
+from astropy.utils.exceptions import AstropyDeprecationWarning
 
 
 def test_create_angles():
@@ -787,6 +791,17 @@ def test_longitude():
     # but not if we explicitly set it
     lon3 = Longitude(lon, wrap_angle='180d')
     assert lon3.wrap_angle == 180 * u.deg
+
+    # check that wrap_angle is always an Angle
+    lon = Longitude(lon, wrap_angle=Longitude(180 * u.deg))
+    assert lon.wrap_angle == 180 * u.deg
+    assert lon.wrap_angle.__class__ is Angle
+
+    # check that wrap_angle is not copied
+    wrap_angle=180 * u.deg
+    lon = Longitude(lon, wrap_angle=wrap_angle)
+    assert lon.wrap_angle == 180 * u.deg
+    assert np.may_share_memory(lon.wrap_angle, wrap_angle)
 
     # check for problem reported in #2037 about Longitude initializing to -0
     lon = Longitude(0, u.deg)


### PR DESCRIPTION
### Description

Document the wrap_angle argument of Longitude angle-like (accept strings) ~and deprecate passing Angle subclasses~.

Followup to: #11118 
@adrn @mhvk @ayshih 

tag: no-changelog-needed