### PR TITLE
Ensure that pickling does not propagate memoized hash.

### DIFF
--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -435,7 +435,7 @@ def generic_recursive_equality_test(a, b, class_history):
     Check if the attributes of a and b are equal. Then,
     check if the attributes of the attributes are equal.
     """
-    dict_a = a.__dict__
+    dict_a = a.__getstate__() if hasattr(a, '__getstate__') else a.__dict__
     dict_b = b.__dict__
     for key in dict_a:
         assert key in dict_b,\

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -870,6 +870,13 @@ class UnitBase:
             self._hash = hash(tuple(parts))
         return self._hash
 
+    def __getstate__(self):
+        # If we get pickled, we should *not* store the memoized hash since
+        # hashes of strings vary between sessions.
+        state = self.__dict__.copy()
+        state.pop('_hash', None)
+        return state
+
     def __eq__(self, other):
         if self is other:
             return True
@@ -1856,7 +1863,7 @@ class IrreducibleUnit(NamedUnit):
         registry = get_current_unit_registry().registry
         return (_recreate_irreducible_unit,
                 (self.__class__, list(self.names), self.name in registry),
-                self.__dict__)
+                self.__getstate__())
 
     @property
     def represents(self):

--- a/docs/changes/units/11879.bugfix.rst
+++ b/docs/changes/units/11879.bugfix.rst
@@ -1,0 +1,3 @@
+Ensure that unpickling quantities and units in new sessions does not change
+hashes and thus cause problems with (de)composition such as getting different
+answers from the ``.si`` attribute.


### PR DESCRIPTION
This becauses hashes vary between sessions, so the hash should be recalculated.

Fixes #11872

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will
review this pull request of some common things to look for. This list
is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] If the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
