### PR TITLE
Fix for printing angle, latitude, and longitude with a NaN in degrees.

### DIFF
--- a/astropy/coordinates/angles.py
+++ b/astropy/coordinates/angles.py
@@ -350,11 +350,17 @@ class Angle(u.SpecificTypeQuantity):
                 "The unit value provided is not an angular unit.")
 
         def do_format(val):
-            s = func(float(val))
-            if alwayssign and not s.startswith('-'):
-                s = '+' + s
-            if format == 'latex':
-                s = f'${s}$'
+            #Check if value is finite to avoid ValueErrors when turning it into
+            #a hexagesimal string.
+            if np.isfinite(val):
+                s = func(float(val))
+                if alwayssign and not s.startswith('-'):
+                    s = '+' + s
+                if format == 'latex':
+                    s = f'${s}$'
+                return s
+            unit_string = unit.to_string(format=format)
+            s = f"{val} {unit_string}"
             return s
 
         format_ufunc = np.vectorize(do_format, otypes=['U'])

--- a/astropy/coordinates/angles.py
+++ b/astropy/coordinates/angles.py
@@ -350,17 +350,16 @@ class Angle(u.SpecificTypeQuantity):
                 "The unit value provided is not an angular unit.")
 
         def do_format(val):
-            #Check if value is finite to avoid ValueErrors when turning it into
-            #a hexagesimal string.
-            if np.isfinite(val):
+            # Check if value is not nan to avoid ValueErrors when turning it into
+            # a hexagesimal string.
+            if not np.isnan(val):
                 s = func(float(val))
                 if alwayssign and not s.startswith('-'):
                     s = '+' + s
                 if format == 'latex':
                     s = f'${s}$'
                 return s
-            unit_string = unit.to_string(format=format)
-            s = f"{val} {unit_string}"
+            s = f"{val}"
             return s
 
         format_ufunc = np.vectorize(do_format, otypes=['U'])

--- a/astropy/coordinates/tests/test_angles.py
+++ b/astropy/coordinates/tests/test_angles.py
@@ -1046,3 +1046,21 @@ def test_angle_multithreading():
         Angle(angles, unit='hour')
     for i in range(10):
         threading.Thread(target=parse_test, args=(i,)).start()
+
+def test_print_longitude_nan():
+    """
+    Regression test for issue #11473
+    """
+    print(Longitude(np.nan * u.deg))
+
+def test_print_latitude_nan():
+    """
+    Regression test for issue #11473
+    """
+    print(Latitude(np.nan * u.deg))
+
+def test_print_angle_nan():
+    """
+    Regression test for issue #11473
+    """
+    print(Angle(np.nan * u.deg))

--- a/astropy/coordinates/tests/test_angles.py
+++ b/astropy/coordinates/tests/test_angles.py
@@ -1047,20 +1047,47 @@ def test_angle_multithreading():
     for i in range(10):
         threading.Thread(target=parse_test, args=(i,)).start()
 
-def test_print_longitude_nan():
+
+def test_print_longitude_nan(capsys):
     """
     Regression test for issue #11473
     """
     print(Longitude(np.nan * u.deg))
+    output, err = capsys.readouterr()
+    assert output == "nan deg\n"
+    print(Longitude(np.nan * u.rad))
+    output, err = capsys.readouterr()
+    assert output == "nan rad\n"
+    print(Longitude(np.nan * u.hour))
+    output, err = capsys.readouterr()
+    assert output == "nan hourangle\n"
 
-def test_print_latitude_nan():
+
+def test_print_latitude_nan(capsys):
     """
     Regression test for issue #11473
     """
     print(Latitude(np.nan * u.deg))
+    output, err = capsys.readouterr()
+    assert output == "nan deg\n"
+    print(Latitude(np.nan * u.rad))
+    output, err = capsys.readouterr()
+    assert output == "nan rad\n"
+    print(Latitude(np.nan * u.hour))
+    output, err = capsys.readouterr()
+    assert output == "nan hourangle\n"
 
-def test_print_angle_nan():
+
+def test_print_angle_nan(capsys):
     """
     Regression test for issue #11473
     """
     print(Angle(np.nan * u.deg))
+    output, err = capsys.readouterr()
+    assert output == "nan deg\n"
+    print(Angle(np.nan * u.rad))
+    output, err = capsys.readouterr()
+    assert output == "nan rad\n"
+    print(Angle(np.nan * u.hour))
+    output, err = capsys.readouterr()
+    assert output == "nan hourangle\n"

--- a/astropy/coordinates/tests/test_angles.py
+++ b/astropy/coordinates/tests/test_angles.py
@@ -1048,46 +1048,50 @@ def test_angle_multithreading():
         threading.Thread(target=parse_test, args=(i,)).start()
 
 
