### PR TITLE
Attempt to fix issue 11719

### DIFF
--- a/astropy/visualization/wcsaxes/patches.py
+++ b/astropy/visualization/wcsaxes/patches.py
@@ -2,12 +2,14 @@
 
 
 import numpy as np
+import warnings
 from matplotlib.patches import Polygon
 
 from astropy import units as u
 from astropy.coordinates import SkyCoord
-from astropy.coordinates.representation import UnitSphericalRepresentation
+from astropy.coordinates.representation import UnitSphericalRepresentation, SphericalRepresentation
 from astropy.coordinates.matrix_utilities import rotation_matrix, matrix_product
+from astropy.utils.exceptions import AstropyUserWarning
 
 
 __all__ = ['Quadrangle', 'SphericalCircle']
@@ -85,11 +87,15 @@ class SphericalCircle(Polygon):
 
         # Extract longitude/latitude, either from a SkyCoord object, or
         # from a tuple of two quantities or a single 2-element Quantity.
+        # The SkyCoord is converted to SphericalRepresentation, if not already.
         if isinstance(center, SkyCoord):
-            if center.frame.name == 'galactic':
-                longitude, latitude = center.l, center.b
-            else:
-                longitude, latitude = center.ra, center.dec
+            rep_type = center.representation_type
+            if not issubclass(rep_type, (SphericalRepresentation,
+                                         UnitSphericalRepresentation)):
+                warnings.warn(f'Received `center` of representation type {rep_type} '
+                              'will be converted to SphericalRepresentation ',
+                              AstropyUserWarning)
+            longitude, latitude = center.spherical.lon, center.spherical.lat
         else:
             longitude, latitude = center
 

--- a/astropy/visualization/wcsaxes/patches.py
+++ b/astropy/visualization/wcsaxes/patches.py
@@ -5,6 +5,7 @@ import numpy as np
 from matplotlib.patches import Polygon
 
 from astropy import units as u
+from astropy.coordinates import SkyCoord
 from astropy.coordinates.representation import UnitSphericalRepresentation
 from astropy.coordinates.matrix_utilities import rotation_matrix, matrix_product
 
@@ -63,7 +64,8 @@ class SphericalCircle(Polygon):
     ----------
     center : tuple or `~astropy.units.Quantity` ['angle']
         This can be either a tuple of two `~astropy.units.Quantity` objects, or
-        a single `~astropy.units.Quantity` array with two elements.
+        a single `~astropy.units.Quantity` array with two elements
+        or a `~astropy.coordinates.SkyCoord` object.
     radius : `~astropy.units.Quantity` ['angle']
         The radius of the circle
     resolution : int, optional
@@ -81,9 +83,15 @@ class SphericalCircle(Polygon):
 
     def __init__(self, center, radius, resolution=100, vertex_unit=u.degree, **kwargs):
 
-        # Extract longitude/latitude, either from a tuple of two quantities, or
-        # a single 2-element Quantity.
-        longitude, latitude = center
+        # Extract longitude/latitude, either from a SkyCoord object, or
+        # from a tuple of two quantities or a single 2-element Quantity.
+        if isinstance(center, SkyCoord):
+            if center.frame.name == 'galactic':
+                longitude, latitude = center.l, center.b
+            else:
+                longitude, latitude = center.ra, center.dec
+        else:
+            longitude, latitude = center
 
         # Start off by generating the circle around the North pole
         lon = np.linspace(0., 2 * np.pi, resolution + 1)[:-1] * u.radian

--- a/astropy/visualization/wcsaxes/tests/test_images.py
+++ b/astropy/visualization/wcsaxes/tests/test_images.py
@@ -664,13 +664,21 @@ class TestBasic(BaseImageTests):
                    edgecolor='red', facecolor='none')
 
         # World coordinates (should not be distorted)
-        r = SphericalCircle((266.4 * u.deg, -29.1 * u.deg), 0.15 * u.degree,
-                            edgecolor='purple', facecolor='none',
-                            transform=ax.get_transform('fk5'))
-        ax.add_patch(r)
+        r1 = SphericalCircle((266.4 * u.deg, -29.1 * u.deg), 0.15 * u.degree,
+                             edgecolor='purple', facecolor='none',
+                             transform=ax.get_transform('fk5'))
+        ax.add_patch(r1)
+
+        r2 = SphericalCircle(SkyCoord(266.4 * u.deg, -29.1 * u.deg), 0.15 * u.degree,
+                             edgecolor='purple', facecolor='none',
+                             transform=ax.get_transform('fk5'))
 
         ax.coords[0].set_ticklabel_visible(False)
         ax.coords[1].set_ticklabel_visible(False)
+
+        # Test to verify that SphericalCircle works irrespective of whether
+        # the input(center) is a tuple or a SkyCoord object.
+        assert (r1.get_xy() == r2.get_xy()).all()
 
         return fig
 

--- a/astropy/visualization/wcsaxes/tests/test_images.py
+++ b/astropy/visualization/wcsaxes/tests/test_images.py
@@ -14,6 +14,7 @@ from astropy.coordinates import SkyCoord
 from astropy.io import fits
 from astropy.tests.image_tests import IMAGE_REFERENCE_DIR
 from astropy.utils.data import get_pkg_data_filename
+from astropy.utils.exceptions import AstropyUserWarning
 from astropy.visualization.wcsaxes import WCSAxes
 from astropy.visualization.wcsaxes.frame import EllipticalFrame
 from astropy.visualization.wcsaxes.patches import Quadrangle, SphericalCircle
