### PR TITLE
xref physical types

### DIFF
--- a/astropy/convolution/kernels.py
+++ b/astropy/convolution/kernels.py
@@ -101,7 +101,7 @@ class Gaussian2DKernel(Kernel2D):
         Standard deviation of the Gaussian in x before rotating by theta.
     y_stddev : float
         Standard deviation of the Gaussian in y before rotating by theta.
-    theta : float or `~astropy.units.Quantity`
+    theta : float or `~astropy.units.Quantity` ['angle']
         Rotation angle. If passed as a float, it is assumed to be in radians.
         The rotation angle increases counterclockwise.
     x_size : int, optional

--- a/astropy/coordinates/angle_utilities.py
+++ b/astropy/coordinates/angle_utilities.py
@@ -678,7 +678,7 @@ def angular_separation(lon1, lat1, lon2, lat2):
 
     Returns
     -------
-    angular separation : `~astropy.units.Quantity` or float
+    angular separation : `~astropy.units.Quantity` ['angle'] or float
         Type depends on input; `Quantity` in angular units, or float in
         radians.
 

--- a/astropy/coordinates/angles.py
+++ b/astropy/coordinates/angles.py
@@ -622,17 +622,16 @@ class Longitude(Angle):
 
     Parameters
     ----------
-    angle : array, list, scalar, `~astropy.units.Quantity`,
-        :class:`~astropy.coordinates.Angle` The angle value(s). If a tuple,
-        will be interpreted as ``(h, m s)`` or ``(d, m, s)`` depending
-        on ``unit``. If a string, it will be interpreted following the
-        rules described for :class:`~astropy.coordinates.Angle`.
+    angle : tuple or angle-like
+        The angle value(s). If a tuple, will be interpreted as ``(h, m s)`` or
+        ``(d, m, s)`` depending on ``unit``. If a string, it will be interpreted
+        following the rules described for :class:`~astropy.coordinates.Angle`.
 
         If ``angle`` is a sequence or array of strings, the resulting
         values will be in the given ``unit``, or if `None` is provided,
         the unit will be taken from the first given value.
 
-    unit : unit-like, optional
+    unit : unit-like ['angle'], optional
         The unit of the value specified for the angle.  This may be
         any string that `~astropy.units.Unit` understands, but it is
         better to give an actual unit object.  Must be an angular

--- a/astropy/coordinates/builtin_frames/altaz.py
+++ b/astropy/coordinates/builtin_frames/altaz.py
@@ -23,16 +23,16 @@ doc_components = """
     alt : `~astropy.coordinates.Angle`, optional, keyword-only
         The Altitude for this object (``az`` must also be given and
         ``representation`` must be None).
-    distance : `~astropy.units.Quantity`, optional, keyword-only
+    distance : `~astropy.units.Quantity` ['length'], optional, keyword-only
         The Distance for this object along the line-of-sight.
 
-    pm_az_cosalt : `~astropy.units.Quantity`, optional, keyword-only
+    pm_az_cosalt : `~astropy.units.Quantity` ['anglular speed'], optional, keyword-only
         The proper motion in azimuth (including the ``cos(alt)`` factor) for
         this object (``pm_alt`` must also be given).
-    pm_alt : `~astropy.units.Quantity`, optional, keyword-only
+    pm_alt : `~astropy.units.Quantity` ['angular speed'], optional, keyword-only
         The proper motion in altitude for this object (``pm_az_cosalt`` must
         also be given).
-    radial_velocity : `~astropy.units.Quantity`, optional, keyword-only
+    radial_velocity : `~astropy.units.Quantity` ['speed'], optional, keyword-only
         The radial velocity of this object."""
 
 doc_footer = """
@@ -45,18 +45,18 @@ doc_footer = """
         The location on the Earth.  This can be specified either as an
         `~astropy.coordinates.EarthLocation` object or as anything that can be
         transformed to an `~astropy.coordinates.ITRS` frame.
-    pressure : `~astropy.units.Quantity`
+    pressure : `~astropy.units.Quantity` ['pressure']
         The atmospheric pressure as an `~astropy.units.Quantity` with pressure
         units.  This is necessary for performing refraction corrections.
         Setting this to 0 (the default) will disable refraction calculations
         when transforming to/from this frame.
-    temperature : `~astropy.units.Quantity`
+    temperature : `~astropy.units.Quantity` ['temperature']
         The ground-level temperature as an `~astropy.units.Quantity` in
         deg C.  This is necessary for performing refraction corrections.
-    relative_humidity : `~astropy.units.Quantity` or number.
+    relative_humidity : `~astropy.units.Quantity` ['dimensionless'] or number
         The relative humidity as a dimensionless quantity between 0 to 1.
         This is necessary for performing refraction corrections.
-    obswl : `~astropy.units.Quantity`
+    obswl : `~astropy.units.Quantity` ['length']
         The average wavelength of observations as an `~astropy.units.Quantity`
          with length units.  This is necessary for performing refraction
          corrections.

--- a/astropy/coordinates/builtin_frames/baseradec.py
+++ b/astropy/coordinates/builtin_frames/baseradec.py
@@ -15,17 +15,17 @@ doc_components = """
     dec : `~astropy.coordinates.Angle`, optional, keyword-only
         The Declination for this object (``ra`` must also be given and
         ``representation`` must be None).
-    distance : `~astropy.units.Quantity`, optional, keyword-only
+    distance : `~astropy.units.Quantity` ['length'], optional, keyword-only
         The Distance for this object along the line-of-sight.
         (``representation`` must be None).
 
-    pm_ra_cosdec : `~astropy.units.Quantity`, optional, keyword-only
+    pm_ra_cosdec : `~astropy.units.Quantity` ['angular speed'], optional, keyword-only
         The proper motion in Right Ascension (including the ``cos(dec)`` factor)
         for this object (``pm_dec`` must also be given).
-    pm_dec : `~astropy.units.Quantity`, optional, keyword-only
+    pm_dec : `~astropy.units.Quantity` ['angular speed'], optional, keyword-only
         The proper motion in Declination for this object (``pm_ra_cosdec`` must
         also be given).
-    radial_velocity : `~astropy.units.Quantity`, optional, keyword-only
+    radial_velocity : `~astropy.units.Quantity` ['speed'], optional, keyword-only
         The radial velocity of this object.
 """
 

--- a/astropy/coordinates/builtin_frames/ecliptic.py
+++ b/astropy/coordinates/builtin_frames/ecliptic.py
@@ -22,17 +22,17 @@ doc_components_ecl = """
     lat : `~astropy.coordinates.Angle`, optional, keyword-only
         The ecliptic latitude for this object (``lon`` must also be given and
         ``representation`` must be None).
-    distance : `~astropy.units.Quantity`, optional, keyword-only
+    distance : `~astropy.units.Quantity` ['length'], optional, keyword-only
         The distance for this object from the {0}.
         (``representation`` must be None).
 
-    pm_lon_coslat : `~astropy.coordinates.Angle`, optional, keyword-only
+    pm_lon_coslat : `~astropy.units.Quantity` ['angualar speed'], optional, keyword-only
         The proper motion in the ecliptic longitude (including the ``cos(lat)``
         factor) for this object (``pm_lat`` must also be given).
-    pm_lat : `~astropy.coordinates.Angle`, optional, keyword-only
+    pm_lat : `~astropy.units.Quantity` ['angular speed'], optional, keyword-only
         The proper motion in the ecliptic latitude for this object
         (``pm_lon_coslat`` must also be given).
-    radial_velocity : `~astropy.units.Quantity`, optional, keyword-only
+    radial_velocity : `~astropy.units.Quantity` ['speed'], optional, keyword-only
         The radial velocity of this object.
 """
 

--- a/astropy/coordinates/builtin_frames/galactic.py
+++ b/astropy/coordinates/builtin_frames/galactic.py
@@ -21,16 +21,16 @@ doc_components = """
     b : `~astropy.coordinates.Angle`, optional, keyword-only
         The Galactic latitude for this object (``l`` must also be given and
         ``representation`` must be None).
-    distance : `~astropy.units.Quantity`, optional, keyword-only
+    distance : `~astropy.units.Quantity` ['length'], optional, keyword-only
         The Distance for this object along the line-of-sight.
 
-    pm_l_cosb : `~astropy.units.Quantity`, optional, keyword-only
+    pm_l_cosb : `~astropy.units.Quantity` ['angular speed'], optional, keyword-only
         The proper motion in Galactic longitude (including the ``cos(b)`` term)
         for this object (``pm_b`` must also be given).
-    pm_b : `~astropy.units.Quantity`, optional, keyword-only
+    pm_b : `~astropy.units.Quantity` ['angular speed'], optional, keyword-only
         The proper motion in Galactic latitude for this object (``pm_l_cosb``
         must also be given).
-    radial_velocity : `~astropy.units.Quantity`, optional, keyword-only
+    radial_velocity : `~astropy.units.Quantity` ['speed'], optional, keyword-only
         The radial velocity of this object.
 """
 

--- a/astropy/coordinates/builtin_frames/galactocentric.py
+++ b/astropy/coordinates/builtin_frames/galactocentric.py
@@ -360,10 +360,10 @@ doc_footer = """
         The ICRS coordinates of the Galactic center.
     galcen_distance : `~astropy.units.Quantity`, optional, keyword-only
         The distance from the sun to the Galactic center.
-    galcen_v_sun : `~astropy.coordinates.representation.CartesianDifferential`, optional, keyword-only
+    galcen_v_sun : `~astropy.coordinates.representation.CartesianDifferential`, `~astropy.units.Quantity` ['speed'], optional, keyword-only
         The velocity of the sun *in the Galactocentric frame* as Cartesian
         velocity components.
-    z_sun : `~astropy.units.Quantity`, optional, keyword-only
+    z_sun : `~astropy.units.Quantity` ['length'], optional, keyword-only
         The distance from the sun to the Galactic midplane.
     roll : `~astropy.coordinates.Angle`, optional, keyword-only
         The angle to rotate about the final x-axis, relative to the

--- a/astropy/coordinates/builtin_frames/lsr.py
+++ b/astropy/coordinates/builtin_frames/lsr.py
@@ -90,17 +90,17 @@ doc_components_gal = """
     b : `~astropy.coordinates.Angle`, optional, keyword-only
         The Galactic latitude for this object (``l`` must also be given and
         ``representation`` must be None).
-    distance : `~astropy.units.Quantity`, optional, keyword-only
+    distance : `~astropy.units.Quantity` ['length'], optional, keyword-only
         The Distance for this object along the line-of-sight.
         (``representation`` must be None).
 
