### PR TITLE
DOC: Misc fixes.

### DIFF
--- a/astropy/config/configuration.py
+++ b/astropy/config/configuration.py
@@ -509,7 +509,7 @@ def get_config(packageormod=None, reload=False, rootname=None):
     package or module.
 
     Parameters
-    -----------
+    ----------
     packageormod : str or None
         The package for which to retrieve the configuration object. If a
         string, it must be a valid package name, or if ``None``, the package from

--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -201,7 +201,7 @@ def convolve(array, kernel, boundary='fill', fill_value=0.,
         `None`, no masking will be performed unless ``array`` is a masked array.
         If ``mask`` is not `None` *and* ``array`` is a masked array, a pixel is
         masked of it is masked in either ``mask`` *or* ``array.mask``.
-    normalization_zero_tol: float, optional
+    normalization_zero_tol : float, optional
         The absolute tolerance on whether the kernel is different than zero.
         If the kernel sums to zero to within this precision, it cannot be
         normalized. Default is "1e-8".
@@ -495,7 +495,7 @@ def convolve_fft(array, kernel, boundary='fill', fill_value=0.,
         e.g., ``normalize_kernel=np.sum`` means that kernel will be modified to be:
         ``kernel = kernel / np.sum(kernel)``.  If True, defaults to
         ``normalize_kernel = np.sum``.
-    normalization_zero_tol: float, optional
+    normalization_zero_tol : float, optional
         The absolute tolerance on whether the kernel is different than zero.
         If the kernel sums to zero to within this precision, it cannot be
         normalized. Default is "1e-8".
@@ -895,7 +895,7 @@ def convolve_models(model, kernel, mode='convolve_fft', **kwargs):
         Keyword representing which function to use for convolution.
             * 'convolve_fft' : use `~astropy.convolution.convolve_fft` function.
             * 'convolve' : use `~astropy.convolution.convolve`.
-    kwargs : dict
+    **kwargs : dict
         Keyword arguments to me passed either to `~astropy.convolution.convolve`
         or `~astropy.convolution.convolve_fft` depending on ``mode``.
 
@@ -925,17 +925,17 @@ def convolve_models_fft(model, kernel, bounding_box, resolution, cache=True, **k
         Functional model
     kernel : `~astropy.modeling.core.Model`
         Convolution kernel
-    bounding_box: tuple
+    bounding_box : tuple
         The bounding box which encompasses enough of the support of both
         the ``model`` and ``kernel`` so that an accurate convolution can be
         computed.
-    resolution: float
+    resolution : float
         The resolution that one wishes to approximate the convolution
         integral at.
-    cache: optional, bool
+    cache : optional, bool
         Default value True. Allow for the storage of the convolution
         computation for later reuse.
-    kwargs : dict
+    **kwargs : dict
         Keyword arguments to be passed either to `~astropy.convolution.convolve`
         or `~astropy.convolution.convolve_fft` depending on ``mode``.
 

--- a/astropy/coordinates/angle_utilities.py
+++ b/astropy/coordinates/angle_utilities.py
@@ -753,9 +753,6 @@ def offset_by(lon, lat, posang, distance):
         The position of the final point.  If any of the angles are arrays,
         these will contain arrays following the appropriate `numpy` broadcasting rules.
         0 <= lon < 2pi.
-
-    Notes
-    -----
     """
     from .angles import Angle
 

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -1504,9 +1504,9 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
         method : str or callable
             If str, it is the name of a method that is applied to the internal
             ``components``. If callable, the function is applied.
-        args : tuple
+        *args : tuple
             Any positional arguments for ``method``.
-        kwargs : dict
+        **kwargs : dict
             Any keyword arguments for ``method``.
         """
         def apply_method(value):

--- a/astropy/coordinates/builtin_frames/galactocentric.py
+++ b/astropy/coordinates/builtin_frames/galactocentric.py
@@ -318,7 +318,7 @@ class galactocentric_frame_defaults(ScienceState):
         references : dict or None, optional
             References for contents of `parameters`.
             None becomes empty dict.
-        **meta: dict, optional
+        **meta : dict, optional
             Any other properties to register.
 
         """

--- a/astropy/coordinates/builtin_frames/utils.py
+++ b/astropy/coordinates/builtin_frames/utils.py
@@ -150,7 +150,7 @@ def get_cip(jd1, jd2):
         Second part of two part Julian date (TDB)
 
     Returns
-    --------
+    -------
     x : float or `np.ndarray`
         x coordinate of the CIP
     y : float or `np.ndarray`
@@ -198,7 +198,7 @@ def aticq(srepr, astrom):
         ERFA astrometry context, as produced by, e.g. ``eraApci13`` or ``eraApcs13``
 
     Returns
-    --------
+    -------
     rc : float or `~numpy.ndarray`
         Right Ascension in radians
     dc : float or `~numpy.ndarray`
@@ -283,7 +283,7 @@ def atciqz(srepr, astrom):
         ERFA astrometry context, as produced by, e.g. ``eraApci13`` or ``eraApcs13``
 
     Returns
-    --------
+    -------
     ri : float or `~numpy.ndarray`
         Right Ascension in radians
     di : float or `~numpy.ndarray`
@@ -334,12 +334,12 @@ def prepare_earth_position_vel(time):
     Get barycentric position and velocity, and heliocentric position of Earth
 
     Parameters
-    -----------
+    ----------
     time : `~astropy.time.Time`
         time at which to calculate position and velocity of Earth
 
     Returns
-    --------
+    -------
     earth_pv : `np.ndarray`
         Barycentric position and velocity of Earth, in au and au/day
     earth_helio : `np.ndarray`

--- a/astropy/coordinates/calculation.py
+++ b/astropy/coordinates/calculation.py
@@ -78,8 +78,8 @@ def horoscope(birthday, corrected=True, chinese=False):
     Enter your birthday as an `astropy.time.Time` object and
     receive a mystical horoscope about things to come.
 
-    Parameter
-    ---------
+    Parameters
+    ----------
     birthday : `astropy.time.Time` or str
         Your birthday as a `datetime.datetime` or `astropy.time.Time` object
         or "YYYY-MM-DD"string.

--- a/astropy/coordinates/earth.py
+++ b/astropy/coordinates/earth.py
@@ -523,7 +523,7 @@ class EarthLocation(u.Quantity):
             If True, load from the data file bundled with astropy and set the
             cache to that.
 
-        returns
+        Returns
         -------
         reg : astropy.coordinates.sites.SiteRegistry
         """
@@ -666,7 +666,7 @@ class EarthLocation(u.Quantity):
             The ``obstime`` to calculate the GCRS position/velocity at.
 
         Returns
-        --------
+        -------
         gcrs : `~astropy.coordinates.GCRS` instance
             With velocity included.
         """
@@ -721,7 +721,7 @@ class EarthLocation(u.Quantity):
             The ``obstime`` to calculate the GCRS position/velocity at.
 
         Returns
-        --------
+        -------
         obsgeoloc : `~astropy.coordinates.CartesianRepresentation`
             The GCRS position of the object
         obsgeovel : `~astropy.coordinates.CartesianRepresentation`
@@ -763,8 +763,8 @@ class EarthLocation(u.Quantity):
             pass in masses for other bodies.
 
         Returns
-        --------
-        redshift :  `~astropy.units.Quantity`
+        -------
+        redshift : `~astropy.units.Quantity`
             Gravitational redshift in velocity units at given obstime.
         """
         # needs to be here to avoid circular imports

--- a/astropy/coordinates/earth_orientation.py
+++ b/astropy/coordinates/earth_orientation.py
@@ -30,7 +30,7 @@ def eccentricity(jd):
     jd : scalar or array_like
         Julian date at which to compute the eccentricity
 
-    returns
+    Returns
     -------
     eccentricity : scalar or array
         The eccentricity (or array of eccentricities)
@@ -57,7 +57,7 @@ def mean_lon_of_perigee(jd):
     jd : scalar or array_like
         Julian date at which to compute the mean longitude of perigee
 
-    returns
+    Returns
     -------
     mean_lon_of_perigee : scalar or array
         Mean longitude of perigee in degrees (or array of mean longitudes)
@@ -90,7 +90,7 @@ def obliquity(jd, algorithm=2006):
         precession models, and a description of the 1980 algorithm can be found
         in the Explanatory Supplement to the Astronomical Almanac.
 
-    returns
+    Returns
     -------
     obliquity : scalar or array
         Mean obliquity in degrees (or array of obliquities)

--- a/astropy/coordinates/name_resolve.py
+++ b/astropy/coordinates/name_resolve.py
@@ -106,7 +106,7 @@ def get_icrs_coordinates(name, parse=False, cache=False):
     ----------
     name : str
         The name of the object to get coordinates for, e.g. ``'M42'``.
-    parse: bool
+    parse : bool
         Whether to attempt extracting the coordinates from the name by
         parsing with a regex. For objects catalog names that have
         J-coordinates embedded in their names eg:

--- a/astropy/coordinates/orbital_elements.py
+++ b/astropy/coordinates/orbital_elements.py
@@ -183,12 +183,12 @@ def calc_moon(t):
     date range CE 1950-2050.
 
     Parameters
-    -----------
+    ----------
     t : `~astropy.time.Time`
         Time of observation.
 
     Returns
-    --------
+    -------
     skycoord : `~astropy.coordinates.SkyCoord`
         ICRS Coordinate for the body
     """

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -360,9 +360,9 @@ class BaseRepresentationOrDifferential(ShapedLikeNDArray):
         method : str or callable
             If str, it is the name of a method that is applied to the internal
             ``components``. If callable, the function is applied.
-        args : tuple
+        *args : tuple
             Any positional arguments for ``method``.
-        kwargs : dict
+        **kwargs : dict
             Any keyword arguments for ``method``.
         """
         if callable(method):
@@ -968,9 +968,9 @@ class BaseRepresentation(BaseRepresentationOrDifferential):
         method : str or callable
             If str, it is the name of a method that is applied to the internal
             ``components``. If callable, the function is applied.
-        args : tuple
+        *args : tuple
             Any positional arguments for ``method``.
-        kwargs : dict
+        **kwargs : dict
             Any keyword arguments for ``method``.
 
         """

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -398,9 +398,9 @@ class SkyCoord(ShapedLikeNDArray):
         method : str or callable
             If str, it is the name of a method that is applied to the internal
             ``components``. If callable, the function is applied.
-        args : tuple
+        *args : tuple
             Any positional arguments for ``method``.
-        kwargs : dict
+        **kwargs : dict
             Any keyword arguments for ``method``.
         """
         def apply_method(value):
@@ -939,7 +939,7 @@ class SkyCoord(ShapedLikeNDArray):
         style : {'hmsdms', 'dms', 'decimal'}
             The formatting specification to use. These encode the three most
             common ways to represent coordinates. The default is `decimal`.
-        kwargs
+        **kwargs
             Keyword args passed to :meth:`~astropy.coordinates.Angle.to_string`.
         """
 
@@ -1897,7 +1897,7 @@ class SkyCoord(ShapedLikeNDArray):
         ----------
         table : astropy.Table
             The table to load data from.
-        coord_kwargs
+        **coord_kwargs
             Any additional keyword arguments are passed directly to this class's
             constructor.
 
@@ -1987,7 +1987,7 @@ class SkyCoord(ShapedLikeNDArray):
             The name of the object to get coordinates for, e.g. ``'M42'``.
         frame : str or `BaseCoordinateFrame` class or instance
             The frame to transform the object to.
-        parse: bool
+        parse : bool
             Whether to attempt extracting the coordinates from the name by
             parsing with a regex. For objects catalog names that have
             J-coordinates embedded in their names, e.g.,

--- a/astropy/coordinates/solar_system.py
+++ b/astropy/coordinates/solar_system.py
@@ -322,7 +322,7 @@ def get_body_barycentric_posvel(body, time, ephemeris=None):
     position, velocity : tuple of `~astropy.coordinates.CartesianRepresentation`
         Tuple of barycentric (ICRS) position and velocity.
 
-    See also
+    See Also
     --------
     get_body_barycentric : to calculate position only.
         This is faster by about a factor two for JPL kernels, but has no
@@ -360,12 +360,9 @@ def get_body_barycentric(body, time, ephemeris=None):
     position : `~astropy.coordinates.CartesianRepresentation`
         Barycentric (ICRS) position of the body in cartesian coordinates
 
-    See also
+    See Also
     --------
     get_body_barycentric_posvel : to calculate both position and velocity.
-
-    Notes
-    -----
     """
     return _get_body_barycentric_posvel(body, time, ephemeris,
                                         get_velocity=False)
@@ -392,6 +389,7 @@ def _get_apparent_body_position(body, time, ephemeris, obsgeoloc=None):
         ``~astropy.coordinates.solar_system_ephemeris.set``
     obsgeoloc : `~astropy.coordinates.CartesianRepresentation`, optional
         The GCRS position of the observer
+
     Returns
     -------
     cartesian_position : `~astropy.coordinates.CartesianRepresentation`
@@ -501,9 +499,6 @@ def get_moon(time, location=None, ephemeris=None):
     -------
     skycoord : `~astropy.coordinates.SkyCoord`
         GCRS Coordinate for the Moon
-
-    Notes
-    -----
     """
 
     return get_body('moon', time, location=location, ephemeris=ephemeris)

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -292,7 +292,7 @@ class BaseInputter:
             Can be either a file name, string (newline separated) with all header and data
             lines (must have at least 2 lines), a file-like object with a ``read()`` method,
             or a list of strings.
-        newline: line separator, if `None` use OS default from ``splitlines()``.
+        newline : line separator, if `None` use OS default from ``splitlines()``.
 
         Returns
         -------

--- a/astropy/io/ascii/daophot.py
+++ b/astropy/io/ascii/daophot.py
@@ -156,7 +156,7 @@ class DaophotHeader(core.BaseHeader):
             List of table lines
 
         Returns
-        ----------
+        -------
         col : list
             List of table Columns
         """

--- a/astropy/logger.py
+++ b/astropy/logger.py
@@ -422,8 +422,6 @@ class AstropyLogger(Logger):
 
         Parameters
         ----------
-        filename : str
-            The file to log messages to.
         filter_level : str
             If set, any log messages less important than ``filter_level`` will
             not be output to the file. Note that this is in addition to the


### PR DESCRIPTION
Add Space before section for proper parsing by numpydoc.

Mostly cosmetic, but spaces in around colon in parameters are necessary
for numpydoc to properly parsed name vs type.

Also remove one non-existing parameter