### PR TITLE
Ensure multi-D masked times roundtrip to FITS

### DIFF
--- a/docs/changes/io.fits/11913.bugfix.rst
+++ b/docs/changes/io.fits/11913.bugfix.rst
@@ -1,0 +1,1 @@
+Ensure masked times round-trip to fits, even if multi-dimensional.

--- a/docs/changes/io.fits/11913.bugfix.rst
+++ b/docs/changes/io.fits/11913.bugfix.rst
@@ -1,1 +1,1 @@
-Ensure masked times round-trip to fits, even if multi-dimensional.
+Ensure masked times round-trip to FITS, even if multi-dimensional.


### PR DESCRIPTION
The title says it all. EDIT: #11911 now merged so no longer a WIP ~Creating as WIP since this include #11911 and surely the changelog bot is going to complain about 2 entries. To judge this, just look at the second commit.~

cc also @aaryapatil since this touches the fitstime code.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will
review this pull request of some common things to look for. This list
is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] If the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
