### PR TITLE
Allow threading when calling sigma clipping C extension

### DIFF
--- a/astropy/stats/src/fast_sigma_clip.c
+++ b/astropy/stats/src/fast_sigma_clip.c
@@ -112,6 +112,8 @@ static void _sigma_clip_fast(
         return;
     }
 
+    Py_BEGIN_ALLOW_THREADS
+
     for (i_o = 0; i_o < n_o;
          i_o++, array += s_array,
                 mask += s_mask,
@@ -154,6 +156,9 @@ static void _sigma_clip_fast(
             *(double *)bound_high = NPY_NAN;
         }
     }
+
+    Py_END_ALLOW_THREADS
+
     PyArray_free((void *)data_buffer);
     if (mad_buffer != NULL) {
         PyArray_free((void *)mad_buffer);

--- a/astropy/stats/src/fast_sigma_clip.c
+++ b/astropy/stats/src/fast_sigma_clip.c
@@ -105,14 +105,14 @@ static void _sigma_clip_fast(
     double *data_buffer = NULL;
     double *mad_buffer = NULL;
 
+    NPY_BEGIN_THREADS_DEF
+
     // data_buffer is used to store the current values being sigma clipped
     data_buffer = (double *)PyArray_malloc(n_i * sizeof(double));
     if (data_buffer == NULL) {
         PyErr_NoMemory();
         return;
     }
-
-    Py_BEGIN_ALLOW_THREADS
 
     for (i_o = 0; i_o < n_o;
          i_o++, array += s_array,
@@ -144,20 +144,23 @@ static void _sigma_clip_fast(
                 }
             }
 
+            NPY_BEGIN_THREADS
+
             compute_sigma_clipped_bounds(
                 data_buffer, count,
                 (int)(*(npy_bool *)use_median), (int)(*(npy_bool *)use_mad_std),
                 *(int *)max_iter,
                 *(double *)sigma_low, *(double *)sigma_high,
                 (double *)bound_low, (double *)bound_high, mad_buffer);
+
+            NPY_END_THREADS
+
         }
         else {
             *(double *)bound_low = NPY_NAN;
             *(double *)bound_high = NPY_NAN;
         }
     }
-
-    Py_END_ALLOW_THREADS
 
     PyArray_free((void *)data_buffer);
     if (mad_buffer != NULL) {


### PR DESCRIPTION
When using the ``sigma_clip`` function in e.g. dask with multi-threading, I think the GIL is still preventing optimal performance. The following code:

```python
import time
import numpy as np
import dask
import dask.array as da
from astropy.stats import sigma_clip

array = 10 ** da.random.uniform(-1, 2, (50000, 128, 128))

array = array.rechunk((-1, 'auto', 'auto'))

def sigma_clip_axis0(data):
    return sigma_clip(data, axis=0, copy=False, masked=True)

result = da.map_blocks(sigma_clip_axis0, array).sum()

arrays = [np.random.random((1024, 1024)) for i in range(256)]

start = time.time()
with dask.config.set(scheduler='synchronous'):
    result.compute()
end = time.time()
print(f'serial: {end - start:.3f} seconds')

start = time.time()
with dask.config.set(scheduler='threads'):
    result.compute()
end = time.time()
print(f'multi-threaded: {end - start:.3f} seconds')
```

gives the following on astropy main:

```
serial: 55.267 seconds
multi-threaded: 39.352 seconds
```

and the following with this PR:

```
serial: 53.922 seconds
multi-threaded: 12.989 seconds
```

This doesn't change any features or anything so I think we can still include in 4.3 as it's just a small improvement? (also not adding a changelog entry since this is new functionality anyway in 4.3)

@mhvk - can you confirm this is the right place to use these directives for a gufunc?