### PR TITLE
Try to avoid pyinstaller failure of unavailable available package

### DIFF
--- a/astropy/coordinates/tests/test_intermediate_transformations.py
+++ b/astropy/coordinates/tests/test_intermediate_transformations.py
@@ -683,9 +683,19 @@ def test_straight_overhead():
     assert_allclose(aa.alt, 90*u.deg)
 
 
+def jplephem_ge(minversion):
+    """Check if jplephem is installed and has version >= minversion."""
+    # This is a separate routine since somehow with pyinstaller the stanza
+    # not HAS_JPLEPHEM or metadata.version('jplephem') < '2.15'
+    # leads to a module not found error.
+    try:
+        return HAS_JPLEPHEM and metadata.version('jplephem') >= minversion
+    except Exception:
+        return False
+
+
 @pytest.mark.remote_data
-@pytest.mark.skipif(not HAS_JPLEPHEM or metadata.version('jplephem') < '2.15',
-                    reason='requires jplephem >= 2.15')
+@pytest.mark.skipif(not jplephem_ge('2.15'), reason='requires jplephem >= 2.15')
 def test_aa_high_precision():
     """These tests are provided by @mkbrewer - see issue #10356.
 


### PR DESCRIPTION
This should address the pyinstaller failure noted in https://github.com/astropy/astropy/pull/11700#issuecomment-833598041... :crossed_fingers: 

I went for the try/except route since I wasn't sure the in-test check would work any better than that inside `pytest.mark.skipif`, and this seemed slightly cleaner.