### PR TITLE
Add attributes to `QuantityIterator` to match `ndarray.flatiter`

### DIFF
--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -110,6 +110,27 @@ class QuantityIterator:
 
     next = __next__
 
+    #### properties and methods to match `numpy.ndarray.flatiter` ####
+
+    @property
+    def base(self):
+        """A reference to the array that is iterated over."""
+        return self._quantity
+
+    @property
+    def coords(self):
+        """An N-dimensional tuple of current coordinates."""
+        return self._dataiter.coords
+
+    @property
+    def index(self):
+        """Current flat index into the array."""
+        return self._dataiter.index
+
+    def copy(self):
+        """Get a copy of the iterator as a 1-D array."""
+        return self._quantity.flatten()
+
 
 class QuantityInfoBase(ParentDtypeInfo):
     # This is on a base class rather than QuantityInfo directly, so that

--- a/astropy/units/tests/test_quantity_array_methods.py
+++ b/astropy/units/tests/test_quantity_array_methods.py
@@ -131,7 +131,7 @@ class TestQuantityReshapeFuncs:
         qf = q.flat
         # see TestQuantityArrayCopy.test_flat for tests of iteration
         # and slicing and setting. Here we test the properties and methods to
-        # match `numpy.ndarray.flatiter` 
+        # match `numpy.ndarray.flatiter`
         assert qf.base is q
         # testing the indices -- flat and full -- into the array
         assert qf.coords == (0, 0, 0)  # to start

--- a/astropy/units/tests/test_quantity_array_methods.py
+++ b/astropy/units/tests/test_quantity_array_methods.py
@@ -73,9 +73,6 @@ class TestQuantityArrayCopy:
         assert q_flat[8] == -1. * u.km / u.s
         assert q[2, 2] == -1. * u.km / u.s
 
-        # also check q_flat copies properly
-        assert all(q_flat.copy() == q.flatten())
-
 
 class TestQuantityReshapeFuncs:
     """Test different ndarray methods that alter the array shape
@@ -125,7 +122,7 @@ class TestQuantityReshapeFuncs:
         assert q_swapaxes.unit == q.unit
         assert np.all(q_swapaxes.value == q.value.swapaxes(0, 2))
 
-    def test_flat(self):
+    def test_flat_attributes(self):
         """While ``flat`` doesn't make a copy, it changes the shape."""
         q = np.arange(6.).reshape(3, 1, 2) * u.m
         qf = q.flat
@@ -140,6 +137,12 @@ class TestQuantityReshapeFuncs:
         endindices = [(qf.index, qf.coords) for x in qf][-2]  # next() oversteps
         assert endindices[0] == 5
         assert endindices[1] == (2, 0, 1)  # shape of q - 1
+
+        # also check q_flat copies properly
+        q_flat_copy = qf.copy()
+        assert all(q_flat_copy == q.flatten())
+        assert isinstance(q_flat_copy, u.Quantity)
+        assert not np.may_share_memory(q_flat_copy, q)
 
 
 class TestQuantityStatsFuncs:

--- a/astropy/units/tests/test_quantity_array_methods.py
+++ b/astropy/units/tests/test_quantity_array_methods.py
@@ -73,6 +73,9 @@ class TestQuantityArrayCopy:
         assert q_flat[8] == -1. * u.km / u.s
         assert q[2, 2] == -1. * u.km / u.s
 
+        # also check q_flat copies properly
+        assert all(q_flat.copy() == q.flatten())
+
 
 class TestQuantityReshapeFuncs:
     """Test different ndarray methods that alter the array shape
@@ -121,6 +124,22 @@ class TestQuantityReshapeFuncs:
         assert isinstance(q_swapaxes, u.Quantity)
         assert q_swapaxes.unit == q.unit
         assert np.all(q_swapaxes.value == q.value.swapaxes(0, 2))
+
+    def test_flat(self):
+        """While ``flat`` doesn't make a copy, it changes the shape."""
+        q = np.arange(6.).reshape(3, 1, 2) * u.m
+        qf = q.flat
+        # see TestQuantityArrayCopy.test_flat for tests of iteration
+        # and slicing and setting. Here we test the properties and methods to
+        # match `numpy.ndarray.flatiter` 
+        assert qf.base is q
+        # testing the indices -- flat and full -- into the array
+        assert qf.coords == (0, 0, 0)  # to start
+        assert qf.index == 0
+        # now consume the iterator
+        endindices = [(qf.index, qf.coords) for x in qf][-2]  # next() oversteps
+        assert endindices[0] == 5
+        assert endindices[1] == (2, 0, 1)  # shape of q - 1
 
 
 class TestQuantityStatsFuncs:

--- a/docs/changes/units/11796.feature.rst
+++ b/docs/changes/units/11796.feature.rst
@@ -1,0 +1,2 @@
+Added attributes ``base``, ``coords``, and ``index`` and method ``copy()`` to
+``QuantityIterator`` to match ``numpy.ndarray.flatiter``.


### PR DESCRIPTION
### Description

Adds attributes ``base``, ``coords``, and ``index`` and method ``copy()`` to  ``QuantityIterator`` to match ``ndarray.flatiter``.

Fixes #11783
Request Review @mhvk 

