### PR TITLE
Delegate transformations to the differentials

### DIFF
--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -2906,7 +2906,7 @@ class UnitSphericalDifferential(BaseSphericalDifferential):
             diff = super().transform(matrix, base, transformed_base)
 
         else:  # switch to dimensional representation
-            du = (self.d_lon.unit / base.lon.unit).decompose()  # deriv unit
+            du = self.d_lon.unit / base.lon.unit  # derivative unit
             diff = self._dimensional_differential(
                 d_lon=self.d_lon, d_lat=self.d_lat, d_distance=0 * du
             ).transform(matrix, base, transformed_base)
@@ -3148,9 +3148,10 @@ class UnitSphericalCosLatDifferential(BaseSphericalCosLatDifferential):
             diff = super().transform(matrix, base, transformed_base)
 
         else:  # switch to dimensional representation
-            du = (self.d_lat.unit / u.rad).decompose()  # derivative unit
+            du = self.d_lat.unit / base.lat.unit  # derivative unit
             diff = self._dimensional_differential(
-                d_lon=self.d_lon_coslat, d_lat=self.d_lat, d_distance=0 * du
+                d_lon_coslat=self.d_lon_coslat, d_lat=self.d_lat,
+                d_distance=0 * du
             ).transform(matrix, base, transformed_base)
 
         return diff

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -1388,13 +1388,8 @@ class CartesianRepresentation(BaseRepresentation):
         # erfa rxp: Multiply a p-vector by an r-matrix.
         p = erfa_ufunc.rxp(matrix, self.get_xyz(xyz_axis=-1))
         # Handle differentials attached to this representation
-        if self.differentials:
-            # TODO: speed this up going via d.d_xyz.
-            new_diffs = dict(
-                (k, d.from_cartesian(d.to_cartesian().transform(matrix)))
-                for k, d in self.differentials.items())
-        else:
-            new_diffs = None
+        new_diffs = dict((k, d.transform(matrix, base=self))
+                         for k, d in self.differentials.items())
 
         return self.__class__(p, xyz_axis=-1, copy=False, differentials=new_diffs)
 
@@ -2002,17 +1997,15 @@ class SphericalRepresentation(BaseRepresentation):
             A 3x3 matrix, such as a rotation matrix (or a stack of matrices).
 
         """
-        if self.differentials:
-            # TODO! shortcut if there are differentials.
-            # Currently just super, which uses Cartesian backend.
-            rep = super().transform(matrix)
+        xyz = erfa_ufunc.s2c(self.lon, self.lat)
+        p = erfa_ufunc.rxp(matrix, xyz)
+        lon, lat, ur = erfa_ufunc.p2s(p)
 
-        else:
-            xyz = erfa_ufunc.s2c(self.lon, self.lat)
-            p = erfa_ufunc.rxp(matrix, xyz)
-            lon, lat, ur = erfa_ufunc.p2s(p)
-            rep = self.__class__(lon=lon, lat=lat, distance=self.distance * ur)
+        new_diffs = dict((k, d.transform(matrix, base=self))
+                         for k, d in self.differentials.items())
 
+        rep = self.__class__(lon=lon, lat=lat, distance=self.distance * ur,
+                             differentials=new_diffs, copy=False)
         return rep
 
     def norm(self):
@@ -2196,21 +2189,18 @@ class PhysicsSphericalRepresentation(BaseRepresentation):
             A 3x3 matrix, such as a rotation matrix (or a stack of matrices).
 
         """
-        if self.differentials:
-            # TODO! shortcut if there are differentials.
-            # Currently just super, which uses Cartesian backend.
-            rep = super().transform(matrix)
+        # apply transformation in unit-spherical coordinates
+        xyz = erfa_ufunc.s2c(self.phi, 90*u.deg-self.theta)
+        p = erfa_ufunc.rxp(matrix, xyz)
+        lon, lat, ur = erfa_ufunc.p2s(p)  # `ur` is transformed unit-`r`
 
