### PR TITLE
Bugfix for `fix_inputs` bounding box

### DIFF
--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -3341,11 +3341,13 @@ class CompoundModel(Model):
         This also presumes that the list of input indices to remove (i.e.,
         input_ind has already been put in reverse sorted order).
         """
-        bounding_box = list(self.left.bounding_box)
+        bounding_box = list(self.left.bounding_box)[::-1]
         for ind in input_ind:
             del bounding_box[ind]
         if self.n_inputs == 1:
             bounding_box = bounding_box[0]
+        else:
+            bounding_box = bounding_box[::-1]
         self.bounding_box = bounding_box
 
     @property

--- a/astropy/modeling/tests/test_compound.py
+++ b/astropy/modeling/tests/test_compound.py
@@ -358,13 +358,13 @@ def test_fix_inputs_with_bounding_box():
     assert gg1.bounding_box == ((-5.5, 5.5), (-5.4, 5.4), (-5.3, 5.3), (-5.2, 5.2))
 
     sg = fix_inputs(gg1, {0: 0, 2: 0})
-    assert sg.bounding_box == ((-5.4, 5.4), (-5.2, 5.2))
+    assert sg.bounding_box == ((-5.5, 5.5), (-5.3, 5.3))
 
     g1 = Gaussian1D(10, 3, 1)
     g = g1 & g1
     g.bounding_box = ((1, 4), (6, 8))
     gf = fix_inputs(g, {0: 1})
-    assert gf.bounding_box == (6, 8)
+    assert gf.bounding_box == (1, 4)
 
 
 def test_indexing_on_instance():

--- a/docs/changes/modeling/11908.bugfix.rst
+++ b/docs/changes/modeling/11908.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed bug in ``fix_inputs`` handling of bounding boxes.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

During some other work on `~astropy.modeling` related to bounding boxes I noticed that the `fix_inputs` routine for handling reducing the bounding box, including the test of that routine were flawed when handling multiple inputs.

Multi-input bounding boxes  are tuples of tuples (e.g. `((-1, 1), (-2, 2))`); however, they are ordered in the "python" or "C" ordering meaning that they are reversed to how one would normally expect to read them. That is if a model has inputs (x, y), then the bounding box would be `((y_min, y_max), (x_min, x_max))` (in the example above `(-1, 1)` is the bounding box for the y, index 1 input). One can see that this is the case by noticing the bounding box reversal [here](https://github.com/astropy/astropy/blob/4654cde65f233f14b2d809fcd1ccf6d97e4638ec/astropy/modeling/core.py#L4171-L4174) in `~astropy.modeling.core`.

Both `fix_inputs` and the bounding_box test for `fix_inputs` assume that the ordering of the bounding boxes in the bounding box tuple matches the order of inputs; however, this is an incorrect assumption in light of the above note. I have fixed this by performing the `fix_inputs` removal of bounding_box entries on the reversed bounding box and then reversing it again.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will
review this pull request of some common things to look for. This list
is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] If the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
