### PR TITLE
Adjust test for matplotlib version failure

### DIFF
--- a/astropy/visualization/wcsaxes/tests/test_misc.py
+++ b/astropy/visualization/wcsaxes/tests/test_misc.py
@@ -24,7 +24,8 @@ from astropy.visualization.wcsaxes.transforms import CurvedTransform
 ft_version = Version(matplotlib.ft2font.__freetype_version__)
 FREETYPE_261 = ft_version == Version("2.6.1")
 TEX_UNAVAILABLE = not matplotlib.checkdep_usetex(True)
-MATPLOTLIB_GT_3_4_1 = Version(matplotlib.__version__) > Version('3.4.1')
+
+MATPLOTLIB_GT_3_4_2 = Version(matplotlib.__version__) > Version('3.4.2')
 
 
 def teardown_function(function):
@@ -78,7 +79,7 @@ def test_no_numpy_warnings(ignore_matplotlibrc, tmpdir, grid_type):
     ax.imshow(np.zeros((100, 200)))
     ax.coords.grid(color='white', grid_type=grid_type)
 
-    if MATPLOTLIB_GT_3_4_1 and grid_type == 'contours':
+    if MATPLOTLIB_GT_3_4_2 and grid_type == 'contours':
         ctx = pytest.raises(AttributeError, match='dpi')
     else:
         ctx = nullcontext()


### PR DESCRIPTION
Over at #11680, I had some failing tests since a new matplotlib version is out (which avoids an expected failure). Not sure if what I do here is the best.