### PR TITLE
change RST links to get ride of redundant “astropy” in links

### DIFF
--- a/astropy/constants/__init__.py
+++ b/astropy/constants/__init__.py
@@ -57,7 +57,7 @@ def set_enabled_constants(modname):
     """
     Context manager to temporarily set values in the ``constants``
     namespace to an older version.
-    See :ref:`astropy:astropy-constants-prior` for usage.
+    See :ref:`astropy:constants-prior` for usage.
 
     Parameters
     ----------

--- a/astropy/coordinates/builtin_frames/equatorial.py
+++ b/astropy/coordinates/builtin_frames/equatorial.py
@@ -64,10 +64,10 @@ class TETE(BaseRADecFrame):
     with local apparent sidereal time to calculate the apparent (TIRS) hour angle.
 
     For more background on TETE, see the references provided in the
-    :ref:`astropy:astropy-coordinates-seealso` section of the documentation.
-    Of particular note are Sections 5 and 6 of
-    `USNO Circular 179 <https://arxiv.org/abs/astro-ph/0602086>`_) and
-    especially the diagram at the top of page 57.
+    :ref:`astropy:coordinates-seealso` section of the documentation.
+    Of particular note are Sections 5 and 6 of `USNO Circular 179
+    <https://arxiv.org/abs/astro-ph/0602086>`_) and especially the diagram at
+    the top of page 57.
 
     This frame also includes frames that are defined *relative* to the center of the Earth,
     but that are offset (in both position and velocity) from the center of the Earth. You
@@ -96,7 +96,7 @@ class TEME(BaseCoordinateFrame):
     conventions and relations to other frames that are set out in Vallado et al (2006).
 
     For more background on TEME, see the references provided in the
-    :ref:`astropy:astropy-coordinates-seealso` section of the documentation.
+    :ref:`astropy:coordinates-seealso` section of the documentation.
     """
 
     default_representation = CartesianRepresentation

--- a/astropy/coordinates/builtin_frames/galactocentric.py
+++ b/astropy/coordinates/builtin_frames/galactocentric.py
@@ -88,8 +88,7 @@ class galactocentric_frame_defaults(ScienceState):
     :meth:`~galactocentric_frame_defaults.get_from_registry` since
     it ensures the immutability of the registry.
 
-    See :ref:`astropy:astropy-coordinates-galactocentric-defaults` for more
-    information.
+    See :ref:`astropy:coordinates-galactocentric-defaults` for more information.
 
     Examples
     --------

--- a/astropy/coordinates/builtin_frames/gcrs.py
+++ b/astropy/coordinates/builtin_frames/gcrs.py
@@ -42,7 +42,7 @@ class GCRS(BaseRADecFrame):
     center-of-mass rather than the solar system Barycenter.  That means this
     frame includes the effects of aberration (unlike ICRS). For more background
     on the GCRS, see the references provided in the
