### PR TITLE
Fix FITS serialization of multi-D masked columns.

### DIFF
--- a/astropy/io/fits/connect.py
+++ b/astropy/io/fits/connect.py
@@ -225,15 +225,19 @@ def read_table_fits(input, hdu=None, astropy_native=False, memmap=False,
         # presence of FITS mask values. For integer columns, this is simply
         # the null header, for float and complex, the presence of NaN, and for
         # string, empty strings.
+        # Since Multi-element columns with dtypes such as '2f8' have a subdtype,
+        # we should look up the type of column on that.
         masked = mask = False
+        coltype = (col.dtype.subdtype[0].type if col.dtype.subdtype
+                   else col.dtype.type)
         if col.null is not None:
             mask = data[col.name] == col.null
             # Return a MaskedColumn even if no elements are masked so
             # we roundtrip better.
             masked = True
-        elif issubclass(col.dtype.type, np.inexact):
+        elif issubclass(coltype, np.inexact):
             mask = np.isnan(data[col.name])
-        elif issubclass(col.dtype.type, np.character):
+        elif issubclass(coltype, np.character):
             mask = col.array == b''
 
         if masked or np.any(mask):

--- a/astropy/io/fits/convenience.py
+++ b/astropy/io/fits/convenience.py
@@ -507,11 +507,15 @@ def table_to_hdu(table, character_as_bytes=False):
         default_fill_value = np.ma.default_fill_value(tarray.dtype)
         for colname, (coldtype, _) in tarray.dtype.fields.items():
             if np.all(tarray.fill_value[colname] == default_fill_value[colname]):
-                if issubclass(coldtype.type, np.complexfloating):
+                # Since multi-element columns with dtypes such as '2f8' have
+                # a subdtype, we should look up the type of column on that.
+                coltype = (coldtype.subdtype[0].type
+                           if coldtype.subdtype else coldtype.type)
+                if issubclass(coltype, np.complexfloating):
                     tarray.fill_value[colname] = complex(np.nan, np.nan)
-                elif issubclass(coldtype.type, np.inexact):
+                elif issubclass(coltype, np.inexact):
                     tarray.fill_value[colname] = np.nan
-                elif issubclass(coldtype.type, np.character):
+                elif issubclass(coltype, np.character):
                     tarray.fill_value[colname] = ''
 
         # TODO: it might be better to construct the FITS table directly from

--- a/astropy/io/fits/tests/test_connect.py
+++ b/astropy/io/fits/tests/test_connect.py
@@ -183,28 +183,42 @@ class TestSingleTable:
 
     @pytest.mark.parametrize('masked', [True, False])
     def test_masked_nan(self, masked, tmpdir):
+        """Check that masked values by default are replaced by NaN.
+
+        This should work for any shape and be independent of whether the
+        Table is formally masked or not.
+
+        """
         filename = str(tmpdir.join('test_masked_nan.fits'))
         a = np.ma.MaskedArray([5.25, 8.5, 3.75, 6.25], mask=[1, 0, 1, 0])
         b = np.ma.MaskedArray([2.5, 4.5, 6.75, 8.875], mask=[1, 0, 0, 1], dtype='f4')
-        t1 = Table([a, b], names=['a', 'b'], masked=masked)
+        c = np.ma.stack([a, b], axis=-1)
+        t1 = Table([a, b, c], names=['a', 'b', 'c'], masked=masked)
         t1.write(filename, overwrite=True)
         t2 = Table.read(filename)
         assert_array_equal(t2['a'].data, [np.nan, 8.5, np.nan, 6.25])
         assert_array_equal(t2['b'].data, [np.nan, 4.5, 6.75, np.nan])
+        assert_array_equal(t2['c'].data, np.stack([t2['a'].data, t2['b'].data],
+                                                  axis=-1))
         assert np.all(t1['a'].mask == t2['a'].mask)
         assert np.all(t1['b'].mask == t2['b'].mask)
+        assert np.all(t1['c'].mask == t2['c'].mask)
 
     def test_masked_serialize_data_mask(self, tmpdir):
         filename = str(tmpdir.join('test_masked_nan.fits'))
         a = np.ma.MaskedArray([5.25, 8.5, 3.75, 6.25], mask=[1, 0, 1, 0])
         b = np.ma.MaskedArray([2.5, 4.5, 6.75, 8.875], mask=[1, 0, 0, 1])
-        t1 = Table([a, b], names=['a', 'b'])
-        t1.write(filename, overwrite=True, serialize_method='data_mask')
+        c = np.ma.stack([a, b], axis=-1)
+        t1 = Table([a, b, c], names=['a', 'b', 'c'])
+        t1.write(filename, overwrite=True)
         t2 = Table.read(filename)
         assert_array_equal(t2['a'].data, [5.25, 8.5, 3.75, 6.25])
         assert_array_equal(t2['b'].data, [2.5, 4.5, 6.75, 8.875])
+        assert_array_equal(t2['c'].data, np.stack([t2['a'].data, t2['b'].data],
+                                                  axis=-1))
         assert np.all(t1['a'].mask == t2['a'].mask)
         assert np.all(t1['b'].mask == t2['b'].mask)
+        assert np.all(t1['c'].mask == t2['c'].mask)
 
     def test_read_from_fileobj(self, tmpdir):
         filename = str(tmpdir.join('test_read_from_fileobj.fits'))

--- a/docs/changes/io.fits/11911.bugfix.rst
+++ b/docs/changes/io.fits/11911.bugfix.rst
@@ -1,0 +1,1 @@
+Ensure multidimensional masked columns round-trip properly to FITS.


### PR DESCRIPTION
Ensure multi-dimensional masked columns also round-trip to fits.

Sorry, @taldcroft, for the flurry of small PRs, but all things figured out while getting the PR for using `Masked` for masked `Time` ready... This was clearly an oversight in the implementation.
I think in principle it could be backported to 4.0.6, but probably not quite worth it - it seems unlikely we'll have another 4.0 bugfix release before 5.0.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will
review this pull request of some common things to look for. This list
is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] If the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
