### PR TITLE
remove outdated mention of ``Cosmology.clone``

### DIFF
--- a/docs/cosmology/index.rst
+++ b/docs/cosmology/index.rst
@@ -346,14 +346,11 @@ redshift by `~astropy.cosmology.wpwaCDM`: :math:`w(z) = w_{p} + w_{a}
 
 Users can specify their own equation of state by subclassing
 `~astropy.cosmology.FLRW`. See the provided subclasses for
-examples. It is recommended, but not required, that all arguments to the
-constructor of a new subclass be available as properties, since the
-``clone`` method assumes this is the case. It is also advisable
-to stick to subclassing `~astropy.cosmology.FLRW` rather than one of
-its subclasses, since some of them use internal optimizations that
-also need to be propagated to any subclasses. Users wishing to
-use similar tricks (which can make distance calculations much faster)
-should consult the cosmology module source code for details.
+examples. It is advisable to stick to subclassing `~astropy.cosmology.FLRW`
+rather than one of its subclasses, since some of them use internal optimizations
+that also need to be propagated to any subclasses. Users wishing to use similar
+tricks (which can make distance calculations much faster) should consult the
+cosmology module source code for details.
 
 Photons and Neutrinos
 ---------------------


### PR DESCRIPTION
``clone`` no longer assumes all arguments to the constructor of a cosmology class have identically named properties.

Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

Suggested tags: no-changelog-needed
Request review: anybody, this PR removes 1 sentence :)

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will
review this pull request of some common things to look for. This list
is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] If the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
