### PR TITLE
Use gufunc fast parser in Time

### DIFF
--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -1261,15 +1261,13 @@ class TimeString(TimeUnique):
     def __init_subclass__(cls, **kwargs):
         if 'fast_parser_pars' in cls.__dict__:
             fpp = cls.fast_parser_pars
-            if isinstance(fpp, dict):  # Parameters given as dict.
-                has_day_of_year = fpp['has_day_of_year']
-                fpp = np.array(list(zip([chr(delim) for delim in fpp['delims']],
-                                        fpp['starts'],
-                                        fpp['stops'],
-                                        fpp['break_allowed'])),
-                               _parse_times.dt_pars)
-                if has_day_of_year:
-                    fpp['start'][1] = fpp['stop'][1] = -1
+            fpp = np.array(list(zip(map(chr, fpp['delims']),
+                                    fpp['starts'],
+                                    fpp['stops'],
+                                    fpp['break_allowed'])),
+                           _parse_times.dt_pars)
+            if cls.fast_parser_pars['has_day_of_year']:
+                fpp['start'][1] = fpp['stop'][1] = -1
             cls._fast_parser = _parse_times.create_parser(fpp)
 
         super().__init_subclass__(**kwargs)

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -1258,6 +1258,22 @@ class TimeString(TimeUnique):
       day-of-year
     """
 
+    def __init_subclass__(cls, **kwargs):
+        if 'fast_parser_pars' in cls.__dict__:
+            fpp = cls.fast_parser_pars
+            if isinstance(fpp, dict):  # Parameters given as dict.
+                has_day_of_year = fpp['has_day_of_year']
+                fpp = np.array(list(zip([chr(delim) for delim in fpp['delims']],
+                                        fpp['starts'],
+                                        fpp['stops'],
+                                        fpp['break_allowed'])),
+                               _parse_times.dt_pars)
+                if has_day_of_year:
+                    fpp['start'][1] = fpp['stop'][1] = -1
+            cls._fast_parser = _parse_times.create_parser(fpp)
+
+        super().__init_subclass__(**kwargs)
+
     def _check_val_type(self, val1, val2):
         if val1.dtype.kind not in ('S', 'U') and val1.size:
             raise TypeError(f'Input values for {self.name} class must be strings')
@@ -1313,7 +1329,7 @@ class TimeString(TimeUnique):
         # if the fast parser is entirely disabled. Note that `use_fast_parser`
         # is ignored for format classes that don't have a fast parser.
         if (self.in_subfmt != '*'
-                or 'fast_parser_pars' not in self.__class__.__dict__
+                or '_fast_parser' not in self.__class__.__dict__
                 or conf.use_fast_parser == 'False'):
             jd1, jd2 = self.get_jds_python(val1, val2)
         else:
@@ -1371,14 +1387,7 @@ class TimeString(TimeUnique):
             chars = val1.view((_parse_times.dt_u1, val1_str_len))
 
         # Set up the ufunc for the parsing and call it.
-        fpp = self.fast_parser_pars
-        parser_info = np.array(list(zip([chr(delim) for delim in fpp['delims']],
-                                        fpp['starts'], fpp['stops'],
-                                        fpp['break_allowed'])), _parse_times.dt_pars)
-        if fpp['has_day_of_year']:
-            parser_info['start'][1] = parser_info['stop'][1] = -1
-        gufunc = _parse_times.create_parser(parser_info)
-        time_struct = gufunc(chars)
+        time_struct = self._fast_parser(chars)
         jd1, jd2 = erfa.dtf2d(self.scale.upper().encode('ascii'),
                               time_struct['year'],
                               time_struct['month'],

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -3,12 +3,10 @@
 import fnmatch
 import time
 import re
-import sys
 import datetime
 import warnings
 from decimal import Decimal
 from collections import OrderedDict, defaultdict
-from pathlib import Path
 
 import numpy as np
 import erfa
@@ -17,6 +15,7 @@ from astropy.utils.decorators import lazyproperty, classproperty
 from astropy.utils.exceptions import AstropyDeprecationWarning
 from astropy import units as u
 
+from . import _parse_times
 from . import utils
 from .utils import day_frac, quantity_day_frac, two_sum, two_product
 from . import conf
@@ -1259,44 +1258,6 @@ class TimeString(TimeUnique):
       day-of-year
     """
 
