### PR TITLE
Remove unncessary ABC registrations for _CardAccessor

### DIFF
--- a/astropy/io/fits/header.py
+++ b/astropy/io/fits/header.py
@@ -2140,10 +2140,6 @@ class _CardAccessor:
         return False
 
 
-collections.abc.Mapping.register(_CardAccessor)
-collections.abc.Sequence.register(_CardAccessor)
-
-
 class _HeaderComments(_CardAccessor):
     """
     A class used internally by the Header class for the Header.comments

--- a/docs/changes/io.fits/11923.api.rst
+++ b/docs/changes/io.fits/11923.api.rst
@@ -1,0 +1,2 @@
+The internal class _CardAccessor is no longer registered as a subclass of
+the Sequence or Mapping ABCs.


### PR DESCRIPTION
Since this is just an internal class anyways I don't think it provides
any value, and in the case of Mapping it was simply incorrect.

I kept the ABC registrations for Header itself since it correctly
implements the interfaces for MutableSequence and MutableMapping AFAICT.

Fixes #11866

### Checklist for package maintainer(s)

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
