### PR TITLE
Support generic os.PathLike instead of pathlib.Path

### DIFF
--- a/astropy/config/configuration.py
+++ b/astropy/config/configuration.py
@@ -10,11 +10,11 @@ configuration files for Astropy and affiliated packages.
 """
 
 import io
-import pathlib
 import pkgutil
 import warnings
 import importlib
 import contextlib
+import os
 from os import path
 from textwrap import TextWrapper
 from warnings import warn
@@ -634,7 +634,7 @@ def generate_config(pkgname='astropy', filename=None, verbose=False):
         filename = get_config_filename(pkgname)
 
     with contextlib.ExitStack() as stack:
-        if isinstance(filename, (str, pathlib.Path)):
+        if isinstance(filename, (str, os.PathLike)):
             fp = stack.enter_context(open(filename, 'w'))
         else:
             # assume it's a file object, or io.StringIO

--- a/astropy/io/fits/convenience.py
+++ b/astropy/io/fits/convenience.py
@@ -54,7 +54,6 @@ explanation of all the different formats.
     around a single format and officially deprecate the other formats.
 """
 
-import pathlib
 import operator
 import os
 import warnings
@@ -1083,8 +1082,8 @@ def _makehdu(data, header):
 
 
 def _stat_filename_or_fileobj(filename):
-    if isinstance(filename, pathlib.Path):
-        filename = str(filename)
+    if isinstance(filename, os.PathLike):
+        filename = os.fspath(filename)
     closed = fileobj_closed(filename)
     name = fileobj_name(filename) or ''
 

--- a/astropy/io/fits/diff.py
+++ b/astropy/io/fits/diff.py
@@ -9,8 +9,8 @@ import fnmatch
 import glob
 import io
 import operator
+import os
 import os.path
-import pathlib
 import textwrap
 
 from collections import defaultdict
@@ -269,7 +269,7 @@ class FITSDiff(_BaseDiff):
             whitespace (default: True).
         """
 
-        if isinstance(a, (str, pathlib.Path)):
+        if isinstance(a, (str, os.PathLike)):
             try:
                 a = fitsopen(a)
             except Exception as exc:
@@ -279,7 +279,7 @@ class FITSDiff(_BaseDiff):
         else:
             close_a = False
 
-        if isinstance(b, (str, pathlib.Path)):
+        if isinstance(b, (str, os.PathLike)):
             try:
                 b = fitsopen(b)
             except Exception as exc:

--- a/astropy/io/fits/file.py
+++ b/astropy/io/fits/file.py
@@ -5,7 +5,6 @@ import errno
 import http.client
 import mmap
 import operator
-import pathlib
 import io
 import os
 import sys
@@ -131,9 +130,8 @@ class _File:
             return
         else:
             self.simulateonly = False
-            # If fileobj is of type pathlib.Path
-            if isinstance(fileobj, pathlib.Path):
-                fileobj = str(fileobj)
+            if isinstance(fileobj, os.PathLike):
+                fileobj = os.fspath(fileobj)
 
         if mode is not None and mode not in IO_FITS_MODES:
             raise ValueError(f"Mode '{mode}' not recognized")

--- a/astropy/io/fits/tests/test_core.py
+++ b/astropy/io/fits/tests/test_core.py
@@ -77,6 +77,25 @@ class TestCore(FitsTestCase):
             with fits.open(self.data('tdim.fits')) as hdulist2:
                 assert FITSDiff(hdulist2, hdulist).identical is True
 
+    def test_fits_pathlike_object(self):
+        """
+        Testing when fits file is passed as os.PathLike object #11579.
+        """
+        class TPath(os.PathLike):
+            def __init__(self, path):
+                self.path = path
+
+            def __fspath__(self):
+                return str(self.path)
+
+        fpath = TPath(self.data('tdim.fits'))
+        with fits.open(fpath) as hdulist:
+            assert hdulist[0].filebytes() == 2880
+            assert hdulist[1].filebytes() == 5760
+
+            with fits.open(self.data('tdim.fits')) as hdulist2:
+                assert FITSDiff(hdulist2, hdulist).identical is True
+
     def test_fits_file_bytes_object(self):
         """
         Testing when fits file is passed as bytes.

--- a/astropy/io/fits/util.py
+++ b/astropy/io/fits/util.py
@@ -6,7 +6,6 @@ import io
 import mmap
 import operator
 import os
-import pathlib
 import platform
 import signal
 import sys
