### PR TITLE
Ensure Table.read/write cannot be overwritten, have their docstrings rendered by sphinx

### DIFF
--- a/astropy/io/registry.py
+++ b/astropy/io/registry.py
@@ -739,7 +739,7 @@ class UnifiedReadWrite:
         return out
 
 
-class UnifiedReadWriteMethod:
+class UnifiedReadWriteMethod(property):
     """Descriptor class for creating read() and write() methods in unified I/O.
 
     The canonical example is in the ``Table`` class, where the ``connect.py``
@@ -757,8 +757,12 @@ class UnifiedReadWriteMethod:
         Class that defines read or write functionality
 
     """
-    def __init__(self, func):
-        self.func = func
-
+    # We subclass property to ensure that __set__ is defined and that,
+    # therefore, we are a data descriptor, which cannot be overridden.
+    # This also means we automatically inherit the __doc__ of fget (which will
+    # be a UnifiedReadWrite subclass), and that this docstring gets recognized
+    # and properly typeset by sphinx (which was previously an issue; see
+    # gh-11554).
+    # We override __get__ to pass both instance and class to UnifiedReadWrite.
     def __get__(self, instance, owner_cls):
-        return self.func(instance, owner_cls)
+        return self.fget(instance, owner_cls)

--- a/astropy/table/connect.py
+++ b/astropy/table/connect.py
@@ -43,7 +43,7 @@ class TableRead(registry.UnifiedReadWrite):
 
     Returns
     -------
-    out : `Table`
+    out : `~astropy.table.Table`
         Table corresponding to file contents
 
     Notes

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -2863,3 +2863,12 @@ def test_items():
 
     for i in list(t.items()):
         assert isinstance(i, tuple)
+
+
+def test_read_write_not_replaceable():
+    t = table.Table()
+    with pytest.raises(AttributeError):
+        t.read = 'fake_read'
+
+    with pytest.raises(AttributeError):
+        t.write = 'fake_write'


### PR DESCRIPTION
Alternative to #11807, ensuring that the docstrings of `Table.read` and `Table.write` get properly rendered in sphinx.

At some level, this is just a work-around for an issue with sphinx, that apparently it happily typesets docstrings for `property`, but not as happily for other descriptors. Hence, the idea to just subclass property for the `UnifiedReadWriteMethod`. It has the benefit that now trying to overwrite `.read` or `.write` will give an `AttributeError` - which surely was the intention all along!

fixes #11554 

p.s.  I think @nstarman is correct in that this may really be a bit of a bug in sphinx-automodapi, so in that sense there may be another issue, but I don't see a reason to leave #11554 open.

EDIT: Close #11807