### PR TITLE
Fix install_requires and remove requires

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,16 +22,13 @@ classifiers =
 [options]
 # We set packages to find: to automatically find all sub-packages
 packages = find:
-requires =
-    numpy
-    pyerfa
-    importlib-metadata ; python_version == '3.7'
 zip_safe = False
 tests_require = pytest-astropy
 setup_requires = setuptools_scm
 install_requires =
     numpy>=1.17
     pyerfa>=1.7.3
+    importlib-metadata ; python_version == '3.7'
 python_requires = >=3.7
 
 [options.packages.find]


### PR DESCRIPTION
Not sure why we have both `requires` and `install_requires` as the first is deprecated in favor of the second (https://setuptools.readthedocs.io/en/latest/references/keywords.html).
I added `importlib-metadata` in #11091 to `requires` though I should have put it in `install_requires` (I guess the first one is not used if the second is defined).