### PR TITLE
Fix problem with multidim Table repr in Jupyter introduced in #11569

### DIFF
--- a/astropy/io/ascii/latex.py
+++ b/astropy/io/ascii/latex.py
@@ -310,6 +310,14 @@ class Latex(core.BaseReader):
     data_class = LatexData
     inputter_class = LatexInputter
 
+    # Strictly speaking latex only supports 1-d columns so this should inherit
+    # the base max_ndim = 1. But as reported in #11695 this causes a strange
+    # problem with Jupyter notebook, which displays a table by first calling
+    # _repr_latex_. For a multidimensional table this issues a stack traceback
+    # before moving on to _repr_html_. Here we prioritize fixing the issue with
+    # Jupyter displaying a Table with multidimensional columns.
+    max_ndim = None
+
     def __init__(self,
                  ignore_latex_commands=['hline', 'vspace', 'tableline',
                                         'toprule', 'midrule', 'bottomrule'],

--- a/astropy/io/ascii/tests/test_write.py
+++ b/astropy/io/ascii/tests/test_write.py
@@ -835,9 +835,10 @@ def test_multidim_column_error(fmt_name_class):
     if not getattr(fmt_cls, '_io_registry_can_write', True):
         return
 
-    # Skip tests for ecsv or HTML without bs4
+    # Skip tests for ecsv or HTML without bs4. See the comment in latex.py
+    # Latex class where max_ndim = None is defined regarding latex and aastex.
     if ((fmt_name == 'html' and not HAS_BS4)
-            or fmt_name == 'ecsv'):
+            or fmt_name in ('ecsv', 'latex', 'aastex')):
         return
 
     out = StringIO()


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to fix a problem with multidim Table repr in Jupyter introduced in #11569.

This is a one-line change that reverts strict checking of the latex io.ascii writer regarding support for outputting multidimensional columns. This is therefore going back to the 4.2 behavior where writing a multidim column to latex uses the `val1 .. valN` representation. This is not strictly correct since it won't round-trip, but better to have this legacy behavior than have Jupyter fail to display such tables.

### Functional testing

- [x] Displayed the table from #11695 in Jupyter notebook correctly (noting that it failed pre-patch)

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #11695

cc: @keflavich @saimn 
