### PR TITLE
Remove error mapping in cosmology cloning

### DIFF
--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -18,6 +18,7 @@ from astropy.utils.exceptions import (AstropyDeprecationWarning,
                                       AstropyUserWarning)
 from astropy.utils.metadata import MetaData
 from astropy.utils.state import ScienceState
+from astropy.utils.exceptions import AstropyUserWarning
 
 
 # Originally authored by Andrew Becker (becker@astro.washington.edu),
@@ -193,15 +194,8 @@ class Cosmology(metaclass=ABCMeta):
         new_init = {**self._init_arguments, "meta": new_meta, **kwargs}
         # Create BoundArgument to handle args versus kwargs.
         # This also handles all errors from mismatched arguments
-        try:
-            ba = self._init_signature.bind_partial(**new_init)
-        except TypeError as e:
-            # for backward compatibility, map TypeError to AttributeError
-            warnings.warn("Starting in Astropy v5.0, passing an unrecognized "
-                          "argument will instead raise a TypeError.",
-                          category=AstropyDeprecationWarning)
-            raise AttributeError(e)
-        # Return new instance, respecting arg vs kwarg.
+        ba = self._init_signature.bind_partial(**new_init)
+        # Return new instance, respecting args vs kwargs
         return self.__class__(*ba.args, **ba.kwargs)
 
 

--- a/astropy/cosmology/tests/test_cosmology.py
+++ b/astropy/cosmology/tests/test_cosmology.py
@@ -301,9 +301,8 @@ def test_clone():
     assert allclose(newclone.wa, 0.2)
 
     # Now test exception if user passes non-parameter
-    with pytest.raises(AttributeError):
-        with pytest.warns(AstropyDeprecationWarning, match="Astropy v5.0"):
-            newclone = cosmo.clone(not_an_arg=4)
+    with pytest.raises(TypeError, match="unexpected keyword argument"):
+        newclone = cosmo.clone(not_an_arg=4)
 
 
 def test_xtfuncs():

--- a/docs/changes/cosmology/11785.api.rst
+++ b/docs/changes/cosmology/11785.api.rst
@@ -1,0 +1,2 @@
+Remove deprecation warning and error remapping in ``Cosmology.clone``.
+Now unknown arguments will raise a ``TypeError``, not an ``AttributeError``.


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

A deprecation marked for v5.0.
Request review: @mhvk 