### PR TITLE
Minor documentation fixes

### DIFF
--- a/docs/coordinates/definitions.rst
+++ b/docs/coordinates/definitions.rst
@@ -29,7 +29,7 @@ the IAU2000 resolutions on celestial coordinate systems):
   are represented as "differential" classes).
 
 * A "Reference System" is a scheme for orienting points in a space and
-  describing how they transforms to other systems. Examples include the ICRS,
+  describing how they transform to other systems. Examples include the ICRS,
   equatorial coordinates with mean equinox, or the WGS84 geoid for
   latitude/longitude on the Earth.
 

--- a/docs/coordinates/index.rst
+++ b/docs/coordinates/index.rst
@@ -82,7 +82,7 @@ because it will be *much* faster than applying the operation to each
 |SkyCoord| in a ``for`` loop. Like the underlying `~numpy.ndarray` instances
 that contain the data, |SkyCoord| objects can be sliced, reshaped, etc.,
 and, on ``numpy`` version 1.17 and later, can be used with functions like
-`numpy.moveaxis`, etc., that affect the shape::
+`numpy.moveaxis`, etc., that affect the shape:
 
 .. doctest-requires:: numpy>=1.17
 

--- a/docs/coordinates/representations.rst
+++ b/docs/coordinates/representations.rst
@@ -132,7 +132,7 @@ To pass array `~astropy.units.Quantity` objects to representations::
       [(0., 10., 20.), (1., 11., 21.), (2., 12., 22.),
        (3., 13., 23.), (4., 14., 24.), (5., 15., 25.)]>
 
-To manipulate using methods and ``numpy`` functions::
+To manipulate using methods and ``numpy`` functions:
 
 .. doctest-requires:: numpy>=1.17
 

--- a/docs/coordinates/skycoord.rst
+++ b/docs/coordinates/skycoord.rst
@@ -334,7 +334,7 @@ dicing, and selection using the same methods and attributes that you use for
 corresponding functions as well as others that affect the shape, such as
 `~numpy.atleast_1d` and `~numpy.rollaxis`, work as expected.  (The relevant
 functions have to be explicitly enabled in ``astropy`` source code; let us
-know if a ``numpy`` function is not supported that you think should work.)::
+know if a ``numpy`` function is not supported that you think should work.):
 
 .. doctest-requires:: numpy>=1.17
 

--- a/docs/coordinates/transforming.rst
+++ b/docs/coordinates/transforming.rst
@@ -73,7 +73,7 @@ coordinate object into the frame of another::
 Some coordinate frames (including `~astropy.coordinates.FK5`,
 `~astropy.coordinates.FK4`, and `~astropy.coordinates.FK4NoETerms`) support
 "self transformations," meaning the *type* of frame does not change, but the
-frame attributes do. Any example is precessing a coordinate from one equinox
+frame attributes do. An example is precessing a coordinate from one equinox
 to another in an equatorial frame. This is done by passing ``transform_to`` a
 frame class with the relevant attributes, as shown below. Note that these
 frames use a default equinox if you do not specify one::

--- a/docs/coordinates/velocities.rst
+++ b/docs/coordinates/velocities.rst
@@ -441,9 +441,9 @@ the same: the radial velocity should be essentially the same in both frames:
 
 But this result is nonsense, with values from -1000 to 1000 km/s instead of the
 ~10 km/s we expected. The root of the problem here is that the machine
-precision is not sufficient to compute differences of order km over distances
-of order kiloparsecs. Hence, the straightforward finite difference method will
-not work for this use case with the default values.
+precision is not sufficient to compute differences on the order of kilometers
+over distances on the order of kiloparsecs. Hence, the straightforward finite
+difference method will not work for this use case with the default values.
 
 .. testsetup::
 

--- a/docs/coordinates/velocities.rst
+++ b/docs/coordinates/velocities.rst
@@ -47,7 +47,7 @@ a star with proper motions measured in ICRS::
 
 For more details on valid operations and limitations of velocity support in
 `astropy.coordinates` (particularly the :ref:`current accuracy limitations
-<astropy-coordinate-finite-difference-velocities>` ), see the more detailed
+<astropy-coordinate-finite-difference-velocities>`), see the more detailed
 discussions below of velocity support in the lower-level frame objects. All
 these same rules apply for |SkyCoord| objects, as they are built directly on top
 of the frame classes' velocity functionality detailed here.
@@ -383,7 +383,7 @@ elements of the transformation:
     times, and computing the difference between those. Note that this step
     depends on assuming that a particular frame attribute represents a "time"
     of relevance for the induced velocity. By convention this is typically the
-    ``obtime`` frame attribute, although it is an option that can be set when
+    ``obstime`` frame attribute, although it is an option that can be set when
     defining a finite difference transformation function.
 
 Example

--- a/docs/time/index.rst
+++ b/docs/time/index.rst
@@ -432,7 +432,7 @@ Examples
 
 .. EXAMPLE START: Reshaping Time Instances Using NumPy Method Analogs
 
-To reshape |Time| instances::
+To reshape |Time| instances:
 
 .. doctest-requires:: numpy>=1.17
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description

This pull request

- hides the few instances of `doctest-requires` directives that are currently visible in the documentation
- fixes a few typos in `docs/coordinates`
- slightly changes the phrasing of a sentence in `docs/coordinates/velocities.rst`
