### PR TITLE
Add physical type aliases for angular speed

### DIFF
--- a/astropy/units/physical.py
+++ b/astropy/units/physical.py
@@ -44,7 +44,7 @@ _units_and_physical_types = [
     (si.m ** 3 / si.mol, "molar volume"),
     (si.kg * si.m / si.s, {"momentum", "impulse"}),
     (si.kg * si.m ** 2 / si.s, {"angular momentum", "action"}),
-    (si.rad / si.s, "angular speed"),
+    (si.rad / si.s, {"angular speed", "angular velocity", "angular frequency"}),
     (si.rad / si.s ** 2, "angular acceleration"),
     (si.rad / si.m, "plate scale"),
     (si.g / (si.m * si.s), "dynamic viscosity"),

--- a/docs/changes/units/11865.feature.rst
+++ b/docs/changes/units/11865.feature.rst
@@ -1,0 +1,2 @@
+Added "angular frequency" and "angular velocity" as aliases for the "angular
+speed" physical type.


### PR DESCRIPTION
"angle / time" is also commonly referred to as an [angular frequency](https://en.wikipedia.org/wiki/Angular_frequency). I added "angular velocity" as another alias because for a length/time we support "speed" or "velocity".