### PR TITLE
Fix #11366

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,8 +37,6 @@ try:
 except ImportError:
     import importlib_metadata
 
-from sphinx.errors import NoUri
-
 try:
     from sphinx_astropy.conf.v1 import *  # noqa
 except ImportError:
@@ -470,7 +468,7 @@ def resolve_astropy_dev_reference(app, env, node, contnode):
         except Exception:
             pass
 
-        # Otherwise return None which should deletegate to intersphinx
+        # Otherwise return None which should delegate to intersphinx
 
 
 def setup(app):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,11 +37,14 @@ try:
 except ImportError:
     import importlib_metadata
 
+from sphinx.errors import NoUri
+
 try:
     from sphinx_astropy.conf.v1 import *  # noqa
 except ImportError:
     print('ERROR: the documentation requires the sphinx-astropy package to be installed')
     sys.exit(1)
+
 
 plot_rcparams = {}
 plot_rcparams['figure.figsize'] = (6, 6)
@@ -443,6 +446,33 @@ def rstjinja(app, docname, source):
         source[0] = rendered
 
 
+def resolve_astropy_dev_reference(app, env, node, contnode):
+    """
+    Reference targets beginning with ``astropy-dev:`` are a special case.
+
+    If we are building the development docs it is a local ref targetting the
+    label ``astropy-dev:<label>``, but for stable docs it should be an
+    intersphinx resolution to the development docs.
+
+    See https://github.com/astropy/astropy/issues/11366
+    """
+
+    reftarget = node.get('reftarget')
+    if dev and reftarget is not None and reftarget.startswith('astropy-dev:'):
+        reftype = node.get('reftype')
+        refdoc = node.get('refdoc', app.env.docname)
+        reftarget = reftarget.split(':', 1)[1]
+        # Delegate to the ref node's original domain/target (typically :ref:)
+        try:
+            domain = app.env.domains[node['refdomain']]
+            return domain.resolve_xref(app.env, refdoc, app.builder,
+                                       reftype, reftarget, node, contnode)
+        except Exception:
+            pass
+
+        # Otherwise return None which should deletegate to intersphinx
+
+
 def setup(app):
     if sphinx_gallery is None:
         msg = ('The sphinx_gallery extension is not installed, so the '
@@ -459,3 +489,8 @@ def setup(app):
 
     # Generate the page from Jinja template
     app.connect("source-read", rstjinja)
+    # Set this to higher priority than intersphinx; this way when building
+    # dev docs astropy-dev: targets will go to the local docs instead of the
+    # intersphinx mapping
+    app.connect("missing-reference", resolve_astropy_dev_reference,
+                priority=400)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -72,6 +72,7 @@ check_sphinx_version("1.2.1")  # noqa: F405
 del intersphinx_mapping['astropy']  # noqa: F405
 
 # add any custom intersphinx for astropy
+intersphinx_mapping['astropy-dev'] = ('https://docs.astropy.org/en/latest/', None)  # noqa: F405
 intersphinx_mapping['pyerfa'] = ('https://pyerfa.readthedocs.io/en/stable/', None)  # noqa: F405
 intersphinx_mapping['pytest'] = ('https://pytest.readthedocs.io/en/stable/', None)  # noqa: F405
 intersphinx_mapping['ipython'] = ('https://ipython.readthedocs.io/en/stable/', None)  # noqa: F405

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -161,7 +161,7 @@ There are some additional tools, mostly of use for maintainers, in the
 
 To read the developer documentation, you will need to go to the :ref:`latest
 developer version of the documentation
-<astropy-dev:developer-documentation>`.
+<astropy-dev:developer-docs>`.
 
 .. toctree::
    :maxdepth: 1

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -159,8 +159,9 @@ There are some additional tools, mostly of use for maintainers, in the
 
 {%else%}
 
-To read the developer documentation, you will need to go to the
-`latest developer version of the documentation <https://docs.astropy.org/en/latest/#developer-documentation>`__.
+To read the developer documentation, you will need to go to the :ref:`latest
+developer version of the documentation
+<astropy-dev:developer-documentation>`.
 
 .. toctree::
    :maxdepth: 1

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -50,12 +50,14 @@ documentation <https://pip.pypa.io/en/stable/user_guide/#user-installs>`_.
 {% if is_development %}
 
 Alternatively, if you intend to do development on other software that uses
-``astropy``, such as an affiliated package, consider installing ``astropy`` into a :ref:`virtualenv<using-virtualenv>`.
+``astropy``, such as an affiliated package, consider installing ``astropy``
+into a :ref:`virtualenv <virtual_envs>`.
 
 {%else%}
 
 Alternatively, if you intend to do development on other software that uses
-``astropy``, such as an affiliated package, consider installing ``astropy`` into a `virtualenv <https://docs.astropy.org/en/latest/development/workflow/virtualenv_detail.html>`__.
+``astropy``, such as an affiliated package, consider installing ``astropy``
+into a :ref:`virtualenv <astropy-dev:virtual_envs>`.
 
 {%endif%}
 
@@ -119,7 +121,8 @@ source code directory, or :ref:`running-tests` for more details.
 
 {%else%}
 
-See the `latest documentation on how to test your installed version of astropy <https://docs.astropy.org/en/latest/install.html#testing-an-installed-astropy>`__.
+See the :ref:`latest documentation on how to test your installed version of
+astropy <astropy-dev:testing_installed_astropy>`.
 
 {%endif%}
 
@@ -292,7 +295,7 @@ using this command::
 
    git clone git://github.com/astropy/astropy.git
 
-If you wish to participate in the development of ``astropy``, see
+If you wish to participate in the development of ``astropy``, see the
 :ref:`developer-docs`. The present document covers only the basics necessary to
 installing ``astropy``.
 
@@ -550,6 +553,7 @@ would like more control over the testing process.
 
 {%else%}
 
-See the `latest documentation on how to run the tests in a source checkout of astropy <https://docs.astropy.org/en/latest/install.html#testing-a-source-code-build-of-astropy>`__.
+See the :ref:`latest documentation on how to run the tests in a source
+checkout of astropy <astropy-dev:sourcebuildtest>`
 
 {%endif%}

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -47,19 +47,9 @@ this case you may consider using the ``--user`` option to install the package
 into your home directory. You can read more about how to do this in the `pip
 documentation <https://pip.pypa.io/en/stable/user_guide/#user-installs>`_.
 
-{% if is_development %}
-
-Alternatively, if you intend to do development on other software that uses
-``astropy``, such as an affiliated package, consider installing ``astropy``
-into a :ref:`virtualenv <virtual_envs>`.
-
-{%else%}
-
 Alternatively, if you intend to do development on other software that uses
 ``astropy``, such as an affiliated package, consider installing ``astropy``
 into a :ref:`virtualenv <astropy-dev:virtual_envs>`.
-
-{%endif%}
 
 Do **not** install ``astropy`` or other third-party packages using ``sudo``
 unless you are fully aware of the risks.


### PR DESCRIPTION
This fixes #11366 by adding two things:

* Adds `astropy-dev` to the intersphinx mappings.  This can be used now anywhere in the Astropy docs to link to docs in the
  current development version (but particularly this is useful for linking to the Developer Guide since it now lives only in the
  development version).

* When building the development version of the docs, `astropy-dev:` references are automatically resolved in the "normal" manner
  as though the `astropy-dev:` prefix weren't there, so it avoids using the intersphinx mapping in this case.