### PR TITLE
Raise exceptions from other exceptions in `table`

### DIFF
--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -606,8 +606,8 @@ class BaseColumn(_ColumnGetitemShim, np.ndarray):
             self._format = prev_format
             raise ValueError(
                 "Invalid format for column '{}': could not display "
-                "values in this column using this format ({})".format(
-                    self.name, err.args[0]))
+                "values in this column using this format".format(
+                    self.name)) from err
 
     @property
     def descr(self):

--- a/astropy/table/groups.py
+++ b/astropy/table/groups.py
@@ -191,9 +191,9 @@ class BaseGroups:
             indices0, indices1 = self.indices[:-1], self.indices[1:]
             try:
                 i0s, i1s = indices0[item], indices1[item]
-            except Exception:
+            except Exception as err:
                 raise TypeError('Index item for groups attribute must be a slice, '
-                                'numpy mask or int array')
+                                'numpy mask or int array') from err
             mask = np.zeros(len(parent), dtype=bool)
             # Is there a way to vectorize this in numpy?
             for i0, i1 in zip(i0s, i1s):
@@ -256,10 +256,10 @@ class ColumnGroups(BaseGroups):
                     vals = func.reduceat(par_col, i0s)
             else:
                 vals = np.array([func(par_col[i0: i1]) for i0, i1 in zip(i0s, i1s)])
-        except Exception:
+        except Exception as err:
             raise TypeError("Cannot aggregate column '{}' with type '{}'"
                             .format(par_col.info.name,
-                                    par_col.info.dtype))
+                                    par_col.info.dtype)) from err
 
         out = par_col.__class__(data=vals,
                                 name=par_col.info.name,

--- a/astropy/table/meta.py
+++ b/astropy/table/meta.py
@@ -434,6 +434,6 @@ def get_header_from_yaml(lines):
     try:
         header = yaml.load(header_yaml, Loader=TableLoader)
     except Exception as err:
-        raise YamlParseError(str(err))
+        raise YamlParseError() from err
 
     return header

--- a/astropy/table/np_utils.py
+++ b/astropy/table/np_utils.py
@@ -98,7 +98,7 @@ def get_descrs(arrays, col_name_map):
             # Beautify the error message when we are trying to merge columns with incompatible
             # types by including the name of the columns that originated the error.
             raise TableMergeError("The '{}' columns have incompatible types: {}"
-                                  .format(names[0], tme._incompat_types))
+                                  .format(names[0], tme._incompat_types)) from tme
 
         # Make sure all input shapes are the same
         uniq_shapes = set(col.shape[1:] for col in in_cols)

--- a/astropy/table/operations.py
+++ b/astropy/table/operations.py
@@ -63,8 +63,8 @@ def _get_list_of_tables(tables):
         else:
             try:
                 tables[ii] = Table([val])
-            except (ValueError, TypeError):
-                raise TypeError(f'cannot convert {val} to table column.')
+            except (ValueError, TypeError) as err:
+                raise TypeError(f'Cannot convert {val} to table column.') from err
 
     return tables
 
@@ -159,8 +159,8 @@ def join_skycoord(distance, distance_func='search_around_sky'):
         import astropy.coordinates as coords
         try:
             distance_func = getattr(coords, distance_func)
-        except AttributeError:
-            raise ValueError('distance_func must be a function in astropy.coordinates')
+        except AttributeError as err:
+            raise ValueError('distance_func must be a function in astropy.coordinates') from err
     else:
         from inspect import isfunction
         if not isfunction(distance_func):
@@ -930,7 +930,7 @@ def get_descrs(arrays, col_name_map):
             # Beautify the error message when we are trying to merge columns with incompatible
             # types by including the name of the columns that originated the error.
             raise TableMergeError("The '{}' columns have incompatible types: {}"
-                                  .format(names[0], tme._incompat_types))
+                                  .format(names[0], tme._incompat_types)) from tme
 
         # Make sure all input shapes are the same
         uniq_shapes = set(col.shape[1:] for col in in_cols)
@@ -955,7 +955,7 @@ def common_dtype(cols):
     except metadata.MergeConflictError as err:
         tme = TableMergeError(f'Columns have incompatible types {err._incompat_types}')
         tme._incompat_types = err._incompat_types
-        raise tme
+        raise tme from err
 
 
 def _get_join_sort_idxs(keys, left, right):
@@ -1200,11 +1200,11 @@ def _join(left, right, keys=None, join_type='inner',
 
             try:
                 col[array_mask] = col.info.mask_val
-            except Exception:  # Not clear how different classes will fail here
+            except Exception as err:  # Not clear how different classes will fail here
                 raise NotImplementedError(
                     "join requires masking column '{}' but column"
                     " type {} does not support masking"
-                    .format(out_name, col.__class__.__name__))
+                    .format(out_name, col.__class__.__name__)) from err
 
         # Set the output table column to the new joined column
         out[out_name] = col
@@ -1307,7 +1307,7 @@ def _vstack(arrays, join_type='outer', col_name_map=None, metadata_conflicts='wa
             # Beautify the error message when we are trying to merge columns with incompatible
             # types by including the name of the columns that originated the error.
             raise TableMergeError("The '{}' columns have incompatible types: {}"
-                                  .format(out_name, err._incompat_types))
+                                  .format(out_name, err._incompat_types)) from err
 
         idx0 = 0
         for name, array in zip(in_names, arrays):
@@ -1322,11 +1322,11 @@ def _vstack(arrays, join_type='outer', col_name_map=None, metadata_conflicts='wa
 
                 try:
                     col[idx0:idx1] = col.info.mask_val
-                except Exception:
+                except Exception as err:
                     raise NotImplementedError(
                         "vstack requires masking column '{}' but column"
                         " type {} does not support masking"
-                        .format(out_name, col.__class__.__name__))
+                        .format(out_name, col.__class__.__name__)) from err
             idx0 = idx1
 
         out[out_name] = col
@@ -1422,11 +1422,11 @@ def _hstack(arrays, join_type='outer', uniq_col_name='{col_name}_{table_name}',
 
                 try:
                     col[arr_len:] = col.info.mask_val
-                except Exception:
+                except Exception as err:
                     raise NotImplementedError(
                         "hstack requires masking column '{}' but column"
                         " type {} does not support masking"
-                        .format(out_name, col.__class__.__name__))
+                        .format(out_name, col.__class__.__name__)) from err
             else:
                 col = array[name][:n_rows]
 

--- a/astropy/table/pprint.py
+++ b/astropy/table/pprint.py
@@ -96,7 +96,7 @@ def get_auto_format_func(
                 if val is np.ma.masked:
                     return str(val)
 
-                raise ValueError(f'Format function for value {val} failed: {err}')
+                raise ValueError(f'Format function for value {val} failed.') from err
             # If the user-supplied function handles formatting masked elements, use
             # it directly.  Otherwise, wrap it in a function that traps them.
             try:

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -3085,7 +3085,7 @@ class Table:
 
         except Exception as err:
             raise ValueError("Unable to insert row because of exception in column '{}':\n{}"
-                             .format(name, err))
+                             .format(name, err)) from err
         else:
             self._replace_cols(columns)
 


### PR DESCRIPTION
xref https://github.com/astropy/astropy/issues/11655. I found these simply by running `grep -r 'except .*Error as' astropy/table` and `grep -r 'except Exception as' astropy/table`. There's others to do in other sub-modules, but I thought there was enough that it was worth splitting them into one PR/sub-module.