### PR TITLE
Fix astropy.io.votable tests that fail when run on installed package

### DIFF
--- a/astropy/io/votable/tests/tree_test.py
+++ b/astropy/io/votable/tests/tree_test.py
@@ -67,7 +67,7 @@ def test_namespace_warning():
           <RESOURCE/>
         </VOTABLE>
     '''
-    with pytest.raises(W41):
+    with pytest.warns(W41):
         parse(io.BytesIO(bad_namespace), verify='exception')
 
     good_namespace_14 = b'''<?xml version="1.0" encoding="utf-8"?>
@@ -95,7 +95,7 @@ def test_version():
     """
 
     # Exercise the checks in __init__
-    with pytest.raises(AstropyDeprecationWarning):
+    with pytest.warns(AstropyDeprecationWarning):
         VOTableFile(version='1.0')
     for version in ('1.1', '1.2', '1.3', '1.4'):
         VOTableFile(version=version)
@@ -123,7 +123,7 @@ def test_version():
 
     # Invalid versions
     for bversion in (b'1.0', b'2.0'):
-        with pytest.raises(W21):
+        with pytest.warns(W21):
             parse(io.BytesIO(begin + bversion + middle + bversion + end), verify='exception')
 
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to address failing tests in the astropy.io.votable module when run on non-editable install of astropy.  The problem is that setup.cfg doesn't exist in site-packages/astropy, so warnings are not converted to exceptions there.  Asserting with pytest.warns works for both editable and non-editable installs.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->