-    @classproperty(lazy=True)
-    def time_struct_dtype(cls):
-        return np.dtype([('year', np.intc),
-                         ('month', np.intc),
-                         ('day', np.intc),
-                         ('hour', np.intc),
-                         ('minute', np.intc),
-                         ('second_int', np.intc),
-                         ('second_frac', np.double)])
-
-    @classproperty(lazy=True)
-    def lib_parse_time(cls):
-        """Class property for ctypes library for fast C parsing of string times."""
-        import numpy.ctypeslib as npct
-        from ctypes import c_int
-
-        # Input types in the parse_times.c code
-        array_1d_char = npct.ndpointer(dtype=np.uint8, ndim=1, flags='C_CONTIGUOUS')
-        array_1d_int = npct.ndpointer(dtype=np.intc, ndim=1, flags='C_CONTIGUOUS')
-
-        array_1d_time_struct = npct.ndpointer(dtype=cls.time_struct_dtype,
-                                              ndim=1, flags='C_CONTIGUOUS')
-
-        # load the library, using numpy mechanisms
-        libpt = npct.load_library("_parse_times", Path(__file__).parent)
-
-        # Set up the return types and argument types for parse_ymdhms_times()
-        # int parse_ymdhms_times(char *times, int n_times, int max_str_len,
-        #                    char *delims, int *starts, int *stops, int *break_allowed,
-        #                    int *years, int *months, int *days, int *hours,
-        #                    int *minutes, double *seconds)
-        libpt.parse_ymdhms_times.restype = c_int
-        libpt.parse_ymdhms_times.argtypes = [array_1d_char, c_int, c_int, c_int,
-                                             array_1d_char, array_1d_int, array_1d_int,
-                                             array_1d_int, array_1d_time_struct]
-
-        return libpt
-
     def _check_val_type(self, val1, val2):
         if val1.dtype.kind not in ('S', 'U') and val1.size:
             raise TypeError(f'Input values for {self.name} class must be strings')
@@ -1396,58 +1357,36 @@ class TimeString(TimeUnique):
         # Handle bytes or str input and flatten down to a single array of uint8.
         if val1.dtype.kind == 'U':
             val1_str_len = val1.dtype.itemsize // 4
+            val1_uint32 = val1.view((np.uint32, val1_str_len))
             # Check that this is pure ASCII.
-            if np.any(val1.view((np.uint32, val1_str_len)) > 127):
+            if np.any(val1_uint32 > 127):
                 raise ValueError('input is not pure ASCII')
 
-            # It might be possible to avoid having ravel() make a copy with
+            # It might be possible to avoid making a copy via astype with
             # cleverness in parse_times.c but leave that for another day.
-            if sys.byteorder == 'big':  # pragma: no cover
-                chars = val1.view((np.uint8, 4*val1_str_len))[..., 3::4].ravel()
-            else:
-                chars = val1.view((np.uint8, 4*val1_str_len))[..., ::4].ravel()
+            chars = val1_uint32.astype(_parse_times.dt_u1)
 
         else:
             val1_str_len = val1.dtype.itemsize
-            chars = val1.view((np.uint8, val1_str_len)).ravel()
+            chars = val1.view((_parse_times.dt_u1, val1_str_len))
 
