### PR TITLE
Fix QDP docstring example (missing a newline)

### DIFF
--- a/astropy/io/ascii/qdp.py
+++ b/astropy/io/ascii/qdp.py
@@ -516,6 +516,7 @@ class QDP(basic.Basic):
     """Quick and Dandy Plot table.
 
     Example::
+
         ! Initial comment line 1
         ! Initial comment line 2
         READ TERR 1
@@ -536,9 +537,8 @@ class QDP(basic.Basic):
     of ``NO``s. Comments are exclamation marks, and missing values are single
     ``NO`` entries. The delimiter is usually whitespace, more rarely a comma.
     The QDP format differentiates between data and error columns. The table
-    above has commands
+    above has commands::
 
-    ::
         READ TERR 1
         READ SERR 3
 
@@ -572,6 +572,7 @@ class QDP(basic.Basic):
     and leave the name specification to the user.
 
     Example::
+
         >               Extra space
         >                   |
         >                   v
@@ -584,6 +585,7 @@ class QDP(basic.Basic):
     table. The comments of each table will be stored in the ``comments`` meta.
 
     Example::
+
         t = Table.read(example_qdp, format='ascii.qdp', table_id=1, names=['a', 'b', 'c', 'd'])
 
     reads the second table (``table_id=1``) in file ``example.qdp`` containing
@@ -594,9 +596,8 @@ class QDP(basic.Basic):
     in the file, while ``t.meta['comments']`` will contain ``Table 1 comment``
 
     The table can be written to another file, preserving the same information,
-    as
+    as::
 
-    ::
         t.write(test_file, err_specs={'terr': [1], 'serr': [3]})
 
     Note how the ``terr`` and ``serr`` commands are passed to the writer.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

Fix QDP docstring example, which was missing a newline.

I marked this as milestone v4.3. Not sure if that is right or feasible now, but it fixes a formatting mistake in the 4.3 release docs. Fixing in 4.3.1 would be fine as well.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will
review this pull request of some common things to look for. This list
is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] If the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
