### PR TITLE
Mark test as requiring jplephem.

### DIFF
--- a/astropy/coordinates/tests/test_solar_system.py
+++ b/astropy/coordinates/tests/test_solar_system.py
@@ -279,6 +279,7 @@ class TestPositionKittPeak:
 
 
 @pytest.mark.remote_data
+@pytest.mark.skipif('not HAS_JPLEPHEM')
 def test_horizons_consistency_with_precision():
     """
     A test to compare at high precision against output of JPL horizons.


### PR DESCRIPTION
An oversight in some previous PR. Should be backported to 4.3. Partially addresses #11857.