### PR TITLE
Stop throwing ValueErrors when checking if Header contains a key.

### DIFF
--- a/astropy/io/fits/header.py
+++ b/astropy/io/fits/header.py
@@ -132,7 +132,7 @@ class Header:
             return True
         try:
             self._cardindex(keyword)
-        except (KeyError, IndexError):
+        except (KeyError, IndexError, ValueError):
             return False
         return True
 

--- a/astropy/io/fits/tests/test_header.py
+++ b/astropy/io/fits/tests/test_header.py
@@ -669,6 +669,18 @@ class TestHeaderFunctions(FitsTestCase):
         with pytest.raises(KeyError, match=r"Keyword 'NAXIS' not found."):
             header['NAXIS']
 
+    def test_header_contains_key(self):
+        """Regression test for
+        https://github.com/astropy/astropy/pull/11729
+
+        Assures that the `in` operator acting on a header behaves dict-like.
+        """
+        header = fits.Header()
+        assert isinstance("NAXIS" in header, bool)
+        assert isinstance(("NAXIS", 0) in header, bool)
+        assert isinstance(0 in header, bool)
+        assert isinstance(None in header, bool)
+
     def test_hierarch_card_lookup(self):
         header = fits.Header()
         header['hierarch abcdefghi'] = 10


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->
The current code behavior is:

```
import astropy.io.fits as fits
h = fits.Header()
None in h

# Traceback (most recent call last):
#   File "<stdin>", line 1, in <module>
#   File "...astropy/astropy/io/fits/header.py", line 134, in __contains__
#     self._cardindex(keyword)
#   File "...astropy/astropy/io/fits/header.py", line 1729, in _cardindex
#     raise ValueError(
# ValueError: Header indices must be either a string, a 2-tuple, or an integer.
```
Which is unexpected and not equivalent to other Python types, nor the default implementation if the `__contains__` method.
```
a = [1, 2, 3]
None in a
# False

b = {"a" : a}
None in b
# False

a = [1, 2, 3, None]
None in a
# True
```
<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to address this issue and make the `in` operator, operating on `Header` behave more as expected. The following is, according to me, the expected behavior: 

```
import astropy.io.fits as fits
h = fits.Header()
None in h

# False
```

I found no similar issues addressing this specific behavior of `Header`, just similar issues regarding `HDUList` and other classes.
