### PR TITLE
Fix automatic masking of invalid values in sigma clipping

### DIFF
--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -298,8 +298,9 @@ class SigmaClip:
             unit = None
 
         if copy is False and masked is False and data.dtype.kind != 'f':
-            raise Exception("cannot mask non-floating-point array with NaN values, "
-                             "set copy=True or masked=True to avoid this.")
+            raise Exception("cannot mask non-floating-point array with NaN "
+                            "values, set copy=True or masked=True to avoid "
+                            "this.")
 
         if axis is None:
             axis = -1 if data.ndim == 1 else tuple(range(data.ndim))
@@ -318,7 +319,7 @@ class SigmaClip:
             data_transposed = data.transpose(transposed_axes)
             transposed_shape = data_transposed.shape
             data_reshaped = data_transposed.reshape(
-                transposed_shape[:data.ndim-len(axis)]+(-1,))
+                transposed_shape[:data.ndim - len(axis)] + (-1,))
             axis = -1
 
         if data_reshaped.dtype.kind != 'f' or data_reshaped.dtype.itemsize > 8:
@@ -337,8 +338,8 @@ class SigmaClip:
             mask = np.broadcast_to(mask, data_reshaped.shape).copy()
 
         bound_lo, bound_hi = _sigma_clip_fast(data_reshaped, mask, self.cenfunc != 'mean',
-                                  -1 if np.isinf(self.maxiters) else self.maxiters,
-                                  self.sigma_lower, self.sigma_upper, axis=axis)
+                                              -1 if np.isinf(self.maxiters) else self.maxiters,
+                                              self.sigma_lower, self.sigma_upper, axis=axis)
 
         with np.errstate(invalid='ignore'):
             mask |= data_reshaped < np.expand_dims(bound_lo, axis)

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -324,17 +324,17 @@ class SigmaClip:
         if data_reshaped.dtype.kind != 'f' or data_reshaped.dtype.itemsize > 8:
             data_reshaped = data_reshaped.astype(float)
 
+        mask = ~np.isfinite(data_reshaped)
+        if np.any(mask):
+            warnings.warn('Input data contains invalid values (NaNs or '
+                          'infs), which were automatically clipped.',
+                          AstropyUserWarning)
+
         if isinstance(data_reshaped, np.ma.MaskedArray):
-            mask = data_reshaped.mask
+            mask |= data_reshaped.mask
             data = data.view(np.ndarray)
             data_reshaped = data_reshaped.view(np.ndarray)
             mask = np.broadcast_to(mask, data_reshaped.shape).copy()
-        else:
-            mask = ~np.isfinite(data_reshaped)
-            if np.any(mask):
-                warnings.warn('Input data contains invalid values (NaNs or '
-                            'infs), which were automatically clipped.',
-                            AstropyUserWarning)
 
         bound_lo, bound_hi = _sigma_clip_fast(data_reshaped, mask, self.cenfunc != 'mean',
                                   -1 if np.isinf(self.maxiters) else self.maxiters,

--- a/astropy/stats/tests/test_sigma_clipping.py
+++ b/astropy/stats/tests/test_sigma_clipping.py
@@ -164,9 +164,15 @@ def test_invalid_sigma_clip():
     data[3, 4] = np.nan
     data[1, 1] = np.inf
 
+    data_ma = np.ma.MaskedArray(data)
+
     with pytest.warns(AstropyUserWarning,
                       match=r'Input data contains invalid values'):
         result = sigma_clip(data)
+        result_ma = sigma_clip(data_ma)
+
+    assert_equal(result.data, result_ma.data)
+    assert_equal(result.mask, result_ma.mask)
 
     # Pre #4051 if data contains any NaN or infs sigma_clip returns the
     # mask containing `False` only or TypeError if data also contains a

--- a/astropy/stats/tests/test_sigma_clipping.py
+++ b/astropy/stats/tests/test_sigma_clipping.py
@@ -197,8 +197,8 @@ def test_invalid_sigma_clip():
     data[0, :] = np.nan     # row of all nans
     with pytest.warns(AstropyUserWarning,
                       match=r'Input data contains invalid values'):
-        result4, minarr, maxarr = sigma_clip(data, axis=1, masked=False,
-                                             return_bounds=True)
+        _, minarr, maxarr = sigma_clip(data, axis=1, masked=False,
+                                       return_bounds=True)
     assert np.isnan(minarr[0])
     assert np.isnan(maxarr[0])
 
@@ -218,7 +218,7 @@ def test_sigmaclip_fully_masked():
     data = np.ma.MaskedArray(data=[[1., 0.], [0., 1.]],
                              mask=[[True, True], [True, True]])
     clipped_data = sigma_clip(data)
-    np.ma.allequal(data, clipped_data)
+    assert np.ma.allequal(data, clipped_data)
 
     clipped_data = sigma_clip(data, masked=False)
     assert not isinstance(clipped_data, np.ma.MaskedArray)
@@ -232,7 +232,7 @@ def test_sigmaclip_empty_masked():
 
     data = np.ma.MaskedArray(data=[], mask=[])
     clipped_data = sigma_clip(data)
-    np.ma.allequal(data, clipped_data)
+    assert np.ma.allequal(data, clipped_data)
 
 
 def test_sigmaclip_empty():

--- a/astropy/stats/tests/test_sigma_clipping.py
+++ b/astropy/stats/tests/test_sigma_clipping.py
@@ -169,6 +169,8 @@ def test_invalid_sigma_clip():
     with pytest.warns(AstropyUserWarning,
                       match=r'Input data contains invalid values'):
         result = sigma_clip(data)
+    with pytest.warns(AstropyUserWarning,
+                      match=r'Input data contains invalid values'):
         result_ma = sigma_clip(data_ma)
 
     assert_equal(result.data, result_ma.data)


### PR DESCRIPTION
https://github.com/astropy/astropy/pull/11219 introduced a regression where (unmasked) invalid values for input `MaskedArray`s were not automatically masked.

Is there a way with towncrier to assign more than 1 PR number to an item in the changelog?