### PR TITLE
Bugfix for issue11651: next_fast_len not available for scipy 1.5

### DIFF
--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -85,6 +85,11 @@ def _next_fast_lengths(shape):
         return np.array([scipy.fft.next_fast_len(j, real=False) for j in shape])
     except ImportError:
         pass
+    except TypeError as ex:
+        # this error happens with scipy version <=1.5
+        if "good_size() takes no keyword arguments" not in str(ex):
+            raise ex
+
 
     newshape = np.empty(len(np.atleast_1d(shape)), dtype=int)
     for i, j in enumerate(shape):

--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -82,13 +82,9 @@ def _next_fast_lengths(shape):
 
     try:
         import scipy.fft
-        return np.array([scipy.fft.next_fast_len(j, real=False) for j in shape])
+        return np.array([scipy.fft.next_fast_len(j) for j in shape])
     except ImportError:
         pass
-    except TypeError as ex:
-        # this error happens with scipy version <=1.5
-        if "good_size() takes no keyword arguments" not in str(ex):
-            raise ex
 
     newshape = np.empty(len(np.atleast_1d(shape)), dtype=int)
     for i, j in enumerate(shape):

--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -90,7 +90,6 @@ def _next_fast_lengths(shape):
         if "good_size() takes no keyword arguments" not in str(ex):
             raise ex
 
-
     newshape = np.empty(len(np.atleast_1d(shape)), dtype=int)
     for i, j in enumerate(shape):
         scale = 10 ** max(int(np.ceil(np.log10(j))) - _good_range, 0)


### PR DESCRIPTION
This is a simple bugfix for #11651 that will revert to the hard-coded fast fft lengths in a case we missed.

EDIT: Fix #11651 , follow up of #11533