### PR TITLE
Cosmological Redshift Units

### DIFF
--- a/astropy/coordinates/distances.py
+++ b/astropy/coordinates/distances.py
@@ -197,7 +197,7 @@ class Distance(u.SpecificTypeQuantity):
         """Short for ``self.compute_z()``"""
         return self.compute_z()
 
-    def compute_z(self, cosmology=None):
+    def compute_z(self, cosmology=None, **atzkw):
         """
         The redshift for this distance assuming its physical distance is
         a luminosity distance.
@@ -207,10 +207,12 @@ class Distance(u.SpecificTypeQuantity):
         cosmology : `~astropy.cosmology.Cosmology` or None
             The cosmology to assume for this calculation, or `None` to use the
             current cosmology (see `astropy.cosmology` for details).
+        **atzkw
+            keyword arguments for :func:`~astropy.cosmology.z_at_value`
 
         Returns
         -------
-        z : float
+        z : `~astropy.units.Quantity`
             The redshift of this distance given the provided ``cosmology``.
 
         Warnings
@@ -228,13 +230,14 @@ class Distance(u.SpecificTypeQuantity):
             Find the redshift corresponding to a
             :meth:`astropy.cosmology.FLRW.luminosity_distance`.
         """
+        from astropy.cosmology import z_at_value
 
         if cosmology is None:
             from astropy.cosmology import default_cosmology
             cosmology = default_cosmology.get()
 
-        from astropy.cosmology import z_at_value
-        return z_at_value(cosmology.luminosity_distance, self, ztol=1.e-10)
+        atzkw.setdefault("ztol", 1.e-10)
+        return z_at_value(cosmology.luminosity_distance, self, **atzkw)
 
     @property
     def distmod(self):