-    :ref:`astropy:astropy-coordinates-seealso` section of the documentation. (Of
+    :ref:`astropy:coordinates-seealso` section of the documentation. (Of
     particular note is Section 1.2 of
     `USNO Circular 179 <https://arxiv.org/abs/astro-ph/0602086>`_)
 

--- a/astropy/coordinates/builtin_frames/hcrs.py
+++ b/astropy/coordinates/builtin_frames/hcrs.py
@@ -34,8 +34,8 @@ class HCRS(BaseRADecFrame):
     of the order of 8 milli-arcseconds.
 
     For more background on the ICRS and related coordinate transformations, see
-    the references provided in the :ref:`astropy:astropy-coordinates-seealso`
-    section of the documentation.
+    the references provided in the :ref:`astropy:coordinates-seealso` section of
+    the documentation.
 
     The frame attributes are listed under **Other Parameters**.
     """

--- a/astropy/coordinates/builtin_frames/icrs.py
+++ b/astropy/coordinates/builtin_frames/icrs.py
@@ -19,6 +19,6 @@ class ICRS(BaseRADecFrame):
     very close (within tens of milliarcseconds) to J2000 equatorial.
 
     For more background on the ICRS and related coordinate transformations, see
-    the references provided in the  :ref:`astropy:astropy-coordinates-seealso`
-    section of the documentation.
+    the references provided in the  :ref:`astropy:coordinates-seealso` section
+    of the documentation.
     """

--- a/astropy/coordinates/builtin_frames/itrs.py
+++ b/astropy/coordinates/builtin_frames/itrs.py
@@ -17,7 +17,7 @@ class ITRS(BaseCoordinateFrame):
     (ITRS).  This is approximately a geocentric system, although strictly it is
     defined by a series of reference locations near the surface of the Earth.
     For more background on the ITRS, see the references provided in the
-    :ref:`astropy:astropy-coordinates-seealso` section of the documentation.
+    :ref:`astropy:coordinates-seealso` section of the documentation.
     """
 
     default_representation = CartesianRepresentation

--- a/astropy/coordinates/builtin_frames/skyoffset.py
+++ b/astropy/coordinates/builtin_frames/skyoffset.py
@@ -105,7 +105,7 @@ class SkyOffsetFrame(BaseCoordinateFrame):
     object's ``lat`` will be pointed in the direction of Dec, while ``lon``
     will point in the direction of RA.
 
-    For more on skyoffset frames, see :ref:`astropy:astropy-skyoffset-frames`.
+    For more on skyoffset frames, see :ref:`astropy:skyoffset-frames`.
 
     Parameters
     ----------

--- a/astropy/io/votable/table.py
+++ b/astropy/io/votable/table.py
@@ -203,7 +203,7 @@ def writeto(table, file, tabledata_format=None):
         one of ``tabledata`` (text representation), ``binary`` or
         ``binary2``.  By default, use the format that was specified in
         each ``table`` object as it was created or read in.  See
-        :ref:`astropy:astropy:votable-serialization`.
+        :ref:`astropy:votable-serialization`.
     """
     from astropy.table import Table
     if isinstance(table, Table):

--- a/astropy/visualization/lupton_rgb.py
+++ b/astropy/visualization/lupton_rgb.py
@@ -334,7 +334,7 @@ def make_lupton_rgb(image_r, image_g, image_b, minimum=0, stretch=5, Q=8,
     The input images can be int or float, and in any range or bit-depth.
 
     For a more detailed look at the use of this method, see the document
-    :ref:`astropy:astropy-visualization-rgb`.
+    :ref:`astropy:visualization-rgb`.
 
     Parameters
     ----------

--- a/docs/constants/index.rst
+++ b/docs/constants/index.rst
@@ -82,7 +82,7 @@ cannot be used in expressions without specifying a system::
 ..
   EXAMPLE END
 
-.. _astropy-constants-prior:
+.. _constants-prior:
 
 Collections of Constants (and Prior Versions)
 =============================================

--- a/docs/coordinates/frames.rst
+++ b/docs/coordinates/frames.rst
@@ -306,7 +306,7 @@ manipulate transformations, see the `~astropy.coordinates.TransformGraph`
 documentation.
 
 
-.. _astropy-coordinates-design:
+.. _coordinates-design:
 
 Defining a New Frame
 ====================
@@ -362,8 +362,8 @@ subclasses.
 Customizing Frame Component Names
 ---------------------------------
 
-First, as mentioned in the point (1) :ref:`above <astropy-coordinates-design>`,
-some frame classes have special names for their components. For example, the
+First, as mentioned in the point (1) :ref:`above <coordinates-design>`, some
+frame classes have special names for their components. For example, the
 `~astropy.coordinates.ICRS` frame and other equatorial frame classes often use
 "Right Ascension" or "RA" in place of longitude, and "Declination" or "Dec." in
 place of latitude. These component name overrides, which change the frame
@@ -429,7 +429,7 @@ Defining Frame Attributes
 -------------------------
 
 Second, as indicated by the point (2) in the :ref:`introduction above
-<astropy-coordinates-design>`, it is often useful for coordinate frames to allow
+<coordinates-design>`, it is often useful for coordinate frames to allow
 specifying frame "attributes" that may specify additional data or parameters
 needed in order to fully specify transformations between a given frame and some
 other frame. For example, the `~astropy.coordinates.FK5` frame allows specifying
@@ -544,7 +544,7 @@ Defining Transformations between Frames
 ---------------------------------------
 
 As indicated by the point (3) in the :ref:`introduction above
-<astropy-coordinates-design>`, a frame class on its own is likely not very
+<coordinates-design>`, a frame class on its own is likely not very
 useful until transformations are defined between it and other coordinate frame
 classes. The key concept for defining transformations in ``astropy.coordinates``
 is the "frame transform graph" (in the "graph theory" sense, not "plot"), which
@@ -630,7 +630,7 @@ Supporting Velocity Data in Frames
 ----------------------------------
 
 As alluded to by point (4) in the :ref:`introduction above
-<astropy-coordinates-design>`, the examples we have seen above mostly deal with
+<coordinates-design>`, the examples we have seen above mostly deal with
 customizing frame behavior for positional information. (For some context about
 how velocities are handled in ``astropy.coordinates``, it may be useful to read
 the overview: :ref:`astropy-coordinate-custom-frame-with-velocities`.)

--- a/docs/coordinates/galactocentric.rst
+++ b/docs/coordinates/galactocentric.rst
@@ -16,10 +16,9 @@ velocity relative to the Galactic center, the solar height above the Galactic
 midplane, etc. Below, `we describe our generalized definition of the
 transformation <astropy-coordinates-galactocentric-transformation>`_ from the
 ICRS to/from Galactocentric coordinates, and `describe how to customize the
-default Galactocentric parameters
-<astropy-coordinates-galactocentric-defaults>`_ that are used when the
-`~astropy.coordinates.Galactocentric` frame is initialized without explicitly
-passing in parameter values.
+default Galactocentric parameters <coordinates-galactocentric-defaults>`_ that
+are used when the `~astropy.coordinates.Galactocentric` frame is initialized
+without explicitly passing in parameter values.
 
 
 .. _astropy-coordinates-galactocentric-transformation:
@@ -145,7 +144,7 @@ The full transformation is then:
     :ref:`sphx_glr_generated_examples_coordinates_plot_galactocentric-frame.py`.
 
 
-.. _astropy-coordinates-galactocentric-defaults:
+.. _coordinates-galactocentric-defaults:
 
 Controlling the Default Frame Parameters
 ========================================

--- a/docs/coordinates/index.rst
+++ b/docs/coordinates/index.rst
@@ -521,7 +521,7 @@ source code, or typing the following in an IPython session::
    do that
 .. include:: performance.inc.rst
 
-.. _astropy-coordinates-seealso:
+.. _coordinates-seealso:
 
 See Also
 ========

--- a/docs/coordinates/matchsep.rst
+++ b/docs/coordinates/matchsep.rst
@@ -129,7 +129,7 @@ offset location::
     <SkyCoord (ICRS): (ra, dec) in deg
         (86.77852168, -31.57496415)>
 
-.. _astropy-skyoffset-frames:
+.. _skyoffset-frames:
 
 "Sky Offset" Frames
 -------------------

--- a/docs/coordinates/transforming.rst
+++ b/docs/coordinates/transforming.rst
@@ -3,17 +3,16 @@
 Transforming between Systems
 ****************************
 
-`astropy.coordinates` supports a rich system for transforming
-coordinates from one frame to another. While common astronomy frames
-are built into Astropy, the transformation infrastructure is dynamic.
-This means it allows users to define new coordinate frames and their
-transformations. The topic of writing your own coordinate frame or
-transforms is detailed in :ref:`astropy-coordinates-design`, and this
-section is focused on how to *use* transformations.
+`astropy.coordinates` supports a rich system for transforming coordinates from
+one frame to another. While common astronomy frames are built into Astropy, the
+transformation infrastructure is dynamic. This means it allows users to define
+new coordinate frames and their transformations. The topic of writing your own
+coordinate frame or transforms is detailed in :ref:`coordinates-design`, and
+this section is focused on how to *use* transformations.
 
-The full list of built-in coordinate frames, the included transformations,
-and the frame names are shown as a (clickable) graph in the
-`~astropy.coordinates` API documentation.
+The full list of built-in coordinate frames, the included transformations, and
+the frame names are shown as a (clickable) graph in the `~astropy.coordinates`
+API documentation.
 
 Examples
 --------

--- a/docs/visualization/rgb.rst
+++ b/docs/visualization/rgb.rst
@@ -1,4 +1,4 @@
-.. _astropy-visualization-rgb:
+.. _visualization-rgb:
 
 *************************
 Creating color RGB images

--- a/examples/coordinates/plot_sgr-coordinate-frame.py
+++ b/examples/coordinates/plot_sgr-coordinate-frame.py
@@ -5,12 +5,12 @@ Create a new coordinate class (for the Sagittarius stream)
 ==========================================================
 
 This document describes in detail how to subclass and define a custom spherical
-coordinate frame, as discussed in :ref:`astropy:astropy-coordinates-design` and
-the docstring for `~astropy.coordinates.BaseCoordinateFrame`. In this example,
-we will define a coordinate system defined by the plane of orbit of the
-Sagittarius Dwarf Galaxy (hereafter Sgr; as defined in Majewski et al. 2003).
-The Sgr coordinate system is often referred to in terms of two angular
-coordinates, :math:`\Lambda,B`.
+coordinate frame, as discussed in :ref:`astropy:coordinates-design` and the
+docstring for `~astropy.coordinates.BaseCoordinateFrame`. In this example, we
+will define a coordinate system defined by the plane of orbit of the Sagittarius
+Dwarf Galaxy (hereafter Sgr; as defined in Majewski et al. 2003). The Sgr
+coordinate system is often referred to in terms of two angular coordinates,
+:math:`\Lambda,B`.
 
 To do this, we need to define a subclass of
 `~astropy.coordinates.BaseCoordinateFrame` that knows the names and units of the


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

I changed the links and then modified line breaks according to the line length.

tags: no-changelog-entry-needed ?
request review: @embray 

Fixes https://github.com/astropy/astropy/pull/11690#discussion_r637108775
