### PR TITLE
attempt to fix issue 11780

### DIFF
--- a/astropy/wcs/wcsapi/fitswcs.py
+++ b/astropy/wcs/wcsapi/fitswcs.py
@@ -502,7 +502,7 @@ class FITSWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
                                       'frame change', AstropyUserWarning)
                         return spectralcoord.to_value(u.m) / self.wcs.restwav - 1.
                     else:
-                        return spectralcoord.in_observer_velocity_frame(observer).to_value(u.m) / self.wcs.restwav - 1.
+                        return spectralcoord.with_observer_stationary_relative_to(observer).to_value(u.m) / self.wcs.restwav - 1.
 
                 classes['spectral'] = (u.Quantity, (), {}, spectralcoord_from_redshift)
                 components[self.wcs.spec] = ('spectral', 0, redshift_from_spectralcoord)
@@ -525,7 +525,7 @@ class FITSWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
                                       'frame change', AstropyUserWarning)
                         return spectralcoord.to_value(u.m / u.s, doppler_equiv) / C_SI
                     else:
-                        return spectralcoord.in_observer_velocity_frame(observer).to_value(u.m / u.s, doppler_equiv) / C_SI
+                        return spectralcoord.with_observer_stationary_relative_to(observer).to_value(u.m / u.s, doppler_equiv) / C_SI
 
                 classes['spectral'] = (u.Quantity, (), {}, spectralcoord_from_beta)
                 components[self.wcs.spec] = ('spectral', 0, beta_from_spectralcoord)
@@ -556,7 +556,7 @@ class FITSWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
                                       'frame change', AstropyUserWarning)
                         return spectralcoord.to_value(**kwargs)
                     else:
-                        return spectralcoord.in_observer_velocity_frame(observer).to_value(**kwargs)
+                        return spectralcoord.with_observer_stationary_relative_to(observer).to_value(**kwargs)
 
                 classes['spectral'] = (u.Quantity, (), {}, spectralcoord_from_value)
                 components[self.wcs.spec] = ('spectral', 0, value_from_spectralcoord)

--- a/astropy/wcs/wcsapi/fitswcs.py
+++ b/astropy/wcs/wcsapi/fitswcs.py
@@ -491,6 +491,8 @@ class FITSWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
             if ctype == 'ZOPT':
 
                 def spectralcoord_from_redshift(redshift):
+                    if isinstance(redshift, SpectralCoord):
+                        return redshift
                     return SpectralCoord((redshift + 1) * self.wcs.restwav,
                                          unit=u.m, observer=observer, target=target)
 
@@ -510,6 +512,8 @@ class FITSWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
             elif ctype == 'BETA':
 
                 def spectralcoord_from_beta(beta):
+                    if isinstance(beta, SpectralCoord):
+                        return beta
                     return SpectralCoord(beta * C_SI,
                                          unit=u.m / u.s,
                                          doppler_convention='relativistic',

--- a/astropy/wcs/wcsapi/tests/test_fitswcs.py
+++ b/astropy/wcs/wcsapi/tests/test_fitswcs.py
@@ -1059,7 +1059,6 @@ def test_different_ctypes(header_spectral_frames, ctype3, observer):
     skycoord, spectralcoord = wcs.pixel_to_world(0, 0, 31)
 
     assert isinstance(spectralcoord, SpectralCoord)
-    print(spectralcoord)
 
     if observer:
         pix = wcs.world_to_pixel(skycoord, spectralcoord)

--- a/docs/changes/wcs/11781.bugfix.rst
+++ b/docs/changes/wcs/11781.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a bug that caused APE 14 WCS transformations for FITS WCS with ZOPT, BETA, VELO, VOPT, or VRAD CTYPE to not work correctly.


### PR DESCRIPTION
See Issue #11780 

This is a very simple attempt to fix the bug introduced in https://github.com/astropy/astropy/commit/e541cef2cffbd4d18b02847d6d1418b3b9d86d98 in which `in_observer_velocity_frame` is not defined.  I'm not 100% sure this is the right method to use.  I am also not sure what tests are needed and why the original bug (assuming it is a bug) wasn't covered.