-def test_print_longitude_nan(capsys):
+@pytest.mark.parametrize("cls", [Angle, Longitude, Latitude])
+@pytest.mark.parametrize("input, expstr, exprepr",
+                         [(np.nan*u.deg,
+                           "nan",
+                           "nan deg"),
+                          ([np.nan, 5, 0]*u.deg,
+                           "[nan 5d00m00s 0d00m00s]",
+                           "[nan, 5., 0.] deg"),
+                          ([6, np.nan, 0]*u.deg,
+                           "[6d00m00s nan 0d00m00s]",
+                           "[6., nan, 0.] deg"),
+                          ([np.nan, np.nan, np.nan]*u.deg,
+                           "[nan nan nan]",
+                           "[nan, nan, nan] deg"),
+                          (np.nan*u.hour,
+                           "nan",
+                           "nan hourangle"),
+                          ([np.nan, 5, 0]*u.hour,
+                           "[nan 5h00m00s 0h00m00s]",
+                           "[nan, 5., 0.] hourangle"),
+                          ([6, np.nan, 0]*u.hour,
+                           "[6h00m00s nan 0h00m00s]",
+                           "[6., nan, 0.] hourangle"),
+                          ([np.nan, np.nan, np.nan]*u.hour,
+                           "[nan nan nan]",
+                           "[nan, nan, nan] hourangle"),
+                          (np.nan*u.rad,
+                           "nan",
+                           "nan rad"),
+                          ([np.nan, 1, 0]*u.rad,
+                           "[nan 1rad 0rad]",
+                           "[nan, 1., 0.] rad"),
+                          ([1.50, np.nan, 0]*u.rad,
+                           "[1.5rad nan 0rad]",
+                           "[1.5, nan, 0.] rad"),
+                          ([np.nan, np.nan, np.nan]*u.rad,
+                           "[nan nan nan]",
+                           "[nan, nan, nan] rad")])
+def test_str_repr_angles_nan(cls, input, expstr, exprepr):
     """
     Regression test for issue #11473
     """
-    print(Longitude(np.nan * u.deg))
-    output, err = capsys.readouterr()
-    assert output == "nan deg\n"
-    print(Longitude(np.nan * u.rad))
-    output, err = capsys.readouterr()
-    assert output == "nan rad\n"
-    print(Longitude(np.nan * u.hour))
-    output, err = capsys.readouterr()
-    assert output == "nan hourangle\n"
-
-
-def test_print_latitude_nan(capsys):
-    """
-    Regression test for issue #11473
-    """
-    print(Latitude(np.nan * u.deg))
-    output, err = capsys.readouterr()
-    assert output == "nan deg\n"
-    print(Latitude(np.nan * u.rad))
-    output, err = capsys.readouterr()
-    assert output == "nan rad\n"
-    print(Latitude(np.nan * u.hour))
-    output, err = capsys.readouterr()
-    assert output == "nan hourangle\n"
-
-
-def test_print_angle_nan(capsys):
-    """
-    Regression test for issue #11473
-    """
-    print(Angle(np.nan * u.deg))
-    output, err = capsys.readouterr()
-    assert output == "nan deg\n"
-    print(Angle(np.nan * u.rad))
-    output, err = capsys.readouterr()
-    assert output == "nan rad\n"
-    print(Angle(np.nan * u.hour))
-    output, err = capsys.readouterr()
-    assert output == "nan hourangle\n"
+    q = cls(input)
+    assert str(q) == expstr
+    # Deleting whitespaces since repr appears to be adding them for some values
+    # making the test fail.
+    assert repr(q).replace(" ", "") == f'<{cls.__name__}{exprepr}>'.replace(" ","")

--- a/docs/changes/coordinates/11943.bugfix.rst
+++ b/docs/changes/coordinates/11943.bugfix.rst
@@ -1,0 +1,1 @@
+NaN values are now printed for Angle, Latitude and Longitude in degrees.

--- a/docs/changes/coordinates/11943.bugfix.rst
+++ b/docs/changes/coordinates/11943.bugfix.rst
@@ -1,1 +1,1 @@
-NaN values are now printed for Angle, Latitude and Longitude in degrees.
+Fixed bug where Angle, Latitude and Longitude with NaN values could not be printed.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

Added a `np.isfinite(val)` check at the beginning of `do_format(val)` function. If value is NaN, function returns a string with `val`'s value (nan) and the degrees being used. This is what is going to be outputted.

Added tests that check if expected outputs are correct for each of the units if nan values are passed, since every value is going to be validated despite of its unit.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #11473

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
