### PR TITLE
Raise exceptions from other exceptions in `coordinates`

### DIFF
--- a/astropy/coordinates/angle_formats.py
+++ b/astropy/coordinates/angle_formats.py
@@ -303,10 +303,10 @@ class _AngleParser:
                 angle, lexer=self._thread_local._lexer, debug=debug)
         except ValueError as e:
             if str(e):
-                raise ValueError(f"{str(e)} in angle {angle!r}")
+                raise ValueError(f"{str(e)} in angle {angle!r}") from e
             else:
                 raise ValueError(
-                    f"Syntax error parsing angle {angle!r}")
+                    f"Syntax error parsing angle {angle!r}")  from e
 
         if unit is None and found_unit is None:
             raise u.UnitsError("No unit specified")
@@ -428,10 +428,10 @@ def dms_to_degrees(d, m, s=None):
         else:
             m = np.floor(np.abs(m))
             s = np.abs(s)
-    except ValueError:
+    except ValueError as err:
         raise ValueError(format_exception(
             "{func}: dms values ({1[0]},{2[1]},{3[2]}) could not be "
-            "converted to numbers.", d, m, s))
+            "converted to numbers.", d, m, s)) from err
 
     return sign * (d + m / 60. + s / 3600.)
 
@@ -454,10 +454,10 @@ def hms_to_hours(h, m, s=None):
         else:
             m = np.floor(np.abs(m))
             s = np.abs(s)
-    except ValueError:
+    except ValueError as err:
         raise ValueError(format_exception(
             "{func}: HMS values ({1[0]},{2[1]},{3[2]}) could not be "
-            "converted to numbers.", h, m, s))
+            "converted to numbers.", h, m, s)) from err
 
     return sign * (h + m / 60. + s / 3600.)
 

--- a/astropy/coordinates/attributes.py
+++ b/astropy/coordinates/attributes.py
@@ -181,7 +181,7 @@ class TimeAttribute(Attribute):
                 out = Time(value)
             except Exception as err:
                 raise ValueError(
-                    f'Invalid time input {self.name}={value!r}\n{err}')
+                    f'Invalid time input {self.name}={value!r}.') from err
             converted = True
 
         # Set attribute as read-only for arrays (not allowed by numpy

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -333,9 +333,9 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
                 if len(shapes) > 1:
                     try:
                         self._no_data_shape = check_broadcast(*shapes.values())
-                    except ValueError:
+                    except ValueError as err:
                         raise ValueError(
-                            f"non-scalar attributes with inconsistent shapes: {shapes}")
+                            f"non-scalar attributes with inconsistent shapes: {shapes}") from err
 
                     # Above, we checked that it is possible to broadcast all
                     # shapes.  By getting and thus validating the attributes,

--- a/astropy/coordinates/earth.py
+++ b/astropy/coordinates/earth.py
@@ -70,9 +70,9 @@ def _get_json_result(url, err_str, use_google):
         # This catches a timeout error, see:
         #   http://stackoverflow.com/questions/2712524/handling-urllib2s-timeout-python
         if isinstance(e.reason, socket.timeout):
-            raise NameResolveError(err_str.format(msg="connection timed out"))
+            raise NameResolveError(err_str.format(msg="connection timed out")) from e
         else:
-            raise NameResolveError(err_str.format(msg=e.reason))
+            raise NameResolveError(err_str.format(msg=e.reason)) from e
 
     except socket.timeout:
         # There are some cases where urllib2 does not catch socket.timeout
@@ -236,9 +236,9 @@ class EarthLocation(u.Quantity):
         if unit is None:
             try:
                 unit = x.unit
-            except AttributeError:
+            except AttributeError as err:
                 raise TypeError("Geocentric coordinates should be Quantities "
-                                "unless an explicit unit is given.")
+                                "unless an explicit unit is given.") from None
         else:
             unit = u.Unit(unit)
 
@@ -367,7 +367,7 @@ class EarthLocation(u.Quantity):
             el = registry[site_name]
         except UnknownSiteException as e:
             raise UnknownSiteException(e.site, 'EarthLocation.get_site_names',
-                                       close_names=e.close_names)
+                                       close_names=e.close_names) from e
 
         if cls is el.__class__:
             return el
@@ -788,11 +788,11 @@ class EarthLocation(u.Quantity):
         for body in bodies:
             try:
                 GMs.append(_masses[body].to(u.m**3/u.s**2, [M_GM_equivalency]))
