### PR TITLE
Sort Cosmology imports

### DIFF
--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -2,24 +2,21 @@
 
 import copy
 import sys
-from math import acos, sin, cos, sqrt, pi, exp, log, floor
+import warnings
 from abc import ABCMeta, abstractmethod
 from inspect import signature
-import warnings
+from math import acos, cos, exp, floor, log, pi, sin, sqrt
 
 import numpy as np
-
-from . import scalar_inv_efuncs
 
 from astropy import constants as const
 from astropy import units as u
 from astropy.utils import isiterable
-from astropy.utils.exceptions import (AstropyDeprecationWarning,
-                                      AstropyUserWarning)
+from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyUserWarning
 from astropy.utils.metadata import MetaData
 from astropy.utils.state import ScienceState
-from astropy.utils.exceptions import AstropyUserWarning
 
+from . import scalar_inv_efuncs
 
 # Originally authored by Andrew Becker (becker@astro.washington.edu),
 # and modified by Neil Crighton (neilcrighton@gmail.com) and Roban

--- a/astropy/cosmology/funcs.py
+++ b/astropy/cosmology/funcs.py
@@ -4,10 +4,12 @@ Convenience functions for `astropy.cosmology`.
 """
 
 import warnings
+
 import numpy as np
 
 from astropy.units import Quantity
 from astropy.utils.exceptions import AstropyUserWarning
+
 from .core import CosmologyError
 
 __all__ = ['z_at_value']

--- a/astropy/cosmology/realizations.py
+++ b/astropy/cosmology/realizations.py
@@ -8,7 +8,7 @@ from astropy.utils.exceptions import AstropyDeprecationWarning
 from astropy.utils.state import ScienceState
 
 from . import parameters
-from .core import Cosmology, _COSMOLOGY_CLASSES
+from .core import _COSMOLOGY_CLASSES, Cosmology
 
 __all__ = ["default_cosmology"] + parameters.available
 

--- a/astropy/cosmology/tests/test_funcs.py
+++ b/astropy/cosmology/tests/test_funcs.py
@@ -1,17 +1,18 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-import sys
 import io
+import sys
 
 import pytest
+
 import numpy as np
 
-from astropy.cosmology import core, funcs, realizations
-from astropy.cosmology.realizations import Planck13, Planck15, Planck18, WMAP5, WMAP7, WMAP9
-from astropy.units import allclose
 from astropy import units as u
-from astropy.utils.exceptions import AstropyUserWarning
+from astropy.cosmology import core, funcs, realizations
+from astropy.cosmology.realizations import WMAP5, WMAP7, WMAP9, Planck13, Planck15, Planck18
+from astropy.units import allclose
 from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa
+from astropy.utils.exceptions import AstropyUserWarning
 
 
 @pytest.mark.skipif('not HAS_SCIPY')

--- a/astropy/cosmology/tests/test_pickle.py
+++ b/astropy/cosmology/tests/test_pickle.py
@@ -2,10 +2,10 @@
 
 import pytest
 
-from astropy.tests.helper import pickle_protocol, check_pickling_recovery
-from astropy import cosmology as cosm
+from astropy.cosmology import FLRW
+from astropy.tests.helper import check_pickling_recovery, pickle_protocol
 
-originals = [cosm.FLRW]
+originals = [FLRW]
 xfails = [False]
 
 


### PR DESCRIPTION
A more consistent imports structure.
Done by the following command ``> isort astropy/cosmology``

Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
