### PR TITLE
Added capabilty to read ORDER and ignore whitespace after null specifier.

### DIFF
--- a/astropy/io/ascii/cds.py
+++ b/astropy/io/ascii/cds.py
@@ -126,8 +126,16 @@ class CdsHeader(core.BaseHeader):
                 col.type = self.get_col_type(col)
 
                 match = re.match(
-                    r'(?P<limits>[\[\]] \S* [\[\]])? \? (?P<equal> =)?'
-                    r'(?P<nullval> \S*) (\s+ (?P<descriptiontext> \S.*))?',
+                    r'(?P<limits>[\[\]] \S* [\[\]])?'  # Matches limits specifier (eg [])
+                                                       # that may or may not be present
+                    r'\?'  # Matches '?' directly
+                    r'((?P<equal>=)(?P<nullval> \S*))?'  # Matches to nullval if and only
+                                                         # if '=' is present
+                    r'(?P<order>[-+]?[=]?)'  # Matches to order specifier:
+                                             # ('+', '-', '+=', '-=')
+                    r'(\s* (?P<descriptiontext> \S.*))?',  # Matches description text even
+                                                           # even if no whitespace is
+                                                           # present after '?'
                     col.description, re.VERBOSE)
                 if match:
                     col.description = (match.group('descriptiontext') or '').strip()
@@ -144,6 +152,8 @@ class CdsHeader(core.BaseHeader):
                             self.data.fill_values.append(('-' * i, fillval, col.name))
                     else:
                         col.null = match.group('nullval')
+                        if (col.null is None):
+                            col.null = ''
                         self.data.fill_values.append((col.null, fillval, col.name))
 
                 cols.append(col)

