### PR TITLE
Allow wildcard pattern-matching when specifying converters

### DIFF
--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -18,6 +18,7 @@ import os
 import re
 import warnings
 import inspect
+import fnmatch
 
 from collections import OrderedDict
 from contextlib import suppress
@@ -1036,13 +1037,14 @@ class BaseOutputter:
 
     def _convert_vals(self, cols):
         for col in cols:
-            # If a specific dtype was specified for a column, then use that
-            # to set the defaults, otherwise use the generic defaults.
-            default_converters = ([convert_numpy(col.dtype)] if col.dtype
-                                  else self.default_converters)
-
-            # If the user supplied a specific convert then that takes precedence over defaults
-            converters = self.converters.get(col.name, default_converters)
+            if col.dtype is not None:
+                converters = [convert_numpy(col.dtype)]
+            else:
+                for key, converters in self.converters.items():
+                    if fnmatch.fnmatch(col.name, key):
+                        break
+                else:
+                    converters = self.default_converters
 
             col.converters = self._validate_and_copy(col, converters)
 

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -1037,12 +1037,12 @@ class BaseOutputter:
 
     def _convert_vals(self, cols):
         for col in cols:
-            if col.dtype is not None:
-                converters = [convert_numpy(col.dtype)]
+            for key, converters in self.converters.items():
+                if fnmatch.fnmatch(col.name, key):
+                    break
             else:
-                for key, converters in self.converters.items():
-                    if fnmatch.fnmatch(col.name, key):
-                        break
+                if col.dtype is not None:
+                    converters = [convert_numpy(col.dtype)]
                 else:
                     converters = self.default_converters
 

--- a/astropy/io/ascii/docs.py
+++ b/astropy/io/ascii/docs.py
@@ -39,7 +39,9 @@ READ_DOCSTRING = """
         Line index for the end of data not counting comment or blank lines.
         This value can be negative to count from the end.
     converters : dict
-        Dictionary of converters
+        Dictionary of converters. Keys in the dictionary are columns names,
+        values are converter functions. In addition to single column names
+        you can use wildcards via `fnmatch` to select multiple columns.
     data_Splitter : `~astropy.io.ascii.BaseSplitter`
         Splitter class to split data columns
     header_Splitter : `~astropy.io.ascii.BaseSplitter`

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -1640,3 +1640,13 @@ False   5
     assert col.dtype.kind == 'b'
     assert np.all(col.mask == [False, False, False, True, False])
     assert np.all(col == [True, False, True, False, False])
+
+
+def test_read_converters_wildcard():
+    '''Test converters where the column name is specified with
+    a wildcard.
+    '''
+    converters = {'F*': [ascii.convert_numpy(np.float32)]}
+    t = ascii.read(['Fabc Iabc', '1 2'], converters=converters)
+    assert np.issubdtype(t['Fabc'].dtype, np.float32)
+    assert not np.issubdtype(t['Iabc'].dtype, np.float32)

--- a/docs/changes/io.ascii/11892.feature.rst
+++ b/docs/changes/io.ascii/11892.feature.rst
@@ -1,0 +1,2 @@
+Added new way to specify the dtype for tables that are read: ``converters``
+can specify column names with wildcards.

--- a/docs/io/ascii/read.rst
+++ b/docs/io/ascii/read.rst
@@ -579,11 +579,11 @@ The default converters for each column can be overridden with the
 
 In addition to single column names you can use wildcards via `fnmatch` to
 select multiple columns. For example, we can set the format for all columns
-where the column name starts with i to `np.unit` while applying default
+where the column name starts with "col" to `np.uint` while applying default
 converters to all other columns in the table::
 
   >>> import numpy as np
-  >>> converters = {'i*': [ascii.convert_numpy(np.uint)]}
+  >>> converters = {'col*': [ascii.convert_numpy(np.uint)]}
   >>> ascii.read('file.dat', converters=converters)  # doctest: +SKIP
 
 

--- a/docs/io/ascii/read.rst
+++ b/docs/io/ascii/read.rst
@@ -579,7 +579,7 @@ The default converters for each column can be overridden with the
 
 In addition to single column names you can use wildcards via `fnmatch` to
 select multiple columns. For example, we can set the format for all columns
-where the column name starts with "col" to `np.uint` while applying default
+with a name starting with "col" to an unsigned integer while applying default
 converters to all other columns in the table::
 
   >>> import numpy as np

--- a/docs/io/ascii/read.rst
+++ b/docs/io/ascii/read.rst
@@ -577,6 +577,15 @@ The default converters for each column can be overridden with the
   ...               'col2': [ascii.convert_numpy(np.float32)]}
   >>> ascii.read('file.dat', converters=converters)  # doctest: +SKIP
 
+In addition to single column names you can use wildcards via `fnmatch` to
+select multiple columns. For example, we can set the format for all columns
+where the column name starts with i to `np.unit` while applying default
+converters to all other columns in the table::
+
+  >>> import numpy as np
+  >>> converters = {'i*': [ascii.convert_numpy(np.uint)]}
+  >>> ascii.read('file.dat', converters=converters)  # doctest: +SKIP
+
 
 .. _fortran_style_exponents:
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

In addition to single column names this PRs allows users to use wildcards via `fnmatch` to select multiple columns.
The code for this PR was written by @taldcroft here: https://github.com/astropy/astropy/pull/11889#issuecomment-867556473

Similarly, @taldcroft spec'ed the required doc changes here: https://github.com/astropy/astropy/pull/11889#issuecomment-867865879

*I'm not quite sure why I open this as a PR, as this is fully @taldcroft's work, but I hope he does not mind.*

This PR is an alternative implementation and is mutually exclusive with #11889. The discussion was spurred by #4934, but this PR technically does not solve #4934, as a `defaultdict` would not behave as requested with this PR. So, if this PR is chosen, I suggest to close #4934 as "won't fix".

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will
review this pull request of some common things to look for. This list
is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] If the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
