### PR TITLE
Make DE440s the default JPL ephemeris

### DIFF
--- a/astropy/coordinates/solar_system.py
+++ b/astropy/coordinates/solar_system.py
@@ -25,7 +25,7 @@ __all__ = ["get_body", "get_moon", "get_body_barycentric",
            "get_body_barycentric_posvel", "solar_system_ephemeris"]
 
 
-DEFAULT_JPL_EPHEMERIS = 'de430'
+DEFAULT_JPL_EPHEMERIS = 'de440s'
 
 """List of kernel pairs needed to calculate positions of a given object."""
 BODY_NAME_TO_KERNEL_SPEC = {

--- a/astropy/coordinates/tests/test_intermediate_transformations.py
+++ b/astropy/coordinates/tests/test_intermediate_transformations.py
@@ -717,14 +717,22 @@ def test_ephemerides():
         moon_helioecl_jpl = moon.transform_to(ecl_frame)
         moon_cirs_jpl = moon.transform_to(cirs_frame)
 
-    # most transformations should differ by an amount which is
-    # non-zero but of order milliarcsecs
+    # Most transformations should differ by an amount which is
+    # non-zero but of order milliarcsecs.
+    # An exception is ICRS in more recent JPL ephemerides, since in DE
+    # 440 the SSB moved by about 100 km relative to previous ones,
+    # includings those that the built-in ERFA one is fit to.  At Earth,
+    # this corresponds to differences of about 100km/1AU ~ 140 mas.
+    # Since the Earth and Moon orbit a point much closer to the Sun
+    # than to the SSB, the HCRS and Heliocentric mean ecliptic are
+    # much more consistent.
     sep_icrs = moon_icrs_builtin.separation(moon_icrs_jpl)
     sep_hcrs = moon_hcrs_builtin.separation(moon_hcrs_jpl)
     sep_helioecl = moon_helioecl_builtin.separation(moon_helioecl_jpl)
     sep_cirs = moon_cirs_builtin.separation(moon_cirs_jpl)
 
-    assert_allclose([sep_icrs, sep_hcrs, sep_helioecl], 0.0*u.deg, atol=10*u.mas)
+    assert_allclose(sep_icrs, 0.0*u.deg, atol=200*u.mas)
+    assert_allclose([sep_hcrs, sep_helioecl], 0.0*u.deg, atol=10*u.mas)
     assert all(sep > 10*u.microarcsecond for sep in (sep_icrs, sep_hcrs, sep_helioecl))
 
     # CIRS should be the same
@@ -849,6 +857,8 @@ def test_aa_hd_high_precision():
     # Note: at this level of precision for the comparison, we have to include
     # the location in the time, as it influences the transformation to TDB.
     t = Time('2017-04-06T00:00:00.0', location=loc)
+    # We also have to stick to exactly the same ephemeris: de432s is not the
+    # same as de430 within these tight limits.
     with solar_system_ephemeris.set('de430'):
         moon = get_body('moon', t, loc)
         moon_aa = moon.transform_to(AltAz(obstime=t, location=loc))

--- a/docs/changes/11608.other.rst
+++ b/docs/changes/11608.other.rst
@@ -1,0 +1,4 @@
+The default 'jpl' ephemeris is now DE440s instead of DE430. This means
+it is a newer ephemeris, but also one that by default covers a smaller
+span in time (1850-2150), in order not to download more than will be
+needed except in very unusual cases.


### PR DESCRIPTION
Follow up on #11601, making the DE 440s ephemeris the default used with `ephemeris='jpl'`.

This replaces DE430 with a newer ephemeris, but also one that by default covers a smaller span in time (1850-2150), in order not to download more than will be needed except in very unusual cases.

One issue is that quite a few of the tests failed in replacing, and I had to adjust more tolerances than I was quite happy with. It would also be good to rerun some of the tests against HORIZONS and SkyField using the DE440 ephemeris in those codes as well. Because of this, setting the milestone to 5.0.