-    pm_l_cosb : `~astropy.units.Quantity`, optional, keyword-only
+    pm_l_cosb : `~astropy.units.Quantity` ['angular speed'], optional, keyword-only
         The proper motion in Galactic longitude (including the ``cos(b)`` term)
         for this object (``pm_b`` must also be given).
-    pm_b : `~astropy.units.Quantity`, optional, keyword-only
+    pm_b : `~astropy.units.Quantity` ['angular speed'], optional, keyword-only
         The proper motion in Galactic latitude for this object (``pm_l_cosb``
         must also be given).
-    radial_velocity : `~astropy.units.Quantity`, optional, keyword-only
+    radial_velocity : `~astropy.units.Quantity` ['speed'], optional, keyword-only
         The radial velocity of this object.
 """
 

--- a/astropy/coordinates/builtin_frames/supergalactic.py
+++ b/astropy/coordinates/builtin_frames/supergalactic.py
@@ -17,16 +17,16 @@ doc_components = """
     sgb : `~astropy.coordinates.Angle`, optional, keyword-only
         The supergalactic latitude for this object (``sgl`` must also be given and
         ``representation`` must be None).
-    distance : `~astropy.units.Quantity`, optional, keyword-only
+    distance : `~astropy.units.Quantity` ['speed'], optional, keyword-only
         The Distance for this object along the line-of-sight.
 
-    pm_sgl_cossgb : `~astropy.units.Quantity`, optional, keyword-only
+    pm_sgl_cossgb : `~astropy.units.Quantity` ['angular speed'], optional, keyword-only
         The proper motion in Right Ascension for this object (``pm_sgb`` must
         also be given).
-    pm_sgb : `~astropy.units.Quantity`, optional, keyword-only
+    pm_sgb : `~astropy.units.Quantity` ['angular speed'], optional, keyword-only
         The proper motion in Declination for this object (``pm_sgl_cossgb`` must
         also be given).
-    radial_velocity : `~astropy.units.Quantity`, optional, keyword-only
+    radial_velocity : `~astropy.units.Quantity` ['speed'], optional, keyword-only
         The radial velocity of this object.
 """
 

--- a/astropy/coordinates/distances.py
+++ b/astropy/coordinates/distances.py
@@ -33,9 +33,9 @@ class Distance(u.SpecificTypeQuantity):
 
     Parameters
     ----------
-    value : scalar or `~astropy.units.Quantity`
+    value : scalar or `~astropy.units.Quantity` ['length']
         The value of this distance.
-    unit : `~astropy.units.UnitBase`
+    unit : `~astropy.units.UnitBase` ['length']
         The units for this distance, *if* ``value`` is not a
         `~astropy.units.Quantity`. Must have dimensions of distance.
     z : float

--- a/astropy/coordinates/earth.py
+++ b/astropy/coordinates/earth.py
@@ -272,7 +272,7 @@ class EarthLocation(u.Quantity):
         lat : `~astropy.coordinates.Latitude` or float
             Earth latitude.  Can be anything that initialises an
             `~astropy.coordinates.Latitude` object (if float, in degrees).
-        height : `~astropy.units.Quantity` or float, optional
+        height : `~astropy.units.Quantity` ['length'] or float, optional
             Height above reference ellipsoid (if float, in meters; default: 0).
         ellipsoid : str, optional
             Name of the reference ellipsoid to use (default: 'WGS84').
@@ -863,7 +863,7 @@ geodetic_base_doc = """{__doc__}
         instances of `~astropy.coordinates.Angle` and either
         `~astropy.coordinates.Longitude` not `~astropy.coordinates.Latitude`,
         depending on the parameter.
-    height : `~astropy.units.Quantity`
+    height : `~astropy.units.Quantity` ['length']
         The height to the point(s).
     copy : bool, optional
         If `True` (default), arrays will be copied. If `False`, arrays will

--- a/astropy/coordinates/funcs.py
+++ b/astropy/coordinates/funcs.py
@@ -57,9 +57,9 @@ def cartesian_to_spherical(x, y, z):
     -------
     r : `~astropy.units.Quantity`
         The radial coordinate (in the same units as the inputs).
-    lat : `~astropy.units.Quantity`
+    lat : `~astropy.units.Quantity` ['angle']
         The latitude in radians
