### PR TITLE
Use new erfa routine to calculate the position of the Moon

### DIFF
--- a/astropy/coordinates/orbital_elements.py
+++ b/astropy/coordinates/orbital_elements.py
@@ -9,6 +9,8 @@ import numpy as np
 from numpy.polynomial.polynomial import polyval
 import erfa
 
+from astropy.utils import deprecated
+
 from astropy import units as u
 from . import ICRS, SkyCoord, GeocentricTrueEcliptic
 from .builtin_frames.utils import get_jd12
@@ -171,6 +173,13 @@ _coA3 = (313.45, 481266.484)
 _coE = (1.0, -0.002516, -0.0000074)
 
 
+@deprecated(since="5.0",
+            alternative="astropy.coordinates.get_moon",
+            message=("The private calc_moon function has been deprecated, "
+                     "as its functionality is now available in ERFA. "
+                     "Note that the coordinate system was not interpreted "
+                     "quite correctly, leading to small inaccuracies. Please "
+                     "use the public get_moon or get_body functions instead."))
 def calc_moon(t):
     """
     Lunar position model ELP2000-82 of (Chapront-Touze' and Chapront, 1983, 124, 50)

--- a/astropy/coordinates/tests/test_intermediate_transformations.py
+++ b/astropy/coordinates/tests/test_intermediate_transformations.py
@@ -744,7 +744,8 @@ def test_aa_high_precision_nodata():
     with a version of the code that passes the tests above, but for the internal solar system
     ephemerides to avoid the use of remote data.
     """
-    TARGET_AZ, TARGET_EL = 15.0321908*u.deg, 50.30263625*u.deg
+    # Last updated when switching to erfa 2.0.0 and its moon98 function.
+    TARGET_AZ, TARGET_EL = 15.03231495*u.deg, 50.3027193*u.deg
     lat = -22.959748*u.deg
     lon = -67.787260*u.deg
     elev = 5186*u.m

--- a/astropy/coordinates/tests/test_solar_system.py
+++ b/astropy/coordinates/tests/test_solar_system.py
@@ -378,10 +378,12 @@ def test_earth_barycentric_velocity_multi_d():
 @pytest.mark.parametrize(('body', 'pos_tol', 'vel_tol'),
                          (('mercury', 1000.*u.km, 1.*u.km/u.s),
                           ('jupiter', 100000.*u.km, 2.*u.km/u.s),
-                          ('earth', 10*u.km, 10*u.mm/u.s)))
+                          ('earth', 10*u.km, 10*u.mm/u.s),
+                          ('moon', 18*u.km, 50*u.mm/u.s)))
 def test_barycentric_velocity_consistency(body, pos_tol, vel_tol):
     # Tolerances are about 1.5 times the rms listed for plan94 and epv00,
-    # except for Mercury (which nominally is 334 km rms)
+    # except for Mercury (which nominally is 334 km rms), and the Moon
+    # (which nominally is 6 km rms).
     t = Time('2016-03-20T12:30:00')
     ep, ev = get_body_barycentric_posvel(body, t, ephemeris='builtin')
     dp, dv = get_body_barycentric_posvel(body, t, ephemeris='de432s')

--- a/docs/changes/coordinates/11753.other.rst
+++ b/docs/changes/coordinates/11753.other.rst
@@ -1,0 +1,5 @@
+Positions for the Moon using the 'builtin' ephemeris now use the new
+``erfa.moon98`` function instead of our own implementation of the Meeus
+algorithm. As this also corrects a misunderstanding of the frame returned by
+the Meeus, this improves the agreement with the JPL ephemeris from about 30 to
+about 6 km rms.

--- a/docs/coordinates/solarsystem.rst
+++ b/docs/coordinates/solarsystem.rst
@@ -68,7 +68,7 @@ ephemeris is set):
       (165.51854528, 2.32861794, 407229.55638763)>
   >>> get_body_barycentric('moon', t) # doctest: +REMOTE_DATA, +FLOAT_CMP
   <CartesianRepresentation (x, y, z) in km
-      (  1.50107535e+08, -866789.11996916, -418963.55218495)>
+      (1.50107535e+08, -866789.11996916, -418963.55218495)>
 
 For one-off calculations with a given ephemeris, you can also pass it directly
 to the various functions:
@@ -78,11 +78,11 @@ to the various functions:
   >>> get_body_barycentric('moon', t, ephemeris='de432s')
   ... # doctest: +REMOTE_DATA, +FLOAT_CMP
   <CartesianRepresentation (x, y, z) in km
-      (  1.50107535e+08, -866789.11996916, -418963.55218495)>
+      (1.50107535e+08, -866789.11996916, -418963.55218495)>
   >>> get_body_barycentric('moon', t, ephemeris='builtin')
   ... # doctest: +FLOAT_CMP
-  <CartesianRepresentation (x, y, z) in km
-      (  1.50107516e+08, -866828.92702829, -418980.15907332)>
+  <CartesianRepresentation (x, y, z) in AU
+      (1.00340683, -0.00579417, -0.00280064)>
 
 ..
   EXAMPLE END

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ tests_require = pytest-astropy
 setup_requires = setuptools_scm
 install_requires =
     numpy>=1.17
-    pyerfa>=1.7.3
+    pyerfa>=2.0
     importlib-metadata ; python_version == '3.7'
 python_requires = >=3.7
 


### PR DESCRIPTION
This replaces our own implementation of the Meeus algorithm for calculating the position of the Moon with the new routine in `erfa` (so the PR also bumps the minimum version of erfa).

I added a comparison between the JPL ephemeris and this new one, and ~oddly the differences in position and velocity are quite a bit larger than they should be according to the `moon98` documentation (see https://pyerfa.readthedocs.io/en/latest/api/erfa.moon98.html#erfa.moon98).~ with the correct implementation pointed out by @mkbrewer the code is now consistent in precision with what was expected.

EDIT: old text for reference only
~In the PR, I write we should also be sure to correct for light-travel time effect (which is included in the Meeus algorithm, but should not be for barycentric position), but from the trials I did I'm not sure that is enough. Am I missing something? (I tried applying in GCRS, which has almost no effect; I also tried applying the Moon-Earth light travel time one finds from the GCRS to the ICRS pos and vel, which does give an improvement but not to the level expected).~
 
Fixes #11739, #11755