### PR TITLE
Fix for the annoying skyoffset origin bugs

### DIFF
--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -663,6 +663,13 @@ class SkyCoord(ShapedLikeNDArray):
                      set(frame_kwargs.keys())):
             frame_kwargs.pop(attr)
 
+        # Always remove the origin frame attribute, as that attribute only makes
+        # sense with a SkyOffsetFrame (in which case it will be stored on the frame).
+        # See gh-11277.
+        # TODO: Should it be a property of the frame attribute that it can
+        # or cannot be stored on a SkyCoord?
+        frame_kwargs.pop('origin', None)
+
         return self.__class__(new_coord, **frame_kwargs)
 
     def apply_space_motion(self, new_obstime=None, dt=None):

--- a/astropy/coordinates/sky_coordinate_parsers.py
+++ b/astropy/coordinates/sky_coordinate_parsers.py
@@ -437,7 +437,7 @@ def _parse_coordinate_arg(coords, frame, units, init_kwargs):
         for attr in frame_transform_graph.frame_attributes:
             value = getattr(coords, attr, None)
             use_value = (isinstance(coords, SkyCoord) or
-                         attr not in coords._attr_names_with_defaults)
+                         attr not in coords.get_frame_attr_names())
             if use_value and value is not None:
                 skycoord_kwargs[attr] = value
 

--- a/astropy/coordinates/tests/test_skyoffset_transformations.py
+++ b/astropy/coordinates/tests/test_skyoffset_transformations.py
@@ -12,6 +12,32 @@ from astropy.time import Time
 from astropy.tests.helper import assert_quantity_allclose as assert_allclose
 
 
+def test_altaz_attribute_transforms():
+    """Test transforms between AltAz frames with different attributes."""
+    el1 = EarthLocation(0*u.deg, 0*u.deg, 0*u.m)
+    origin1 = AltAz(0 * u.deg, 0*u.deg, obstime=Time("2000-01-01T12:00:00"),
+                    location=el1)
+    frame1 = SkyOffsetFrame(origin=origin1)
+    coo1 = SkyCoord(1 * u.deg, 1 * u.deg, frame=frame1)
+
+    el2 = EarthLocation(0*u.deg, 0*u.deg, 0*u.m)
+    origin2 = AltAz(0 * u.deg, 0*u.deg, obstime=Time("2000-01-01T11:00:00"),
+                    location=el2)
+    frame2 = SkyOffsetFrame(origin=origin2)
+    coo2 = coo1.transform_to(frame2)
+    coo2_expected = [1.22522446, 0.70624298] * u.deg
+    assert_allclose([coo2.lon.wrap_at(180*u.deg), coo2.lat],
+                    coo2_expected, atol=convert_precision)
+
+    el3 = EarthLocation(0*u.deg, 90*u.deg, 0*u.m)
+    origin3 = AltAz(0 * u.deg, 90*u.deg, obstime=Time("2000-01-01T12:00:00"),
+                    location=el3)
+    frame3 = SkyOffsetFrame(origin=origin3)
+    coo3 = coo2.transform_to(frame3)
+    assert_allclose([coo3.lon.wrap_at(180*u.deg), coo3.lat],
+                    [1*u.deg, 1*u.deg], atol=convert_precision)
+
+
 @pytest.mark.parametrize("inradec,expectedlatlon, tolsep", [
     ((45, 45)*u.deg, (0, 0)*u.deg, .001*u.arcsec),
     ((45, 0)*u.deg, (0, -45)*u.deg, .001*u.arcsec),
@@ -215,32 +241,6 @@ def test_m31_coord_transforms(fromsys, tosys, fromcoo, tocoo):
     roundtrip_pos = target_pos.transform_to(from_pos)
     assert_allclose([roundtrip_pos.lon.wrap_at(180*u.deg), roundtrip_pos.lat],
                     [1.0*u.deg, 1.0*u.deg], atol=convert_precision)
-
-
-def test_altaz_attribute_transforms():
-    """Test transforms between AltAz frames with different attributes."""
-    el1 = EarthLocation(0*u.deg, 0*u.deg, 0*u.m)
-    origin1 = AltAz(0 * u.deg, 0*u.deg, obstime=Time("2000-01-01T12:00:00"),
-                    location=el1)
-    frame1 = SkyOffsetFrame(origin=origin1)
-    coo1 = SkyCoord(1 * u.deg, 1 * u.deg, frame=frame1)
-
-    el2 = EarthLocation(0*u.deg, 0*u.deg, 0*u.m)
-    origin2 = AltAz(0 * u.deg, 0*u.deg, obstime=Time("2000-01-01T11:00:00"),
-                    location=el2)
-    frame2 = SkyOffsetFrame(origin=origin2)
-    coo2 = coo1.transform_to(frame2)
-    coo2_expected = [1.22522446, 0.70624298] * u.deg
-    assert_allclose([coo2.lon.wrap_at(180*u.deg), coo2.lat],
-                    coo2_expected, atol=convert_precision)
-
-    el3 = EarthLocation(0*u.deg, 90*u.deg, 0*u.m)
-    origin3 = AltAz(0 * u.deg, 90*u.deg, obstime=Time("2000-01-01T12:00:00"),
-                    location=el3)
-    frame3 = SkyOffsetFrame(origin=origin3)
-    coo3 = coo2.transform_to(frame3)
-    assert_allclose([coo3.lon.wrap_at(180*u.deg), coo3.lat],
-                    [1*u.deg, 1*u.deg], atol=convert_precision)
 
 
 @pytest.mark.parametrize("rotation, expectedlatlon", [

--- a/astropy/coordinates/tests/test_skyoffset_transformations.py
+++ b/astropy/coordinates/tests/test_skyoffset_transformations.py
@@ -56,15 +56,8 @@ def test_skyoffset(inradec, expectedlatlon, tolsep, originradec=(45, 45)*u.deg):
 
     assert skycoord_inaf.separation(expected) < tolsep
     # Check we can also transform back (regression test for gh-11254).
-    try:
-        roundtrip = skycoord_inaf.transform_to(ICRS())
-    except AttributeError as err:
-        if 'to_geodetic' in str(err):
-            pytest.xfail('See Issue 11277')
-        else:
-            raise
-    else:
-        assert roundtrip.separation(skycoord) < 1*u.uas
+    roundtrip = skycoord_inaf.transform_to(ICRS())
+    assert roundtrip.separation(skycoord) < 1*u.uas
 
 
 def test_skyoffset_functional_ra():

--- a/docs/changes/coordinates/11730.bugfix.rst
+++ b/docs/changes/coordinates/11730.bugfix.rst
@@ -1,0 +1,5 @@
+Different ``SkyOffsetFrame`` classes no longer interfere with each other,
+causing difficult to debug problems with the ``origin`` attribute. The
+``origin`` attribute now no longer is propagated, so while it remains
+available on a ``SkyCoord`` that is an offset, it no longer is available once
+that coordinate is transformed to another frame. [#11730]


### PR DESCRIPTION
Fixes #11277!

It turned out there were two separate bugs: one that the `origin` validation cannot generally be done, since it varies by SkyOffsetFrame class. For that, I ended up just not propagating 'origin' to `SkyCoord`. After all, it is not like the other atttributes, which can still be used in a future transformation.

But it turned out 'origin' was also set on the SkyCoord at the end of a transformation (where for reasons we need to fix, the whole initialization gets redone even though everything is perfectly organized already). This was because of a bug in the argument parser, which led to frame attributes to be needlessly set on the SkyCoord.

@eteq - am hoping this can still be backported...