### PR TITLE
Add DN as new unit

### DIFF
--- a/astropy/units/astrophys.py
+++ b/astropy/units/astrophys.py
@@ -99,6 +99,15 @@ def_unit(['R', 'Rayleigh', 'rayleigh'],
 
 
 ###########################################################################
+# EVENTS
+
+def_unit((['ct', 'count'], ['count']),
+         format={'fits': 'count', 'ogip': 'count', 'vounit': 'count'},
+         namespace=_ns, prefixes=True, exclude_prefixes=['p'])
+def_unit(['adu'], namespace=_ns, prefixes=True)
+def_unit(['DN', 'dn'], namespace=_ns, prefixes=False)
+
+###########################################################################
 # MISCELLANEOUS
 
 # Some of these are very FITS-specific and perhaps considered a mistake.
@@ -106,21 +115,8 @@ def_unit(['R', 'Rayleigh', 'rayleigh'],
 # TODO: This is defined by the FITS standard as "relative to the sun".
 # Is that mass, volume, what?
 def_unit(['Sun'], namespace=_ns)
-
-
-###########################################################################
-# EVENTS
-
-def_unit((['ct', 'count'], ['count']),
-         format={'fits': 'count', 'ogip': 'count', 'vounit': 'count'},
-         namespace=_ns, prefixes=True, exclude_prefixes=['p'])
-
-###########################################################################
-# MISCELLANEOUS
-
 def_unit(['chan'], namespace=_ns, prefixes=True)
 def_unit(['bin'], namespace=_ns, prefixes=True)
-def_unit(['adu'], namespace=_ns, prefixes=True)
 def_unit(['beam'], namespace=_ns, prefixes=True)
 def_unit(['electron'], doc="Number of electrons", namespace=_ns,
          format={'latex': r'e^{-}', 'unicode': 'e⁻'})

--- a/docs/changes/units/11591.feature.rst
+++ b/docs/changes/units/11591.feature.rst
@@ -1,0 +1,1 @@
+Add a new "DN" unit, ``units.dn`` or ``units.DN``, representing data number for a detector.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request adds the name "DN" as a string that can generate a count unit, `u.ct`.  "DN", or digital number, is a common name used for counts in the FITS header keyword BUNIT and in FITS binary table column units.  In fact, an example in the existing Astropy documentation has this unit

https://docs.astropy.org/en/stable/io/fits/usage/table.html?highlight=DN

but that unit doesn't currently parse into a `u.ct`.  This PR enables that.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->
