### PR TITLE
When writing a table, make only a shallow copy

### DIFF
--- a/astropy/io/ascii/tests/test_write.py
+++ b/astropy/io/ascii/tests/test_write.py
@@ -848,3 +848,20 @@ def test_multidim_column_error(fmt_name_class):
     fast = fmt_name in ascii.core.FAST_CLASSES
     with pytest.raises(ValueError, match=r'column\(s\) with dimension'):
         ascii.write(t, out, format=fmt_name, fast_writer=fast)
+
+
+@pytest.mark.parametrize("fast_writer", [True, False])
+def test_write_as_columns(fast_writer):
+    """
+    Test that writing a set of columns also roundtrips (as long as the
+    table does not have metadata, etc.)
+    """
+    # Use masked in case that makes it more difficult.
+    data = ascii.read(tab_to_fill)
+    data = table.Table(data, masked=True)
+    data['a'].mask = [True, False]
+    data['c'].mask = [False, True]
+    data = list(data.columns.values())
+
+    for test_def in test_def_masked_fill_value:
+        check_write_table(test_def, data, fast_writer)

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -805,10 +805,9 @@ def write(table, output=None, format=None, Writer=None, fast_writer=True, *,
     # Ensure that `table` is a Table subclass.
     names = kwargs.get('names')
     if isinstance(table, Table):
-        # Note that making a copy of the table here is inefficient but
-        # without this copy a number of tests break (e.g. in test_fixedwidth).
-        # See #7605.
-        new_tbl = table.__class__(table, names=names)
+        # While we are only going to read data from columns, we may need to
+        # to adjust info attributes such as format, so we make a shallow copy.
+        new_tbl = table.__class__(table, names=names, copy=False)
 
         # This makes a copy of the table columns.  This is subject to a
         # corner-case problem if writing a table with masked columns to ECSV
@@ -821,7 +820,7 @@ def write(table, output=None, format=None, Writer=None, fast_writer=True, *,
                 new_col.info.serialize_method = col.info.serialize_method
         table = new_tbl
     else:
-        table = Table(table, names=names)
+        table = Table(table, names=names, copy=False)
 
     table0 = table[:0].copy()
     core._apply_include_exclude_names(table0, kwargs.get('names'),

--- a/docs/changes/io.ascii/11919.other.rst
+++ b/docs/changes/io.ascii/11919.other.rst
@@ -1,0 +1,4 @@
+When writing, the input data are no longer copied, improving performance.
+Metadata that might be changed, such as format and serialization
+information, is copied, hence users can continue on there being no
+changes to the input data.


### PR DESCRIPTION
I looked into the errors that occur when writing a table without first making a copy. It is clear the problem is that the writer can set `info` properties such as `format` - obviously, these should not propagate back to the input table. A copy avoids this, but it is not necessary for this to be a deep copy.

<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->


<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #7605

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
