### PR TITLE
Ensure MaskedColumn(masked_column) propagates info.serialize_method.

### DIFF
--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -807,19 +807,9 @@ def write(table, output=None, format=None, Writer=None, fast_writer=True, *,
     if isinstance(table, Table):
         # While we are only going to read data from columns, we may need to
         # to adjust info attributes such as format, so we make a shallow copy.
-        new_tbl = table.__class__(table, names=names, copy=False)
-
-        # This makes a copy of the table columns.  This is subject to a
-        # corner-case problem if writing a table with masked columns to ECSV
-        # where serialize_method is set to 'data_mask'.  In this case that
-        # attribute gets dropped in the copy, so do the copy here.  This
-        # should be removed when `info` really contains all the attributes
-        # (#6720).
-        for new_col, col in zip(new_tbl.itercols(), table.itercols()):
-            if isinstance(col, MaskedColumn):
-                new_col.info.serialize_method = col.info.serialize_method
-        table = new_tbl
+        table = table.__class__(table, names=names, copy=False)
     else:
+        # Otherwise, create a table from the input.
         table = Table(table, names=names, copy=False)
 
     table0 = table[:0].copy()

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -536,6 +536,8 @@ class BaseColumn(_ColumnGetitemShim, np.ndarray):
         if not hasattr(self, 'indices'):  # may have been copied in __new__
             self.indices = []
         self._copy_attrs(obj)
+        if 'info' in getattr(obj, '__dict__', {}):
+            self.info = obj.info
 
     def __array_wrap__(self, out_arr, context=None):
         """
@@ -1393,6 +1395,10 @@ class MaskedColumn(Column, _MaskedColumnGetitemShim, ma.MaskedArray):
                                unit=unit, format=format, description=description,
                                meta=meta, copy=copy, copy_indices=copy_indices)
         self = ma.MaskedArray.__new__(cls, data=self_data, mask=mask)
+        # The above process preserves info relevant for Column, but this does not
+        # include serialize_method relevant for MaskedColumn.
+        if isinstance(data, MaskedColumn) and 'info' in getattr(data, '__dict__', {}):
+            self.info.serialize_method = data.info.serialize_method
 
         # Note: do not set fill_value in the MaskedArray constructor because this does not
         # go through the fill_value workarounds.

--- a/astropy/table/tests/test_column.py
+++ b/astropy/table/tests/test_column.py
@@ -922,7 +922,7 @@ def test_column_value_access():
 
 
 def test_masked_column_serialize_method_propagation():
-    mc = table.MaskedColumn([1., 2.], mask=[True, False])
+    mc = table.MaskedColumn([1., 2., 3.], mask=[True, False, True])
     assert mc.info.serialize_method['ecsv'] == 'null_value'
     mc.info.serialize_method['ecsv'] = 'data_mask'
     assert mc.info.serialize_method['ecsv'] == 'data_mask'
@@ -932,3 +932,5 @@ def test_masked_column_serialize_method_propagation():
     assert mc3.info.serialize_method['ecsv'] == 'data_mask'
     mc4 = mc.view(table.MaskedColumn)
     assert mc4.info.serialize_method['ecsv'] == 'data_mask'
+    mc5 = mc[1:]
+    assert mc5.info.serialize_method['ecsv'] == 'data_mask'

--- a/astropy/table/tests/test_column.py
+++ b/astropy/table/tests/test_column.py
@@ -919,3 +919,16 @@ def test_column_value_access():
     assert type(tbl['b'].value) == np.ma.MaskedArray
     assert type(tbl['c'].value) == np.ndarray
     assert type(tbl['d'].value) == np.ndarray
+
+
+def test_masked_column_serialize_method_propagation():
+    mc = table.MaskedColumn([1., 2.], mask=[True, False])
+    assert mc.info.serialize_method['ecsv'] == 'null_value'
+    mc.info.serialize_method['ecsv'] = 'data_mask'
+    assert mc.info.serialize_method['ecsv'] == 'data_mask'
+    mc2 = mc.copy()
+    assert mc2.info.serialize_method['ecsv'] == 'data_mask'
+    mc3 = table.MaskedColumn(mc)
+    assert mc3.info.serialize_method['ecsv'] == 'data_mask'
+    mc4 = mc.view(table.MaskedColumn)
+    assert mc4.info.serialize_method['ecsv'] == 'data_mask'

--- a/docs/changes/table/11917.bugfix.rst
+++ b/docs/changes/table/11917.bugfix.rst
@@ -1,0 +1,3 @@
+Ensured that ``MaskedColumn.info`` is propagated in all cases, so that when
+tables are sliced, writing will still be as reques on
+``info.serialize_method``.

--- a/docs/changes/table/11917.bugfix.rst
+++ b/docs/changes/table/11917.bugfix.rst
@@ -1,3 +1,3 @@
 Ensured that ``MaskedColumn.info`` is propagated in all cases, so that when
-tables are sliced, writing will still be as reques on
+tables are sliced, writing will still be as requested on
 ``info.serialize_method``.


### PR DESCRIPTION
There was a work-around for that in io/ascii/ui.py that can now be removed.

Also ensured .view and .copy propagate .info correctly by adjusting `__array_finalize__`.

Despite the latter, felt this was more of a refactoring than a bug fix, but am happy to change that (in which case this would be for 4.3.1, I guess).

Saw this while trying to get `Masked` to propagate properly and wondered if this also was an 'info doesn't propagate right' problem. Turns out it was! Still puzzling a bit over why the table is copied there (#7605), and will see if I can solve that too. But one issue at a time!

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
