### PR TITLE
Fix MaskedInfo class so table operations work

### DIFF
--- a/astropy/utils/masked/core.py
+++ b/astropy/utils/masked/core.py
@@ -353,6 +353,8 @@ class MaskedArraySubclassInfo:
     # This is used below in __init_subclass__.
     # TODO: Find some way to ensure that 'serialize_method' of MaskedNDArray
     # is also accessible.
+    mask_val = np.ma.masked
+
     def _represent_as_dict(self):
         # Use the data_cls as the class name for serialization,
         # so that we do not have to store all possible masked classes


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is a partial fix for an issue noted on slack by @adrn that `Quantity` does not yet work with Table operations like `hstack` that may require masking. This is expected, but I noticed that a one-line addition to set the Info class `mask_val` allows `MaskedQuantity` columns to work in Table operations. If the user knows that masking will be required they can pre-convert using `t['q'] = Masked(t['q'])` prior to doing the Table operation.

I think this counts as a Bug fix because (I think!) the `mask_val` should have been set from the outset. Since there is no 4.3.1 milestone yet, I put this in as 4.3.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

