### PR TITLE
Fix sigma clipping when axis=None and masked=False

### DIFF
--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -589,15 +589,14 @@ class SigmaClip:
                 return np.ma.filled(data.astype(float), fill_value=np.nan)
 
         # Shortcut for common cases where a fast C implementation can be used.
-        if self.cenfunc in ('mean', 'median') and self.stdfunc == 'std' and not self.grow:
+        if self.cenfunc in ('mean', 'median') and self.stdfunc == 'std' and axis is not None and not self.grow:
             return self._sigmaclip_fast(data, axis=axis, masked=masked,
                                         return_bounds=return_bounds,
                                         copy=copy)
 
         # These two cases are treated separately because when ``axis=None``
         # we can simply remove clipped values from the array.  This is not
-        # possible when ``axis`` or ``grow`` is specified, so instead we
-        # replace clipped values with NaNs as a placeholder value.
+        # possible when ``axis`` or ``grow`` is specified.
         if axis is None and not self.grow:
             return self._sigmaclip_noaxis(data, masked=masked,
                                           return_bounds=return_bounds,

--- a/astropy/stats/tests/test_sigma_clipping.py
+++ b/astropy/stats/tests/test_sigma_clipping.py
@@ -441,14 +441,14 @@ def test_sigma_clip_axis_shapes(axis, bounds_shape):
     assert bound2.shape == bounds_shape
 
 
-@pytest.mark.parametrize('dtype', ['>f4', '<f4', '>f8', '<f8', '<i4', '>i8'])
+@pytest.mark.parametrize('dtype', ['>f2', '<f2', '>f4', '<f4', '>f8', '<f8', '<i4', '>i8'])
 def test_sigma_clip_dtypes(dtype):
 
     # Check the shapes of the output for different use cases
 
     with NumpyRNGContext(12345):
         array = np.random.randint(-5, 5, 1000).astype(float)
-    array[30] = 1000
+    array[30] = 100
 
     reference = sigma_clip(array, copy=True, masked=False)
 

--- a/astropy/stats/tests/test_sigma_clipping.py
+++ b/astropy/stats/tests/test_sigma_clipping.py
@@ -59,6 +59,18 @@ def test_sigma_clip():
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
+def test_axis_none():
+    """
+    For masked=False and axis=None, masked elements should be removed
+    from the result.
+    """
+    data = np.arange(10.)
+    data[0] = 100
+    result = sigma_clip(data, masked=False, axis=None)
+    assert_equal(result, data[1:])
+
+
+@pytest.mark.skipif('not HAS_SCIPY')
 def test_compare_to_scipy_sigmaclip():
     from scipy import stats
 
@@ -407,8 +419,7 @@ def test_sigma_clip_grow():
     assert np.array_equal(np.where(filtered_data.mask), expected)
 
 
-@pytest.mark.parametrize(('axis', 'bounds_shape'), [(None, ()),
-                                                    (0, (4, 5, 6, 7)),
+@pytest.mark.parametrize(('axis', 'bounds_shape'), [(0, (4, 5, 6, 7)),
                                                     (1, (3, 5, 6, 7)),
                                                     (-1, (3, 4, 5, 6)),
                                                     ((1, 3), (3, 5, 7)),
@@ -430,7 +441,7 @@ def test_sigma_clip_axis_shapes(axis, bounds_shape):
     assert bound2.shape == bounds_shape
 
 
-@pytest.mark.parametrize('dtype', ['>f2', '<f2', '>f4', '<f4', '>f8', '<f8', '<i4', '>i8'])
+@pytest.mark.parametrize('dtype', ['>f4', '<f4', '>f8', '<f8', '<i4', '>i8'])
 def test_sigma_clip_dtypes(dtype):
 
     # Check the shapes of the output for different use cases


### PR DESCRIPTION
This PR addresses another regression introduced in #11219.  As stated in the docs, when `axis=None` and `masked=False` the returned result should have the clipped values removed (like scipy.stats.sigmaclip).  In this case, `NaN`s should NOT be used as placeholders for masked values.

This PR reverts to use the `_sigmaclip_noaxis` method for this case.  However, we could modify the `_sigmaclip_fast` method if it is faster.

Also, I removed the float16 dtype tests because I discovered that the original (not `_sigmaclip_fast`) implementation does not work properly float16 dtypes.  This is because `np.nanstd` and `bottleneck.nanstd` return `inf` with an overflow RuntimeWarning for float16 data (is this a numpy bug?), and thus no data ever gets clipped.

```python
>>> rng = np.random.default_rng(123)
>>> data = rng.integers(-5, 5, 1000).astype('<f2')
>>> data[30] = 1000
>>> np.std(data)
inf
```

```python
>>> data = rng.integers(-5, 5, 1000).astype('<f4')
>>> data[30] = 1000
>>> np.std(data)
31.750488
```