### PR TITLE
Expose WCSCOMPARE_* constants through the wcs module

### DIFF
--- a/astropy/wcs/docstrings.py
+++ b/astropy/wcs/docstrings.py
@@ -365,8 +365,8 @@ cmp : int, optional
     A bit field controlling the strictness of the comparison.  When 0,
     (the default), all fields must be identical.
 
-    The following constants may be or'ed together to loosen the
-    comparison.
+    The following constants, defined in the `astropy.wcs` module,
+    may be or'ed together to loosen the comparison.
 
     - ``WCSCOMPARE_ANCILLARY``: Ignores ancillary keywords that don't
       change the WCS transformation, such as ``DATE-OBS`` or

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -101,7 +101,7 @@ if _wcs is not None:
 
     # Copy all the constants from the C extension into this module's namespace
     for key, val in _wcs.__dict__.items():
-        if key.startswith(('WCSSUB', 'WCSHDR', 'WCSHDO')):
+        if key.startswith(('WCSSUB_', 'WCSHDR_', 'WCSHDO_', 'WCSCOMPARE_')):
             locals()[key] = val
             __all__.append(key)
 

--- a/docs/changes/wcs/11647.bugfix.rst
+++ b/docs/changes/wcs/11647.bugfix.rst
@@ -1,0 +1,1 @@
+Added ``WCSCOMPARE_*`` constants to the list of WCSLIB constants available/exposed through the ``astropy.wcs`` module.


### PR DESCRIPTION
This PR exposes `WCSCOMPARE_*` constants from WCSLIB through the `astropy.wcs` module.

Given that these constants were defined in WCSLIB since, at least 2014 or maybe even since the beginning, I consider this to be a bug since documentation refers to these constants.

Fixes #11631