-            except KeyError:
-                raise KeyError(f'body "{body}" does not have a mass!')
+            except KeyError as err:
+                raise KeyError(f'Body "{body}" does not have a mass.') from err
             except u.UnitsError as exc:
                 exc.args += ('"masses" argument values must be masses or '
-                             'gravitational parameters',)
+                             'gravitational parameters.',)
                 raise
 
         positions = [get_body_barycentric(name, obstime) for name in bodies]

--- a/astropy/coordinates/earth.py
+++ b/astropy/coordinates/earth.py
@@ -236,7 +236,7 @@ class EarthLocation(u.Quantity):
         if unit is None:
             try:
                 unit = x.unit
-            except AttributeError as err:
+            except AttributeError:
                 raise TypeError("Geocentric coordinates should be Quantities "
                                 "unless an explicit unit is given.") from None
         else:
@@ -789,7 +789,7 @@ class EarthLocation(u.Quantity):
             try:
                 GMs.append(_masses[body].to(u.m**3/u.s**2, [M_GM_equivalency]))
             except KeyError as err:
-                raise KeyError(f'Body "{body}" does not have a mass.') from err
+                raise KeyError(f'body "{body}" does not have a mass.') from err
             except u.UnitsError as exc:
                 exc.args += ('"masses" argument values must be masses or '
                              'gravitational parameters.',)

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -150,7 +150,7 @@ class BaseRepresentationOrDifferentialInfo(MixinInfo):
             try:
                 out[0] = rep[0]
             except Exception as err:
-                raise ValueError(f'Input representations are inconsistent.') from err
+                raise ValueError(f'input representations are inconsistent.') from err
 
         # Set (merged) info attributes.
         for attr in ('name', 'meta', 'description'):
@@ -201,7 +201,7 @@ class BaseRepresentationOrDifferential(ShapedLikeNDArray):
             for component in components:
                 try:
                     attr = args.pop(0) if args else kwargs.pop(component)
-                except KeyError as err:
+                except KeyError:
                     raise TypeError(f'__init__() missing 1 required positional '
                                     f'argument: {component!r}') from None
 

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -150,7 +150,7 @@ class BaseRepresentationOrDifferentialInfo(MixinInfo):
             try:
                 out[0] = rep[0]
             except Exception as err:
-                raise ValueError(f'input representations are inconsistent: {err}')
+                raise ValueError(f'Input representations are inconsistent.') from err
 
         # Set (merged) info attributes.
         for attr in ('name', 'meta', 'description'):
@@ -201,9 +201,9 @@ class BaseRepresentationOrDifferential(ShapedLikeNDArray):
             for component in components:
                 try:
                     attr = args.pop(0) if args else kwargs.pop(component)
-                except KeyError:
+                except KeyError as err:
                     raise TypeError(f'__init__() missing 1 required positional '
-                                    f'argument: {component!r}')
+                                    f'argument: {component!r}') from None
 
                 if attr is None:
                     raise TypeError(f'__init__() missing 1 required positional '
@@ -231,12 +231,12 @@ class BaseRepresentationOrDifferential(ShapedLikeNDArray):
                  for component, attr in zip(components, attrs)]
         try:
             bc_attrs = np.broadcast_arrays(*attrs, subok=True)
-        except ValueError:
+        except ValueError  as err:
             if len(components) <= 2:
                 c_str = ' and '.join(components)
             else:
                 c_str = ', '.join(components[:2]) + ', and ' + components[2]
-            raise ValueError(f"Input parameters {c_str} cannot be broadcast")
+            raise ValueError(f"Input parameters {c_str} cannot be broadcast") from err
 
         # If inputs have been copied, there is no reason to output a broadcasted array for a
         # component, so we perform another copy of any component that has been broadcasted
@@ -697,9 +697,9 @@ class BaseRepresentation(BaseRepresentationOrDifferential):
         for key in differentials:
             try:
                 diff = differentials[key]
-            except TypeError:
+            except TypeError as err:
                 raise TypeError("'differentials' argument must be a "
-                                "dictionary-like object")
+                                "dictionary-like object") from err
 
             diff._check_base(self)
 
@@ -823,14 +823,14 @@ class BaseRepresentation(BaseRepresentationOrDifferential):
             try:
                 new_diffs[k] = diff.represent_as(differential_class[k],
                                                  base=self)
