### PR TITLE
TST: Un-ignore datfix warning from wcslib

### DIFF
--- a/docs/nddata/ccddata.rst
+++ b/docs/nddata/ccddata.rst
@@ -41,7 +41,7 @@ A `~astropy.nddata.CCDData` object can also be initialized from a FITS filename
 or URL:
 
     >>> ccd = CCDData.read('my_file.fits', unit="adu")  # doctest: +SKIP
-    >>> ccd = CCDData.read('http://data.astropy.org/tutorials/FITS-images/HorseHead.fits', unit="adu", cache=True)  # doctest: +REMOTE_DATA
+    >>> ccd = CCDData.read('http://data.astropy.org/tutorials/FITS-images/HorseHead.fits', unit="adu", cache=True)  # doctest: +REMOTE_DATA +IGNORE_WARNINGS
 
 If there is a unit in the FITS file (in the ``BUNIT`` keyword), that will be
 used, but explicitly providing a unit in ``read`` will override any unit in the

--- a/setup.cfg
+++ b/setup.cfg
@@ -143,7 +143,6 @@ filterwarnings =
     # Ignore a warning we emit about not supporting the parallel
     # reading option for now, can be removed once the issue is fixed
     ignore:parallel reading does not currently work, so falling back to serial
-    ignore:'datfix' made the change:astropy.wcs.wcs.FITSFixedWarning
 doctest_norecursedirs =
     */setup_package.py
 doctest_subpackage_requires =


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

The warning (seen since #11260) was unintentional and should have been fixed in the bundled code (#11549).
