### PR TITLE
Resolve intersphinx to astropy as current build

### DIFF
--- a/astropy/constants/__init__.py
+++ b/astropy/constants/__init__.py
@@ -57,7 +57,7 @@ def set_enabled_constants(modname):
     """
     Context manager to temporarily set values in the ``constants``
     namespace to an older version.
-    See :ref:`astropy-constants-prior` for usage.
+    See :ref:`astropy:astropy-constants-prior` for usage.
 
     Parameters
     ----------

--- a/astropy/coordinates/builtin_frames/equatorial.py
+++ b/astropy/coordinates/builtin_frames/equatorial.py
@@ -64,7 +64,7 @@ class TETE(BaseRADecFrame):
     with local apparent sidereal time to calculate the apparent (TIRS) hour angle.
 
     For more background on TETE, see the references provided in the
-    :ref:`astropy-coordinates-seealso` section of the documentation.
+    :ref:`astropy:astropy-coordinates-seealso` section of the documentation.
     Of particular note are Sections 5 and 6 of
     `USNO Circular 179 <https://arxiv.org/abs/astro-ph/0602086>`_) and
     especially the diagram at the top of page 57.
@@ -96,7 +96,7 @@ class TEME(BaseCoordinateFrame):
     conventions and relations to other frames that are set out in Vallado et al (2006).
 
     For more background on TEME, see the references provided in the
-    :ref:`astropy-coordinates-seealso` section of the documentation.
+    :ref:`astropy:astropy-coordinates-seealso` section of the documentation.
     """
 
     default_representation = CartesianRepresentation

--- a/astropy/coordinates/builtin_frames/galactocentric.py
+++ b/astropy/coordinates/builtin_frames/galactocentric.py
@@ -88,7 +88,8 @@ class galactocentric_frame_defaults(ScienceState):
     :meth:`~galactocentric_frame_defaults.get_from_registry` since
     it ensures the immutability of the registry.
 
-    See :ref:`astropy-coordinates-galactocentric-defaults` for more information.
+    See :ref:`astropy:astropy-coordinates-galactocentric-defaults` for more
+    information.
 
     Examples
     --------
@@ -461,7 +462,7 @@ class Galactocentric(BaseCoordinateFrame):
     roughly towards the North Galactic Pole (:math:`b=90^\circ`).
 
     For a more detailed look at the math behind this transformation, see
-    the document :ref:`coordinates-galactocentric`.
+    the document :ref:`astropy:coordinates-galactocentric`.
 
     The frame attributes are listed under **Other Parameters**.
     """

--- a/astropy/coordinates/builtin_frames/gcrs.py
+++ b/astropy/coordinates/builtin_frames/gcrs.py
@@ -42,7 +42,7 @@ class GCRS(BaseRADecFrame):
     center-of-mass rather than the solar system Barycenter.  That means this
     frame includes the effects of aberration (unlike ICRS). For more background
     on the GCRS, see the references provided in the
-    :ref:`astropy-coordinates-seealso` section of the documentation. (Of
+    :ref:`astropy:astropy-coordinates-seealso` section of the documentation. (Of
     particular note is Section 1.2 of
     `USNO Circular 179 <https://arxiv.org/abs/astro-ph/0602086>`_)
 

--- a/astropy/coordinates/builtin_frames/hcrs.py
+++ b/astropy/coordinates/builtin_frames/hcrs.py
@@ -34,8 +34,8 @@ class HCRS(BaseRADecFrame):
     of the order of 8 milli-arcseconds.
 
     For more background on the ICRS and related coordinate transformations, see
-    the references provided in the :ref:`astropy-coordinates-seealso` section of
-    the documentation.
+    the references provided in the :ref:`astropy:astropy-coordinates-seealso`
+    section of the documentation.
 
     The frame attributes are listed under **Other Parameters**.
     """

--- a/astropy/coordinates/builtin_frames/icrs.py
+++ b/astropy/coordinates/builtin_frames/icrs.py
@@ -19,6 +19,6 @@ class ICRS(BaseRADecFrame):
     very close (within tens of milliarcseconds) to J2000 equatorial.
 
     For more background on the ICRS and related coordinate transformations, see
-    the references provided in the  :ref:`astropy-coordinates-seealso` section
-    of the documentation.
+    the references provided in the  :ref:`astropy:astropy-coordinates-seealso`
+    section of the documentation.
     """

--- a/astropy/coordinates/builtin_frames/itrs.py
+++ b/astropy/coordinates/builtin_frames/itrs.py
@@ -17,7 +17,7 @@ class ITRS(BaseCoordinateFrame):
     (ITRS).  This is approximately a geocentric system, although strictly it is
     defined by a series of reference locations near the surface of the Earth.
     For more background on the ITRS, see the references provided in the
-    :ref:`astropy-coordinates-seealso` section of the documentation.
+    :ref:`astropy:astropy-coordinates-seealso` section of the documentation.
     """
 
     default_representation = CartesianRepresentation

--- a/astropy/coordinates/builtin_frames/skyoffset.py
+++ b/astropy/coordinates/builtin_frames/skyoffset.py
@@ -105,7 +105,7 @@ class SkyOffsetFrame(BaseCoordinateFrame):
     object's ``lat`` will be pointed in the direction of Dec, while ``lon``
     will point in the direction of RA.
 
