### PR TITLE
Raise NotImplementedError when parsing with output-only format

### DIFF
--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -2013,6 +2013,8 @@ class _UnitMetaClass(type):
 
             try:
                 return f.parse(s)
+            except NotImplementedError:
+                raise
             except Exception as e:
                 if parse_strict == 'silent':
                     pass

--- a/astropy/units/format/base.py
+++ b/astropy/units/format/base.py
@@ -1,8 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-import os
-
-
 class _FormatterMeta(type):
     registry = {}
 
@@ -37,7 +34,7 @@ class Base(metaclass=_FormatterMeta):
         """
 
         raise NotImplementedError(
-            f"Can not parse {cls.__name__}")
+            f"Can not parse with {cls.__name__} format")
 
     @classmethod
     def to_string(cls, u):

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -626,3 +626,9 @@ def test_unicode(string, unit):
 def test_unicode_failures(string):
     with pytest.raises(ValueError):
         u.Unit(string)
+
+
+@pytest.mark.parametrize('format_', ('unicode', 'latex', 'latex_inline'))
+def test_parse_error_message_for_output_only_format(format_):
+    with pytest.raises(NotImplementedError, match='not parse'):
+        u.Unit('m', format=format_)

--- a/docs/changes/units/11829.bugfix.rst
+++ b/docs/changes/units/11829.bugfix.rst
@@ -1,0 +1,2 @@
+Give a more informative ``NotImplementedError`` when trying to parse a unit
+using an output-only format such as 'unicode' or 'latex'.


### PR DESCRIPTION
EDIT: Really, just resolving over-eager exception catching...

Previously,
```
u.Unit('m', format='unicode')
...
ValueError: 'm' did not parse as unicode unit: Can not parse Unicode If this is meant to be a custom unit, define it with 'u.def_unit'. To have it recognized inside a file reader or other code, enable it with 'u.add_enabled_units'. For details, see https://docs.astropy.org/en/latest/units/combining_and_defining.html
```

Now:
```
NotImplementedError: Can not parse with Unicode format
```

fixes #11828

milestone'd 5.0, since really this is just a change in error type.

cc @olebole, @pllim 