### PR TITLE
Added support for stdfunc='mad_std' in sigma clipping

### DIFF
--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -603,7 +603,9 @@ class SigmaClip:
                 return np.ma.filled(data.astype(float), fill_value=np.nan)
 
         # Shortcut for common cases where a fast C implementation can be used.
-        if self.cenfunc in ('mean', 'median') and self.stdfunc in ('std', 'mad_std') and axis is not None and not self.grow:
+        if (self.cenfunc in ('mean', 'median') and
+                self.stdfunc in ('std', 'mad_std') and
+                axis is not None and not self.grow):
             return self._sigmaclip_fast(data, axis=axis, masked=masked,
                                         return_bounds=return_bounds,
                                         copy=copy)

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -151,7 +151,7 @@ class SigmaClip:
     cenfunc : {'median', 'mean'} or callable, optional
         The statistic or callable function/object used to compute the
         center value for the clipping. If using a callable function/object and
-        the ``axis`` keyword is used, then it must be callable that can ignore
+        the ``axis`` keyword is used, then it must be able to ignore
         NaNs (e.g., `numpy.nanmean`) and has an ``axis`` keyword to return an
         array with axis dimension(s) removed.  The default is ``'median'``.
 
@@ -159,7 +159,7 @@ class SigmaClip:
         The statistic or callable function/object used to compute the
         standard deviation about the center value. If using a callable
         function/object and the ``axis`` keyword is used, then it must
-        be callable that can ignore NaNs (e.g., `numpy.nanstd`) and has
+        be able to ignore NaNs (e.g., `numpy.nanstd`) and has
         an ``axis`` keyword to return an array with axis dimension(s)
         removed.  The default is ``'std'``.
 