@@ -26,8 +25,7 @@ import numpy as np
 
 from astropy.utils.exceptions import AstropyUserWarning
 
-from os import PathLike
-path_like = (str, PathLike)
+path_like = (str, os.PathLike)
 
 cmp = lambda a, b: (a > b) - (a < b)
 
@@ -429,7 +427,7 @@ def fileobj_closed(f):
     they are file-like objects with no sense of a 'closed' state.
     """
 
-    if isinstance(f, (str, pathlib.Path)):
+    if isinstance(f, path_like):
         return True
 
     if hasattr(f, 'closed'):

--- a/astropy/io/registry.py
+++ b/astropy/io/registry.py
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import contextlib
-import pathlib
 import re
 import sys
 import inspect
@@ -24,7 +23,7 @@ _readers = OrderedDict()
 _writers = OrderedDict()
 _identifiers = OrderedDict()
 
-PATH_TYPES = (str, pathlib.Path)
+PATH_TYPES = (str, os.PathLike)
 
 
 class IORegistryError(Exception):
@@ -504,9 +503,9 @@ def read(cls, *args, format=None, cache=False, **kwargs):
             if len(args):
                 if isinstance(args[0], PATH_TYPES) and not os.path.isdir(args[0]):
                     from astropy.utils.data import get_readable_fileobj
-                    # path might be a pathlib.Path object
-                    if isinstance(args[0], pathlib.Path):
-                        args = (str(args[0]),) + args[1:]
+                    # path might be a os.PathLike object
+                    if isinstance(args[0], os.PathLike):
+                        args = (os.fspath(args[0]),) + args[1:]
                     path = args[0]
                     try:
                         ctx = get_readable_fileobj(args[0], encoding='binary', cache=cache)
@@ -555,9 +554,9 @@ def write(data, *args, format=None, **kwargs):
         fileobj = None
         if len(args):
             if isinstance(args[0], PATH_TYPES):
-                # path might be a pathlib.Path object
-                if isinstance(args[0], pathlib.Path):
-                    args = (str(args[0]),) + args[1:]
+                # path might be a os.PathLike object
+                if isinstance(args[0], os.PathLike):
+                    args = (os.fspath(args[0]),) + args[1:]
                 path = args[0]
                 fileobj = None
             elif hasattr(args[0], 'read'):

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -9,7 +9,6 @@ import fnmatch
 import hashlib
 import os
 import io
-import pathlib
 import re
 import shutil
 import socket
@@ -229,7 +228,6 @@ def get_readable_fileobj(name_or_obj, encoding=None, cache=False,
     # passed in.  In that case it is not the responsibility of this
     # function to close it: doing so could result in a "double close"
     # and an "invalid file descriptor" exception.
-    PATH_TYPES = (str, pathlib.Path)
 
     close_fds = []
     delete_fds = []
@@ -238,11 +236,12 @@ def get_readable_fileobj(name_or_obj, encoding=None, cache=False,
         # use configfile default
         remote_timeout = conf.remote_timeout
 
-    # Get a file object to the content
-    if isinstance(name_or_obj, PATH_TYPES):
-        # name_or_obj could be a Path object if pathlib is available
-        name_or_obj = str(name_or_obj)
+    # name_or_obj could be an os.PathLike object
+    if isinstance(name_or_obj, os.PathLike):
+        name_or_obj = os.fspath(name_or_obj)
 
+    # Get a file object to the content
+    if isinstance(name_or_obj, str):
         is_url = _is_url(name_or_obj)
         if is_url:
             name_or_obj = download_file(

--- a/docs/changes/io.fits/11580.feature.rst
+++ b/docs/changes/io.fits/11580.feature.rst
@@ -1,0 +1,1 @@
+Enable the use of ``os.PathLike`` objects when dealing with (mainly FITS) files.


### PR DESCRIPTION
### Description

This PR replaces all appearances of 

```Python
 if isinstance(fileobj, pathlib.Path): 
     fileobj = str(fileobj) 
```
with 
```Python
if isinstance(fileobs, os.PathLike):
    fileobj = fileobj.__fspath__()
```
Rationale: In Python, paths are not necessarily strings or `pathlib.Path` objects, but anything that is `os.Pathlike` is acceptable in `open()`. One use case here is a specific path like object that retrieves/builds a file just before it is opened (f.e. for a cache).
The canonical way to access the file path on the OS is then done by `__fspath__()`, not by `str()`.

Fixes #11579 