-        # Pre-allocate output components
-        n_times = val1.size
-        time_struct = np.empty(n_times, dtype=self.time_struct_dtype)
-
-        # Set up parser parameters as numpy arrays for passing to C parser
-        pars = self.fast_parser_pars
-        delims = np.array(pars['delims'], dtype=np.uint8)
-        starts = np.array(pars['starts'], dtype=np.intc)
-        stops = np.array(pars['stops'], dtype=np.intc)
-        break_allowed = np.array(pars['break_allowed'], dtype=np.intc)
-
-        # Call C parser
-        status = self.lib_parse_time.parse_ymdhms_times(
-            chars, n_times, val1_str_len, pars['has_day_of_year'],
-            delims, starts, stops, break_allowed, time_struct)
-
-        if status == 0:
-            # All went well, finish the job
-            jd1, jd2 = erfa.dtf2d(self.scale.upper().encode('ascii'),
-                                  time_struct['year'],
-                                  time_struct['month'],
-                                  time_struct['day'],
-                                  time_struct['hour'],
-                                  time_struct['minute'],
-                                  time_struct['second_int'] + time_struct['second_frac'])
-            jd1.shape = val1.shape
-            jd2.shape = val1.shape
-            jd1, jd2 = day_frac(jd1, jd2)
-        else:
-            msgs = {1: 'time string ends at beginning of component where break is not allowed',
-                    2: 'time string ends in middle of component',
-                    3: 'required delimiter character not found',
-                    4: 'non-digit found where digit (0-9) required',
-                    5: 'bad day of year (1 <= doy <= 365 or 366 for leap year'}
-            raise ValueError(f'fast C time string parser failed: {msgs[status]}')
-
-        return jd1, jd2
+        # Set up the ufunc for the parsing and call it.
+        fpp = self.fast_parser_pars
+        parser_info = np.array(list(zip([chr(delim) for delim in fpp['delims']],
+                                        fpp['starts'], fpp['stops'],
+                                        fpp['break_allowed'])), _parse_times.dt_pars)
+        if fpp['has_day_of_year']:
+            parser_info['start'][1] = parser_info['stop'][1] = -1
+        gufunc = _parse_times.create_parser(parser_info)
+        time_struct = gufunc(chars)
+        jd1, jd2 = erfa.dtf2d(self.scale.upper().encode('ascii'),
+                              time_struct['year'],
+                              time_struct['month'],
+                              time_struct['day'],
+                              time_struct['hour'],
+                              time_struct['minute'],
+                              time_struct['second_int'] + time_struct['second_frac'])
+        return day_frac(jd1, jd2)
 
     def str_kwargs(self):
         """

--- a/astropy/time/setup_package.py
+++ b/astropy/time/setup_package.py
@@ -3,7 +3,6 @@
 # Copied from astropy/convolution/setup_package.py
 
 import os
-import sys
 from setuptools import Extension
 
 import numpy
@@ -13,20 +12,12 @@ C_TIME_PKGDIR = os.path.relpath(os.path.dirname(__file__))
 SRC_FILES = [os.path.join(C_TIME_PKGDIR, filename)
              for filename in ['src/parse_times.c']]
 
-if sys.platform.startswith('win'):
-    extra_compile_args = ['/DNDEBUG']
-    extra_link_args = ['/EXPORT:parse_ymdhms_times']
-else:
-    extra_compile_args = ['-UNDEBUG', '-fPIC']
-    extra_link_args = []
-
 
 def get_extensions():
     # Add '-Rpass-missed=.*' to ``extra_compile_args`` when compiling with clang
     # to report missed optimizations
-    _time_ext = Extension(name='astropy.time._parse_times', sources=SRC_FILES,
-                          extra_compile_args=extra_compile_args,
-                          extra_link_args=extra_link_args,
+    _time_ext = Extension(name='astropy.time._parse_times',
+                          sources=SRC_FILES,
                           include_dirs=[numpy.get_include()],
                           language='c')
 

--- a/astropy/time/src/parse_times.c
+++ b/astropy/time/src/parse_times.c
@@ -1,12 +1,32 @@
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#include "Python.h"
+#include "numpy/arrayobject.h"
+#include "numpy/ufuncobject.h"
 #include <stdio.h>
 #include <string.h>
+
+#define MODULE_DOCSTRING \
+    "Fast time parsers.\n\n" \
+    "This module allows one to create gufuncs that vectorize the parsing of\n" \
+    "standard time strings."
+#define CREATE_PARSER_DOCSTRING \
+    "create_parser()\n\n" \
+    "Create a gufunc that parsers according to the passed in parameters.\n\n" \
+    "Parameters\n" \
+    "----------\n" \
+    "pars : ~numpy.ndarray\n" \
+    "    Should have delims, start, stop, break_allowed for each of\n" \
+    "    year, month, day, hour, minute, integer second, fractional second.\n\n" \
+    "Returns\n" \
+    "-------\n" \
+    "parser : `~numpy.ufunc`\n" \
+    "    Will parser bytes or unicode."
+
 
 // ASCII codes for '0' and '9'
 const char char_zero = 48;
 const char char_nine = 57;
 
-// Use pragma pack to prevent fill bytes
-#pragma pack(4)
 struct time_struct_t {
     int year;
     int month;
@@ -15,6 +35,13 @@ struct time_struct_t {
     int minute;
     int second_int;
     double second_frac;
+};
+
+struct pars_struct_t {
+    char delim;
+    int start;
+    int stop;
+    npy_bool break_allowed;
 };
 
 // Distutils on Windows automatically exports ``PyInit__parse_times``,
@@ -219,51 +246,32 @@ int convert_day_of_year_to_month_day(int year, int day_of_year, int *month, int 
 }
 
 
-int parse_ymdhms_times(char *times, int n_times, int max_str_len, int has_day_of_year,
-                   char *delims, int *starts, int *stops, int *break_allowed,
-                   struct time_struct_t *time_structs)
-// Parse a string time in `chars` which has year, (month, day | day_of_year),
-// hour, minute, seconds components.
-//
-// Examples: "2020-01-24T12:13:14.5556", "2020:123:12:13:14.5556"
-//
-// Inputs:
-//  char *times: time characters (flattened n_times x max_str_len array)
-//  int n_times: number of time strings (each max_str_len long)
-//  int max_str_len: max length of string (may be null-terminated before this)
-//  int has_day_of_year: time includes day-of-year instead of month, day-of-month
-//  char *delims: array of delimiters preceding yr, mon, day, hr, min, isec, frac
-//      components. Value of 0 means no preceding delimiter.
-//  int *starts, *stop: arrays of start/stop indexes into time string.
-//  int *break_allowed: if true (1) then the time string can legally end just
-//      before the corresponding component (e.g. "2000-01-01" is a valid time but
-//      "2000-01-01 12" is not).
-//
-// Outputs:
-//  int *year, *month, *day, *hour, *minute: output components (n_times long)
-//  double *second: output seconds (n_times long)
-//
-// Returns:
-//  int status:
-//    0: OK
-//    1: String ends at the beginning of requested value
-//    2: String ends in the middle of requested value
-//    3: Required delimiter character not found
-//    4: Non-digit found where digit (0-9) required
-//    5: Bad day of year
+static void
+parser_loop(char **args, npy_intp *dimensions, npy_intp *steps, void *data)
 {
-    int str_len;
-    int status = 0;
-    char *time;
-    int i, ii;
+    npy_intp n = dimensions[0];
+    npy_intp max_str_len = dimensions[1];
+    char *time = args[0];
+    char *tm_ptr = args[1];
+    npy_intp i_time=steps[0];
+    npy_intp i_tm=steps[1];
+    struct pars_struct_t *pars;
+
+    npy_intp ii, i, str_len, status;
     struct time_struct_t *tm;
+    npy_bool has_day_of_year;
 
-    for (ii = 0; ii < n_times; ii++)
+    static char *msgs[5] = {
+        "time string ends at beginning of component where break is not allowed",
+        "time string ends in middle of component",
+        "required delimiter character not found",
+        "non-digit found where digit (0-9) required",
+        "bad day of year (1 <= doy <= 365 or 366 for leap year"};
+
+    for (ii = 0; ii < n; ii++, time+=i_time, tm_ptr+=i_tm)
     {
-        time = times + ii * max_str_len;
-        tm = time_structs + ii;
-
         // Initialize default values
+        tm = (struct time_struc_t *)tm_ptr;
         tm->month = 1;
         tm->day = 1;
         tm->hour = 0;
@@ -285,59 +293,216 @@ int parse_ymdhms_times(char *times, int n_times, int max_str_len, int has_day_of
         }
 
         // Get each time component year, month, day, hour, minute, isec, frac
-        status = parse_int_from_char_array(time, str_len, delims[0], starts[0], stops[0], &tm->year);
+        pars = (struct pars_struct_t *)data;
+        status = parse_int_from_char_array(time, str_len, pars->delim, pars->start, pars->stop, &tm->year);
         if (status) {
-            if (status == 1 && break_allowed[0]) { continue; }
-            else { return status; }
+            if (status == 1 && pars->break_allowed) { continue; }
+            else { goto error; }
         }
 
+        pars++;
+        has_day_of_year = pars->start < 0;
         // Optionally parse month
-        if (! has_day_of_year) {
-            status = parse_int_from_char_array(time, str_len, delims[1], starts[1], stops[1], &tm->month);
+        if (!has_day_of_year) {
+            status = parse_int_from_char_array(time, str_len, pars->delim, pars->start, pars->stop, &tm->month);
             if (status) {
-                if (status == 1 && break_allowed[1]) { continue; }
-                else { return status; }
+                if (status == 1 && pars->break_allowed) { continue; }
+                else { goto error; }
             }
         }
 
+        pars++;
         // This might be day-of-month or day-of-year
-        status = parse_int_from_char_array(time, str_len, delims[2], starts[2], stops[2], &tm->day);
+        status = parse_int_from_char_array(time, str_len, pars->delim, pars->start, pars->stop, &tm->day);
         if (status) {
-            if (status == 1 && break_allowed[2]) { continue; }
-            else { return status; }
+            if (status == 1 && pars->break_allowed) { continue; }
+            else { goto error; }
         }
 
         if (has_day_of_year) {
             // day contains day of year at this point, but convert it to day of month
             status = convert_day_of_year_to_month_day(tm->year, tm->day, &tm->month, &tm->day);
-            if (status) {
-                return status;
-            }
+            if (status) { goto error; }
         }
 
-        status = parse_int_from_char_array(time, str_len, delims[3], starts[3], stops[3], &tm->hour);
+        pars++;
+        status = parse_int_from_char_array(time, str_len, pars->delim, pars->start, pars->stop, &tm->hour);
         if (status) {
-            if (status == 1 && break_allowed[3]) { continue; }
-            else { return status; }
+            if (status == 1 && pars->break_allowed) { continue; }
+            else { goto error; }
         }
 
-        status = parse_int_from_char_array(time, str_len, delims[4], starts[4], stops[4], &tm->minute);
+        pars++;
+        status = parse_int_from_char_array(time, str_len, pars->delim, pars->start, pars->stop, &tm->minute);
         if (status) {
-            if (status == 1 && break_allowed[4]) { continue; }
-            else { return status; }
+            if (status == 1 && pars->break_allowed) { continue; }
+            else { goto error; }
         }
 
-        status = parse_int_from_char_array(time, str_len, delims[5], starts[5], stops[5], &tm->second_int);
+        pars++;
+        status = parse_int_from_char_array(time, str_len, pars->delim, pars->start, pars->stop, &tm->second_int);
         if (status) {
-            if (status == 1 && break_allowed[5]) { continue; }
-            else { return status; }
+            if (status == 1 && pars->break_allowed) { continue; }
+            else { goto error; }
         }
 
-        status = parse_frac_from_char_array(time, str_len, delims[6], starts[6], &tm->second_frac);
+        pars++;
+        status = parse_frac_from_char_array(time, str_len, pars->delim, pars->start, &tm->second_frac);
         if (status) {
-            if (status != 1 || ! break_allowed[6]) { return status; }
+            if (status != 1 || !pars->break_allowed) { goto error; }
         }
+
+    }
+    return;
+
+  error:
+    PyErr_Format(PyExc_ValueError,
+                 "fast C time string parser failed: %s", msgs[status-1]);
+    return;
+}
+
+
+/* Create a gufunc parser */
+
+static PyArray_Descr *dt_pars = NULL;   /* Set in PyInit_ufunc */
+static PyArray_Descr *gufunc_dtypes[2];
+
+
+static PyObject *
+create_parser(PyObject *NPY_UNUSED(dummy), PyObject *args, PyObject *kwds)
+{
+    /* Input arguments */
+    char *kw_list[] = {"pars", "name", "doc", NULL};
+    PyObject *pars;
+    char *name=NULL, *doc=NULL;
+    /* Output */
+    PyUFuncObject *gufunc=NULL;
+
+    PyArrayObject *pars_array;
+    int status;
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|ss", kw_list,
+                                     &pars, &name, &doc)) {
+        return NULL;
+    }
+    if (name == NULL) {
+        name = "fast_parser";
+    }
+    Py_INCREF(dt_pars);
+    pars_array = (PyArrayObject *)PyArray_FromAny(pars, dt_pars, 1, 1,
+                     (NPY_ARRAY_CARRAY | NPY_ARRAY_ENSURECOPY), NULL);
+    if (pars_array == NULL) {
+        return NULL;
+    }
+    if (PyArray_SIZE(pars_array) != 7) {
+        PyErr_SetString(PyExc_ValueError,
+                        "Parameter array must have 7 entries"
+                        "(year, month, day, hour, minute, integer second, fraction)");
     }
 
-    return 0;
+    gufunc = (PyUFuncObject *)PyUFunc_FromFuncAndDataAndSignature(
+        NULL, NULL, NULL, 0, 1, 1, PyUFunc_None, name, doc, 0, "(n)->()");
+    if (gufunc == NULL) {
+        goto fail;
+    }
+    status = PyUFunc_RegisterLoopForDescr(
+        gufunc, gufunc_dtypes[0], parser_loop, gufunc_dtypes, PyArray_DATA(pars_array));
+    if (status != 0) {
+        goto fail;
+    }
+    /*
+     * We need to keep array around, as this has the required information, but
+     * it should be deallocated when the ufunc is deleted. Use ->obj for this
+     * (also used in frompyfunc).
+     */
+    gufunc->obj = pars_array;
+    return (PyObject *)gufunc;
+
+  fail:
+    Py_XDECREF(pars_array);
+    Py_XDECREF(gufunc);
+    return NULL;
+}
+
+
+static PyMethodDef parse_times_methods[] = {
+    {"create_parser", (PyCFunction)create_parser,
+         METH_VARARGS | METH_KEYWORDS, CREATE_PARSER_DOCSTRING},
+    {NULL, NULL, 0, NULL}        /* Sentinel */
+};
+
+static struct PyModuleDef moduledef = {
+        PyModuleDef_HEAD_INIT,
+        "parse_times",
+        MODULE_DOCSTRING,
+        -1,
+        parse_times_methods,
+        NULL,
+        NULL,
+        NULL,
+        NULL
+};
+
+/* Initialization function for the module */
+PyMODINIT_FUNC PyInit__parse_times(void) {
+    PyObject *m;
+    PyObject *d;
+    PyObject *dtype_def;
+    PyArray_Descr *dt_u1 = NULL, *dt_ymdhmsf = NULL;
+
+    m = PyModule_Create(&moduledef);
+    if (m == NULL) {
+        return NULL;
+    }
+    import_array();
+    import_ufunc();
+
+    d = PyModule_GetDict(m);
+
+    /* parameter and output dtypes */
+    dtype_def = Py_BuildValue(
+        "[(s, s), (s, s), (s, s), (s, s)]",
+        "delim", "S1",
+        "start", "i4",
+        "stop", "i4",
+        "break_allowed", "?");
+    PyArray_DescrAlignConverter(dtype_def, &dt_pars);
+    Py_DECREF(dtype_def);
+
+    dtype_def = Py_BuildValue("[(s, s)]", "byte", "u1");
+    PyArray_DescrAlignConverter(dtype_def, &dt_u1);
+    Py_DECREF(dtype_def);
+
+    dtype_def = Py_BuildValue(
+        "[(s, s), (s, s), (s, s), (s, s), (s, s), (s, s), (s, s)]",
+        "year", "i4",
+        "month", "i4",
+        "day", "i4",
+        "hour", "i4",
+        "minute", "i4",
+        "second_int", "i4",
+        "second_frac", "f8");
+    PyArray_DescrAlignConverter(dtype_def, &dt_ymdhmsf);
+    Py_DECREF(dtype_def);
+    if (dt_pars == NULL || dt_u1 == NULL || dt_ymdhmsf == NULL) {
+        goto fail;
+    }
+    PyDict_SetItemString(d, "dt_pars", (PyObject *)dt_pars);
+    PyDict_SetItemString(d, "dt_u1", (PyObject *)dt_u1);
+    PyDict_SetItemString(d, "dt_ymdhmsf", (PyObject *)dt_ymdhmsf);
+
+    gufunc_dtypes[0] = dt_u1;
+    gufunc_dtypes[1] = dt_ymdhmsf;
+
+    goto decref;
+
+  fail:
+    Py_XDECREF(m);
+    m = NULL;
+
+  decref:
+    Py_XDECREF(dt_pars);
+    Py_XDECREF(dt_u1);
+    Py_XDECREF(dt_ymdhmsf);
+    return m;
 }

--- a/astropy/time/src/parse_times.c
+++ b/astropy/time/src/parse_times.c
@@ -34,16 +34,6 @@ struct pars_struct_t {
     npy_bool break_allowed;
 };
 
-// Distutils on Windows automatically exports ``PyInit__parse_times``,
-// create dummy to prevent linker complaining about missing symbol.
-// Based on convolution/src/convolve.c.
-#if defined(_MSC_VER)
-void PyInit__parse_times(void)
-{
-    return;
-}
-#endif
-
 int parse_int_from_char_array(char *chars, int str_len,
                               char delim, int idx0, int idx1,
                               int *val)
@@ -245,7 +235,8 @@ parser_loop(char **args, npy_intp *dimensions, npy_intp *steps, void *data)
     struct pars_struct_t *pars = (struct pars_struct_t *)PyArray_DATA((PyArrayObject *)data);
     npy_bool has_day_of_year = pars[1].start < 0;
 
-    npy_intp ii, i, str_len, status;
+    npy_intp ii;
+    int i, str_len, status;
 
     static char *msgs[5] = {
         "time string ends at beginning of component where break is not allowed",
@@ -388,7 +379,7 @@ create_parser(PyObject *NPY_UNUSED(dummy), PyObject *args, PyObject *kwds)
      * it should be deallocated when the ufunc is deleted. Use ->obj for this
      * (also used in frompyfunc).
      */
-    gufunc->obj = pars_array;
+    gufunc->obj = (PyObject *)pars_array;
     gufunc->data = &gufunc->obj;
     return (PyObject *)gufunc;
 


### PR DESCRIPTION
@taldcroft - some time ago I wrote a gufunc replacement for the fast parser, in part because that means that shapes are automatically dealt with, but also because it can automatically deal with masked input (as it can be overridden with `__array_ufunc__`). I also found it nice that it more cleanly separates the parsing and loading parser information, dealing with status codes, etc. I cleaned it up a bit today, so we can discuss.

One thing I did then which in hindsight I probably shouldn't have, is change the format for the parser information, to a structured array. This is helpful for the ufunc, as it means I can just store the array inside, but obviously breaks API. So, at the very least I should add support for interpreting the old format. But I can also just keep the old format and convert it to my structured array format in `__init_subclass__`. Anyway, before I do anything I thought I'd better let you have a look and see which one you prefer.

EDIT: In this version, I replaced the time structured array with a tuple, as it seemed slightly easier (if only just in the `erfa` call at the end); I have another version where the structured array is kept.