### PR TITLE
DOC: minor docstring updates in _KnuthF class

### DIFF
--- a/astropy/stats/histogram.py
+++ b/astropy/stats/histogram.py
@@ -376,7 +376,7 @@ class _KnuthF:
         self.gammaln = special.gammaln
 
     def bins(self, M):
-        """Return the bin edges given a width dx"""
+        """Return the bin edges given M number of bins"""
         return np.linspace(self.data[0], self.data[-1], int(M) + 1)
 
     def __call__(self, M):
@@ -387,13 +387,13 @@ class _KnuthF:
 
         Parameters
         ----------
-        dx : float
-            Width of bins
+        M : int
+            Number of bins
 
         Returns
         -------
         F : float
-            evaluation of the negative Knuth likelihood function:
+            evaluation of the negative Knuth loglikelihood function:
             smaller values indicate a better fit.
         """
         M = int(M)


### PR DESCRIPTION
### Description

This PR updates the docstrings of the class ``_KnuthF`` so as to make it consistent with the inputs of its methods.  In particular the docstrings of `eval` and `bin` refer the input as `dx` (the width of a bin), when it actually takes `M` (the number of bins) as the actual input. 

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
