### PR TITLE
Revert "Updating spinner API, keeping enum"

### DIFF
--- a/astropy/utils/console.py
+++ b/astropy/utils/console.py
@@ -831,7 +831,7 @@ class Spinner:
 
         with Spinner("Reticulating splines", "green") as s:
             for item in enumerate(items):
-                s.update()
+                s.next()
     """
     _default_unicode_chars = "◓◑◒◐"
     _default_ascii_chars = "-/|\\"
@@ -880,11 +880,6 @@ class Spinner:
 
         self._silent = not isatty(file)
 
-        if self._silent:
-            self._iter = self._silent_iterator()
-        else:
-            self._iter = self._iterator()
-
     def _iterator(self):
         chars = self._chars
         index = 0
@@ -917,7 +912,10 @@ class Spinner:
             index = (index + 1) % len(chars)
 
     def __enter__(self):
-        return self
+        if self._silent:
+            return self._silent_iterator()
+        else:
+            return self._iterator()
 
     def __exit__(self, exc_type, exc_value, traceback):
         file = self._file
@@ -932,27 +930,6 @@ class Spinner:
         else:
             color_print(' [Failed]', 'red', file=file)
         flush()
-
-    def __iter__(self):
-        return self
-
-    def __next__(self):
-        next(self._iter)
-
-    def update(self, value=None):
-        """Update the spin wheel in the terminal.
-
-        Parameters
-        ----------
-        value : int, optional
-            The number of iterations for the spin graphic (defaults to one).
-
-        """
-        if value is None:
-            value = 1
-
-        for _ in range(value):
-            next(self)
 
     def _silent_iterator(self):
         color_print(self._msg, self._color, file=self._file, end='')
@@ -1031,7 +1008,10 @@ class ProgressBarOrSpinner:
         Update the progress bar to the given value (out of the total
         given to the constructor.
         """
-        self._obj.update(value)
+        if self._is_spinner:
+            next(self._iter)
+        else:
+            self._obj.update(value)
 
 
 def print_code_line(line, col=None, file=None, tabwidth=8, width=70):

--- a/docs/changes/utils/11046.api.rst
+++ b/docs/changes/utils/11046.api.rst
@@ -1,3 +1,0 @@
-Updated ``utils.console.Spinner`` to better resemble the API of
-``utils.console.ProgressBar``, including an ``update()`` method and
-iterator support.


### PR DESCRIPTION
Reverts astropy/astropy#11046

Try this just to see if it can fix the RTD build. 