### PR TITLE
Fixes bug in `LevMarLSQFitter` weights.

### DIFF
--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -1228,8 +1228,14 @@ class LevMarLSQFitter(metaclass=_FitterMeta):
             return [np.ravel(_) for _ in residues]
         else:
             if z is None:
-                return [np.ravel(_) for _ in np.ravel(weights) *
-                        np.array(model.fit_deriv(x, *params))]
+                try:
+                    return np.array([np.ravel(_) for _ in np.array(weights) *
+                                     np.array(model.fit_deriv(x, *params))])
+                except ValueError:
+                    return np.array([np.ravel(_) for _ in np.array(weights) *
+                                     np.moveaxis(
+                                         np.array(model.fit_deriv(x, *params)),
+                                         -1, 0)]).transpose()
             else:
                 if not model.col_fit_deriv:
                     return [np.ravel(_) for _ in

--- a/docs/changes/modeling/11603.bugfix.rst
+++ b/docs/changes/modeling/11603.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed bug in ``LevMarLSQFitter`` when using weights and vector inputs.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request fixes crashes in when fitting with `LevMarLSQFitter` when using weights when the inputs are have certain shapes.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #11581 
