### PR TITLE
change to just links for whatsnew index

### DIFF
--- a/docs/whatsnew/index.rst
+++ b/docs/whatsnew/index.rst
@@ -12,9 +12,9 @@ functionality highlighted in these pages.
    :maxdepth: 1
 
    5.0
-   4.3
-   4.2
 
+* `What's New in Astropy 4.3? <https://docs.astropy.org/en/v4.3post1/whatsnew/4.3.html>`__
+* `What's New in Astropy 4.2? <https://docs.astropy.org/en/v4.2/whatsnew/4.2.html>`__
 * `What's New in Astropy 4.1? <https://docs.astropy.org/en/v4.1/whatsnew/4.1.html>`__
 * `What's New in Astropy 4.0? <https://docs.astropy.org/en/v4.0/whatsnew/4.0.html>`__
 * `What's New in Astropy 3.2? <https://docs.astropy.org/en/v3.2/whatsnew/3.2.html>`__


### PR DESCRIPTION
This is a pretty minor thing but I noticed an inconsistency in `docs/whatsnew/index.rst` - it seems to be using two different linking idioms.  This PR corrects the links to effectively point to the "latest" version rather than the "old" versions.

There might have been some reason we left it this way, though?  I honestly can't recall (maybe even I thought it was important? :shrug:) Maybe @bsipocz has some insight on this? (as the last editor of that page)