### PR TITLE
Add registry of cosmology classes

### DIFF
--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -82,6 +82,10 @@ a_B_c2 = 4e-3 * const.sigma_sb.value / const.c.value ** 3
 kB_evK = const.k_B.to(u.eV / u.K)
 
 
+# registry of cosmology classes with {key=name : value=class}
+_COSMOLOGY_CLASSES = dict()
+
+
 class CosmologyError(Exception):
     pass
 
@@ -105,7 +109,6 @@ class Cosmology(metaclass=ABCMeta):
     Class instances are static -- you cannot (and should not) change the values
     of the parameters.  That is, all of the above attributes (except meta) are
     read only.
-
     """
 
     meta = MetaData()
@@ -116,6 +119,8 @@ class Cosmology(metaclass=ABCMeta):
         sig = signature(cls.__init__)
         sig = sig.replace(parameters=list(sig.parameters.values())[1:])
         cls._init_signature = sig  # store (immutable) initialization signature
+
+        _COSMOLOGY_CLASSES[cls.__qualname__] = cls
 
     def __new__(cls, *args, **kwargs):
         # bundle initialization argument

--- a/astropy/cosmology/tests/test_cosmology.py
+++ b/astropy/cosmology/tests/test_cosmology.py
@@ -3,16 +3,16 @@
 from io import StringIO
 
 import pytest
+
 import numpy as np
 
+import astropy.constants as const
+import astropy.units as u
 from astropy.cosmology import core, funcs, realizations
-from astropy.cosmology.realizations import Planck13, Planck15, Planck18, WMAP5, WMAP7, WMAP9
+from astropy.cosmology.realizations import WMAP5, WMAP7, WMAP9, Planck13, Planck15, Planck18
 from astropy.units import allclose
-from astropy import constants as const
-from astropy import units as u
-from astropy.utils.exceptions import (AstropyDeprecationWarning,
-                                      AstropyUserWarning)
 from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa
+from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyUserWarning
 
 
 def test_init():


### PR DESCRIPTION
Add a private registry of cosmology classes.
(the `test_cosmology` changes are from running `isort`. I ended up not writing a test because it's tested in `realizations.py`, but it's worth keeping the imports cleanup)

Suggested Tag: no-changelog-entry-needed
Request Review: @mhvk  (PR arose from a discussion on this)

Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
