### PR TITLE
Dropping support for numpy 1.17

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,5 +54,5 @@ workflows:
   tests:
     jobs:
       - image-tests-mpl302
-      - image-tests-mpl310
+#      - image-tests-mpl310
       - image-tests-mpldev

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -73,10 +73,10 @@ jobs:
             python: 3.7
             toxenv: py37-test-oldestdeps
 
-          - name: Python 3.8 with numpy 1.17 and full coverage
+          - name: Python 3.8 with numpy 1.18 and full coverage
             os: ubuntu-latest
             python: 3.8
-            toxenv: py38-test-alldeps-numpy117-cov-clocale
+            toxenv: py38-test-alldeps-numpy118-cov-clocale
             toxposargs: --remote-data=astropy
 
           - name: Python 3.8 with all optional dependencies (Windows)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,7 +148,7 @@ package.
   * Are the [coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html) followed?
   * Is the code compatible with Python >=3.7?
   * Are there dependencies other than the `astropy` core, the Python Standard
-    Library, and NumPy 1.17.0 or later?
+    Library, and NumPy 1.18.0 or later?
     * Is the package importable even if the C-extensions are not built?
     * Are additional dependencies handled appropriately?
     * Do functions that require additional dependencies raise an `ImportError`

--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -269,17 +269,6 @@ def treat_deprecations_as_exceptions():
             for s in _warnings_to_ignore_by_pyver[v]:
                 warnings.filterwarnings("ignore", s[0], s[1])
 
-    # If using Matplotlib < 3, we should ignore the following warning since
-    # this is beyond our control
-    try:
-        import matplotlib
-    except ImportError:
-        pass
-    else:
-        if matplotlib.__version__[0] < '3':
-            warnings.filterwarnings('ignore', category=DeprecationWarning,
-                                    module='numpy.lib.type_check')
-
 
 # TODO: Plan a roadmap of deprecation as pytest.warns has matured over the years.
 # See https://github.com/astropy/astropy/issues/6761

--- a/astropy/units/quantity_helper/function_helpers.py
+++ b/astropy/units/quantity_helper/function_helpers.py
@@ -42,7 +42,7 @@ import numpy as np
 
 from astropy.units.core import (
     UnitsError, UnitTypeError, dimensionless_unscaled)
-from astropy.utils.compat import NUMPY_LT_1_18, NUMPY_LT_1_20
+from astropy.utils.compat import NUMPY_LT_1_20
 from astropy.utils import isiterable
 
 # In 1.17, overrides are enabled by default, but it is still possible to
@@ -91,9 +91,6 @@ SUBCLASS_SAFE_FUNCTIONS |= {
     np.apply_along_axis, np.take_along_axis, np.put_along_axis,
     np.linalg.cond, np.linalg.multi_dot}
 
-if NUMPY_LT_1_18:
-    SUBCLASS_SAFE_FUNCTIONS |= {np.alen}
-
 # Implemented as methods on Quantity:
 # np.ediff1d is from setops, but we support it anyway; the others
 # currently return NotImplementedError.