-            except Exception:
+            except Exception as err:
                 if (differential_class[k] not in
                         new_rep._compatible_differentials):
                     raise TypeError("Desired differential class {} is not "
                                     "compatible with the desired "
                                     "representation class {}"
                                     .format(differential_class[k],
-                                            new_rep.__class__))
+                                            new_rep.__class__)) from err
                 else:
                     raise
 
@@ -1478,10 +1478,10 @@ class CartesianRepresentation(BaseRepresentation):
         """
         try:
             other_c = other.to_cartesian()
-        except Exception:
+        except Exception as err:
             raise TypeError("cannot only take dot product with another "
                             "representation, not a {} instance."
-                            .format(type(other)))
+                            .format(type(other))) from err
         # erfa pdp: p-vector inner (=scalar=dot) product.
         return erfa_ufunc.pdp(self.get_xyz(xyz_axis=-1),
                               other_c.get_xyz(xyz_axis=-1))
@@ -1502,10 +1502,10 @@ class CartesianRepresentation(BaseRepresentation):
         self._raise_if_has_differentials('cross')
         try:
             other_c = other.to_cartesian()
-        except Exception:
+        except Exception as err:
             raise TypeError("cannot only take cross product with another "
                             "representation, not a {} instance."
-                            .format(type(other)))
+                            .format(type(other))) from err
         # erfa pxp: p-vector outer (=vector=cross) product.
         sxo = erfa_ufunc.pxp(self.get_xyz(xyz_axis=-1),
                              other_c.get_xyz(xyz_axis=-1))
@@ -1934,7 +1934,7 @@ class SphericalRepresentation(BaseRepresentation):
                     raise ValueError("Distance must be >= 0. To allow negative "
                                      "distance values, you must explicitly pass"
                                      " in a `Distance` object with the the "
-                                     "argument 'allow_negative=True'.")
+                                     "argument 'allow_negative=True'.") from e
                 else:
                     raise
 

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -148,7 +148,7 @@ class SkyCoordInfo(MixinInfo):
             try:
                 out[0] = skycoord[0]
             except Exception as err:
-                raise ValueError(f'input skycoords are inconsistent: {err}')
+                raise ValueError(f'Input skycoords are inconsistent.') from err
 
         # Set (merged) info attributes
         for attr in ('name', 'meta', 'description'):

--- a/astropy/coordinates/sky_coordinate_parsers.py
+++ b/astropy/coordinates/sky_coordinate_parsers.py
@@ -349,9 +349,9 @@ def _get_representation_component_units(args, kwargs):
             units.extend(None for x in range(3 - len(units)))
             if len(units) > 3:
                 raise ValueError()
-        except Exception:
+        except Exception as err:
             raise ValueError('Unit keyword must have one to three unit values as '
-                             'tuple or comma-separated string')
+                             'tuple or comma-separated string.') from err
 
     return units
 
@@ -522,12 +522,13 @@ def _parse_coordinate_arg(coords, frame, units, init_kwargs):
             # lengths the same
             try:
                 n_coords = sorted(set(len(x) for x in vals))
-            except Exception:
-                raise ValueError('One or more elements of input sequence does not have a length')
+            except Exception as err:
+                raise ValueError('One or more elements of input sequence '
+                                 'does not have a length.') from err
 
             if len(n_coords) > 1:
-                raise ValueError('Input coordinate values must have same number of elements, found {}'
-                                 .format(n_coords))
+                raise ValueError('Input coordinate values must have '
+                                 'same number of elements, found {}'.format(n_coords))
             n_coords = n_coords[0]
 
             # Must have no more coord inputs than representation attributes
@@ -559,7 +560,7 @@ def _parse_coordinate_arg(coords, frame, units, init_kwargs):
                                                           copy=False)
     except Exception as err:
         raise ValueError('Cannot parse first argument data "{}" for attribute '
-                         '{}'.format(value, frame_attr_name), err)
+                         '{}'.format(value, frame_attr_name)) from err
     return skycoord_kwargs, components
 
 


### PR DESCRIPTION
xref #11655. I found these simply by running grep -r 'except .*Error as' astropy/coordinates and grep -r 'except Exception as' astropy/coordinates. There's others to do in other sub-modules, but I thought there was enough that it was worth splitting them into one PR/sub-module.