--- a/astropy/cosmology/__init__.py
+++ b/astropy/cosmology/__init__.py
@@ -9,7 +9,7 @@ detailed usage examples and references.
 """
 
 from . import core, flrw, funcs, units, utils
-from . import io  # isort: split  # needed before 'realizations'
+from . import io  # needed before 'realizations'  # isort: split
 from . import realizations
 from .core import *
 from .flrw import *

--- a/astropy/cosmology/funcs.py
+++ b/astropy/cosmology/funcs.py
@@ -10,8 +10,8 @@ import numpy as np
 from astropy.units import Quantity
 from astropy.utils.exceptions import AstropyUserWarning
 
+from . import units as cu
 from .core import CosmologyError
-from .units import redshift as redshift_unit
 
 __all__ = ['z_at_value']
 
@@ -331,8 +331,8 @@ def z_at_value(func, fval, zmin=1e-8, zmax=1000, ztol=1e-8, maxfun=500,
     # passing the elements to `_z_at_scalar_value`.
     fval = np.asanyarray(fval)
     unit = getattr(fval, 'unit', 1)  # can be unitless
-    zmin = Quantity(zmin, redshift_unit).value  # must be unitless
-    zmax = Quantity(zmax, redshift_unit).value
+    zmin = Quantity(zmin, cu.redshift).value  # must be unitless
+    zmax = Quantity(zmax, cu.redshift).value
 
     # bracket must be an object array (assumed to be correct) or a 'scalar'
     # bracket: 2 or 3 elt sequence
@@ -363,5 +363,4 @@ def z_at_value(func, fval, zmin=1e-8, zmax=1000, ztol=1e-8, maxfun=500,
         # cast to the same type as the function value.
         result = it.operands[-1]  # zs
 
-    # degrade to scalar if 0d array
-    return (result if result.shape else result[()]) << redshift_unit
+    return result << cu.redshift

--- a/astropy/cosmology/tests/test_funcs.py
+++ b/astropy/cosmology/tests/test_funcs.py
@@ -107,10 +107,10 @@ class Test_ZatValue:
 
     def test_scalar_input_to_output(self):
         """Test scalar input returns a scalar."""
-        assert isinstance(
-            z_at_value(self.cosmo.angular_diameter_distance, 1500 * u.Mpc,
-                       zmin=0, zmax=2),
-            np.float64)
+        z = z_at_value(self.cosmo.angular_diameter_distance, 1500 * u.Mpc,
+                       zmin=0, zmax=2)
+        assert isinstance(z, u.Quantity)
+        assert z.dtype == np.float64
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
@@ -135,7 +135,7 @@ def test_z_at_value_verbose(monkeypatch):
     monkeypatch.setattr(sys, 'stdout', mock_stdout)
 
     resx = z_at_value(cosmo.age, 2 * u.Gyr, verbose=True)
-    assert str(resx) in mock_stdout.getvalue()  # test "verbose" prints res
+    assert str(resx.value) in mock_stdout.getvalue()  # test "verbose" prints res
 
 
 @pytest.mark.skipif('not HAS_SCIPY')

--- a/astropy/cosmology/tests/test_funcs.py
+++ b/astropy/cosmology/tests/test_funcs.py
@@ -111,6 +111,7 @@ class Test_ZatValue:
                        zmin=0, zmax=2)
         assert isinstance(z, u.Quantity)
         assert z.dtype == np.float64
+        assert z.shape == ()
 
 
 @pytest.mark.skipif('not HAS_SCIPY')

--- a/astropy/cosmology/tests/test_units.py
+++ b/astropy/cosmology/tests/test_units.py
@@ -77,8 +77,20 @@ def test_dimensionless_redshift():
     assert z.unit == cu.redshift
     assert z.unit != u.one
 
-    assert z.to(u.one, equivalencies=cu.dimensionless_redshift()) == val
+    # test equivalency enabled by default
+    assert z.to(u.one) == val
+    
+    # also test that it works for powers
+    assert (3 * cu.redshift ** 3).to(u.one) == val
 
+    # and in composite units
+    assert (3 * u.km / cu.redshift**3).to(u.km) == 3 * u.km
+
+    # test it also works as an equivalency
+    with u.set_enabled_equivalencies([]):  # turn off default equivalencies
+        assert z.to(u.one, equivalencies=cu.dimensionless_redshift()) == val
+
+    # if this fails, something is really wrong
     with u.add_enabled_equivalencies(cu.dimensionless_redshift()):
         assert z.to(u.one) == val
 

--- a/astropy/cosmology/tests/test_units.py
+++ b/astropy/cosmology/tests/test_units.py
@@ -11,7 +11,7 @@ import pytest
 
 import astropy.cosmology.units as cu
 import astropy.units as u
-from astropy.cosmology import default_cosmology, Planck13
+from astropy.cosmology import Planck13, default_cosmology
 from astropy.tests.helper import assert_quantity_allclose
 from astropy.utils.compat.optional_deps import HAS_ASDF, HAS_SCIPY
 from astropy.utils.exceptions import AstropyDeprecationWarning
@@ -68,8 +68,7 @@ def test_littleh():
 
 @pytest.mark.skipif(not HAS_SCIPY, reason="Cosmology needs scipy")
 def test_dimensionless_redshift():
-    """Test the equivalency  ``dimensionless_redshift``.
-    """
+    """Test the equivalency  ``dimensionless_redshift``."""
     z = 3 * cu.redshift
     val = 3 * u.one
 
@@ -78,79 +77,143 @@ def test_dimensionless_redshift():
     assert z.unit != u.one
 
     # test equivalency enabled by default
-    assert z.to(u.one) == val
+    assert z == val
 
     # also test that it works for powers
-    assert (3 * cu.redshift ** 3).to(u.one) == val
+    assert (3 * cu.redshift ** 3) == val
 
     # and in composite units
-    assert (3 * u.km / cu.redshift**3).to(u.km) == 3 * u.km
+    assert (3 * u.km / cu.redshift ** 3) == 3 * u.km
 
     # test it also works as an equivalency
     with u.set_enabled_equivalencies([]):  # turn off default equivalencies
         assert z.to(u.one, equivalencies=cu.dimensionless_redshift()) == val
 
+        with pytest.raises(ValueError):
+            z.to(u.one)
+
     # if this fails, something is really wrong
     with u.add_enabled_equivalencies(cu.dimensionless_redshift()):
-        assert z.to(u.one) == val
+        assert z == val
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason="Cosmology needs scipy")
-def test_with_redshift():
-    """Test the equivalency  ``with_redshift``.
-    """
-    cosmo = Planck13.clone(Tcmb0=3*u.K)  # make non-default cosmology
+def test_redshift_temperature():
+    """Test the equivalency  ``with_redshift``."""
+    cosmo = Planck13.clone(Tcmb0=3 * u.K)
+    default_cosmo = default_cosmology.get()
     z = 15 * cu.redshift
     Tcmb = cosmo.Tcmb(z)
 
-    default_cosmo = default_cosmology.get()
-    assert default_cosmo != cosmo  # shows changing default
-
     # 1) Default (without specifying the cosmology)
     with default_cosmology.set(cosmo):
-        # A) Default (Tcmb=True)
-        equivalency = cu.with_redshift()
+        equivalency = cu.redshift_temperature()
         assert_quantity_allclose(z.to(u.K, equivalency), Tcmb)
         assert_quantity_allclose(Tcmb.to(cu.redshift, equivalency), z)
 
-        # B) Tcmb=False
-        equivalency = cu.with_redshift(Tcmb=False)
-        with pytest.raises(u.UnitConversionError, match="'redshift' and 'K'"):
-            z.to(u.K, equivalency)
-
     # showing the answer changes if the cosmology changes
     # this test uses the default cosmology
-    equivalency = cu.with_redshift()
-    assert_quantity_allclose(z.to(u.K, equivalency),
-                             default_cosmo.Tcmb(z))
+    equivalency = cu.redshift_temperature()
+    assert_quantity_allclose(z.to(u.K, equivalency), default_cosmo.Tcmb(z))
     assert default_cosmo.Tcmb(z) != Tcmb
 
     # 2) Specifying the cosmology
-    # A) Default (Tcmb=True)
-    equivalency = cu.with_redshift(cosmo)
+    equivalency = cu.redshift_temperature(cosmo)
     assert_quantity_allclose(z.to(u.K, equivalency), Tcmb)
     assert_quantity_allclose(Tcmb.to(cu.redshift, equivalency), z)
 
-    # B) Tcmb=False
-    equivalency = cu.with_redshift(cosmo, Tcmb=False)
-    with pytest.raises(u.UnitConversionError, match="'redshift' and 'K'"):
-        z.to(u.K, equivalency)
-
-    # Test atzkw
-    # this is really just a test that 'atzkw' doesn't fail
-    equivalency = cu.with_redshift(cosmo, atzkw={"ztol": 1e-10})
+    # Test `atzkw`
+    equivalency = cu.redshift_temperature(cosmo, ztol=1e-10)
     assert_quantity_allclose(Tcmb.to(cu.redshift, equivalency), z)
+
+
+@pytest.mark.skipif(not HAS_SCIPY, reason="Cosmology needs scipy")
+class Test_with_redshift:
+    @pytest.fixture
+    def cosmo(self):
+        return Planck13.clone(Tcmb0=3 * u.K)
+
+    # ===========================================
+
+    def test_cosmo_different(self, cosmo):
+        default_cosmo = default_cosmology.get()
+        assert default_cosmo != cosmo  # shows changing default
+
+    def test_no_equivalency(self, cosmo):
+        """Test the equivalency  ``with_redshift`` without any enabled."""
+        z = 15 * cu.redshift
+
+        equivalency = cu.with_redshift(Tcmb=False)
+        assert len(equivalency) == 0
+
+    # -------------------------------------------
+
+    def test_temperature_off(self, cosmo):
+        """Test the equivalency  ``with_redshift``."""
+        default_cosmo = default_cosmology.get()
+        z = 15 * cu.redshift
+        Tcmb = cosmo.Tcmb(z)
+
+        # 1) Default (without specifying the cosmology)
+        with default_cosmology.set(cosmo):
+            equivalency = cu.with_redshift(Tcmb=False)
+            with pytest.raises(u.UnitConversionError, match="'redshift' and 'K'"):
+                z.to(u.K, equivalency)
+
+        # 2) Specifying the cosmology
+        equivalency = cu.with_redshift(cosmo, Tcmb=False)
+        with pytest.raises(u.UnitConversionError, match="'redshift' and 'K'"):
+            z.to(u.K, equivalency)
+
+    def test_temperature(self, cosmo):
+        """Test the equivalency  ``with_redshift``."""
+        default_cosmo = default_cosmology.get()
+        z = 15 * cu.redshift
+        Tcmb = cosmo.Tcmb(z)
+
+        # 1) Default (without specifying the cosmology)
+        with default_cosmology.set(cosmo):
+            equivalency = cu.with_redshift(Tcmb=True)
+            assert_quantity_allclose(z.to(u.K, equivalency), Tcmb)
+            assert_quantity_allclose(Tcmb.to(cu.redshift, equivalency), z)
+
+        # showing the answer changes if the cosmology changes
+        # this test uses the default cosmology
+        equivalency = cu.with_redshift(Tcmb=True)
+        assert_quantity_allclose(z.to(u.K, equivalency), default_cosmo.Tcmb(z))
+        assert default_cosmo.Tcmb(z) != Tcmb
+
+        # 2) Specifying the cosmology
+        equivalency = cu.with_redshift(cosmo, Tcmb=True)
+        assert_quantity_allclose(z.to(u.K, equivalency), Tcmb)
+        assert_quantity_allclose(Tcmb.to(cu.redshift, equivalency), z)
+
+        # Test `atzkw`
+        # this is really just a test that 'atzkw' doesn't fail
+        equivalency = cu.with_redshift(cosmo, Tcmb=True, atzkw={"ztol": 1e-10})
+        assert_quantity_allclose(Tcmb.to(cu.redshift, equivalency), z)
 
 
 # FIXME! get "dimensionless_redshift", "with_redshift" to work in this
 # they are not in ``astropy.units.equivalencies``, so the following fails
 @pytest.mark.skipif(not HAS_ASDF, reason="requires ASDF")
-@pytest.mark.parametrize('equiv',[cu.with_H0])
+@pytest.mark.parametrize("equiv", [cu.with_H0])
 def test_equivalencies_asdf(tmpdir, equiv):
     from asdf.tests import helpers
 
-    tree = {'equiv': equiv()}
-    with (pytest.warns(AstropyDeprecationWarning, match="`with_H0`")
-          if equiv.__name__ == "with_H0" else contextlib.nullcontext()):
+    tree = {"equiv": equiv()}
+    with (
+        pytest.warns(AstropyDeprecationWarning, match="`with_H0`")
+        if equiv.__name__ == "with_H0"
+        else contextlib.nullcontext()
+    ):
 
         helpers.assert_roundtrip_tree(tree, tmpdir)
+
+
+def test_equivalency_context_manager():
+    base_registry = u.get_current_unit_registry()
+
+    # check starting with only the dimensionless_redshift equivalency.
+    assert len(base_registry.equivalencies) == 1
+    assert str(base_registry.equivalencies[0][0]) == "redshift"

--- a/astropy/cosmology/units.py
+++ b/astropy/cosmology/units.py
@@ -7,12 +7,18 @@
 import astropy.units as u
 from astropy.units.utils import generate_unit_summary as _generate_unit_summary
 
-__all__ = ["littleh", "with_H0"]
+__all__ = ["littleh", "redshift",
+           # equivalencies
+           "dimensionless_redshift", "with_H0"]
 
 _ns = globals()
 
+
 ###############################################################################
 # Cosmological Units
+
+redshift = u.def_unit(['redshift'], prefixes=False, namespace=_ns,
+                      doc="Cosmological redshift.", format={'latex': r''})
 
 # This is not formally a unit, but is used in that way in many contexts, and
 # an appropriate equivalency is only possible if it's treated as a unit (see
@@ -26,6 +32,17 @@ littleh = u.def_unit(['littleh'], namespace=_ns, prefixes=False,
 
 ###############################################################################
 # Equivalencies
+
+
+def dimensionless_redshift():
+    """Allow Cosmological redshift to be 1-to-1 equivalent to dimensionless.
+
+    It is special compared to other equivalency pairs in that it
+    allows this independent of the power to which the angle is raised,
+    and independent of whether it is part of a more complicated unit.
+    """
+    return u.Equivalency([(redshift, None)], "dimensionless_redshift")
+
 
 def with_H0(H0=None):
     """

