### PR TITLE
Allow differentials of a SkyCoord to be serialized

### DIFF
--- a/astropy/coordinates/tests/test_regression.py
+++ b/astropy/coordinates/tests/test_regression.py
@@ -668,6 +668,16 @@ def test_regression_10092():
                              atol=1.0e-5*u.mas/u.yr)
 
 
+def test_regression_10226():
+    # Dictionary representation of SkyCoord should contain differentials.
+    sc = SkyCoord([270, 280]*u.deg, [30, 35]*u.deg, [10, 11]*u.pc,
+                  radial_velocity=[20, -20]*u.km/u.s)
+    sc_as_dict = sc.info._represent_as_dict()
+    assert 'radial_velocity' in sc_as_dict
+    # But only the components that have been specified.
+    assert 'pm_dec' not in sc_as_dict
+
+
 @pytest.mark.parametrize('mjd', (
     52000, [52000], [[52000]], [52001, 52002], [[52001], [52002]]))
 def test_regression_10422(mjd):

--- a/astropy/io/fits/tests/test_connect.py
+++ b/astropy/io/fits/tests/test_connect.py
@@ -17,6 +17,7 @@ from astropy.io import fits
 from astropy import units as u
 from astropy.table import Table, QTable, NdarrayMixin, Column
 from astropy.table.table_helpers import simple_table
+from astropy.units import allclose as quantity_allclose
 from astropy.units.format.fits import UnitScaleError
 from astropy.utils.data import get_pkg_data_filename
 from astropy.utils.exceptions import (AstropyUserWarning,
@@ -686,10 +687,13 @@ def assert_objects_equal(obj1, obj2, attrs, compare_class=True):
             if a2 is None:
                 a2 = {}
 
-        assert np.all(a1 == a2)
+        if isinstance(a1, np.ndarray) and a1.dtype.kind == 'f':
+            assert quantity_allclose(a1, a2, rtol=1e-15)
+        else:
+            assert np.all(a1 == a2)
 
 # Testing FITS table read/write with mixins.  This is mostly
-# copied from ECSV mixin testing.
+# copied from ECSV mixin testing.  Analogous tests also exist for HDF5.
 
 
 el = EarthLocation(x=1 * u.km, y=3 * u.km, z=5 * u.km)
@@ -703,8 +707,17 @@ sd = SphericalCosLatDifferential(
 srd = SphericalRepresentation(sr, differentials=sd)
 sc = SkyCoord([1, 2], [3, 4], unit='deg,deg', frame='fk4',
               obstime='J1990.5')
-scc = sc.copy()
-scc.representation_type = 'cartesian'
+scd = SkyCoord([1, 2], [3, 4], [5, 6], unit='deg,deg,m', frame='fk4',
+               obstime=['J1990.5', 'J1991.5'])
+scdc = scd.copy()
+scdc.representation_type = 'cartesian'
+scpm = SkyCoord([1, 2], [3, 4], [5, 6], unit='deg,deg,pc',
+                pm_ra_cosdec=[7, 8]*u.mas/u.yr, pm_dec=[9, 10]*u.mas/u.yr)
+scpmrv = SkyCoord([1, 2], [3, 4], [5, 6], unit='deg,deg,pc',
+                  pm_ra_cosdec=[7, 8]*u.mas/u.yr, pm_dec=[9, 10]*u.mas/u.yr,
+                  radial_velocity=[11, 12]*u.km/u.s)
+scrv = SkyCoord([1, 2], [3, 4], [5, 6], unit='deg,deg,pc',
+                radial_velocity=[11, 12]*u.km/u.s)
 tm = Time([2450814.5, 2450815.5], format='jd', scale='tai', location=el)
 
 # NOTE: in the test below the name of the column "x" for the Quantity is
@@ -714,9 +727,11 @@ mixin_cols = {
     'tm': tm,
     'dt': TimeDelta([1, 2] * u.day),
     'sc': sc,
-    'scc': scc,
-    'scd': SkyCoord([1, 2], [3, 4], [5, 6], unit='deg,deg,m', frame='fk4',
-                    obstime=['J1990.5', 'J1991.5']),
+    'scd': scd,
+    'scdc': scdc,
+    'scpm': scpm,
+    'scpmrv': scpmrv,
+    'scrv': scrv,
     'x': [1, 2] * u.m,
     'lat': Latitude([1, 2] * u.deg),
     'lon': Longitude([1, 2] * u.deg, wrap_angle=180. * u.deg),
@@ -735,8 +750,14 @@ compare_attrs = {
     'tm': time_attrs,
     'dt': ['shape', 'value', 'format', 'scale'],
     'sc': ['ra', 'dec', 'representation_type', 'frame.name'],
-    'scc': ['x', 'y', 'z', 'representation_type', 'frame.name'],
     'scd': ['ra', 'dec', 'distance', 'representation_type', 'frame.name'],
+    'scdc': ['x', 'y', 'z', 'representation_type', 'frame.name'],
+    'scpm': ['ra', 'dec', 'distance', 'pm_ra_cosdec', 'pm_dec',
+             'representation_type', 'frame.name'],
+    'scpmrv': ['ra', 'dec', 'distance', 'pm_ra_cosdec', 'pm_dec',
+               'radial_velocity', 'representation_type', 'frame.name'],
+    'scrv': ['ra', 'dec', 'distance', 'radial_velocity', 'representation_type',
+             'frame.name'],
     'x': ['value', 'unit'],
     'lon': ['value', 'unit', 'wrap_angle'],
     'lat': ['value', 'unit'],
@@ -803,9 +824,17 @@ def test_fits_mixins_as_one(table_cls, tmpdir):
                         'lat',
                         'lon',
                         'sc.ra', 'sc.dec',
-                        'scc.x', 'scc.y', 'scc.z',
                         'scd.ra', 'scd.dec', 'scd.distance',
                         'scd.obstime.jd1', 'scd.obstime.jd2',
+                        'scdc.x', 'scdc.y', 'scdc.z',
+                        'scdc.obstime.jd1', 'scdc.obstime.jd2',
+                        'scpm.ra', 'scpm.dec', 'scpm.distance',
+                        'scpm.pm_ra_cosdec', 'scpm.pm_dec',
+                        'scpmrv.ra', 'scpmrv.dec', 'scpmrv.distance',
+                        'scpmrv.pm_ra_cosdec', 'scpmrv.pm_dec',
+                        'scpmrv.radial_velocity',
+                        'scrv.ra', 'scrv.dec', 'scrv.distance',
+                        'scrv.radial_velocity',
                         'sd.d_lon_coslat', 'sd.d_lat', 'sd.d_distance',
                         'sr.lon', 'sr.lat', 'sr.distance',
                         'srd.lon', 'srd.lat', 'srd.distance',

--- a/docs/changes/coordinates/11750.bugfix.rst
+++ b/docs/changes/coordinates/11750.bugfix.rst
@@ -1,0 +1,3 @@
+If a ``Table`` containing a ``SkyCoord`` object as a column is written to a
+FITS, ECSV or HDF5 file then any velocity information that might be present
+will be retained.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request will allow the `SkyCoordInfo._represent_as_dict()` method to include the velocity components and `obstime` of a `SkyCoord` object in its output, which in turn allows them to be serialized.

Fixes #10226