-        else:
-            # apply transformation in unit-spherical coordinates
-            xyz = erfa_ufunc.s2c(self.phi, 90*u.deg-self.theta)
-            p = erfa_ufunc.rxp(matrix, xyz)
-            lon, lat, ur = erfa_ufunc.p2s(p)  # `ur` is transformed unit-`r`
+        new_diffs = dict((k, d.transform(matrix, base=self))
+                         for k, d in self.differentials.items())
 
-            # create transformed physics-spherical representation,
-            # reapplying the distance scaling
-            rep = self.__class__(phi=lon, theta=90*u.deg-lat, r=self.r * ur)
-
+        # create transformed physics-spherical representation,
+        # reapplying the distance scaling
+        rep = self.__class__(phi=lon, theta=90*u.deg-lat, r=self.r * ur,
+                             differentials=new_diffs, copy=False)
         return rep
 
     def norm(self):
@@ -2549,6 +2539,29 @@ class BaseDifferential(BaseRepresentationOrDifferential):
 
         return cls.from_cartesian(cartesian, base)
 
+    def transform(self, matrix, base):
+        """Transform coordinates using a 3x3 matrix in a Cartesian basis.
+
+        This returns a new differential and does not modify the original one.
+        Any differentials attached to this representation will also be
+        transformed.
+
+        Parameters
+        ----------
+        matrix : (3,3) array-like
+            A 3x3 (or stack thereof) matrix, such as a rotation matrix.
+        base : instance of ``cls.base_representation``
+            Base relative to which the differentials are defined.  If the other
+            class is a differential representation, the base will be converted
+            to its ``base_representation``.
+        """
+        # route transformation through Cartesian
+        cdiff = self.represent_as(CartesianDifferential, base=base
+                                  ).transform(matrix)
+        # move back to original representation
+        diff = cdiff.represent_as(self.__class__, base)
+        return diff
+
     def _scale_operation(self, op, *args):
         """Scale all components.
 
@@ -2697,6 +2710,25 @@ class CartesianDifferential(BaseDifferential):
     @classmethod
     def from_cartesian(cls, other, base=None):
         return cls(*[getattr(other, c) for c in other.components])
+
+    def transform(self, matrix, base=None):
+        """Transform coordinates using a 3x3 matrix in a Cartesian basis.
+
+        This returns a new differential and does not modify the original one.
+        Any differentials attached to this representation will also be
+        transformed.
+
+        Parameters
+        ----------
+        matrix : (3,3) array-like
+            A 3x3 (or stack thereof) matrix, such as a rotation matrix.
+        base : `~astropy.coordinates.CartesianRepresentation` or None, optional
+            Not used in the Cartesian transformation.
+        """
+        # erfa rxp: Multiply a p-vector by an r-matrix.
+        p = erfa_ufunc.rxp(matrix, self.get_d_xyz(xyz_axis=-1))
+
+        return self.__class__(p, xyz_axis=-1, copy=False)
 
     def get_d_xyz(self, xyz_axis=0):
         """Return a vector array of the x, y, and z coordinates.

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -343,6 +343,10 @@ class TestSphericalRepresentation:
         assert_allclose_quantity(s2.lon, s1.lon + 10 * u.deg)
         assert_allclose_quantity(s2.lat, s1.lat)
         assert_allclose_quantity(s2.distance, s1.distance)
+        # check differentials. they shouldn't have changed.
+        assert_allclose_quantity(ds2.d_lon, ds1.d_lon)
+        assert_allclose_quantity(ds2.d_lat, ds1.d_lat)
+        assert_allclose_quantity(ds2.d_distance, ds1.d_distance)
         assert_allclose_quantity(ds2.d_lon, dexpected.d_lon)
         assert_allclose_quantity(ds2.d_lat, dexpected.d_lat)
         assert_allclose_quantity(ds2.d_distance, dexpected.d_distance)
@@ -393,6 +397,11 @@ class TestSphericalRepresentation:
         assert_allclose_quantity(ds2.d_lon, dexpected.d_lon)
         assert_allclose_quantity(ds2.d_lat, dexpected.d_lat)
         assert_allclose_quantity(ds2.d_distance, dexpected.d_distance)