@@ -689,7 +689,7 @@ def sigma_clip(data, sigma=3, sigma_lower=None, sigma_upper=None, maxiters=5,
     cenfunc : {'median', 'mean'} or callable, optional
         The statistic or callable function/object used to compute the
         center value for the clipping. If using a callable function/object and
-        the ``axis`` keyword is used, then it must be callable that can ignore
+        the ``axis`` keyword is used, then it must be able to ignore
         NaNs (e.g., `numpy.nanmean`) and has an ``axis`` keyword to return an
         array with axis dimension(s) removed.  The default is ``'median'``.
 
@@ -697,7 +697,7 @@ def sigma_clip(data, sigma=3, sigma_lower=None, sigma_upper=None, maxiters=5,
         The statistic or callable function/object used to compute the
         standard deviation about the center value. If using a callable
         function/object and the ``axis`` keyword is used, then it must
-        be callable that can ignore NaNs (e.g., `numpy.nanstd`) and has
+        be able to ignore NaNs (e.g., `numpy.nanstd`) and has
         an ``axis`` keyword to return an array with axis dimension(s)
         removed.  The default is ``'std'``.
 
@@ -862,7 +862,7 @@ def sigma_clipped_stats(data, mask=None, mask_value=None, sigma=3.0,
     cenfunc : {'median', 'mean'} or callable, optional
         The statistic or callable function/object used to compute the
         center value for the clipping. If using a callable function/object and
-        the ``axis`` keyword is used, then it must be callable that can ignore
+        the ``axis`` keyword is used, then it must be able to ignore
         NaNs (e.g., `numpy.nanmean`) and has an ``axis`` keyword to return an
         array with axis dimension(s) removed.  The default is ``'median'``.
 
@@ -870,7 +870,7 @@ def sigma_clipped_stats(data, mask=None, mask_value=None, sigma=3.0,
         The statistic or callable function/object used to compute the
         standard deviation about the center value. If using a callable
         function/object and the ``axis`` keyword is used, then it must
-        be callable that can ignore NaNs (e.g., `numpy.nanstd`) and has
+        be able to ignore NaNs (e.g., `numpy.nanstd`) and has
         an ``axis`` keyword to return an array with axis dimension(s)
         removed.  The default is ``'std'``.
 

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -281,7 +281,6 @@ class SigmaClip:
             else:
                 raise ValueError(f'{stdfunc} is an invalid stdfunc.')
 
-
         return stdfunc
 
     def _compute_bounds(self, data, axis=None):

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -150,21 +150,14 @@ class SigmaClip:
 
     cenfunc : {'median', 'mean'} or callable, optional
         The statistic or callable function/object used to compute the
-        center value for the clipping.  If set to ``'median'`` or
-        ``'mean'`` then having the optional `bottleneck`_ package
-        installed will result in the best performance.  If using a
-        callable function/object and the ``axis`` keyword is used, then
-        it must be callable that can ignore NaNs (e.g., `numpy.nanmean`)
-        and has an ``axis`` keyword to return an array with axis
-        dimension(s) removed.  The default is ``'median'``.
-
-        .. _bottleneck:  https://github.com/pydata/bottleneck
+        center value for the clipping. If using a callable function/object and
+        the ``axis`` keyword is used, then it must be callable that can ignore
+        NaNs (e.g., `numpy.nanmean`) and has an ``axis`` keyword to return an
+        array with axis dimension(s) removed.  The default is ``'median'``.
 
     stdfunc : {'std', 'mad_std'} or callable, optional
         The statistic or callable function/object used to compute the
-        standard deviation about the center value.  If set to ``'std'``
-        then having the optional `bottleneck`_ package installed will
-        result in the best performance.  If using a callable
+        standard deviation about the center value. If using a callable
         function/object and the ``axis`` keyword is used, then it must
         be callable that can ignore NaNs (e.g., `numpy.nanstd`) and has
         an ``axis`` keyword to return an array with axis dimension(s)
@@ -176,6 +169,16 @@ class SigmaClip:
         specified). As an example, for a 2D image a value of 1 will mask the
         nearest pixels in a cross pattern around each deviant pixel, while
         1.5 will also reject the nearest diagonal neighbours and so on.
+
+    Notes
+    -----
+
+    The best performance will typically be obtained by setting ``cenfunc`` and
+    ``stdfunc`` to one of the built-in functions specified as as string. If one of
+    the options is set to a string while the other has a custom callable, you may in some
+    cases see better performance if you have the `bottleneck`_ package installed.
+
+    .. _bottleneck:  https://github.com/pydata/bottleneck
 
     See Also
     --------
@@ -683,21 +686,14 @@ def sigma_clip(data, sigma=3, sigma_lower=None, sigma_upper=None, maxiters=5,
 
     cenfunc : {'median', 'mean'} or callable, optional
         The statistic or callable function/object used to compute the
-        center value for the clipping.  If set to ``'median'`` or
-        ``'mean'`` then having the optional `bottleneck`_ package
-        installed will result in the best performance.  If using a
-        callable function/object and the ``axis`` keyword is used, then
-        it must be callable that can ignore NaNs (e.g., `numpy.nanmean`)
-        and has an ``axis`` keyword to return an array with axis
-        dimension(s) removed.  The default is ``'median'``.
-
-        .. _bottleneck:  https://github.com/pydata/bottleneck
+        center value for the clipping. If using a callable function/object and
+        the ``axis`` keyword is used, then it must be callable that can ignore
+        NaNs (e.g., `numpy.nanmean`) and has an ``axis`` keyword to return an
+        array with axis dimension(s) removed.  The default is ``'median'``.
 
     stdfunc : {'std', 'mad_std'} or callable, optional
         The statistic or callable function/object used to compute the
-        standard deviation about the center value.  If set to ``'std'``
-        then having the optional `bottleneck`_ package installed will
-        result in the best performance.  If using a callable
+        standard deviation about the center value. If using a callable
         function/object and the ``axis`` keyword is used, then it must
         be callable that can ignore NaNs (e.g., `numpy.nanstd`) and has
         an ``axis`` keyword to return an array with axis dimension(s)
@@ -758,6 +754,16 @@ def sigma_clip(data, sigma=3, sigma_lower=None, sigma_upper=None, maxiters=5,
         will also contain ``np.nan`` where the input mask was `True`.
         If ``return_bounds=True`` then the returned minimum and maximum
         clipping thresholds will be be `~numpy.ndarray`\\s.
+
+    Notes
+    -----
+
+    The best performance will typically be obtained by setting ``cenfunc`` and
+    ``stdfunc`` to one of the built-in functions specified as as string. If one of
+    the options is set to a string while the other has a custom callable, you may in some
+    cases see better performance if you have the `bottleneck`_ package installed.
+
+    .. _bottleneck:  https://github.com/pydata/bottleneck
 
     See Also
     --------
@@ -853,21 +859,14 @@ def sigma_clipped_stats(data, mask=None, mask_value=None, sigma=3.0,
 
     cenfunc : {'median', 'mean'} or callable, optional
         The statistic or callable function/object used to compute the
-        center value for the clipping.  If set to ``'median'`` or
-        ``'mean'`` then having the optional `bottleneck`_ package
-        installed will result in the best performance.  If using a
-        callable function/object and the ``axis`` keyword is used, then
-        it must be callable that can ignore NaNs (e.g., `numpy.nanmean`)
-        and has an ``axis`` keyword to return an array with axis
-        dimension(s) removed.  The default is ``'median'``.
-
-        .. _bottleneck:  https://github.com/pydata/bottleneck
+        center value for the clipping. If using a callable function/object and
+        the ``axis`` keyword is used, then it must be callable that can ignore
+        NaNs (e.g., `numpy.nanmean`) and has an ``axis`` keyword to return an
+        array with axis dimension(s) removed.  The default is ``'median'``.
 
     stdfunc : {'std', 'mad_std'} or callable, optional
         The statistic or callable function/object used to compute the
-        standard deviation about the center value.  If set to ``'std'``
-        then having the optional `bottleneck`_ package installed will
-        result in the best performance.  If using a callable
+        standard deviation about the center value. If using a callable
         function/object and the ``axis`` keyword is used, then it must
         be callable that can ignore NaNs (e.g., `numpy.nanstd`) and has
         an ``axis`` keyword to return an array with axis dimension(s)
@@ -890,6 +889,16 @@ def sigma_clipped_stats(data, mask=None, mask_value=None, sigma=3.0,
         specified). As an example, for a 2D image a value of 1 will mask the
         nearest pixels in a cross pattern around each deviant pixel, while
         1.5 will also reject the nearest diagonal neighbours and so on.
+
+    Notes
+    -----
+
+    The best performance will typically be obtained by setting ``cenfunc`` and
+    ``stdfunc`` to one of the built-in functions specified as as string. If one of
+    the options is set to a string while the other has a custom callable, you may in some
+    cases see better performance if you have the `bottleneck`_ package installed.
+
+    .. _bottleneck:  https://github.com/pydata/bottleneck
 
     Returns
     -------

--- a/astropy/stats/src/compute_bounds.c
+++ b/astropy/stats/src/compute_bounds.c
@@ -34,7 +34,6 @@ void compute_sigma_clipped_bounds(double buffer[], int count, int use_median,
 
     if (use_mad_std) {
 
-      buffer2 = malloc(count * sizeof(double*));
       for (i = 0; i < count; i++) {
         buffer2[i] = fabs(buffer[i] - median);
       }

--- a/astropy/stats/src/compute_bounds.c
+++ b/astropy/stats/src/compute_bounds.c
@@ -2,10 +2,10 @@
 #include <math.h>
 #include <stdlib.h>
 
-void compute_sigma_clipped_bounds(double buffer[], int count, int use_median,
+void compute_sigma_clipped_bounds(double data_buffer[], int count, int use_median,
                                   int use_mad_std, int maxiters, double sigma_lower,
                                   double sigma_upper, double *lower_bound,
-                                  double *upper_bound, double buffer2[]) {
+                                  double *upper_bound, double  mad_buffer[]) {
 
   double mean, std, median, cen;
   int i, new_count, iteration = 0;
@@ -13,7 +13,7 @@ void compute_sigma_clipped_bounds(double buffer[], int count, int use_median,
   while (1) {
 
     if (use_median || use_mad_std) {
-      median = wirth_median(buffer, count);
+      median = wirth_median(data_buffer, count);
     }
 
     // Note that we don't use an else clause here, because the mean
@@ -21,7 +21,7 @@ void compute_sigma_clipped_bounds(double buffer[], int count, int use_median,
     if (!use_median || !use_mad_std) {
       mean = 0;
       for (i = 0; i < count; i++) {
-        mean += buffer[i];
+        mean += data_buffer[i];
       }
       mean /= count;
     }
@@ -35,15 +35,15 @@ void compute_sigma_clipped_bounds(double buffer[], int count, int use_median,
     if (use_mad_std) {
 
       for (i = 0; i < count; i++) {
-        buffer2[i] = fabs(buffer[i] - median);
+        mad_buffer[i] = fabs(data_buffer[i] - median);
       }
-      std = wirth_median(buffer2, count) * 1.482602218505602;
+      std = wirth_median(mad_buffer, count) * 1.482602218505602;
 
     } else {
 
       std = 0;
       for (i = 0; i < count; i++) {
-        std += pow(mean - buffer[i], 2);
+        std += pow(mean - data_buffer[i], 2);
       }
       std = sqrt(std / count);
 
@@ -57,8 +57,8 @@ void compute_sigma_clipped_bounds(double buffer[], int count, int use_median,
     // packed array of 'valid' values
     new_count = 0;
     for (i = 0; i < count; i++) {
-      if (buffer[i] >= *lower_bound && buffer[i] <= *upper_bound) {
-        buffer[new_count] = buffer[i];
+      if (data_buffer[i] >= *lower_bound && data_buffer[i] <= *upper_bound) {
+        data_buffer[new_count] = data_buffer[i];
         new_count += 1;
       }
     }

--- a/astropy/stats/src/compute_bounds.h
+++ b/astropy/stats/src/compute_bounds.h
@@ -1,8 +1,8 @@
 #ifndef __COMPUTE_BOUNDS_H__
 #define __COMPUTE_BOUNDS_H__
 
-void compute_sigma_clipped_bounds(double buffer[], int count, int use_median, int use_mad_std,
+void compute_sigma_clipped_bounds(double data_buffer[], int count, int use_median, int use_mad_std,
                                   int maxiters, double sigma_lower, double sigma_upper,
-                                  double *lower_bound, double *upper_bound, double buffer2[]);
+                                  double *lower_bound, double *upper_bound, double mad_buffer[]);
 
 #endif

--- a/astropy/stats/src/compute_bounds.h
+++ b/astropy/stats/src/compute_bounds.h
@@ -1,8 +1,8 @@
 #ifndef __COMPUTE_BOUNDS_H__
 #define __COMPUTE_BOUNDS_H__
 
-void compute_sigma_clipped_bounds(double buffer[], int count, int use_median,
+void compute_sigma_clipped_bounds(double buffer[], int count, int use_median, int use_mad_std,
                                   int maxiters, double sigma_lower, double sigma_upper,
-                                  double *lower_bound, double *upper_bound);
+                                  double *lower_bound, double *upper_bound, double buffer2[]);
 
 #endif

--- a/astropy/stats/src/fast_sigma_clip.c
+++ b/astropy/stats/src/fast_sigma_clip.c
@@ -29,10 +29,11 @@ static PyMethodDef module_methods[] = {{NULL, NULL, 0, NULL}};
 MOD_INIT(_fast_sigma_clip) {
     PyObject *m, *d;
     PyUFuncObject *ufunc;
-    static char types[8] = {
+    static char types[9] = {
         NPY_DOUBLE, /* data array */
         NPY_BOOL, /* mask array */
         NPY_BOOL, /* use median */
+        NPY_BOOL, /* use mad_std */
         NPY_INT, /* max iter */
         NPY_DOUBLE, /* sigma low */
         NPY_DOUBLE, /* sigma high */
@@ -54,8 +55,8 @@ MOD_INIT(_fast_sigma_clip) {
     import_umath();
 
     ufunc = (PyUFuncObject *)PyUFunc_FromFuncAndDataAndSignature(
-        funcs, data, types, 1, 6, 2, PyUFunc_None, "_sigma_clip_fast",
-        _sigma_clip_fast_docstring, 0, "(n),(n),(),(),(),()->(),()");
+        funcs, data, types, 1, 7, 2, PyUFunc_None, "_sigma_clip_fast",
+        _sigma_clip_fast_docstring, 0, "(n),(n),(),(),(),(),()->(),()");
     if (ufunc == NULL) {
         goto fail;
     }
@@ -83,6 +84,8 @@ static void _sigma_clip_fast(
     npy_intp s_mask = *steps++;
     char *use_median = *args++;
     npy_intp s_use_median = *steps++;
+    char *use_mad_std = *args++;
+    npy_intp s_use_mad_std = *steps++;
     char *max_iter = *args++;
     npy_intp s_max_iter = *steps++;
     char *sigma_low = *args++;
@@ -100,17 +103,30 @@ static void _sigma_clip_fast(
     npy_intp is_mask = *steps++;
 
     double *buffer = NULL;
+    double *buffer2 = NULL;
 
+    // buffer is used to store the current values being sigma clipped
     buffer = (double *)PyArray_malloc(n_i * sizeof(double));
     if (buffer == NULL) {
         PyErr_NoMemory();
         return;
     }
+
+    // buffer2 is available to be used by compute_sigma_clipped_bounds
+    // for other purposes if needed, such as when computing mad_std.
+    buffer2 = (double *)PyArray_malloc(n_i * sizeof(double));
+    if (buffer2 == NULL) {
+        PyErr_NoMemory();
+        return;
+    }
+
     for (i_o = 0; i_o < n_o;
-         i_o++, array += s_array, mask += s_mask,
-             use_median += s_use_median, max_iter += s_max_iter,
-             sigma_low += s_sigma_low, sigma_high += s_sigma_high,
-             bound_low += s_bound_low, bound_high += s_bound_high) {
+         i_o++, array += s_array,
+                mask += s_mask,
+                use_median += s_use_median, use_mad_std += s_use_mad_std,
+                max_iter += s_max_iter,
+                sigma_low += s_sigma_low, sigma_high += s_sigma_high,
+                bound_low += s_bound_low, bound_high += s_bound_high) {
         /* copy to buffer */
         in_array = array;
         in_mask = mask;
@@ -124,9 +140,10 @@ static void _sigma_clip_fast(
         if (count > 0) {
             compute_sigma_clipped_bounds(
                 buffer, count,
-                (int)(*(npy_bool *)use_median), *(int *)max_iter,
+                (int)(*(npy_bool *)use_median), (int)(*(npy_bool *)use_mad_std),
+                *(int *)max_iter,
                 *(double *)sigma_low, *(double *)sigma_high,
-                (double *)bound_low, (double *)bound_high);
+                (double *)bound_low, (double *)bound_high, buffer2);
         }
         else {
             *(double *)bound_low = NPY_NAN;

--- a/astropy/stats/tests/test_sigma_clipping.py
+++ b/astropy/stats/tests/test_sigma_clipping.py
@@ -499,7 +499,7 @@ def test_mad_std():
     # And now test with a larger array and compare with Python mad_std function
 
     with NumpyRNGContext(12345):
-        array = np.random.uniform(-1, 2, (300, 400))
+        array = np.random.uniform(-1, 2, (30, 40))
 
     def nan_mad_std(data, axis=None):
         return mad_std(data, axis=axis, ignore_nan=True)

--- a/astropy/stats/tests/test_sigma_clipping.py
+++ b/astropy/stats/tests/test_sigma_clipping.py
@@ -468,7 +468,7 @@ def test_sigma_clip_dtypes(dtype):
 
 def test_mad_std():
 
-    # Test out the stdfunc=mad_std option
+    # Check with a small array where we know how the result should differ from std
 
     # Choose an array with few elements and a high proportion of outliers since
     # in this case std and mad_std will be very different.
@@ -495,6 +495,9 @@ def test_mad_std():
     result_mad_std = sigma_clip(array, cenfunc='median', stdfunc='mad_std',
                                 maxiters=1, sigma=5, masked=False, axis=0)
     assert_equal(result_mad_std, [1, np.nan, 4, 3, np.nan])
+
+
+def test_mad_std_large():
 
     # And now test with a larger array and compare with Python mad_std function
 

--- a/docs/changes/stats/11664.feature.rst
+++ b/docs/changes/stats/11664.feature.rst
@@ -1,3 +1,3 @@
 Added the ability to specify stdfunc='mad_std' when doing sigma clipping,
-which leads to significant performance improvements if cenfunc is 'mean'
-or 'median'.
+which will use a built-in function and lead to significant performance
+improvements if cenfunc is 'mean' or 'median'.

--- a/docs/changes/stats/11664.feature.rst
+++ b/docs/changes/stats/11664.feature.rst
@@ -1,0 +1,3 @@
+Added the ability to specify stdfunc='mad_std' when doing sigma clipping,
+which leads to significant performance improvements if cenfunc is 'mean'
+or 'median'.


### PR DESCRIPTION
This includes the required changes to make sure that the new C implementation can recognize this, leading to significant speedup in some cases:

![Screenshot_2021-04-29_15-36-01](https://user-images.githubusercontent.com/314716/116569266-23771400-a901-11eb-91a0-5c0b983817e8.png)

cc @keflavich FYI