### PR TITLE
Allow SkyCoords to be converted to Tables

### DIFF
--- a/docs/changes/coordinates/11743.feature.rst
+++ b/docs/changes/coordinates/11743.feature.rst
@@ -1,0 +1,2 @@
+``SkyCoord`` objects now have a ``to_table()`` method, which allows them to be
+converted to a ``QTable``.

--- a/docs/coordinates/skycoord.rst
+++ b/docs/coordinates/skycoord.rst
@@ -1197,6 +1197,47 @@ example::
   >>> FK4() == FK4(obstime='2020-01-01')
   False
 
+.. _skycoord-table-conversion:
+
+Converting a SkyCoord to a Table
+================================
+
+A |SkyCoord| object can be converted to a |QTable| using its
+:meth:`~astropy.coordinates.SkyCoord.to_table` method. The attributes of the
+|SkyCoord| are converted to columns of the table or added to its metadata
+depending on whether or not they have the same length as the |SkyCoord|. This
+means that attributes such as ``obstime`` can become columns or metadata::
+
+  >>> from astropy.coordinates import SkyCoord
+  >>> from astropy.time import Time
+  >>> sc = SkyCoord(ra=[15, 30], dec=[-70, -50], unit=u.deg,
+  ...               obstime=Time([2000, 2010], format='jyear'))
+  >>> t = sc.to_table()
+  >>> t
+  <QTable length=2>
+     ra     dec   obstime
+    deg     deg
+  float64 float64   Time
+  ------- ------- -------
+     15.0   -70.0  2000.0
+     30.0   -50.0  2010.0
+  >>> t.meta
+  {'representation_type': 'spherical', 'frame': 'icrs'}
+
+  >>> sc = SkyCoord(l=[0, 20], b=[20, 0], unit=u.deg, frame='galactic',
+  ...               obstime=Time(2000, format='jyear'))
+  >>> t = sc.to_table()
+  >>> t
+  <QTable length=2>
+     l       b
+    deg     deg
+  float64 float64
+  ------- -------
+      0.0    20.0
+     20.0     0.0
+  >>> t.meta
+  {'obstime': <Time object: scale='tt' format='jyear' value=2000.0>,
+   'representation_type': 'spherical', 'frame': 'galactic'}
 
 Convenience Methods
 ===================

--- a/docs/table/construct_table.rst
+++ b/docs/table/construct_table.rst
@@ -14,8 +14,8 @@ Examples
 Much of the flexibility lies in the types of data structures
 which can be used to initialize the table data. The examples below show how to
 create a table from scratch with no initial data, as well as create a table
-with a list of columns, a dictionary of columns, or from ``numpy`` arrays
-(either structured or homogeneous).
+with a list of columns, a dictionary of columns, from ``numpy`` arrays (either
+structured or homogeneous), or from a |SkyCoord| object.
 
 Setup
 -----
@@ -523,6 +523,13 @@ from another table, or generated on the fly::
       2     5.0 False
 
 .. EXAMPLE END
+
+SkyCoord
+--------
+
+A |SkyCoord| object can be converted to a |QTable| using its
+:meth:`~astropy.coordinates.SkyCoord.to_table` method. For details and examples
+see :ref:`Converting a SkyCoord to a Table <skycoord-table-conversion>`.
 
 Pandas DataFrame
 ----------------

--- a/docs/table/construct_table.rst
+++ b/docs/table/construct_table.rst
@@ -11,12 +11,6 @@ best way to understand how to make a table is by example.
 Examples
 ========
 
-Much of the flexibility lies in the types of data structures
-which can be used to initialize the table data. The examples below show how to
-create a table from scratch with no initial data, as well as create a table
-with a list of columns, a dictionary of columns, from ``numpy`` arrays (either
-structured or homogeneous), or from a |SkyCoord| object.
-
 Setup
 -----
 
@@ -529,7 +523,7 @@ SkyCoord
 
 A |SkyCoord| object can be converted to a |QTable| using its
 :meth:`~astropy.coordinates.SkyCoord.to_table` method. For details and examples
-see :ref:`Converting a SkyCoord to a Table <skycoord-table-conversion>`.
+see :ref:`skycoord-table-conversion`.
 
 Pandas DataFrame
 ----------------

--- a/docs/table/index.rst
+++ b/docs/table/index.rst
@@ -73,7 +73,7 @@ Comments:
 
 There are many other ways of :ref:`construct_table`, including from a list of
 rows (either tuples or dicts), from a ``numpy`` structured or 2D array, by
-adding columns or rows incrementally, from a |SkyCoord|, or even from a
+adding columns or rows incrementally, or even converting from a |SkyCoord| or a
 :class:`pandas.DataFrame`.
 
 There are a few ways of :ref:`access_table`. You can get detailed information

--- a/docs/table/index.rst
+++ b/docs/table/index.rst
@@ -73,7 +73,8 @@ Comments:
 
 There are many other ways of :ref:`construct_table`, including from a list of
 rows (either tuples or dicts), from a ``numpy`` structured or 2D array, by
-adding columns or rows incrementally, or even from a :class:`pandas.DataFrame`.
+adding columns or rows incrementally, from a |SkyCoord|, or even from a
+:class:`pandas.DataFrame`.
 
 There are a few ways of :ref:`access_table`. You can get detailed information
 about the table values and column definitions as follows::


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

Currently it is possible to add `SkyCoord` objects to a `Table` as a column, and it is (often) possible to initialize a `SkyCoord` from a `Table` using `SkyCoord.guess_from_table()`. This pull request would allow a `SkyCoord` object to be converted to a `Table`. The coordinates (together with differentials and obstimes, if present) of the `SkyCoord` would become the `Table` columns, and and any coordinate frame attributes would be recorded in the `Table` metadata.