+        # the 2nd component is NaN since the 2nd distance is NaN
+        # TODO! this will change when ``.transform`` skips Cartesian
+        assert_array_equal(np.isnan(ds2.d_lon), (False, True))
+        assert_array_equal(np.isnan(ds2.d_lat), (False, True))
+        assert_array_equal(np.isnan(ds2.d_distance), (False, True))
 
         # now with a non rotation matrix
         matrix = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
@@ -586,8 +595,12 @@ class TestUnitSphericalRepresentation:
 
         assert_allclose_quantity(s2.lon, s1.lon + 10 * u.deg)
         assert_allclose_quantity(s2.lat, s1.lat)
+        # compare differentials. they should be unchanged (ds1).
+        assert_allclose_quantity(ds2.d_lon, ds1.d_lon)
+        assert_allclose_quantity(ds2.d_lat, ds1.d_lat)
         assert_allclose_quantity(ds2.d_lon, dexpected.d_lon)
         assert_allclose_quantity(ds2.d_lat, dexpected.d_lat)
+        assert not hasattr(ds2, "d_distance")
 
         # now with a non rotation matrix
         # note that the result will be a Spherical, not UnitSpherical
@@ -795,6 +808,10 @@ class TestPhysicsSphericalRepresentation:
         assert_allclose_quantity(s2.phi, s1.phi + 10 * u.deg)
         assert_allclose_quantity(s2.theta, s1.theta)
         assert_allclose_quantity(s2.r, s1.r)
+        # compare differentials. should be unchanged (ds1).
+        assert_allclose_quantity(ds2.d_phi, ds1.d_phi)
+        assert_allclose_quantity(ds2.d_theta, ds1.d_theta)
+        assert_allclose_quantity(ds2.d_r, ds1.d_r)
         assert_allclose_quantity(ds2.d_phi, dexpected.d_phi)
         assert_allclose_quantity(ds2.d_theta, dexpected.d_theta)
         assert_allclose_quantity(ds2.d_r, dexpected.d_r)
@@ -1131,6 +1148,11 @@ class TestCartesianRepresentation:
         dexpected = CartesianDifferential.from_cartesian(
             ds1.to_cartesian(base=s1).transform(matrix), base=s2)
 
+        assert_allclose_quantity(ds2.d_x, dexpected.d_x)
+        assert_allclose_quantity(ds2.d_y, dexpected.d_y)
+        assert_allclose_quantity(ds2.d_z, dexpected.d_z)
+
+        # also explicitly calculate, since we can
         assert_allclose(s2.x.value, [1 * 1 + 2 * 3 + 3 * 5, 1 * 2 + 2 * 4 + 3 * 6])
         assert_allclose(s2.y.value, [4 * 1 + 5 * 3 + 6 * 5, 4 * 2 + 5 * 4 + 6 * 6])
         assert_allclose(s2.z.value, [7 * 1 + 8 * 3 + 9 * 5, 7 * 2 + 8 * 4 + 9 * 6])

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -25,6 +25,13 @@ from astropy.coordinates.representation import (
     UnitSphericalCosLatDifferential)
 
 
+# create matrices for use in testing ``.transform()`` methods
+matrices = {
+    "rotation": rotation_matrix(-10, "z", u.deg),
+    "general": np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+}
+
+
 # Preserve the original REPRESENTATION_CLASSES dict so that importing
 #   the test file doesn't add a persistent test subclass (LogDRepresentation)
 def setup_function(func):
@@ -323,7 +330,7 @@ class TestSphericalRepresentation:
         assert representation_equal_up_to_angular_type(got, expected)
 
     def test_transform(self):
-        """Test ``.transform()`` on rotation and general transform matrices."""
+        """Test ``.transform()`` on rotation and general matrices."""
         # set up representation
         ds1 = SphericalDifferential(
             d_lon=[1, 2] * u.mas / u.yr, d_lat=[3, 4] * u.mas / u.yr,
@@ -331,14 +338,12 @@ class TestSphericalRepresentation:
         s1 = SphericalRepresentation(lon=[1, 2] * u.deg, lat=[3, 4] * u.deg,
                                      distance=[5, 6] * u.kpc, differentials=ds1)
 
-        matrix = rotation_matrix(-10, "z", u.deg)
-
         # transform representation & get comparison (thru CartesianRep)
-        s2 = s1.transform(matrix)
+        s2 = s1.transform(matrices["rotation"])
         ds2 =  s2.differentials["s"]
 
         dexpected = SphericalDifferential.from_cartesian(
-            ds1.to_cartesian(base=s1).transform(matrix), base=s2)
+            ds1.to_cartesian(base=s1).transform(matrices["rotation"]), base=s2)
 
         assert_allclose_quantity(s2.lon, s1.lon + 10 * u.deg)
         assert_allclose_quantity(s2.lat, s1.lat)
