### PR TITLE
Update changelog section of maintainer workflow

### DIFF
--- a/docs/development/workflow/maintainer_workflow.rst
+++ b/docs/development/workflow/maintainer_workflow.rst
@@ -155,9 +155,11 @@ General guidelines for labels:
 Updating and Maintaining the Changelog
 ======================================
 
-The Astropy "changelog" is managed with ``towncrier``, which is used to generate
+The Astropy "changelog" is managed with
+`towncrier <https://pypi.org/project/towncrier/`_, which is used to generate
 the ``CHANGES.rst`` file at the root of the repository. The changelog fragment
-files should be added with each PR as described in ``docs/changes/README.rst``.
+files should be added with each PR as described in
+`docs/changes/README.rst <https://github.com/astropy/astropy/blob/main/docs/changes/README.rst>`_.
 The purpose of this file is to give a technical, but still user (and developer)
 oriented overview of what changes were made to Astropy between each public
 release.  The idea is that it's a little more to the point and easier to follow
@@ -166,81 +168,5 @@ between versions, so that a user can easily find out from reading the changelog
 when a feature was added.  Likewise it lists any features or APIs that were
 changed (and how they were changed) or removed.  It also lists all bug fixes.
 Affiliated packages are encouraged to maintain a similar changelog.
-
-Adding to the changelog
------------------------
-
-There are two approaches one may take to adding a new entry to the changelog,
-each with certain pros and cons.  Before describing the two specific approaches
-it should be said that *all* additions to the changelog should be made first
-in the 'main' branch.  This is because every release of Astropy includes a
-copy of the changelog, and it should list all the changes in every prior
-version of Astropy.  For example, when Astropy v0.3.0 is released, in addition
-to the changes new to that version the changelog should have all the changes
-from every v0.2.x version (and earlier) released up to that point.
-
-Two approaches for including a changelog entry for a new feature or bug fix
-are:
-
-* Include the changelog update in the same pull request as the change.  That
-  is, assuming this change is being made in a pull request it can include an
-  accurate changelog update along with it.
-
-  Pro: An addition to the changelog is just like any other documentation
-  update, and should be part of any atomic change to the software.  It can
-  be pulled into main along with the rest of the change.
-
-  Con: If many pull requests also include changelog updates, they can quickly
-  conflict with each other and require rebasing.  This is not difficult to
-  resolve if the only conflict is in the changelog, but it can still be trouble
-  especially for new contributors.
-
-* Add to the changelog after a change has been merged to main, whether by
-  pull request or otherwise.
-
-  Pro: Largely escapes the merge conflict issue.
-
-  Cons: Isn't included "atomically" in the merge commit, making it more
-  difficult to keep track of for backporting.  Requires new contributors to
-  either make a second pull request or have a developer with push access to the
-  main repository make the commit.
-
-The first approach is probably preferable, especially for core contributors.
-But the latter approach is acceptable as well.
-
-Changelog format
-----------------
-
-The exact formatting of the changelog content is a bit loose for now (though
-it might become stricter if we want to develop more tools around the
-changelog).  The format can be mostly inferred by looking at previous versions.
-Each release gets its own heading (using the ``-`` heading marker) with the
-version and release date.  Releases still under development have
-``(unreleased)`` as there is no release date yet.
-
-There are generally up to three subheadings (using the ``^`` marker): "New
-Features", "API Changes", "Bug Fixes", and "Other Changes and Additions".  The
-latter is mostly a catch-all for miscellaneous changes, though there's no
-reason not to make up additional sub-headings if it seems appropriate.
-
-Under each sub-heading, changes are typically grouped according to which
-sub-package they pertain to.  Changes that apply to more than one sub-package
-or that only apply to support modules like ``logging`` or ``utils`` may go
-under a "Misc" group.
-
-The actual texts of the changelog entries are typically just one to three
-sentences--they should be easy to glance over.  Most entries end with a
-reference to an issue/pull request number in square brackets.
-
-A single changelog entry may also reference multiple small changes.  For
-example::
-
-
-  - Minor documentation fixes and restructuring.
-    [#935, #967, #978, #1004, #1028, #1047]
-
-Beyond that, the best advice for updating the changelog is just to look at
-existing entries for previous releases and copy the format.
-
 
 .. include:: links.inc

--- a/docs/development/workflow/maintainer_workflow.rst
+++ b/docs/development/workflow/maintainer_workflow.rst
@@ -156,7 +156,7 @@ Updating and Maintaining the Changelog
 ======================================
 
 The Astropy "changelog" is managed with
-`towncrier <https://pypi.org/project/towncrier/`_, which is used to generate
+`towncrier <https://pypi.org/project/towncrier/>`_, which is used to generate
 the ``CHANGES.rst`` file at the root of the repository. The changelog fragment
 files should be added with each PR as described in
 `docs/changes/README.rst <https://github.com/astropy/astropy/blob/main/docs/changes/README.rst>`_.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

Most of the `Changelog` section in the maintainers workflow document has been rendered obsolete by the switch to towncrier. 

The philosophical discussion about the two approaches is no longer needed (we always use approach 1). 

The second block seems aimed at telling maintainers how to update the `CHANGES.rst` file by hand. Since the changelog is auto-generated the second block seems overtaken as well.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>
