### PR TITLE
WIP: Reorganize developer docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -51,7 +51,7 @@ for line in importlib_metadata.requires('astropy'):
         except importlib_metadata.PackageNotFoundError:
             missing_requirements[req_package] = req_specifier
 
-        if version not in SpecifierSet(req_specifier):
+        if version not in SpecifierSet(req_specifier, prereleases=True):
             missing_requirements[req_package] = req_specifier
 
 if missing_requirements:

--- a/docs/development/index.rst
+++ b/docs/development/index.rst
@@ -35,7 +35,6 @@ as a whole, see :doc:`development/vision`.
    releasing
    workflow/maintainer_workflow
    astropy-package-template
-   ../changelog
 
 There are some additional tools, mostly of use for maintainers, in the
 `astropy/astropy-procedures repository

--- a/docs/development/index.rst
+++ b/docs/development/index.rst
@@ -1,0 +1,42 @@
+:orphan:
+
+***********************
+Contributing to Astropy
+***********************
+
+So you are interested in contributing to the Astropy Project?  Excellent! We
+love contributions! Astropy is open source, built on open source, and we'd
+love to have in our community.
+
+For the time being, please see our `CONTRIBUTING.md
+<https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md>`_ document
+for an overview of ways you can contribute to Astropy.  The rest of this
+document is focused specifically on documentation for contributors and
+maintainers on how to work the Astropy repository for submitting
+documentation and code changes.
+
+For the guiding vision of this process and the project
+as a whole, see :doc:`development/vision`.
+
+.. toctree::
+   :maxdepth: 1
+
+   workflow/development_workflow
+   workflow/get_devel_version
+   when_to_rebase
+   codeguide
+   docguide
+   style-guide
+   testguide
+   ../testhelpers
+   scripts
+   building
+   ccython
+   releasing
+   workflow/maintainer_workflow
+   astropy-package-template
+   ../changelog
+
+There are some additional tools, mostly of use for maintainers, in the
+`astropy/astropy-procedures repository
+<https://github.com/astropy/astropy-procedures>`__.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -131,31 +131,8 @@ as well as coding, documentation, and testing guidelines.
 
 {% if is_development %}
 
-For the guiding vision of this process and the project
-as a whole, see :doc:`development/vision`.
-
-.. toctree::
-   :maxdepth: 1
-
-   development/workflow/development_workflow
-   development/workflow/get_devel_version
-   development/when_to_rebase
-   development/codeguide
-   development/docguide
-   development/style-guide
-   development/testguide
-   testhelpers
-   development/scripts
-   development/building
-   development/ccython
-   development/releasing
-   development/workflow/maintainer_workflow
-   development/astropy-package-template
-   changelog
-
-There are some additional tools, mostly of use for maintainers, in the
-`astropy/astropy-procedures repository
-<https://github.com/astropy/astropy-procedures>`__.
+The developer/contributor documentation has been moved to its own page at
+:doc:`development/index`.
 
 {%else%}
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -158,6 +158,7 @@ Project details
 
    stability
    whatsnew/index
+   changelog
    known_issues
    credits
    license


### PR DESCRIPTION
This PR is to address #11621.

It starts by adding a new landing/index page for the developer docs, which is linked to from the main index page.  It's also now titled "Contributing to Astropy" though this can be bikeshedded.

Still several other bullet points from #11621 to work on, in particular adding a new, easier to follow quick-start guide for making a contribution through the repository/GitHub.