### PR TITLE
Ensure string-valued columns with units can be added to a QTable

### DIFF
--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -3861,21 +3861,27 @@ class QTable(Table):
 
     def _convert_col_for_table(self, col):
         if isinstance(col, Column) and getattr(col, 'unit', None) is not None:
-            # What to do with MaskedColumn with units: leave as MaskedColumn or
-            # turn into Quantity and drop mask?  Assuming we have masking support
-            # in Quantity someday, let's drop the mask (consistent with legacy
-            # behavior) but issue a warning.
-            if isinstance(col, MaskedColumn) and np.any(col.mask):
-                warnings.warn("dropping mask in Quantity column '{}': "
-                              "masked Quantity not supported".format(col.info.name))
-
             # We need to turn the column into a quantity, or a subclass
             # identified in the unit (such as u.mag()).
             q_cls = getattr(col.unit, '_quantity_class', Quantity)
-            qcol = q_cls(col.data, col.unit, copy=False)
-            qcol.info = col.info
-            qcol.info.indices = col.info.indices
-            col = qcol
+            try:
+                qcol = q_cls(col.data, col.unit, copy=False)
+            except Exception as exc:
+                warnings.warn(f"column {col.info.name} has a unit but is kept as "
+                              f"a {col.__class__.__name__} as an attempt to "
+                              f"convert it to Quantity failed with:\n{exc!r}")
+            else:
+                # What to do with MaskedColumn with units: leave as MaskedColumn or
+                # turn into Quantity and drop mask?  Assuming we have masking support
+                # in Quantity someday, let's drop the mask (consistent with legacy
+                # behavior) but issue a warning.
+                if isinstance(col, MaskedColumn) and np.any(col.mask):
+                    warnings.warn("dropping mask in Quantity column '{}': "
+                                  "masked Quantity not supported".format(col.info.name))
+
+                qcol.info = col.info
+                qcol.info.indices = col.info.indices
+                col = qcol
         else:
             col = super()._convert_col_for_table(col)
 

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -18,6 +18,7 @@ from astropy import log
 from astropy.units import Quantity, QuantityInfo
 from astropy.utils import isiterable, ShapedLikeNDArray
 from astropy.utils.console import color_print
+from astropy.utils.exceptions import AstropyUserWarning
 from astropy.utils.metadata import MetaData, MetaAttribute
 from astropy.utils.data_info import BaseColumnInfo, MixinInfo, ParentDtypeInfo, DataInfo
 from astropy.utils.decorators import format_doc
@@ -3869,7 +3870,8 @@ class QTable(Table):
             except Exception as exc:
                 warnings.warn(f"column {col.info.name} has a unit but is kept as "
                               f"a {col.__class__.__name__} as an attempt to "
-                              f"convert it to Quantity failed with:\n{exc!r}")
+                              f"convert it to Quantity failed with:\n{exc!r}",
+                              AstropyUserWarning)
             else:
                 # What to do with MaskedColumn with units: leave as MaskedColumn or
                 # turn into Quantity and drop mask?  Assuming we have masking support
@@ -3877,7 +3879,8 @@ class QTable(Table):
                 # behavior) but issue a warning.
                 if isinstance(col, MaskedColumn) and np.any(col.mask):
                     warnings.warn("dropping mask in Quantity column '{}': "
-                                  "masked Quantity not supported".format(col.info.name))
+                                  "masked Quantity not supported".format(col.info.name),
+                                  AstropyUserWarning)
 
                 qcol.info = col.info
                 qcol.info.indices = col.info.indices

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -14,7 +14,7 @@ import numpy as np
 from numpy.testing import assert_allclose, assert_array_equal
 
 from astropy.io import fits
-from astropy.table import (Table, QTable, MaskedColumn, TableReplaceWarning,
+from astropy.table import (Table, QTable, Column, MaskedColumn, TableReplaceWarning,
                            TableAttribute)
 from astropy.tests.helper import assert_follows_unicode_guidelines
 from astropy.coordinates import SkyCoord
@@ -2105,11 +2105,19 @@ class TestReplaceColumn(SetupData):
         t['a'][0] = 10
         assert t['a'][0] == a[0]
 
+
+class TestQTableColumnConversionCornerCases:
     def test_replace_with_masked_col_with_units_in_qtable(self):
         """This is a small regression from #8902"""
         t = QTable([[1, 2], [3, 4]], names=['a', 'b'])
         t['a'] = MaskedColumn([5, 6], unit='m')
         assert isinstance(t['a'], u.Quantity)
+
+    def test_do_not_replace_string_column_with_units_in_qtable(self):
+        t = QTable([[1*u.m]])
+        with pytest.warns(UserWarning, match='convert it to Quantity failed'):
+            t['a'] = Column(['a'], unit=u.m)
+        assert isinstance(t['a'], Column)
 
 
 class Test__Astropy_Table__():

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -20,6 +20,7 @@ from astropy.tests.helper import assert_follows_unicode_guidelines
 from astropy.coordinates import SkyCoord
 
 from astropy.utils.data import get_pkg_data_filename
+from astropy.utils.exceptions import AstropyUserWarning
 from astropy import table
 from astropy import units as u
 from astropy.time import Time, TimeDelta
@@ -2115,7 +2116,7 @@ class TestQTableColumnConversionCornerCases:
 
     def test_do_not_replace_string_column_with_units_in_qtable(self):
         t = QTable([[1*u.m]])
-        with pytest.warns(UserWarning, match='convert it to Quantity failed'):
+        with pytest.warns(AstropyUserWarning, match='convert it to Quantity failed'):
             t['a'] = Column(['a'], unit=u.m)
         assert isinstance(t['a'], Column)
 

--- a/docs/changes/table/11585.bugfix.rst
+++ b/docs/changes/table/11585.bugfix.rst
@@ -1,0 +1,3 @@
+Fix a bug where a string-valued ``Column`` that happened to have a ``unit``
+attribute could not be added to a ``QTable``.  Such columns are now simply
+kept as ``Column`` instances (with a warning).


### PR DESCRIPTION
Fixes #11523 

Encapsulate the conversion of `Column` instances with `units` in a try/except so that problems in the conversion lead to a warning rather than an exception.