### PR TITLE
Add a new SkyCoord method: spherical_offsets_by

### DIFF
--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -1163,6 +1163,44 @@ class SkyCoord(ShapedLikeNDArray):
         dlat = acoord.spherical.lat.view(Angle)
         return dlon, dlat
 
+    def spherical_offsets_by(self, d_lon, d_lat):
+        """
+        Computes the coordinates at the specified angular offsets from this
+        coordinate.
+
+        Parameters
+        ----------
+        d_lon : angle-like
+            The longitude offset.
+        d_lat : angle-like
+            The latitude offset.
+
+        Returns
+        -------
+        newcoord : `~astropy.coordinates.SkyCoord`
+            The coordinates for the location that corresponds to offsetting by
+            ``d_lat`` in the latitude direction and ``d_lon`` in the longitude
+            direction.
+
+        Notes
+        -----
+        This internally uses `~astropy.coordinates.SkyOffsetFrame` to do the
+        transformation. For a more complete set of transform offsets, use
+        `~astropy.coordinates.SkyOffsetFrame` or `~astropy.wcs.WCS` manually.
+
+        See Also
+        --------
+        spherical_offsets_to : compute the angular offsets to another coordinate
+        directional_offset_by : offset a coordinate by an angle in a direction
+        """
+        if self.shape:
+            raise ValueError(
+                "Computing offset coordinates is only supported for scalar "
+                "coordinate data.")
+
+        return SkyOffsetFrame(d_lon, d_lat,
+                              origin=self).transform_to(self.frame)
+
     def directional_offset_by(self, position_angle, separation):
         """
         Computes coordinates at the given offset from this coordinate.

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -1127,10 +1127,12 @@ class SkyCoord(ShapedLikeNDArray):
         Returns
         -------
         lon_offset : `~astropy.coordinates.Angle`
-            The angular offset in the longitude direction (e.g., RA for
+            The angular offset in the longitude direction. The definition of
+            "longitude" depends on this coordinate's frame (e.g., RA for
             equatorial coordinates).
         lat_offset : `~astropy.coordinates.Angle`
-            The angular offset in the latitude direction (e.g., Dec for
+            The angular offset in the latitude direction. The definition of
+            "latitude" depends on this coordinate's frame (e.g., Dec for
             equatorial coordinates).
 
         Raises
@@ -1165,15 +1167,18 @@ class SkyCoord(ShapedLikeNDArray):
 
     def spherical_offsets_by(self, d_lon, d_lat):
         """
-        Computes the coordinates at the specified angular offsets.
+        Computes the coordinate that is a specified pair of angular offsets away
+        from this coordinate.
 
         Parameters
         ----------
         d_lon : angle-like
-            The angular offset in the longitude direction (e.g., RA for
+            The angular offset in the longitude direction. The definition of
+            "longitude" depends on this coordinate's frame (e.g., RA for
             equatorial coordinates).
         d_lat : angle-like
-            The angular offset in the latitude direction (e.g., Dec for
+            The angular offset in the latitude direction. The definition of
+            "latitude" depends on this coordinate's frame (e.g., Dec for
             equatorial coordinates).
 
         Returns
@@ -1188,14 +1193,16 @@ class SkyCoord(ShapedLikeNDArray):
         This internally uses `~astropy.coordinates.SkyOffsetFrame` to do the
         transformation. For a more complete set of transform offsets, use
         `~astropy.coordinates.SkyOffsetFrame` or `~astropy.wcs.WCS` manually.
+        This specific method can be reproduced by doing
+        ``SkyCoord(SkyOffsetFrame(d_lon, d_lat, origin=self.frame).transform_to(self))``.
 
         See Also
         --------
         spherical_offsets_to : compute the angular offsets to another coordinate
         directional_offset_by : offset a coordinate by an angle in a direction
         """
-        return SkyCoord(SkyOffsetFrame(d_lon, d_lat,
-                                       origin=self.frame).transform_to(self))
+        return self.__class__(
+            SkyOffsetFrame(d_lon, d_lat, origin=self.frame).transform_to(self))
 
     def directional_offset_by(self, position_angle, separation):
         """

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -1127,10 +1127,10 @@ class SkyCoord(ShapedLikeNDArray):
         Returns
         -------
         lon_offset : `~astropy.coordinates.Angle`
