### PR TITLE
Allow unit parser to deal with more unicode representations

### DIFF
--- a/astropy/units/astrophys.py
+++ b/astropy/units/astrophys.py
@@ -31,11 +31,11 @@ def_unit(['pc', 'parsec'], _si.pc, namespace=_ns, prefixes=True,
 
 def_unit(['solRad', 'R_sun', 'Rsun'], _si.R_sun, namespace=_ns,
          doc="Solar radius", prefixes=False,
-         format={'latex': r'R_{\odot}', 'unicode': 'R⊙'})
+         format={'latex': r'R_{\odot}', 'unicode': 'R\N{SUN}'})
 def_unit(['jupiterRad', 'R_jup', 'Rjup', 'R_jupiter', 'Rjupiter'],
          _si.R_jup, namespace=_ns, prefixes=False, doc="Jupiter radius",
          # LaTeX jupiter symbol requires wasysym
-         format={'latex': r'R_{\rm J}', 'unicode': 'R♃'})
+         format={'latex': r'R_{\rm J}', 'unicode': 'R\N{JUPITER}'})
 def_unit(['earthRad', 'R_earth', 'Rearth'], _si.R_earth, namespace=_ns,
          prefixes=False, doc="Earth radius",
          # LaTeX earth symbol requires wasysym
@@ -50,11 +50,11 @@ def_unit(['lyr', 'lightyear'], (_si.c * si.yr).to(si.m),
 
 def_unit(['solMass', 'M_sun', 'Msun'], _si.M_sun, namespace=_ns,
          prefixes=False, doc="Solar mass",
-         format={'latex': r'M_{\odot}', 'unicode': 'M⊙'})
+         format={'latex': r'M_{\odot}', 'unicode': 'M\N{SUN}'})
 def_unit(['jupiterMass', 'M_jup', 'Mjup', 'M_jupiter', 'Mjupiter'],
          _si.M_jup, namespace=_ns, prefixes=False, doc="Jupiter mass",
          # LaTeX jupiter symbol requires wasysym
-         format={'latex': r'M_{\rm J}', 'unicode': 'M♃'})
+         format={'latex': r'M_{\rm J}', 'unicode': 'M\N{JUPITER}'})
 def_unit(['earthMass', 'M_earth', 'Mearth'], _si.M_earth, namespace=_ns,
          prefixes=False, doc="Earth mass",
          # LaTeX earth symbol requires wasysym
@@ -79,7 +79,7 @@ def_unit(['Ry', 'rydberg'],
 
 def_unit(['solLum', 'L_sun', 'Lsun'], _si.L_sun, namespace=_ns,
          prefixes=False, doc="Solar luminance",
-         format={'latex': r'L_{\odot}', 'unicode': 'L⊙'})
+         format={'latex': r'L_{\odot}', 'unicode': 'L\N{SUN}'})
 
 
 ###########################################################################

--- a/astropy/units/format/generic.py
+++ b/astropy/units/format/generic.py
@@ -14,10 +14,8 @@
 Handles a "generic" string format for units
 """
 
-import os
 import re
 import warnings
-import sys
 from fractions import Fraction
 import unicodedata
 
@@ -25,17 +23,6 @@ from . import core, utils
 from .base import Base
 from astropy.utils import classproperty, parsing
 from astropy.utils.misc import did_you_mean
-
-
-def _is_ascii(s):
-    if sys.version_info >= (3, 7, 0):
-        return s.isascii()
-    else:
-        try:
-            s.encode('ascii')
-            return True
-        except UnicodeEncodeError:
-            return False
 
 
 def _to_string(cls, unit):
@@ -449,7 +436,7 @@ class Generic(Base):
         if s == '%':
             return registry['percent']
 
-        if not _is_ascii(s):
+        if not s.isascii():
             if s[0] == '\N{MICRO SIGN}':
                 s = 'u' + s[1:]
             if s[-1] == '\N{GREEK CAPITAL LETTER OMEGA}':
@@ -509,7 +496,7 @@ class Generic(Base):
     def parse(cls, s, debug=False):
         if not isinstance(s, str):
             s = s.decode('ascii')
-        elif not _is_ascii(s):
+        elif not s.isascii():
             # common normalization of unicode strings to avoid
             # having to deal with multiple representations of
             # the same character. This normalizes to "composed" form

--- a/astropy/units/format/generic.py
+++ b/astropy/units/format/generic.py
@@ -433,16 +433,18 @@ class Generic(Base):
     @classmethod
     def _parse_unit(cls, s, detailed_exception=True):
         registry = core.get_current_unit_registry().registry
-        if s == '%':
-            return registry['percent']
+        if s in cls._unit_symbols:
+            s = cls._unit_symbols[s]
 
-        if not s.isascii():
+        elif not s.isascii():
             if s[0] == '\N{MICRO SIGN}':
                 s = 'u' + s[1:]
-            if s[-1] == '\N{GREEK CAPITAL LETTER OMEGA}':
-                s = s[:-1] + 'Ohm'
-            elif s[-1] == '\N{LATIN CAPITAL LETTER A WITH RING ABOVE}':
-                s = s[:-1] + 'Angstrom'
+            if s[-1] in cls._prefixable_unit_symbols:
+                s = s[:-1] + cls._prefixable_unit_symbols[s[-1]]
+            elif len(s) > 1 and s[-1] in cls._unit_suffix_symbols:
+                s = s[:-1] + cls._unit_suffix_symbols[s[-1]]
+            elif s.endswith('R\N{INFINITY}'):
+                s = s[:-2] + 'Ry'
 
         if s in registry:
             return registry[s]
@@ -452,6 +454,30 @@ class Generic(Base):
                 f'{s} is not a valid unit. {did_you_mean(s, registry)}')
         else:
             raise ValueError()
+
+    _unit_symbols = {
+        '%': 'percent',
+        '\N{PRIME}': 'arcmin',
+        '\N{DOUBLE PRIME}': 'arcsec',
+        '\N{MODIFIER LETTER SMALL H}': 'hourangle',
+        'e\N{SUPERSCRIPT MINUS}': 'electron',
+    }
+
+    _prefixable_unit_symbols = {
+        '\N{GREEK CAPITAL LETTER OMEGA}': 'Ohm',
+        '\N{LATIN CAPITAL LETTER A WITH RING ABOVE}': 'Angstrom',
+        '\N{SCRIPT SMALL L}': 'l',
+    }
+
+    _unit_suffix_symbols = {
+        '\N{CIRCLED DOT OPERATOR}': 'sun',
+        '\N{SUN}': 'sun',
+        '\N{CIRCLED PLUS}': 'earth',
+        '\N{EARTH}': 'earth',
+        '\N{JUPITER}': 'jupiter',
+        '\N{LATIN SUBSCRIPT SMALL LETTER E}': '_e',
+        '\N{LATIN SUBSCRIPT SMALL LETTER P}': '_p',
+    }
 
     _translations = str.maketrans({
         '\N{GREEK SMALL LETTER MU}': '\N{MICRO SIGN}',
@@ -479,7 +505,7 @@ class Generic(Base):
     )
 
     _superscript_translations = str.maketrans(_superscripts, '-+0123456789')
-    _regex_superscript = re.compile(f'[{_superscripts}]+')
+    _regex_superscript = re.compile(f'[{_superscripts}]?[{_superscripts[2:]}]+')
     _regex_deg = re.compile('°([CF])?')
 
     @classmethod

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -181,9 +181,11 @@ def test_ogip_grammar_fail(string):
 class RoundtripBase:
     deprecated_units = set()
 
-    def check_roundtrip(self, unit):
+    def check_roundtrip(self, unit, output_format=None):
+        if output_format is None:
+            output_format = self.format_
         with pytest.warns(None) as w:
-            s = unit.to_string(self.format_)
+            s = unit.to_string(output_format)
             a = core.Unit(s, format=self.format_)
 
         if s in self.deprecated_units:
@@ -213,6 +215,7 @@ class TestRoundtripGeneric(RoundtripBase):
             not isinstance(unit, core.PrefixUnit))])
     def test_roundtrip(self, unit):
         self.check_roundtrip(unit)
+        self.check_roundtrip(unit, output_format='unicode')
         self.check_roundtrip_decompose(unit)
 
 
@@ -609,6 +612,14 @@ def test_powers(power, expected):
     ('m\N{ANGSTROM SIGN}', u.milliAngstrom),
     ('°C', u.deg_C),
     ('°', u.deg),
+    ('M⊙', u.Msun),  # \N{CIRCLED DOT OPERATOR}
+    ('L☉', u.Lsun),  # \N{SUN}
+    ('M⊕', u.Mearth),  # normal earth symbol = \N{CIRCLED PLUS}
+    ('M♁', u.Mearth),  # be generous with \N{EARTH}
+    ('R♃', u.Rjup),  # \N{JUPITER}
+    ('′', u.arcmin),  # \N{PRIME}
+    ('R∞', u.Ry),
+    ('Mₚ', u.M_p),
 ])
 def test_unicode(string, unit):
     assert u_format.Generic.parse(string) == unit

--- a/docs/changes/units/11827.bugfix.rst
+++ b/docs/changes/units/11827.bugfix.rst
@@ -1,0 +1,2 @@
+Units initialization with unicode has been expanded to include strings such as
+'M☉' and 'e⁻'.


### PR DESCRIPTION
Specifically, ensures that for non-composite units, `u.Unit(unit.to_string('unicode'))` now correctly round-trips.

Fixes #11826

Note that to me it is a cross between a bugfix and feature request. I think it is fine to just have it in 5.0, and not backport.