### PR TITLE
Close ascii files with unified file read interface

### DIFF
--- a/astropy/coordinates/tests/test_solar_system.py
+++ b/astropy/coordinates/tests/test_solar_system.py
@@ -443,9 +443,8 @@ def test_file_ephemeris_wrong_input():
     # To fix this issue, an upstream fix is required in jplephem
     # package.
     # Try loading a file that does exist, but is not an ephemeris file:
-    with pytest.warns(ResourceWarning):
-        with pytest.raises(ValueError):
-            get_body('earth', time, ephemeris=__file__)
+    with pytest.warns(ResourceWarning), pytest.raises(ValueError):
+        get_body('earth', time, ephemeris=__file__)
 
 
 def test_regression_10271():

--- a/astropy/coordinates/tests/test_solar_system.py
+++ b/astropy/coordinates/tests/test_solar_system.py
@@ -99,6 +99,7 @@ def test_positions_skyfield(tmpdir):
             skyfield_angular_separation_tolerance)
     assert (mercury_astropy.separation_3d(skyfield_mercury) <
             skyfield_separation_tolerance)
+    planets.close()
 
 
 class TestPositionsGeocentric:

--- a/astropy/coordinates/tests/test_solar_system.py
+++ b/astropy/coordinates/tests/test_solar_system.py
@@ -437,9 +437,14 @@ def test_file_ephemeris_wrong_input():
     # Try loading a non-existing file:
     with pytest.raises(ValueError):
         get_body('earth', time, ephemeris='/path/to/nonexisting/file.bsp')
+
+    # NOTE: This test currently leaves the file open (ResourceWarning).
+    # To fix this issue, an upstream fix is required in jplephem
+    # package.
     # Try loading a file that does exist, but is not an ephemeris file:
-    with pytest.raises(ValueError):
-        get_body('earth', time, ephemeris=__file__)
+    with pytest.warns(ResourceWarning):
+        with pytest.raises(ValueError):
+            get_body('earth', time, ephemeris=__file__)
 
 
 def test_regression_10271():

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -1047,8 +1047,10 @@ def test_guessing_file_object():
     """
     Test guessing a file object.  Fixes #3013 and similar issue noted in #3019.
     """
-    t = ascii.read(open('data/ipac.dat.bz2', 'rb'))
+    fd = open('data/ipac.dat.bz2', 'rb')
+    t = ascii.read(fd)
     assert t.colnames == ['ra', 'dec', 'sai', 'v2', 'sptype']
+    fd.close()
 
 
 def test_pformat_roundtrip():
@@ -1412,7 +1414,10 @@ def test_read_chunks_input_types():
     fpath = 'data/test5.dat'
     t1 = ascii.read(fpath, header_start=1, data_start=3, )
 
-    for fp in (fpath, open(fpath, 'r'), open(fpath, 'r').read()):
+    fd1 = open(fpath, 'r')
+    fd2 = open(fpath, 'r')
+
+    for fp in (fpath, fd1, fd2.read()):
         t_gen = ascii.read(fp, header_start=1, data_start=3,
                            guess=False, format='fast_basic',
                            fast_reader={'chunk_size': 400, 'chunk_generator': True})
@@ -1426,11 +1431,19 @@ def test_read_chunks_input_types():
         t2 = table.vstack(ts)
         assert np.all(t1 == t2)
 
-    for fp in (fpath, open(fpath, 'r'), open(fpath, 'r').read()):
+    fd1.close()
+    fd2.close()
+
+    fd1 = open(fpath, 'r')
+    fd2 = open(fpath, 'r')
+    for fp in (fpath, fd1, fd2.read()):
         # Now read the full table in chunks
         t3 = ascii.read(fp, header_start=1, data_start=3,
                         fast_reader={'chunk_size': 300})
         assert np.all(t1 == t3)
+
+    fd1.close()
+    fd2.close()
 
 
 @pytest.mark.parametrize('masked', [True, False])

--- a/astropy/io/fits/tests/test_core.py
+++ b/astropy/io/fits/tests/test_core.py
@@ -115,7 +115,6 @@ class TestCore(FitsTestCase):
         p.del_col('FOO')
         assert p.names == ['BAR']
 
-    @pytest.mark.filterwarnings('ignore::ResourceWarning')
     def test_add_del_columns2(self):
         hdulist = fits.open(self.data('tb.fits'))
         table = hdulist[1]
@@ -134,7 +133,7 @@ class TestCore(FitsTestCase):
         assert table.columns.names == ['c2', 'c4', 'foo']
 
         hdulist.writeto(self.temp('test.fits'), overwrite=True)
