### PR TITLE
Add support for "complex" bounding boxes.

### DIFF
--- a/astropy/modeling/bounding_box.py
+++ b/astropy/modeling/bounding_box.py
@@ -1,0 +1,146 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+from collections import UserDict
+from .utils import _BoundingBox
+
+import numpy as np
+
+
+class BoundingBox(_BoundingBox):
+    @classmethod
+    def validate(cls, model, bounding_box, slice_arg=None):
+        """
+        Validate a given bounding box sequence against the given model (which
+        may be either a subclass of `~astropy.modeling.Model` or an instance
+        thereof, so long as the ``.inputs`` attribute is defined.
+
+        Currently this just checks that the bounding_box is either a 2-tuple
+        of lower and upper bounds for 1-D models, or an N-tuple of 2-tuples
+        for N-D models.
+
+        This also returns a normalized version of the bounding_box input to
+        ensure it is always an N-tuple (even for the 1-D case).
+        """
+
+        if isinstance(bounding_box, dict) or isinstance(bounding_box, CompoundBoundingBox):
+            return CompoundBoundingBox.validate(model, bounding_box, slice_arg=slice_arg)
+
+        nd = model.n_inputs
+        if slice_arg is not None:
+            if isinstance(slice_arg, tuple):
+                nd -= len(slice_arg)
+            else:
+                nd -= 1
+
+        return cls._validate(model, bounding_box, nd)
+
+    def reverse(self, axes_ind):
+        bbox = [self[ind] for ind in axes_ind][::-1]
+
+        return _BoundingBox(bbox, self._model)
+
+
+class CompoundBoundingBox(UserDict):
+    def __init__(self, bounding_box,  model=None, slice_arg=None, remove_slice_arg=False):
+        super().__init__(bounding_box)
+        self._model = model
+
+        if self._model is None:
+            self._slice_arg = slice_arg
+        else:
+            self.set_slice_arg(slice_arg)
+
+        self._remove_slice_arg = remove_slice_arg
+
+    @property
+    def slice_arg(self):
+        return self._slice_arg
+
+    @property
+    def remove_slice_arg(self):
+        return self._remove_slice_arg
+
+    def _get_arg_index(self, slice_arg):
+        if np.issubdtype(type(slice_arg), np.integer):
+            arg_index = slice_arg
+        else:
+            if slice_arg in self._model.inputs:
+                arg_index = self._model.inputs.index(slice_arg)
+            else:
+                raise ValueError(f'{slice_arg} is not an input of of your model inputs {self._model.inputs}')
+
+        if arg_index < self._model.n_inputs:
+            return arg_index
+        else:
+            raise ValueError(f'{arg_index} is out of model argument bounds')
+
+    @classmethod
+    def validate(cls, model, bounding_box, slice_arg=None, remove_slice_arg=None):
+        if isinstance(bounding_box, CompoundBoundingBox) and slice_arg is None:
+            slice_arg = bounding_box.slice_arg
+
+        if remove_slice_arg is None:
+            if isinstance(bounding_box, CompoundBoundingBox):
+                remove_slice_arg = bounding_box.remove_slice_arg
+            else:
+                remove_slice_arg = False
+
+        new_box = cls({}, model, slice_arg, remove_slice_arg)
+
+        if not remove_slice_arg:
+            slice_arg = None
+
+        for slice_index, slice_box in bounding_box.items():
+            new_box[slice_index] = BoundingBox.validate(model, slice_box, slice_arg)
+
+        return new_box
+
+    def set_slice_arg(self, slice_arg):
+        if slice_arg is None:
+            self._slice_arg = slice_arg
+        elif isinstance(slice_arg, tuple):
+            self._slice_arg = tuple([self._get_arg_index(arg) for arg in slice_arg])
+        else:
+            self._slice_arg = self._get_arg_index(slice_arg)
+
+    def _get_slice_index(self, inputs, slice_arg):
+        if inputs is None:
+            raise RuntimeError('Inputs must not be None in order to lookup slice')
+
+        slice_index = inputs[self._get_arg_index(slice_arg)]
+        if isinstance(slice_index, np.ndarray):
+            slice_index = slice_index.item()
+
+        return slice_index
+
+    def get_bounding_box(self, inputs=None, slice_index=True):
+        if isinstance(slice_index, bool) and slice:
+            if self._slice_arg is None:
+                return None
+            else:
+                if isinstance(self._slice_arg, tuple):
+                    slice_index = tuple([self._get_slice_index(inputs, slice_arg)
+                                         for slice_arg in self._slice_arg])
+                else:
+                    slice_index = self._get_slice_index(inputs, self._slice_arg)
+
+        if slice_index in self:
+            return self[slice_index]
+        else:
+            raise RuntimeError(f"No bounding_box is defined for slice: {slice_index}!")
+
+    def reverse(self, axes_ind):
+        # bbox = {slice_index: slice_box.reverse(axes_ind)
+        #         for slice_index, slice_box in self.items()}
+        bbox = {}
+        for slice_index, slice_box in self.items():
+            bbox[slice_index] = [slice_box[ind] for ind in axes_ind][::-1]
+
+        return CompoundBoundingBox(bbox, self._model, self._slice_arg, self._remove_slice_arg)
+
+    def py_order(self, axes_order):
+        bbox = {}
+        for slice_index, slice_box in self.items():
+            bbox[slice_index] = tuple(slice_box[::-1][i] for i in axes_order)
+
+        return CompoundBoundingBox(bbox, self._model, self._slice_arg, self._remove_slice_arg)

--- a/astropy/modeling/bounding_box.py
+++ b/astropy/modeling/bounding_box.py
@@ -1,14 +1,19 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from collections import UserDict
+from collections import UserDict, namedtuple
 from .utils import _BoundingBox
+from astropy.utils import isiterable
 
 import numpy as np
+from typing import List, Dict, Any, Callable, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .core import Model
 
 
 class BoundingBox(_BoundingBox):
     @classmethod
-    def validate(cls, model, bounding_box, slice_arg=None):
+    def validate(cls, model, bounding_box, slice_args=None):
         """
         Validate a given bounding box sequence against the given model (which
         may be either a subclass of `~astropy.modeling.Model` or an instance
@@ -23,124 +28,326 @@ class BoundingBox(_BoundingBox):
         """
 
         if isinstance(bounding_box, dict) or isinstance(bounding_box, CompoundBoundingBox):
-            return CompoundBoundingBox.validate(model, bounding_box, slice_arg=slice_arg)
+            return CompoundBoundingBox.validate(bounding_box, slice_args=slice_args,
+                                                model=model)
 
         nd = model.n_inputs
-        if slice_arg is not None:
-            if isinstance(slice_arg, tuple):
-                nd -= len(slice_arg)
-            else:
-                nd -= 1
+        if slice_args is not None:
+            # Get list of removed if possible
+            try:
+                slice_args = slice_args.removed
+            except AttributeError:
+                pass
+
+            # Get the number of args to remove
+            try:
+                length = len(slice_args)
+            except TypeError:
+                length = 1
+
+            nd -= length
 
         return cls._validate(model, bounding_box, nd)
 
-    def reverse(self, axes_ind):
-        bbox = [self[ind] for ind in axes_ind][::-1]
 
-        return _BoundingBox(bbox, self._model)
+_BaseModelArgument = namedtuple('_BaseModelArgument', "name remove index")
+
+
+class ModelArgument(_BaseModelArgument):
+    @staticmethod
+    def _get_index(name: str, model=None):
+        if name is None:
+            return None
+
+        if model is None:
+            return None
+        else:
+            if name in model.inputs:
+                return model.inputs.index(name)
+            else:
+                raise ValueError(f'{name} is not an input of your model inputs: {model.inputs}.')
+
+    @classmethod
+    def validate(cls, model=None, name=None, remove=False, index=None):
+        valid_index = cls._get_index(name, model)
+        if valid_index is None:
+            valid_index = index
+        else:
+            if index is not None and valid_index != index:
+                raise IndexError(f"Index should be {valid_index}, but was given {index}.")
+
+        if name is None or valid_index is None:
+            raise ValueError("Enough information must be given so that both name and index can be determined.")
+        else:
+            return cls(name, remove, valid_index)
+
+    def get_slice(self, **kwargs):
+        if self.name in kwargs:
+            return kwargs[self.name]
+        else:
+            raise ValueError(f"Cannot find a valid input corresponding to {self.name} in: {kwargs}.")
+
+    @staticmethod
+    def _removed_bounding_box():
+        return BoundingBox((-np.inf, np.inf))
+
+    def _add_bounding_box(self, bounding_box: BoundingBox) -> BoundingBox:
+        if not isinstance(bounding_box, BoundingBox):
+            bounding_box = BoundingBox(bounding_box)
+
+        if bounding_box.dimension == 1:
+            new_bounding_box = [bounding_box]
+        else:
+            new_bounding_box = list(bounding_box)
+
+        new_bounding_box.insert(self.index, self._removed_bounding_box())
+
+        return BoundingBox(new_bounding_box)
+
+    def add_bounding_box(self, bounding_box: BoundingBox) -> BoundingBox:
+        if self.remove:
+            return self._add_bounding_box(bounding_box)
+        else:
+            return bounding_box
+
+    def add_removed_axis(self, axes_ind: np.ndarray):
+        if self.remove and self.index not in axes_ind:
+            return np.append(axes_ind, self.index)
+        else:
+            return axes_ind
+
+
+class ModelArguments(object):
+    def __init__(self, arguments=List[ModelArgument]):
+        self._arguments = arguments
+
+    @property
+    def arguments(self) -> List[ModelArgument]:
+        return self._arguments
+
+    @property
+    def names(self) -> List[str]:
+        return [arg.name for arg in self._arguments]
+
+    @property
+    def indices(self) -> Dict[str, int]:
+        return {arg.name: arg.index for arg in self._arguments}
+
+    @property
+    def sorted(self) -> 'ModelArguments':
+        return ModelArguments(sorted(self._arguments, key=lambda x: x.index))
+
+    @property
+    def removed(self):
+        return [arg for arg in self._arguments if arg.remove]
+
+    @staticmethod
+    def _validate_argument(model, arg):
+        if isinstance(arg, list) or isinstance(arg, tuple):
+            return ModelArgument.validate(model, *arg)
+        else:
+            return ModelArgument.validate(model, name=arg)
+
+    @classmethod
+    def validate(cls, model=None, arguments=None):
+        if arguments is None:
+            arguments = []
+
+        if isinstance(arguments, ModelArguments):
+            arguments = arguments.arguments
+
+        valid_arguments = [cls._validate_argument(model, arg) for arg in arguments]
+
+        return cls(valid_arguments)
+
+    def __eq__(self, value):
+        if isinstance(value, ModelArguments):
+            return self.arguments == value.arguments
+        else:
+            return False
+
+    def get_slice(self, **kwargs) -> tuple:
+        slice_tuple = tuple([arg.get_slice(**kwargs) for arg in self._arguments])
+
+        if len(slice_tuple) == 1:
+            return slice_tuple[0]
+        else:
+            return slice_tuple
+
+    def add_bounding_box(self, bounding_box: BoundingBox) -> BoundingBox:
+        for argument in self._arguments:
+            bounding_box = argument.add_bounding_box(bounding_box)
+        return bounding_box
+
+    def add_removed_axes(self, axes_ind: np.ndarray):
+        for argument in self._arguments:
+            axes_ind = argument.add_removed_axis(axes_ind)
+        return axes_ind
 
 
 class CompoundBoundingBox(UserDict):
-    def __init__(self, bounding_box,  model=None, slice_arg=None, remove_slice_arg=False):
+    def __init__(self, bounding_box: Dict[Any, BoundingBox],
+                 model: "Model"=None, slice_args: ModelArguments=None,
+                 create_slice: Callable=None):
         super().__init__(bounding_box)
         self._model = model
-
-        if self._model is None:
-            self._slice_arg = slice_arg
-        else:
-            self.set_slice_arg(slice_arg)
-
-        self._remove_slice_arg = remove_slice_arg
+        self._slice_args = ModelArguments.validate(model, slice_args)
+        self._create_slice = create_slice
 
     @property
-    def slice_arg(self):
-        return self._slice_arg
+    def slice_args(self):
+        return self._slice_args
 
     @property
-    def remove_slice_arg(self):
-        return self._remove_slice_arg
+    def slice_names(self):
+        return self._slice_args.names
 
-    def _get_arg_index(self, slice_arg):
-        if np.issubdtype(type(slice_arg), np.integer):
-            arg_index = slice_arg
-        else:
-            if slice_arg in self._model.inputs:
-                arg_index = self._model.inputs.index(slice_arg)
-            else:
-                raise ValueError(f'{slice_arg} is not an input of of your model inputs {self._model.inputs}')
-
-        if arg_index < self._model.n_inputs:
-            return arg_index
-        else:
-            raise ValueError(f'{arg_index} is out of model argument bounds')
+    @property
+    def slice_indicies(self):
+        return self._slice_args.indices
 
     @classmethod
-    def validate(cls, model, bounding_box, slice_arg=None, remove_slice_arg=None):
-        if isinstance(bounding_box, CompoundBoundingBox) and slice_arg is None:
-            slice_arg = bounding_box.slice_arg
+    def validate(cls, bounding_box, slice_args=None, model=None):
+        if isinstance(bounding_box, CompoundBoundingBox) and slice_args is None:
+            slice_args = ModelArguments.validate(model,
+                                                 bounding_box.slice_args)
+        else:
+            slice_args = ModelArguments.validate(model, slice_args)
 
-        if remove_slice_arg is None:
-            if isinstance(bounding_box, CompoundBoundingBox):
-                remove_slice_arg = bounding_box.remove_slice_arg
-            else:
-                remove_slice_arg = False
-
-        new_box = cls({}, model, slice_arg, remove_slice_arg)
-
-        if not remove_slice_arg:
-            slice_arg = None
+        new_box = cls({}, model, slice_args)
 
         for slice_index, slice_box in bounding_box.items():
