### PR TITLE
Fix #9773 -  VOTABLE namespace attributes on write

### DIFF
--- a/astropy/io/votable/tests/data/regression.bin.tabledata.truth.1.3.xml
+++ b/astropy/io/votable/tests/data/regression.bin.tabledata.truth.1.3.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Produced with astropy.io.votable version testing
      http://www.astropy.org/ -->
-<VOTABLE version="1.3" xmlns="http://www.ivoa.net/xml/VOTable/v1.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.3">
+<VOTABLE version="1.3" xmlns="http://www.ivoa.net/xml/VOTable/v1.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.ivoa.net/xml/VOTable/v1.3 http://www.ivoa.net/xml/VOTable/VOTable-1.3.xsd">
  <DESCRIPTION>
   The VOTable format is an XML standard for the interchange of data
   represented as a set of tables. In this context, a table is an

--- a/astropy/io/votable/tests/tree_test.py
+++ b/astropy/io/votable/tests/tree_test.py
@@ -162,4 +162,4 @@ def test_votable_tag():
     xml = votable_xml_string('1.4')
     assert 'xmlns="http://www.ivoa.net/xml/VOTable/v1.3"' in xml
     assert 'xsi:schemaLocation="http://www.ivoa.net/xml/VOTable/v1.3 '
-    'https://www.ivoa.net/xml/VOTable/VOTable-1.4.xsd"' in xml
+    assert 'https://www.ivoa.net/xml/VOTable/VOTable-1.4.xsd"' in xml

--- a/astropy/io/votable/tests/tree_test.py
+++ b/astropy/io/votable/tests/tree_test.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import io
+
 import pytest
 
 from astropy.io.votable.exceptions import W07, W08, W21, W41

--- a/astropy/io/votable/tests/tree_test.py
+++ b/astropy/io/votable/tests/tree_test.py
@@ -7,7 +7,6 @@ from astropy.io.votable.exceptions import W07, W08, W21, W41
 from astropy.io.votable import tree
 from astropy.io.votable.table import parse
 from astropy.io.votable.tree import VOTableFile, Resource
-from astropy.tests.helper import raises
 from astropy.utils.data import get_pkg_data_filename
 
 

--- a/astropy/io/votable/tests/tree_test.py
+++ b/astropy/io/votable/tests/tree_test.py
@@ -1,23 +1,26 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import io
+import pytest
 
-from astropy.io.votable import exceptions
+from astropy.io.votable.exceptions import W07, W08, W21, W41
 from astropy.io.votable import tree
 from astropy.io.votable.table import parse
+from astropy.io.votable.tree import VOTableFile, Resource
 from astropy.tests.helper import raises
 from astropy.utils.data import get_pkg_data_filename
 
 
-@raises(exceptions.W07)
 def test_check_astroyear_fail():
-    config = {'verify': 'exception'}
-    field = tree.Field(None, name='astroyear', arraysize='1')
-    tree.check_astroyear('X2100', field, config)
+    with raises(W07):
+        config = {'verify': 'exception'}
+        field = tree.Field(None, name='astroyear', arraysize='1')
+        tree.check_astroyear('X2100', field, config)
 
 
-@raises(exceptions.W08)
 def test_string_fail():
-    config = {'verify': 'exception'}
-    tree.check_string(42, 'foo', config)
+    with raises(W08):
+        config = {'verify': 'exception'}
+        tree.check_string(42, 'foo', config)
 
 
 def test_make_Fields():
@@ -50,3 +53,113 @@ def test_unit_format():
     data = parse(get_pkg_data_filename('data/timesys.xml'))
     assert data._config['version'] == '1.4'
     assert tree._get_default_unit_format(data._config) == 'vounit'