-
+        hdulist.close()
         # NOTE: If you see a warning, might be related to
         # https://github.com/spacetelescope/PyFITS/issues/44
         with fits.open(self.temp('test.fits')) as hdulist:

--- a/astropy/io/fits/tests/test_core.py
+++ b/astropy/io/fits/tests/test_core.py
@@ -824,7 +824,8 @@ class TestFileFunctions(FitsTestCase):
         """Test detection of a zip file when the extension is not .zip."""
 
         zf = self._make_zip_file(filename='test0.fz')
-        assert len(fits.open(zf)) == 5
+        with fits.open(zf) as fits_handle:
+            assert len(fits_handle) == 5
 
     def test_open_zipped_writeable(self):
         """Opening zipped files in a writeable mode should fail."""

--- a/astropy/io/fits/tests/test_division.py
+++ b/astropy/io/fits/tests/test_division.py
@@ -32,6 +32,5 @@ class TestDivisionFunctions(FitsTestCase):
 
     def test_section(self, capsys):
         # section testing
-        fs = fits.open(self.data('arange.fits'))
-        assert np.all(fs[0].section[3, 2, 5] == np.array([357]))
-        fs.close()
+        with fits.open(self.data('arange.fits')) as fs:
+            assert np.all(fs[0].section[3, 2, 5] == np.array([357]))

--- a/astropy/io/fits/tests/test_division.py
+++ b/astropy/io/fits/tests/test_division.py
@@ -34,3 +34,4 @@ class TestDivisionFunctions(FitsTestCase):
         # section testing
         fs = fits.open(self.data('arange.fits'))
         assert np.all(fs[0].section[3, 2, 5] == np.array([357]))
+        fs.close()

--- a/astropy/io/fits/tests/test_header.py
+++ b/astropy/io/fits/tests/test_header.py
@@ -1903,8 +1903,8 @@ class TestHeaderFunctions(FitsTestCase):
             f.seek(346)  # Location of the exponent 'E' symbol
             f.write(encode_ascii('e'))
 
-        hdul = fits.open(self.temp('test.fits'))
-        with pytest.warns(AstropyUserWarning) as w:
+        with fits.open(self.temp('test.fits')) as hdul, \
+             pytest.warns(AstropyUserWarning) as w:
             hdul.writeto(self.temp('temp.fits'), output_verify='warn')
         assert len(w) == 5
         # The first two warnings are just the headers to the actual warning
@@ -1913,7 +1913,6 @@ class TestHeaderFunctions(FitsTestCase):
         # something to think about...
         msg = str(w[3].message)
         assert "(invalid value string: '5.0022221e-07')" in msg
-        hdul.close()
 
     def test_leading_zeros(self):
         """

--- a/astropy/io/fits/tests/test_header.py
+++ b/astropy/io/fits/tests/test_header.py
@@ -1913,6 +1913,7 @@ class TestHeaderFunctions(FitsTestCase):
         # something to think about...
         msg = str(w[3].message)
         assert "(invalid value string: '5.0022221e-07')" in msg
+        hdul.close()
 
     def test_leading_zeros(self):
         """

--- a/astropy/io/fits/tests/test_image.py
+++ b/astropy/io/fits/tests/test_image.py
@@ -868,7 +868,6 @@ class TestImageFunctions(FitsTestCase):
         hdul.close()
         hdul = fits.open(self.temp('test_new.fits'))
         assert (hdul[0].data == orig_data).all()
-        hdul = fits.open(self.temp('test_new.fits'))
         hdul.close()
 
     def test_image_update_header(self):
@@ -1351,7 +1350,6 @@ class TestCompressedImage(FitsTestCase):
         hdul.close()
         hdul = fits.open(self.temp('test_new.fits'))
         assert (hdul[1].data == orig_data).all()
-        hdul = fits.open(self.temp('test_new.fits'))
         hdul.close()
 
     def test_scale_back_compressed(self):

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -2949,6 +2949,7 @@ class TestVLATables(FitsTestCase):
         assert data.shape == (500,)
         assert data['i'][497] == 497
         assert np.array_equal(data['arr'][497], [0, 1, 2, 3, 4])
+        hdul.close()
 
 
 # These are tests that solely test the Column and ColDefs interfaces and

--- a/astropy/timeseries/io/kepler.py
+++ b/astropy/timeseries/io/kepler.py
@@ -91,6 +91,8 @@ def kepler_fits_reader(filename):
     # Remove original time column
     tab.remove_column('time')
 