@@ -116,7 +113,7 @@ UNSUPPORTED_FUNCTIONS |= {np.linalg.slogdet}
 # test_quantity_non_ufuncs.py)
 IGNORED_FUNCTIONS = {
     # Deprecated
-    np.asscalar,
+    np.asscalar, np.alen,
     # I/O - useless for Quantity, since no way to store the unit.
     np.save, np.savez, np.savetxt, np.savez_compressed,
     # Polynomials
@@ -127,10 +124,6 @@ if NUMPY_LT_1_20:
     IGNORED_FUNCTIONS |= {np.fv, np.ipmt, np.irr, np.mirr, np.nper,
                           np.npv, np.pmt, np.ppmt, np.pv, np.rate}
 
-if NUMPY_LT_1_18:
-    IGNORED_FUNCTIONS |= {np.rank}
-else:
-    IGNORED_FUNCTIONS |= {np.alen}
 UNSUPPORTED_FUNCTIONS |= IGNORED_FUNCTIONS
 
 

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -11,7 +11,7 @@ from astropy import units as u
 from astropy.units.quantity_helper.function_helpers import (
     ARRAY_FUNCTION_ENABLED, SUBCLASS_SAFE_FUNCTIONS, UNSUPPORTED_FUNCTIONS,
     FUNCTION_HELPERS, DISPATCHED_FUNCTIONS, IGNORED_FUNCTIONS)
-from astropy.utils.compat import NUMPY_LT_1_18, NUMPY_LT_1_20
+from astropy.utils.compat import NUMPY_LT_1_20
 
 
 needs_array_function = pytest.mark.xfail(
@@ -82,11 +82,6 @@ class NoUnitTestSetup(BasicTestSetup):
 
 
 class TestShapeInformation(BasicTestSetup):
-    # alen is deprecated in Numpy 1.8
-    if NUMPY_LT_1_18:
-        def test_alen(self):
-            assert np.alen(self.q) == 3
-
     def test_shape(self):
         assert np.shape(self.q) == (3, 3)
 
@@ -2044,13 +2039,7 @@ if NUMPY_LT_1_20:
                            if f in np.lib.financial.__dict__.values()}
     untested_functions |= financial_functions
 
-deprecated_functions = {
-    np.asscalar
-    }
-if NUMPY_LT_1_18:
-    deprecated_functions |= {np.rank}
-else:
-    deprecated_functions |= {np.alen}
+deprecated_functions = {np.asscalar, np.alen}
 
 untested_functions |= deprecated_functions
 io_functions = {np.save, np.savez, np.savetxt, np.savez_compressed}

--- a/astropy/utils/compat/numpycompat.py
+++ b/astropy/utils/compat/numpycompat.py
@@ -5,12 +5,11 @@ earlier versions of Numpy.
 """
 from astropy.utils import minversion
 
-__all__ = ['NUMPY_LT_1_18', 'NUMPY_LT_1_19', 'NUMPY_LT_1_20', 'NUMPY_LT_1_22']
+__all__ = ['NUMPY_LT_1_19', 'NUMPY_LT_1_20', 'NUMPY_LT_1_22']
 
 # TODO: It might also be nice to have aliases to these named for specific
 # features/bugs we're checking for (ex:
 # astropy.table.table._BROKEN_UNICODE_TABLE_SORT)
-NUMPY_LT_1_18 = not minversion('numpy', '1.18')
 NUMPY_LT_1_19 = not minversion('numpy', '1.19')
 NUMPY_LT_1_20 = not minversion('numpy', '1.20')
 NUMPY_LT_1_22 = not minversion('numpy', '1.22')

--- a/astropy/utils/masked/function_helpers.py
+++ b/astropy/utils/masked/function_helpers.py
@@ -13,8 +13,7 @@ import numpy as np
 
 from astropy.units.quantity_helper.function_helpers import (
     FunctionAssigner)
-from astropy.utils.compat import NUMPY_LT_1_18, NUMPY_LT_1_19, NUMPY_LT_1_20
-
+from astropy.utils.compat import NUMPY_LT_1_19, NUMPY_LT_1_20
 
 # This module should not really be imported, but we define __all__
 # such that sphinx can typeset the functions with docstrings.
@@ -80,9 +79,7 @@ Issues or PRs for support for functions are very welcome.
 # Almost all from np.core.fromnumeric defer to methods so are OK.
 MASKED_SAFE_FUNCTIONS |= set(
     getattr(np, name) for name in np.core.fromnumeric.__all__
-    if name not in ({'choose', 'put', 'resize', 'searchsorted', 'where'}
-                    | {'rank' if NUMPY_LT_1_18 else 'alen'}))
-
+    if name not in ({'choose', 'put', 'resize', 'searchsorted', 'where', 'alen'}))
 
 MASKED_SAFE_FUNCTIONS |= {
     # built-in from multiarray
@@ -117,7 +114,7 @@ MASKED_SAFE_FUNCTIONS |= {
 
 IGNORED_FUNCTIONS = {
     # Deprecated
-    np.asscalar,
+    np.asscalar, np.alen,
     # I/O - useless for Masked, since no way to store the mask.
     np.save, np.savez, np.savetxt, np.savez_compressed,
     # Polynomials
@@ -127,10 +124,6 @@ if NUMPY_LT_1_20:
     # financial
     IGNORED_FUNCTIONS |= {np.fv, np.ipmt, np.irr, np.mirr, np.nper,
                           np.npv, np.pmt, np.ppmt, np.pv, np.rate}
-if NUMPY_LT_1_18:
-    IGNORED_FUNCTIONS |= {np.rank}
-else:
-    IGNORED_FUNCTIONS |= {np.alen}
 
 # TODO: some of the following could in principle be supported.
 IGNORED_FUNCTIONS |= {

--- a/astropy/utils/masked/tests/test_function_helpers.py
+++ b/astropy/utils/masked/tests/test_function_helpers.py
@@ -18,7 +18,7 @@ import pytest
 import numpy as np
 from numpy.testing import assert_array_equal
 
-from astropy.utils.compat import NUMPY_LT_1_18, NUMPY_LT_1_19, NUMPY_LT_1_20
+from astropy.utils.compat import NUMPY_LT_1_19, NUMPY_LT_1_20
 from astropy.units.tests.test_quantity_non_ufuncs import (
     get_wrapped_functions)
 
@@ -71,11 +71,6 @@ class InvariantMaskTestSetup(MaskedArraySetup):
 
 
 class TestShapeInformation(BasicTestSetup):
-    # alen is deprecated in Numpy 1.8
-    if NUMPY_LT_1_18:
-        def test_alen(self):
-            assert np.alen(self.ma) == 2
-
     def test_shape(self):
         assert np.shape(self.ma) == (2, 3)
 
@@ -1240,8 +1235,6 @@ deprecated_functions = {
     np.asscalar,
     np.alen,
     }
-if NUMPY_LT_1_18:
-    deprecated_functions |= {np.rank}
 
 untested_functions |= deprecated_functions
 io_functions = {np.save, np.savez, np.savetxt, np.savez_compressed}

--- a/docs/changes/11935.other.rst
+++ b/docs/changes/11935.other.rst
@@ -1,0 +1,1 @@
+Minimum version of required Numpy is now 1.18.

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ zip_safe = False
 tests_require = pytest-astropy
 setup_requires = setuptools_scm
 install_requires =
-    numpy>=1.17
+    numpy>=1.18
     pyerfa>=2.0
     PyYAML>=3.13
     importlib-metadata ; python_version == '3.7'

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{37,38,39,dev}-test{,-recdeps,-alldeps,-oldestdeps,-devdeps,-numpy117,-numpy118,-numpy119}{,-cov}{,-clocale}
+    py{38,39,dev}-test{,-recdeps,-alldeps,-oldestdeps,-devdeps,-numpy118,-numpy119,-numpy120,-numpy121}{,-cov}{,-clocale}
     build_docs
     linkcheck
     codestyle
@@ -50,26 +50,27 @@ description =
     devdeps: with the latest developer version of key dependencies
     oldestdeps: with the oldest supported version of key dependencies
     cov: and test coverage
-    numpy117: with numpy 1.17.*
     numpy118: with numpy 1.18.*
     numpy119: with numpy 1.19.*
+    numpy120: with numpy 1.20.*
+    numpy121: with numpy 1.21.*
     image: with image tests
     mpldev: with the latest developer version of matplotlib
     double: twice in a row to check for global state changes
 
 deps =
-
     py37: importlib-metadata<3.9
 
-    numpy117: numpy==1.17.*
     numpy118: numpy==1.18.*
     numpy119: numpy==1.19.*
+    numpy120: numpy==1.20.*
+    numpy121: numpy==1.21.*
 
     image: pytest-mpl
 
     # The oldestdeps factor is intended to be used to install the oldest versions of all
     # dependencies that have a minimum version.
-    oldestdeps: numpy==1.17.*
+    oldestdeps: numpy==1.18.*
     oldestdeps: matplotlib==3.0.*
     oldestdeps: asdf==2.6.*
     oldestdeps: scipy==1.1.*


### PR DESCRIPTION
Second part of #11934 due to changelog issues , dropping numpy

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