@@ -352,15 +357,13 @@ class TestSphericalRepresentation:
         assert_allclose_quantity(ds2.d_distance, dexpected.d_distance)
 
         # now with a non rotation matrix
-        matrix = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
-
         # transform representation & get comparison (thru CartesianRep)
-        s3 = s1.transform(matrix)
+        s3 = s1.transform(matrices["general"])
         ds3 = s3.differentials["s"]
 
         expected = (s1.represent_as(CartesianRepresentation,
                                     CartesianDifferential)
-                    .transform(matrix)
+                    .transform(matrices["general"])
                     .represent_as(SphericalRepresentation,
                                   SphericalDifferential))
         dexpected = expected.differentials["s"]
@@ -382,14 +385,12 @@ class TestSphericalRepresentation:
                                      distance=[5, np.nan] * u.kpc,
                                      differentials=ds1)
 
-        matrix = rotation_matrix(-10, "z", u.deg)
-
         # transform representation & get comparison (thru CartesianRep)
-        s2 = s1.transform(matrix)
+        s2 = s1.transform(matrices["rotation"])
         ds2 =  s2.differentials["s"]
 
         dexpected = SphericalDifferential.from_cartesian(
-            ds1.to_cartesian(base=s1).transform(matrix), base=s2)
+            ds1.to_cartesian(base=s1).transform(matrices["rotation"]), base=s2)
 
         assert_allclose_quantity(s2.lon, s1.lon + 10 * u.deg)
         assert_allclose_quantity(s2.lat, s1.lat)
@@ -404,14 +405,12 @@ class TestSphericalRepresentation:
         assert_array_equal(np.isnan(ds2.d_distance), (False, True))
 
         # now with a non rotation matrix
-        matrix = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
-
-        s3 = s1.transform(matrix)
+        s3 = s1.transform(matrices["general"])
         ds3 = s3.differentials["s"]
 
         thruC = (s1.represent_as(CartesianRepresentation,
                                 CartesianDifferential)
-                    .transform(matrix)
+                    .transform(matrices["general"])
                     .represent_as(SphericalRepresentation,
                               differential_class=SphericalDifferential))
         dthruC = thruC.differentials["s"]
@@ -577,21 +576,19 @@ class TestUnitSphericalRepresentation:
         assert representation_equal_up_to_angular_type(got, expected)
 
     def test_transform(self):
-
+        """Test ``.transform()`` on rotation and general matrices."""
         # set up representation
         ds1 = UnitSphericalDifferential(d_lon=[1, 2] * u.mas / u.yr,
                                         d_lat=[3, 4] * u.mas / u.yr,)
         s1 = UnitSphericalRepresentation(lon=[1, 2] * u.deg, lat=[3, 4] * u.deg,
                                          differentials=ds1)
 
-        matrix = rotation_matrix(-10, "z", u.deg)
-
         # transform representation & get comparison (thru CartesianRep)
-        s2 = s1.transform(matrix)
+        s2 = s1.transform(matrices["rotation"])
         ds2 =  s2.differentials["s"]
 
         dexpected = UnitSphericalDifferential.from_cartesian(
-            ds1.to_cartesian(base=s1).transform(matrix), base=s2)
+            ds1.to_cartesian(base=s1).transform(matrices["rotation"]), base=s2)
 
         assert_allclose_quantity(s2.lon, s1.lon + 10 * u.deg)
         assert_allclose_quantity(s2.lat, s1.lat)
@@ -604,14 +601,12 @@ class TestUnitSphericalRepresentation:
 
         # now with a non rotation matrix
         # note that the result will be a Spherical, not UnitSpherical