--- a/astropy/cosmology/units.py
+++ b/astropy/cosmology/units.py
@@ -70,6 +70,13 @@ def with_H0(H0=None):
     return u.Equivalency([(h100_val_unit, None)], "with_H0", kwargs={"H0": H0})
 
 
+# ===================================================================
+# Enable the set of default equivalencies.
+# If the cosmology package is imported, this is added to the list.
+
+u.add_enabled_equivalencies(dimensionless_redshift())
+
+
 # =============================================================================
 # DOCSTRING
 

--- a/astropy/units/tests/test_equivalencies.py
+++ b/astropy/units/tests/test_equivalencies.py
@@ -691,7 +691,11 @@ def test_equivalency_context_manager():
 
     tf_dimensionless_angles = just_to_from_units(u.dimensionless_angles())
     tf_spectral = just_to_from_units(u.spectral())
-    assert base_registry.equivalencies == []
+
+    # check starting with only the dimensionless_redshift equivalency.
+    assert len(base_registry.equivalencies) == 1
+    assert str(base_registry.equivalencies[0][0]) == "redshift"
+
     with u.set_enabled_equivalencies(u.dimensionless_angles()):
         new_registry = u.get_current_unit_registry()
         assert (set(just_to_from_units(new_registry.equivalencies)) ==

--- a/astropy/units/tests/test_equivalencies.py
+++ b/astropy/units/tests/test_equivalencies.py
@@ -692,9 +692,8 @@ def test_equivalency_context_manager():
     tf_dimensionless_angles = just_to_from_units(u.dimensionless_angles())
     tf_spectral = just_to_from_units(u.spectral())
 
-    # check starting with only the dimensionless_redshift equivalency.
-    assert len(base_registry.equivalencies) == 1
-    assert str(base_registry.equivalencies[0][0]) == "redshift"
+    # <=1 b/c might have the dimensionless_redshift equivalency enabled.
+    assert len(base_registry.equivalencies) <= 1
 
     with u.set_enabled_equivalencies(u.dimensionless_angles()):
         new_registry = u.get_current_unit_registry()

--- a/docs/changes/cosmology/11786.feature.rst
+++ b/docs/changes/cosmology/11786.feature.rst
@@ -1,3 +1,4 @@
 A new unit, ``redshift``, is defined. It is a dimensionless unit to distinguish
 redshift quantities from other non-redshift values. For compatibility with
 dimensionless quantities the equivalency ``dimensionless_redshift`` is added.
+This equivalency is enabled by default.

--- a/docs/changes/cosmology/11786.feature.rst
+++ b/docs/changes/cosmology/11786.feature.rst
@@ -1,0 +1,3 @@
+A new unit, ``redshift``, is defined. It is a dimensionless unit to distinguish
+redshift quantities from other non-redshift values. For compatibility with
+dimensionless quantities the equivalency ``dimensionless_redshift`` is added.

--- a/docs/cosmology/index.rst
+++ b/docs/cosmology/index.rst
@@ -287,7 +287,7 @@ To find the redshift using ``z_at_value``:
   >>> import astropy.units as u
   >>> from astropy.cosmology import Planck13, z_at_value
   >>> z_at_value(Planck13.age, 2 * u.Gyr)  # doctest: +FLOAT_CMP
-  3.1981226843560968
+  <Quantity 3.19812061 redshift>
 
 ..
   EXAMPLE END

--- a/docs/cosmology/units.rst
+++ b/docs/cosmology/units.rst
@@ -7,9 +7,6 @@ Cosmological Units and Equivalencies
 .. currentmodule:: astropy.cosmology.units
 
 This package defines and collects cosmological units and equivalencies.
-Some of the units and equivalencies are also available in
-:mod:`astropy.units`.
-
 We suggest importing this units package as
 
     >>> import astropy.cosmology.units as cu
@@ -38,7 +35,7 @@ Cosmological Redshift and Dimensionless Equivalency
 ---------------------------------------------------
 
 There are numerous measures of distance in cosmology -- luminosities,
-CMB temperature, the universe's age, etc -- but redshift is the principal
+CMB temperature, the universe's age, etc. -- but redshift is the principal
 measure from which others are defined. In cosmology, distance measures are
 commonly exasperating to follow in a derivation, because they are used
 so interchangeably. ``astropy`` provides the ``redshift`` unit and associated
@@ -67,8 +64,8 @@ The equivalency works as part of a quantity with composite units
 Since the redshift is not a true unit and is used so frequently, the
 redshift / dimensionless equivalency is actually enabled by default.
 
-    >>> z.to(u.dimensionless_unscaled)
-    <Quantity 1100.>
+    >>> z == 1100 * u.dimensionless_unscaled
+    True
 
     >>> q.to(u.K)
     <Quantity 2970. K>
@@ -77,8 +74,10 @@ To temporarily remove the equivalency and enforce unit strictness, use
 :func:`astropy.units.set_enabled_equivalencies` as a context.
 
     >>> with u.set_enabled_equivalencies([]):
-    ...     try: z.to(u.dimensionless_unscaled)
-    ...     except u.UnitConversionError: print("equivalency disabled")
+    ...     try:
+    ...         z.to(u.dimensionless_unscaled)
+    ...     except u.UnitConversionError:
+    ...         print("equivalency disabled")
     equivalency disabled
 
 .. EXAMPLE END
@@ -104,7 +103,6 @@ so too will the conversions.
 If no argument is given (or the argument is `None`), this equivalency assumes
 the current default :class:`~astropy.cosmology.Cosmology`:
 
-    >>> excosmo = WMAP9.clone(Tcmb0=3.0)
     >>> z.to(u.K, cu.with_redshift())
     <Quantity 3000.7755 K>
 

--- a/docs/cosmology/units.rst
+++ b/docs/cosmology/units.rst
@@ -7,8 +7,8 @@ Cosmological Units and Equivalencies
 .. currentmodule:: astropy.cosmology.units
 
 This package defines and collects cosmological units and equivalencies.
-Many of the units and equivalencies are also available in the
-:mod:`astropy.units` namespace.
+Some of the units and equivalencies are also available in
+:mod:`astropy.units`.
 
 We suggest importing this units package as
 
@@ -19,11 +19,104 @@ To enable the main :mod:`astropy.units` to access these units when searching
 for unit conversions and equivalencies, use
 :func:`~astropy.units.add_enabled_units`.
 
+    >>> import astropy.units as u
     >>> u.add_enabled_units(cu)  # doctest: +SKIP
 
 
 About the Units
 ===============
+
+.. doctest::
+   :hide:
+
+   >>> import astropy.units as u
+
+
+.. _cosmological-redshift:
+
+Cosmological Redshift and Dimensionless Equivalency
+---------------------------------------------------
+
+There are numerous measures of distance in cosmology -- luminosities,
+CMB temperature, the universe's age, etc -- but redshift is the principal
+measure from which others are defined. In cosmology, distance measures are
+commonly exasperating to follow in a derivation, because they are used
+so interchangeably. ``astropy`` provides the ``redshift`` unit and associated
+equivalencies to assist in these derivations by providing a way to convert
+to/from redshift "units".
+
+Examples
+^^^^^^^^
+
+.. EXAMPLE START: Using redshift-dimensionless equivalency
+
+To convert to or from dimensionless to "redshift" units:
+
+    >>> import astropy.units as u
+    >>> import astropy.cosmology.units as cu
+    >>> z = 1100 * cu.redshift
+    >>> z.to(u.dimensionless_unscaled, equivalencies=cu.dimensionless_redshift())
+    <Quantity 1100.>
+
+The equivalency works as part of a quantity with composite units
+
+    >>> q = (2.7 * u.K) * z
+    >>> q.to(u.K, equivalencies=cu.dimensionless_redshift())
+    <Quantity 2970. K>
+
+Since the redshift is not a true unit and is used so frequently, the
+redshift / dimensionless equivalency is actually enabled by default.
+
+    >>> z.to(u.dimensionless_unscaled)
+    <Quantity 1100.>
+
+    >>> q.to(u.K)
+    <Quantity 2970. K>
+
+To temporarily remove the equivalency and enforce unit strictness, use
+:func:`astropy.units.set_enabled_equivalencies` as a context.
+
+    >>> with u.set_enabled_equivalencies([]):
+    ...     try: z.to(u.dimensionless_unscaled)
+    ...     except u.UnitConversionError: print("equivalency disabled")
+    equivalency disabled
+
+.. EXAMPLE END
+
+
+.. EXAMPLE START: Using `with_redshift` equivalency
+
+The other redshift equivalency is `~astropy.cosmology.units.with_redshift`,
+enabling redshift to be converted to other units, like temperature.
+
+    >>> from astropy.cosmology import WMAP9
+    >>> z = 1100 * cu.redshift
+    >>> z.to(u.K, cu.with_redshift(WMAP9))
+    <Quantity 3000.225 K>
+
+These conversions are cosmology dependent, so if the cosmology changes,
+so too will the conversions.
+
+    >>> excosmo = WMAP9.clone(Tcmb0=3.0)
+    >>> z.to(u.K, cu.with_redshift(excosmo))
+    <Quantity 3303. K>
+
+If no argument is given (or the argument is `None`), this equivalency assumes
+the current default :class:`~astropy.cosmology.Cosmology`:
+
+    >>> excosmo = WMAP9.clone(Tcmb0=3.0)
+    >>> z.to(u.K, cu.with_redshift())
+    <Quantity 3000.7755 K>
+
+To use this equivalency in a larger block of code:
+
+    >>> with u.add_enabled_equivalencies(cu.with_redshift()):
+    ...     # long derivation here
+    ...     z.to(u.K)
+    <Quantity 3000.7755 K>
+
+.. EXAMPLE END
+
 
 .. _littleh-and-H0-equivalency:
 

--- a/docs/whatsnew/5.0.rst
+++ b/docs/whatsnew/5.0.rst
@@ -9,7 +9,7 @@ What's New in Astropy 5.0?
 Overview
 ========
 
-.. _whatsnew-5.0-cosmology:
+.. _whatsnew-5.0-cosmology-io:
 
 Support for reading, writing, and converting ``Cosmology``
 ==========================================================
@@ -49,6 +49,34 @@ e.g. enabling::
     >>> cosmo = Cosmology.from_format(cm, format="mapping")
     >>> cosmo == Planck18
     True
+
+.. _whatsnew-5.0-cosmology-units:
+
+``Cosmology`` units module
+==========================
+
+A new module -- ``cosmology.units`` -- is added to the cosmology subpackage for
+defining and collecting cosmological units and equivalencies.
+The unit ``littleh`` and equivalency ``with_H0`` are deprecated from the main
+``astropy.units`` subpackage and moved to ``cosmology.units``.
+A new unit, ``redshift``, is added for tracking factors of cosmological redshift.
+As this is a pseudo-unit an equivalency ``dimensionless_redshift`` is added
+(and enabled by default) to allow for redshift - dimensionless conversions.
+To convert between redshift and other cosmological distance measures, e.g.
+CMB temperature, the equivalency ``with_redshift`` is also added.
+
+    >>> import astropy.units as u
+    >>> import astropy.cosmology.units as cu
+    >>> z = 1100 * cu.redshift
+
+    >>> z.to(u.dimensionless_unscaled)
+    <Quantity 1100.>
+
+    >>> from astropy.cosmology import WMAP9
+    >>> z.to(u.K, cu.with_redshift(WMAP9))
+    <Quantity 3000.225 K>
+
+Further details are available in an addition to the docs.
 
 
 Full change log


### PR DESCRIPTION
It's a dimensionless unit that useful for redshift-related equivalencies, like redshift-dimensionless, and cosmology-dependent conversions like redshift-temperature, redshift-distance.

Followup to: #12092
Fixes #11784 