--- a/astropy/io/ascii/tests/data/cds/null/ReadMe1
+++ b/astropy/io/ascii/tests/data/cds/null/ReadMe1
@@ -1,0 +1,72 @@
+J/A+A/511/A56       Abundances of five open clusters            (Pancino+, 2010)
+================================================================================
+Chemical abundance analysis of the open clusters Cr 110, NGC 2420, NGC 7789,
+and M 67 (NGC 2682).
+    Pancino E., Carrera R., Rossetti, E., Gallart C.
+   <Astron. Astrophys. 511, A56 (2010)>
+   =2010A&A...511A..56P
+================================================================================
+ADC_Keywords: Clusters, open ; Stars, giant ; Equivalent widths ; Spectroscopy
+Keywords: stars: abundances - Galaxy: disk -
+          open clusters and associations: general
+
+Abstract:
+    Tables modified for testing. Added order specifiers "+=", "-=" and "+"
+    to cols 5, 8 and 9 respectively and removed whitespace after "?" in 
+    col 6.
+    Beginning of original abstract follows:
+    The present number of Galactic open clusters that have high resolution
+    abundance determinations, not only of [Fe/H], but also of other key
+    elements, is largely insufficient to enable a clear modeling of the
+    Galactic disk chemical evolution. To increase the number of Galactic
+    open clusters with high quality measurements, we obtained high
+    resolution (R~30000), high quality (S/N~50-100 per pixel), echelle
+    spectra with the fiber spectrograph FOCES, at Calar Alto, Spain, for
+    three red clump stars in each of five Open Clusters. We used the
+    classical equivalent width analysis method to obtain accurate
+    abundances of sixteen elements: Al, Ba, Ca, Co, Cr, Fe, La, Mg, Na,
+    Nd, Ni, Sc, Si, Ti, V, and Y. We also derived the oxygen abundance
+    using spectral synthesis of the 6300{AA} forbidden line.
+
+Description:
+    Atomic data and equivalent widths for 15 red clump giants in 5 open
+    clusters: Cr 110, NGC 2099, NGC 2420, M 67, NGC 7789.
+
+File Summary:
+--------------------------------------------------------------------------------
+ FileName   Lrecl  Records   Explanations
+--------------------------------------------------------------------------------
+ReadMe         80        .   This file
+table1.dat    103       15   Observing logs and programme stars information
+table5.dat     56     5265   Atomic data and equivalent widths
+--------------------------------------------------------------------------------
+
+See also:
+ J/A+A/455/271 : Abundances of red giants in NGC 6441 (Gratton+, 2006)
+ J/A+A/464/953 : Abundances of red giants in NGC 6441 (Gratton+, 2007)
+ J/A+A/505/117 : Abund. of red giants in 15 globular clusters (Carretta+, 2009)
+
+Byte-by-byte Description of file: table.dat
+--------------------------------------------------------------------------------
+   Bytes Format Units     Label     Explanations
+--------------------------------------------------------------------------------
+   1-  7  A7    ---       Cluster   Cluster name
+   9- 12  I4    ---       Star      
+  14- 20  F7.2  0.1nm     Wave      wave
+                                    ? Wavelength in Angstroms
+  22- 23  A2    ---       El        a
+      24  I1    ---       ion       ?=0
+                                    - Ionization stage (1 for neutral element)
+  26- 30  F5.2  eV        chiEx     [1/20843]?+= Catalogue Identification Number
+  32- 37  F6.2  ---       loggf     ]0/140[?Temperature class codified (10)
+  39- 43  F5.1  0.1pm     EW        ?=-9.9 Equivalent width (in mA)
+  44- 45  F5.1  0.1pm     EW        [1/52]?-= Equivalent width (in mA)
+  46- 49  F4.1  0.1pm   e_EW        [1/6]?+ Luminosity class codified (11)
+  51- 56  F6.3  ---       Q         ?=-9.999 DAOSPEC quality parameter Q
+                                     (large values are bad)
+--------------------------------------------------------------------------------
+
+Acknowledgements:
+    Elena Pancino, elena.pancino(at)oabo.inaf.it
+================================================================================
+(End)    Elena Pancino [INAF-OABo, Italy], Patricia Vannier [CDS]    23-Nov-2009

--- a/astropy/io/ascii/tests/test_cds_header_from_readme.py
+++ b/astropy/io/ascii/tests/test_cds_header_from_readme.py
@@ -196,6 +196,34 @@ def test_cds_ignore_nullable():
     assert_equal(r.header.cols[5].description, 'Pericenter position angle (18)')
 
 
+def test_cds_no_whitespace():
+    # Make sure CDS Reader only checks null values when an '=' symbol is present,
+    # and read description text even if there is no whitespace after '?'.
+    readme = 'data/cds/null/ReadMe1'
+    data = 'data/cds/null/table.dat'
+    r = ascii.Cds(readme)
+    r.read(data)
+    assert_equal(r.header.cols[6].description, 'Temperature class codified (10)')
+    assert_equal(r.header.cols[6].null, '')
+    assert_equal(r.header.cols[7].description, 'Equivalent width (in mA)')
+    assert_equal(r.header.cols[7].null, '-9.9')
+    assert_equal(r.header.cols[10].description,
+                 'DAOSPEC quality parameter Q(large values are bad)')
+    assert_equal(r.header.cols[10].null, '-9.999')
+
+
+def test_cds_order():
+    # Make sure CDS Reader does not ignore order specifier that maybe present after
+    # the null specifier '?'
+    readme = 'data/cds/null/ReadMe1'
+    data = 'data/cds/null/table.dat'
+    r = ascii.Cds(readme)
+    r.read(data)
+    assert_equal(r.header.cols[5].description, 'Catalogue Identification Number')
+    assert_equal(r.header.cols[8].description, 'Equivalent width (in mA)')
+    assert_equal(r.header.cols[9].description, 'Luminosity class codified (11)')
+
+
 if __name__ == "__main__":  # run from main directory; not from test/
     test_header_from_readme()
     test_multi_header()
@@ -203,3 +231,5 @@ if __name__ == "__main__":  # run from main directory; not from test/
     test_description()
     test_cds_units()
     test_cds_ignore_nullable()
+    test_cds_no_whitespace()
+    test_cds_order()

--- a/docs/changes/io.ascii/11593.bugfix.rst
+++ b/docs/changes/io.ascii/11593.bugfix.rst
@@ -1,0 +1,4 @@
+Made sure that the CDS reader does not ignore an order specifier that
+may be present after the null specifier '?'. Also made sure that it
+checks null values only when an '=' symbol is present and reads
+description text even if there is no whitespace after '?'.


### PR DESCRIPTION
Added functionality to CDS reader that does not ignore the ORDER specifier that may be present after the null specifier '?'. Also made sure it only checks null values when a '=' symbol is present and read the description text even if there is no whitespace after '?'.

Fixes #11546
