### PR TITLE
Allow additional kwargs when reading VOTables using the Unified I/O

### DIFF
--- a/astropy/io/votable/connect.py
+++ b/astropy/io/votable/connect.py
@@ -44,7 +44,8 @@ def is_votable(origin, filepath, fileobj, *args, **kwargs):
         return False
 
 
-def read_table_votable(input, table_id=None, use_names_over_ids=False, verify=None):
+def read_table_votable(input, table_id=None, use_names_over_ids=False,
+                       verify=None, **kwargs):
     """
     Read a Table object from an VO table file
 
@@ -76,9 +77,13 @@ def read_table_votable(input, table_id=None, use_names_over_ids=False, verify=No
         mechanisms.  See the `warnings` module in the Python standard library
         for more information. When not provided, uses the configuration setting
         ``astropy.io.votable.verify``, which defaults to ``'ignore'``.
+
+    **kwargs
+        Additional keyword arguments are passed on to
+        :func:`astropy.io.votable.table.parse`.
     """
     if not isinstance(input, (VOTableFile, VOTable)):
-        input = parse(input, table_id=table_id, verify=verify)
+        input = parse(input, table_id=table_id, verify=verify, **kwargs)
 
     # Parse all table objects
     table_id_mapping = dict()

--- a/astropy/io/votable/tests/table_test.py
+++ b/astropy/io/votable/tests/table_test.py
@@ -15,7 +15,7 @@ from astropy.io.votable.table import parse, writeto
 from astropy.io.votable import tree, conf
 from astropy.io.votable.exceptions import VOWarning, W39, E25
 from astropy.table import Column, Table
-from astropy.units import UnrecognizedUnit
+from astropy.units import Unit
 from astropy.utils.exceptions import AstropyDeprecationWarning
 
 
@@ -105,7 +105,7 @@ def test_pass_kwargs_through_table_interface():
     # Table.read() should pass on keyword arguments meant for parse()
     filename = get_pkg_data_filename('data/nonstandard_units.xml')
     t = Table.read(filename, format='votable', unit_format='generic')
-    assert not isinstance(t['Flux1'].unit, UnrecognizedUnit)
+    assert t['Flux1'].unit == Unit("erg / (Angstrom cm2 s)")
 
 
 def test_names_over_ids():

--- a/astropy/io/votable/tests/table_test.py
+++ b/astropy/io/votable/tests/table_test.py
@@ -14,6 +14,7 @@ from astropy.utils.data import get_pkg_data_filename, get_pkg_data_fileobj
 from astropy.io.votable.table import parse, writeto
 from astropy.io.votable import tree, conf
 from astropy.io.votable.exceptions import VOWarning, W39, E25
+from astropy.table import Column, Table
 from astropy.utils.exceptions import AstropyDeprecationWarning
 
 
@@ -72,8 +73,6 @@ def test_table(tmpdir):
 
 
 def test_read_through_table_interface(tmpdir):
-    from astropy.table import Table
-
     with get_pkg_data_fileobj('data/regression.xml', encoding='binary') as fd:
         t = Table.read(fd, format='votable', table_id='main_table')
 
@@ -95,8 +94,6 @@ def test_read_through_table_interface(tmpdir):
 
 
 def test_read_through_table_interface2():
-    from astropy.table import Table
-
     with get_pkg_data_fileobj('data/regression.xml', encoding='binary') as fd:
         t = Table.read(fd, format='votable', table_id='last_table')
 
@@ -130,8 +127,6 @@ def test_table_read_with_unnamed_tables():
     """
     Issue #927
     """
-    from astropy.table import Table
-
     with get_pkg_data_fileobj('data/names.xml', encoding='binary') as fd:
         t = Table.read(fd, format='votable')
 
@@ -150,7 +145,6 @@ def test_votable_path_object():
 
 
 def test_from_table_without_mask():
-    from astropy.table import Table, Column
     t = Table()
     c = Column(data=[1, 2, 3], name='a')
     t.add_column(c)
@@ -159,7 +153,6 @@ def test_from_table_without_mask():
 
 
 def test_write_with_format():
-    from astropy.table import Table, Column
     t = Table()
     c = Column(data=[1, 2, 3], name='a')
     t.add_column(c)

--- a/astropy/io/votable/tests/table_test.py
+++ b/astropy/io/votable/tests/table_test.py
@@ -15,6 +15,7 @@ from astropy.io.votable.table import parse, writeto
 from astropy.io.votable import tree, conf
 from astropy.io.votable.exceptions import VOWarning, W39, E25
 from astropy.table import Column, Table
+from astropy.units import UnrecognizedUnit
 from astropy.utils.exceptions import AstropyDeprecationWarning
 
 
@@ -98,6 +99,13 @@ def test_read_through_table_interface2():
         t = Table.read(fd, format='votable', table_id='last_table')
 
     assert len(t) == 0
+
+
+def test_pass_kwargs_through_table_interface():
+    # Table.read() should pass on keyword arguments meant for parse()
+    filename = get_pkg_data_filename('data/nonstandard_units.xml')
+    t = Table.read(filename, format='votable', unit_format='generic')
+    assert not isinstance(t['Flux1'].unit, UnrecognizedUnit)
 
 
 def test_names_over_ids():

--- a/docs/changes/io.votable/11643.feature.rst
+++ b/docs/changes/io.votable/11643.feature.rst
@@ -1,0 +1,4 @@
+When reading VOTables using the Unified File Read/Write Interface (i.e. using
+the ``Table.read()`` or ``QTable.read()`` functions) it is now possible to
+specify all keyword arguments that are valid for
+``astropy.io.votable.table.parse()``.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

Reading in VOTables with the functions https://github.com/astropy/astropy/blob/8df6dcfbfe9081074c418b6955e060d37e87ee9b/astropy/io/votable/table.py#L170 or https://github.com/astropy/astropy/blob/8df6dcfbfe9081074c418b6955e060d37e87ee9b/astropy/io/votable/table.py#L30
allows the user to specify many keyword arguments, which are not available when using the Unified File Read/Write Interface. This pull request would allow all keyword arguments that are valid for the `parse()` function to be specified when calling the `Table.read()` or `QTable.read()` functions.

An example of where this would be useful is reading in Gaia archive VOTables as QTables. Calling something like `QTable.read(filename, unit_format='vounit')` would be enough to ensure that composite units get parsed properly.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #10791
