### PR TITLE
Change SkyCoord __eq__ behavior to not raise exception

### DIFF
--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -364,16 +364,19 @@ class SkyCoord(ShapedLikeNDArray):
         equivalent, extra frame attributes are equivalent, and that the
         representation data are exactly equal.
         """
-        # Make sure that any extra frame attribute names are equivalent.
-        for attr in self._extra_frameattr_names | value._extra_frameattr_names:
-            if not self.frame._frameattr_equiv(getattr(self, attr),
-                                               getattr(value, attr)):
-                raise ValueError(f"cannot compare: extra frame attribute "
-                                 f"'{attr}' is not equivalent "
-                                 f"(perhaps compare the frames directly to avoid "
-                                 f"this exception)")
+        try:
+            # Make sure that any extra frame attribute names are equivalent.
+            for attr in self._extra_frameattr_names | value._extra_frameattr_names:
+                if not self.frame._frameattr_equiv(getattr(self, attr),
+                                                   getattr(value, attr)):
+                    raise ValueError(f"cannot compare: extra frame attribute "
+                                     f"'{attr}' is not equivalent "
+                                     f"(perhaps compare the frames directly to avoid "
+                                     f"this exception)")
 
-        return self._sky_coord_frame == value._sky_coord_frame
+            return self._sky_coord_frame == value._sky_coord_frame
+        except Exception:
+            return False
 
     def __ne__(self, value):
         return np.logical_not(self == value)

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -384,15 +384,11 @@ def test_equal():
     assert (sc1[0] != sc2[0]) == False  # noqa
 
 
-def test_equal_exceptions():
+def test_equal_no_equal():
     sc1 = SkyCoord(1*u.deg, 2*u.deg, obstime='B1955')
     sc2 = SkyCoord(1*u.deg, 2*u.deg)
-    with pytest.raises(ValueError, match=r"cannot compare: extra frame "
-                       r"attribute 'obstime' is not equivalent \(perhaps compare the "
-                       r"frames directly to avoid this exception\)"):
-        sc1 == sc2
-    # Note that this exception is the only one raised directly in SkyCoord.
-    # All others come from lower-level classes and are tested in test_frames.py.
+    assert not sc1 == sc2
+    assert not sc1 == 'my_string'
 
 
 def test_attr_inheritance():

--- a/docs/changes/coordinates/11663.api.rst
+++ b/docs/changes/coordinates/11663.api.rst
@@ -1,0 +1,2 @@
+``SkyCoord`` equality check now returns ``False`` on invalid check instead
+of throwing exception.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to fix #11661 . It does change existing behavior, as I had to modify a test with this change, so it doesn't qualify as bug fix and should not be backported.

If this is too controversial and need time for discussion, please move the milestone.