### PR TITLE
Modeling: add function `tie_inputs`

### DIFF
--- a/astropy/modeling/models.py
+++ b/astropy/modeling/models.py
@@ -6,7 +6,7 @@ Creates a common namespace for all pre-defined models.
 
 # pylint: disable=unused-wildcard-import, unused-import, wildcard-import
 
-from .core import custom_model, hide_inverse, fix_inputs # pylint: disable=W0611
+from .core import custom_model, hide_inverse, fix_inputs, tie_inputs # pylint: disable=W0611
 from .mappings import *
 from .projections import *
 from .rotations import *

--- a/astropy/modeling/tests/test_core.py
+++ b/astropy/modeling/tests/test_core.py
@@ -579,3 +579,32 @@ def test_bounding_box_general_inverse():
     inverse_model = model.inverse
     with pytest.raises(NotImplementedError):
         inverse_model.bounding_box
+
+
+def test_tie_inputs():
+    """Test the helper function ``tie_inputs``."""
+    # first need to make an Model
+    # this has parameters amplitude, x_0, y_0, a, b, theta
+    model = models.Ellipse2D(a=3)
+
+    assert model.b.tied is False
+
+    # tie model inputs
+    models.tie_inputs(model, dict(b=("a", 2)))
+    assert callable(model.b.tied)
+    assert model.b == 6
+
+    # also test repr of _TieParameterTo
+    s = repr(model.b.tied)
+    assert 'TieParameterTo' in s
+    assert "'a'" in s
+    assert str(2) in s
+
+    # now pass in a custom function
+    # first, reset
+    model.b.tied = False
+    assert model.b.tied is False
+
+    models.tie_inputs(model, dict(b=lambda model: 10 * model.a))
+    assert callable(model.b.tied)
+    assert model.b == 30

--- a/astropy/modeling/utils.py
+++ b/astropy/modeling/utils.py
@@ -5,7 +5,7 @@ This module provides utility functions for the models package.
 """
 # pylint: disable=invalid-name
 from collections import deque, UserDict
-from collections.abc import MutableMapping
+from collections.abc import MutableMapping, Callable
 from inspect import signature
 
 import numpy as np
@@ -531,6 +531,29 @@ class _BoundingBox(tuple):
             return [np.arange(self[i][0], self[i][1] + resolution, resolution) for i in range(self.dimension)]
         else:
             raise ValueError('Bounding box must have positive dimension')
+
+
+class _TieParameterTo(Callable):
+    """Tie `astropy.modeling.Parameter` to another parameter.
+
+    Parameters
+    ----------
+    to : str
+        Name of parameter in model instance.
+    mul : float (optional)
+        Multiplicative factor for parameter `to`
+    """
+
+    def __init__(self, to, mul = 1):
+        self._to = to
+        self._mul = mul
+
+    def __call__(self, modelinstance):
+        val = getattr(modelinstance, self._to) * self._mul
+        return val
+
+    def __repr__(self):
+        return f"<TieParameterTo('{self._to}',{self._mul}) at {hex(id(self))}>"
 
 
 def make_binary_operator_eval(oper, f, g):

--- a/docs/changes/modeling/11613.feature.rst
+++ b/docs/changes/modeling/11613.feature.rst
@@ -1,0 +1,3 @@
+A utility function ``tie_inputs`` is added to enable quick tying of parameters.
+Multiplicative scalings have a shortcut syntax, but Parameters can be tied with
+any custom callable.


### PR DESCRIPTION
### Description

Modeled (😛) after `fix_inputs`, this function enables quick tying of parameters in a model instance.
@nden @perrygreenfield 

```python
model = Ellipse2D(a=3)

# shortcut for equality
tie_inputs(model, {"b": "a"})  # b = a

# shortcut for scaling
tie_inputs(model, {"b": ("a", 2)})  # b = a * 2

# any callable is allowed
tie_inputs(model, {"b": lambda model: 10 * model.a})  # b = a * 10
```

@pllim : I think v5.0, thanks!

Edit: as it says in the comment in the code, I would like to figure out how to compile a function via AST from an arbitrary string, e.g. enabling ``tie_inputs(model, {"b": "np.sqrt(a)"})``. I've seen this implemented in the lmfit package and it would be a cool addition. But out of scope of this PR.