+
+
+def test_namespace_warning():
+    """
+    A version 1.4 VOTable must use the same namespace as 1.3.
+    (see https://www.ivoa.net/documents/VOTable/20191021/REC-VOTable-1.4-20191021.html#ToC16)
+    """
+    bad_namespace = b'''<?xml version="1.0" encoding="utf-8"?>
+        <VOTABLE version="1.4" xmlns="http://www.ivoa.net/xml/VOTable/v1.4"
+                               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+          <RESOURCE/>
+        </VOTABLE>
+    '''
+    with pytest.raises(W41):
+        parse(io.BytesIO(bad_namespace), verify='exception')
+
+    good_namespace_14 = b'''<?xml version="1.0" encoding="utf-8"?>
+        <VOTABLE version="1.4" xmlns="http://www.ivoa.net/xml/VOTable/v1.3"
+                               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+          <RESOURCE/>
+        </VOTABLE>
+    '''
+    parse(io.BytesIO(good_namespace_14), verify='exception')
+
+    good_namespace_13 = b'''<?xml version="1.0" encoding="utf-8"?>
+        <VOTABLE version="1.3" xmlns="http://www.ivoa.net/xml/VOTable/v1.3"
+                               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+          <RESOURCE/>
+        </VOTABLE>
+    '''
+    parse(io.BytesIO(good_namespace_13), verify='exception')
+
+
+def test_version():
+    """
+    VOTableFile.__init__ allows versions of '1.0', '1.1', '1.2', '1.3' and '1.4'.
+    The '1.0' is curious since other checks in parse() and the version setter do not allow '1.0'.
+    This test confirms that behavior for now.  A future change may remove the '1.0'.
+    """
+
+    # Exercise the checks in __init__
+    VOTableFile(version='1.0')
+    VOTableFile(version='1.1')
+    VOTableFile(version='1.2')
+    VOTableFile(version='1.3')
+    VOTableFile(version='1.4')
+    with pytest.raises(ValueError):
+        VOTableFile(version='0.9')
+    with pytest.raises(ValueError, match=r"should be in \('1.0', '1.1', '1.2', '1.3', '1.4'\)."):
+        VOTableFile(version='2.0')
+
+    # Exercise the checks in the setter
+    vot = VOTableFile()
+    vot.version = '1.1'
+    vot.version = '1.2'
+    vot.version = '1.3'
+    vot.version = '1.4'
+    with pytest.raises(ValueError):
+        vot.version = '1.0'
+    with pytest.raises(ValueError, match=r"supports VOTable versions '1.1', '1.2', '1.3', '1.4'$"):
+        vot.version = '2.0'
+
+    # Exercise the checks in the parser.
+    begin = b'<?xml version="1.0" encoding="utf-8"?><VOTABLE version="'
+    middle = b'" xmlns="http://www.ivoa.net/xml/VOTable/v'
+    end = b'" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><RESOURCE/></VOTABLE>'
+
+    # Valid versions
+    parse(io.BytesIO(begin + b'1.1' + middle + b'1.1' + end), verify='exception')
+    parse(io.BytesIO(begin + b'1.2' + middle + b'1.2' + end), verify='exception')
+    parse(io.BytesIO(begin + b'1.3' + middle + b'1.3' + end), verify='exception')
+    parse(io.BytesIO(begin + b'1.4' + middle + b'1.3' + end), verify='exception')
+
+    # Invalid versions
+    with pytest.raises(W21):
+        parse(io.BytesIO(begin + b'1.0' + middle + b'1.0' + end), verify='exception')
+    with pytest.raises(W21):
+        parse(io.BytesIO(begin + b'2.0' + middle + b'1.0' + end), verify='exception')
+
+
+def votable_xml_string(version):
+    votable_file = VOTableFile(version=version)
+    votable_file.resources.append(Resource())
+
+    xml_bytes = io.BytesIO()
+    votable_file.to_xml(xml_bytes)
+    xml_bytes.seek(0)
+    bstring = xml_bytes.read()
+    s = bstring.decode("utf-8")
+    return s
+
+
+def test_votable_tag():
+    xml = votable_xml_string('1.1')
+    assert 'xmlns="http://www.ivoa.net/xml/VOTable/v1.1"' in xml
+    assert 'xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.1"' in xml
+
+    xml = votable_xml_string('1.2')
+    assert 'xmlns="http://www.ivoa.net/xml/VOTable/v1.2"' in xml
+    assert 'xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.2"' in xml
+
+    xml = votable_xml_string('1.3')
+    assert 'xmlns="http://www.ivoa.net/xml/VOTable/v1.3"' in xml
+    assert 'xsi:schemaLocation="http://www.ivoa.net/xml/VOTable/v1.3 '
+    'https://www.ivoa.net/xml/VOTable/VOTable-1.3.xsd"' in xml
+
+    xml = votable_xml_string('1.4')
+    assert 'xmlns="http://www.ivoa.net/xml/VOTable/v1.3"' in xml
+    assert 'xsi:schemaLocation="http://www.ivoa.net/xml/VOTable/v1.3 '
+    'https://www.ivoa.net/xml/VOTable/VOTable-1.4.xsd"' in xml

