### PR TITLE
Update SourceExtractor urls

### DIFF
--- a/astropy/io/ascii/sextractor.py
+++ b/astropy/io/ascii/sextractor.py
@@ -112,7 +112,7 @@ class SExtractor(core.BaseReader):
     SExtractor is a package for faint-galaxy photometry (Bertin & Arnouts
     1996, A&A Supp. 317, 393.)
 
-    See: http://www.astromatic.net/software/sextractor
+    See: https://sextractor.readthedocs.io/en/latest/
 
     Example::
 

--- a/docs/io/ascii/extension_classes.rst
+++ b/docs/io/ascii/extension_classes.rst
@@ -26,5 +26,5 @@ well-defined but idiosyncratic formats.
 * :class:`~astropy.io.ascii.NoHeader`: basic table with no header where columns are auto-named.
 * :class:`~astropy.io.ascii.Rdb`: tab-separated values with an extra line after the column definition line.
 * :class:`~astropy.io.ascii.RST`: `reStructuredText simple format table <https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#simple-tables>`_.
-* :class:`~astropy.io.ascii.SExtractor`: `SExtractor format table <https://sextractor.readthedocs.io/en/latest/`_.
+* :class:`~astropy.io.ascii.SExtractor`: `SExtractor format table <https://sextractor.readthedocs.io/en/latest/>`_.
 * :class:`~astropy.io.ascii.Tab`: tab-separated values.

--- a/docs/io/ascii/extension_classes.rst
+++ b/docs/io/ascii/extension_classes.rst
@@ -26,5 +26,5 @@ well-defined but idiosyncratic formats.
 * :class:`~astropy.io.ascii.NoHeader`: basic table with no header where columns are auto-named.
 * :class:`~astropy.io.ascii.Rdb`: tab-separated values with an extra line after the column definition line.
 * :class:`~astropy.io.ascii.RST`: `reStructuredText simple format table <https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#simple-tables>`_.
-* :class:`~astropy.io.ascii.SExtractor`: `SExtractor format table <http://www.astromatic.net/software/sextractor>`_.
+* :class:`~astropy.io.ascii.SExtractor`: `SExtractor format table <https://sextractor.readthedocs.io/en/latest/`_.
 * :class:`~astropy.io.ascii.Tab`: tab-separated values.

--- a/docs/io/ascii/index.rst
+++ b/docs/io/ascii/index.rst
@@ -27,7 +27,7 @@ section on `Supported formats`_ contains the full list.
 * :class:`~astropy.io.ascii.HTML`: HTML format table contained in a <table> tag
 * :class:`~astropy.io.ascii.Latex`: LaTeX table with datavalue in the ``tabular`` environment
 * :class:`~astropy.io.ascii.Rdb`: tab-separated values with an extra line after the column definition line
-* :class:`~astropy.io.ascii.SExtractor`: `SExtractor format table <http://www.astromatic.net/software/sextractor>`_
+* :class:`~astropy.io.ascii.SExtractor`: `SExtractor format table <https://sextractor.readthedocs.io/en/latest/>`_
 
 The strength of `astropy.io.ascii` is the support for astronomy-specific
 formats (often with metadata) and specialized data types such as


### PR DESCRIPTION
The SourceExtractor links to https://astromatic.net/software/sextractor/ have been acting a bit flaky, sometimes causing the `linkcheck` CI test to fail (e.g., https://github.com/astropy/astropy/pull/11604/checks?check_run_id=2384301884#step:7:8322).

This PR updates the URLs to the SourceExtractor RTD page.

Close #11587

Close #11538