### PR TITLE
Add exptime_oir_ccd, inverse of signal_to_noise_oir_ccd

### DIFF
--- a/astropy/stats/tests/test_funcs.py
+++ b/astropy/stats/tests/test_funcs.py
@@ -2,6 +2,8 @@
 
 import pytest
 
+from hypothesis import given
+from hypothesis.strategies import floats
 import numpy as np
 from numpy.testing import assert_equal, assert_allclose
 
@@ -257,6 +259,21 @@ def test_signal_to_noise_oir_ccd():
     # make sure snr increases with time
     result = funcs.signal_to_noise_oir_ccd(2, 25, 0, 0, 0, 1)
     assert result > 5.0
+
+
+@given(t=floats(min_value=1, max_value=1e9),
+       source_eps=floats(min_value=1, max_value=1e9),
+       sky_eps=floats(min_value=0, max_value=1e9),
+       dark_eps=floats(min_value=0, max_value=1e9),
+       rd=floats(min_value=0, max_value=1e9),
+       npix=floats(min_value=0, max_value=1e9),
+       gain=floats(min_value=1, max_value=1e9))
+def test_exptime_oir_ccd(t, source_eps, sky_eps, dark_eps, rd, npix, gain):
+    snr = funcs.signal_to_noise_oir_ccd(
+        t, source_eps, sky_eps, dark_eps, rd, npix, gain=gain)
+    t_result = funcs.exptime_oir_ccd(
+        snr, source_eps, sky_eps, dark_eps, rd, npix, gain=gain)
+    assert t_result == pytest.approx(t)
 
 
 def test_bootstrap():


### PR DESCRIPTION
### Description
This handy inverse function calculates the exposure time to achieve a given signal to noise ratio. The implementation is straightforward: it's just the quadratic formula.

I am using this in https://github.com/nasa/dorado-sensitivity, but I think astropy is a better home for this function.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
