### PR TITLE
Fix a broken link in change log

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5549,8 +5549,10 @@ astropy.convolution
   ``nan_treatment`` argument. ``astropy.convolution.convolve`` also no longer
   double-interpolates interpolates over NaNs, although that is now available
   as a separate ``astropy.convolution.interpolate_replace_nans`` function. See
-  :ref:`the backwards compatibility note <astropy_convolve_compat>` for more
-  on how to get the old behavior (and why you probably don't want to.) [#5782]
+  `the backwards compatibility note
+  <https://docs.astropy.org/en/v2.0.16/convolution/index.html#a-note-on-backward-compatibility-pre-v2-0>`_
+  for more on how to get the old behavior (and why you probably don't want to.)
+  [#5782]
 
 astropy.coordinates
 ^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
### Description
This pull request is a follow-up to #11880, which removed many obsolete sections from the documentation. A change log entry contained a link to one of those sections, so removing it broke the documentation build and it was not caught by any CI tests. This pull request fixes that by making the change log entry in question point to version 2.0.16 documentation on-line.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will
review this pull request of some common things to look for. This list
is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] If the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
