### PR TITLE
Up PyERFA minimum version to 1.7.3

### DIFF
--- a/docs/changes/11637.other.rst
+++ b/docs/changes/11637.other.rst
@@ -1,0 +1,1 @@
+The minimum version of ``pyerfa`` is now 1.7.3.

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ tests_require = pytest-astropy
 setup_requires = setuptools_scm
 install_requires =
     numpy>=1.17
-    pyerfa>=1.7.2
+    pyerfa>=1.7.3
 python_requires = >=3.7
 
 [options.packages.find]


### PR DESCRIPTION
Which makes us nicely up to date.