--- a/astropy/io/votable/tests/tree_test.py
+++ b/astropy/io/votable/tests/tree_test.py
@@ -11,9 +11,9 @@ from astropy.utils.data import get_pkg_data_filename
 
 
 def test_check_astroyear_fail():
-    with raises(W07):
-        config = {'verify': 'exception'}
-        field = tree.Field(None, name='astroyear', arraysize='1')
+    config = {'verify': 'exception'}
+    field = tree.Field(None, name='astroyear', arraysize='1')
+    with pytest.raises(W07):
         tree.check_astroyear('X2100', field, config)
 
 

--- a/astropy/io/votable/tests/tree_test.py
+++ b/astropy/io/votable/tests/tree_test.py
@@ -18,8 +18,8 @@ def test_check_astroyear_fail():
 
 
 def test_string_fail():
-    with raises(W08):
-        config = {'verify': 'exception'}
+    config = {'verify': 'exception'}
+    with pytest.raises(W08):
         tree.check_string(42, 'foo', config)
 
 

--- a/astropy/io/votable/tests/tree_test.py
+++ b/astropy/io/votable/tests/tree_test.py
@@ -157,7 +157,7 @@ def test_votable_tag():
     xml = votable_xml_string('1.3')
     assert 'xmlns="http://www.ivoa.net/xml/VOTable/v1.3"' in xml
     assert 'xsi:schemaLocation="http://www.ivoa.net/xml/VOTable/v1.3 '
-    'https://www.ivoa.net/xml/VOTable/VOTable-1.3.xsd"' in xml
+    assert 'https://www.ivoa.net/xml/VOTable/VOTable-1.3.xsd"' in xml
 
     xml = votable_xml_string('1.4')
     assert 'xmlns="http://www.ivoa.net/xml/VOTable/v1.3"' in xml

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -8,6 +8,7 @@ import gzip
 import base64
 import codecs
 import urllib.request
+import warnings
 
 # THIRD-PARTY
 import numpy as np
@@ -18,6 +19,7 @@ from astropy.io import fits
 from astropy import __version__ as astropy_version
 from astropy.utils.collections import HomogeneousList
 from astropy.utils.xml.writer import XMLWriter
+from astropy.utils.exceptions import AstropyDeprecationWarning
 
 from . import converters
 from .exceptions import (warn_or_raise, vo_warn, vo_raise, vo_reraise,
@@ -3404,7 +3406,10 @@ class VOTableFile(Element, _IDProperty, _DescriptionProperty):
         self._groups = HomogeneousList(Group)
 
         version = str(version)
-        if (version != '1.0') and (version not in self._version_namespace_map):
+        if version == '1.0':
+            warnings.warn('VOTable 1.0 support is deprecated in astropy 4.3 and will be '
+                          'removed in a future release', AstropyDeprecationWarning)
+        elif (version != '1.0') and (version not in self._version_namespace_map):
             allowed_from_map = "', '".join(self._version_namespace_map)
             raise ValueError(f"'version' should be in ('1.0', '{allowed_from_map}').")
 

--- a/docs/changes/io.votable/11659.api.rst
+++ b/docs/changes/io.votable/11659.api.rst
@@ -1,0 +1,1 @@
+The use of ``version='1.0'`` is now fully deprecated in constructing a ``astropy.io.votable.tree.VOTableFile``.

--- a/docs/changes/io.votable/11659.bugfix.rst
+++ b/docs/changes/io.votable/11659.bugfix.rst
@@ -1,0 +1,1 @@
+VOTables are now written with the correct namespace and schema location attributes.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to address issue #9773 which pointed out that starting with VOTables were being written with invalid namespace attributes.  This behavior meant among other things that VOTables written by `astropy.io.votable` failed `volint` checks.

For VOTable versions prior to 1.4, the namespace URI and schema URL were easy to derive with a template string and the version number.  Version 1.4 coincided with a change in how the IVOA versioned namespaces with minor revs to a standard, so the template didn't work anymore.  When v1.4 was implemented here, that templating was missed, so the wrong values were written out.

Instead of modifying the logic to be more version dependent and harder to read, I decided to explicitly declare the  namespace URI and schema location in a map for each version.  I then used that same map as the list of allowable versions in scattered checks in the parser and constructor.  I'm hoping this approach will make implementing the next version just slightly easier and less error prone.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #9773
