### PR TITLE
TST: Use pytest.raises instead of astropy.tests.helper.raises

### DIFF
--- a/astropy/io/votable/tests/ucd_test.py
+++ b/astropy/io/votable/tests/ucd_test.py
@@ -1,9 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+import pytest
 
-from astropy.tests.helper import raises
-
-# LOCAL
 from astropy.io.votable import ucd
 
 
@@ -42,16 +40,16 @@ def test_check():
         assert ucd.check_ucd(s, True, True)
 
 
-@raises(ValueError)
 def test_too_many_colons():
-    ucd.parse_ucd("ivoa:stsci:phot", True, True)
+    with pytest.raises(ValueError):
+        ucd.parse_ucd("ivoa:stsci:phot", True, True)
 
 
-@raises(ValueError)
 def test_invalid_namespace():
-    ucd.parse_ucd("_ivoa:phot.mag", True, True)
+    with pytest.raises(ValueError):
+        ucd.parse_ucd("_ivoa:phot.mag", True, True)
 
 
-@raises(ValueError)
 def test_invalid_word():
-    ucd.parse_ucd("-pho")
+    with pytest.raises(ValueError):
+        ucd.parse_ucd("-pho")

--- a/astropy/io/votable/tests/util_test.py
+++ b/astropy/io/votable/tests/util_test.py
@@ -2,11 +2,9 @@
 """
 A set of tests for the util.py module
 """
+import pytest
 
-
-# LOCAL
 from astropy.io.votable import util
-from astropy.tests.helper import raises
 
 
 def test_range_list():
@@ -22,10 +20,10 @@ def test_range_list3():
         "5e-07,8e-07;FOO", 3)
 
 
-@raises(ValueError)
 def test_range_list4a():
-    util.coerce_range_list_param(
-        (5e-7, (None, 8e-7), (4, None), (4, 5), "J", "FOO"))
+    with pytest.raises(ValueError):
+        util.coerce_range_list_param(
+            (5e-7, (None, 8e-7), (4, None), (4, 5), "J", "FOO"))
 
 
 def test_range_list4():
@@ -34,14 +32,14 @@ def test_range_list4():
             ("5e-07,/8e-07,4/,4/5,J;FOO", 6))
 
 
-@raises(ValueError)
 def test_range_list5():
-    util.coerce_range_list_param(('FOO', ))
+    with pytest.raises(ValueError):
+        util.coerce_range_list_param(('FOO', ))
 
 
-@raises(ValueError)
 def test_range_list6():
-    print(util.coerce_range_list_param((5, 'FOO'), util.stc_reference_frames))
+    with pytest.raises(ValueError):
+        print(util.coerce_range_list_param((5, 'FOO'), util.stc_reference_frames))
 
 
 def test_range_list7():
@@ -57,9 +55,9 @@ def test_range_list8():
         assert util.coerce_range_list_param(s, numeric=False)[0] == s
 
 
-@raises(ValueError)
 def test_range_list9a():
-    util.coerce_range_list_param("52,-27.8;FOO", util.stc_reference_frames)
+    with pytest.raises(ValueError):
+        util.coerce_range_list_param("52,-27.8;FOO", util.stc_reference_frames)
 
 
 def test_range_list9():

--- a/astropy/utils/tests/test_collections.py
+++ b/astropy/utils/tests/test_collections.py
@@ -2,21 +2,19 @@
 
 import pytest
 
-from astropy.tests.helper import raises
-
 from astropy.utils import collections
 
 
-@raises(TypeError)
 def test_homogeneous_list():
     l = collections.HomogeneousList(int)
-    l.append(5.0)
+    with pytest.raises(TypeError):
+        l.append(5.0)
 
 
-@raises(TypeError)
 def test_homogeneous_list2():
     l = collections.HomogeneousList(int)
-    l.extend([5.0])
+    with pytest.raises(TypeError):
+        l.extend([5.0])
 
 
 def test_homogeneous_list3():
@@ -31,10 +29,10 @@ def test_homogeneous_list4():
     assert l == [5]
 
 
-@raises(TypeError)
 def test_homogeneous_list5():
     l = collections.HomogeneousList(int, [1, 2, 3])
-    l[1] = 5.0
+    with pytest.raises(TypeError):
+        l[1] = 5.0
 
 
 def test_homogeneous_list_setitem_works():


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

Not sure how this fell through the cracks. Thought we handled it in #10504. Noticed it while reviewing #11659.