-    For more on skyoffset frames, see :ref:`astropy-skyoffset-frames`.
+    For more on skyoffset frames, see :ref:`astropy:astropy-skyoffset-frames`.
 
     Parameters
     ----------

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -1035,7 +1035,7 @@ class SkyCoord(ShapedLikeNDArray):
             not give the same answer in this case.
 
         For more on how to use this (and related) functionality, see the
-        examples in :doc:`/coordinates/matchsep`.
+        examples in :doc:`astropy:/coordinates/matchsep`.
 
         Parameters
         ----------
@@ -1081,7 +1081,7 @@ class SkyCoord(ShapedLikeNDArray):
         and another.
 
         For more on how to use this (and related) functionality, see the
-        examples in :doc:`/coordinates/matchsep`.
+        examples in :doc:`astropy:/coordinates/matchsep`.
 
         Parameters
         ----------
@@ -1259,7 +1259,7 @@ class SkyCoord(ShapedLikeNDArray):
         catalog coordinates.
 
         For more on how to use this (and related) functionality, see the
-        examples in :doc:`/coordinates/matchsep`.
+        examples in :doc:`astropy:/coordinates/matchsep`.
 
         Parameters
         ----------
@@ -1324,7 +1324,7 @@ class SkyCoord(ShapedLikeNDArray):
         ``catalogcoord`` object.
 
         For more on how to use this (and related) functionality, see the
-        examples in :doc:`/coordinates/matchsep`.
+        examples in :doc:`astropy:/coordinates/matchsep`.
 
         Parameters
         ----------
@@ -1389,7 +1389,7 @@ class SkyCoord(ShapedLikeNDArray):
         `~astropy.coordinates.SkyCoord.separation`.
 
         For more on how to use this (and related) functionality, see the
-        examples in :doc:`/coordinates/matchsep`.
+        examples in :doc:`astropy:/coordinates/matchsep`.
 
         Parameters
         ----------
@@ -1448,7 +1448,7 @@ class SkyCoord(ShapedLikeNDArray):
         `~astropy.coordinates.SkyCoord.separation_3d`.
 
         For more on how to use this (and related) functionality, see the
-        examples in :doc:`/coordinates/matchsep`.
+        examples in :doc:`astropy:/coordinates/matchsep`.
 
         Parameters
         ----------

--- a/astropy/coordinates/spectral_quantity.py
+++ b/astropy/coordinates/spectral_quantity.py
@@ -196,7 +196,8 @@ class SpectralQuantity(SpecificTypeQuantity):
             by the `~astropy.units` package, and should be a spectral unit.
         equivalencies : list of `~astropy.units.equivalencies.Equivalency`, optional
             A list of equivalence pairs to try if the units are not
-            directly convertible (along with spectral).  See :ref:`unit_equivalencies`.
+            directly convertible (along with spectral).
+            See :ref:`astropy:unit_equivalencies`.
             If not provided or ``[]``, spectral equivalencies will be used.
             If `None`, no equivalencies will be applied at all, not even any
             set globally or within a context.

--- a/astropy/io/ascii/fixedwidth.py
+++ b/astropy/io/ascii/fixedwidth.py
@@ -291,7 +291,7 @@ class FixedWidth(basic.Basic):
        1.2hello there   3
        2.4many words    7
 
-    See the :ref:`fixed_width_gallery` for specific usage examples.
+    See the :ref:`astropy:fixed_width_gallery` for specific usage examples.
 
     """
     _format_name = 'fixed_width'
@@ -342,7 +342,7 @@ class FixedWidthNoHeader(FixedWidth):
     This class is just a convenience wrapper around the ``FixedWidth`` reader
     but with ``header_start=None`` and ``data_start=0``.
 
-    See the :ref:`fixed_width_gallery` for specific usage examples.
+    See the :ref:`astropy:fixed_width_gallery` for specific usage examples.
 
     """
     _format_name = 'fixed_width_no_header'
@@ -399,7 +399,7 @@ class FixedWidthTwoLine(FixedWidth):
       |  2.4 | there world|
       +------+------------+
 
-    See the :ref:`fixed_width_gallery` for specific usage examples.
+    See the :ref:`astropy:fixed_width_gallery` for specific usage examples.
 
     """
     _format_name = 'fixed_width_two_line'

--- a/astropy/io/ascii/ipac.py
+++ b/astropy/io/ascii/ipac.py
@@ -391,7 +391,7 @@ class Ipac(basic.Basic):
     of missing or bad data. On writing, this value defaults to ``null``.
     To specify a different null value, use the ``fill_values`` option to
     replace masked values with a string or number of your choice as
-    described in :ref:`io_ascii_write_parameters`::
+    described in :ref:`astropy:io_ascii_write_parameters`::
 
         >>> from astropy.io.ascii import masked
         >>> fill = [(masked, 'N/A', 'ra'), (masked, -999, 'sptype')]

--- a/astropy/io/ascii/qdp.py
+++ b/astropy/io/ascii/qdp.py
@@ -2,7 +2,7 @@
 """
 This package contains functions for reading and writing QDP tables that are
 not meant to be used directly, but instead are available as readers/writers in