-            new_box[slice_index] = BoundingBox.validate(model, slice_box, slice_arg)
+            new_box[slice_index] = BoundingBox.validate(model, slice_box, slice_args)
 
         return new_box
 
-    def set_slice_arg(self, slice_arg):
-        if slice_arg is None:
-            self._slice_arg = slice_arg
-        elif isinstance(slice_arg, tuple):
-            self._slice_arg = tuple([self._get_arg_index(arg) for arg in slice_arg])
-        else:
-            self._slice_arg = self._get_arg_index(slice_arg)
-
-    def _get_slice_index(self, inputs, slice_arg):
-        if inputs is None:
-            raise RuntimeError('Inputs must not be None in order to lookup slice')
-
-        slice_index = inputs[self._get_arg_index(slice_arg)]
-        if isinstance(slice_index, np.ndarray):
-            slice_index = slice_index.item()
-
-        return slice_index
-
-    def get_bounding_box(self, inputs=None, slice_index=True):
-        if isinstance(slice_index, bool) and slice:
-            if self._slice_arg is None:
-                return None
-            else:
-                if isinstance(self._slice_arg, tuple):
-                    slice_index = tuple([self._get_slice_index(inputs, slice_arg)
-                                         for slice_arg in self._slice_arg])
-                else:
-                    slice_index = self._get_slice_index(inputs, self._slice_arg)
-
+    def _get_slice(self, slice_index) -> BoundingBox:
         if slice_index in self:
-            return self[slice_index]
+            bbox = self[slice_index]
+        elif self._create_slice is not None:
+            bbox = self._create_slice(self._model, slice_index)
+            self[slice_index] = bbox
         else:
             raise RuntimeError(f"No bounding_box is defined for slice: {slice_index}!")
 
-    def reverse(self, axes_ind):
-        # bbox = {slice_index: slice_box.reverse(axes_ind)
-        #         for slice_index, slice_box in self.items()}
-        bbox = {}
-        for slice_index, slice_box in self.items():
-            bbox[slice_index] = [slice_box[ind] for ind in axes_ind][::-1]
+        return bbox
 
-        return CompoundBoundingBox(bbox, self._model, self._slice_arg, self._remove_slice_arg)
+    def _get_bounding_box(self, **kwargs) -> BoundingBox:
+        slice_index = self._slice_args.get_slice(**kwargs)
 
-    def py_order(self, axes_order):
-        bbox = {}
-        for slice_index, slice_box in self.items():
-            bbox[slice_index] = tuple(slice_box[::-1][i] for i in axes_order)
+        return self._get_slice(slice_index)
 
-        return CompoundBoundingBox(bbox, self._model, self._slice_arg, self._remove_slice_arg)
+    def _add_bounding_box(self, bounding_box: BoundingBox):
+        return self._slice_args.sorted.add_bounding_box(bounding_box)
+
+    def get_bounding_box(self, **kwargs):
+        return self._add_bounding_box(self._get_bounding_box(**kwargs))
+
+    def add_removed_axes(self, axes_ind: np.ndarray):
+        return np.argsort(self._slice_args.add_removed_axes(axes_ind))
+
+
+# class CompoundBoundingBox(UserDict):
+#     def __init__(self, bounding_box,  model=None, slice_arg=None, remove_slice_arg=False):
+#         super().__init__(bounding_box)
+#         self._model = model
+
+#         if self._model is None:
+#             self._slice_arg = slice_arg
+#         else:
+#             self.set_slice_arg(slice_arg)
+
+#         self._remove_slice_arg = remove_slice_arg
+
+#     @property
+#     def slice_arg(self):
+#         return self._slice_arg
+
+#     @property
+#     def remove_slice_arg(self):
+#         return self._remove_slice_arg
+
+#     def _get_arg_index(self, slice_arg):
+#         if np.issubdtype(type(slice_arg), np.integer):
+#             arg_index = slice_arg
+#         else:
+#             if slice_arg in self._model.inputs:
+#                 arg_index = self._model.inputs.index(slice_arg)
+#             else:
+#                 raise ValueError(f'{slice_arg} is not an input of of your model inputs {self._model.inputs}')
+
+#         if arg_index < self._model.n_inputs:
+#             return arg_index
+#         else:
+#             raise ValueError(f'{arg_index} is out of model argument bounds')
+
+#     @classmethod
+#     def validate(cls, model, bounding_box, slice_arg=None, remove_slice_arg=None):
+#         if isinstance(bounding_box, CompoundBoundingBox) and slice_arg is None:
+#             slice_arg = bounding_box.slice_arg
+
+#         if remove_slice_arg is None:
+#             if isinstance(bounding_box, CompoundBoundingBox):
+#                 remove_slice_arg = bounding_box.remove_slice_arg
+#             else:
+#                 remove_slice_arg = False
+
+#         new_box = cls({}, model, slice_arg, remove_slice_arg)
+
+#         if not remove_slice_arg:
+#             slice_arg = None
+
+#         for slice_index, slice_box in bounding_box.items():
+#             new_box[slice_index] = BoundingBox.validate(model, slice_box, slice_arg)
+
+#         return new_box
+
+#     def set_slice_arg(self, slice_arg):
+#         if slice_arg is None:
+#             self._slice_arg = slice_arg
+#         elif isinstance(slice_arg, tuple):
+#             self._slice_arg = tuple([self._get_arg_index(arg) for arg in slice_arg])
+#         else:
+#             self._slice_arg = self._get_arg_index(slice_arg)
+
+#     def _get_slice_index(self, inputs, slice_arg):
+#         if inputs is None:
+#             raise RuntimeError('Inputs must not be None in order to lookup slice')
+
+#         slice_index = inputs[self._get_arg_index(slice_arg)]
+#         if isinstance(slice_index, np.ndarray):
+#             slice_index = slice_index.item()
+
+#         return slice_index
+
+#     def get_bounding_box(self, inputs=None, slice_index=True):
+#         if isinstance(slice_index, bool) and slice:
+#             if self._slice_arg is None:
+#                 return None
+#             else:
+#                 if isinstance(self._slice_arg, tuple):
+#                     slice_index = tuple([self._get_slice_index(inputs, slice_arg)
+#                                          for slice_arg in self._slice_arg])
+#                 else:
+#                     slice_index = self._get_slice_index(inputs, self._slice_arg)
+
+#         if slice_index in self:
+#             return self[slice_index]
+#         else:
+#             raise RuntimeError(f"No bounding_box is defined for slice: {slice_index}!")
+
+#     def reverse(self, axes_ind):
+#         # bbox = {slice_index: slice_box.reverse(axes_ind)
+#         #         for slice_index, slice_box in self.items()}
+#         bbox = {}
+#         for slice_index, slice_box in self.items():
+#             bbox[slice_index] = [slice_box[ind] for ind in axes_ind][::-1]
+
+#         return CompoundBoundingBox(bbox, self._model, self._slice_arg, self._remove_slice_arg)
+
+#     def py_order(self, axes_order):
+#         bbox = {}
+#         for slice_index, slice_box in self.items():
+#             bbox[slice_index] = tuple(slice_box[::-1][i] for i in axes_order)
+
+#         return CompoundBoundingBox(bbox, self._model, self._slice_arg, self._remove_slice_arg)

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -39,7 +39,7 @@ from astropy.utils.exceptions import AstropyDeprecationWarning
 from astropy.nddata.utils import add_array, extract_array
 from .utils import (combine_labels, make_binary_operator_eval,
                     get_inputs_and_params, _BoundingBox, _combine_equivalency_dict,
-                    _ConstraintsDict, _SpecialOperatorsDict)
+                    _ConstraintsDict, _SpecialOperatorsDict, ComplexBoundingBox)
 from .parameters import (Parameter, InputParameterError,
                          param_repr_oneline, _tofloat)
 
@@ -929,8 +929,8 @@ class Model(metaclass=_ModelMeta):
             # positional arguments to ``__call__``.
 
             # These are the keys that are always present as keyword arguments.
-            keys = ['model_set_axis', 'with_bounding_box', 'fill_value',
-                    'equivalencies', 'inputs_map']
+            keys = ['model_set_axis', 'with_bounding_box','slice_index',
+                    'fill_value', 'equivalencies', 'inputs_map']
 
             new_inputs = {}
             # kwargs contain the names of the new inputs + ``keys``

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -3605,7 +3605,7 @@ for idx, ops in enumerate(_ORDER_OF_OPERATORS):
 del idx, op, ops
 
 
-def fix_inputs(modelinstance, values):
+def fix_inputs(modelinstance, values, bbox=None, slice_args=None):
     """
     This function creates a compound model with one or more of the input
     values of the input model assigned fixed values (scalar or array).
@@ -3629,7 +3629,9 @@ def fix_inputs(modelinstance, values):
 
     Results in a 1D function equivalent to Gaussian2D(1, 2, 3, 4, 5)(x=2.5, y)
     """
-    return CompoundModel('fix_inputs', modelinstance, values)
+    model = CompoundModel('fix_inputs', modelinstance, values)
+    
+    return model
 
 
 def bind_complex_bounding_box(modelinstance, bbox, slice_arg=None):

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -3630,7 +3630,26 @@ def fix_inputs(modelinstance, values, bbox=None, slice_args=None):
     Results in a 1D function equivalent to Gaussian2D(1, 2, 3, 4, 5)(x=2.5, y)
     """
     model = CompoundModel('fix_inputs', modelinstance, values)
-    
+    if bbox is not None:
+        if slice_args is None:
+            slice_arg = tuple(values.keys())
+            slice_index = tuple(values.values())
+        else:
+            if not hasattr(slice_args, '__iter__'):
+                slice_args = tuple([slice_args])
+
+            if all(arg in values for arg in slice_args):
+                slice_arg = tuple(slice_args)
+                slice_index = tuple(values[arg] for arg in slice_args)
+            else:
+                raise ValueError(f"{slice_args} must all be keys of {values}")
+        if len(slice_arg) == 1:
+            slice_arg = slice_arg[0]
+            slice_index = slice_index[0]
+
+        complex_bbox = ComplexBoundingBox.validate(modelinstance, bbox, slice_arg=slice_arg)
+        model.bounding_box = complex_bbox.get_bounding_box(slice_index=slice_index)
+
     return model
 
 

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -4167,6 +4167,7 @@ def get_bounding_box(self, inputs, slice_index=None):
         else:
             return bbox
 
+
 def generic_call(self, *inputs, **kwargs):
     """ The base ``Model. __call__`` method."""
     inputs, format_info = self.prepare_inputs(*inputs, **kwargs)

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -929,8 +929,8 @@ class Model(metaclass=_ModelMeta):
             # positional arguments to ``__call__``.
 
             # These are the keys that are always present as keyword arguments.
-            keys = ['model_set_axis', 'with_bounding_box','slice_index',
-                    'fill_value', 'equivalencies', 'inputs_map']
+            keys = ['model_set_axis', 'with_bounding_box', 'fill_value',
+                    'equivalencies', 'inputs_map']
 
             new_inputs = {}
             # kwargs contain the names of the new inputs + ``keys``
@@ -4107,7 +4107,7 @@ def check_consistent_shapes(*shapes):
     return rshape
 
 
-def get_bounding_box(self):
+def get_bounding_box(self, slice_index=None):
     """
     Return the ``bounding_box`` of a model.
 
@@ -4119,8 +4119,7 @@ def get_bounding_box(self):
     try:
         bbox = self.bounding_box
     except NotImplementedError:
-        bbox = None
-    return bbox
+        return None
 
     if isinstance(bbox, ComplexBoundingBox):
         if slice_index in bbox:
@@ -4138,11 +4137,14 @@ def generic_call(self, *inputs, **kwargs):
         parameters = ()
     else:
         parameters = self._param_sets(raw=True, units=True)
-    with_bbox = kwargs.pop('with_bounding_box', False)
-    slice_index = kwargs.pop('slice_index', None)
+
+    slice_index = kwargs.pop('with_bounding_box', None)
+    if isinstance(slice_index, bool) and not slice_index:
+        slice_index = None
+
     fill_value = kwargs.pop('fill_value', np.nan)
     bbox = get_bounding_box(self, slice_index=slice_index)
-    if with_bbox and bbox is not None:
+    if (slice_index is not None) and bbox is not None:
         input_shape = _validate_input_shapes(
             inputs, self.inputs, self._n_models, self.model_set_axis,
             self.standard_broadcasting)

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -3647,7 +3647,9 @@ def fix_inputs(modelinstance, values, bbox=None, slice_args=None):
             slice_arg = slice_arg[0]
             slice_index = slice_index[0]
 
-        complex_bbox = ComplexBoundingBox.validate(modelinstance, bbox, slice_arg=slice_arg)
+        complex_bbox = ComplexBoundingBox.validate(modelinstance, bbox,
+                                                   slice_arg=slice_arg,
+                                                   remove_slice_arg=True)
         model.bounding_box = complex_bbox.get_bounding_box(slice_index=slice_index)
 
     return model

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -2818,12 +2818,16 @@ class CompoundModel(Model):
             # Restructure to be useful for the individual model lookup
             kw['inputs_map'] = [(value[0], (value[1], key)) for
                                 key, value in self.inputs_map().items()]
-        with_bbox = kw.pop('with_bounding_box', False)
+
+        slice_index = kw.pop('with_bounding_box', None)
+        if isinstance(slice_index, bool) and not slice_index:
+            slice_index = None
+
         fill_value = kw.pop('fill_value', np.nan)
         # Use of bounding box for compound models requires special treatment
         # in selecting only valid inputs to pass along to constituent models.