-            The angular offset in the longitude direction (i.e. RA for
+            The angular offset in the longitude direction (e.g., RA for
             equatorial coordinates).
         lat_offset : `~astropy.coordinates.Angle`
-            The angular offset in the latitude direction (i.e. Dec for
+            The angular offset in the latitude direction (e.g., Dec for
             equatorial coordinates).
 
         Raises
@@ -1165,16 +1165,15 @@ class SkyCoord(ShapedLikeNDArray):
 
     def spherical_offsets_by(self, d_lon, d_lat):
         """
-        Computes the coordinates at the specified angular offsets from this
-        coordinate.
+        Computes the coordinates at the specified angular offsets.
 
         Parameters
         ----------
         d_lon : angle-like
-            The angular offset in the longitude direction (i.e. RA for
+            The angular offset in the longitude direction (e.g., RA for
             equatorial coordinates).
         d_lat : angle-like
-            The angular offset in the latitude direction (i.e. Dec for
+            The angular offset in the latitude direction (e.g., Dec for
             equatorial coordinates).
 
         Returns
@@ -1195,11 +1194,6 @@ class SkyCoord(ShapedLikeNDArray):
         spherical_offsets_to : compute the angular offsets to another coordinate
         directional_offset_by : offset a coordinate by an angle in a direction
         """
-        if self.shape:
-            raise ValueError(
-                "Computing offset coordinates is only supported for scalar "
-                "coordinate data.")
-
         return SkyCoord(SkyOffsetFrame(d_lon, d_lat,
                                        origin=self.frame).transform_to(self))
 

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -1198,8 +1198,8 @@ class SkyCoord(ShapedLikeNDArray):
                 "Computing offset coordinates is only supported for scalar "
                 "coordinate data.")
 
-        return SkyOffsetFrame(d_lon, d_lat,
-                              origin=self).transform_to(self.frame)
+        return SkyCoord(SkyOffsetFrame(d_lon, d_lat,
+                                       origin=self.frame).transform_to(self))
 
     def directional_offset_by(self, position_angle, separation):
         """

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -1127,10 +1127,10 @@ class SkyCoord(ShapedLikeNDArray):
         Returns
         -------
         lon_offset : `~astropy.coordinates.Angle`
-            The angular offset in the longitude direction (i.e., RA for
+            The angular offset in the longitude direction (i.e. RA for
             equatorial coordinates).
         lat_offset : `~astropy.coordinates.Angle`
-            The angular offset in the latitude direction (i.e., Dec for
+            The angular offset in the latitude direction (i.e. Dec for
             equatorial coordinates).
 
         Raises
@@ -1171,9 +1171,11 @@ class SkyCoord(ShapedLikeNDArray):
         Parameters
         ----------
         d_lon : angle-like
-            The longitude offset.
+            The angular offset in the longitude direction (i.e. RA for
+            equatorial coordinates).
         d_lat : angle-like
-            The latitude offset.
+            The angular offset in the latitude direction (i.e. Dec for
+            equatorial coordinates).
 
         Returns
         -------

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -1526,7 +1526,7 @@ def test_spherical_offsets():
     assert_allclose(dra, -1*u.arcmin)
     assert_allclose(ddec, 1*u.arcmin)
     i10_back = i01.spherical_offsets_by(-dra, -ddec)
-    # TODO: this roundtripping accuracy is bad!
+    # TODO: this roundtripping accuracy isn't great!
     assert_allclose(i10_back.ra, i10.ra, atol=1e-9*u.deg)
     assert_allclose(i10_back.dec, i10.dec, atol=1e-9*u.deg)
 
@@ -1534,9 +1534,16 @@ def test_spherical_offsets():
     assert_allclose(ddec, 1*u.arcmin)
     assert 0*u.arcmin < dra < 1*u.arcmin
     i11_back = i22.spherical_offsets_by(-dra, -ddec)
-    # TODO: this roundtripping accuracy is bad!
+    # TODO: this roundtripping accuracy isn't great!
     assert_allclose(i11_back.ra, i11.ra, atol=1e-9*u.deg)
     assert_allclose(i11_back.dec, i11.dec, atol=1e-9*u.deg)
+
+    # Test roundtripping the other direction:
+    init_c = SkyCoord(40.*u.deg, 40.*u.deg)
+    new_c = init_c.spherical_offsets_by(3.534*u.deg, 2.2134*u.deg)
+    dlon, dlat = new_c.spherical_offsets_to(init_c)
+    back_c = new_c.spherical_offsets_by(dlon, dlat)
+    assert init_c.separation(back_c) < 1e-10*u.deg
 
     fk5 = SkyCoord(0*u.arcmin, 0*u.arcmin, frame='fk5')
 

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -1535,9 +1535,12 @@ def test_spherical_offsets_roundtrip(frame, comparison_data):
     assert_allclose(dlat, comparison.data.lat)
 
     i00_back = comparison.spherical_offsets_by(-dlon, -dlat)
-    # TODO: this roundtripping accuracy isn't great
-    assert_allclose(i00_back.data.lon, i00.data.lon, atol=1e-9*u.deg)
-    assert_allclose(i00_back.data.lat, i00.data.lat, atol=1e-9*u.deg)
+
+    # This reaches machine precision when only one component is changed, but for
+    # the third parametrized case (both lon and lat change), the transformation
+    # will have finite accuracy:
+    assert_allclose(i00_back.data.lon, i00.data.lon, atol=1e-10*u.rad)
+    assert_allclose(i00_back.data.lat, i00.data.lat, atol=1e-10*u.rad)
 
     # Test roundtripping the other direction:
     init_c = SkyCoord(40.*u.deg, 40.*u.deg, frame=frame)

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -1511,18 +1511,32 @@ def test_spherical_offsets():
     dra, ddec = i00.spherical_offsets_to(i01)
     assert_allclose(dra, 0*u.arcmin)
     assert_allclose(ddec, 1*u.arcmin)
+    i00_back = i01.spherical_offsets_by(-dra, -ddec)
+    assert_allclose(i00_back.ra, i00.ra, atol=1e-13*u.deg)
+    assert_allclose(i00_back.dec, i00.dec, atol=1e-13*u.deg)
 
     dra, ddec = i00.spherical_offsets_to(i10)
     assert_allclose(dra, 1*u.arcmin)
     assert_allclose(ddec, 0*u.arcmin)
+    i00_back = i10.spherical_offsets_by(-dra, -ddec)
+    assert_allclose(i00_back.ra, i00.ra, atol=1e-13*u.deg)
+    assert_allclose(i00_back.dec, i00.dec, atol=1e-13*u.deg)
 
     dra, ddec = i10.spherical_offsets_to(i01)
     assert_allclose(dra, -1*u.arcmin)
     assert_allclose(ddec, 1*u.arcmin)
+    i10_back = i01.spherical_offsets_by(-dra, -ddec)
+    # TODO: this roundtripping accuracy is bad!
+    assert_allclose(i10_back.ra, i10.ra, atol=1e-9*u.deg)
+    assert_allclose(i10_back.dec, i10.dec, atol=1e-9*u.deg)
 
     dra, ddec = i11.spherical_offsets_to(i22)
     assert_allclose(ddec, 1*u.arcmin)
     assert 0*u.arcmin < dra < 1*u.arcmin
+    i11_back = i22.spherical_offsets_by(-dra, -ddec)
+    # TODO: this roundtripping accuracy is bad!
+    assert_allclose(i11_back.ra, i11.ra, atol=1e-9*u.deg)
+    assert_allclose(i11_back.dec, i11.dec, atol=1e-9*u.deg)
 
     fk5 = SkyCoord(0*u.arcmin, 0*u.arcmin, frame='fk5')
 
@@ -1541,6 +1555,10 @@ def test_spherical_offsets():
     dra, ddec = i00s.spherical_offsets_to(i01s)
     assert_allclose(dra, 0*u.arcmin)
     assert_allclose(ddec, np.arange(4)*u.arcmin)
+
+    # spherical_offsets_by only supports scalar frame data:
+    with pytest.raises(ValueError):
+        i01s.spherical_offsets_by(-dra, -ddec)
 
 
 def test_frame_attr_changes():

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -1501,11 +1501,10 @@ def test_getitem_representation():
     assert sc[0].representation_type is CartesianRepresentation
 
 
-def test_spherical_offsets_api():
+def test_spherical_offsets_to_api():
     i00 = SkyCoord(0*u.arcmin, 0*u.arcmin, frame='icrs')
 
     fk5 = SkyCoord(0*u.arcmin, 0*u.arcmin, frame='fk5')
-
     with pytest.raises(ValueError):
         # different frames should fail
         i00.spherical_offsets_to(fk5)
@@ -1521,10 +1520,6 @@ def test_spherical_offsets_api():
     dra, ddec = i00s.spherical_offsets_to(i01s)
     assert_allclose(dra, 0*u.arcmin)
     assert_allclose(ddec, np.arange(4)*u.arcmin)
-
-    # spherical_offsets_by only supports scalar frame data:
-    with pytest.raises(ValueError):
-        i01s.spherical_offsets_by(-dra, -ddec)
 
 
 @pytest.mark.parametrize('frame', ['icrs', 'galactic'])

--- a/docs/changes/coordinates/11635.feature.rst
+++ b/docs/changes/coordinates/11635.feature.rst
@@ -1,0 +1,4 @@
+Added a new method to ``SkyCoord``, ``spherical_offsets_by()``, which is the
+conceptual inverse of ``spherical_offsets_to()``: Given angular offsets in
+longitude and latitude, this method returns a new coordinate with the offsets
+applied.

--- a/docs/coordinates/matchsep.rst
+++ b/docs/coordinates/matchsep.rst
@@ -12,7 +12,7 @@ as methods on the coordinate objects.
 In the examples below, we will assume that the following imports have already
 been executed::
 
-    >>> import astropy units as u
+    >>> import astropy.units as u
     >>> from astropy.coordinates import SkyCoord
 
 Separations

--- a/docs/coordinates/matchsep.rst
+++ b/docs/coordinates/matchsep.rst
@@ -117,6 +117,17 @@ telescope operator to move from a bright star to a fainter target)::
     >>> ddec.to(u.arcsec)  # doctest: +FLOAT_CMP
     <Angle 10.60510342 arcsec>
 
+The conceptual method to
+:meth:`~astropy.coordinates.SkyCoord.spherical_offsets_to` is also available as
+a method on any |SkyCoord| object:
+:meth:`~astropy.coordinates.SkyCoord.spherical_offsets_by`, which accepts two
+angular offsets (in longitude and latitude) and returns the coordinates at the
+offset location::
+
+    >>> target_star = SkyCoord(86.75309*u.deg, -31.5633*u.deg, frame='icrs')
+    >>> target_star.spherical_offsets_by(1.3*u.arcmin, -0.7*u.arcmin)  # doctest: +FLOAT_CMP
+    <SkyCoord (ICRS): (ra, dec) in deg
+        (86.77852168, -31.57496415)>
 
 .. _astropy-skyoffset-frames:
 

--- a/docs/coordinates/matchsep.rst
+++ b/docs/coordinates/matchsep.rst
@@ -117,7 +117,7 @@ telescope operator to move from a bright star to a fainter target)::
     >>> ddec.to(u.arcsec)  # doctest: +FLOAT_CMP
     <Angle 10.60510342 arcsec>
 
-The conceptual method to
+The conceptual inverse of
 :meth:`~astropy.coordinates.SkyCoord.spherical_offsets_to` is also available as
 a method on any |SkyCoord| object:
 :meth:`~astropy.coordinates.SkyCoord.spherical_offsets_by`, which accepts two

--- a/docs/coordinates/matchsep.rst
+++ b/docs/coordinates/matchsep.rst
@@ -9,6 +9,12 @@ determining separations between coordinates and those for matching a
 coordinate (or coordinates) to a catalog. These are mainly implemented
 as methods on the coordinate objects.
 
+In the examples below, we will assume that the following imports have already
+been executed::
+
+    >>> import astropy units as u
+    >>> from astropy.coordinates import SkyCoord
+
 Separations
 ===========
 
@@ -17,9 +23,6 @@ The on-sky separation can be computed with the
 :meth:`astropy.coordinates.SkyCoord.separation` methods,
 which computes the great-circle distance (*not* the small-angle approximation)::
 
-    >>> import numpy as np
-    >>> from astropy import units as u
-    >>> from astropy.coordinates import SkyCoord
     >>> c1 = SkyCoord('5h23m34.5s', '-69d45m22s', frame='icrs')
     >>> c2 = SkyCoord('0h52m44.8s', '-72d49m43s', frame='fk5')
     >>> sep = c1.separation(c2)
@@ -50,8 +53,6 @@ In addition to the on-sky separation described above,
 determine the 3D distance between two coordinates that have ``distance``
 defined::
 
-    >>> from astropy import units as u
-    >>> from astropy.coordinates import SkyCoord
     >>> c1 = SkyCoord('5h23m34.5s', '-69d45m22s', distance=70*u.kpc, frame='icrs')
     >>> c2 = SkyCoord('0h52m44.8s', '-72d49m43s', distance=80*u.kpc, frame='icrs')
     >>> sep = c1.separation_3d(c2)
@@ -74,8 +75,6 @@ computes the position angle between one
 |SkyCoord| instance and another (passed as the argument) following the
 astronomy convention (positive angles East of North)::
 
-    >>> from astropy import units as u
-    >>> from astropy.coordinates import SkyCoord
     >>> c1 = SkyCoord(1*u.deg, 1*u.deg, frame='icrs')
     >>> c2 = SkyCoord(2*u.deg, 2*u.deg, frame='icrs')
     >>> c1.position_angle(c2).to(u.deg)  # doctest: +FLOAT_CMP
@@ -87,8 +86,6 @@ directional offsets. To do the inverse operation — determining the new
 "destination" coordinate given a separation and position angle — the
 :meth:`~astropy.coordinates.SkyCoord.directional_offset_by` method is provided::
 
-    >>> from astropy import units as u
-    >>> from astropy.coordinates import SkyCoord
     >>> c1 = SkyCoord(1*u.deg, 1*u.deg, frame='icrs')
     >>> position_angle = 45 * u.deg
     >>> separation = 1.414 * u.deg
@@ -100,8 +97,6 @@ This technique is also useful for computing the midpoint (or indeed any point)
 between two coordinates in a way that accounts for spherical geometry
 (i.e., instead of averaging the RAs/Decs separately)::
 
-    >>> from astropy import units as u
-    >>> from astropy.coordinates import SkyCoord
     >>> coord1 = SkyCoord(0*u.deg, 0*u.deg, frame='icrs')
     >>> coord2 = SkyCoord(1*u.deg, 1*u.deg, frame='icrs')
     >>> pa = coord1.position_angle(coord2)
@@ -110,14 +105,10 @@ between two coordinates in a way that accounts for spherical geometry
     <SkyCoord (ICRS): (ra, dec) in deg
         (0.49996192, 0.50001904)>
 
-
-
 There is also a :meth:`~astropy.coordinates.SkyCoord.spherical_offsets_to`
 method for computing angular offsets (e.g., small shifts like you might give a
 telescope operator to move from a bright star to a fainter target)::
 
-    >>> from astropy import units as u
-    >>> from astropy.coordinates import SkyCoord
     >>> bright_star = SkyCoord('8h50m59.75s', '+11d39m22.15s', frame='icrs')
     >>> faint_galaxy = SkyCoord('8h50m47.92s', '+11d39m32.74s', frame='icrs')
     >>> dra, ddec = bright_star.spherical_offsets_to(faint_galaxy)
@@ -139,8 +130,7 @@ These are known as "sky offset frames," as they are a convenient way to create
 a frame centered on an arbitrary position on the sky suitable for computing
 positional offsets (e.g., for astrometry)::
 
-    >>> from astropy import units as u
-    >>> from astropy.coordinates import SkyOffsetFrame, ICRS, SkyCoord
+    >>> from astropy.coordinates import SkyOffsetFrame, ICRS
     >>> center = ICRS(10*u.deg, 45*u.deg)
     >>> center.transform_to(SkyOffsetFrame(origin=center)) # doctest: +FLOAT_CMP
     <SkyOffsetICRS Coordinate (rotation=0.0 deg, origin=<ICRS Coordinate: (ra, dec) in deg
@@ -222,8 +212,6 @@ of other coordinates. For example, assuming ``ra1``/``dec1`` and
 
 .. doctest-requires:: scipy
 
-    >>> from astropy.coordinates import SkyCoord
-    >>> from astropy import units as u
     >>> c = SkyCoord(ra=ra1*u.degree, dec=dec1*u.degree)
     >>> catalog = SkyCoord(ra=ra2*u.degree, dec=dec2*u.degree)
     >>> idx, d2d, d3d = c.match_to_catalog_sky(catalog)


### PR DESCRIPTION
This comes up enough on Slack or in issues that I finally had some time to implement this, as it would be great to have in for v4.3. This adds a new method to `SkyCoord`, `.spherical_offsets_by()`, which takes offsets in longitude and latitude and returns a new `SkyCoord` after applying the offsets. The implementation here basically uses what I suggested in https://github.com/astropy/astropy/issues/11199#issuecomment-752984008 .

Fixes #11199

cc @janerigby 

TODO:
- [x] Documentation
- [x] Changelog
~~What's New entry~~