### PR TITLE
Ensure any .info on Masked instances is propagated correctly.

### DIFF
--- a/astropy/utils/data_info.py
+++ b/astropy/utils/data_info.py
@@ -355,6 +355,9 @@ reference with ``c = col[3:5]`` followed by ``c.info``.""")
                 # _attrs, so speed matters up by not accessing defaults.
                 # Doing this before difference in for loop helps speed.
                 attr_names = attr_names & set(value._attrs)  # NOT in-place!
+            else:
+                # For different classes, copy over the attributes in common.
+                attr_names = attr_names & (value.attr_names - value._attrs_no_copy)
 
             for attr in attr_names - info.attrs_from_parent - info._attrs_no_copy:
                 info._attrs[attr] = deepcopy(getattr(value, attr))

--- a/astropy/utils/masked/tests/test_table.py
+++ b/astropy/utils/masked/tests/test_table.py
@@ -1,7 +1,6 @@
 # coding: utf-8
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from astropy.units.quantity import Quantity
 import numpy as np
 from numpy.testing import assert_array_equal
 import pytest
@@ -34,6 +33,13 @@ class MaskedArrayTableSetup:
         self.t = QTable([self.ma], names=['ma'])
 
 
+class MaskedQuantityTableSetup(MaskedArrayTableSetup):
+    @classmethod
+    def setup_arrays(self):
+        self.a = np.array([3., 5., 0.]) << u.m
+        self.mask_a = np.array([True, False, False])
+
+
 class TestMaskedArrayTable(MaskedArrayTableSetup):
     def test_table_initialization(self):
         assert_array_equal(self.t['ma'].unmasked, self.a)
@@ -42,6 +48,23 @@ class TestMaskedArrayTable(MaskedArrayTableSetup):
             '    ———',
             '    5.0',
             '    0.0']
+
+    def test_info_basics(self):
+        assert self.t['ma'].info.name == 'ma'
+        assert 'serialize_method' in self.t['ma'].info.attr_names
+        t2 = self.t.copy()
+        t2['ma'].info.format = '.2f'
+        t2['ma'].info.serialize_method['fits'] = 'nonsense'
+        assert repr(t2).splitlines()[-3:] == [
+            '    ———',
+            '   5.00',
+            '   0.00']
+        # Check that if we slice, things get copied over correctly.
+        t3 = t2[:2]
+        assert t3['ma'].info.name == 'ma'
+        assert t3['ma'].info.format == '.2f'
+        assert 'serialize_method' in t3['ma'].info.attr_names
+        assert t3['ma'].info.serialize_method['fits'] == 'nonsense'
 
     @pytest.mark.parametrize('file_format', FILE_FORMATS)
     def test_table_write(self, file_format, tmpdir):
@@ -56,18 +79,14 @@ class TestMaskedArrayTable(MaskedArrayTableSetup):
         assert isinstance(t2['ma'], self.ma.__class__)
         assert np.all(t2['ma'] == self.ma)
         assert np.all(t2['ma'].mask == self.mask_a)
-        if file_format == 'fits' and type(self.a) is np.ndarray:
+        if file_format == 'fits':
             # Imperfect roundtrip through FITS native format description.
             assert self.t['ma'].info.format in t2['ma'].info.format
         else:
             assert t2['ma'].info.format == self.t['ma'].info.format
 
-
-class TestSerializationMethods(MaskedArrayTableSetup):
-    # TODO: ensure this works for MaskedQuantity, etc., as well.
-    # Needs to somehow pass on serialize_method; see MaskedArraySubclassInfo.
     @pytest.mark.parametrize('serialize_method', ['data_mask', 'null_value'])
-    def test_table_write(self, serialize_method, tmpdir):
+    def test_table_write_serialization(self, serialize_method, tmpdir):
         name = str(tmpdir.join("test.ecsv"))
         self.t.write(name, serialize_method=serialize_method)
         with open(name) as fh:
@@ -94,12 +113,8 @@ class TestSerializationMethods(MaskedArrayTableSetup):
             self.t.write(name, serialize_method='bad_serialize_method')
 
 
-class TestMaskedQuantityTable(TestMaskedArrayTable):
-    @classmethod
-    def setup_arrays(self):
-        self.a = np.array([3., 5., 0.]) << u.m
-        self.mask_a = np.array([True, False, False])
-
+class TestMaskedQuantityTable(TestMaskedArrayTable, MaskedQuantityTableSetup):
+    # Runs tests from TestMaskedArrayTable as well as some extra ones.
     def test_table_operations_requiring_masking(self):
         t1 = self.t
         t2 = QTable({'ma2': Masked([1, 2] * u.m)})

--- a/docs/changes/utils/11910.bugfix.rst
+++ b/docs/changes/utils/11910.bugfix.rst
@@ -1,0 +1,3 @@
+Ensure any ``.info`` on ``Masked`` instances is propagated correctly when
+viewing or slicing. As a consequence, ``MaskedQuantity`` can now be correctly
+written to, e.g., ECSV format with ``serialize_method='data_mask'``.


### PR DESCRIPTION
I thought I had dealt with `.info` in the original implementation, but I clearly missed updating it in viewing or slicing. With this change, ``MaskedQuantity`` can now be correctly written to, e.g., ECSV format with ``serialize_method='data_mask'``. So, added tests for serialization of masked quantities. It should also fix the one remaining issue in using `Masked` inside `Time`.


<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to address ...

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will
review this pull request of some common things to look for. This list
is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] If the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
