### PR TITLE
Return False for SkyCoord == OtherType

### DIFF
--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -364,6 +364,8 @@ class SkyCoord(ShapedLikeNDArray):
         equivalent, extra frame attributes are equivalent, and that the
         representation data are exactly equal.
         """
+        if not isinstance(value, SkyCoord):
+            return NotImplemented
         # Make sure that any extra frame attribute names are equivalent.
         for attr in self._extra_frameattr_names | value._extra_frameattr_names:
             if not self.frame._frameattr_equiv(getattr(self, attr),

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -384,6 +384,13 @@ def test_equal():
     assert (sc1[0] != sc2[0]) == False  # noqa
 
 
+def test_equal_different_type():
+    sc1 = SkyCoord([1, 2]*u.deg, [3, 4]*u.deg, obstime='B1955')
+    # Test equals and not equals operators against different types
+    assert sc1 != 'a string'
+    assert not (sc1 == 'a string')
+
+
 def test_equal_exceptions():
     sc1 = SkyCoord(1*u.deg, 2*u.deg, obstime='B1955')
     sc2 = SkyCoord(1*u.deg, 2*u.deg)

--- a/docs/changes/coordinates/11666.bugfix.rst
+++ b/docs/changes/coordinates/11666.bugfix.rst
@@ -1,0 +1,2 @@
+Comparing a non-SkyCoord object to a ``SkyCoord`` using ``==`` no longer
+raises an error.


### PR DESCRIPTION
Fixes https://github.com/astropy/astropy/issues/11661. It seems pythonic to me to return `False` instead of `NotImplemented` for different types, e.g. `'a string' == 2` evaluates to `False`.