### PR TITLE
Add docstrings to table read and write methods

### DIFF
--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -595,6 +595,11 @@ class Table:
 
     # Unified I/O read and write methods from .connect
     read = UnifiedReadWriteMethod(TableRead)
+    """
+    Read and parse a data table and return as a Table.
+    """
+
+    #: Write this Table object out in the specified format.
     write = UnifiedReadWriteMethod(TableWrite)
 
     pprint_exclude_names = PprintIncludeExclude()


### PR DESCRIPTION
As reported in #11554, docstrings are missing for the `Table` `read` and `write` methods.  These methods are defined via descriptor classes.  Usually, the docstring is inherited from the descriptor class (which is usually too general to be useful -- I have the same issues with descriptor docstrings in `photutils` and `regions`), but for some reason it's not here.  In any case, I've found a workaround to document these class-level variables.  One can either add a triple-quoted docstring below the assignment, or a specially-formated comment docstring above the variable assignment.  This PR includes both examples (I can update this PR to whichever is preferred, if any).

With this PR:

Attributes docs:
<img width="330" alt="attr-docs" src="https://user-images.githubusercontent.com/4992897/120513139-f69f9c00-c399-11eb-8b16-2735b09a9af3.png">

Attributes summary:
<img width="513" alt="attr-summary" src="https://user-images.githubusercontent.com/4992897/120513145-f8695f80-c399-11eb-824b-ac3140734406.png">

As a separate issue, `read` and `write` are really class static *methods*, not attributes.  I have no idea how to fix that.

CC: @nstarman, @pllim, @taldcroft 