### PR TITLE
Allow pre-releases vesions (dev, alpha, etc.) of documentation requirements

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -51,7 +51,7 @@ for line in importlib_metadata.requires('astropy'):
         except importlib_metadata.PackageNotFoundError:
             missing_requirements[req_package] = req_specifier
 
-        if version not in SpecifierSet(req_specifier):
+        if version not in SpecifierSet(req_specifier, prereleases=True):
             missing_requirements[req_package] = req_specifier
 
 if missing_requirements:


### PR DESCRIPTION
...so long as the meet the minimum
requirements.

This will be needed especially for development/testing of our own
packages, such as sphinx-astropy.

Fixes #11838