### PR TITLE
IO registry `write` returns results

### DIFF
--- a/astropy/io/registry.py
+++ b/astropy/io/registry.py
@@ -567,7 +567,7 @@ def write(data, *args, format=None, **kwargs):
             'write', data.__class__, path, fileobj, args, kwargs)
 
     writer = get_writer(format, data.__class__)
-    writer(data, *args, **kwargs)
+    return writer(data, *args, **kwargs)
 
 
 def _is_best_match(class1, class2, format_classes):

--- a/astropy/io/tests/test_registry.py
+++ b/astropy/io/tests/test_registry.py
@@ -401,6 +401,13 @@ def test_read_valid_return():
     assert isinstance(t, TestData)
 
 
+def test_write_return():
+    """Most writers will return None, but other values are not forbidden."""
+    io_registry.register_writer('test', TestData, lambda *args: True)
+    res = TestData.write(TestData(), format="test")
+    assert res is True
+
+
 def test_non_existing_unknown_ext():
     """Raise the correct error when attempting to read a non-existing
     file with an unknown extension."""

--- a/docs/changes/io.registry/11916.api.rst
+++ b/docs/changes/io.registry/11916.api.rst
@@ -1,0 +1,1 @@
+The ``write`` function now returns content results.

--- a/docs/changes/io.registry/11916.api.rst
+++ b/docs/changes/io.registry/11916.api.rst
@@ -1,1 +1,3 @@
-The ``write`` function now returns content results.
+The ``write`` function now is allowed to return possible content results, which
+means that custom writers could, for example, create and return an instance of
+some container class rather than a file on disk.

--- a/docs/io/registry.rst
+++ b/docs/io/registry.rst
@@ -106,6 +106,7 @@ above, we can write a custom writer::
 
    def my_table_writer(table, filename, overwrite=False):
        ...  # Write the table out to a file
+       return ...  # generally None, but other values are not forbidden.
 
 Writer functions should take a dataset object (either an instance of the
 :class:`~astropy.table.Table` or :class:`~astropy.nddata.NDData`


### PR DESCRIPTION
This shouldn't change anything for existing writers, but allows for registered write methods to return something, if they so choose.

Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>


### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will
review this pull request of some common things to look for. This list
is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] If the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
