### PR TITLE
Unit format refactoring

### DIFF
--- a/astropy/units/format/base.py
+++ b/astropy/units/format/base.py
@@ -1,31 +1,25 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-class _FormatterMeta(type):
-    registry = {}
-
-    def __new__(mcls, name, bases, members):
-        if 'name' in members:
-            formatter_name = members['name'].lower()
-        else:
-            formatter_name = members['name'] = name.lower()
-
-        cls = super().__new__(mcls, name, bases, members)
-
-        mcls.registry[formatter_name] = cls
-
-        return cls
-
-
-class Base(metaclass=_FormatterMeta):
+class Base:
     """
     The abstract base class of all unit formats.
     """
+    registry = {}
 
     def __new__(cls, *args, **kwargs):
         # This __new__ is to make it clear that there is no reason to
         # instantiate a Formatter--if you try to you'll just get back the
         # class
         return cls
+
+    def __init_subclass__(cls, **kwargs):
+        # Keep a registry of all formats.  Key by the class name unless a name
+        # is explicitly set (i.e., one *not* inherited from a superclass).
+        if 'name' not in cls.__dict__:
+            cls.name = cls.__name__.lower()
+
+        Base.registry[cls.name] = cls
+        super().__init_subclass__(**kwargs)
 
     @classmethod
     def parse(cls, s):


### PR DESCRIPTION
An old metaclass I happened to come across while doing #11829 - which is just to keep a registry, something for which `__init_subclass__` is very well suitable. Partially addresses #7144  (and similar to what @adrn did in #11090).