### PR TITLE
Ensure that `SkyCoord.apply_space_motion()` respects differential types

### DIFF
--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -811,7 +811,13 @@ class SkyCoord(ShapedLikeNDArray):
         frattrs = {attrnm: getattr(self, attrnm)
                    for attrnm in self._extra_frameattr_names}
         frattrs['obstime'] = new_obstime
-        return self.__class__(icrs2, **frattrs).transform_to(self.frame)
+        result = self.__class__(icrs2, **frattrs).transform_to(self.frame)
+
+        # Without this the output might not have the right differential type.
+        # Not sure if this fixes the problem or just hides it.  See #11932
+        result.differential_type = self.differential_type
+
+        return result
 
     def _is_name(self, string):
         """

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -1679,7 +1679,7 @@ def test_apply_space_motion():
     assert isinstance(applied1.frame, c1.frame.__class__)
     assert isinstance(applied2.frame, c1.frame.__class__)
     assert_allclose(applied1.ra, applied2.ra)
-    assert_allclose(applied1.pm_ra, applied2.pm_ra)
+    assert_allclose(applied1.pm_ra_cosdec, applied2.pm_ra_cosdec)
     assert_allclose(applied1.dec, applied2.dec)
     assert_allclose(applied1.distance, applied2.distance)
 

--- a/docs/changes/coordinates/11932.bugfix.rst
+++ b/docs/changes/coordinates/11932.bugfix.rst
@@ -1,0 +1,2 @@
+The output of ``SkyCoord.apply_space_motion()`` now always has the same
+differential type as the ``SkyCoord`` itself.


### PR DESCRIPTION
### Description

The `SkyCoord.apply_space_motion()` method ensures that its output is in the same coordinate system as the `SkyCoord` itself, but it does not ensure that the `differential_type` of the output matches that of the `SkyCoord`. This pull request fixes that oversight.

It is important to point out that this pull request might cause problems for code that is adapted to the current behavior. Would a change log entry be enough to notify users of possible backwards compatibility issues or is a more complicated solution required?

Fixes #11761

EDIT: Looks like the issue with differential types was caused by `SkyCoord.transform_to()`. Adding a single line of code there fixes both `transform_to()` and `apply_space_motion()`.

EDIT2: Updating `transform_to()` is not as simple as it seemed, so this pull request will only update `apply_space_motion()`.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
