### PR TITLE
Adjust Time.argsort() for slightly faster performance.

### DIFF
--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -1195,10 +1195,9 @@ class TimeBase(ShapedLikeNDArray):
         that the full precision given by the two doubles ``jd1`` and ``jd2``
         is used.  See :func:`~numpy.argmin` for detailed documentation.
         """
-        # first get the minimum at normal precision.
-        jd = self.jd1 + self.jd2
-
-        approx = np.min(jd, axis, keepdims=True)
+        # First get the minimum at normal precision.
+        jd1, jd2 = self.jd1, self.jd2
+        approx = np.min(jd1 + jd2, axis, keepdims=True)
 
         # Approx is very close to the true minimum, and by subtracting it at
         # full precision, all numbers near 0 can be represented correctly,
@@ -1208,7 +1207,7 @@ class TimeBase(ShapedLikeNDArray):
         # which translates to:
         # approx_jd1, approx_jd2 = day_frac(approx, 0.)
         # dt = (self.jd1 - approx_jd1) + (self.jd2 - approx_jd2)
-        dt = (self.jd1 - approx) + self.jd2
+        dt = (jd1 - approx) + jd2
 
         return dt.argmin(axis, out)
 
@@ -1220,11 +1219,10 @@ class TimeBase(ShapedLikeNDArray):
         is used.  See :func:`~numpy.argmax` for detailed documentation.
         """
         # For procedure, see comment on argmin.
-        jd = self.jd1 + self.jd2
+        jd1, jd2 = self.jd1, self.jd2
+        approx = np.max(jd1 + jd2, axis, keepdims=True)
 
-        approx = np.max(jd, axis, keepdims=True)
-
-        dt = (self.jd1 - approx) + self.jd2
+        dt = (jd1 - approx) + jd2
 
         return dt.argmax(axis, out)
 
@@ -1236,12 +1234,15 @@ class TimeBase(ShapedLikeNDArray):
         is used, and that corresponding attributes are copied.  Internally,
         it uses :func:`~numpy.lexsort`, and hence no sort method can be chosen.
         """
-        jd_approx = self.jd
-        jd_remainder = (self - self.__class__(jd_approx, format='jd', scale=self.scale)).jd
+        # For procedure, see comment on argmin.
+        jd1, jd2 = self.jd1, self.jd2
+        approx = jd1 + jd2
+        remainder = (jd1 - approx) + jd2
+
         if axis is None:
-            return np.lexsort((jd_remainder.ravel(), jd_approx.ravel()))
+            return np.lexsort((remainder.ravel(), approx.ravel()))
         else:
-            return np.lexsort(keys=(jd_remainder, jd_approx), axis=axis)
+            return np.lexsort(keys=(remainder, approx), axis=axis)
 
     def min(self, axis=None, out=None, keepdims=False):
         """Minimum along a given axis.

--- a/astropy/time/tests/test_precision.py
+++ b/astropy/time/tests/test_precision.py
@@ -498,6 +498,28 @@ def test_jd_add_subtract_round_trip(scale, jds, delta):
         raise
 
 
+@given(scale=sampled_from(STANDARD_TIME_SCALES),
+       jds=reasonable_jd(),
+       delta=floats(-3*tiny, 3*tiny))
+@example(scale='tai', jds=(0.0, 3.5762786865234384), delta=2.220446049250313e-16)
+def test_time_argminmaxsort(scale, jds, delta):
+    jd1, jd2 = jds
+    t = Time(jd1, jd2+np.array([0, delta]), scale=scale, format="jd")
+    imin = t.argmin()
+    imax = t.argmax()
+    isort = t.argsort()
+    diff = (t.jd1[1]-t.jd1[0]) + (t.jd2[1]-t.jd2[0])
+    if diff < 0:  # item 1 smaller
+        assert delta < 0
+        assert imin == 1 and imax == 0 and np.all(isort == [1, 0])
+    elif diff == 0:  # identical within precision
+        assert abs(delta) <= tiny
+        assert imin == 0 and imax == 0 and np.all(isort == [0, 1])
+    else:
+        assert delta > 0
+        assert imin == 0 and imax == 1 and np.all(isort == [0, 1])
+
+
 @given(sampled_from(STANDARD_TIME_SCALES), unreasonable_jd(), unreasonable_jd())
 @example(scale='utc',
          jds_a=(2455000.0, 0.0),


### PR DESCRIPTION
This came from ensuring the new Masked class worked properly with Time, but to ensure that PR does not become too big, I split it out - it is small but good on its own anyway.

The real change is for `.argsort`; the ones for `.argmin` and `.argmax` only avoid an attribute access - the changes are mostly just to make the code as similar as possible between the 3 methods, so that it is easier to follow.

<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to address ...

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will
review this pull request of some common things to look for. This list
is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] If the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
