### PR TITLE
Small fix to WCS compare doc

### DIFF
--- a/astropy/wcs/docstrings.py
+++ b/astropy/wcs/docstrings.py
@@ -369,8 +369,9 @@ cmp : int, optional
     comparison.
 
     - ``WCSCOMPARE_ANCILLARY``: Ignores ancillary keywords that don't
-      change the WCS transformation, such as ``DATE-OBS`` or
-      ``EQUINOX``.
+      change the WCS transformation, such as ``XPOSURE`` or
+      ``EQUINOX``. Note that this also ignores ``DATE-OBS``, which does
+      change the WCS transformation in some cases.
 
     - ``WCSCOMPARE_TILING``: Ignore integral differences in
       ``CRPIXja``.  This is the 'tiling' condition, where two WCSes


### PR DESCRIPTION
For at least some WCS transformations (e.g. heliographic stonyhurst > heliographic stonyhurst, with different date-obs), the date-obs keyword does change the transformation, so I have tidied up a docstring to reflect this.