### PR TITLE
Avoid leap second update on astropy import

### DIFF
--- a/astropy/timeseries/tests/test_downsample.py
+++ b/astropy/timeseries/tests/test_downsample.py
@@ -12,8 +12,6 @@ from astropy.timeseries.downsample import aggregate_downsample, reduceat
 
 INPUT_TIME = Time(['2016-03-22T12:30:31', '2016-03-22T12:30:32',
                    '2016-03-22T12:30:33', '2016-03-22T12:30:34'])
-ts = TimeSeries(time=INPUT_TIME, data=[[1, 2, 3, 4]], names=['a'])
-ts_units = TimeSeries(time=INPUT_TIME, data=[[1, 2, 3, 4] * u.count], names=['a'])
 
 
 def test_reduceat():
@@ -41,6 +39,9 @@ def test_timeseries_invalid():
 
 
 def test_downsample():
+    ts = TimeSeries(time=INPUT_TIME, data=[[1, 2, 3, 4]], names=['a'])
+    ts_units = TimeSeries(time=INPUT_TIME, data=[[1, 2, 3, 4] * u.count], names=['a'])
+
     down_1 = aggregate_downsample(ts, time_bin_size=1*u.second)
     u.isclose(down_1.time_bin_size, [1, 1, 1, 1]*u.second)
     assert_equal(down_1.time_bin_start.isot, Time(['2016-03-22T12:30:31.000', '2016-03-22T12:30:32.000',

--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -881,6 +881,11 @@ class LeapSeconds(QTable):
     ``iers.LEAP_SECONDS_LIST_URL``.  Many systems also store a version
     of ``leap-seconds.list`` for use with ``ntp`` (e.g., on Debian/Ubuntu
     systems, ``/usr/share/zoneinfo/leap-seconds.list``).
+
+    To prevent querying internet resources if the available local leap second
+    file(s) are out of date, set ``iers.conf.auto_download = False``. This
+    must be done prior to performing any ``Time`` scale transformations related
+    to UTC (e.g. converting from UTC to TAI).
     """
     # Note: Time instances in this class should use scale='tai' to avoid
     # needing leap seconds in their creation or interpretation.

--- a/astropy/utils/iers/tests/test_leap_second.py
+++ b/astropy/utils/iers/tests/test_leap_second.py
@@ -12,49 +12,11 @@ import erfa
 from astropy.time import Time, TimeDelta
 from astropy.utils.iers import iers
 from astropy.utils.data import get_pkg_data_filename
+from astropy.tests.tests.test_imports import test_imports
 
-# Import every top-level astropy subpackage as a test that the ERFA leap second
+# Import every top-level astropy module as a test that the ERFA leap second
 # table is not updated for normal imports.
-import astropy.config
-import astropy.constants
-import astropy.convolution
-import astropy.coordinates
-import astropy.cosmology
-import astropy.extern
-import astropy.io.fits
-import astropy.io.ascii
-import astropy.io.misc
-import astropy.io.registry
-import astropy.io.tests
-import astropy.io.votable
-import astropy.modeling
-import astropy.nddata
-import astropy.samp
-import astropy.stats
-import astropy.table
-import astropy.tests
-import astropy.time
-import astropy.timeseries
-import astropy.uncertainty
-import astropy.units
-import astropy.utils.argparse
-import astropy.utils.codegen
-import astropy.utils.collections
-import astropy.utils.console
-import astropy.utils.data
-import astropy.utils.data_info
-import astropy.utils.decorators
-import astropy.utils.diff
-import astropy.utils.exceptions
-import astropy.utils.introspection
-import astropy.utils.metadata
-import astropy.utils.misc
-import astropy.utils.parsing
-import astropy.utils.setup_package
-import astropy.utils.shapes
-import astropy.utils.state
-import astropy.visualization
-import astropy.wcs
+test_imports()
 
 # Now test that the erfa leap_seconds table has not been udpated. This must be
 # done at the module level, which unfortunately will abort the entire test run

--- a/astropy/utils/iers/tests/test_leap_second.py
+++ b/astropy/utils/iers/tests/test_leap_second.py
@@ -13,6 +13,63 @@ from astropy.time import Time, TimeDelta
 from astropy.utils.iers import iers
 from astropy.utils.data import get_pkg_data_filename
 
+# Import every top-level astropy subpackage as a test that the ERFA leap second
+# table is not updated for normal imports.
+import astropy.config
+import astropy.constants
+import astropy.convolution
+import astropy.coordinates
+import astropy.cosmology
+import astropy.extern
+import astropy.io.fits
+import astropy.io.ascii
+import astropy.io.misc
+import astropy.io.registry
+import astropy.io.tests
+import astropy.io.votable
+import astropy.modeling
+import astropy.nddata
+import astropy.samp
+import astropy.stats
+import astropy.table
+import astropy.tests
+import astropy.time
+import astropy.timeseries
+import astropy.uncertainty
+import astropy.units
+import astropy.utils.argparse
+import astropy.utils.codegen
+import astropy.utils.collections
+import astropy.utils.console
+import astropy.utils.data
+import astropy.utils.data_info
+import astropy.utils.decorators
+import astropy.utils.diff
+import astropy.utils.exceptions
+import astropy.utils.introspection
+import astropy.utils.metadata
+import astropy.utils.misc
+import astropy.utils.parsing
+import astropy.utils.setup_package
+import astropy.utils.shapes
+import astropy.utils.state
+import astropy.visualization
+import astropy.wcs
+
+# Now test that the erfa leap_seconds table has not been udpated. This must be
+# done at the module level, which unfortunately will abort the entire test run
+# if if fails. Running within a normal pytest test will not work because the
+# other tests will end up updating this attribute by virtue of doing Time UTC
+# transformations.
+assert erfa.leap_seconds._expires is None
+
+# Tests in this module assume that the erfa.leap_seconds attribute has been
+# updated from the `erfa` package built-in table to the astropy built-in
+# leap-second table. That has the effect of ensuring that the
+# `erfa.leap_seconds.expires` property is sufficiently in the future.
+iers_table = iers.LeapSeconds.auto_open()
+erfa.leap_seconds.update(iers_table)
+assert erfa.leap_seconds._expires is not None
 
 SYSTEM_FILE = '/usr/share/zoneinfo/leap-seconds.list'
 

--- a/docs/changes/utils/11638.feature.rst
+++ b/docs/changes/utils/11638.feature.rst
@@ -1,0 +1,8 @@
+Change the Time and IERS leap second handling so that the leap second table is
+updated only when a Time transform involving UTC is performed. Previously this
+update check was done the first time a ``Time`` object was created, which in
+practice occured when importing common astropy subpackages like
+``astropy.coordinates``. Now you can prevent querying internet resources (for
+instance on a cluster) by setting ``iers.conf.auto_download = False``. This can
+be done after importing astrpoy but prior to performing any ``Time`` scale
+transformations related to UTC.

--- a/docs/utils/iers.rst
+++ b/docs/utils/iers.rst
@@ -76,8 +76,9 @@ of the automatic IERS downloading:
   auto_download:
     Enable auto-downloading of the latest IERS data.  If set to ``False`` then
     the local IERS-B file will be used by default (even if the full IERS file
-    with predictions was already downloaded and cached).  This replicates the
-    behavior prior to astropy 1.2.  (default=True)
+    with predictions was already downloaded and cached).  This parameter also
+    controls whether internet resources will be queried to update the leap
+    second table if the installed version is out of date.
 
   auto_max_age:
     Maximum age of predictive data before auto-downloading (days).  See


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to address #11426. Before really getting much further this initial draft raises some questions that probably need @mhvk to answer.

The current version is the minimal implementation that can avoid the leap second update when importing parts of astropy which create Time objects (e.g. coordinates). It moves the leap second checking from `Time.__new__` to `Time._set_scale` (when one of the scales is `'utc'`).

This immediately fails a few of the tests in `test_update_leap_seconds.py`. After some head scratching I discovered that the tests are only passing in `main` because of a what seems like a side-effect of the implementation. The side effect is that `Time` objects are created to represent the `expires` attributes. For instance, one might have decided to represent those `expires` objects as `datetime` instead. I did this with these diffs (in `main`) and indeed saw test failures.
```
diff --git a/astropy/utils/iers/iers.py b/astropy/utils/iers/iers.py
index 01a471750..4f55039fe 100644
--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -1045,8 +1045,7 @@ class LeapSeconds(QTable):
                 if match:
                     day, month, year = match.groups()[0].split()
                     month_nb = MONTH_ABBR.index(month[:3]) + 1
-                    expires = Time(f'{year}-{month_nb:02d}-{day}',
-                                   scale='tai', out_subfmt='date')
+                    expires = datetime(int(year), month_nb, int(day))
                     break
             else:
                 raise ValueError(f'did not find expiration date in {file}')
@@ -1118,9 +1117,7 @@ class LeapSeconds(QTable):
             with erfa.
         """
         current = cls(erfa.leap_seconds.get())
-        current._expires = Time('{0.year:04d}-{0.month:02d}-{0.day:02d}'
-                                .format(erfa.leap_seconds.expires),
-                                scale='tai')
+        current._expires = erfa.leap_seconds.expires
         if not built_in:
             return current
```
A minimal example, inspired by one of the simpler tests, is below. Again, this only works because the auto-update machinery happens to be called in `from_erfa()`.
```
from astropy.utils import iers
from datetime import datetime

built_in = iers.LeapSeconds.from_iers_leap_seconds()
erfa_ls = iers.LeapSeconds.from_erfa()
print('assert', erfa_ls.expires > datetime.now())
```

In the version here in this PR, the side effect goes away and so the tests fail.

Questions:
- Suggestions for where to go with this issue?
- Will the complexity of the code being potentially re-entrant go away now? I confess to begin unable to follow the code logic because of the leap second handling code calling `Time` itself.

Also, in #11426 we settled on a solution with a new configuration variable `leap_second_check_action`. In retrospect this seems a bit over-engineered and I wonder if we can avoid the extra complexity by just relying on `auto_download` to disable leap second internet checking. This goes along with the big-picture goal of trying to reduce complexity (knobs) in astropy.
 
<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>
