### PR TITLE
DOC: Small fixes for convolution kernel docs

### DIFF
--- a/astropy/convolution/kernels.py
+++ b/astropy/convolution/kernels.py
@@ -697,7 +697,7 @@ class AiryDisk2DKernel(Kernel2D):
     2D Airy disk kernel.
 
     This kernel models the diffraction pattern of a circular aperture. This
-    kernel is normalized to a peak value of 1.
+    kernel is normalized so that it sums to 1.
 
     Parameters
     ----------

--- a/astropy/convolution/kernels.py
+++ b/astropy/convolution/kernels.py
@@ -392,7 +392,7 @@ class Ring2DKernel(Kernel2D):
     See Also
     --------
     Gaussian2DKernel, Box2DKernel, Tophat2DKernel, RickerWavelet2DKernel,
-    Ring2DKernel, AiryDisk2DKernel, Moffat2DKernel
+    TrapezoidDisk2DKernel, AiryDisk2DKernel, Moffat2DKernel
 
     Examples
     --------
@@ -727,7 +727,7 @@ class AiryDisk2DKernel(Kernel2D):
     See Also
     --------
     Gaussian2DKernel, Box2DKernel, Tophat2DKernel, RickerWavelet2DKernel,
-    Ring2DKernel, TrapezoidDisk2DKernel, AiryDisk2DKernel, Moffat2DKernel
+    Ring2DKernel, TrapezoidDisk2DKernel, Moffat2DKernel
 
     Examples
     --------

--- a/astropy/convolution/kernels.py
+++ b/astropy/convolution/kernels.py
@@ -32,6 +32,8 @@ class Gaussian1DKernel(Kernel1D):
     The Gaussian filter is a filter with great smoothing properties. It is
     isotropic and does not produce artifacts.
 
+    The generated kernel is normalized so that it integrates to 1.
+
     Parameters
     ----------
     stddev : number
@@ -94,6 +96,8 @@ class Gaussian2DKernel(Kernel2D):
 
     The Gaussian filter is a filter with great smoothing properties. It is
     isotropic and does not produce artifacts.
+
+    The generated kernel is normalized so that it integrates to 1.
 
     Parameters
     ----------
@@ -168,7 +172,9 @@ class Box1DKernel(Kernel1D):
     1D Box filter kernel.
 
     The Box filter or running mean is a smoothing filter. It is not isotropic
-    and can produce artifacts, when applied repeatedly to the same data.
+    and can produce artifacts when applied repeatedly to the same data.
+
+    The generated kernel is normalized so that it integrates to 1.
 
     By default the Box kernel uses the ``linear_interp`` discretization mode,
     which allows non-shifting, even-sized kernels.  This is achieved by
@@ -236,7 +242,9 @@ class Box2DKernel(Kernel2D):
     2D Box filter kernel.
 
     The Box filter or running mean is a smoothing filter. It is not isotropic
-    and can produce artifact, when applied repeatedly to the same data.
+    and can produce artifacts when applied repeatedly to the same data.
+
+    The generated kernel is normalized so that it integrates to 1.
 
     By default the Box kernel uses the ``linear_interp`` discretization mode,
     which allows non-shifting, even-sized kernels.  This is achieved by
@@ -308,6 +316,8 @@ class Tophat2DKernel(Kernel2D):
     The Tophat filter is an isotropic smoothing filter. It can produce
     artifacts when applied repeatedly on the same data.
 
+    The generated kernel is normalized so that it integrates to 1.
+
     Parameters
     ----------
     radius : int
@@ -366,6 +376,8 @@ class Ring2DKernel(Kernel2D):
     The Ring filter kernel is the difference between two Tophat kernels of
     different width. This kernel is useful for, e.g., background estimation.
 
+    The generated kernel is normalized so that it integrates to 1.
+
     Parameters
     ----------
     radius_in : number
@@ -422,6 +434,8 @@ class Ring2DKernel(Kernel2D):
 class Trapezoid1DKernel(Kernel1D):
     """
     1D trapezoid kernel.
+
+    The generated kernel is normalized so that it integrates to 1.
 
     Parameters
     ----------
@@ -480,6 +494,8 @@ class Trapezoid1DKernel(Kernel1D):
 class TrapezoidDisk2DKernel(Kernel2D):
     """
     2D trapezoid kernel.
+
+    The generated kernel is normalized so that it integrates to 1.
 
     Parameters
     ----------
@@ -696,8 +712,9 @@ class AiryDisk2DKernel(Kernel2D):
     """
     2D Airy disk kernel.
 
-    This kernel models the diffraction pattern of a circular aperture. This
-    kernel is normalized so that it sums to 1.
+    This kernel models the diffraction pattern of a circular aperture.
+
+    The generated kernel is normalized so that it integrates to 1.
 
     Parameters
     ----------
@@ -760,6 +777,8 @@ class Moffat2DKernel(Kernel2D):
     2D Moffat kernel.
 
     This kernel is a typical model for a seeing limited PSF.
+
+    The generated kernel is normalized so that it integrates to 1.
 
     Parameters
     ----------

--- a/docs/convolution/kernels.rst
+++ b/docs/convolution/kernels.rst
@@ -220,6 +220,7 @@ Available Kernels
    RickerWavelet2DKernel
    Model1DKernel
    Model2DKernel
+   Moffat2DKernel
    Ring2DKernel
    Tophat2DKernel
    Trapezoid1DKernel


### PR DESCRIPTION
### Description

A few small doc fixes:

- The docs for `astropy.convolution.AiryDisk2DKernel` say "this kernel is normalized to a peak value of 1," but the normalization actually ensures that the sum, not the peak value, is 1 (see below). This PR adjusts the text accordingly.

```>>> from astropy.convolution import AiryDisk2DKernel
>>> from astropy.convolution import AiryDisk2DKernel
>>> k = AiryDisk2DKernel(10)
>>> k.array.sum()
1.0
>>> k.array.max()
0.012127255578959403
```

- Adds `Moffat2DKernel` to the list of available kernels on the "Convolution Kernels" docs page, where it had been omitted.
- Corrects inconsistencies in the "See Also" sections of the docs for `Ring2DKernel` and `AiryDisk2DKernel`.