### PR TITLE
Minor physical type updates

### DIFF
--- a/astropy/units/physical.py
+++ b/astropy/units/physical.py
@@ -253,7 +253,7 @@ class PhysicalType:
     A pascal is intended to represent pressure and stress, but the unit
     decomposition is equivalent to that of energy density.
 
-    >>> pressure = get_physical_type("pressure")
+    >>> pressure = u.get_physical_type("pressure")
     >>> pressure
     PhysicalType({'energy density', 'pressure', 'stress'})
     >>> 'energy density' in pressure

--- a/astropy/units/tests/test_physical.py
+++ b/astropy/units/tests/test_physical.py
@@ -7,7 +7,7 @@ Unit tests for the handling of physical types in `astropy.units`.
 import pytest
 
 from astropy import units as u
-from astropy.units import physical
+from astropy.units import physical, imperial
 from astropy.constants import hbar
 
 
@@ -24,7 +24,7 @@ unit_physical_type_pairs = [
     (u.photon / (u.cm ** 2 * u.s * u.Hz), "photon flux density"),
     (u.byte, "data quantity"),
     (u.bit, "data quantity"),
-    (u.imperial.mi / u.week, "speed"),
+    (imperial.mi / u.week, "speed"),
     (u.erg / u.s, "power"),
     (u.C / u.s, "electrical current"),
     (u.C / u.s / u.cm ** 2, "electrical current density"),
@@ -42,9 +42,9 @@ unit_physical_type_pairs = [
     (u.mol, "amount of substance"),
     (u.K, "temperature"),
     (u.deg_C, "temperature"),
-    (u.imperial.deg_F, "temperature"),
-    (u.imperial.deg_R, "temperature"),
-    (u.imperial.deg_R / u.m, "temperature_gradient"),
+    (imperial.deg_F, "temperature"),
+    (imperial.deg_R, "temperature"),
+    (imperial.deg_R / u.m, "temperature_gradient"),
     (u.N, "force"),
     (u.J, "energy"),
     (u.Pa, "pressure"),
@@ -89,9 +89,9 @@ unit_physical_type_pairs = [
     (u.cgs.statampere, "electrical current (ESU)"),
     (u.cgs.Biot, "electrical current (EMU)"),
     (u.cgs.abcoulomb, "electrical charge (EMU)"),
-    (u.imperial.btu / (u.s * u.m * u.imperial.deg_F), "thermal conductivity"),
-    (u.imperial.cal / u.deg_C, "heat capacity"),
-    (u.imperial.cal / u.deg_C / u.g, "specific heat capacity"),
+    (imperial.btu / (u.s * u.m * imperial.deg_F), "thermal conductivity"),
+    (imperial.cal / u.deg_C, "heat capacity"),
+    (imperial.cal / u.deg_C / u.g, "specific heat capacity"),
     (u.J * u.m ** -2 * u.s ** -1, "energy flux"),
     (u.W / u.m ** 2, "energy flux"),
     (u.m ** 3 / u.mol, "molar volume"),
@@ -105,16 +105,16 @@ unit_physical_type_pairs = [
     (u.m / u.s ** 5, "crackle"),
     (u.m / u.s ** 6, "pop"),
     (u.deg_C / u.m, "temperature gradient"),
-    (u.imperial.deg_F / u.m, "temperature gradient"),
-    (u.imperial.deg_R / u.imperial.ft, "temperature gradient"),
-    (u.imperial.Calorie / u.g, "specific energy"),
+    (imperial.deg_F / u.m, "temperature gradient"),
+    (imperial.deg_R / imperial.ft, "temperature gradient"),
+    (imperial.Calorie / u.g, "specific energy"),
     (u.mol / u.L / u.s, "reaction rate"),
-    (u.imperial.lbf * u.imperial.ft * u.s ** 2, "moment of inertia"),
+    (imperial.lbf * imperial.ft * u.s ** 2, "moment of inertia"),
     (u.mol / u.s, "catalytic activity"),
-    (u.imperial.kcal / u.deg_C / u.mol, "molar heat capacity"),
+    (imperial.kcal / u.deg_C / u.mol, "molar heat capacity"),
     (u.mol / u.kg, "molality"),
-    (u.imperial.inch * u.hr, "absement"),
-    (u.imperial.ft ** 3 / u.s, "volumetric flow rate"),
+    (imperial.inch * u.hr, "absement"),
+    (imperial.ft ** 3 / u.s, "volumetric flow rate"),
     (u.Hz / u.s, "frequency drift"),
     (u.Pa ** -1, "compressibility"),
     (u.dimensionless_unscaled, "dimensionless"),
@@ -282,9 +282,9 @@ equivalent_unit_pairs = [
     (u.N, u.kg * u.m * u.s ** -2),
     (u.barn * u.Mpc, u.cm ** 3),
     (u.K, u.deg_C),
-    (u.K, u.imperial.deg_R),
-    (u.K, u.imperial.deg_F),
-    (u.deg_C, u.imperial.deg_F),
+    (u.K, imperial.deg_R),
+    (u.K, imperial.deg_F),
+    (u.deg_C, imperial.deg_F),
     (u.m ** 18, u.pc ** 18),
 ]
 
@@ -317,7 +317,7 @@ nonequivalent_unit_pairs = [
     (u.m, u.s),
     (u.m ** 18, u.m ** 19),
     (u.N, u.J),
-    (u.barn, u.imperial.deg_F),
+    (u.barn, imperial.deg_F),
 ]
 
 
@@ -406,9 +406,6 @@ def test_invalid_physical_types(invalid_input):
     with pytest.raises(ValueError):
         physical.PhysicalType(obscure_unit, invalid_input)
     assert obscure_unit.physical_type == "unknown"
-
-
-# Test that get_physical_type of a PhysicalType returns itself
 
 
 class TestDefPhysType:


### PR DESCRIPTION
This is a quick follow-up to #11204.  The main change is to import `imperial` from `astropy.units` directly, which is hopefully enough to address the problem in this [comment](https://github.com/astropy/astropy/pull/11204#issuecomment-821844588) about #11204 having broken the `pyinstaller` cron job.