### PR TITLE
Allow specifying parse_strict for units when reading FITS tables

### DIFF
--- a/astropy/io/fits/connect.py
+++ b/astropy/io/fits/connect.py
@@ -112,7 +112,7 @@ def _decode_mixins(tbl):
 
 
 def read_table_fits(input, hdu=None, astropy_native=False, memmap=False,
-                    character_as_bytes=True):
+                    character_as_bytes=True, unit_parse_strict='silent'):
     """
     Read a Table object from an FITS file
 
@@ -152,6 +152,12 @@ def read_table_fits(input, hdu=None, astropy_native=False, memmap=False,
         ``U``) internally, you should set this to `False`, but note that this
         will use more memory. If set to `False`, string columns will not be
         memory-mapped even if ``memmap`` is `True`.
+    unit_parse_strict: str, optional
+        Behaviour when encountering invalid column units in the FITS header.
+        Default is "silent", which will create a
+        :class:`~astropy.units.core.UnrecognizedUnit`.
+        Values are the ones allowed by the ``parse_strict`` argument of
+        :class:`~astropy.units.core.Unit`.
     """
 
     if isinstance(input, HDUList):
@@ -211,8 +217,11 @@ def read_table_fits(input, hdu=None, astropy_native=False, memmap=False,
                             memmap=memmap)
 
         try:
-            return read_table_fits(hdulist, hdu=hdu,
-                                   astropy_native=astropy_native)
+            return read_table_fits(
+                hdulist, hdu=hdu,
+                astropy_native=astropy_native,
+                unit_parse_strict=unit_parse_strict,
+            )
         finally:
             hdulist.close()
 
@@ -249,7 +258,7 @@ def read_table_fits(input, hdu=None, astropy_native=False, memmap=False,
 
         # Copy over units
         if col.unit is not None:
-            column.unit = u.Unit(col.unit, format='fits', parse_strict='silent')
+            column.unit = u.Unit(col.unit, format='fits', parse_strict=unit_parse_strict)
 
         # Copy over display format
         if col.disp is not None:

--- a/astropy/io/fits/connect.py
+++ b/astropy/io/fits/connect.py
@@ -112,7 +112,7 @@ def _decode_mixins(tbl):
 
 
 def read_table_fits(input, hdu=None, astropy_native=False, memmap=False,
-                    character_as_bytes=True, unit_parse_strict='silent'):
+                    character_as_bytes=True, unit_parse_strict='warn'):
     """
     Read a Table object from an FITS file
 

--- a/astropy/io/fits/tests/test_connect.py
+++ b/astropy/io/fits/tests/test_connect.py
@@ -234,7 +234,8 @@ class TestSingleTable:
         hdu.columns[0].unit = 'RADIANS'
         hdu.columns[1].unit = 'spam'
         hdu.columns[2].unit = 'millieggs'
-        t = Table.read(hdu)
+        with pytest.warns(u.UnitsWarning, match="did not parse as fits unit"):
+            t = Table.read(hdu)
         assert equal_data(t, self.data)
 
     @pytest.mark.parametrize('table_type', (Table, QTable))
@@ -657,7 +658,8 @@ def test_unit_warnings_read_write(tmpdir):
         t1.write(filename, overwrite=True)
     assert len(w) == 1
 
-    Table.read(filename, hdu=1)
+    with pytest.warns(u.UnitsWarning, match="'not-a-unit' did not parse as fits unit") as w:
+        Table.read(filename, hdu=1)
 
 
 def test_convert_comment_convention(tmpdir):

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -3529,7 +3529,10 @@ def test_unit_parse_strict(tmp_path):
     with fits.open(path, mode='update') as hdul:
         hdul[1].header['TUNIT1'] = invalid_unit
 
-    t = Table.read(path)
+    # default is "warn"
+    with pytest.warns(UnitsWarning):
+        t = Table.read(path)
+
     assert isinstance(t['a'].unit, UnrecognizedUnit)
 
     t = Table.read(path, unit_parse_strict='silent')

--- a/astropy/table/tests/test_showtable.py
+++ b/astropy/table/tests/test_showtable.py
@@ -1,5 +1,6 @@
 import os
 import re
+import pytest
 
 from astropy.table.scripts import showtable
 
@@ -53,8 +54,13 @@ def test_fits(capsys):
 
 
 def test_fits_hdu(capsys):
-    showtable.main([os.path.join(FITS_ROOT, 'data/zerowidth.fits'),
-                    '--hdu', 'AIPS OF'])
+    from astropy.units import UnitsWarning
+    with pytest.warns(UnitsWarning):
+        showtable.main([
+            os.path.join(FITS_ROOT, 'data/zerowidth.fits'),
+            '--hdu', 'AIPS OF',
+        ])
+
     out, err = capsys.readouterr()
     assert out.startswith(
         '   TIME    SOURCE ID ANTENNA NO. SUBARRAY FREQ ID ANT FLAG STATUS 1\n'

--- a/astropy/timeseries/io/tests/test_kepler.py
+++ b/astropy/timeseries/io/tests/test_kepler.py
@@ -68,8 +68,13 @@ def test_raise_timesys_tess(mock_file):
 
 @pytest.mark.remote_data(source='astropy')
 def test_kepler_astropy():
+    from astropy.units import UnitsWarning
+
     filename = get_pkg_data_filename('timeseries/kplr010666592-2009131110544_slc.fits')
-    timeseries = kepler_fits_reader(filename)
+
+    with pytest.warns(UnitsWarning):
+        timeseries = kepler_fits_reader(filename)
+
     assert timeseries["time"].format == 'isot'
     assert timeseries["time"].scale == 'tdb'
     assert timeseries["sap_flux"].unit.to_string() == 'electron / s'

--- a/astropy/timeseries/tests/test_sampled.py
+++ b/astropy/timeseries/tests/test_sampled.py
@@ -323,8 +323,13 @@ def test_read():
 
 @pytest.mark.remote_data(source='astropy')
 def test_kepler_astropy():
+    from astropy.units import UnitsWarning
+
     filename = get_pkg_data_filename('timeseries/kplr010666592-2009131110544_slc.fits')
-    timeseries = TimeSeries.read(filename, format='kepler.fits')
+
+    with pytest.warns(UnitsWarning):
+        timeseries = TimeSeries.read(filename, format='kepler.fits')
+
     assert timeseries["time"].format == 'isot'
     assert timeseries["time"].scale == 'tdb'
     assert timeseries["sap_flux"].unit.to_string() == 'electron / s'

--- a/docs/changes/io.fits/11843.feature.rst
+++ b/docs/changes/io.fits/11843.feature.rst
@@ -1,0 +1,4 @@
+Add option ``unit_parse_strict`` to `~astropy.io.fits.connect.read_table_fits`
+to enable warnings or errors about invalid FITS units when using `~astropy.table.Table.read`.
+The default for this new option is ``"warn"``, which means warnings are now raised for
+columns with invalid units.

--- a/docs/timeseries/index.rst
+++ b/docs/timeseries/index.rst
@@ -49,7 +49,7 @@ source::
 We can then use the |TimeSeries| class to read in this file::
 
     >>> from astropy.timeseries import TimeSeries
-    >>> ts = TimeSeries.read(filename, format='kepler.fits')  # doctest: +REMOTE_DATA
+    >>> ts = TimeSeries.read(filename, format='kepler.fits')  # doctest: +REMOTE_DATA +IGNORE_WARNINGS
 
 Time series are specialized kinds of |Table| objects::
 


### PR DESCRIPTION
### Description

This pull request is to address the first half of #11842, so we can get unit warnings / errors when reading FITS files.

