### PR TITLE
Fix deprecation warning with asdf 2.8

### DIFF
--- a/astropy/io/misc/asdf/tags/table/tests/test_table.py
+++ b/astropy/io/misc/asdf/tags/table/tests/test_table.py
@@ -98,8 +98,15 @@ def test_table_inline(tmpdir):
     def check(ff):
         assert len(list(ff.blocks.internal_blocks)) == 0
 
-    helpers.assert_roundtrip_tree({'table': t}, tmpdir, asdf_check_func=check,
-                                  write_options={'auto_inline': 64})
+    if hasattr(asdf, 'config_context'):
+        # asdf 2.8
+        with asdf.config_context() as config:
+            config.array_inline_threshold = 64
+            helpers.assert_roundtrip_tree({'table': t}, tmpdir, asdf_check_func=check)
+    else:
+        # asdf 2.7
+        helpers.assert_roundtrip_tree({'table': t}, tmpdir, asdf_check_func=check,
+                                      write_options={'auto_inline': 64})
 
 
 def test_mismatched_columns():

--- a/astropy/io/misc/asdf/tags/table/tests/test_table.py
+++ b/astropy/io/misc/asdf/tags/table/tests/test_table.py
@@ -6,6 +6,7 @@ import pytest
 asdf = pytest.importorskip('asdf')
 
 import numpy as np
+from packaging.version import Version
 
 import astropy.units as u
 from astropy import table
@@ -98,13 +99,12 @@ def test_table_inline(tmpdir):
     def check(ff):
         assert len(list(ff.blocks.internal_blocks)) == 0
 
-    if hasattr(asdf, 'config_context'):
-        # asdf 2.8
+    if Version(asdf.__version__) >= Version('2.8.0'):
+        # The auto_inline argument is deprecated as of asdf 2.8.0.
         with asdf.config_context() as config:
             config.array_inline_threshold = 64
             helpers.assert_roundtrip_tree({'table': t}, tmpdir, asdf_check_func=check)
     else:
-        # asdf 2.7
         helpers.assert_roundtrip_tree({'table': t}, tmpdir, asdf_check_func=check,
                                       write_options={'auto_inline': 64})
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to address a deprecation warning in a test that will be caused by asdf 2.8 (due to be released later today).

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->
