### PR TITLE
Implement Table.update()

### DIFF
--- a/astropy/table/operations.py
+++ b/astropy/table/operations.py
@@ -684,6 +684,10 @@ def hstack(tables, join_type='outer',
     stacked_table : `~astropy.table.Table` object
         New table containing the stacked data from the input tables.
 
+    See Also
+    --------
+    Table.add_columns, Table.replace_column, Table.update
+
     Examples
     --------
     To stack two tables horizontally (along columns) do::

--- a/docs/changes/table/11904.feature.rst
+++ b/docs/changes/table/11904.feature.rst
@@ -1,0 +1,2 @@
+Added a new method ``Table.update()`` which does a dictionary-style update of a
+``Table`` by adding or replacing columns.

--- a/docs/table/modify_table.rst
+++ b/docs/table/modify_table.rst
@@ -138,6 +138,31 @@ using broadcasting will be done, for example::
 
 .. EXAMPLE END
 
+**Perform a dictionary-style update**
+
+It is possible to perform a dictionary-style update, which adds new columns to
+the table and replaces existing ones::
+
+  >>> t1 = Table({'name': ['foo', 'bar'], 'val': [0., 0.]}, meta={'n': 2})
+  >>> t2 = Table({'val': [1., 2.], 'val2': [10., 10.]}, meta={'id': 0})
+  >>> t1.update(t2)
+  >>> t1
+  <Table length=2>
+  name   val     val2
+  str3 float64 float64
+  ---- ------- -------
+   foo     1.0    10.0
+   bar     2.0    10.0
+
+:meth:`~astropy.table.Table.update` also takes care of silently :ref:`merging_metadata`::
+
+  >>> t1.meta
+  {'n': 2, 'id': 0}
+
+The input of :meth:`~astropy.table.Table.update` does not have to be a |Table|,
+it can be anything that can be used for :ref:`construct_table` with a
+compatible number of rows.
+
 **Rename columns**
 
 .. EXAMPLE START: Renaming Columns in Tables

--- a/docs/table/operations.rst
+++ b/docs/table/operations.rst
@@ -999,6 +999,8 @@ in the |join| example defined previously::
    M31       2012-01-02  17.0  16.0    1999-01-05  43.1
    M82       2012-10-29  16.2  15.2    2012-10-29  45.0
 
+.. _merging_metadata:
+
 Merging Metadata
 ^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
### Description
This pull request is meant to implement a `Table.update()` method, which would be analogous to Python's `dict.update()`, i.e. `t1.update(t2)` would add columns of `t2` to `t1` replacing columns if there is any overlap.

This pull request is opened as a draft to see if having such a method is considered to be worth the effort, and to get an idea how much effort that would be, but proper implementation also requires deciding about details such as whether the argument of the method should be a `Table` or if it could anything that can initialize a `Table` (e.g. `dict` or list of `Column` objects).

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will
review this pull request of some common things to look for. This list
is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] If the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