-        matrix = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
-
-        s3 = s1.transform(matrix)
+        s3 = s1.transform(matrices["general"])
         ds3 = s3.differentials["s"]
 
         expected = (s1.represent_as(CartesianRepresentation,
                                     CartesianDifferential)
-                    .transform(matrix)
+                    .transform(matrices["general"])
                     .represent_as(SphericalRepresentation,
                                   differential_class=SphericalDifferential))
         dexpected = expected.differentials["s"]
@@ -796,14 +791,12 @@ class TestPhysicsSphericalRepresentation:
             phi=[1, 2] * u.deg, theta=[3, 4] * u.deg, r=[5, 6] * u.kpc,
             differentials=ds1)
 
-        matrix = rotation_matrix(-10, "z", u.deg)
-
         # transform representation & get comparison (thru CartesianRep)
-        s2 = s1.transform(matrix)
+        s2 = s1.transform(matrices["rotation"])
         ds2 = s2.differentials["s"]
 
         dexpected = PhysicsSphericalDifferential.from_cartesian(
-            ds1.to_cartesian(base=s1).transform(matrix), base=s2)
+            ds1.to_cartesian(base=s1).transform(matrices["rotation"]), base=s2)
 
         assert_allclose_quantity(s2.phi, s1.phi + 10 * u.deg)
         assert_allclose_quantity(s2.theta, s1.theta)
@@ -817,15 +810,13 @@ class TestPhysicsSphericalRepresentation:
         assert_allclose_quantity(ds2.d_r, dexpected.d_r)
 
         # now with a non rotation matrix
-        matrix = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
-
         # transform representation & get comparison (thru CartesianRep)
-        s3 = s1.transform(matrix)
+        s3 = s1.transform(matrices["general"])
         ds3 = s3.differentials["s"]
 
         expected = (s1.represent_as(CartesianRepresentation,
                                     CartesianDifferential)
-                    .transform(matrix)
+                    .transform(matrices["general"])
                     .represent_as(PhysicsSphericalRepresentation,
                                   PhysicsSphericalDifferential))
         dexpected = expected.differentials["s"]
@@ -847,14 +838,12 @@ class TestPhysicsSphericalRepresentation:
             phi=[1, 2] * u.deg, theta=[3, 4] * u.deg, r=[5, np.nan] * u.kpc,
             differentials=ds1)
 
-        matrix = rotation_matrix(-10, "z", u.deg)
-
         # transform representation & get comparison (thru CartesianRep)
-        s2 = s1.transform(matrix)
+        s2 = s1.transform(matrices["rotation"])
         ds2 =  s2.differentials["s"]
 
         dexpected = PhysicsSphericalDifferential.from_cartesian(
-            ds1.to_cartesian(base=s1).transform(matrix), base=s2)
+            ds1.to_cartesian(base=s1).transform(matrices["rotation"]), base=s2)
 
         assert_allclose_quantity(s2.phi, s1.phi + 10 * u.deg)
         assert_allclose_quantity(s2.theta, s1.theta)
@@ -864,14 +853,12 @@ class TestPhysicsSphericalRepresentation:
         assert_allclose_quantity(ds2.d_r, dexpected.d_r)
 
         # now with a non rotation matrix
-        matrix = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
-
-        s3 = s1.transform(matrix)
+        s3 = s1.transform(matrices["general"])
         ds3 = s3.differentials["s"]
 
         thruC = (s1.represent_as(CartesianRepresentation,
                                  CartesianDifferential)
-                    .transform(matrix)
+                    .transform(matrices["general"])
                     .represent_as(PhysicsSphericalRepresentation,
                                   PhysicsSphericalDifferential))
         dthruC = thruC.differentials["s"]
@@ -1139,14 +1126,12 @@ class TestCartesianRepresentation:
         s1 = CartesianRepresentation(x=[1, 2] * u.kpc, y=[3, 4] * u.kpc,
                                      z=[5, 6] * u.kpc, differentials=ds1)
 
-        matrix = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
-
         # transform representation & get comparison (thru CartesianRep)
