### PR TITLE
Include information on output-only in unknown formats error message.

### DIFF
--- a/astropy/units/format/__init__.py
+++ b/astropy/units/format/__init__.py
@@ -11,20 +11,29 @@ A collection of different unit formats.
 import sys
 core = sys.modules['astropy.units.core']
 
-from .base import Base
-from .generic import Generic, Unscaled
-from .cds import CDS
-from .console import Console
-from .fits import Fits
-from .latex import Latex, LatexInline
-from .ogip import OGIP
-from .unicode_format import Unicode
-from .vounit import VOUnit
+from .base import Base  # noqa
+from .generic import Generic, Unscaled  # noqa
+from .cds import CDS  # noqa
+from .console import Console  # noqa
+from .fits import Fits  # noqa
+from .latex import Latex, LatexInline  # noqa
+from .ogip import OGIP  # noqa
+from .unicode_format import Unicode  # noqa
+from .vounit import VOUnit  # noqa
 
 
 __all__ = [
     'Base', 'Generic', 'CDS', 'Console', 'Fits', 'Latex', 'LatexInline',
     'OGIP', 'Unicode', 'Unscaled', 'VOUnit', 'get_format']
+
+
+def _known_formats():
+    inout = [name for name, cls in Base.registry.items()
+             if cls.parse.__func__ is not Base.parse.__func__]
+    out_only = [name for name, cls in Base.registry.items()
+                if cls.parse.__func__ is Base.parse.__func__]
+    return (f"Valid formatter names are: {inout} for input and output, "
+            f"and {out_only} for output only.")
 
 
 def get_format(format=None):
@@ -42,21 +51,19 @@ def get_format(format=None):
     format : `astropy.units.format.Base` instance
         The requested formatter.
     """
+    if format is None:
+        return Generic
+
     if isinstance(format, type) and issubclass(format, Base):
         return format
     elif not (isinstance(format, str) or format is None):
         raise TypeError(
-            "Formatter must a subclass or instance of a subclass of {!r} "
-            "or a string giving the name of the formatter.  Valid formatter "
-            "names are: [{}]".format(Base, ', '.join(Base.registry)))
-
-    if format is None:
-        format = 'generic'
+            f"Formatter must a subclass or instance of a subclass of {Base!r} "
+            f"or a string giving the name of the formatter. {_known_formats()}.")
 
     format_lower = format.lower()
 
     if format_lower in Base.registry:
         return Base.registry[format_lower]
 
-    raise ValueError("Unknown format {!r}.  Valid formatter names are: "
-                     "[{}]".format(format, ', '.join(Base.registry)))
+    raise ValueError(f"Unknown format {format!r}.  {_known_formats()}")

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -632,3 +632,8 @@ def test_unicode_failures(string):
 def test_parse_error_message_for_output_only_format(format_):
     with pytest.raises(NotImplementedError, match='not parse'):
         u.Unit('m', format=format_)
+
+
+def test_unknown_parser():
+    with pytest.raises(ValueError, match=r"Unknown.*unicode'\] for output only"):
+        u.Unit('m', format='foo')


### PR DESCRIPTION
@olebole - it is not too simple to change the error message specific to input or output, as it happens inside `units.format`, but how about this improved message?
```
ValueError: Unknown format 'foo'.  Valid formatter names are: [['generic', 'unscaled', 'cds', 'console*', 'fits', 'latex*', 'latex_inline*', 'ogip', 'unicode*', 'vounit']] (where those marked with a * are output-only)
```

EDIT: final change to
```
ValueError: Unknown format 'foo'.  Valid formatter names are: ['generic', 'unscaled', 'cds', 'fits', 'ogip', 'vounit'] for input and output, and ['console', 'latex', 'latex_inline', 'unicode'] for output only.
```