@@ -673,12 +674,22 @@ class TestBasic(BaseImageTests):
                              edgecolor='purple', facecolor='none',
                              transform=ax.get_transform('fk5'))
 
+        with pytest.warns(AstropyUserWarning,
+                          match="Received `center` of representation type "
+                                "<class 'astropy.coordinates.representation.CartesianRepresentation'> "
+                                "will be converted to SphericalRepresentation"):
+            r3 = SphericalCircle(SkyCoord(x=-0.05486461, y=-0.87204803, z=-0.48633538, representation_type='cartesian'),
+                                 0.15 * u.degree, edgecolor='purple',
+                                 facecolor='none', transform=ax.get_transform('fk5'))
+
         ax.coords[0].set_ticklabel_visible(False)
         ax.coords[1].set_ticklabel_visible(False)
 
         # Test to verify that SphericalCircle works irrespective of whether
         # the input(center) is a tuple or a SkyCoord object.
         assert (r1.get_xy() == r2.get_xy()).all()
+        assert np.allclose(r1.get_xy(), r3.get_xy())
+        assert (r2.get_xy()[0] == [266.4, -29.25]).all()
 
         return fig
 

--- a/docs/changes/visualization/11790.feature.rst
+++ b/docs/changes/visualization/11790.feature.rst
@@ -1,0 +1,1 @@
+Added a feature so that SphericalCircle will accept center parameter as an object.

--- a/docs/changes/visualization/11790.feature.rst
+++ b/docs/changes/visualization/11790.feature.rst
@@ -1,1 +1,1 @@
-Added a feature so that SphericalCircle will accept center parameter as an object.
+Added a feature so that SphericalCircle will accept center parameter as a SkyCoord object.

--- a/docs/visualization/wcsaxes/overlays.rst
+++ b/docs/visualization/wcsaxes/overlays.rst
@@ -300,7 +300,7 @@ image to plot the contours for:
 Spherical patches
 *****************
 
-In the case where you are making a plot of a celestial image, and want to plot a circle that represents the area within a certain angle of a longitude/latitude, the `~matplotlib.patches.Circle` patch is not appropriate, since it will result in a distorted shape (because longitude is not the same as the angle on the sky). For this use case, you can instead use `~astropy.visualization.wcsaxes.SphericalCircle`, which takes a tuple of `~astropy.units.Quantity` as the input, and a `~astropy.units.Quantity` as the radius:
+In the case where you are making a plot of a celestial image, and want to plot a circle that represents the area within a certain angle of a longitude/latitude, the `~matplotlib.patches.Circle` patch is not appropriate, since it will result in a distorted shape (because longitude is not the same as the angle on the sky). For this use case, you can instead use `~astropy.visualization.wcsaxes.SphericalCircle`, which takes a tuple of `~astropy.units.Quantity` or a `~astropy.coordinates.SkyCoord` object as the input, and a `~astropy.units.Quantity` as the radius:
 
 .. plot::
    :context: reset
@@ -326,9 +326,20 @@ In the case where you are making a plot of a celestial image, and want to plot a
    :align: center
 
     from astropy import units as u
+    from astropy.coordinates import SkyCoord
     from astropy.visualization.wcsaxes import SphericalCircle
+
 
     r = SphericalCircle((266.4 * u.deg, -29.1 * u.deg), 0.15 * u.degree,
                          edgecolor='yellow', facecolor='none',
                          transform=ax.get_transform('fk5'))
+
     ax.add_patch(r)
+
+    #The following lines show the usage of a SkyCoord object as the input.
+    skycoord_object = SkyCoord(266.4 * u.deg, -28.7 * u.deg)
+    s = SphericalCircle(skycoord_object, 0.15 * u.degree,
+                        edgecolor='white', facecolor='none',
+                        transform=ax.get_transform('fk5'))
+
+    ax.add_patch(s)

--- a/docs/visualization/wcsaxes/overlays.rst
+++ b/docs/visualization/wcsaxes/overlays.rst
@@ -300,7 +300,10 @@ image to plot the contours for:
 Spherical patches
 *****************
 
-In the case where you are making a plot of a celestial image, and want to plot a circle that represents the area within a certain angle of a longitude/latitude, the `~matplotlib.patches.Circle` patch is not appropriate, since it will result in a distorted shape (because longitude is not the same as the angle on the sky). For this use case, you can instead use `~astropy.visualization.wcsaxes.SphericalCircle`, which takes a tuple of `~astropy.units.Quantity` or a `~astropy.coordinates.SkyCoord` object as the input, and a `~astropy.units.Quantity` as the radius:
+In the case where you are making a plot of a celestial image, and want to plot a circle that represents the area within a certain angle of a longitude/latitude,
+the `~matplotlib.patches.Circle` patch is not appropriate, since it will result in a distorted shape (because longitude is not the same as the angle on the sky).
+For this use case, you can instead use `~astropy.visualization.wcsaxes.SphericalCircle`, which takes a tuple of |Quantity| or a |SkyCoord| object as the input,
+and a |Quantity| as the radius:
 
 .. plot::
    :context: reset


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

This pull request is to try and implement #11719 

I went through the docs, and the package and came to a conclusion.

- If the frame of the SkyCoord object being passed is "galactic", then the center object would have "l and b" as the data members, and for the other three frames(I read that only 4 frames are preferred while using SpericalCircle plot), the center object would have "ra and dec" as the data members.

- And also that SphericalCircle should accept "center" as a tuple, the current implementation.

- I don't know if importing SkyCoord is a good idea, I'll look for an alternate method.

I've implemented this approach, not sure if this is the right way, please correct me if I'm wrong.
