### PR TITLE
Fix wrong docstring section headers [skip ci]

### DIFF
--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -1794,8 +1794,8 @@ class Time(TimeBase):
         --------
         astropy.time.Time.sidereal_time
 
-        Reference
-        ---------
+        References
+        ----------
         IAU 2006 NFA Glossary
         (currently located at: https://syrte.obspm.fr/iauWGnfa/NFA_Glossary.html)
 
@@ -1856,8 +1856,8 @@ class Time(TimeBase):
         --------
         astropy.time.Time.earth_rotation_angle
 
-        Reference
-        ---------
+        References
+        ----------
         IAU 2006 NFA Glossary
         (currently located at: https://syrte.obspm.fr/iauWGnfa/NFA_Glossary.html)
 


### PR DESCRIPTION
Fixes current readthedocs failures on master - the PR that introduced these docstrings, #11680, passed all tests when it was last changed, but that was before the numpydoc checks were merged...

I skipped CI since really only `readthedocs` is affected. But that one obviously better pass!