-`astropy.table`. See :ref:`table_io` for more details.
+`astropy.table`. See :ref:`astropy:table_io` for more details.
 """
 import re
 import copy

--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -525,8 +525,8 @@ class Column(NotifierMixin):
                  time_ref_pos=None):
         """
         Construct a `Column` by specifying attributes.  All attributes
-        except ``format`` can be optional; see :ref:`column_creation` and
-        :ref:`creating_ascii_table` for more information regarding
+        except ``format`` can be optional; see :ref:`astropy:column_creation`
+        and :ref:`astropy:creating_ascii_table` for more information regarding
         ``TFORM`` keyword.
 
         Parameters

--- a/astropy/io/fits/convenience.py
+++ b/astropy/io/fits/convenience.py
@@ -401,8 +401,8 @@ def writeto(filename, data, header=None, output_verify='exception',
         Output verification option.  Must be one of ``"fix"``, ``"silentfix"``,
         ``"ignore"``, ``"warn"``, or ``"exception"``.  May also be any
         combination of ``"fix"`` or ``"silentfix"`` with ``"+ignore"``,
-        ``+warn``, or ``+exception" (e.g. ``"fix+warn"``).  See :ref:`verify`
-        for more info.
+        ``+warn``, or ``+exception" (e.g. ``"fix+warn"``).  See
+        :ref:`astropy:verify` for more info.
 
     overwrite : bool, optional
         If ``True``, overwrite the output file if it exists. Raises an

--- a/astropy/io/fits/hdu/base.py
+++ b/astropy/io/fits/hdu/base.py
@@ -359,7 +359,7 @@ class _BaseHDU(metaclass=_BaseHDUMeta):
             ``"silentfix"``, ``"ignore"``, ``"warn"``, or
             ``"exception"``.  May also be any combination of ``"fix"`` or
             ``"silentfix"`` with ``"+ignore"``, ``+warn``, or ``+exception"
-            (e.g. ``"fix+warn"``).  See :ref:`verify` for more info.
+            (e.g. ``"fix+warn"``).  See :ref:`astropy:verify` for more info.
 
         overwrite : bool, optional
             If ``True``, overwrite the output file if it exists. Raises an
@@ -1122,7 +1122,7 @@ class _ValidHDU(_BaseHDU, _Verify):
             ``"silentfix"``, ``"ignore"``, ``"warn"``, or
             ``"exception"``.  May also be any combination of ``"fix"`` or
             ``"silentfix"`` with ``"+ignore"``, ``+warn``, or ``+exception"
-            (e.g. ``"fix+warn"``).  See :ref:`verify` for more info.
+            (e.g. ``"fix+warn"``).  See :ref:`astropy:verify` for more info.
 
         errlist : list
             A list of validation errors already found in the FITS file; this is

--- a/astropy/io/fits/hdu/groups.py
+++ b/astropy/io/fits/hdu/groups.py
@@ -253,8 +253,8 @@ class GroupsHDU(PrimaryHDU, _TableLikeHDU):
     """
     FITS Random Groups HDU class.
 
-    See the :ref:`random-groups` section in the Astropy documentation for more
-    details on working with this type of HDU.
+    See the :ref:`astropy:random-groups` section in the Astropy documentation
+    for more details on working with this type of HDU.
     """
 
     _bitpix2tform = {8: 'B', 16: 'I', 32: 'J', 64: 'K', -32: 'E', -64: 'D'}

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -141,7 +141,7 @@ def fitsopen(name, mode='readonly', memmap=None, save_backup=False,
         ``"silentfix"``, ``"ignore"``, ``"warn"``, or
         ``"exception"``.  May also be any combination of ``"fix"`` or
         ``"silentfix"`` with ``"+ignore"``, ``+warn``, or ``+exception"
-        (e.g. ``"fix+warn"``).  See :ref:`verify` for more info.
+        (e.g. ``"fix+warn"``).  See :ref:`astropy:verify` for more info.
 
     Returns
     -------
@@ -805,7 +805,7 @@ class HDUList(list, _Verify):
             ``"silentfix"``, ``"ignore"``, ``"warn"``, or
             ``"exception"``.  May also be any combination of ``"fix"`` or
             ``"silentfix"`` with ``"+ignore"``, ``+warn``, or ``+exception"
-            (e.g. ``"fix+warn"``).  See :ref:`verify` for more info.
+            (e.g. ``"fix+warn"``).  See :ref:`astropy:verify` for more info.
 
         verbose : bool
             When `True`, print verbose messages
@@ -907,7 +907,7 @@ class HDUList(list, _Verify):
             ``"silentfix"``, ``"ignore"``, ``"warn"``, or
             ``"exception"``.  May also be any combination of ``"fix"`` or
             ``"silentfix"`` with ``"+ignore"``, ``+warn``, or ``+exception"
-            (e.g. ``"fix+warn"``).  See :ref:`verify` for more info.
+            (e.g. ``"fix+warn"``).  See :ref:`astropy:verify` for more info.
 
         overwrite : bool, optional
             If ``True``, overwrite the output file if it exists. Raises an
@@ -965,7 +965,7 @@ class HDUList(list, _Verify):
             ``"silentfix"``, ``"ignore"``, ``"warn"``, or
             ``"exception"``.  May also be any combination of ``"fix"`` or
             ``"silentfix"`` with ``"+ignore"``, ``+warn``, or ``+exception"
-            (e.g. ``"fix+warn"``).  See :ref:`verify` for more info.
+            (e.g. ``"fix+warn"``).  See :ref:`astropy:verify` for more info.
 
         verbose : bool
             When `True`, print out verbose messages.

--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -194,8 +194,8 @@ class _ImageBaseHDU(_ValidHDU):
 
         Sections are mostly obsoleted by memmap support, but should still be
         used to deal with very large scaled images.  See the
-        :ref:`data-sections` section of the Astropy documentation for more
-        details.
+        :ref:`astropy:data-sections` section of the Astropy documentation for
+        more details.
         """
 
         return Section(self)
@@ -932,8 +932,8 @@ class Section:
     Section slices cannot be assigned to, and modifications to a section are
     not saved back to the underlying file.
 
-    See the :ref:`data-sections` section of the Astropy documentation for more
-    details.
+    See the :ref:`astropy:data-sections` section of the Astropy documentation
+    for more details.
     """
 
     def __init__(self, hdu):

--- a/astropy/io/fits/verify.py
+++ b/astropy/io/fits/verify.py
@@ -60,7 +60,7 @@ class _Verify:
             ``"silentfix"``, ``"ignore"``, ``"warn"``, or
             ``"exception"``.  May also be any combination of ``"fix"`` or
             ``"silentfix"`` with ``"+ignore"``, ``"+warn"``, or ``"+exception"``
-            (e.g. ``"fix+warn"``).  See :ref:`verify` for more info.
+            (e.g. ``"fix+warn"``).  See :ref:`astropy:verify` for more info.
         """
 
         opt = option.lower()

--- a/astropy/io/misc/hdf5.py
+++ b/astropy/io/misc/hdf5.py
@@ -2,7 +2,7 @@
 """
 This package contains functions for reading and writing HDF5 tables that are
 not meant to be used directly, but instead are available as readers/writers in
-`astropy.table`. See :ref:`table_io` for more details.
+`astropy.table`. See :ref:`astropy:table_io` for more details.
 """
 
 import os

--- a/astropy/io/votable/connect.py
+++ b/astropy/io/votable/connect.py
@@ -149,7 +149,7 @@ def write_table_votable(input, output, table_id=None, overwrite=False,
     tabledata_format : str, optional
         The format of table data to write.  Must be one of ``tabledata``
         (text representation), ``binary`` or ``binary2``.  Default is
-        ``tabledata``.  See :ref:`votable-serialization`.
+        ``tabledata``.  See :ref:`astropy:votable-serialization`.
     """
 
     # Only those columns which are instances of BaseColumn or Quantity can be written

--- a/astropy/io/votable/exceptions.py
+++ b/astropy/io/votable/exceptions.py
@@ -267,7 +267,7 @@ class W01(VOTableSpecWarning):
 
     Many VOTable files in the wild use commas as a separator instead,
     and ``astropy.io.votable`` supports this convention when not in
-    :ref:`pedantic-mode`.
+    :ref:`astropy:pedantic-mode`.
 
     ``astropy.io.votable`` always outputs files using only spaces, regardless of
     how they were input.

--- a/astropy/io/votable/table.py
+++ b/astropy/io/votable/table.py
@@ -203,7 +203,7 @@ def writeto(table, file, tabledata_format=None):
         one of ``tabledata`` (text representation), ``binary`` or
         ``binary2``.  By default, use the format that was specified in
         each ``table`` object as it was created or read in.  See
-        :ref:`votable-serialization`.
+        :ref:`astropy:astropy:votable-serialization`.
     """
     from astropy.table import Table
     if isinstance(table, Table):

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -2249,7 +2249,7 @@ class Table(Element, _IDProperty, _NameProperty, _UcdProperty,
         file, can not be written out.  Any file read in with 'fits'
         format will be read out, by default, in 'tabledata' format.
 
-        See :ref:`votable-serialization`.
+        See :ref:`astropy:votable-serialization`.
         """
         return self._format
 
@@ -3644,7 +3644,7 @@ class VOTableFile(Element, _IDProperty, _DescriptionProperty):
             be one of ``tabledata`` (text representation), ``binary`` or
             ``binary2``.  By default, use the format that was specified
             in each `Table` object as it was created or read in.  See
-            :ref:`votable-serialization`.
+            :ref:`astropy:votable-serialization`.
         """
         if tabledata_format is not None:
             if tabledata_format.lower() not in (

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -992,7 +992,7 @@ class Model(metaclass=_ModelMeta):
         that pertains to which model a parameter value pertains to--as
         specified when the model was initialized.
 
-        See the documentation on :ref:`modeling-model-sets`
+        See the documentation on :ref:`astropy:modeling-model-sets`
         for more details.
         """
 
@@ -1199,7 +1199,7 @@ class Model(metaclass=_ModelMeta):
         this property just raises `NotImplementedError` by default (but may be
         assigned a custom value by a user).  ``bounding_box`` can be set
         manually to an array-like object of shape ``(model.n_inputs, 2)``. For
-        further usage, see :ref:`bounding-boxes`
+        further usage, see :ref:`astropy:bounding-boxes`
 
         The limits are ordered according to the `numpy` indexing
         convention, and are the reverse of the model input order,
@@ -1531,7 +1531,7 @@ class Model(metaclass=_ModelMeta):
 
         Examples
         --------
-        :ref:`bounding-boxes`
+        :ref:`astropy:bounding-boxes`
         """
 
         try:
@@ -3397,7 +3397,7 @@ class CompoundModel(Model):
 
         Examples
         --------
-        :ref:`bounding-boxes`
+        :ref:`astropy:bounding-boxes`
         """
 
         try:
@@ -3792,7 +3792,7 @@ def render_model(model, arr=None, coords=None):
 
     Examples
     --------
-    :ref:`bounding-boxes`
+    :ref:`astropy:bounding-boxes`
     """
 
     bbox = model.bounding_box

--- a/astropy/modeling/mappings.py
+++ b/astropy/modeling/mappings.py
@@ -20,7 +20,7 @@ class Mapping(FittableModel):
     mapping : tuple
         A tuple of integers representing indices of the inputs to this model
         to return and in what order to return them.  See
-        :ref:`compound-model-mappings` for more details.
+        :ref:`astropy:compound-model-mappings` for more details.
     n_inputs : int
         Number of inputs; if `None` (default) then ``max(mapping) + 1`` is
         used (i.e. the highest input index used in the mapping).

--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -138,7 +138,7 @@ class Parameter:
 
 
 
-    See :ref:`modeling-parameters` for more details.
+    See :ref:`astropy:modeling-parameters` for more details.
 
     Parameters
     ----------

--- a/astropy/modeling/polynomial.py
+++ b/astropy/modeling/polynomial.py
@@ -189,7 +189,7 @@ class OrthoPolynomialBase(PolynomialBase):
     The polynomials implemented here require a maximum degree in x and y.
 
     For explanation of ``x_domain``, ``y_domain``, ```x_window`` and ```y_window``
-    see :ref:`Notes regarding usage of domain and window <domain-window-note>`.
+    see :ref:`Notes regarding usage of domain and window <astropy:domain-window-note>`.
 
 
     Parameters

--- a/astropy/nddata/compat.py
+++ b/astropy/nddata/compat.py
@@ -254,7 +254,7 @@ class NDDataArray(NDArithmeticMixin, NDSlicingMixin, NDIOMixin, NDData):
 
         equivalencies : list of tuple
            A list of equivalence pairs to try if the units are not
-           directly convertible.  See :ref:`unit_equivalencies`.
+           directly convertible.  See :ref:`astropy:unit_equivalencies`.
 
         Returns
         -------

--- a/astropy/nddata/utils.py
+++ b/astropy/nddata/utils.py
@@ -374,7 +374,7 @@ class Cutout2D:
     will also contain a copy of the original WCS, but updated for the
     cutout array.
 
-    For example usage, see :ref:`cutout_images`.
+    For example usage, see :ref:`astropy:cutout_images`.
 
     .. warning::
 

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -808,7 +808,7 @@ class BaseColumn(_ColumnGetitemShim, np.ndarray):
 
         equivalencies : list of tuple
            A list of equivalence pairs to try if the unit are not
-           directly convertible.  See :ref:`unit_equivalencies`.
+           directly convertible.  See :ref:`astropy:unit_equivalencies`.
 
         Raises
         ------

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -2382,7 +2382,7 @@ class TimeDelta(TimeBase):
             The unit to convert to.
         equivalencies : list of tuple
             A list of equivalence pairs to try if the units are not directly
-            convertible (see :ref:`unit_equivalencies`). If `None`, no
+            convertible (see :ref:`astropy:unit_equivalencies`). If `None`, no
             equivalencies will be applied at all, not even any set globallyq
             or within a context.
 
@@ -2448,7 +2448,7 @@ class TimeDelta(TimeBase):
             The unit in which the value should be given.
         equivalencies : list of tuple
             A list of equivalence pairs to try if the units are not directly
-            convertible (see :ref:`unit_equivalencies`). If `None`, no
+            convertible (see :ref:`astropy:unit_equivalencies`). If `None`, no
             equivalencies will be applied at all, not even any set globally or
             within a context.
 

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -921,7 +921,7 @@ class UnitBase:
 
         equivalencies : list of tuple
             A list of equivalence pairs to try if the units are not
-            directly convertible.  See :ref:`unit_equivalencies`.
+            directly convertible.  See :ref:`astropy:unit_equivalencies`.
             This list is in addition to possible global defaults set by, e.g.,
             `set_enabled_equivalencies`.
             Use `None` to turn off all equivalencies.
@@ -1104,7 +1104,7 @@ class UnitBase:
 
         equivalencies : list of tuple
             A list of equivalence pairs to try if the units are not
-            directly convertible.  See :ref:`unit_equivalencies`.
+            directly convertible.  See :ref:`astropy:unit_equivalencies`.
             This list is in addition to possible global defaults set by, e.g.,
             `set_enabled_equivalencies`.
             Use `None` to turn off all equivalencies.
@@ -1286,7 +1286,7 @@ class UnitBase:
         ----------
         equivalencies : list of tuple
             A list of equivalence pairs to also list.  See
-            :ref:`unit_equivalencies`.
+            :ref:`astropy:unit_equivalencies`.
             This list is in addition to possible global defaults set by, e.g.,
             `set_enabled_equivalencies`.
             Use `None` to turn off all equivalencies.
@@ -1521,7 +1521,7 @@ class UnitBase:
         ----------
         equivalencies : list of tuple
             A list of equivalence pairs to also pull options from.
-            See :ref:`unit_equivalencies`.  It must already be
+            See :ref:`astropy:unit_equivalencies`.  It must already be
             normalized using `_normalize_equivalencies`.
         """
         unit_registry = get_current_unit_registry()
@@ -1617,7 +1617,7 @@ class UnitBase:
         ----------
         equivalencies : list of tuple
             A list of equivalence pairs to also list.  See
-            :ref:`unit_equivalencies`.
+            :ref:`astropy:unit_equivalencies`.
             Any list given, including an empty one, supersedes global defaults
             that may be in effect (as set by `set_enabled_equivalencies`)
 

--- a/astropy/units/function/core.py
+++ b/astropy/units/function/core.py
@@ -178,7 +178,7 @@ class FunctionUnitBase(metaclass=ABCMeta):
 
         equivalencies : list of tuple
             A list of equivalence pairs to try if the units are not
-            directly convertible.  See :ref:`unit_equivalencies`.
+            directly convertible.  See :ref:`astropy:unit_equivalencies`.
             This list is in addition to the built-in equivalencies between the
             function unit and the physical one, as well as possible global
             defaults set by, e.g., `~astropy.units.set_enabled_equivalencies`.
@@ -214,7 +214,7 @@ class FunctionUnitBase(metaclass=ABCMeta):
 
         equivalencies : list of tuple
             A list of equivalence pairs to try if the units are not
-            directly convertible.  See :ref:`unit_equivalencies`.
+            directly convertible.  See :ref:`astropy:unit_equivalencies`.
             This list is in meant to treat only equivalencies between different
             physical units; the build-in equivalency between the function
             unit and the physical one is automatically taken into account.

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -682,7 +682,7 @@ class Quantity(np.ndarray):
 
         equivalencies : list of tuple
             A list of equivalence pairs to try if the units are not
-            directly convertible.  See :ref:`unit_equivalencies`.
+            directly convertible.  See :ref:`astropy:unit_equivalencies`.
             If not provided or ``[]``, class default equivalencies will be used
             (none for `~astropy.units.Quantity`, but may be set for subclasses)
             If `None`, no equivalencies will be applied at all, not even any
@@ -720,8 +720,8 @@ class Quantity(np.ndarray):
 
         equivalencies : list of tuple, optional
             A list of equivalence pairs to try if the units are not directly
-            convertible (see :ref:`unit_equivalencies`). If not provided or
-            ``[]``, class default equivalencies will be used (none for
+            convertible (see :ref:`astropy:unit_equivalencies`). If not provided
+            or ``[]``, class default equivalencies will be used (none for
             `~astropy.units.Quantity`, but may be set for subclasses).
             If `None`, no equivalencies will be applied at all, not even any
             set globally or within a context.

--- a/astropy/utils/state.py
+++ b/astropy/utils/state.py
@@ -1,6 +1,6 @@
 """
 A simple class to manage a piece of global science state.  See
-:ref:`config-developer` for more details.
+:ref:`astropy:config-developer` for more details.
 """
 
 

--- a/astropy/visualization/lupton_rgb.py
+++ b/astropy/visualization/lupton_rgb.py
@@ -334,7 +334,7 @@ def make_lupton_rgb(image_r, image_g, image_b, minimum=0, stretch=5, Q=8,
     The input images can be int or float, and in any range or bit-depth.
 
     For a more detailed look at the use of this method, see the document
-    :ref:`astropy-visualization-rgb`.
+    :ref:`astropy:astropy-visualization-rgb`.
 
     Parameters
     ----------

--- a/astropy/wcs/docstrings.py
+++ b/astropy/wcs/docstrings.py
@@ -736,7 +736,7 @@ relax : bool or int
       standard.
 
     - `int`: a bit field selecting specific extensions to accept.  See
-      :ref:`relaxread` for details.
+      :ref:`astropy:relaxread` for details.
 
 keysel : sequence of flags
     Used to restrict the keyword types considered:
@@ -2108,7 +2108,7 @@ relax : bool or int
       standard.
 
     - `int`: a bit field selecting specific extensions to write.
-      See :ref:`relaxwrite` for details.
+      See :ref:`astropy:relaxwrite` for details.
 
 Returns
 -------
@@ -2253,7 +2253,7 @@ relax : bool or int, optional
       standard.
 
     - `int`: a bit field selecting specific extensions to accept.  See
-      :ref:`relaxread` for details.
+      :ref:`astropy:relaxread` for details.
 
 naxis : int, optional
     The number of world coordinates axes for the object.  (*naxis* may

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -266,7 +266,7 @@ class WCS(FITSWCSAPIMixin, WCSBase):
           published WCS standard.
 
         - `int`: a bit field selecting specific extensions to accept.
-          See :ref:`relaxread` for details.
+          See :ref:`astropy:relaxread` for details.
 
     naxis : int or sequence, optional
         Extracts specific coordinate axes using
@@ -2551,7 +2551,7 @@ reduce these to 2 dimensions using the naxis kwarg.
               WCS standard.
 
             - `int`: a bit field selecting specific extensions to
-              write.  See :ref:`relaxwrite` for details.
+              write.  See :ref:`astropy:relaxwrite` for details.
 
         key : str
             The name of a particular WCS transform to use.  This may be
@@ -2598,7 +2598,7 @@ reduce these to 2 dimensions using the naxis kwarg.
               WCS standard.
 
             - `int`: a bit field selecting specific extensions to
-              write.  See :ref:`relaxwrite` for details.
+              write.  See :ref:`astropy:relaxwrite` for details.
 
             If the ``relax`` keyword argument is not given and any
             keywords were omitted from the output, an
@@ -3303,7 +3303,7 @@ def find_all_wcs(header, relax=True, keysel=None, fix=True,
           published WCS standard.
 
         - `int`: a bit field selecting specific extensions to accept.
-          See :ref:`relaxread` for details.
+          See :ref:`astropy:relaxread` for details.
 
     keysel : sequence of str, optional
         A list of flags used to select the keyword types considered by

--- a/docs/changes/11690.other.rst
+++ b/docs/changes/11690.other.rst
@@ -1,0 +1,5 @@
+In docstrings, Sphinx cross-reference targets now use intersphinx, even if the
+target is an internal link (``link`` is now ``'astropy:link``).
+When built in Astropy these links are interpreted as internal links. When built
+in affiliate packages, the link target is set by the key 'astropy' in the
+intersphinx mapping.

--- a/docs/changes/coordinates/11690.other.rst
+++ b/docs/changes/coordinates/11690.other.rst
@@ -1,3 +1,3 @@
-RST links in SkyCoord now use intersphinx for affiliate package convenience.
-Outside the astropy package, subclasses of SkyCoord, with inherited docstrings,
-will now link to the astropy docs instead of raising a warning / error.
+Sphinx RST links in ``SkyCoord`` now use intersphinx for downstream packages' convenience.
+Outside the ``astropy`` package, subclasses of ``SkyCoord``, with inherited docstrings,
+will now link to the ``astropy`` docs instead of raising a warning or an error.

--- a/docs/changes/coordinates/11690.other.rst
+++ b/docs/changes/coordinates/11690.other.rst
@@ -1,0 +1,3 @@
+RST links in SkyCoord now use intersphinx for affiliate package convenience.
+Outside the astropy package, subclasses of SkyCoord, with inherited docstrings,
+will now link to the astropy docs instead of raising a warning / error.

--- a/docs/changes/coordinates/11690.other.rst
+++ b/docs/changes/coordinates/11690.other.rst
@@ -1,3 +1,0 @@
-Sphinx RST links in ``SkyCoord`` now use intersphinx for downstream packages' convenience.
-Outside the ``astropy`` package, subclasses of ``SkyCoord``, with inherited docstrings,
-will now link to the ``astropy`` docs instead of raising a warning or an error.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -372,6 +372,9 @@ def resolve_astropy_and_dev_reference(app, env, node, contnode):
     # should the node be processed?
     reftarget = node.get('reftarget')  # str or None
     if str(reftarget).startswith('astropy:'):
+        # This allows Astropy to use intersphinx links to itself and have
+        # them resolve to local links. Downstream packages will see intersphinx.
+        # TODO! deprecate this if sphinx-doc/sphinx/issues/9169 is implemented.
         process, replace = True, 'astropy:'
     elif dev and str(reftarget).startswith('astropy-dev:'):
         process, replace = True, 'astropy-dev:'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -355,22 +355,39 @@ def rstjinja(app, docname, source):
         source[0] = rendered
 
 
-def resolve_astropy_dev_reference(app, env, node, contnode):
+def resolve_astropy_and_dev_reference(app, env, node, contnode):
     """
-    Reference targets beginning with ``astropy-dev:`` are a special case.
+    Reference targets for ``astropy:`` and ``astropy-dev:`` are special cases.
 
-    If we are building the development docs it is a local ref targetting the
+    Documentation links in astropy can be set up as intersphinx links so that
+    affiliate packages do not have to override the docstrings when building
+    the docs.
+
+    If we are building the development docs it is a local ref targeting the
     label ``astropy-dev:<label>``, but for stable docs it should be an
     intersphinx resolution to the development docs.
 
     See https://github.com/astropy/astropy/issues/11366
     """
+    # should the node be processed?
+    reftarget = node.get('reftarget')  # str or None
+    if str(reftarget).startswith('astropy:'):
+        process, replace = True, 'astropy:'
+    elif dev and str(reftarget).startswith('astropy-dev:'):
+        process, replace = True, 'astropy-dev:'
+    else:
+        process, replace = False, ''
 
-    reftarget = node.get('reftarget')
-    if dev and reftarget is not None and reftarget.startswith('astropy-dev:'):
+    # make link local
+    if process:
         reftype = node.get('reftype')
         refdoc = node.get('refdoc', app.env.docname)
-        reftarget = reftarget.split(':', 1)[1]
+        # convert astropy intersphinx targets to local links.
+        # there are a few types of intersphinx link patters, as described in
+        # https://docs.readthedocs.io/en/stable/guides/intersphinx.html
+        reftarget = reftarget.replace(replace, '')
+        if reftype == "doc":  # also need to replace the doc link
+            node.replace_attr("reftarget", reftarget)
         # Delegate to the ref node's original domain/target (typically :ref:)
         try:
             domain = app.env.domains[node['refdomain']]
@@ -401,5 +418,5 @@ def setup(app):
     # Set this to higher priority than intersphinx; this way when building
     # dev docs astropy-dev: targets will go to the local docs instead of the
     # intersphinx mapping
-    app.connect("missing-reference", resolve_astropy_dev_reference,
+    app.connect("missing-reference", resolve_astropy_and_dev_reference,
                 priority=400)

--- a/docs/development/docguide.rst
+++ b/docs/development/docguide.rst
@@ -44,12 +44,6 @@ the standard Astropy docstring format.
 * All documentation should be written using the `Sphinx`_
   documentation tool.
 
-  + cross-reference links (``:ref:``, ``:doc:``, etc.), **including internal
-    Astropy links**, should use the `intersphinx format
-    <https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html>`_.
-    Note that in Astropy these internal links are to the current build, while
-    for affiliate packages these links resolve to the stable version.
-
 * ReST substitutions are centralized in ``docs/conf.py::rst_epilog`` for
   consistency across the documentation and docstrings. These should be used over
   custom redefinitions; and new substitutions should probably be placed there.
@@ -61,6 +55,16 @@ the standard Astropy docstring format.
 
 * Docstrings should follow the `numpydoc format
   <https://numpydoc.readthedocs.io/en/latest/format.html>`_.
+
+* References in docstrings, **including internal Astropy links**, should use the
+  `intersphinx format
+  <https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html>`_.
+  For example a link to the Astropy section on unit equivalencies would be
+  `` :ref:`astropy:unit_equivalencies` ``.
+  When built in Astropy, links starting with 'astropy' resolve to the current
+  build. In affiliate packages using ``sphinx-astropy``'s intersphinx mapping,
+  the links resolve to the stable version of Astropy. For linking to the
+  development version, use the intersphinx target 'astropy-dev'.
 
 * Examples and/or tutorials are strongly encouraged for typical use-cases of a
   particular module or class.

--- a/docs/development/docguide.rst
+++ b/docs/development/docguide.rst
@@ -43,7 +43,13 @@ the standard Astropy docstring format.
 
 * All documentation should be written using the `Sphinx`_
   documentation tool.
-  
+
+  + cross-reference links (``:ref:``, ``:doc:``, etc.), **including internal
+    Astropy links**, should use the `intersphinx format
+    <https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html>`_.
+    Note that in Astropy these internal links are to the current build, while
+    for affiliate packages these links resolve to the stable version.
+
 * ReST substitutions are centralized in ``docs/conf.py::rst_epilog`` for
   consistency across the documentation and docstrings. These should be used over
   custom redefinitions; and new substitutions should probably be placed there.

--- a/examples/coordinates/plot_sgr-coordinate-frame.py
+++ b/examples/coordinates/plot_sgr-coordinate-frame.py
@@ -5,12 +5,12 @@ Create a new coordinate class (for the Sagittarius stream)
 ==========================================================
 
 This document describes in detail how to subclass and define a custom spherical
-coordinate frame, as discussed in :ref:`astropy-coordinates-design` and the
-docstring for `~astropy.coordinates.BaseCoordinateFrame`. In this example, we
-will define a coordinate system defined by the plane of orbit of the Sagittarius
-Dwarf Galaxy (hereafter Sgr; as defined in Majewski et al. 2003).  The Sgr
-coordinate system is often referred to in terms of two angular coordinates,
-:math:`\Lambda,B`.
+coordinate frame, as discussed in :ref:`astropy:astropy-coordinates-design` and
+the docstring for `~astropy.coordinates.BaseCoordinateFrame`. In this example,
+we will define a coordinate system defined by the plane of orbit of the
+Sagittarius Dwarf Galaxy (hereafter Sgr; as defined in Majewski et al. 2003).
+The Sgr coordinate system is often referred to in terms of two angular
+coordinates, :math:`\Lambda,B`.
 
 To do this, we need to define a subclass of
 `~astropy.coordinates.BaseCoordinateFrame` that knows the names and units of the


### PR DESCRIPTION
This enables astropy to use astropy intersphinx links and correctly resolve them to the version being built.
This is implemented in SkyCoord so that links to the docs works in affiliate packages.

Part of #11555 
Request Review: @mhvk @adrn @pllim @embray 

Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>