### PR TITLE
Use the right time scale in an epoch propagation example

### DIFF
--- a/docs/coordinates/apply_space_motion.rst
+++ b/docs/coordinates/apply_space_motion.rst
@@ -135,7 +135,7 @@ The 2MASS data for all sources within 1 arcminute around the above position
 
 We will first create a |SkyCoord| object from the information provided in the
 TGAS catalog. Note that we set the ``obstime`` of the object to the reference
-epoch provided by the TGAS catalog (J2015.0)::
+epoch provided by the TGAS catalog (J2015.0 in Barycentric Coordinate Time)::
 
     >>> import astropy.units as u
     >>> from astropy.coordinates import SkyCoord, Distance
@@ -145,7 +145,8 @@ epoch provided by the TGAS catalog (J2015.0)::
     ...              distance=Distance(parallax=result_tgas['parallax'] * u.mas),
     ...              pm_ra_cosdec=result_tgas['pmra'] * u.mas/u.yr,
     ...              pm_dec=result_tgas['pmdec'] * u.mas/u.yr,
-    ...              obstime=Time(result_tgas['ref_epoch'], format='jyear'))
+    ...              obstime=Time(result_tgas['ref_epoch'], format='jyear',
+                                  scale='tcb'))
 
 We next create a |SkyCoord| object with the sky positions from the 2MASS
 catalog, and an `~astropy.time.Time` object for the date of the 2MASS


### PR DESCRIPTION
An example of epoch propagation in the documentation includes
initializing a `Time` object from the reference epoch of the TGAS
catalog. The reference epoch is in TCB, but this is not specified in the
example and `Time` uses UTC by default. This commit ensures that the
`Time` object is initialized using the correct time scale.

Related to #11009