### PR TITLE
Add physical module to units index, and include list of types

### DIFF
--- a/astropy/units/physical.py
+++ b/astropy/units/physical.py
@@ -2,6 +2,7 @@
 
 """Defines the physical types that correspond to different units."""
 
+import io
 import numbers
 
 from . import core
@@ -526,5 +527,30 @@ def get_physical_type(obj):
 
 for unit, physical_type in _units_and_physical_types:
     def_physical_type(unit, physical_type)
+
+
+# This generates a docstring addition for this module that describes all of the
+# standard physical types defined here.
+if __doc__ is not None:
+    docstring = io.StringIO()
+
+    docstring.write("""
+
+.. list-table:: Units with known Physical Type
+   :header-rows: 1
+   :widths: 20 60
+
+   * - Unit
+     - Physical Type(s)
+""")
+
+    for physical_type in _physical_unit_mapping.values():
+        docstring.write(f"""
+   * - :math:`{physical_type._unit.to_string('latex')[1:-1]}`
+     - {physical_type}
+""")
+
+    __doc__ += docstring.getvalue()
+
 
 del unit, physical_type

--- a/astropy/units/physical.py
+++ b/astropy/units/physical.py
@@ -2,7 +2,6 @@
 
 """Defines the physical types that correspond to different units."""
 
-import io
 import numbers
 
 from . import core
@@ -532,25 +531,23 @@ for unit, physical_type in _units_and_physical_types:
 # This generates a docstring addition for this module that describes all of the
 # standard physical types defined here.
 if __doc__ is not None:
-    docstring = io.StringIO()
+    doclines = [
+        ".. list-table:: Defined Physical Types",
+        "    :header-rows: 1",
+        "    :widths: 30 10 50",
+        "",
+        "    * - Physical type",
+        "      - Unit",
+        "      - Other physical type(s) with same unit"]
 
-    docstring.write("""
+    for name in sorted(_name_physical_mapping.keys()):
+        physical_type = _name_physical_mapping[name]
+        doclines.extend([
+            f"    * - {name}",
+            f"      - :math:`{physical_type._unit.to_string('latex')[1:-1]}`",
+            f"      - {', '.join([n for n in physical_type if n != name])}"])
 
-.. list-table:: Units with known Physical Type
-   :header-rows: 1
-   :widths: 20 60
-
-   * - Unit
-     - Physical Type(s)
-""")
-
-    for physical_type in _physical_unit_mapping.values():
-        docstring.write(f"""
-   * - :math:`{physical_type._unit.to_string('latex')[1:-1]}`
-     - {physical_type}
-""")
-
-    __doc__ += docstring.getvalue()
+    __doc__ += '\n\n' + '\n'.join(doclines)
 
 
 del unit, physical_type

--- a/docs/units/index.rst
+++ b/docs/units/index.rst
@@ -247,6 +247,8 @@ Reference/API
 
 .. automodapi:: astropy.units.cds
 
+.. automodapi:: astropy.units.physical
+
 .. automodapi:: astropy.units.equivalencies
 
 .. automodapi:: astropy.units.function


### PR DESCRIPTION
This is an alternative to part of #11595, to typeset the known physical types in the documentation, following how units lists are created. It should be easy to extend this to allow links, but that's for follow-up.

Note that this also makes the `physical` module visible in the units documentation - that was an oversight in #11118.