### PR TITLE
document QTable int to float conversion

### DIFF
--- a/docs/table/mixin_columns.rst
+++ b/docs/table/mixin_columns.rst
@@ -141,6 +141,16 @@ You can conveniently convert |Table| to |QTable| and vice-versa::
    ordinary `~astropy.table.Table` then it gets converted to an ordinary
    `~astropy.table.Column` with the corresponding ``unit`` attribute.
 
+.. attention::
+
+   When a column of ``int`` ``dtype`` is converted to `~astropy.units.Quantity`,
+   its ``dtype`` is converted to ``float``.
+
+   For example, for a quality flag column of ``int``, if it is
+   assigned with the :ref:`dimensionless unit <doc_dimensionless_unit>`, it will still
+   be converted to ``float``. Therefore such columns typically should not be
+   assigned with any unit.
+
 .. EXAMPLE END
 
 .. _mixin_attributes:


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
Partly addressed #10964.

Document existing `QTable` behavior (the implicit `int` to `float` conversion). There is no code change.

<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

