### PR TITLE
Change equality to allclose to fix test on 32 bit

### DIFF
--- a/astropy/coordinates/tests/test_representation_arithmetic.py
+++ b/astropy/coordinates/tests/test_representation_arithmetic.py
@@ -214,8 +214,9 @@ class TestArithmetic():
             in_rep + (in_rep / u.s)
         r2 = in_rep - in_rep
         assert isinstance(r2, representation)
-        assert np.all(representation_equal(
-            r2.to_cartesian(), CartesianRepresentation(0.*u.m, 0.*u.m, 0.*u.m)))
+        assert_representation_allclose(
+            r2.to_cartesian(), CartesianRepresentation(0.*u.m, 0.*u.m, 0.*u.m),
+            atol=1e-15*u.kpc)
         r3 = in_rep - in_rep / 2.
         assert isinstance(r3, representation)
         expected = in_rep / 2.


### PR DESCRIPTION
Saw this failing test on https://github.com/astropy/astropy/pull/11879/checks?check_run_id=2889899758

It seems to be a problem in 4.3 as well - see https://github.com/astropy/astropy/runs/2887279374

Fix #11878