### PR TITLE
TST: xfail flatiter test for s390x and numpy<1.22

### DIFF
--- a/astropy/units/tests/test_quantity_array_methods.py
+++ b/astropy/units/tests/test_quantity_array_methods.py
@@ -1,11 +1,15 @@
 # The purpose of these tests are to ensure that calling quantities using
 # array methods returns quantities with the right units, or raises exceptions.
+import os
 
 import pytest
 import numpy as np
 from numpy.testing import assert_array_equal
 
 from astropy import units as u
+from astropy.utils.compat import NUMPY_LT_1_22
+
+IS_S390X = os.environ.get('ARCH_ON_CI', 'normal') == 's390x'
 
 
 class TestQuantityArrayCopy:
@@ -122,6 +126,7 @@ class TestQuantityReshapeFuncs:
         assert q_swapaxes.unit == q.unit
         assert np.all(q_swapaxes.value == q.value.swapaxes(0, 2))
 
+    @pytest.mark.xfail(IS_S390X and NUMPY_LT_1_22, reason="Numpy GitHub Issue 19153")
     def test_flat_attributes(self):
         """While ``flat`` doesn't make a copy, it changes the shape."""
         q = np.arange(6.).reshape(3, 1, 2) * u.m

--- a/astropy/units/tests/test_quantity_array_methods.py
+++ b/astropy/units/tests/test_quantity_array_methods.py
@@ -1,6 +1,6 @@
 # The purpose of these tests are to ensure that calling quantities using
 # array methods returns quantities with the right units, or raises exceptions.
-import os
+import sys
 
 import pytest
 import numpy as np
@@ -8,8 +8,6 @@ from numpy.testing import assert_array_equal
 
 from astropy import units as u
 from astropy.utils.compat import NUMPY_LT_1_22
-
-IS_S390X = os.environ.get('ARCH_ON_CI', 'normal') == 's390x'
 
 
 class TestQuantityArrayCopy:
@@ -126,7 +124,8 @@ class TestQuantityReshapeFuncs:
         assert q_swapaxes.unit == q.unit
         assert np.all(q_swapaxes.value == q.value.swapaxes(0, 2))
 
-    @pytest.mark.xfail(IS_S390X and NUMPY_LT_1_22, reason="Numpy GitHub Issue 19153")
+    @pytest.mark.xfail(sys.byteorder == 'big' and NUMPY_LT_1_22,
+                       reason="Numpy GitHub Issue 19153")
     def test_flat_attributes(self):
         """While ``flat`` doesn't make a copy, it changes the shape."""
         q = np.arange(6.).reshape(3, 1, 2) * u.m

--- a/astropy/utils/compat/numpycompat.py
+++ b/astropy/utils/compat/numpycompat.py
@@ -5,7 +5,7 @@ earlier versions of Numpy.
 """
 from astropy.utils import minversion
 
-__all__ = ['NUMPY_LT_1_18', 'NUMPY_LT_1_19', 'NUMPY_LT_1_20']
+__all__ = ['NUMPY_LT_1_18', 'NUMPY_LT_1_19', 'NUMPY_LT_1_20', 'NUMPY_LT_1_22']
 
 # TODO: It might also be nice to have aliases to these named for specific
 # features/bugs we're checking for (ex:
@@ -13,3 +13,4 @@ __all__ = ['NUMPY_LT_1_18', 'NUMPY_LT_1_19', 'NUMPY_LT_1_20']
 NUMPY_LT_1_18 = not minversion('numpy', '1.18')
 NUMPY_LT_1_19 = not minversion('numpy', '1.19')
 NUMPY_LT_1_20 = not minversion('numpy', '1.20')
+NUMPY_LT_1_22 = not minversion('numpy', '1.22')


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to fix #11804 .

A direct follow-up of #11796. Also see numpy/numpy#19153.

p.s. Ignore the `linkcheck` failure.