-        s2 = s1.transform(matrix)
+        s2 = s1.transform(matrices["general"])
         ds2 =  s2.differentials["s"]
 
         dexpected = CartesianDifferential.from_cartesian(
-            ds1.to_cartesian(base=s1).transform(matrix), base=s2)
+            ds1.to_cartesian(base=s1).transform(matrices["general"]), base=s2)
 
         assert_allclose_quantity(ds2.d_x, dexpected.d_x)
         assert_allclose_quantity(ds2.d_y, dexpected.d_y)
@@ -1306,9 +1291,7 @@ class TestCylindricalRepresentation:
         s1 = CylindricalRepresentation(phi=[1, 2] * u.deg, z=[3, 4] * u.pc,
                                        rho=[5, 6] * u.kpc)
 
-        matrix = rotation_matrix(-10, "z", u.deg)
-
-        s2 = s1.transform(matrix)
+        s2 = s1.transform(matrices["rotation"])
 
         assert_allclose_quantity(s2.phi, s1.phi + 10 * u.deg)
         assert_allclose_quantity(s2.z, s1.z)
@@ -1319,14 +1302,34 @@ class TestCylindricalRepresentation:
         assert s2.rho.unit is u.kpc
 
         # now with a non rotation matrix
-        matrix = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
-
-        s3 = s1.transform(matrix)
-        expected = s1.to_cartesian().transform(matrix).represent_as(CylindricalRepresentation)
+        s3 = s1.transform(matrices["general"])
+        expected = (s1.to_cartesian().transform(matrices["general"])
+                    ).represent_as(CylindricalRepresentation)
 
         assert_allclose_quantity(s3.phi, expected.phi)
         assert_allclose_quantity(s3.z, expected.z)
         assert_allclose_quantity(s3.rho, expected.rho)
+
+
+class TestUnitSphericalCosLatDifferential:
+
+    @pytest.mark.parametrize("matrix", list(matrices.values()))
+    def test_transform(self, matrix):
+        """Test ``.transform()`` on rotation and general matrices."""
+        # set up representation
+        ds1 = UnitSphericalCosLatDifferential(d_lon_coslat=[1, 2] * u.mas / u.yr,
+                                              d_lat=[3, 4] * u.mas / u.yr,)
+        s1 = UnitSphericalRepresentation(lon=[1, 2] * u.deg, lat=[3, 4] * u.deg)
+
+        # transform representation & get comparison (thru CartesianRep)
+        s2 = s1.transform(matrix)
+        ds2 = ds1.transform(matrix, s1, s2)
+
+        dexpected = UnitSphericalCosLatDifferential.from_cartesian(
+            ds1.to_cartesian(base=s1).transform(matrix), base=s2)
+
+        assert_allclose_quantity(ds2.d_lon_coslat, dexpected.d_lon_coslat)
+        assert_allclose_quantity(ds2.d_lat, dexpected.d_lat)
 
 
 def test_cartesian_spherical_roundtrip():
@@ -1883,9 +1886,7 @@ class TestCartesianRepresentationWithDifferential:
                                      z=[5, 6] * u.kpc,
                                      differentials=d1)
 
-        matrix = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
-
-        r2 = r1.transform(matrix)
+        r2 = r1.transform(matrices["general"])
         d2 = r2.differentials['s']
         assert_allclose_quantity(d2.d_x, [22., 28]*u.km/u.s)
         assert_allclose_quantity(d2.d_y, [49, 64]*u.km/u.s)

--- a/docs/changes/coordinates/11654.feature.rst
+++ b/docs/changes/coordinates/11654.feature.rst
@@ -1,0 +1,3 @@
+``transform`` methods are added to ``BaseDifferential`` and ``CartesianDifferential``.
+All transform methods on Representations now delegate transforming differentials
+to the differential objects.


### PR DESCRIPTION
``transform`` methods are added to ``BaseDifferential`` and ``CartesianDifferential``.
All transform methods on Representations now delegate transforming differentials
to the differential objects.

For followup : implement ``transform()`` for spherical differentials to prevent NaN leakage.

@mhvk @adrn 

TODO:
- [x] solve repeat transform issue.
- [x] get review. Is this the right approach, given the implemented solution for the above?
- [x] write test for physics-spherical 

Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

fixes #11560