+    hdulist.close()
+
     return TimeSeries(time=time, data=tab)
 
 

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -62,6 +62,16 @@ __all__ = [
 _dataurls_to_alias = {}
 
 
+class _NonClosingBufferedReader(io.BufferedReader):
+    def __del__(self):
+        try:
+            # NOTE: self.raw will not be closed, but left in the state
+            # it was in at detactment
+            self.detach()
+        except Exception:
+            pass
+
+
 class _NonClosingTextIOWrapper(io.TextIOWrapper):
     def __del__(self):
         try:
@@ -379,7 +389,7 @@ def get_readable_fileobj(name_or_obj, encoding=None, cache=False,
                 fileobj = io.FileIO(tmp.name, 'r')
                 close_fds.append(fileobj)
 
-        fileobj = io.BufferedReader(fileobj)
+        fileobj = _NonClosingBufferedReader(fileobj)
         fileobj = _NonClosingTextIOWrapper(fileobj, encoding=encoding)
 
         # Ensure that file is at the start - io.FileIO will for

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -62,6 +62,16 @@ __all__ = [
 _dataurls_to_alias = {}
 
 
+class _NonClosingTextIOWrapper(io.TextIOWrapper):
+    def __del__(self):
+        try:
+            # NOTE: self.stream will not be closed, but left in the state
+            # it was in at detactment
+            self.detach()
+        except Exception:
+            pass
+
+
 class Conf(_config.ConfigNamespace):
     """
     Configuration parameters for `astropy.utils.data`.
@@ -370,7 +380,7 @@ def get_readable_fileobj(name_or_obj, encoding=None, cache=False,
                 close_fds.append(fileobj)
 
         fileobj = io.BufferedReader(fileobj)
-        fileobj = io.TextIOWrapper(fileobj, encoding=encoding)
+        fileobj = _NonClosingTextIOWrapper(fileobj, encoding=encoding)
 
         # Ensure that file is at the start - io.FileIO will for
         # example not always be at the start:

--- a/docs/changes/utils/11809.bugfix.rst
+++ b/docs/changes/utils/11809.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug in ``get_readable_fileobj`` that prevented the unified file read interface from closing ASCII files.

--- a/docs/io/fits/index.rst
+++ b/docs/io/fits/index.rst
@@ -468,6 +468,7 @@ attribute::
     >>> fits_table_filename = fits.util.get_testdata_filepath('tb.fits')
     >>> hdul = fits.open(fits_table_filename)
     >>> data = hdul[1].data # assuming the first extension is a table
+    >>> hdul.close()
 
 If you are familiar with ``numpy`` `~numpy.recarray` (record array) objects, you
 will find the table data is basically a record array with some extra
@@ -612,6 +613,10 @@ file opened with update mode:
         hdul.flush()  # changes are written back to original.fits
 
     # closing the file will also flush any changes and prevent further writing
+
+Here we explicitly close the ``hdulist`` opened earlier::
+
+    >>> hdul.close()
 
 
 Creating a New FITS File

--- a/docs/io/fits/index.rst
+++ b/docs/io/fits/index.rst
@@ -614,10 +614,6 @@ file opened with update mode:
 
     # closing the file will also flush any changes and prevent further writing
 
-Here we explicitly close the ``hdulist`` opened earlier::
-
-    >>> hdul.close()
-
 
 Creating a New FITS File
 ------------------------

--- a/docs/wcs/index.rst
+++ b/docs/wcs/index.rst
@@ -77,6 +77,7 @@ with default values, converting from pixel to world coordinates::
     >>> print(sky)  # doctest: +FLOAT_CMP
     <SkyCoord (ICRS): (ra, dec) in deg
         (5.52844243, -72.05207809)>
+    >>> f.close()
 
 Similarly, another use of the high-level API is to use the
 `~astropy.wcs.wcs.WCS.world_to_pixel` to yield another simple WCS, while
@@ -91,6 +92,7 @@ converting from world to pixel coordinates::
     >>> x, y = w.world_to_pixel(sky)
     >>> print(x, y)  # doctest: +FLOAT_CMP
     30.00000214673885 39.999999958235094
+    >>> f.close()
 
 Using `astropy.wcs`
 ===================

--- a/docs/wcs/legacy_interface.rst
+++ b/docs/wcs/legacy_interface.rst
@@ -34,6 +34,7 @@ one of the methods below::
     >>> fn = get_pkg_data_filename('data/j94f05bgq_flt.fits', package='astropy.wcs.tests')
     >>> f = fits.open(fn)
     >>> wcsobj = wcs.WCS(f[1].header)
+    >>> f.close()
 
 Optionally, if the FITS file uses any deprecated or non-standard features, you may need
 to call one of the `~astropy.wcs.wcs.WCS.fix` methods on the object.

--- a/docs/wcs/wcsapi.rst
+++ b/docs/wcs/wcsapi.rst
@@ -56,7 +56,8 @@ simple image with two celestial axes (Right Ascension and Declination)::
     >>> from astropy.utils.data import get_pkg_data_filename
     >>> from astropy.io import fits
     >>> filename = get_pkg_data_filename('galactic_center/gc_2mass_k.fits')  # doctest: +REMOTE_DATA
-    >>> hdu = fits.open(filename)[0]  # doctest: +REMOTE_DATA
+    >>> hdulist = fits.open(filename)  # doctest: +REMOTE_DATA
+    >>> hdu = hdulist[0]  # doctest: +REMOTE_DATA
     >>> wcs = WCS(hdu.header)  # doctest: +REMOTE_DATA
     >>> wcs  # doctest: +REMOTE_DATA
     WCS Keywords
@@ -131,6 +132,7 @@ the nearest integer values::
     (357, 357)
     >>> hdu.data[index]  # doctest: +REMOTE_DATA +FLOAT_CMP
     563.7532
+    >>> hdulist.close()  # doctest: +REMOTE_DATA
 
 Advanced usage
 ^^^^^^^^^^^^^^
@@ -139,7 +141,8 @@ Let's now take a look at a WCS for a spectral cube (two celestial axes and one
 spectral axis)::
 
     >>> filename = get_pkg_data_filename('l1448/l1448_13co.fits')  # doctest: +REMOTE_DATA
-    >>> hdu = fits.open(filename)[0]  # doctest: +REMOTE_DATA
+    >>> hdulist = fits.open(filename)  # doctest: +REMOTE_DATA
+    >>> hdu = hdulist[0]  # doctest: +REMOTE_DATA
     >>> wcs = WCS(hdu.header)  # doctest: +REMOTE_DATA
     >>> wcs  # doctest: +REMOTE_DATA
     WCS Keywords
@@ -197,6 +200,7 @@ And as before we can index array values using::
     (7, 71, 8)
     >>> hdu.data[index]  # doctest: +REMOTE_DATA +FLOAT_CMP
     0.22262384
+    >>> hdulist.close()  # doctest: +REMOTE_DATA
 
 If you are interested in converting to/from world values as simple Python scalars
 or Numpy arrays without using high-level astropy objects, there are methods

--- a/setup.cfg
+++ b/setup.cfg
@@ -117,7 +117,6 @@ qt_no_exception_capture = 1
 filterwarnings =
     error
     ignore:Distutils was imported before Setuptools
-    ignore:unclosed file:ResourceWarning
     ignore:unclosed <socket:ResourceWarning
     ignore:unclosed <ssl.SSLSocket:ResourceWarning
     ignore:numpy.ufunc size changed:RuntimeWarning


### PR DESCRIPTION
The `regions` package recently added the unified file read/write interface for regions (ascii) files.  While running tests, I noticed that region files read with the unified I/O give a `ResourceWarning` about the file being unclosed.  This exact issue was reported in #8673.

Starting with the hints provided by @taldcroft and @saimn in #8673 and #8675, I have a workaround/solution (based on code in `click`: https://github.com/pallets/click/blob/9da166957f5848b641231d485467f6140bca2bc0/src/click/_compat.py#L61).  Essentially `TextIOWrapper` always closes the wrapped file when it is garbage collected and this somehow messes up the file closing by the context manager.  The solution is to detach the underlying stream from `TextIOWrapper` before it is deleted (i.e., in its `__del__` method).  The same issue appears to apply to `BufferedReader` because both were necessary to close the files.

Those changes fixed most of the failing `io.ascii` tests due to files being left open (i.e., after no longer ignoring the `ResourceWarnings` in `setup.cfg`).  The remaining test failures in the tests and documentation (doctests) were simple cases of files being opened, but not closed (fixed here).

There was one remaining test case that left a file open, but I could not fix.  I removed this test because the fix requires a fix in an upstream package (`jplephem`).  Essentially `jplephem` opens an invalid ephem file and then immediately raises a `ValueError` before closing the file.  There's no way to fix that on the astropy side. 

Closes #8673.

Addresses part of #9619 .