### PR TITLE
DOC: Pin max version of Sphinx

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -82,7 +82,7 @@ all =
     ipython>=4.2
     pytest
 docs =
-    sphinx
+    sphinx<4
     sphinx-astropy>=1.3
     pytest
     PyYAML>=3.13


### PR DESCRIPTION
New Sphinx release today appears to have broken our doc build over at RTD, which I reported upstream at sphinx-doc/sphinx#9210 . This PR is to temporarily pin max version of Sphinx until we figure out how to fix the failure permanently.