-    lon : `~astropy.units.Quantity`
+    lon : `~astropy.units.Quantity` ['angle']
         The longitude in radians
     """
     if not hasattr(x, 'unit'):
@@ -94,9 +94,9 @@ def spherical_to_cartesian(r, lat, lon):
     ----------
     r : scalar, array-like, or `~astropy.units.Quantity`
         The radial coordinate (in the same units as the inputs).
-    lat : scalar, array-like, or `~astropy.units.Quantity`
+    lat : scalar, array-like, or `~astropy.units.Quantity` ['angle']
         The latitude (in radians if array or scalar)
-    lon : scalar, array-like, or `~astropy.units.Quantity`
+    lon : scalar, array-like, or `~astropy.units.Quantity` ['angle']
         The longitude (in radians if array or scalar)
 
     Returns

--- a/astropy/coordinates/matching.py
+++ b/astropy/coordinates/matching.py
@@ -52,7 +52,7 @@ def match_coordinates_3d(matchcoord, catalogcoord, nthneighbor=1, storekdtree='k
     sep2d : `~astropy.coordinates.Angle`
         The on-sky separation between the closest match for each ``matchcoord``
         and the ``matchcoord``. Shape matches ``matchcoord``.
-    dist3d : `~astropy.units.Quantity`
+    dist3d : `~astropy.units.Quantity` ['length']
         The 3D distance between the closest match for each ``matchcoord`` and
         the ``matchcoord``. Shape matches ``matchcoord``.
 
@@ -128,7 +128,7 @@ def match_coordinates_sky(matchcoord, catalogcoord, nthneighbor=1, storekdtree='
     sep2d : `~astropy.coordinates.Angle`
         The on-sky separation between the closest match for each
         ``matchcoord`` and the ``matchcoord``. Shape matches ``matchcoord``.
-    dist3d : `~astropy.units.Quantity`
+    dist3d : `~astropy.units.Quantity` ['length']
         The 3D distance between the closest match for each ``matchcoord`` and
         the ``matchcoord``. Shape matches ``matchcoord``.  If either
         ``matchcoord`` or ``catalogcoord`` don't have a distance, this is the 3D
@@ -195,8 +195,8 @@ def search_around_3d(coords1, coords2, distlimit, storekdtree='kdtree_3d'):
     coords2 : `~astropy.coordinates.BaseCoordinateFrame` or `~astropy.coordinates.SkyCoord`
         The second set of coordinates, which will be searched for matches from
         ``coords1`` within ``seplimit``.  Cannot be a scalar coordinate.
-    distlimit : `~astropy.units.Quantity`
-        The physical radius to search within. Must have distance units.
+    distlimit : `~astropy.units.Quantity` ['length']
+        The physical radius to search within.
     storekdtree : bool or str, optional
         If a string, will store the KD-Tree used in the search with the name
         ``storekdtree`` in ``coords2.cache``. This speeds up subsequent calls
@@ -213,7 +213,7 @@ def search_around_3d(coords1, coords2, distlimit, storekdtree='kdtree_3d'):
     sep2d : `~astropy.coordinates.Angle`
         The on-sky separation between the coordinates. Shape matches ``idx1``
         and ``idx2``.
-    dist3d : `~astropy.units.Quantity`
+    dist3d : `~astropy.units.Quantity` ['length']
         The 3D distance between the coordinates. Shape matches ``idx1`` and
         ``idx2``. The unit is that of ``coords1``.
 
@@ -298,8 +298,8 @@ def search_around_sky(coords1, coords2, seplimit, storekdtree='kdtree_sky'):
     coords2 : coordinate-like
         The second set of coordinates, which will be searched for matches from
         ``coords1`` within ``seplimit``. Cannot be a scalar coordinate.
-    seplimit : `~astropy.units.Quantity`
-        The on-sky separation to search within. Must have angular units.
+    seplimit : `~astropy.units.Quantity` ['angle']
+        The on-sky separation to search within.
     storekdtree : bool or str, optional
         If a string, will store the KD-Tree used in the search with the name
         ``storekdtree`` in ``coords2.cache``. This speeds up subsequent calls
@@ -316,7 +316,7 @@ def search_around_sky(coords1, coords2, seplimit, storekdtree='kdtree_sky'):
     sep2d : `~astropy.coordinates.Angle`
         The on-sky separation between the coordinates. Shape matches ``idx1``
         and ``idx2``.
-    dist3d : `~astropy.units.Quantity`
+    dist3d : `~astropy.units.Quantity` ['length']
         The 3D distance between the coordinates. Shape matches ``idx1``
         and ``idx2``; the unit is that of ``coords1``.
         If either ``coords1`` or ``coords2`` don't have a distance,

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -1514,7 +1514,7 @@ class UnitSphericalRepresentation(BaseRepresentation):
 
     Parameters
     ----------
-    lon, lat : `~astropy.units.Quantity` or str
+    lon, lat : `~astropy.units.Quantity` ['angle'] or str
         The longitude and latitude of the point(s), in angular units. The
         latitude should be between -90 and 90 degrees, and the longitude will
         be wrapped to an angle between 0 and 360 degrees. These can also be
@@ -1683,7 +1683,7 @@ class UnitSphericalRepresentation(BaseRepresentation):
 
         Returns
         -------
-        norm : `~astropy.units.Quantity`
+        norm : `~astropy.units.Quantity` ['dimensionless']
             Dimensionless ones, with the same shape as the representation.
         """
         return u.Quantity(np.ones(self.shape), u.dimensionless_unscaled,
@@ -1759,7 +1759,7 @@ class RadialRepresentation(BaseRepresentation):
 
     Parameters
     ----------
-    distance : `~astropy.units.Quantity`
+    distance : `~astropy.units.Quantity` ['length']
         The distance of the point(s) from the origin.
 
     differentials : dict, `~astropy.coordinates.BaseDifferential`, optional
@@ -1821,7 +1821,7 @@ class RadialRepresentation(BaseRepresentation):
 
         Returns
         -------
-        norm : `~astropy.units.Quantity`
+        norm : `~astropy.units.Quantity` ['dimensionless']
             Dimensionless ones, with the same shape as the representation.
         """
         return self.distance
@@ -1849,14 +1849,14 @@ class SphericalRepresentation(BaseRepresentation):
 
     Parameters
     ----------
-    lon, lat : `~astropy.units.Quantity`
+    lon, lat : `~astropy.units.Quantity` ['angle']
         The longitude and latitude of the point(s), in angular units. The
         latitude should be between -90 and 90 degrees, and the longitude will
         be wrapped to an angle between 0 and 360 degrees. These can also be
         instances of `~astropy.coordinates.Angle`,
         `~astropy.coordinates.Longitude`, or `~astropy.coordinates.Latitude`.
 
-    distance : `~astropy.units.Quantity`
+    distance : `~astropy.units.Quantity` ['length']
         The distance to the point(s). If the distance is a length, it is
         passed to the :class:`~astropy.coordinates.Distance` class, otherwise
         it is passed to the :class:`~astropy.units.Quantity` class.
@@ -3234,11 +3234,11 @@ class CylindricalDifferential(BaseDifferential):
 
     Parameters
     ----------
-    d_rho : `~astropy.units.Quantity`
+    d_rho : `~astropy.units.Quantity` ['speed']
         The differential cylindrical radius.
-    d_phi : `~astropy.units.Quantity`
+    d_phi : `~astropy.units.Quantity` ['angular speed']
         The differential azimuth.
-    d_z : `~astropy.units.Quantity`
+    d_z : `~astropy.units.Quantity` ['speed']
         The differential height.
     copy : bool, optional
         If `True` (default), arrays will be copied. If `False`, arrays will

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -244,20 +244,20 @@ class SkyCoord(ShapedLikeNDArray):
             RA and Dec for frames where ``ra`` and ``dec`` are keys in the
             frame's ``representation_component_names``, including `ICRS`,
             `FK5`, `FK4`, and `FK4NoETerms`.
-        pm_ra_cosdec, pm_dec  : `~astropy.units.Quantity`, optional
+        pm_ra_cosdec, pm_dec  : `~astropy.units.Quantity` ['angular speed'], optional
             Proper motion components, in angle per time units.
         l, b : angle-like, optional
             Galactic ``l`` and ``b`` for for frames where ``l`` and ``b`` are
             keys in the frame's ``representation_component_names``, including
             the `Galactic` frame.
-        pm_l_cosb, pm_b : `~astropy.units.Quantity`, optional
+        pm_l_cosb, pm_b : `~astropy.units.Quantity` ['angular speed'], optional
             Proper motion components in the `Galactic` frame, in angle per time
             units.
-        x, y, z : float or `~astropy.units.Quantity`, optional
+        x, y, z : float or `~astropy.units.Quantity` ['length'], optional
             Cartesian coordinates values
-        u, v, w : float or `~astropy.units.Quantity`, optional
+        u, v, w : float or `~astropy.units.Quantity` ['length'], optional
             Cartesian coordinates values for the Galactic frame.
-        radial_velocity : `~astropy.units.Quantity`, optional
+        radial_velocity : `~astropy.units.Quantity` ['speed'], optional
             The component of the velocity along the line-of-sight (i.e., the
             radial direction), in velocity units.
     """
@@ -1242,7 +1242,7 @@ class SkyCoord(ShapedLikeNDArray):
             The on-sky separation between the closest match for each
             element in this object in ``catalogcoord``. Shape matches
             this object.
-        dist3d : `~astropy.units.Quantity`
+        dist3d : `~astropy.units.Quantity` ['length']
             The 3D distance between the closest match for each element
             in this object in ``catalogcoord``. Shape matches this
             object. Unless both this and ``catalogcoord`` have associated
@@ -1307,7 +1307,7 @@ class SkyCoord(ShapedLikeNDArray):
             The on-sky separation between the closest match for each
             element in this object in ``catalogcoord``. Shape matches
             this object.
-        dist3d : `~astropy.units.Quantity`
+        dist3d : `~astropy.units.Quantity` ['length']
             The 3D distance between the closest match for each element
             in this object in ``catalogcoord``. Shape matches this
             object.
@@ -1354,8 +1354,8 @@ class SkyCoord(ShapedLikeNDArray):
             The coordinates to search around to try to find matching points in
             this `SkyCoord`. This should be an object with array coordinates,
             not a scalar coordinate object.
-        seplimit : `~astropy.units.Quantity`
-            The on-sky separation to search within. Must have angular units.
+        seplimit : `~astropy.units.Quantity` ['angle']
+            The on-sky separation to search within.
 
         Returns
         -------
@@ -1370,7 +1370,7 @@ class SkyCoord(ShapedLikeNDArray):
         sep2d : `~astropy.coordinates.Angle`
             The on-sky separation between the coordinates. Shape matches
             ``idxsearcharound`` and ``idxself``.
-        dist3d : `~astropy.units.Quantity`
+        dist3d : `~astropy.units.Quantity` ['length']
             The 3D distance between the coordinates. Shape matches
             ``idxsearcharound`` and ``idxself``.
 
@@ -1413,8 +1413,8 @@ class SkyCoord(ShapedLikeNDArray):
             The coordinates to search around to try to find matching points in
             this `SkyCoord`. This should be an object with array coordinates,
             not a scalar coordinate object.
-        distlimit : `~astropy.units.Quantity`
-            The physical radius to search within. Must have distance units.
+        distlimit : `~astropy.units.Quantity` ['length']
+            The physical radius to search within.
 
         Returns
         -------
@@ -1429,7 +1429,7 @@ class SkyCoord(ShapedLikeNDArray):
         sep2d : `~astropy.coordinates.Angle`
             The on-sky separation between the coordinates. Shape matches
             ``idxsearcharound`` and ``idxself``.
-        dist3d : `~astropy.units.Quantity`
+        dist3d : `~astropy.units.Quantity` ['length']
             The 3D distance between the coordinates. Shape matches
             ``idxsearcharound`` and ``idxself``.
 
@@ -1692,11 +1692,11 @@ class SkyCoord(ShapedLikeNDArray):
 
         Returns
         -------
-        vcorr : `~astropy.units.Quantity`
+        vcorr : `~astropy.units.Quantity` ['speed']
             The  correction with a positive sign.  I.e., *add* this
             to an observed radial velocity to get the barycentric (or
             heliocentric) velocity. If m/s precision or better is needed,
-            see the notes below. Must have physical type of 'speed'.
+            see the notes below.
 
         Notes
         -----

--- a/astropy/coordinates/spectral_coordinate.py
+++ b/astropy/coordinates/spectral_coordinate.py
@@ -172,7 +172,7 @@ class SpectralCoord(SpectralQuantity):
         The coordinate (position and velocity) of target. If no velocities
         are present on this object, the target is assumed to be stationary
         relative to the frame origin.
-    radial_velocity : `~astropy.units.Quantity`, optional
+    radial_velocity : `~astropy.units.Quantity` ['speed'], optional
         The radial velocity of the target with respect to the observer. This
         can only be specified if ``redshift`` is not specified.
     redshift : float, optional
@@ -325,7 +325,7 @@ class SpectralCoord(SpectralQuantity):
             The coordinate (position and velocity) of observer.
         target : `~astropy.coordinates.BaseCoordinateFrame` or `~astropy.coordinates.SkyCoord`, optional
             The coordinate (position and velocity) of target.
-        radial_velocity : `~astropy.units.Quantity`, optional
+        radial_velocity : `~astropy.units.Quantity` ['speed'], optional
             The radial velocity of the target with respect to the observer.
         redshift : float, optional
             The relativistic redshift of the target with respect to the observer.
@@ -447,7 +447,7 @@ class SpectralCoord(SpectralQuantity):
 
         Returns
         -------
-        `~astropy.units.Quantity`
+        `~astropy.units.Quantity` ['speed']
             Radial velocity of target.
 
         Notes
@@ -495,7 +495,7 @@ class SpectralCoord(SpectralQuantity):
 
         Returns
         -------
-        `~astropy.units.Quantity`
+        `~astropy.units.Quantity` ['speed']
             The radial velocity of the target with respect to the observer.
         """
 
@@ -640,9 +640,9 @@ class SpectralCoord(SpectralQuantity):
 
         Parameters
         ----------
-        target_shift : float or `~astropy.units.Quantity`
+        target_shift : float or `~astropy.units.Quantity` ['speed']
             Shift value to apply to current target.
-        observer_shift : float or `~astropy.units.Quantity`
+        observer_shift : float or `~astropy.units.Quantity` ['speed']
             Shift value to apply to current observer.
 
         Returns

--- a/astropy/coordinates/spectral_quantity.py
+++ b/astropy/coordinates/spectral_quantity.py
@@ -39,7 +39,7 @@ class SpectralQuantity(SpecificTypeQuantity):
         Spectral axis data values.
     unit : unit-like
         Unit for the given data.
-    doppler_rest : `~astropy.units.Quantity`, optional
+    doppler_rest : `~astropy.units.Quantity` ['speed'], optional
         The rest value to use for conversions from/to velocities
     doppler_convention : str, optional
         The convention to use when converting the spectral data to/from
@@ -110,7 +110,7 @@ class SpectralQuantity(SpecificTypeQuantity):
 
         Returns
         -------
-        `~astropy.units.Quantity`
+        `~astropy.units.Quantity` ['speed']
             Rest value as an astropy `~astropy.units.Quantity` object.
         """
         return self._doppler_rest
@@ -123,7 +123,7 @@ class SpectralQuantity(SpecificTypeQuantity):
 
         Parameters
         ----------
-        value : `~astropy.units.Quantity`
+        value : `~astropy.units.Quantity` ['speed']
             Rest value.
         """
         if self._doppler_rest is not None:
@@ -200,7 +200,7 @@ class SpectralQuantity(SpecificTypeQuantity):
             If not provided or ``[]``, spectral equivalencies will be used.
             If `None`, no equivalencies will be applied at all, not even any
             set globally or within a context.
-        doppler_rest : `~astropy.units.Quantity`, optional
+        doppler_rest : `~astropy.units.Quantity` ['speed'], optional
             The rest value used when converting to/from velocities. This will
             also be set at an attribute on the output
             `~astropy.coordinates.SpectralQuantity`.

--- a/astropy/coordinates/transformations.py
+++ b/astropy/coordinates/transformations.py
@@ -686,7 +686,7 @@ class TransformGraph:
 
         Parameters
         ----------
-        dt : `~astropy.units.Quantity` or callable
+        dt : `~astropy.units.Quantity` ['time'] or callable
             If a quantity, this is the size of the differential used to do the finite difference.
             If a callable, should accept ``(fromcoord, toframe)`` and return the ``dt`` value.
         """
@@ -894,7 +894,7 @@ class FunctionTransformWithFiniteDifference(FunctionTransform):
         attribute, but only one needs to have it. If None, no velocity
         component induced from the frame itself will be included - only the
         re-orientation of any existing differential.
-    finite_difference_dt : `~astropy.units.Quantity` or callable
+    finite_difference_dt : `~astropy.units.Quantity` ['time'] or callable
         If a quantity, this is the size of the differential used to do the
         finite difference.  If a callable, should accept
         ``(fromcoord, toframe)`` and return the ``dt`` value.

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -192,7 +192,7 @@ class FLRW(Cosmology):
 
     Parameters
     ----------
-    H0 : float or scalar `~astropy.units.Quantity`
+    H0 : float or scalar `~astropy.units.Quantity` ['frequency']
         Hubble constant at z = 0.  If a float, must be in [km/sec/Mpc]
 
     Om0 : float
@@ -204,7 +204,7 @@ class FLRW(Cosmology):
         Omega dark energy: density of dark energy in units of the critical
         density at z=0.
 
-    Tcmb0 : float or scalar `~astropy.units.Quantity`, optional
+    Tcmb0 : float or scalar `~astropy.units.Quantity` ['temperature'], optional
         Temperature of the CMB z=0. If a float, must be in [K].
         Default: 0 [K]. Setting this to zero will turn off both photons
         and neutrinos (even massive ones).
@@ -212,7 +212,7 @@ class FLRW(Cosmology):
     Neff : float, optional
         Effective number of Neutrino species. Default 3.04.
 
-    m_nu : quantity-like or array-like, optional
+    m_nu : quantity-like ['energy', 'mass'] or array-like, optional
         Mass of each neutrino species in [eV] (mass-energy equivalency enabled).
         If this is a scalar Quantity, then all neutrino species are assumed to
         have that mass. Otherwise, the mass of each species. The actual number
@@ -723,7 +723,7 @@ class FLRW(Cosmology):
 
         Returns
         -------
-        Tcmb : `~astropy.units.Quantity`
+        Tcmb : `~astropy.units.Quantity` ['temperature']
           The temperature of the CMB in K.
         """
 
@@ -741,7 +741,7 @@ class FLRW(Cosmology):
 
         Returns
         -------
-        Tnu : `~astropy.units.Quantity`
+        Tnu : `~astropy.units.Quantity` ['temperature']
           The temperature of the cosmic neutrino background in K.
         """
 
@@ -1045,7 +1045,7 @@ class FLRW(Cosmology):
 
         Returns
         -------
-        H : `~astropy.units.Quantity`
+        H : `~astropy.units.Quantity` ['frequency']
           Hubble parameter at each input redshift.
         """
 
@@ -1086,7 +1086,7 @@ class FLRW(Cosmology):
 
         Returns
         -------
-        t : `~astropy.units.Quantity`
+        t : `~astropy.units.Quantity` ['time']
           Lookback time in Gyr to each input redshift.
 
         See Also
@@ -1108,7 +1108,7 @@ class FLRW(Cosmology):
 
         Returns
         -------
-        t : `~astropy.units.Quantity`
+        t : `~astropy.units.Quantity` ['time']
           Lookback time in Gyr to each input redshift.
         """
         return self._integral_lookback_time(z)
@@ -1126,7 +1126,7 @@ class FLRW(Cosmology):
 
         Returns
         -------
-        t : `~astropy.units.Quantity`
+        t : `~astropy.units.Quantity` ['time']
           Lookback time in Gyr to each input redshift.
         """
         from scipy.integrate import quad
@@ -1147,7 +1147,7 @@ class FLRW(Cosmology):
 
         Returns
         -------
-        d : `~astropy.units.Quantity`
+        d : `~astropy.units.Quantity` ['length']
           Lookback distance in Mpc
         """
         return (self.lookback_time(z) * const.c).to(u.Mpc)
@@ -1162,7 +1162,7 @@ class FLRW(Cosmology):
 
         Returns
         -------
-        t : `~astropy.units.Quantity`
+        t : `~astropy.units.Quantity` ['time']
           The age of the universe in Gyr at each input redshift.
 
         See Also
@@ -1183,7 +1183,7 @@ class FLRW(Cosmology):
 
         Returns
         -------
-        t : `~astropy.units.Quantity`
+        t : `~astropy.units.Quantity` ['time']
           The age of the universe in Gyr at each input redshift.
         """
         return self._integral_age(z)
@@ -1200,7 +1200,7 @@ class FLRW(Cosmology):
 
         Returns
         -------
-        t : `~astropy.units.Quantity`
+        t : `~astropy.units.Quantity` ['time']
           The age of the universe in Gyr at each input redshift.
 
         See Also
@@ -1243,7 +1243,7 @@ class FLRW(Cosmology):
 
         Returns
         -------
-        d : `~astropy.units.Quantity`
+        d : `~astropy.units.Quantity` ['length']
           Comoving distance in Mpc to each input redshift.
         """
 
@@ -1264,7 +1264,7 @@ class FLRW(Cosmology):
 
         Returns
         -------
-        d : `~astropy.units.Quantity`
+        d : `~astropy.units.Quantity` ['length']
           Comoving distance in Mpc between each input redshift.
         """
         return self._integral_comoving_distance_z1z2(z1, z2)
@@ -1284,7 +1284,7 @@ class FLRW(Cosmology):
 
         Returns
         -------
-        d : `~astropy.units.Quantity`
+        d : `~astropy.units.Quantity` ['length']
           Comoving distance in Mpc between each input redshift.
         """
 
@@ -1308,7 +1308,7 @@ class FLRW(Cosmology):
 
         Returns
         -------
-        d : `~astropy.units.Quantity`
+        d : `~astropy.units.Quantity` ['length']
           Comoving transverse distance in Mpc at each input redshift.
 
         Notes
@@ -1335,7 +1335,7 @@ class FLRW(Cosmology):
 
         Returns
         -------
-        d : `~astropy.units.Quantity`
+        d : `~astropy.units.Quantity` ['length']
           Comoving transverse distance in Mpc between input redshift.
 
         Notes
@@ -1373,7 +1373,7 @@ class FLRW(Cosmology):
 
         Returns
         -------
-        d : `~astropy.units.Quantity`
+        d : `~astropy.units.Quantity` ['length']
           Angular diameter distance in Mpc at each input redshift.
         """
 
@@ -1396,7 +1396,7 @@ class FLRW(Cosmology):
 
         Returns
         -------
-        d : `~astropy.units.Quantity`
+        d : `~astropy.units.Quantity` ['length']
           Luminosity distance in Mpc at each input redshift.
 
         See Also
@@ -1480,7 +1480,7 @@ class FLRW(Cosmology):
 
         Returns
         -------
-        distmod : `~astropy.units.Quantity`
+        distmod : `~astropy.units.Quantity` ['length']
           Distance modulus at each input redshift, in magnitudes
 
         See Also
@@ -1564,7 +1564,7 @@ class FLRW(Cosmology):
 
         Returns
         -------
-        d : `~astropy.units.Quantity`
+        d : `~astropy.units.Quantity` ['length']
           The distance in comoving kpc corresponding to an arcmin at each
           input redshift.
         """
@@ -1582,7 +1582,7 @@ class FLRW(Cosmology):
 
         Returns
         -------
-        d : `~astropy.units.Quantity`
+        d : `~astropy.units.Quantity` ['length']
           The distance in proper kpc corresponding to an arcmin at each
           input redshift.
         """
@@ -1600,7 +1600,7 @@ class FLRW(Cosmology):
 
         Returns
         -------
-        theta : `~astropy.units.Quantity`
+        theta : `~astropy.units.Quantity` ['angle']
           The angular separation in arcsec corresponding to a comoving kpc
           at each input redshift.
         """
@@ -1618,7 +1618,7 @@ class FLRW(Cosmology):
 
         Returns
         -------
-        theta : `~astropy.units.Quantity`
+        theta : `~astropy.units.Quantity` ['angle']
           The angular separation in arcsec corresponding to a proper kpc
           at each input redshift.
         """
@@ -1633,7 +1633,7 @@ class LambdaCDM(FLRW):
 
     Parameters
     ----------
-    H0 : float or `~astropy.units.Quantity`
+    H0 : float or `~astropy.units.Quantity` ['frequency']
         Hubble constant at z = 0.  If a float, must be in [km/sec/Mpc]
 
     Om0 : float
@@ -1644,7 +1644,7 @@ class LambdaCDM(FLRW):
         Omega dark energy: density of the cosmological constant in units of
         the critical density at z=0.
 
-    Tcmb0 : float or scalar `~astropy.units.Quantity`, optional
+    Tcmb0 : float or scalar `~astropy.units.Quantity` ['temperature'], optional
         Temperature of the CMB z=0. If a float, must be in [K].
         Default: 0 [K]. Setting this to zero will turn off both photons
         and neutrinos (even massive ones).
@@ -1652,7 +1652,7 @@ class LambdaCDM(FLRW):
     Neff : float, optional
         Effective number of Neutrino species. Default 3.04.
 
-    m_nu : quantity-like or array-like, optional
+    m_nu : quantity-like ['energy', 'mass'] or array-like, optional
         Mass of each neutrino species in [eV] (mass-energy equivalency enabled).
         If this is a scalar Quantity, then all neutrino species are assumed to
         have that mass. Otherwise, the mass of each species. The actual number
@@ -1802,7 +1802,7 @@ class LambdaCDM(FLRW):
 
         Returns
         -------
-        d : `~astropy.units.Quantity`
+        d : `~astropy.units.Quantity` ['length']
           Comoving distance in Mpc between each input redshift.
         """
         from scipy.special import ellipkinc
@@ -1870,7 +1870,7 @@ class LambdaCDM(FLRW):
 
         Returns
         -------
-        d : `~astropy.units.Quantity`
+        d : `~astropy.units.Quantity` ['length']
           Comoving distance in Mpc between each input redshift.
         """
         try:
@@ -1897,7 +1897,7 @@ class LambdaCDM(FLRW):
 
         Returns
         -------
-        d : `~astropy.units.Quantity`
+        d : `~astropy.units.Quantity` ['length']
           Comoving distance in Mpc between each input redshift.
         """
         try:
@@ -1928,7 +1928,7 @@ class LambdaCDM(FLRW):
 
         Returns
         -------
-        d : `~astropy.units.Quantity`
+        d : `~astropy.units.Quantity` ['length']
           Comoving distance in Mpc between each input redshift.
         """
         try:
@@ -1968,7 +1968,7 @@ class LambdaCDM(FLRW):
 
         Returns
         -------
-        t : `~astropy.units.Quantity`
+        t : `~astropy.units.Quantity` ['time']
           The age of the universe in Gyr at each input redshift.
         """
         return self._hubble_time * inf_like(z)
@@ -1987,7 +1987,7 @@ class LambdaCDM(FLRW):
 
         Returns
         -------
-        t : `~astropy.units.Quantity`
+        t : `~astropy.units.Quantity` ['time']
           The age of the universe in Gyr at each input redshift.
         """
         if isiterable(z):
@@ -2009,7 +2009,7 @@ class LambdaCDM(FLRW):
 
         Returns
         -------
-        t : `~astropy.units.Quantity`
+        t : `~astropy.units.Quantity` ['time']
           The age of the universe in Gyr at each input redshift.
         """
         if isiterable(z):
@@ -2040,7 +2040,7 @@ class LambdaCDM(FLRW):
 
         Returns
         -------
-        t : `~astropy.units.Quantity`
+        t : `~astropy.units.Quantity` ['time']
           Lookback time in Gyr to each input redshift.
         """
         return self._EdS_age(0) - self._EdS_age(z)
@@ -2063,7 +2063,7 @@ class LambdaCDM(FLRW):
 
         Returns
         -------
-        t : `~astropy.units.Quantity`
+        t : `~astropy.units.Quantity` ['time']
           Lookback time in Gyr to each input redshift.
         """
         if isiterable(z):
@@ -2088,7 +2088,7 @@ class LambdaCDM(FLRW):
 
         Returns
         -------
-        t : `~astropy.units.Quantity`
+        t : `~astropy.units.Quantity` ['time']
           Lookback time in Gyr to each input redshift.
         """
         return self._flat_age(0) - self._flat_age(z)
@@ -2165,14 +2165,14 @@ class FlatLambdaCDM(LambdaCDM):
 
     Parameters
     ----------
-    H0 : float or `~astropy.units.Quantity`
+    H0 : float or `~astropy.units.Quantity` ['frequency']
         Hubble constant at z = 0.  If a float, must be in [km/sec/Mpc]
 
     Om0 : float
         Omega matter: density of non-relativistic matter in units of the
         critical density at z=0.
 
-    Tcmb0 : float or scalar `~astropy.units.Quantity`, optional
+    Tcmb0 : float or scalar `~astropy.units.Quantity` ['temperature'], optional
         Temperature of the CMB z=0. If a float, must be in [K].
         Default: 0 [K]. Setting this to zero will turn off both photons
         and neutrinos (even massive ones).
@@ -2180,7 +2180,7 @@ class FlatLambdaCDM(LambdaCDM):
     Neff : float, optional
         Effective number of Neutrino species. Default 3.04.
 
-    m_nu : quantity-like or array-like, optional
+    m_nu : quantity-like ['energy', 'mass'] or array-like, optional
         Mass of each neutrino species in [eV] (mass-energy equivalency enabled).
         If this is a scalar Quantity, then all neutrino species are assumed to
         have that mass. Otherwise, the mass of each species. The actual number
@@ -2315,7 +2315,7 @@ class wCDM(FLRW):
     Parameters
     ----------
 
-    H0 : float or `~astropy.units.Quantity`
+    H0 : float or `~astropy.units.Quantity` ['frequency']
         Hubble constant at z = 0. If a float, must be in [km/sec/Mpc]
 
     Om0 : float
@@ -2331,7 +2331,7 @@ class wCDM(FLRW):
         pressure/density for dark energy in units where c=1. A cosmological
         constant has w0=-1.0.
 
-    Tcmb0 : float or scalar `~astropy.units.Quantity`, optional
+    Tcmb0 : float or scalar `~astropy.units.Quantity` ['temperature'], optional
         Temperature of the CMB z=0. If a float, must be in [K].
         Default: 0 [K]. Setting this to zero will turn off both photons
         and neutrinos (even massive ones).
@@ -2339,7 +2339,7 @@ class wCDM(FLRW):
     Neff : float, optional
         Effective number of Neutrino species. Default 3.04.
 
-    m_nu : quantity-like or array-like, optional
+    m_nu : quantity-like ['energy', 'mass'] or array-like, optional
         Mass of each neutrino species in [eV] (mass-energy equivalency enabled).
         If this is a scalar Quantity, then all neutrino species are assumed to
         have that mass. Otherwise, the mass of each species. The actual number
@@ -2528,7 +2528,7 @@ class FlatwCDM(wCDM):
     Parameters
     ----------
 
-    H0 : float or `~astropy.units.Quantity`
+    H0 : float or `~astropy.units.Quantity` ['frequency']
         Hubble constant at z = 0. If a float, must be in [km/sec/Mpc]
 
     Om0 : float
@@ -2540,7 +2540,7 @@ class FlatwCDM(wCDM):
         pressure/density for dark energy in units where c=1. A cosmological
         constant has w0=-1.0.
 
-    Tcmb0 : float or scalar `~astropy.units.Quantity`, optional
+    Tcmb0 : float or scalar `~astropy.units.Quantity` ['temperature'], optional
         Temperature of the CMB z=0. If a float, must be in [K].
         Default: 0 [K]. Setting this to zero will turn off both photons
         and neutrinos (even massive ones).
@@ -2548,7 +2548,7 @@ class FlatwCDM(wCDM):
     Neff : float, optional
         Effective number of Neutrino species. Default 3.04.
 
-    m_nu : quantity-like or array-like, optional
+    m_nu : quantity-like ['energy', 'mass'] or array-like, optional
         Mass of each neutrino species in [eV] (mass-energy equivalency enabled).
         If this is a scalar Quantity, then all neutrino species are assumed to
         have that mass. Otherwise, the mass of each species. The actual number
@@ -2682,7 +2682,7 @@ class w0waCDM(FLRW):
 
     Parameters
     ----------
-    H0 : float or `~astropy.units.Quantity`
+    H0 : float or `~astropy.units.Quantity` ['frequency']
         Hubble constant at z = 0. If a float, must be in [km/sec/Mpc]
 
     Om0 : float
@@ -2701,7 +2701,7 @@ class w0waCDM(FLRW):
         Negative derivative of the dark energy equation of state with respect
         to the scale factor. A cosmological constant has w0=-1.0 and wa=0.0.
 
-    Tcmb0 : float or scalar `~astropy.units.Quantity`, optional
+    Tcmb0 : float or scalar `~astropy.units.Quantity` ['temperature'], optional
         Temperature of the CMB z=0. If a float, must be in [K].
         Default: 0 [K]. Setting this to zero will turn off both photons
         and neutrinos (even massive ones).
@@ -2709,7 +2709,7 @@ class w0waCDM(FLRW):
     Neff : float, optional
         Effective number of Neutrino species. Default 3.04.
 
-    m_nu : quantity-like or array-like, optional
+    m_nu : quantity-like ['energy', 'mass'] or array-like, optional
         Mass of each neutrino species in [eV] (mass-energy equivalency enabled).
         If this is a scalar Quantity, then all neutrino species are assumed to
         have that mass. Otherwise, the mass of each species. The actual number
@@ -2854,7 +2854,7 @@ class Flatw0waCDM(w0waCDM):
     Parameters
     ----------
 
-    H0 : float or `~astropy.units.Quantity`
+    H0 : float or `~astropy.units.Quantity` ['frequency']
         Hubble constant at z = 0. If a float, must be in [km/sec/Mpc]
 
     Om0 : float
@@ -2869,7 +2869,7 @@ class Flatw0waCDM(w0waCDM):
         Negative derivative of the dark energy equation of state with respect
         to the scale factor. A cosmological constant has w0=-1.0 and wa=0.0.
 
-    Tcmb0 : float or scalar `~astropy.units.Quantity`, optional
+    Tcmb0 : float or scalar `~astropy.units.Quantity` ['temperature'], optional
         Temperature of the CMB z=0. If a float, must be in [K].
         Default: 0 [K]. Setting this to zero will turn off both photons
         and neutrinos (even massive ones).
@@ -2877,7 +2877,7 @@ class Flatw0waCDM(w0waCDM):
     Neff : float, optional
         Effective number of Neutrino species. Default 3.04.
 
-    m_nu : quantity-like or array-like, optional
+    m_nu : quantity-like ['energy', 'mass'] or array-like, optional
         Mass of each neutrino species in [eV] (mass-energy equivalency enabled).
         If this is a scalar Quantity, then all neutrino species are assumed to
         have that mass. Otherwise, the mass of each species. The actual number
@@ -2956,7 +2956,7 @@ class wpwaCDM(FLRW):
     Parameters
     ----------
 
-    H0 : float or `~astropy.units.Quantity`
+    H0 : float or `~astropy.units.Quantity` ['frequency']
         Hubble constant at z = 0. If a float, must be in [km/sec/Mpc]
 
     Om0 : float
@@ -2978,7 +2978,7 @@ class wpwaCDM(FLRW):
     zp : float, optional
         Pivot redshift -- the redshift where w(z) = wp
 
-    Tcmb0 : float or scalar `~astropy.units.Quantity`, optional
+    Tcmb0 : float or scalar `~astropy.units.Quantity` ['temperature'], optional
         Temperature of the CMB z=0. If a float, must be in [K].
         Default: 0 [K]. Setting this to zero will turn off both photons
         and neutrinos (even massive ones).
@@ -2986,7 +2986,7 @@ class wpwaCDM(FLRW):
     Neff : float, optional
         Effective number of Neutrino species. Default 3.04.
 
-    m_nu : quantity-like or array-like, optional
+    m_nu : quantity-like ['energy', 'mass'] or array-like, optional
         Mass of each neutrino species in [eV] (mass-energy equivalency enabled).
         If this is a scalar Quantity, then all neutrino species are assumed to
         have that mass. Otherwise, the mass of each species. The actual number
@@ -3143,8 +3143,7 @@ class w0wzCDM(FLRW):
 
     Parameters
     ----------
-
-    H0 : float or `~astropy.units.Quantity`
+    H0 : float or `~astropy.units.Quantity` ['frequency']
         Hubble constant at z = 0. If a float, must be in [km/sec/Mpc]
 
     Om0 : float
@@ -3163,7 +3162,7 @@ class w0wzCDM(FLRW):
         Derivative of the dark energy equation of state with respect to z.
         A cosmological constant has w0=-1.0 and wz=0.0.
 
-    Tcmb0 : float or scalar `~astropy.units.Quantity`, optional
+    Tcmb0 : float or scalar `~astropy.units.Quantity` ['temperature'], optional
         Temperature of the CMB z=0. If a float, must be in [K].
         Default: 0 [K]. Setting this to zero will turn off both photons
         and neutrinos (even massive ones).
@@ -3171,7 +3170,7 @@ class w0wzCDM(FLRW):
     Neff : float, optional
         Effective number of Neutrino species. Default 3.04.
 
-    m_nu : quantity-like or array-like, optional
+    m_nu : quantity-like ['energy', 'mass'] or array-like, optional
         Mass of each neutrino species in [eV] (mass-energy equivalency enabled).
         If this is a scalar Quantity, then all neutrino species are assumed to
         have that mass. Otherwise, the mass of each species. The actual number

--- a/astropy/modeling/physical_models.py
+++ b/astropy/modeling/physical_models.py
@@ -24,10 +24,10 @@ class BlackBody(Fittable1DModel):
 
     Parameters
     ----------
-    temperature : `~astropy.units.Quantity`
+    temperature : `~astropy.units.Quantity` ['temperature']
         Blackbody temperature.
 
-    scale : float or `~astropy.units.Quantity`
+    scale : float or `~astropy.units.Quantity` ['dimensionless']
         Scale factor
 
     Notes
@@ -82,7 +82,7 @@ class BlackBody(Fittable1DModel):
 
         Parameters
         ----------
-        x : float, `~numpy.ndarray`, or `~astropy.units.Quantity`
+        x : float, `~numpy.ndarray`, or `~astropy.units.Quantity` ['frequency']
             Frequency at which to compute the blackbody. If no units are given,
             this defaults to Hz.
 
@@ -90,7 +90,7 @@ class BlackBody(Fittable1DModel):
             Temperature of the blackbody. If no units are given, this defaults
             to Kelvin.
 
-        scale : float, `~numpy.ndarray`, or `~astropy.units.Quantity`
+        scale : float, `~numpy.ndarray`, or `~astropy.units.Quantity` ['dimensionless']
             Desired scale for the blackbody.
 
         Returns
@@ -380,7 +380,7 @@ class NFW(Fittable1DModel):
 
     Parameters
     ----------
-    mass : float or `~astropy.units.Quantity`
+    mass : float or `~astropy.units.Quantity` ['mass']
         Mass of NFW peak within specified overdensity radius.
     concentration : float
         Concentration of the NFW profile.
@@ -463,9 +463,9 @@ class NFW(Fittable1DModel):
 
         Parameters
         ----------
-        r : float or `~astropy.units.Quantity`
+        r : float or `~astropy.units.Quantity` ['length']
             Radial position of density to be calculated for the NFW profile.
-        mass : float or `~astropy.units.Quantity`
+        mass : float or `~astropy.units.Quantity` ['mass']
             Mass of NFW peak within specified overdensity radius.
         concentration : float
             Concentration of the NFW profile.
@@ -474,7 +474,7 @@ class NFW(Fittable1DModel):
 
         Returns
         -------
-        density : float or `~astropy.units.Quantity`
+        density : float or `~astropy.units.Quantity` ['density']
             NFW profile mass density at location ``r``. The density units are:
             [``mass`` / ``r`` ^3]
 
@@ -659,12 +659,12 @@ class NFW(Fittable1DModel):
 
         Parameters
         ----------
-        r : float or `~astropy.units.Quantity`
+        r : float or `~astropy.units.Quantity` ['length']
             Radial position of velocity to be calculated for the NFW profile.
 
         Returns
         -------
-        velocity : float or `~astropy.units.Quantity`
+        velocity : float or `~astropy.units.Quantity` ['speed']
             NFW profile circular velocity at location ``r``. The velocity units are:
             [km / s]
 

--- a/astropy/modeling/rotations.py
+++ b/astropy/modeling/rotations.py
@@ -209,7 +209,7 @@ class EulerAngleRotation(_EulerRotation, Model):
 
     Parameters
     ----------
-    phi, theta, psi : float or `~astropy.units.Quantity`
+    phi, theta, psi : float or `~astropy.units.Quantity` ['angle']
         "proper" Euler angles in deg.
         If floats, they should be in deg.
     axes_order : str
@@ -288,11 +288,11 @@ class RotateNative2Celestial(_SkyRotation):
 
     Parameters
     ----------
-    lon : float or `~astropy.units.Quantity`
+    lon : float or `~astropy.units.Quantity` ['angle']
         Celestial longitude of the fiducial point.
-    lat : float or `~astropy.units.Quantity`
+    lat : float or `~astropy.units.Quantity` ['angle']
         Celestial latitude of the fiducial point.
-    lon_pole : float or `~astropy.units.Quantity`
+    lon_pole : float or `~astropy.units.Quantity` ['angle']
         Longitude of the celestial pole in the native system.
 
     Notes
@@ -325,17 +325,17 @@ class RotateNative2Celestial(_SkyRotation):
         """
         Parameters
         ----------
-        phi_N, theta_N : float or `~astropy.units.Quantity`
+        phi_N, theta_N : float or `~astropy.units.Quantity` ['angle']
             Angles in the Native coordinate system.
             it is assumed that numerical only inputs are in degrees.
             If float, assumed in degrees.
-        lon, lat, lon_pole : float or `~astropy.units.Quantity`
+        lon, lat, lon_pole : float or `~astropy.units.Quantity` ['angle']
             Parameter values when the model was initialized.
             If float, assumed in degrees.
 
         Returns
         -------
-        alpha_C, delta_C : float or `~astropy.units.Quantity`
+        alpha_C, delta_C : float or `~astropy.units.Quantity` ['angle']
             Angles on the Celestial sphere.
             If float, in degrees.
         """
@@ -363,11 +363,11 @@ class RotateCelestial2Native(_SkyRotation):
 
     Parameters
     ----------
-    lon : float or `~astropy.units.Quantity`
+    lon : float or `~astropy.units.Quantity` ['angle']
         Celestial longitude of the fiducial point.
-    lat : float or `~astropy.units.Quantity`
+    lat : float or `~astropy.units.Quantity` ['angle']
         Celestial latitude of the fiducial point.
-    lon_pole : float or `~astropy.units.Quantity`
+    lon_pole : float or `~astropy.units.Quantity` ['angle']
         Longitude of the celestial pole in the native system.
 
     Notes
@@ -403,16 +403,16 @@ class RotateCelestial2Native(_SkyRotation):
         """
         Parameters
         ----------
-        alpha_C, delta_C : float or `~astropy.units.Quantity`
+        alpha_C, delta_C : float or `~astropy.units.Quantity` ['angle']
             Angles in the Celestial coordinate frame.
             If float, assumed in degrees.
-        lon, lat, lon_pole : float or `~astropy.units.Quantity`
+        lon, lat, lon_pole : float or `~astropy.units.Quantity` ['angle']
             Parameter values when the model was initialized.
             If float, assumed in degrees.
 
         Returns
         -------
-        phi_N, theta_N : float or `~astropy.units.Quantity`
+        phi_N, theta_N : float or `~astropy.units.Quantity` ['angle']
             Angles on the Native sphere.
             If float, in degrees.
 
@@ -442,7 +442,7 @@ class Rotation2D(Model):
 
     Parameters
     ----------
-    angle : float or `~astropy.units.Quantity`
+    angle : float or `~astropy.units.Quantity` ['angle']
         Angle of rotation (if float it should be in deg).
     """
     n_inputs = 2
@@ -472,7 +472,7 @@ class Rotation2D(Model):
         ----------
         x, y : array-like
             Input quantities
-        angle : float or `~astropy.units.Quantity`
+        angle : float or `~astropy.units.Quantity` ['angle']
             Angle of rotations.
             If float, assumed in degrees.
 

--- a/astropy/modeling/utils.py
+++ b/astropy/modeling/utils.py
@@ -645,7 +645,7 @@ def ellipse_extent(a, b, theta):
         Major axis.
     b : float or `~astropy.units.Quantity`
         Minor axis.
-    theta : float or `~astropy.units.Quantity`
+    theta : float or `~astropy.units.Quantity` ['angle']
         Rotation angle. If given as a floating-point value, it is assumed to be
         in radians.
 

--- a/astropy/stats/circstats.py
+++ b/astropy/stats/circstats.py
@@ -120,8 +120,8 @@ def circvar(data, axis=None, weights=None):
 
     Returns
     -------
-    circvar : ndarray or `~astropy.units.Quantity`
-        Circular variance. Dimensionless, if Quantity.
+    circvar : ndarray or `~astropy.units.Quantity` ['dimensionless']
+        Circular variance.
 
     Examples
     --------
@@ -187,9 +187,8 @@ def circstd(data, axis=None, weights=None, method='angular'):
 
     Returns
     -------
-    circstd : ndarray or `~astropy.units.Quantity`
+    circstd : ndarray or `~astropy.units.Quantity` ['dimensionless']
         Angular or circular standard deviation.
-        Dimensionless, if Quantity.
 
     Examples
     --------
@@ -311,8 +310,8 @@ def circcorrcoef(alpha, beta, axis=None, weights_alpha=None,
 
     Returns
     -------
-    rho : ndarray or `~astropy.units.Quantity`
-        Circular correlation coefficient. Dimensionless, if Quantity.
+    rho : ndarray or `~astropy.units.Quantity` ['dimensionless']
+        Circular correlation coefficient.
 
     Examples
     --------
@@ -375,8 +374,7 @@ def rayleightest(data, axis=None, weights=None):
 
     Returns
     -------
-    p-value : float or `~astropy.units.Quantity`
-        p-value. Dimensionless, if Quantity.
+    p-value : float or `~astropy.units.Quantity` ['dimensionless']
 
     Examples
     --------
@@ -424,7 +422,7 @@ def vtest(data, mu=0.0, axis=None, weights=None):
     data : ndarray or `~astropy.units.Quantity`
         Array of circular (directional) data, which is assumed to be in
         radians whenever ``data`` is ``numpy.ndarray``.
-    mu : float or `~astropy.units.Quantity`, optional
+    mu : float or `~astropy.units.Quantity` ['angle'], optional
         Mean angle. Assumed to be known.
     axis : int, optional
         Axis along which the V test will be performed.
@@ -436,8 +434,7 @@ def vtest(data, mu=0.0, axis=None, weights=None):
 
     Returns
     -------
-    p-value : float or `~astropy.units.Quantity`
-        p-value. Dimensionless, if Quantity.
+    p-value : float or `~astropy.units.Quantity` ['dimensionless']
 
     Examples
     --------
@@ -505,8 +502,8 @@ def vonmisesmle(data, axis=None):
     -------
     mu : float or `~astropy.units.Quantity`
         The mean (aka location parameter).
-    kappa : float or `~astropy.units.Quantity`
-        The concentration parameter. Dimensionless, if Quantity.
+    kappa : float or `~astropy.units.Quantity` ['dimensionless']
+        The concentration parameter.
 
     Examples
     --------

--- a/astropy/table/operations.py
+++ b/astropy/table/operations.py
@@ -110,7 +110,7 @@ def join_skycoord(distance, distance_func='search_around_sky'):
 
     Parameters
     ----------
-    distance : `~astropy.units.Quantity`
+    distance : `~astropy.units.Quantity` ['angle', 'length']
         Maximum distance between points to be considered a join match.
         Must have angular or distance units.
     distance_func : str or function
@@ -222,7 +222,7 @@ def join_distance(distance, kdtree_args=None, query_args=None):
 
     Parameters
     ----------
-    distance : float or `~astropy.units.Quantity`
+    distance : float or `~astropy.units.Quantity` ['length']
         Maximum distance between points to be considered a join match
     kdtree_args : dict, None
         Optional extra args for `~scipy.spatial.cKDTree`

--- a/astropy/timeseries/downsample.py
+++ b/astropy/timeseries/downsample.py
@@ -40,7 +40,7 @@ def aggregate_downsample(time_series, *, time_bin_size=None, time_bin_start=None
     ----------
     time_series : :class:`~astropy.timeseries.TimeSeries`
         The time series to downsample.
-    time_bin_size : `~astropy.units.Quantity`
+    time_bin_size : `~astropy.units.Quantity` ['time']
         The time interval for the binned time series.
     time_bin_start : `~astropy.time.Time`, optional
         The start time for the binned time series. Defaults to the first

--- a/astropy/timeseries/periodograms/bls/core.py
+++ b/astropy/timeseries/periodograms/bls/core.py
@@ -123,9 +123,9 @@ class BoxLeastSquares(BasePeriodogram):
 
         Parameters
         ----------
-        duration : float, array-like, or `~astropy.units.Quantity`
+        duration : float, array-like, or `~astropy.units.Quantity` ['time']
             The set of durations that will be considered.
-        minimum_period, maximum_period : float or `~astropy.units.Quantity`, optional
+        minimum_period, maximum_period : float or `~astropy.units.Quantity` ['time'], optional
             The minimum/maximum periods to search. If not provided, these will
             be computed as described in the notes below.
         minimum_n_transits : int, optional
@@ -141,7 +141,7 @@ class BoxLeastSquares(BasePeriodogram):
 
         Returns
         -------
-        period : array-like or `~astropy.units.Quantity`
+        period : array-like or `~astropy.units.Quantity` ['time']
             The set of periods computed using these heuristics with the same
             units as ``t``.
 
@@ -237,9 +237,9 @@ class BoxLeastSquares(BasePeriodogram):
 
         Parameters
         ----------
-        period : array-like or `~astropy.units.Quantity`
+        period : array-like or `~astropy.units.Quantity` ['time']
             The periods where the power should be computed
-        duration : float, array-like, or `~astropy.units.Quantity`
+        duration : float, array-like, or `~astropy.units.Quantity` ['time']
             The set of durations to test
         objective : {'likelihood', 'snr'}, optional
             The scalar that should be optimized to find the best fit phase,
@@ -379,9 +379,9 @@ class BoxLeastSquares(BasePeriodogram):
         ----------
         t_model : array-like, `~astropy.units.Quantity`, or `~astropy.time.Time`
             Times at which to compute the model.
-        period : float or `~astropy.units.Quantity`
+        period : float or `~astropy.units.Quantity` ['time']
             The period of the transits.
-        duration : float or `~astropy.units.Quantity`
+        duration : float or `~astropy.units.Quantity` ['time']
             The duration of the transit.
         transit_time : float or `~astropy.units.Quantity` or `~astropy.time.Time`
             The mid-transit time of a reference transit.
@@ -431,9 +431,9 @@ class BoxLeastSquares(BasePeriodogram):
 
         Parameters
         ----------
-        period : float or `~astropy.units.Quantity`
+        period : float or `~astropy.units.Quantity` ['time']
             The period of the transits.
-        duration : float or `~astropy.units.Quantity`
+        duration : float or `~astropy.units.Quantity` ['time']
             The duration of the transit.
         transit_time : float or `~astropy.units.Quantity` or `~astropy.time.Time`
             The mid-transit time of a reference transit.
@@ -574,11 +574,11 @@ class BoxLeastSquares(BasePeriodogram):
 
         Parameters
         ----------
-        t_model : array-like or `~astropy.units.Quantity`
+        t_model : array-like or `~astropy.units.Quantity` ['time']
             Times where the mask should be evaluated.
-        period : float or `~astropy.units.Quantity`
+        period : float or `~astropy.units.Quantity` ['time']
             The period of the transits.
-        duration : float or `~astropy.units.Quantity`
+        duration : float or `~astropy.units.Quantity` ['time']
             The duration of the transit.
         transit_time : float or `~astropy.units.Quantity` or `~astropy.time.Time`
             The mid-transit time of a reference transit.
@@ -670,14 +670,14 @@ class BoxLeastSquares(BasePeriodogram):
 
         Parameters
         ----------
-        period : float, array-like, or `~astropy.units.Quantity`
+        period : float, array-like, or `~astropy.units.Quantity` ['time']
             The set of test periods.
-        duration : float, array-like, or `~astropy.units.Quantity`
+        duration : float, array-like, or `~astropy.units.Quantity` ['time']
             The set of durations that will be considered.
 
         Returns
         -------
-        period, duration : array-like or `~astropy.units.Quantity`
+        period, duration : array-like or `~astropy.units.Quantity` ['time']
             The inputs reformatted with the correct shapes and units.
 
         Raises
@@ -708,7 +708,7 @@ class BoxLeastSquares(BasePeriodogram):
             The minimum time in the time series (a reference time).
         objective : str
             The name of the objective used in the optimization.
-        period : array-like or `~astropy.units.Quantity`
+        period : array-like or `~astropy.units.Quantity` ['time']
             The set of trial periods.
         results : tuple
             The output of one of the periodogram implementations.
@@ -765,7 +765,7 @@ class BoxLeastSquaresResults(dict):
     objective : str
         The scalar used to optimize to find the best fit phase, duration, and
         depth. See :func:`BoxLeastSquares.power` for more information.
-    period : array-like or `~astropy.units.Quantity`
+    period : array-like or `~astropy.units.Quantity` ['time']
         The set of test periods.
     power : array-like or `~astropy.units.Quantity`
         The periodogram evaluated at the periods in ``period``. If
@@ -781,7 +781,7 @@ class BoxLeastSquaresResults(dict):
         The estimated depth of the maximum power model at each period.
     depth_err : array-like or `~astropy.units.Quantity`
         The 1-sigma uncertainty on ``depth``.
-    duration : array-like or `~astropy.units.Quantity`
+    duration : array-like or `~astropy.units.Quantity` ['time']
         The maximum power duration at each period.
     transit_time : array-like, `~astropy.units.Quantity`, or `~astropy.time.Time`
         The maximum power phase of the transit in units of time. This

--- a/astropy/timeseries/periodograms/lombscargle/core.py
+++ b/astropy/timeseries/periodograms/lombscargle/core.py
@@ -36,7 +36,7 @@ class LombScargle(BasePeriodogram):
 
     Parameters
     ----------
-    t : array-like or `~astropy.units.Quantity`
+    t : array-like or `~astropy.units.Quantity` ['time']
         sequence of observation times
     y : array-like or `~astropy.units.Quantity`
         sequence of observations associated with times t
@@ -223,7 +223,7 @@ class LombScargle(BasePeriodogram):
 
         Returns
         -------
-        frequency : ndarray or `~astropy.units.Quantity`
+        frequency : ndarray or `~astropy.units.Quantity` ['frequency']
             The heuristically-determined optimal frequency bin
         """
         baseline = self._trel.max() - self._trel.min()
@@ -280,11 +280,11 @@ class LombScargle(BasePeriodogram):
         nyquist_factor : float, optional
             The multiple of the average nyquist frequency used to choose the
             maximum frequency if maximum_frequency is not provided.
-        minimum_frequency : float or `~astropy.units.Quantity`, optional
+        minimum_frequency : float or `~astropy.units.Quantity` ['frequency'], optional
             If specified, then use this minimum frequency rather than one
             chosen based on the size of the baseline. Should be `~astropy.units.Quantity`
             if inputs to LombScargle are `~astropy.units.Quantity`.
-        maximum_frequency : float or `~astropy.units.Quantity`, optional
+        maximum_frequency : float or `~astropy.units.Quantity` ['frequency'], optional
             If specified, then use this maximum frequency rather than one
             chosen based on the average nyquist frequency. Should be `~astropy.units.Quantity`
             if inputs to LombScargle are `~astropy.units.Quantity`.
@@ -310,7 +310,7 @@ class LombScargle(BasePeriodogram):
 
         Parameters
         ----------
-        frequency : array-like or `~astropy.units.Quantity`
+        frequency : array-like or `~astropy.units.Quantity` ['frequency']
             frequencies (not angular frequencies) at which to evaluate the
             periodogram. Note that in order to use method='fast', frequencies
             must be regularly-spaced.
@@ -399,7 +399,7 @@ class LombScargle(BasePeriodogram):
 
         Parameters
         ----------
-        t : array-like or `~astropy.units.Quantity`
+        t : array-like or `~astropy.units.Quantity` ['time']
             Times (length ``n_samples``) at which to compute the model.
         frequency : float
             the frequency for the model

--- a/astropy/timeseries/periodograms/lombscargle/implementations/main.py
+++ b/astropy/timeseries/periodograms/lombscargle/implementations/main.py
@@ -55,7 +55,7 @@ def _get_frequency_grid(frequency, assume_regular_frequency=False):
 
     Parameters
     ----------
-    frequency : array-like or `~astropy.units.Quantity`
+    frequency : array-like or `~astropy.units.Quantity` ['frequency']
         input frequency grid
     assume_regular_frequency : bool (default = False)
         if True, then do not check whether frequency is a regular grid

--- a/astropy/timeseries/sampled.py
+++ b/astropy/timeseries/sampled.py
@@ -46,7 +46,7 @@ class TimeSeries(BaseTimeSeries):
     time_start : `~astropy.time.Time` or str
         The time of the first sample in the time series. This is an alternative
         to providing ``time`` and requires that ``time_delta`` is also provided.
-    time_delta : `~astropy.time.TimeDelta` or `~astropy.units.Quantity`
+    time_delta : `~astropy.time.TimeDelta` or `~astropy.units.Quantity` ['time']
         The step size in time for the series. This can either be a scalar if
         the time series is evenly sampled, or an array of values if it is not.
     n_samples : int
@@ -150,18 +150,18 @@ class TimeSeries(BaseTimeSeries):
 
         Parameters
         ----------
-        period : `~astropy.units.Quantity`
+        period : `~astropy.units.Quantity` ['time']
             The period to use for folding
         epoch_time : `~astropy.time.Time`
             The time to use as the reference epoch, at which the relative time
             offset / phase will be ``epoch_phase``. Defaults to the first time
             in the time series.
-        epoch_phase : float or `~astropy.units.Quantity`
+        epoch_phase : float or `~astropy.units.Quantity` ['dimensionless', 'time']
             Phase of ``epoch_time``. If ``normalize_phase`` is `True`, this
             should be a dimensionless value, while if ``normalize_phase`` is
             ``False``, this should be a `~astropy.units.Quantity` with time
             units. Defaults to 0.
-        wrap_phase : float or `~astropy.units.Quantity`
+        wrap_phase : float or `~astropy.units.Quantity` ['dimensionless', 'time']
             The value of the phase above which values are wrapped back by one
             period. If ``normalize_phase`` is `True`, this should be a
             dimensionless value, while if ``normalize_phase`` is ``False``,

--- a/astropy/uncertainty/core.py
+++ b/astropy/uncertainty/core.py
@@ -210,7 +210,7 @@ class Distribution:
 
         Returns
         -------
-        percentiles : `~astropy.units.Quantity`
+        percentiles : `~astropy.units.Quantity` ['dimensionless']
             The ``fracs`` percentiles of this distribution.
         """
         percentile = u.Quantity(percentile, u.percent).value

--- a/astropy/units/equivalencies.py
+++ b/astropy/units/equivalencies.py
@@ -560,7 +560,7 @@ def brightness_temperature(frequency, beam_area=None):
         BACKWARD COMPATIBILITY NOTE: previous versions of the brightness
         temperature equivalency used the keyword ``disp``, which is no longer
         supported.
-    beam_area : `~astropy.units.Quantity`
+    beam_area : `~astropy.units.Quantity` ['solid angle']
         Beam area in angular units, i.e. steradian equivalent
 
     Examples
@@ -800,7 +800,7 @@ def with_H0(H0=None):
 
     Parameters
     ----------
-    H0 : None or `~astropy.units.Quantity`
+    H0 : None or `~astropy.units.Quantity` ['frequency']
         The value of the Hubble constant to assume. If a `~astropy.units.Quantity`,
         will assume the quantity *is* ``H0``.  If `None` (default), use the
         ``H0`` attribute from the default `astropy.cosmology` cosmology.

--- a/astropy/units/equivalencies.py
+++ b/astropy/units/equivalencies.py
@@ -666,7 +666,7 @@ def thermodynamic_temperature(frequency, T_cmb=None):
     frequency : `~astropy.units.Quantity`
         The observed `spectral` equivalent `~astropy.units.Unit` (e.g.,
         frequency or wavelength). Must have spectral units.
-    T_cmb :  `~astropy.units.Quantity` or None
+    T_cmb :  `~astropy.units.Quantity` ['temperature'] or None
         The CMB temperature at z=0.  If `None`, the default cosmology will be
         used to get this temperature. Must have units of temperature.
 

--- a/astropy/units/physical.py
+++ b/astropy/units/physical.py
@@ -543,7 +543,7 @@ if __doc__ is not None:
     for name in sorted(_name_physical_mapping.keys()):
         physical_type = _name_physical_mapping[name]
         doclines.extend([
-            f"    * - {name}",
+            f"    * - _`{name}`",
             f"      - :math:`{physical_type._unit.to_string('latex')[1:-1]}`",
             f"      - {', '.join([n for n in physical_type if n != name])}"])
 

--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -293,12 +293,10 @@ class IERS(QTable):
 
         Returns
         -------
-        D_x : `~astropy.units.Quantity`
+        D_x : `~astropy.units.Quantity` ['angle']
             x component of CIP correction for the requested times.
-            Must have angular units.
-        D_y : `~astropy.units.Quantity`
+        D_y : `~astropy.units.Quantity` ['angle']
             y component of CIP correction for the requested times
-            Must have angular units.
         status : int or int array
             Status values (if ``return_status``=``True``)::
             ``iers.FROM_IERS_B``
@@ -327,12 +325,10 @@ class IERS(QTable):
 
         Returns
         -------
-        PM_x : `~astropy.units.Quantity`
+        PM_x : `~astropy.units.Quantity` ['angle']
             x component of polar motion for the requested times.
-            Must have angular units.
-        PM_y : `~astropy.units.Quantity`
+        PM_y : `~astropy.units.Quantity` ['angle']
             y component of polar motion for the requested times.
-            Must have angular units.
         status : int or int array
             Status values (if ``return_status``=``True``)::
             ``iers.FROM_IERS_B``

--- a/astropy/visualization/wcsaxes/patches.py
+++ b/astropy/visualization/wcsaxes/patches.py
@@ -61,10 +61,10 @@ class SphericalCircle(Polygon):
 
     Parameters
     ----------
-    center : tuple or `~astropy.units.Quantity`
+    center : tuple or `~astropy.units.Quantity` ['angle']
         This can be either a tuple of two `~astropy.units.Quantity` objects, or
         a single `~astropy.units.Quantity` array with two elements.
-    radius : `~astropy.units.Quantity`
+    radius : `~astropy.units.Quantity` ['angle']
         The radius of the circle
     resolution : int, optional
         The number of points that make up the circle - increase this to get a
@@ -115,17 +115,17 @@ class Quadrangle(Polygon):
 
     Parameters
     ----------
-    anchor : tuple or `~astropy.units.Quantity`
+    anchor : tuple or `~astropy.units.Quantity` ['angle']
         This can be either a tuple of two `~astropy.units.Quantity` objects, or
         a single `~astropy.units.Quantity` array with two elements.
-    width : `~astropy.units.Quantity`
+    width : `~astropy.units.Quantity` ['angle']
         The width of the quadrangle in longitude (or, e.g., right ascension)
-    height : `~astropy.units.Quantity`
+    height : `~astropy.units.Quantity` ['angle']
         The height of the quadrangle in latitude (or, e.g., declination)
     resolution : int, optional
         The number of points that make up each side of the quadrangle -
         increase this to get a smoother quadrangle.
-    vertex_unit : `~astropy.units.Unit`
+    vertex_unit : `~astropy.units.Unit` ['angle']
         The units in which the resulting polygon should be defined - this
         should match the unit that the transformation (e.g. the WCS
         transformation) expects as input.

--- a/docs/changes/11595.other.rst
+++ b/docs/changes/11595.other.rst
@@ -1,0 +1,5 @@
+Sphinx cross-reference link targets are added for every ``PhysicalType``.
+Now in the parameter types in the Parameters, Other Parameters, Returns and
+Yields sections of the docstring, the physical type of a quantity can be
+annotated in square brackets.
+E.g. `` distance : `~astropy.units.Quantity` ['length'] ``

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -135,7 +135,7 @@ numpydoc_xref_ignore = {
 # https://github.com/numpy/numpydoc/blob/b352cd7635f2ea7748722f410a31f937d92545cc/numpydoc/xref.py#L62-L94
 # so we only need to define Astropy-specific x-refs
 numpydoc_xref_aliases = {
-    # ulta-general
+    # ultra-general
     "-like": ":term:`-like`",
     # python & adjacent
     "file-like": ":term:`python:file-like object`",
@@ -163,6 +163,17 @@ numpydoc_xref_aliases = {
     "readable": ":term:`readable file-like object`",
     "BaseHDU": ":doc:`HDU </io/fits/api/hdus>`"
 }
+# Astropy units physical types
+from astropy.units.physical import _units_and_physical_types
+numpydoc_xref_physical_type_aliases = {}
+for _, ptypes in _units_and_physical_types:
+    ptypes = {ptypes} if isinstance(ptypes, str) else ptypes
+    for ptype in ptypes:
+        key = f"'{ptype}'"
+        val = f":ref:`'{ptype}' <{ptype}>`"
+        numpydoc_xref_physical_type_aliases[key] = val
+
+numpydoc_xref_aliases.update(numpydoc_xref_physical_type_aliases)
 
 
 # -- Project information ------------------------------------------------------

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -35,7 +35,7 @@ Astropy Glossary
        The physical type of a quantity can be annotated in square brackets
        following a `~astropy.units.Quantity` (or similar :term:`quantity-like`).
 
-       E.g. `` distance : quantity-like ['length'] ``
+       For example, ``distance : quantity-like ['length']``
 
    angle-like
       :term:`quantity-like`, but interpreted by an angular

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -31,6 +31,12 @@ Astropy Glossary
       ``Quantity("180d")`` is 180 **days**, while ``Angle("180d")`` is 180
       **degrees** -- so check the string parses as intended for ``Quantity``.
 
+   ['physical type']
+       The physical type of a quantity can be annotated in square brackets
+       following a `~astropy.units.Quantity` (or similar :term:`quantity-like`).
+
+       E.g. `` distance : quantity-like ['length'] ``
+
    angle-like
       :term:`quantity-like`, but interpreted by an angular
       `~astropy.units.SpecificTypeQuantity`, like `~astropy.coordinates.Angle`


### PR DESCRIPTION
Now that #11118 is in (🥳 ), it's time for followups. One of the more interesting followups came from discussion with @adrn on methods to annotate physical types for Quantity and the like. @namurphy's great #11204 is in and #11606 is done, so I thought I'd give this a go.

See https://astropy--11595.org.readthedocs.build/en/11595/ for the compiled docs.

Part of #11555 
Requires : ~#11618~ (done)

## What this does (edited)

- convert the name of each physical type in the table of physical types in the docs to an ReST link target. These can be referenced (with sphinx :ref:) both in the docs and in parameters of docstrings by...
- Adding the link target to the target map in ``docs/conf.py::numpydoc_xref_aliases``.
- An explanation is added to the glossary.rst
- implements a non-exhaustive addition of physical type annotations in the docs. Some may be wrong! 

### Example

<img width="719" alt="Screen Shot 2021-04-27 at 17 46 04" src="https://user-images.githubusercontent.com/8949649/116316789-72e20680-a780-11eb-99db-3455f64e9dfc.png">

Links to the appropriate row in 

<img width="748" alt="Screen Shot 2021-04-27 at 17 46 31" src="https://user-images.githubusercontent.com/8949649/116316832-82f9e600-a780-11eb-8bfa-444332819942.png">


And the best part is that the link just looks like ``... ['length']``!


## Subpackage review sign-off sheet

@adonath @adamginsburg @StuartLittlefair @astrojuanlu @hamogu @dhomeier @saimn @matteobachetti @eslavich @tboch @tomdonaldson @perrygreenfield @mwcraig ~@taldcroft~ ~@adrn~ ~@mhvk~ @pllim @bsipocz @eteq @larrybradley @Cadair @astrofrog @mcara @nden

Please check and add your github handle after an approving review
- [ ] convolution:
- [x] coordinates: @mhvk @adrn
- [ ] modeling:
- [ ] stats:
- [x] table: @taldcroft @mhvk
- [ ] timeseries:
- [x] uncertainties: @mhvk
- [x] units: @mhvk @adrn 
- [ ] utils:
- [ ] visualization: