### PR TITLE
Remove fallback in getdata when ext specified

### DIFF
--- a/astropy/io/fits/convenience.py
+++ b/astropy/io/fits/convenience.py
@@ -211,10 +211,9 @@ def getdata(filename, *args, header=None, lower=None, upper=None, view=None,
                 hdu = hdulist[1]
                 data = hdu.data
                 warnings.warn(
-                    """Fallback to the first extension when primary has no
-                    data is deprecated. In the future this will raise a
-                    ValueError.
-                    """, AstropyDeprecationWarning
+                    'Fallback to the first extension when primary has no '
+                    'data is deprecated. In the future this will raise a '
+                    'ValueError.', AstropyDeprecationWarning
                 )
             except IndexError:
                 pass

--- a/astropy/io/fits/convenience.py
+++ b/astropy/io/fits/convenience.py
@@ -137,9 +137,9 @@ def getdata(filename, *args, header=None, lower=None, upper=None, view=None,
             getdata('in.fits')
 
         .. note::
-            Exclusive to ``getdata``: if extension is not specified 
+            Exclusive to ``getdata``: if extension is not specified
             and primary header contains no data, ``getdata`` attempts
-            to retrieve data from first extension. 
+            to retrieve data from first extension.
 
         By extension number::
 
@@ -213,14 +213,14 @@ def getdata(filename, *args, header=None, lower=None, upper=None, view=None,
         if data is None:
             if ext_given:
                 raise IndexError(f"No data in HDU #{extidx}.")
- 
+
             # fallback to the first non-primary extension
             if len(hdulist) == 1:
                 raise IndexError(
                     "No data in Primary HDU and no extension HDU found."
                     )
             hdu = hdulist[1]
-            data = hdu.data                   
+            data = hdu.data
             if data is None:
                 raise IndexError(
                     "No data in either Primary or first extension HDUs."

--- a/astropy/io/fits/convenience.py
+++ b/astropy/io/fits/convenience.py
@@ -68,7 +68,7 @@ from .hdu.image import PrimaryHDU, ImageHDU
 from .hdu.table import BinTableHDU
 from .header import Header
 from .util import fileobj_closed, fileobj_name, fileobj_mode, _is_int
-from astropy.utils.exceptions import AstropyUserWarning, AstropyDeprecationWarning
+from astropy.utils.exceptions import AstropyUserWarning
 from astropy.utils.decorators import deprecated_renamed_argument
 
 try:
@@ -206,15 +206,10 @@ def getdata(filename, *args, header=None, lower=None, upper=None, view=None,
         hdu = hdulist[extidx]
         data = hdu.data
         if data is None and no_user_ext:
-            # deprecated fallback to the first non-primary extension
+            # fallback to the first non-primary extension
             try:
                 hdu = hdulist[1]
                 data = hdu.data
-                warnings.warn(
-                    'Fallback to the first extension when primary has no '
-                    'data is deprecated. In the future this will raise a '
-                    'ValueError.', AstropyDeprecationWarning
-                )
             except IndexError:
                 pass
         if data is None:

--- a/astropy/io/fits/tests/test_convenience.py
+++ b/astropy/io/fits/tests/test_convenience.py
@@ -372,7 +372,7 @@ class TestConvenience(FitsTestCase):
 
         with pytest.raises(IndexError):
             fits.getdata(buf)
-   
+
     def test_getdata_ext_not_given_nodata_noext(self):
         # tests exception raised when there is no data in the
         # Primary HDU and there are no extension HDUs
@@ -384,4 +384,3 @@ class TestConvenience(FitsTestCase):
 
         with pytest.raises(IndexError):
             fits.getdata(buf)
-   

--- a/astropy/io/fits/tests/test_convenience.py
+++ b/astropy/io/fits/tests/test_convenience.py
@@ -3,6 +3,7 @@
 import os
 import pathlib
 import warnings
+import io
 
 import pytest
 import numpy as np
@@ -307,3 +308,80 @@ class TestConvenience(FitsTestCase):
 
         with fits.open(testfile) as hdul:
             np.testing.assert_array_equal(hdul[0].data, data)
+
+    def test_getdata_ext_given(self):
+        prihdu = fits.PrimaryHDU(data=np.zeros((5, 5), dtype=int))
+        exthdu1 = fits.ImageHDU(data=np.ones((5, 5), dtype=int))
+        exthdu2 = fits.ImageHDU(data=2 * np.ones((5, 5), dtype=int))
+        hdulist = fits.HDUList([prihdu, exthdu1, exthdu2])
+        buf = io.BytesIO()
+        hdulist.writeto(buf)
+
+        for ext in [0, 1, 2]:
+            buf.seek(0)
+            data = fits.getdata(buf, ext=ext)
+            assert data[0, 0] == ext
+
+    def test_getdata_ext_given_nodata(self):
+        prihdu = fits.PrimaryHDU(data=np.zeros((5, 5), dtype=int))
+        exthdu1 = fits.ImageHDU(data=np.ones((5, 5), dtype=int))
+        exthdu2 = fits.ImageHDU(data=None)
+        hdulist = fits.HDUList([prihdu, exthdu1, exthdu2])
+        buf = io.BytesIO()
+        hdulist.writeto(buf)
+        buf.seek(0)
+
+        with pytest.raises(IndexError):
+            fits.getdata(buf, ext=2)
+
+    def test_getdata_ext_not_given_with_data_in_primary(self):
+        prihdu = fits.PrimaryHDU(data=np.zeros((5, 5), dtype=int))
+        exthdu1 = fits.ImageHDU(data=None)
+        exthdu2 = fits.ImageHDU(data=None)
+        hdulist = fits.HDUList([prihdu, exthdu1, exthdu2])
+        buf = io.BytesIO()
+        hdulist.writeto(buf)
+        buf.seek(0)
+
+        data = fits.getdata(buf)
+        assert data[0, 0] == 0
+
+    def test_getdata_ext_not_given_with_data_in_ext(self):
+        # tests fallback mechanism
+        prihdu = fits.PrimaryHDU(data=None)
+        exthdu1 = fits.ImageHDU(data=np.ones((5, 5), dtype=int))
+        exthdu2 = fits.ImageHDU(data=None)
+        hdulist = fits.HDUList([prihdu, exthdu1, exthdu2])
+        buf = io.BytesIO()
+        hdulist.writeto(buf)
+        buf.seek(0)
+
+        data = fits.getdata(buf)
+        assert data[0, 0] == 1
+
+    def test_getdata_ext_not_given_nodata_any(self):
+        # tests exception raised when there is no data in either
+        # Primary HDU or first extension HDU
+        prihdu = fits.PrimaryHDU(data=None)
+        exthdu1 = fits.ImageHDU(data=None)
+        exthdu2 = fits.ImageHDU(data=np.ones((5, 5), dtype=int))
+        hdulist = fits.HDUList([prihdu, exthdu1, exthdu2])
+        buf = io.BytesIO()
+        hdulist.writeto(buf)
+        buf.seek(0)
+
+        with pytest.raises(IndexError):
+            fits.getdata(buf)
+   
+    def test_getdata_ext_not_given_nodata_noext(self):
+        # tests exception raised when there is no data in the
+        # Primary HDU and there are no extension HDUs
+        prihdu = fits.PrimaryHDU(data=None)
+        hdulist = fits.HDUList([prihdu])
+        buf = io.BytesIO()
+        hdulist.writeto(buf)
+        buf.seek(0)
+
+        with pytest.raises(IndexError):
+            fits.getdata(buf)
+   

--- a/astropy/io/fits/tests/test_convenience.py
+++ b/astropy/io/fits/tests/test_convenience.py
@@ -331,7 +331,7 @@ class TestConvenience(FitsTestCase):
         hdulist.writeto(buf)
         buf.seek(0)
 
-        with pytest.raises(IndexError):
+        with pytest.raises(IndexError, match="No data in HDU #2."):
             fits.getdata(buf, ext=2)
 
     def test_getdata_ext_not_given_with_data_in_primary(self):
@@ -370,7 +370,10 @@ class TestConvenience(FitsTestCase):
         hdulist.writeto(buf)
         buf.seek(0)
 
-        with pytest.raises(IndexError):
+        with pytest.raises(
+            IndexError,
+            match="No data in either Primary or first extension HDUs."
+        ):
             fits.getdata(buf)
 
     def test_getdata_ext_not_given_nodata_noext(self):
@@ -382,5 +385,8 @@ class TestConvenience(FitsTestCase):
         hdulist.writeto(buf)
         buf.seek(0)
 
-        with pytest.raises(IndexError):
+        with pytest.raises(
+            IndexError,
+            match="No data in Primary HDU and no extension HDU found."
+        ):
             fits.getdata(buf)

--- a/docs/changes/io.fits/11860.bugfix.rst
+++ b/docs/changes/io.fits/11860.bugfix.rst
@@ -1,3 +1,2 @@
 In ``fits.io.getdata`` do not fall back to first non-primary extension when
-user explicitly specifies an extension. Also, deprecate fallback mechanism
-when no extension is specified.
+user explicitly specifies an extension.

--- a/docs/changes/io.fits/11860.bugfix.rst
+++ b/docs/changes/io.fits/11860.bugfix.rst
@@ -1,0 +1,3 @@
+In ``fits.io.getdata`` do not fall back to first non-primary extension when
+user explicitly specifies an extension. Also, deprecate fallback mechanism
+when no extension is specified.


### PR DESCRIPTION
### Description
In this PR I try to address some of the issues mentioned in #11795. In particular, I removed the fallback to the first extension when the user explicitly specifies an extension. However, for backward compatibility, I retained the fallback for when the extension is not specified and raised a deprecation warning. I believe the fallback should be removed, as suggested by @dhomeier, because `getheader(file)` does not have such a fallback, and this may cause the data and the header to come from different HDUs. 

Fixes #11795