-        bbox = get_bounding_box(self)
-        if with_bbox and bbox is not None:
+        bbox = get_bounding_box(self, slice_index=slice_index)
+        if (slice_index is not None) and bbox is not None:
             # first check inputs are consistent in shape
             input_shape = _validate_input_shapes(args, (), self._n_models,
                                                  self.model_set_axis, self.standard_broadcasting)

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -4120,18 +4120,22 @@ def get_bounding_box(self, slice_index=None):
     NotImplementedError
         If ``bounding_box`` is not defined.
     """
-    try:
-        bbox = self.bounding_box
-    except NotImplementedError:
-        return None
 
-    if isinstance(bbox, ComplexBoundingBox):
-        if slice_index in bbox:
-            return bbox[slice_index]
-        else:
-            raise RuntimeError(f"No bounding_box is defined for slice: {slice_index}!")
+    if slice_index is None:
+        return None
     else:
-        return bbox
+        try:
+            bbox = self.bounding_box
+        except NotImplementedError:
+            return None
+
+        if  isinstance(bbox, ComplexBoundingBox):
+            if slice_index in bbox:
+                return bbox[slice_index]
+            else:
+                raise RuntimeError(f"No bounding_box is defined for slice: {slice_index}!")
+        else:
+            return bbox
 
 def generic_call(self, *inputs, **kwargs):
     """ The base ``Model. __call__`` method."""

--- a/astropy/modeling/tests/test_bounding_box.py
+++ b/astropy/modeling/tests/test_bounding_box.py
@@ -86,21 +86,28 @@ class TestModelArgument:
         assert str(err.value) == \
             "Enough information must be given so that both name and index can be determined."
 
-    def test_get_slice(self):
+    def test_get_slice_value(self):
         argument = ModelArgument('test', True, 7)
-        value_kwarg = mk.MagicMock()
-        kwargs = {'test': value_kwarg, 'other': mk.MagicMock()}
+        arg_value = mk.MagicMock()
+        args = [mk.MagicMock for _ in range(10)]
+        args[7] = arg_value
+        args = tuple(args)
+        kwarg_value = mk.MagicMock()
+        kwargs = {'test': kwarg_value, 'other': mk.MagicMock()}
 
-        # Test success
-        kwargs = {'test': value_kwarg, 'other': mk.MagicMock()}
-        assert argument.get_slice(**kwargs) == value_kwarg
+        # Test success in kwarg
+        assert argument.get_slice_value(*args, **kwargs) == kwarg_value
+
+        # Test success in args
+        kwargs = {'thing': kwarg_value, 'other': mk.MagicMock()}
+        assert argument.get_slice_value(*args, **kwargs) == arg_value
 
         # Test fail
-        kwargs = {'thing': value_kwarg, 'other': mk.MagicMock()}
+        args = tuple([mk.MagicMock for _ in range(3)])
         with pytest.raises(ValueError) as err:
-            argument.get_slice(**kwargs)
+            argument.get_slice_value(*args, **kwargs)
         assert str(err.value) == \
-            f"Cannot find a valid input corresponding to test in: {kwargs}."
+            f"Cannot find a valid input corresponding to key: test in: {kwargs} or index: 7 in: {args}."
 
     def test__removed_bounding_box(self):
         argument = ModelArgument('test', True, 7)
@@ -207,6 +214,17 @@ class TestModelArguments:
 
         assert arguments.removed == [arg2, arg0]
 
+    def test_removed_index(self):
+        arg0 = ModelArgument(mk.MagicMock(), True, 0)
+        arg1 = ModelArgument(mk.MagicMock(), False, 1)
+        arg2 = ModelArgument(mk.MagicMock(), True, 2)
+        arg3 = ModelArgument(mk.MagicMock(), False, 3)
+
+        args = [arg2, arg0, arg3, arg1]
+        arguments = ModelArguments(args)
+
+        assert arguments.removed_index == [2, 0]
+
     def test_validate(self):
         names = [f"name{idx}" for idx in range(3)]
         model = mk.MagicMock()
@@ -271,18 +289,26 @@ class TestModelArguments:
         # Not equal do to different type
         assert not arguments0 == mk.MagicMock()
 
-    def test_get_slice(self):
-        args = [ModelArgument(f"name{idx}", mk.MagicMock(), idx)
-                for idx in range(3)]
-        kwargs = {arg.name: mk.MagicMock() for arg in args}
+    def test_get_slice_index(self):
+        model_args = [ModelArgument(f"name{idx}", mk.MagicMock(), idx)
+                      for idx in range(3)]
+        args = tuple([mk.MagicMock() for _ in range(7)])
 
-        # Full tuple
-        arguments = ModelArguments(args)
-        assert arguments.get_slice(**kwargs) == tuple(kwargs.values())
+        # Full tuple from kwargs
+        kwargs = {arg.name: mk.MagicMock() for arg in model_args}
+        arguments = ModelArguments(model_args)
+        assert arguments.get_slice_index(*args, **kwargs) == tuple(kwargs.values())
+        # Single argument from kwargs
+        arguments = ModelArguments([model_args[1]])
+        assert arguments.get_slice_index(*args, **kwargs) == kwargs[model_args[1].name]
 
-        # Single argument
-        arguments = ModelArguments([args[1]])
-        assert arguments.get_slice(**kwargs) == kwargs[args[1].name]
+        # Full tuple from args
+        kwargs = {f"thing{idx}": mk.MagicMock() for idx in range(3)}
+        arguments = ModelArguments(model_args)
+        assert arguments.get_slice_index(*args, **kwargs) == tuple(args[:3])
+        # Single argument from args
+        arguments = ModelArguments([model_args[1]])
+        assert arguments.get_slice_index(*args, **kwargs) == args[1]
 
     def test_add_bounding_box(self):
         args = [ModelArgument(f"name{idx}", idx, mk.MagicMock())
@@ -315,6 +341,60 @@ class TestModelArguments:
                 mk.call(args[1], new_axes_ind[0]),
                 mk.call(args[2], new_axes_ind[1]),
             ]
+
+    def test__add_argument(self):
+        args = [ModelArgument(f"name{idx}", idx, mk.MagicMock())
+                for idx in range(3)]
+        arguments = ModelArguments(args)
+        assert len(arguments.arguments) == 3
+
+        # Add with name and model
+        arguments._add_argument('x', model=Gaussian1D())
+        assert len(arguments.arguments) == 4
+        assert arguments.arguments[-1] == ('x', False, 0)
+
+        # Add with name and remove and model
+        arguments._add_argument('x', True, model=Gaussian1D())
+        assert len(arguments.arguments) == 5
+        assert arguments.arguments[-1] == ('x', True, 0)
+
+        # Add with no model
+        arguments._add_argument('x', 33, 5)
+        assert len(arguments.arguments) == 6
+        assert arguments.arguments[-1] == ('x', 33, 5)
+
+    def test_add_arguments(self):
+        args = [ModelArgument(f"name{idx}", idx, mk.MagicMock())
+                for idx in range(3)]
+        arguments = ModelArguments(args)
+        assert len(arguments.arguments) == 3
+
+        # Add with names and model
+        arguments.add_arguments(*['x', 'y'], model=Gaussian2D())
+        assert len(arguments.arguments) == 5
+        assert arguments.arguments[-2] == ('x', False, 0)
+        assert arguments.arguments[-1] == ('y', False, 1)
+
+        # Add with names and remove, and model
+        arguments.add_arguments(*[('x', True), ('y', True)], model=Gaussian2D())
+        assert len(arguments.arguments) == 7
+        assert arguments.arguments[-2] == ('x', True, 0)
+        assert arguments.arguments[-1] == ('y', True, 1)
+
+        # Add with no model
+        arguments.add_arguments(*[('x', 11, 41), ('y', 17, 4)])
+        assert len(arguments.arguments) == 9
+        assert arguments.arguments[-2] == ('x', 11, 41)
+        assert arguments.arguments[-1] == ('y', 17, 4)
+
+    def test_reset_arguments(self):
+        args = [ModelArgument(f"name{idx}", idx, mk.MagicMock())
+                for idx in range(3)]
+        arguments = ModelArguments(args.copy())
+        assert arguments.arguments == args
+
+        arguments.reset_arguments()
+        assert arguments.arguments == [] != args
 
 
 class TestCompoundBoundingBox:
@@ -384,17 +464,17 @@ class TestCompoundBoundingBox:
         assert (bounding_box._model.parameters == Gaussian2D().parameters).all()
         assert bounding_box._slice_args == ModelArguments([ModelArgument('y', True, 1)])
 
-    def test__get_slice(self):
+    def test_get_slice(self):
         bbox = {1: (-1, 0), 2: (0, 1)}
         bounding_box = CompoundBoundingBox(bbox, Gaussian2D(), slice_args=['x', 'y'])
 
         # Normal Get
-        assert bounding_box._get_slice(1) == (-1, 0)
-        assert bounding_box._get_slice(2) == (0, 1)
+        assert bounding_box.get_slice(1) == (-1, 0)
+        assert bounding_box.get_slice(2) == (0, 1)
 
         # Error
         with pytest.raises(RuntimeError) as err:
-            bounding_box._get_slice(3)
+            bounding_box.get_slice(3)
         assert str(err.value) == \
             "No bounding_box is defined for slice: 3!"
 
@@ -404,18 +484,23 @@ class TestCompoundBoundingBox:
         bounding_box._model = model
         bounding_box._create_slice = create
         assert 3 not in bounding_box
-        assert bounding_box._get_slice(3) == create.return_value
+        assert bounding_box.get_slice(3) == create.return_value
         assert 3 in bounding_box
         assert bounding_box[3] == create.return_value
 
         assert create.call_args_list == [mk.call(model, 3)]
 
-    def test__get_bounding_box(self):
+    def test__get_slice(self):
         bbox = {1: (-1, 0), 2: (0, 1)}
         bounding_box = CompoundBoundingBox(bbox, Gaussian2D(), slice_args=['y'])
 
-        assert bounding_box._get_bounding_box(y=1) == (-1, 0)
-        assert bounding_box._get_bounding_box(y=2) == (0, 1)
+        # Using **kwarg
+        assert bounding_box._get_slice(y=1) == (-1, 0)
+        assert bounding_box._get_slice(y=2) == (0, 1)
+
+        # Using *arg
+        assert bounding_box._get_slice(0, 1) == (-1, 0)
+        assert bounding_box._get_slice(1, 2) == (0, 1)
 
     def test__add_bounding_box(self):
         origin_bbox = BoundingBox((1, 2))
@@ -442,15 +527,31 @@ class TestCompoundBoundingBox:
     def test_get_bounding_box(self):
         bbox = {1: (-1, 0), 2: (0, 1)}
         bounding_box = CompoundBoundingBox(bbox, Gaussian2D(), slice_args=['y'])
+        args = tuple([mk.MagicMock() for _ in range(3)])
         kwargs = {'test': mk.MagicMock()}
 
         with mk.patch.object(CompoundBoundingBox, '_add_bounding_box',
                              autospec=True) as mkAdd:
-            with mk.patch.object(CompoundBoundingBox, '_get_bounding_box',
+            with mk.patch.object(CompoundBoundingBox, '_get_slice',
                                  autospec=True) as mkGet:
-                assert bounding_box.get_bounding_box(**kwargs) == mkAdd.return_value
+                # Default
+                assert bounding_box.get_bounding_box(*args, **kwargs) == mkGet.return_value
+                assert mkAdd.call_args_list == []
+                assert mkGet.call_args_list == [mk.call(bounding_box, *args, **kwargs)]
+                mkGet.reset_mock()
+
+                # Don't add removed bounding_box
+                kwargs['add_removed'] = False
+                assert bounding_box.get_bounding_box(*args, **kwargs) == mkGet.return_value
+                assert mkAdd.call_args_list == []
+                assert mkGet.call_args_list == [mk.call(bounding_box, *args, test=kwargs['test'])]
+                mkGet.reset_mock()
+
+                # Add removed bounding_box
+                kwargs['add_removed'] = True
+                assert bounding_box.get_bounding_box(*args, **kwargs) == mkAdd.return_value
                 assert mkAdd.call_args_list == [mk.call(bounding_box, mkGet.return_value)]
-                assert mkGet.call_args_list == [mk.call(bounding_box, **kwargs)]
+                assert mkGet.call_args_list == [mk.call(bounding_box, *args, test=kwargs['test'])]
 
     def test_add_removed_axes(self):
         bbox = {1: (-1, 0), 2: (0, 1)}
@@ -464,129 +565,24 @@ class TestCompoundBoundingBox:
                 assert mkSort.call_args_list == [mk.call(mkAdd.return_value)]
                 assert mkAdd.call_args_list == [mk.call(bounding_box.slice_args, axes_ind)]
 
+    def test_set_slice_args(self):
+        bbox = {1: (-1, 0), 2: (0, 1)}
+        model = mk.MagicMock()
+        slice_args = ModelArguments([])
+        bounding_box = CompoundBoundingBox(bbox, model=model, slice_args=slice_args)
 
-# def test_CompoundBoundingBox__init__():
-#     bbox = {1: (-1, 0), 2: (0, 1)}
-#     bounding_box = CompoundBoundingBox(bbox)
+        args = tuple([mk.MagicMock() for _ in range(3)])
 
-#     assert bounding_box == bbox
-#     assert bounding_box._model is None
-#     assert bounding_box._slice_arg is None
+        with mk.patch.object(ModelArguments, 'reset_arguments',
+                             autospec=True) as mkReset:
+            with mk.patch.object(ModelArguments, 'add_arguments',
+                                 autospec=True) as mkAdd:
+                main = mk.MagicMock()
+                main.attach_mock(mkReset, 'reset')
+                main.attach_mock(mkAdd, 'add')
 
-#     bounding_box = CompoundBoundingBox(bbox, Gaussian1D(), 'x')
-#     assert bounding_box == bbox
-#     assert (bounding_box._model.parameters == Gaussian1D().parameters).all()
-#     assert bounding_box._slice_arg == 0
-
-
-# def test_CompoundBoundingBox__get_arg_index():
-#     bounding_box = CompoundBoundingBox({}, Gaussian2D())
-
-#     assert bounding_box._get_arg_index(0) == 0
-#     assert bounding_box._get_arg_index(1) == 1
-#     with pytest.raises(ValueError):
-#         bounding_box._get_arg_index(2)
-
-#     assert bounding_box._get_arg_index('x') == 0
-#     assert bounding_box._get_arg_index('y') == 1
-#     with pytest.raises(ValueError):
-#         bounding_box._get_arg_index('z')
-
-
-# def test_CompoundBoundingBox_validate():
-#     bbox = {1: (-1, 0), 2: (0, 1)}
-#     model = Gaussian1D()
-#     bounding_box = CompoundBoundingBox.validate(model, bbox, 'x')
-
-#     assert bounding_box == bbox
-#     assert bounding_box._model == model
-#     assert bounding_box._slice_arg == 0
-#     for slice_box in bounding_box.values():
-#         assert isinstance(slice_box, BoundingBox)
-
-#     model = Gaussian2D()
-#     bounding_box = CompoundBoundingBox.validate(model, bbox, 'x',
-#                                                remove_slice_arg=True)
-#     assert bounding_box == bbox
-#     assert bounding_box._model == model
-#     assert bounding_box._slice_arg == 0
-#     for slice_box in bounding_box.values():
-#         assert isinstance(slice_box, BoundingBox)
-
-
-# def test_CompoundBoundingBox_set_slice_arg():
-#     bounding_box = CompoundBoundingBox((), slice_arg='arg')
-#     assert bounding_box._slice_arg == 'arg'
-
-#     bounding_box.set_slice_arg(None)
-#     assert bounding_box._slice_arg is None
-
-#     bounding_box._model = Gaussian1D()
-#     with pytest.raises(ValueError):
-#         bounding_box.set_slice_arg('arg')
-
-#     with pytest.raises(ValueError):
-#         bounding_box.set_slice_arg(('x', 'y'))
-
-#     bounding_box.set_slice_arg('x')
-#     assert bounding_box._slice_arg == 0
-#     bounding_box.set_slice_arg(0)
-#     assert bounding_box._slice_arg == 0
-
-#     bounding_box._model = Gaussian2D()
-#     bounding_box.set_slice_arg(('x', 'y'))
-#     assert bounding_box._slice_arg == (0, 1)
-#     bounding_box.set_slice_arg((0, 1))
-#     assert bounding_box._slice_arg == (0, 1)
-
-
-# def test_CompoundBoundingBox__get_slice_index():
-#     bounding_box = CompoundBoundingBox({}, Gaussian2D())
-
-#     inputs = [mk.MagicMock(), mk.MagicMock(), mk.MagicMock()]
-#     assert bounding_box._get_slice_index(inputs, 'x') == inputs[0]
-#     assert bounding_box._get_slice_index(inputs, 'y') == inputs[1]
-#     with pytest.raises(RuntimeError):
-#         bounding_box._get_slice_index(None, 'x')
-
-#     inputs = [np.array(1), np.array(2), np.array(3)]
-#     assert bounding_box._get_slice_index(inputs, 'x') == 1
-#     assert bounding_box._get_slice_index(inputs, 'y') == 2
-#     with pytest.raises(RuntimeError):
-#         bounding_box._get_slice_index(None, 'x')
-
-
-# def test_CompoundBoundingBox_get_bounding_box():
-#     inputs = [np.array(1), np.array(2), np.array(3)]
-
-#     bounding_box = CompoundBoundingBox({}, Gaussian2D())
-#     assert bounding_box._slice_arg is None
-#     assert bounding_box.get_bounding_box(inputs) is None
-#     with pytest.raises(RuntimeError):
-#         bounding_box.get_bounding_box(inputs, slice_index=mk.MagicMock())
-
-#     bbox = {(1, 2): mk.MagicMock(), (3, 4): mk.MagicMock()}
-#     bounding_box = CompoundBoundingBox(bbox, Gaussian2D(), ('x', 'y'))
-#     assert bounding_box.get_bounding_box(inputs) == bbox[(1, 2)]
-#     assert bounding_box.get_bounding_box(inputs, slice_index=(3, 4)) == bbox[(3, 4)]
-#     with pytest.raises(RuntimeError):
-#         bounding_box.get_bounding_box([np.array(4), np.array(5)])
-#     bounding_box = CompoundBoundingBox(bbox, Gaussian2D(), (0, 1))
-
-#     assert bounding_box.get_bounding_box(inputs) == bbox[(1, 2)]
-#     assert bounding_box.get_bounding_box(inputs, slice_index=(3, 4)) == bbox[(3, 4)]
-#     with pytest.raises(RuntimeError):
-#         bounding_box.get_bounding_box([np.array(4), np.array(5)])
-
-#     bbox = {1: mk.MagicMock(), 2: mk.MagicMock()}
-#     bounding_box = CompoundBoundingBox(bbox, Gaussian2D(), 'x')
-#     assert bounding_box.get_bounding_box(inputs) == bbox[1]
-#     assert bounding_box.get_bounding_box(inputs, slice_index=2) == bbox[2]
-#     with pytest.raises(RuntimeError):
-#         bounding_box.get_bounding_box([np.array(3)])
-
-#     bounding_box = CompoundBoundingBox(bbox, Gaussian2D(), 0)
-#     assert bounding_box.get_bounding_box(inputs) == bbox[1]
-#     assert bounding_box.get_bounding_box(inputs, slice_index=2) == bbox[2]
-#     with pytest.raises(RuntimeError):
-#         bounding_box.get_bounding_box([np.array(3)])
+                bounding_box.set_slice_args(*args)
+                main.mock_calls == [
+                    mk.call.reset(slice_args),
+                    mk.call.add(slice_args, *args, model=model)
+                ]

--- a/astropy/modeling/tests/test_bounding_box.py
+++ b/astropy/modeling/tests/test_bounding_box.py
@@ -1,0 +1,135 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+from astropy.modeling.models import Gaussian1D, Gaussian2D
+from astropy.modeling.bounding_box import (BoundingBox, CompoundBoundingBox)
+
+import numpy as np
+import pytest
+import unittest.mock as mk
+
+
+def test_CompoundBoundingBox__init__():
+    bbox = {1: (-1, 0), 2: (0, 1)}
+    bounding_box = CompoundBoundingBox(bbox)
+
+    assert bounding_box == bbox
+    assert bounding_box._model is None
+    assert bounding_box._slice_arg is None
+
+    bounding_box = CompoundBoundingBox(bbox, Gaussian1D(), 'x')
+    assert bounding_box == bbox
+    assert (bounding_box._model.parameters == Gaussian1D().parameters).all()
+    assert bounding_box._slice_arg == 0
+
+
+def test_CompoundBoundingBox__get_arg_index():
+    bounding_box = CompoundBoundingBox({}, Gaussian2D())
+
+    assert bounding_box._get_arg_index(0) == 0
+    assert bounding_box._get_arg_index(1) == 1
+    with pytest.raises(ValueError):
+        bounding_box._get_arg_index(2)
+
+    assert bounding_box._get_arg_index('x') == 0
+    assert bounding_box._get_arg_index('y') == 1
+    with pytest.raises(ValueError):
+        bounding_box._get_arg_index('z')
+
+
+def test_CompoundBoundingBox_validate():
+    bbox = {1: (-1, 0), 2: (0, 1)}
+    model = Gaussian1D()
+    bounding_box = CompoundBoundingBox.validate(model, bbox, 'x')
+
+    assert bounding_box == bbox
+    assert bounding_box._model == model
+    assert bounding_box._slice_arg == 0
+    for slice_box in bounding_box.values():
+        assert isinstance(slice_box, BoundingBox)
+
+    model = Gaussian2D()
+    bounding_box = CompoundBoundingBox.validate(model, bbox, 'x',
+                                               remove_slice_arg=True)
+    assert bounding_box == bbox
+    assert bounding_box._model == model
+    assert bounding_box._slice_arg == 0
+    for slice_box in bounding_box.values():
+        assert isinstance(slice_box, BoundingBox)
+
+
+def test_CompoundBoundingBox_set_slice_arg():
+    bounding_box = CompoundBoundingBox((), slice_arg='arg')
+    assert bounding_box._slice_arg == 'arg'
+
+    bounding_box.set_slice_arg(None)
+    assert bounding_box._slice_arg is None
+
+    bounding_box._model = Gaussian1D()
+    with pytest.raises(ValueError):
+        bounding_box.set_slice_arg('arg')
+
+    with pytest.raises(ValueError):
+        bounding_box.set_slice_arg(('x', 'y'))
+
+    bounding_box.set_slice_arg('x')
+    assert bounding_box._slice_arg == 0
+    bounding_box.set_slice_arg(0)
+    assert bounding_box._slice_arg == 0
+
+    bounding_box._model = Gaussian2D()
+    bounding_box.set_slice_arg(('x', 'y'))
+    assert bounding_box._slice_arg == (0, 1)
+    bounding_box.set_slice_arg((0, 1))
+    assert bounding_box._slice_arg == (0, 1)
+
+
+def test_CompoundBoundingBox__get_slice_index():
+    bounding_box = CompoundBoundingBox({}, Gaussian2D())
+
+    inputs = [mk.MagicMock(), mk.MagicMock(), mk.MagicMock()]
+    assert bounding_box._get_slice_index(inputs, 'x') == inputs[0]
+    assert bounding_box._get_slice_index(inputs, 'y') == inputs[1]
+    with pytest.raises(RuntimeError):
+        bounding_box._get_slice_index(None, 'x')
+
+    inputs = [np.array(1), np.array(2), np.array(3)]
+    assert bounding_box._get_slice_index(inputs, 'x') == 1
+    assert bounding_box._get_slice_index(inputs, 'y') == 2
+    with pytest.raises(RuntimeError):
+        bounding_box._get_slice_index(None, 'x')
+
+
+def test_CompoundBoundingBox_get_bounding_box():
+    inputs = [np.array(1), np.array(2), np.array(3)]
+
+    bounding_box = CompoundBoundingBox({}, Gaussian2D())
+    assert bounding_box._slice_arg is None
+    assert bounding_box.get_bounding_box(inputs) is None
+    with pytest.raises(RuntimeError):
+        bounding_box.get_bounding_box(inputs, slice_index=mk.MagicMock())
+
+    bbox = {(1, 2): mk.MagicMock(), (3, 4): mk.MagicMock()}
+    bounding_box = CompoundBoundingBox(bbox, Gaussian2D(), ('x', 'y'))
+    assert bounding_box.get_bounding_box(inputs) == bbox[(1, 2)]
+    assert bounding_box.get_bounding_box(inputs, slice_index=(3, 4)) == bbox[(3, 4)]
+    with pytest.raises(RuntimeError):
+        bounding_box.get_bounding_box([np.array(4), np.array(5)])
+    bounding_box = CompoundBoundingBox(bbox, Gaussian2D(), (0, 1))
+
+    assert bounding_box.get_bounding_box(inputs) == bbox[(1, 2)]
+    assert bounding_box.get_bounding_box(inputs, slice_index=(3, 4)) == bbox[(3, 4)]
+    with pytest.raises(RuntimeError):
+        bounding_box.get_bounding_box([np.array(4), np.array(5)])
+
+    bbox = {1: mk.MagicMock(), 2: mk.MagicMock()}
+    bounding_box = CompoundBoundingBox(bbox, Gaussian2D(), 'x')
+    assert bounding_box.get_bounding_box(inputs) == bbox[1]
+    assert bounding_box.get_bounding_box(inputs, slice_index=2) == bbox[2]
+    with pytest.raises(RuntimeError):
+        bounding_box.get_bounding_box([np.array(3)])
+
+    bounding_box = CompoundBoundingBox(bbox, Gaussian2D(), 0)
+    assert bounding_box.get_bounding_box(inputs) == bbox[1]
+    assert bounding_box.get_bounding_box(inputs, slice_index=2) == bbox[2]
+    with pytest.raises(RuntimeError):
+        bounding_box.get_bounding_box([np.array(3)])

--- a/astropy/modeling/tests/test_bounding_box.py
+++ b/astropy/modeling/tests/test_bounding_box.py
@@ -1,135 +1,592 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 from astropy.modeling.models import Gaussian1D, Gaussian2D
-from astropy.modeling.bounding_box import (BoundingBox, CompoundBoundingBox)
+from astropy.modeling.bounding_box import (BoundingBox,
+                                           _BaseModelArgument, ModelArgument,
+                                           ModelArguments, CompoundBoundingBox)
 
 import numpy as np
 import pytest
 import unittest.mock as mk
 
 
-def test_CompoundBoundingBox__init__():
-    bbox = {1: (-1, 0), 2: (0, 1)}
-    bounding_box = CompoundBoundingBox(bbox)
+class TestModelArgument:
+    def test_create(self):
+        argument = ModelArgument('test', True, 7)
+        assert isinstance(argument, tuple)
+        assert isinstance(argument, _BaseModelArgument)
+        assert argument.name == 'test' == argument[0]
+        assert argument.remove == True == argument[1]
+        assert argument.index == 7 == argument[2]
+        assert argument == ('test', True, 7)
 
-    assert bounding_box == bbox
-    assert bounding_box._model is None
-    assert bounding_box._slice_arg is None
+    def test__get_index(self):
+        argument = ModelArgument('test', True, 7)
 
-    bounding_box = CompoundBoundingBox(bbox, Gaussian1D(), 'x')
-    assert bounding_box == bbox
-    assert (bounding_box._model.parameters == Gaussian1D().parameters).all()
-    assert bounding_box._slice_arg == 0
+        # name is None
+        assert argument._get_index(None, mk.MagicMock()) is None
+
+        # model is None
+        assert argument._get_index(mk.MagicMock(), None) is None
+        assert argument._get_index(mk.MagicMock()) is None
+
+        # neither is None
+        model = mk.MagicMock()
+        model.inputs = ['test', 'name']
+        assert argument._get_index('test', model) == 0
+        assert argument._get_index('name', model) == 1
+
+        # Error
+        with pytest.raises(ValueError) as err:
+            argument._get_index('other', model)
+        assert str(err.value) == \
+            "other is not an input of your model inputs: ['test', 'name']."
+
+    def test_validate(self):
+        model = mk.MagicMock()
+        model.inputs = [mk.MagicMock(), 'name']
+
+        # Success with full data
+        assert ModelArgument.validate(model, 'name', True, 1) == ('name', 1, True)
+
+        # Fail with full data
+        with pytest.raises(IndexError) as err:
+            ModelArgument.validate(model, 'name', index=2)
+        assert str(err.value) == \
+            "Index should be 1, but was given 2."
+
+        # Success with missing inputs
+        assert ModelArgument.validate(model, 'name')  == ('name', False, 1)
+        assert ModelArgument.validate(model, 'name', index=1) == ('name', False, 1)
+        assert ModelArgument.validate(name='name', index=1)  == ('name', False, 1)
+
+        # Fail with missing inputs
+        with pytest.raises(ValueError) as err:
+            ModelArgument.validate(model, index=1)
+        assert str(err.value) == \
+            "Enough information must be given so that both name and index can be determined."
+
+        with pytest.raises(ValueError) as err:
+            ModelArgument.validate(model)
+        assert str(err.value) == \
+            "Enough information must be given so that both name and index can be determined."
+
+        with pytest.raises(ValueError) as err:
+            ModelArgument.validate(name='name')
+        assert str(err.value) == \
+            "Enough information must be given so that both name and index can be determined."
+
+        with pytest.raises(ValueError) as err:
+            ModelArgument.validate(index=1)
+        assert str(err.value) == \
+            "Enough information must be given so that both name and index can be determined."
+
+        with pytest.raises(ValueError) as err:
+            ModelArgument.validate()
+        assert str(err.value) == \
+            "Enough information must be given so that both name and index can be determined."
+
+    def test_get_slice(self):
+        argument = ModelArgument('test', True, 7)
+        value_kwarg = mk.MagicMock()
+        kwargs = {'test': value_kwarg, 'other': mk.MagicMock()}
+
+        # Test success
+        kwargs = {'test': value_kwarg, 'other': mk.MagicMock()}
+        assert argument.get_slice(**kwargs) == value_kwarg
+
+        # Test fail
+        kwargs = {'thing': value_kwarg, 'other': mk.MagicMock()}
+        with pytest.raises(ValueError) as err:
+            argument.get_slice(**kwargs)
+        assert str(err.value) == \
+            f"Cannot find a valid input corresponding to test in: {kwargs}."
+
+    def test__removed_bounding_box(self):
+        argument = ModelArgument('test', True, 7)
+        bbox = argument._removed_bounding_box()
+
+        assert isinstance(bbox, BoundingBox)
+        assert bbox == (-np.inf, np.inf)
+
+        for num in [0, -1, -100, 3.14, 10^100, -10^100]:
+            assert not num < bbox[0]
+            assert num > bbox[0]
+
+            assert not num > bbox[1]
+            assert num < bbox[1]
+
+    def test__add_bounding_box(self):
+        argument = ModelArgument('test', True, 2)
+
+        # bounding_box is dim 1
+        bounding_box = BoundingBox(((0, 1), (2, 3)))
+        bbox = argument._add_bounding_box(bounding_box)
+        assert isinstance(bbox, BoundingBox)
+        assert bbox == ((0, 1), (2, 3), (-np.inf, np.inf))
+
+        # bounding_box is only a tuple
+        bounding_box = ((0, 1), (2, 3))
+        bbox = argument._add_bounding_box(bounding_box)
+        assert isinstance(bbox, BoundingBox)
+        assert bbox == ((0, 1), (2, 3), (-np.inf, np.inf))
+
+        # bounding_box is dim > 1
+        base_box = [(0, 1), (2, 3)]
+        true_box = [(0, 1), (2, 3), (-np.inf, np.inf)]
+        for _ in range(3):
+            base_box.append((0, 1))
+            true_box.append((0, 1))
+            bounding_box = BoundingBox(tuple(base_box))
+
+            bbox = argument._add_bounding_box(bounding_box)
+            assert isinstance(bbox, BoundingBox)
+            assert bbox == tuple(true_box)
+
+    def test_add_bounding_box(self):
+        bounding_box = mk.MagicMock()
+        with mk.patch.object(ModelArgument, '_add_bounding_box',
+                             autospec=True) as mkAdd:
+            # No Remove
+            argument = ModelArgument('test', False, 7)
+            assert argument.add_bounding_box(bounding_box) == bounding_box
+            assert mkAdd.call_args_list == []
+
+            # Remove
+            argument = ModelArgument('test', True, 7)
+            assert argument.add_bounding_box(bounding_box) == mkAdd.return_value
+            assert mkAdd.call_args_list == [mk.call(argument, bounding_box)]
+
+    def test_add_removed_axis(self):
+        # Test no change, due to not removed
+        argument = ModelArgument('test', False, 2)
+        assert (argument.add_removed_axis(np.array([0, 1])) == np.array([0, 1])).all()
+
+        # Test no change, due to removed and present
+        argument = ModelArgument('test', True, 2)
+        assert (argument.add_removed_axis(np.array([0, 1, 2])) == np.array([0, 1, 2])).all()
+
+        # Add change
+        argument = ModelArgument('test', True, 2)
+        assert (argument.add_removed_axis(np.array([0, 1])) == np.array([0, 1, 2])).all()
 
 
-def test_CompoundBoundingBox__get_arg_index():
-    bounding_box = CompoundBoundingBox({}, Gaussian2D())
+class TestModelArguments:
+    def test_properties(self):
+        args = [ModelArgument(mk.MagicMock(), mk.MagicMock(), mk.MagicMock())
+                for _ in range(3)]
+        arguments = ModelArguments(args)
 
-    assert bounding_box._get_arg_index(0) == 0
-    assert bounding_box._get_arg_index(1) == 1
-    with pytest.raises(ValueError):
-        bounding_box._get_arg_index(2)
+        assert arguments._arguments == args
+        assert arguments.arguments == args
 
-    assert bounding_box._get_arg_index('x') == 0
-    assert bounding_box._get_arg_index('y') == 1
-    with pytest.raises(ValueError):
-        bounding_box._get_arg_index('z')
+        assert arguments.names == [arg[0] for arg in args]
+        assert arguments.indices == {arg[0]: arg[2] for arg in args}
+
+    def test_sorted(self):
+        arg0 = ModelArgument(mk.MagicMock(), mk.MagicMock(), 0)
+        arg1 = ModelArgument(mk.MagicMock(), mk.MagicMock(), 1)
+        arg2 = ModelArgument(mk.MagicMock(), mk.MagicMock(), 2)
+        arg3 = ModelArgument(mk.MagicMock(), mk.MagicMock(), 3)
+
+        args = [arg2, arg0, arg3, arg1]
+        arguments = ModelArguments(args)
+
+        new = arguments.sorted
+        assert isinstance(new, ModelArguments)
+        assert new.arguments == [arg0, arg1, arg2, arg3]
+
+    def test_removed(self):
+        arg0 = ModelArgument(mk.MagicMock(), True, 0)
+        arg1 = ModelArgument(mk.MagicMock(), False, 1)
+        arg2 = ModelArgument(mk.MagicMock(), True, 2)
+        arg3 = ModelArgument(mk.MagicMock(), False, 3)
+
+        args = [arg2, arg0, arg3, arg1]
+        arguments = ModelArguments(args)
+
+        assert arguments.removed == [arg2, arg0]
+
+    def test_validate(self):
+        names = [f"name{idx}" for idx in range(3)]
+        model = mk.MagicMock()
+        model.inputs = names
+
+        # just names
+        arguments = ModelArguments.validate(model, names)
+        assert isinstance(arguments, ModelArguments)
+        for idx, arg in enumerate(arguments.arguments):
+            assert isinstance(arg, ModelArgument)
+            assert arg == (names[idx], False, idx)
+
+        # Names and remove
+        args = [(name, True) for name in names]
+        arguments = ModelArguments.validate(model, args)
+        assert isinstance(arguments, ModelArguments)
+        for idx, arg in enumerate(arguments.arguments):
+            assert isinstance(arg, ModelArgument)
+            assert arg == (names[idx], True, idx)
+
+        # Names, remove, and index
+        args = [(name, True, idx) for idx, name in enumerate(names)]
+        arguments = ModelArguments.validate(model, args)
+        assert isinstance(arguments, ModelArguments)
+        for idx, arg in enumerate(arguments.arguments):
+            assert isinstance(arg, ModelArgument)
+            assert arg == (names[idx], True, idx)
+
+        # Other ModelArguments
+        args = ModelArguments([ModelArgument(name, True, idx) for idx, name in enumerate(names)])
+        arguments = ModelArguments.validate(model, args)
+        assert isinstance(arguments, ModelArguments)
+        for idx, arg in enumerate(arguments.arguments):
+            assert isinstance(arg, ModelArgument)
+            assert arg == (names[idx], True, idx)
+        assert id(args) != id(arguments)
+
+        # No arguments
+        arguments = ModelArguments.validate(model)
+        assert isinstance(arguments, ModelArguments)
+        assert arguments.arguments == []
+
+        # Invalid
+        args = [(name, True, idx + 1) for idx, name in enumerate(names)]
+        with pytest.raises(IndexError):
+            arguments = ModelArguments.validate(model, args)
+
+    def test__eq__(self):
+        args = [ModelArgument(f"name{idx}", idx, mk.MagicMock())
+                for idx in range(3)]
+        arguments0 = ModelArguments(args.copy())
+        arguments1 = ModelArguments(args.copy())
+
+        # Equal
+        assert arguments0 == arguments1
+        assert id(arguments0) != id(arguments1)
+
+        # Not equal do to argument differences
+        arguments1._arguments.append(mk.MagicMock())
+        assert not arguments0 == arguments1
+
+        # Not equal do to different type
+        assert not arguments0 == mk.MagicMock()
+
+    def test_get_slice(self):
+        args = [ModelArgument(f"name{idx}", mk.MagicMock(), idx)
+                for idx in range(3)]
+        kwargs = {arg.name: mk.MagicMock() for arg in args}
+
+        # Full tuple
+        arguments = ModelArguments(args)
+        assert arguments.get_slice(**kwargs) == tuple(kwargs.values())
+
+        # Single argument
+        arguments = ModelArguments([args[1]])
+        assert arguments.get_slice(**kwargs) == kwargs[args[1].name]
+
+    def test_add_bounding_box(self):
+        args = [ModelArgument(f"name{idx}", idx, mk.MagicMock())
+                for idx in range(3)]
+        arguments = ModelArguments(args)
+        bounding_box = mk.MagicMock()
+
+        new_bbox = [mk.MagicMock() for _ in range(3)]
+        with mk.patch.object(ModelArgument, 'add_bounding_box',
+                             autospec=True, side_effect=new_bbox) as mkAdd:
+            assert arguments.add_bounding_box(bounding_box) == new_bbox[2]
+            assert mkAdd.call_args_list == [
+                mk.call(args[0], bounding_box),
+                mk.call(args[1], new_bbox[0]),
+                mk.call(args[2], new_bbox[1]),
+            ]
+
+    def test_add_removed_axes(self):
+        args = [ModelArgument(f"name{idx}", idx, mk.MagicMock())
+                for idx in range(3)]
+        arguments = ModelArguments(args)
+        axes_ind = mk.MagicMock()
+
+        new_axes_ind = [mk.MagicMock() for _ in range(3)]
+        with mk.patch.object(ModelArgument, 'add_removed_axis',
+                             autospec=True, side_effect=new_axes_ind) as mkAdd:
+            assert arguments.add_removed_axes(axes_ind) == new_axes_ind[2]
+            assert mkAdd.call_args_list == [
+                mk.call(args[0], axes_ind),
+                mk.call(args[1], new_axes_ind[0]),
+                mk.call(args[2], new_axes_ind[1]),
+            ]
 
 
-def test_CompoundBoundingBox_validate():
-    bbox = {1: (-1, 0), 2: (0, 1)}
-    model = Gaussian1D()
-    bounding_box = CompoundBoundingBox.validate(model, bbox, 'x')
+class TestCompoundBoundingBox:
+    def test___init__(self):
+        create = mk.MagicMock()
+        bbox = {1: (-1, 0), 2: (0, 1)}
 
-    assert bounding_box == bbox
-    assert bounding_box._model == model
-    assert bounding_box._slice_arg == 0
-    for slice_box in bounding_box.values():
-        assert isinstance(slice_box, BoundingBox)
+        bounding_box = CompoundBoundingBox(bbox)
+        assert bounding_box == bbox
+        assert bounding_box._model is None
+        assert bounding_box._slice_args == ModelArguments([])
+        assert bounding_box._create_slice is None
 
-    model = Gaussian2D()
-    bounding_box = CompoundBoundingBox.validate(model, bbox, 'x',
-                                               remove_slice_arg=True)
-    assert bounding_box == bbox
-    assert bounding_box._model == model
-    assert bounding_box._slice_arg == 0
-    for slice_box in bounding_box.values():
-        assert isinstance(slice_box, BoundingBox)
+        bounding_box = CompoundBoundingBox(bbox, Gaussian1D(), 'x', create)
+        assert bounding_box == bbox
+        assert (bounding_box._model.parameters == Gaussian1D().parameters).all()
+        assert bounding_box._slice_args == ModelArguments([ModelArgument('x', False, 0)])
+        assert bounding_box._create_slice == create
+
+        bounding_box = CompoundBoundingBox(bbox, Gaussian1D(), [('x', True)], create)
+        assert bounding_box == bbox
+        assert (bounding_box._model.parameters == Gaussian1D().parameters).all()
+        assert bounding_box._slice_args == ModelArguments([ModelArgument('x', True, 0)])
+        assert bounding_box._create_slice == create
+
+    def test_slice_args(self):
+        bbox = {1: (-1, 0), 2: (0, 1)}
+        bounding_box = CompoundBoundingBox(bbox, slice_args=[('x', True, 0)])
+
+        assert bounding_box._slice_args == ModelArguments([ModelArgument('x', True, 0)])
+        assert bounding_box.slice_args == ModelArguments([ModelArgument('x', True, 0)])
+
+    def test_slice_names(self):
+        bbox = {1: (-1, 0), 2: (0, 1)}
+        bounding_box = CompoundBoundingBox(bbox, Gaussian2D(), slice_args=['x', 'y'])
+
+        assert bounding_box.slice_names == ['x', 'y']
+
+    def test_slice_indicies(self):
+        bbox = {1: (-1, 0), 2: (0, 1)}
+        bounding_box = CompoundBoundingBox(bbox, Gaussian2D(), slice_args=['x', 'y'])
+
+        assert bounding_box.slice_indicies == {'x': 0, 'y': 1}
+
+    def test_validate(self):
+        # Main validate
+        bbox = {1: (-1, 0), 2: (0, 1)}
+        bounding_box = CompoundBoundingBox.validate(bbox, slice_args=['x', ('y', True)], model=Gaussian2D())
+        assert bounding_box == bbox
+        for bbox_slice in bounding_box.values():
+            assert isinstance(bbox_slice, BoundingBox)
+        assert (bounding_box._model.parameters == Gaussian2D().parameters).all()
+        assert bounding_box._slice_args == ModelArguments([ModelArgument('x', False, 0),
+                                                           ModelArgument('y', True, 1)])
+
+        # Re validate
+        new_bounding_box = CompoundBoundingBox.validate(bounding_box, model=Gaussian2D())
+        assert new_bounding_box == bounding_box
+        assert new_bounding_box._slice_args == bounding_box._slice_args
+
+        # Simple validate
+        bbox = {1: (-1, 0), 2: (0, 1)}
+        bounding_box = CompoundBoundingBox.validate(bbox, slice_args=[('y', True)], model=Gaussian2D())
+        assert bounding_box == bbox
+        for bbox_slice in bounding_box.values():
+            assert isinstance(bbox_slice, BoundingBox)
+        assert (bounding_box._model.parameters == Gaussian2D().parameters).all()
+        assert bounding_box._slice_args == ModelArguments([ModelArgument('y', True, 1)])
+
+    def test__get_slice(self):
+        bbox = {1: (-1, 0), 2: (0, 1)}
+        bounding_box = CompoundBoundingBox(bbox, Gaussian2D(), slice_args=['x', 'y'])
+
+        # Normal Get
+        assert bounding_box._get_slice(1) == (-1, 0)
+        assert bounding_box._get_slice(2) == (0, 1)
+
+        # Error
+        with pytest.raises(RuntimeError) as err:
+            bounding_box._get_slice(3)
+        assert str(err.value) == \
+            "No bounding_box is defined for slice: 3!"
+
+        # New box
+        model = mk.MagicMock()
+        create = mk.MagicMock()
+        bounding_box._model = model
+        bounding_box._create_slice = create
+        assert 3 not in bounding_box
+        assert bounding_box._get_slice(3) == create.return_value
+        assert 3 in bounding_box
+        assert bounding_box[3] == create.return_value
+
+        assert create.call_args_list == [mk.call(model, 3)]
+
+    def test__get_bounding_box(self):
+        bbox = {1: (-1, 0), 2: (0, 1)}
+        bounding_box = CompoundBoundingBox(bbox, Gaussian2D(), slice_args=['y'])
+
+        assert bounding_box._get_bounding_box(y=1) == (-1, 0)
+        assert bounding_box._get_bounding_box(y=2) == (0, 1)
+
+    def test__add_bounding_box(self):
+        origin_bbox = BoundingBox((1, 2))
+        bbox = {1: (-1, 0), 2: (0, 1)}
+
+        bounding_box = CompoundBoundingBox(bbox, Gaussian2D(), slice_args=['x', 'y'])
+        assert bounding_box._add_bounding_box(origin_bbox) == (1, 2)
+
+        bounding_box = CompoundBoundingBox(bbox, Gaussian2D(), slice_args=['x', ('y', True)])
+        assert bounding_box._add_bounding_box(origin_bbox) == ((1, 2), (-np.inf, np.inf))
+
+        bounding_box = CompoundBoundingBox(bbox, Gaussian2D(), slice_args=[('x', True), ('y', True)])
+        assert bounding_box._add_bounding_box(origin_bbox) == ((-np.inf, np.inf), (-np.inf, np.inf), (1, 2))
+
+        bounding_box = CompoundBoundingBox(bbox, Gaussian2D(), slice_args=['y', 'x'])
+        assert bounding_box._add_bounding_box(origin_bbox) == (1, 2)
+
+        bounding_box = CompoundBoundingBox(bbox, Gaussian2D(), slice_args=['y', ('x', True)])
+        assert bounding_box._add_bounding_box(origin_bbox) == ((-np.inf, np.inf), (1, 2))
+
+        bounding_box = CompoundBoundingBox(bbox, Gaussian2D(), slice_args=[('y', True), ('x', True)])
+        assert bounding_box._add_bounding_box(origin_bbox) == ((-np.inf, np.inf), (-np.inf, np.inf), (1, 2))
+
+    def test_get_bounding_box(self):
+        bbox = {1: (-1, 0), 2: (0, 1)}
+        bounding_box = CompoundBoundingBox(bbox, Gaussian2D(), slice_args=['y'])
+        kwargs = {'test': mk.MagicMock()}
+
+        with mk.patch.object(CompoundBoundingBox, '_add_bounding_box',
+                             autospec=True) as mkAdd:
+            with mk.patch.object(CompoundBoundingBox, '_get_bounding_box',
+                                 autospec=True) as mkGet:
+                assert bounding_box.get_bounding_box(**kwargs) == mkAdd.return_value
+                assert mkAdd.call_args_list == [mk.call(bounding_box, mkGet.return_value)]
+                assert mkGet.call_args_list == [mk.call(bounding_box, **kwargs)]
+
+    def test_add_removed_axes(self):
+        bbox = {1: (-1, 0), 2: (0, 1)}
+        bounding_box = CompoundBoundingBox(bbox, Gaussian2D(), slice_args=['y'])
+        axes_ind = mk.MagicMock()
+
+        with mk.patch.object(ModelArguments, 'add_removed_axes',
+                             autospec=True) as mkAdd:
+            with mk.patch.object(np, 'argsort', autospec=True) as mkSort:
+                assert bounding_box.add_removed_axes(axes_ind) == mkSort.return_value
+                assert mkSort.call_args_list == [mk.call(mkAdd.return_value)]
+                assert mkAdd.call_args_list == [mk.call(bounding_box.slice_args, axes_ind)]
 
 
-def test_CompoundBoundingBox_set_slice_arg():
-    bounding_box = CompoundBoundingBox((), slice_arg='arg')
-    assert bounding_box._slice_arg == 'arg'
+# def test_CompoundBoundingBox__init__():
+#     bbox = {1: (-1, 0), 2: (0, 1)}
+#     bounding_box = CompoundBoundingBox(bbox)
 
-    bounding_box.set_slice_arg(None)
-    assert bounding_box._slice_arg is None
+#     assert bounding_box == bbox
+#     assert bounding_box._model is None
+#     assert bounding_box._slice_arg is None
 
-    bounding_box._model = Gaussian1D()
-    with pytest.raises(ValueError):
-        bounding_box.set_slice_arg('arg')
-
-    with pytest.raises(ValueError):
-        bounding_box.set_slice_arg(('x', 'y'))
-
-    bounding_box.set_slice_arg('x')
-    assert bounding_box._slice_arg == 0
-    bounding_box.set_slice_arg(0)
-    assert bounding_box._slice_arg == 0
-
-    bounding_box._model = Gaussian2D()
-    bounding_box.set_slice_arg(('x', 'y'))
-    assert bounding_box._slice_arg == (0, 1)
-    bounding_box.set_slice_arg((0, 1))
-    assert bounding_box._slice_arg == (0, 1)
+#     bounding_box = CompoundBoundingBox(bbox, Gaussian1D(), 'x')
+#     assert bounding_box == bbox
+#     assert (bounding_box._model.parameters == Gaussian1D().parameters).all()
+#     assert bounding_box._slice_arg == 0
 
 
-def test_CompoundBoundingBox__get_slice_index():
-    bounding_box = CompoundBoundingBox({}, Gaussian2D())
+# def test_CompoundBoundingBox__get_arg_index():
+#     bounding_box = CompoundBoundingBox({}, Gaussian2D())
 
-    inputs = [mk.MagicMock(), mk.MagicMock(), mk.MagicMock()]
-    assert bounding_box._get_slice_index(inputs, 'x') == inputs[0]
-    assert bounding_box._get_slice_index(inputs, 'y') == inputs[1]
-    with pytest.raises(RuntimeError):
-        bounding_box._get_slice_index(None, 'x')
+#     assert bounding_box._get_arg_index(0) == 0
+#     assert bounding_box._get_arg_index(1) == 1
+#     with pytest.raises(ValueError):
+#         bounding_box._get_arg_index(2)
 
-    inputs = [np.array(1), np.array(2), np.array(3)]
-    assert bounding_box._get_slice_index(inputs, 'x') == 1
-    assert bounding_box._get_slice_index(inputs, 'y') == 2
-    with pytest.raises(RuntimeError):
-        bounding_box._get_slice_index(None, 'x')
+#     assert bounding_box._get_arg_index('x') == 0
+#     assert bounding_box._get_arg_index('y') == 1
+#     with pytest.raises(ValueError):
+#         bounding_box._get_arg_index('z')
 
 
-def test_CompoundBoundingBox_get_bounding_box():
-    inputs = [np.array(1), np.array(2), np.array(3)]
+# def test_CompoundBoundingBox_validate():
+#     bbox = {1: (-1, 0), 2: (0, 1)}
+#     model = Gaussian1D()
+#     bounding_box = CompoundBoundingBox.validate(model, bbox, 'x')
 
-    bounding_box = CompoundBoundingBox({}, Gaussian2D())
-    assert bounding_box._slice_arg is None
-    assert bounding_box.get_bounding_box(inputs) is None
-    with pytest.raises(RuntimeError):
-        bounding_box.get_bounding_box(inputs, slice_index=mk.MagicMock())
+#     assert bounding_box == bbox
+#     assert bounding_box._model == model
+#     assert bounding_box._slice_arg == 0
+#     for slice_box in bounding_box.values():
+#         assert isinstance(slice_box, BoundingBox)
 
-    bbox = {(1, 2): mk.MagicMock(), (3, 4): mk.MagicMock()}
-    bounding_box = CompoundBoundingBox(bbox, Gaussian2D(), ('x', 'y'))
-    assert bounding_box.get_bounding_box(inputs) == bbox[(1, 2)]
-    assert bounding_box.get_bounding_box(inputs, slice_index=(3, 4)) == bbox[(3, 4)]
-    with pytest.raises(RuntimeError):
-        bounding_box.get_bounding_box([np.array(4), np.array(5)])
-    bounding_box = CompoundBoundingBox(bbox, Gaussian2D(), (0, 1))
+#     model = Gaussian2D()
+#     bounding_box = CompoundBoundingBox.validate(model, bbox, 'x',
+#                                                remove_slice_arg=True)
+#     assert bounding_box == bbox
+#     assert bounding_box._model == model
+#     assert bounding_box._slice_arg == 0
+#     for slice_box in bounding_box.values():
+#         assert isinstance(slice_box, BoundingBox)
 
-    assert bounding_box.get_bounding_box(inputs) == bbox[(1, 2)]
-    assert bounding_box.get_bounding_box(inputs, slice_index=(3, 4)) == bbox[(3, 4)]
-    with pytest.raises(RuntimeError):
-        bounding_box.get_bounding_box([np.array(4), np.array(5)])
 
-    bbox = {1: mk.MagicMock(), 2: mk.MagicMock()}
-    bounding_box = CompoundBoundingBox(bbox, Gaussian2D(), 'x')
-    assert bounding_box.get_bounding_box(inputs) == bbox[1]
-    assert bounding_box.get_bounding_box(inputs, slice_index=2) == bbox[2]
-    with pytest.raises(RuntimeError):
-        bounding_box.get_bounding_box([np.array(3)])
+# def test_CompoundBoundingBox_set_slice_arg():
+#     bounding_box = CompoundBoundingBox((), slice_arg='arg')
+#     assert bounding_box._slice_arg == 'arg'
 
-    bounding_box = CompoundBoundingBox(bbox, Gaussian2D(), 0)
-    assert bounding_box.get_bounding_box(inputs) == bbox[1]
-    assert bounding_box.get_bounding_box(inputs, slice_index=2) == bbox[2]
-    with pytest.raises(RuntimeError):
-        bounding_box.get_bounding_box([np.array(3)])
+#     bounding_box.set_slice_arg(None)
+#     assert bounding_box._slice_arg is None
+
+#     bounding_box._model = Gaussian1D()
+#     with pytest.raises(ValueError):
+#         bounding_box.set_slice_arg('arg')
+
+#     with pytest.raises(ValueError):
+#         bounding_box.set_slice_arg(('x', 'y'))
+
+#     bounding_box.set_slice_arg('x')
+#     assert bounding_box._slice_arg == 0
+#     bounding_box.set_slice_arg(0)
+#     assert bounding_box._slice_arg == 0
+
+#     bounding_box._model = Gaussian2D()
+#     bounding_box.set_slice_arg(('x', 'y'))
+#     assert bounding_box._slice_arg == (0, 1)
+#     bounding_box.set_slice_arg((0, 1))
+#     assert bounding_box._slice_arg == (0, 1)
+
+
+# def test_CompoundBoundingBox__get_slice_index():
+#     bounding_box = CompoundBoundingBox({}, Gaussian2D())
+
+#     inputs = [mk.MagicMock(), mk.MagicMock(), mk.MagicMock()]
+#     assert bounding_box._get_slice_index(inputs, 'x') == inputs[0]
+#     assert bounding_box._get_slice_index(inputs, 'y') == inputs[1]
+#     with pytest.raises(RuntimeError):
+#         bounding_box._get_slice_index(None, 'x')
+
+#     inputs = [np.array(1), np.array(2), np.array(3)]
+#     assert bounding_box._get_slice_index(inputs, 'x') == 1
+#     assert bounding_box._get_slice_index(inputs, 'y') == 2
+#     with pytest.raises(RuntimeError):
+#         bounding_box._get_slice_index(None, 'x')
+
+
+# def test_CompoundBoundingBox_get_bounding_box():
+#     inputs = [np.array(1), np.array(2), np.array(3)]
+
+#     bounding_box = CompoundBoundingBox({}, Gaussian2D())
+#     assert bounding_box._slice_arg is None
+#     assert bounding_box.get_bounding_box(inputs) is None
+#     with pytest.raises(RuntimeError):
+#         bounding_box.get_bounding_box(inputs, slice_index=mk.MagicMock())
+
+#     bbox = {(1, 2): mk.MagicMock(), (3, 4): mk.MagicMock()}
+#     bounding_box = CompoundBoundingBox(bbox, Gaussian2D(), ('x', 'y'))
+#     assert bounding_box.get_bounding_box(inputs) == bbox[(1, 2)]
+#     assert bounding_box.get_bounding_box(inputs, slice_index=(3, 4)) == bbox[(3, 4)]
+#     with pytest.raises(RuntimeError):
+#         bounding_box.get_bounding_box([np.array(4), np.array(5)])
+#     bounding_box = CompoundBoundingBox(bbox, Gaussian2D(), (0, 1))
+
+#     assert bounding_box.get_bounding_box(inputs) == bbox[(1, 2)]
+#     assert bounding_box.get_bounding_box(inputs, slice_index=(3, 4)) == bbox[(3, 4)]
+#     with pytest.raises(RuntimeError):
+#         bounding_box.get_bounding_box([np.array(4), np.array(5)])
+
+#     bbox = {1: mk.MagicMock(), 2: mk.MagicMock()}
+#     bounding_box = CompoundBoundingBox(bbox, Gaussian2D(), 'x')
+#     assert bounding_box.get_bounding_box(inputs) == bbox[1]
+#     assert bounding_box.get_bounding_box(inputs, slice_index=2) == bbox[2]
+#     with pytest.raises(RuntimeError):
+#         bounding_box.get_bounding_box([np.array(3)])
+
+#     bounding_box = CompoundBoundingBox(bbox, Gaussian2D(), 0)
+#     assert bounding_box.get_bounding_box(inputs) == bbox[1]
+#     assert bounding_box.get_bounding_box(inputs, slice_index=2) == bbox[2]
+#     with pytest.raises(RuntimeError):
+#         bounding_box.get_bounding_box([np.array(3)])

--- a/astropy/modeling/tests/test_core.py
+++ b/astropy/modeling/tests/test_core.py
@@ -737,18 +737,26 @@ def test_get_bounding_box():
 
     with pytest.raises(NotImplementedError):
         model.bounding_box
-    assert get_bounding_box(model, []) is None
-    assert get_bounding_box(model, [], slice_index=17) is None
+    assert get_bounding_box(model, []) == (None, [])
+    assert get_bounding_box(model, [], slice_index=17) == (None, [])
 
     model.bounding_box = (0, 1)
     assert not isinstance(model.bounding_box, ComplexBoundingBox)
-    assert get_bounding_box(model, []) == None
-    assert get_bounding_box(model, [], 15) == (0, 1)
+    assert get_bounding_box(model, []) == (None, [])
+    assert get_bounding_box(model, [], 15) == ((0, 1), [])
 
     model.bounding_box = {1: (-1, 0), 2: (0, 1)}
     assert isinstance(model.bounding_box, ComplexBoundingBox)
-    assert get_bounding_box(model, []) is None
-    assert get_bounding_box(model, [], slice_index=1) == (-1, 0)
+    assert get_bounding_box(model, []) == (None, [])
+    assert get_bounding_box(model, [], slice_index=1) == ((-1, 0), [])
+    with pytest.raises(RuntimeError):
+        get_bounding_box(model, [], slice_index=0)
+
+    bounding_box = ComplexBoundingBox({1: (-1, 0), 2: (0, 1)},
+                                      slice_arg=4, remove_slice_arg=True)
+    model._user_bounding_box = bounding_box
+    assert get_bounding_box(model, []) == (None, [])
+    assert get_bounding_box(model, [], slice_index=1) == ((-1, 0), [4])
     with pytest.raises(RuntimeError):
         get_bounding_box(model, [], slice_index=0)
 

--- a/astropy/modeling/tests/test_core.py
+++ b/astropy/modeling/tests/test_core.py
@@ -822,4 +822,3 @@ def test_bind_complex_bounding_box():
     assert model(1, with_bounding_box=True) == truth(1)
     with pytest.raises(RuntimeError):
         model(0.5, with_bounding_box=True)
-

--- a/astropy/modeling/tests/test_core.py
+++ b/astropy/modeling/tests/test_core.py
@@ -15,7 +15,7 @@ from astropy.modeling.core import (Model, CompoundModel, custom_model,
                                    bind_complex_bounding_box, fix_inputs)
 from astropy.modeling.parameters import Parameter
 from astropy.modeling import models
-from astropy.modeling.utils import ComplexBoundingBox
+from astropy.modeling.bounding_box import CompoundBoundingBox
 from astropy.convolution import convolve_models
 import astropy.units as u
 from astropy.tests.helper import assert_quantity_allclose
@@ -741,18 +741,18 @@ def test_get_bounding_box():
     assert get_bounding_box(model, [], slice_index=17) == (None, [])
 
     model.bounding_box = (0, 1)
-    assert not isinstance(model.bounding_box, ComplexBoundingBox)
+    assert not isinstance(model.bounding_box, CompoundBoundingBox)
     assert get_bounding_box(model, []) == (None, [])
     assert get_bounding_box(model, [], 15) == ((0, 1), [])
 
     model.bounding_box = {1: (-1, 0), 2: (0, 1)}
-    assert isinstance(model.bounding_box, ComplexBoundingBox)
+    assert isinstance(model.bounding_box, CompoundBoundingBox)
     assert get_bounding_box(model, []) == (None, [])
     assert get_bounding_box(model, [], slice_index=1) == ((-1, 0), [])
     with pytest.raises(RuntimeError):
         get_bounding_box(model, [], slice_index=0)
 
-    bounding_box = ComplexBoundingBox({1: (-1, 0), 2: (0, 1)},
+    bounding_box = CompoundBoundingBox({1: (-1, 0), 2: (0, 1)},
                                       slice_arg=4, remove_slice_arg=True)
     model._user_bounding_box = bounding_box
     assert get_bounding_box(model, []) == (None, [])

--- a/astropy/modeling/tests/test_utils.py
+++ b/astropy/modeling/tests/test_utils.py
@@ -7,9 +7,10 @@ import pytest
 
 from astropy.utils.exceptions import AstropyDeprecationWarning
 from astropy.modeling.utils import ExpressionTree as ET, ellipse_extent
-from astropy.modeling.models import Ellipse2D
+from astropy.modeling.models import Ellipse2D, Gaussian1D
 
-from astropy.modeling.utils import _SpecialOperatorsDict
+from astropy.modeling.utils import (_SpecialOperatorsDict,
+                                    ComplexBoundingBox, _BoundingBox)
 
 
 def test_traverse_postorder_duplicate_subtrees():
@@ -103,6 +104,29 @@ def test_ellipse_extent():
         s = actual.sum(axis=i)
         diff = np.abs(limits[2 * i] - np.where(s > 0)[0][0])
         assert diff < 1
+
+
+def test_ComplexBoundingBox__init__():
+    bbox = {1: (-1, 0), 2: (0, 1)}
+    bounding_box = ComplexBoundingBox(bbox)
+
+    assert bounding_box == bbox
+    assert bounding_box._model is None
+
+    bounding_box = ComplexBoundingBox(bbox, 5)
+    assert bounding_box == bbox
+    assert bounding_box._model == 5
+
+
+def test_ComplexBoundingBox_validate():
+    bbox = {1: (-1, 0), 2: (0, 1)}
+    model = Gaussian1D()
+    bounding_box = ComplexBoundingBox.validate(model, bbox)
+
+    assert bounding_box == bbox
+    assert bounding_box._model == model
+    for slice_box in bounding_box.values():
+        assert isinstance(slice_box, _BoundingBox)
 
 
 def test__SpecialOperatorsDict__set_value():

--- a/astropy/modeling/tests/test_utils.py
+++ b/astropy/modeling/tests/test_utils.py
@@ -11,7 +11,7 @@ from astropy.modeling.utils import ExpressionTree as ET, ellipse_extent
 from astropy.modeling.models import Ellipse2D, Gaussian1D, Gaussian2D
 
 from astropy.modeling.utils import (_SpecialOperatorsDict,
-                                    ComplexBoundingBox, _BoundingBox)
+                                    _BoundingBox)
 
 
 def test_traverse_postorder_duplicate_subtrees():
@@ -105,133 +105,6 @@ def test_ellipse_extent():
         s = actual.sum(axis=i)
         diff = np.abs(limits[2 * i] - np.where(s > 0)[0][0])
         assert diff < 1
-
-
-def test_ComplexBoundingBox__init__():
-    bbox = {1: (-1, 0), 2: (0, 1)}
-    bounding_box = ComplexBoundingBox(bbox)
-
-    assert bounding_box == bbox
-    assert bounding_box._model is None
-    assert bounding_box._slice_arg is None
-
-    bounding_box = ComplexBoundingBox(bbox, Gaussian1D(), 'x')
-    assert bounding_box == bbox
-    assert (bounding_box._model.parameters == Gaussian1D().parameters).all()
-    assert bounding_box._slice_arg == 0
-
-
-def test_ComplexBoundingBox__get_arg_index():
-    bounding_box = ComplexBoundingBox({}, Gaussian2D())
-
-    assert bounding_box._get_arg_index(0) == 0
-    assert bounding_box._get_arg_index(1) == 1
-    with pytest.raises(ValueError):
-        bounding_box._get_arg_index(2)
-
-    assert bounding_box._get_arg_index('x') == 0
-    assert bounding_box._get_arg_index('y') == 1
-    with pytest.raises(ValueError):
-        bounding_box._get_arg_index('z')
-
-
-def test_ComplexBoundingBox_validate():
-    bbox = {1: (-1, 0), 2: (0, 1)}
-    model = Gaussian1D()
-    bounding_box = ComplexBoundingBox.validate(model, bbox, 'x')
-
-    assert bounding_box == bbox
-    assert bounding_box._model == model
-    assert bounding_box._slice_arg == 0
-    for slice_box in bounding_box.values():
-        assert isinstance(slice_box, _BoundingBox)
-
-    model = Gaussian2D()
-    bounding_box = ComplexBoundingBox.validate(model, bbox, 'x',
-                                               remove_slice_arg=True)
-    assert bounding_box == bbox
-    assert bounding_box._model == model
-    assert bounding_box._slice_arg == 0
-    for slice_box in bounding_box.values():
-        assert isinstance(slice_box, _BoundingBox)
-
-
-def test_ComplexBoundingBox_set_slice_arg():
-    bounding_box = ComplexBoundingBox((), slice_arg='arg')
-    assert bounding_box._slice_arg == 'arg'
-
-    bounding_box.set_slice_arg(None)
-    assert bounding_box._slice_arg is None
-
-    bounding_box._model = Gaussian1D()
-    with pytest.raises(ValueError):
-        bounding_box.set_slice_arg('arg')
-
-    with pytest.raises(ValueError):
-        bounding_box.set_slice_arg(('x', 'y'))
-
-    bounding_box.set_slice_arg('x')
-    assert bounding_box._slice_arg == 0
-    bounding_box.set_slice_arg(0)
-    assert bounding_box._slice_arg == 0
-
-    bounding_box._model = Gaussian2D()
-    bounding_box.set_slice_arg(('x', 'y'))
-    assert bounding_box._slice_arg == (0, 1)
-    bounding_box.set_slice_arg((0, 1))
-    assert bounding_box._slice_arg == (0, 1)
-
-
-def test_ComplexBoundingBox__get_slice_index():
-    bounding_box = ComplexBoundingBox({}, Gaussian2D())
-
-    inputs = [mk.MagicMock(), mk.MagicMock(), mk.MagicMock()]
-    assert bounding_box._get_slice_index(inputs, 'x') == inputs[0]
-    assert bounding_box._get_slice_index(inputs, 'y') == inputs[1]
-    with pytest.raises(RuntimeError):
-        bounding_box._get_slice_index(None, 'x')
-
-    inputs = [np.array(1), np.array(2), np.array(3)]
-    assert bounding_box._get_slice_index(inputs, 'x') == 1
-    assert bounding_box._get_slice_index(inputs, 'y') == 2
-    with pytest.raises(RuntimeError):
-        bounding_box._get_slice_index(None, 'x')
-
-
-def test_ComplexBoundingBox_get_bounding_box():
-    inputs = [np.array(1), np.array(2), np.array(3)]
-
-    bounding_box = ComplexBoundingBox({}, Gaussian2D())
-    assert bounding_box._slice_arg is None
-    assert bounding_box.get_bounding_box(inputs) is None
-    with pytest.raises(RuntimeError):
-        bounding_box.get_bounding_box(inputs, slice_index=mk.MagicMock())
-
-    bbox = {(1, 2): mk.MagicMock(), (3, 4): mk.MagicMock()}
-    bounding_box = ComplexBoundingBox(bbox, Gaussian2D(), ('x', 'y'))
-    assert bounding_box.get_bounding_box(inputs) == bbox[(1, 2)]
-    assert bounding_box.get_bounding_box(inputs, slice_index=(3, 4)) == bbox[(3, 4)]
-    with pytest.raises(RuntimeError):
-        bounding_box.get_bounding_box([np.array(4), np.array(5)])
-    bounding_box = ComplexBoundingBox(bbox, Gaussian2D(), (0, 1))
-
-    assert bounding_box.get_bounding_box(inputs) == bbox[(1, 2)]
-    assert bounding_box.get_bounding_box(inputs, slice_index=(3, 4)) == bbox[(3, 4)]
-    with pytest.raises(RuntimeError):
-        bounding_box.get_bounding_box([np.array(4), np.array(5)])
-
-    bbox = {1: mk.MagicMock(), 2: mk.MagicMock()}
-    bounding_box = ComplexBoundingBox(bbox, Gaussian2D(), 'x')
-    assert bounding_box.get_bounding_box(inputs) == bbox[1]
-    assert bounding_box.get_bounding_box(inputs, slice_index=2) == bbox[2]
-    with pytest.raises(RuntimeError):
-        bounding_box.get_bounding_box([np.array(3)])
-
-    bounding_box = ComplexBoundingBox(bbox, Gaussian2D(), 0)
-    assert bounding_box.get_bounding_box(inputs) == bbox[1]
-    assert bounding_box.get_bounding_box(inputs, slice_index=2) == bbox[2]
-    with pytest.raises(RuntimeError):
-        bounding_box.get_bounding_box([np.array(3)])
 
 
 def test__SpecialOperatorsDict__set_value():

--- a/astropy/modeling/tests/test_utils.py
+++ b/astropy/modeling/tests/test_utils.py
@@ -146,6 +146,15 @@ def test_ComplexBoundingBox_validate():
     for slice_box in bounding_box.values():
         assert isinstance(slice_box, _BoundingBox)
 
+    model = Gaussian2D()
+    bounding_box = ComplexBoundingBox.validate(model, bbox, 'x',
+                                               remove_slice_arg=True)
+    assert bounding_box == bbox
+    assert bounding_box._model == model
+    assert bounding_box._slice_arg == 0
+    for slice_box in bounding_box.values():
+        assert isinstance(slice_box, _BoundingBox)
+
 
 def test_ComplexBoundingBox_set_slice_arg():
     bounding_box = ComplexBoundingBox((), slice_arg='arg')

--- a/astropy/modeling/tests/test_utils.py
+++ b/astropy/modeling/tests/test_utils.py
@@ -112,21 +112,38 @@ def test_ComplexBoundingBox__init__():
 
     assert bounding_box == bbox
     assert bounding_box._model is None
+    assert bounding_box._slice_arg is None
 
-    bounding_box = ComplexBoundingBox(bbox, 5)
+    bounding_box = ComplexBoundingBox(bbox, 5, 'arg')
     assert bounding_box == bbox
     assert bounding_box._model == 5
+    assert bounding_box._slice_arg == 'arg'
 
 
 def test_ComplexBoundingBox_validate():
     bbox = {1: (-1, 0), 2: (0, 1)}
     model = Gaussian1D()
-    bounding_box = ComplexBoundingBox.validate(model, bbox)
+    bounding_box = ComplexBoundingBox.validate(model, bbox, 'x')
 
     assert bounding_box == bbox
     assert bounding_box._model == model
+    assert bounding_box._slice_arg == 'x'
     for slice_box in bounding_box.values():
         assert isinstance(slice_box, _BoundingBox)
+
+
+def test_set_slice_arg():
+    bbox = {1: (-1, 0), 2: (0, 1)}
+    bounding_box = ComplexBoundingBox(bbox, slice_arg='arg')
+    bounding_box.set_slice_arg(None)
+    assert bounding_box._slice_arg is None
+
+    bounding_box._model = Gaussian1D()
+    with pytest.raises(ValueError):
+        bounding_box.set_slice_arg('arg')
+
+    bounding_box.set_slice_arg('x')
+    assert bounding_box._slice_arg == 'x'
 
 
 def test__SpecialOperatorsDict__set_value():

--- a/astropy/modeling/tests/test_utils.py
+++ b/astropy/modeling/tests/test_utils.py
@@ -179,10 +179,14 @@ def test_ComplexBoundingBox__get_slice_index():
     inputs = [mk.MagicMock(), mk.MagicMock(), mk.MagicMock()]
     assert bounding_box._get_slice_index(inputs, 'x') == inputs[0]
     assert bounding_box._get_slice_index(inputs, 'y') == inputs[1]
+    with pytest.raises(RuntimeError):
+        bounding_box._get_slice_index(None, 'x')
 
     inputs = [np.array(1), np.array(2), np.array(3)]
     assert bounding_box._get_slice_index(inputs, 'x') == 1
     assert bounding_box._get_slice_index(inputs, 'y') == 2
+    with pytest.raises(RuntimeError):
+        bounding_box._get_slice_index(None, 'x')
 
 
 def test_ComplexBoundingBox_get_bounding_box():
@@ -200,9 +204,21 @@ def test_ComplexBoundingBox_get_bounding_box():
     assert bounding_box.get_bounding_box(inputs, slice_index=(3, 4)) == bbox[(3, 4)]
     with pytest.raises(RuntimeError):
         bounding_box.get_bounding_box([np.array(4), np.array(5)])
+    bounding_box = ComplexBoundingBox(bbox, Gaussian2D(), (0, 1))
+
+    assert bounding_box.get_bounding_box(inputs) == bbox[(1, 2)]
+    assert bounding_box.get_bounding_box(inputs, slice_index=(3, 4)) == bbox[(3, 4)]
+    with pytest.raises(RuntimeError):
+        bounding_box.get_bounding_box([np.array(4), np.array(5)])
 
     bbox = {1: mk.MagicMock(), 2: mk.MagicMock()}
     bounding_box = ComplexBoundingBox(bbox, Gaussian2D(), 'x')
+    assert bounding_box.get_bounding_box(inputs) == bbox[1]
+    assert bounding_box.get_bounding_box(inputs, slice_index=2) == bbox[2]
+    with pytest.raises(RuntimeError):
+        bounding_box.get_bounding_box([np.array(3)])
+
+    bounding_box = ComplexBoundingBox(bbox, Gaussian2D(), 0)
     assert bounding_box.get_bounding_box(inputs) == bbox[1]
     assert bounding_box.get_bounding_box(inputs, slice_index=2) == bbox[2]
     with pytest.raises(RuntimeError):

--- a/astropy/modeling/utils.py
+++ b/astropy/modeling/utils.py
@@ -550,14 +550,11 @@ class ComplexBoundingBox(UserDict):
 
         return new_box
 
-    def set_slice_arg(self, slice_arg=None):
-        if slice_arg is None:
-            self._slice_arg = None
+    def set_slice_arg(self, slice_arg):
+        if (slice_arg is None) or (slice_arg in self._model.inputs):
+            self._slice_arg = slice_arg
         else:
-            if slice_arg in self._model.inputs:
-                self._slice_arg = slice_arg
-            else:
-                raise ValueError(f'{slice_arg} is not an input of of your model inputs {self._model.inputs}')
+            raise ValueError(f'{slice_arg} is not an input of of your model inputs {self._model.inputs}')
 
     def get_bounding_box(self, inputs, slice_index=True):
         if isinstance(slice_index, bool) and slice:

--- a/astropy/modeling/utils.py
+++ b/astropy/modeling/utils.py
@@ -564,8 +564,11 @@ class ComplexBoundingBox(UserDict):
             raise ValueError(f'{arg_index} is out of model argument bounds')
 
     @classmethod
-    def validate(cls, model, bounding_box, slice_arg=None):
+    def validate(cls, model, bounding_box, slice_arg=None, remove_slice_arg=False):
         new_box = cls({}, model, slice_arg)
+
+        if not remove_slice_arg:
+            slice_arg = None
 
         for slice_index, slice_box in bounding_box.items():
             new_box[slice_index] = _BoundingBox.validate(model, slice_box, slice_arg)

--- a/astropy/modeling/utils.py
+++ b/astropy/modeling/utils.py
@@ -457,7 +457,7 @@ class _BoundingBox(tuple):
             "adjustable parameters.")
 
     @classmethod
-    def validate(cls, model, bounding_box, slice_arg=None):
+    def validate(cls, model, bounding_box):
         """
         Validate a given bounding box sequence against the given model (which
         may be either a subclass of `~astropy.modeling.Model` or an instance
@@ -471,16 +471,10 @@ class _BoundingBox(tuple):
         ensure it is always an N-tuple (even for the 1-D case).
         """
 
-        if isinstance(bounding_box, dict) or isinstance(bounding_box, ComplexBoundingBox):
-            return ComplexBoundingBox.validate(model, bounding_box, slice_arg=slice_arg)
+        return cls._validate(model, bounding_box, model.n_inputs)
 
-        nd = model.n_inputs
-        if slice_arg is not None:
-            if isinstance(slice_arg, tuple):
-                nd -= len(slice_arg)
-            else:
-                nd -= 1
-
+    @classmethod
+    def _validate(cls, model, bounding_box,  nd):
         if nd == 1:
             MESSAGE = f"""Bounding box for {model.__class__.__name__} model must be a sequence
             of length 2 consisting of a lower and upper bound, or a 1-tuple
@@ -540,117 +534,6 @@ class _BoundingBox(tuple):
             return [np.arange(self[i][0], self[i][1] + resolution, resolution) for i in range(self.dimension)]
         else:
             raise ValueError('Bounding box must have positive dimension')
-
-    def reverse(self, axes_ind):
-        bbox = [self[ind] for ind in axes_ind][::-1]
-
-        return _BoundingBox(bbox, self._model)
-
-
-class ComplexBoundingBox(UserDict):
-    def __init__(self, bounding_box,  model=None, slice_arg=None, remove_slice_arg=False):
-        super().__init__(bounding_box)
-        self._model = model
-
-        if self._model is None:
-            self._slice_arg = slice_arg
-        else:
-            self.set_slice_arg(slice_arg)
-
-        self._remove_slice_arg = remove_slice_arg
-
-    @property
-    def slice_arg(self):
-        return self._slice_arg
-
-    @property
-    def remove_slice_arg(self):
-        return self._remove_slice_arg
-
-    def _get_arg_index(self, slice_arg):
-        if np.issubdtype(type(slice_arg), np.integer):
-            arg_index = slice_arg
-        else:
-            if slice_arg in self._model.inputs:
-                arg_index = self._model.inputs.index(slice_arg)
-            else:
-                raise ValueError(f'{slice_arg} is not an input of of your model inputs {self._model.inputs}')
-
-        if arg_index < self._model.n_inputs:
-            return arg_index
-        else:
-            raise ValueError(f'{arg_index} is out of model argument bounds')
-
-    @classmethod
-    def validate(cls, model, bounding_box, slice_arg=None, remove_slice_arg=None):
-        if isinstance(bounding_box, ComplexBoundingBox) and slice_arg is None:
-            slice_arg = bounding_box.slice_arg
-
-        if remove_slice_arg is None:
-            if isinstance(bounding_box, ComplexBoundingBox):
-                remove_slice_arg = bounding_box.remove_slice_arg
-            else:
-                remove_slice_arg = False
-
-        new_box = cls({}, model, slice_arg, remove_slice_arg)
-
-        if not remove_slice_arg:
-            slice_arg = None
-
-        for slice_index, slice_box in bounding_box.items():
-            new_box[slice_index] = _BoundingBox.validate(model, slice_box, slice_arg)
-
-        return new_box
-
-    def set_slice_arg(self, slice_arg):
-        if slice_arg is None:
-            self._slice_arg = slice_arg
-        elif isinstance(slice_arg, tuple):
-            self._slice_arg = tuple([self._get_arg_index(arg) for arg in slice_arg])
-        else:
-            self._slice_arg = self._get_arg_index(slice_arg)
-
-    def _get_slice_index(self, inputs, slice_arg):
-        if inputs is None:
-            raise RuntimeError('Inputs must not be None in order to lookup slice')
-
-        slice_index = inputs[self._get_arg_index(slice_arg)]
-        if isinstance(slice_index, np.ndarray):
-            slice_index = slice_index.item()
-
-        return slice_index
-
-    def get_bounding_box(self, inputs=None, slice_index=True):
-        if isinstance(slice_index, bool) and slice:
-            if self._slice_arg is None:
-                return None
-            else:
-                if isinstance(self._slice_arg, tuple):
-                    slice_index = tuple([self._get_slice_index(inputs, slice_arg)
-                                         for slice_arg in self._slice_arg])
-                else:
-                    slice_index = self._get_slice_index(inputs, self._slice_arg)
-
-        if slice_index in self:
-            return self[slice_index]
-        else:
-            raise RuntimeError(f"No bounding_box is defined for slice: {slice_index}!")
-
-    def reverse(self, axes_ind):
-        # bbox = {slice_index: slice_box.reverse(axes_ind)
-        #         for slice_index, slice_box in self.items()}
-        bbox = {}
-        for slice_index, slice_box in self.items():
-            bbox[slice_index] = [slice_box[ind] for ind in axes_ind][::-1]
-
-        return ComplexBoundingBox(bbox, self._model, self._slice_arg, self._remove_slice_arg)
-
-    def py_order(self, axes_order):
-        bbox = {}
-        for slice_index, slice_box in self.items():
-            bbox[slice_index] = tuple(slice_box[::-1][i] for i in axes_order)
-
-        return ComplexBoundingBox(bbox, self._model, self._slice_arg, self._remove_slice_arg)
 
 
 def make_binary_operator_eval(oper, f, g):

--- a/astropy/modeling/utils.py
+++ b/astropy/modeling/utils.py
@@ -534,6 +534,20 @@ class _BoundingBox(tuple):
             raise ValueError('Bounding box must have positive dimension')
 
 
+class ComplexBoundingBox(UserDict):
+    def __init__(self, bounding_box,  model=None):
+        super().__init__(bounding_box)
+        self._model = model
+
+    @classmethod
+    def validate(cls, model, bounding_box: dict):
+        new_box = cls({}, model)
+        for slice_index, slice_box in bounding_box.items():
+            new_box[slice_index] = _BoundingBox.validate(model, slice_box)
+
+        return new_box
+
+
 def make_binary_operator_eval(oper, f, g):
     """
     Given a binary operator (as a callable of two arguments) ``oper`` and


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

Often one ends of with models for images with many slices have a dependency on that slice. These models can be extremely complex, being comprised of ~100 models, which are nearly identical for all slices, but have different bounding boxes for each slice. The bounding box calculations for each slice can become expensive if there is a need to run the model multiple times. For this reason, it is useful to be able to bind a "complex" bounding box to the model, which can select the "correct" bounding box based on a slice argument.

In this pull request, I introduce a `ComplexBoundingBox` which essentially is a dictionary of bounding boxes with keys given by the slice values. Then `Model` and `CompoundModel` were modified so that they can use this complex bounding box when the need arises. Moreover, the interface `bind_complex_bounding_box` was added to facilitate the easy creation and adding of a complex bounding box to any existing model.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->
