### PR TITLE
Cosmology read/write methods

### DIFF
--- a/astropy/cosmology/connect.py
+++ b/astropy/cosmology/connect.py
@@ -1,0 +1,109 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+import copy
+import warnings
+
+from astropy.io import registry as io_registry
+from astropy.utils.exceptions import AstropyUserWarning
+
+__all__ = ["CosmologyRead", "CosmologyWrite"]
+__doctest_skip__ = __all__
+
+
+class CosmologyRead(io_registry.UnifiedReadWrite):
+    """Read and parse data to a `~astropy.cosmology.Cosmology`.
+
+    This is *only* implemented on `~astropy.cosmology.Cosmology`,
+    not any subclass.
+
+    This function provides the Cosmology interface to the Astropy unified I/O
+    layer. This allows easily reading a file in supported data formats using
+    syntax such as::
+
+        >>> from astropy.cosmology import Cosmology
+        >>> cosmo1 = Cosmology.read('[file name]')
+
+    Get help on the available readers using the ``help()`` method::
+
+      >>> Cosmology.read.help()  # Get help reading and list supported formats
+      >>> Cosmology.read.help('[format]')  # Get detailed help on a format
+      >>> Cosmology.read.list_formats()  # Print list of available formats
+
+    See also: https://docs.astropy.org/en/stable/io/unified.html
+
+    Parameters
+    ----------
+    *args
+        Positional arguments passed through to data reader. If supplied the
+        first argument is typically the input filename.
+    format : str (optional, keyword-only)
+        File format specifier.
+    **kwargs
+        Keyword arguments passed through to data reader.
+
+    Returns
+    -------
+    out : `~astropy.cosmology.Cosmology` subclass instance
+        `~astropy.cosmology.Cosmology` corresponding to file contents.
+
+    Warns
+    -----
+    `~astropy.utils.exceptions.AstropyUserWarning`
+        If ``read`` is examined not from the Cosmology base class.
+    """
+
+    def __new__(cls, instance, cosmo_cls):
+        from astropy.cosmology.core import Cosmology
+
+        # warn that ``read`` is not (yet) implemented for subclasses
+        if cosmo_cls is not Cosmology:
+            warnings.warn(("``Cosmology.read()`` is not implemented for "
+                           "``Cosmology`` subclasses."),
+                           category=AstropyUserWarning)
+            return NotImplemented
+            # TODO! implement for non-abstract subclasses, using that class as
+            # the assumed Cosmology type. 
+
+        return super().__new__(cls)
+
+    def __init__(self, instance, cosmo_cls):
+        super().__init__(instance, cosmo_cls, "read")
+
+    def __call__(self, *args, **kwargs):
+        cosmo = io_registry.read(self._cls, *args, **kwargs)
+        return cosmo
+
+
+class CosmologyWrite(io_registry.UnifiedReadWrite):
+    """Write this Cosmology object out in the specified format.
+
+    This function provides the Cosmology interface to the astropy unified I/O
+    layer.  This allows easily writing a file in supported data formats
+    using syntax such as::
+
+      >>> from astropy.cosmology import Planck18
+      >>> Planck18.write('[file name]')
+
+    Get help on the available writers for ``Cosmology`` using the``help()``
+    method::
+
+      >>> Cosmology.write.help()  # Get help writing and list supported formats
+      >>> Cosmology.write.help('[format]')  # Get detailed help on format
+      >>> Cosmology.write.list_formats()  # Print list of available formats
+
+    Parameters
+    ----------
+    *args
+        Positional arguments passed through to data writer. If supplied the
+        first argument is the output filename.
+    format : str (optional, keyword-only)
+        File format specifier.
+    **kwargs
+        Keyword arguments passed through to data writer.
+    """
+
+    def __init__(self, instance, cls):
+        super().__init__(instance, cls, "write")
+
+    def __call__(self, *args, **kwargs):
+        io_registry.write(self._instance, *args, **kwargs)

--- a/astropy/cosmology/connect.py
+++ b/astropy/cosmology/connect.py
@@ -62,7 +62,7 @@ class CosmologyRead(io_registry.UnifiedReadWrite):
                            category=AstropyUserWarning)
             return NotImplemented
             # TODO! implement for non-abstract subclasses, using that class as
-            # the assumed Cosmology type. 
+            # the assumed Cosmology type.
 
         return super().__new__(cls)
 

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -10,14 +10,16 @@ from types import MappingProxyType
 
 import numpy as np
 
-from astropy import constants as const
-from astropy import units as u
+import astropy.constants as const
+import astropy.units as u
+from astropy.io.registry import UnifiedReadWriteMethod
 from astropy.utils import isiterable
 from astropy.utils.decorators import classproperty
 from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyUserWarning
 from astropy.utils.metadata import MetaData
 
 from . import scalar_inv_efuncs
+from .connect import CosmologyRead, CosmologyWrite
 from .utils import _float_or_none, inf_like, vectorize_if_needed
 
 # Originally authored by Andrew Becker (becker@astro.washington.edu),
@@ -112,6 +114,11 @@ class Cosmology(metaclass=ABCMeta):
     """
 
     meta = MetaData()
+
+    # Unified I/O read and write methods
+    # The 'read' method in subclasses is NotImplemented.
+    read = UnifiedReadWriteMethod(CosmologyRead)
+    write = UnifiedReadWriteMethod(CosmologyWrite)
 
     def __init_subclass__(cls):
         super().__init_subclass__()

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -116,7 +116,6 @@ class Cosmology(metaclass=ABCMeta):
     meta = MetaData()
 
     # Unified I/O read and write methods
-    # The 'read' method in subclasses is NotImplemented.
     read = UnifiedReadWriteMethod(CosmologyRead)
     write = UnifiedReadWriteMethod(CosmologyWrite)
 

--- a/astropy/cosmology/tests/test_connect.py
+++ b/astropy/cosmology/tests/test_connect.py
@@ -1,0 +1,133 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+import copy
+import os
+import json
+
+import pytest
+
+import numpy as np
+
+import astropy.units as u
+from astropy import cosmology
+from astropy.cosmology import Cosmology
+from astropy.cosmology.connect import CosmologyRead
+from astropy.cosmology.core import _COSMOLOGY_CLASSES, Cosmology
+from astropy.io import registry as io_registry
+from astropy.utils.exceptions import AstropyUserWarning
+
+cosmo_instances = cosmology.parameters.available
+save_formats = ["json"]
+
+
+###############################################################################
+# Setup
+
+def from_mapping(map, **kwargs):
+    params = copy.deepcopy(map)  # so can pop
+
+    # get cosmology. if string, parse to class
+    cosmology = params.pop("cosmology")
+    if isinstance(cosmology, str):
+        cosmology = _COSMOLOGY_CLASSES[cosmology]
+
+    # select arguments from mapping that are in the cosmo's signature.
+    ba = cosmology._init_signature.bind_partial()  # blank set of args
+    ba.apply_defaults()  # fill in the defaults
+    for k in cosmology._init_signature.parameters.keys():  # iter thru sig
+        if k in params:  # transfer argument, if in params
+            ba.arguments[k] = params.pop(k)
+
+    return cosmology(*ba.args, **ba.kwargs)
+
+
+def to_mapping(cosmology, *args, **kwargs):
+    m = {}
+    m["cosmology"] = cosmology.__class__
+    m.update({k: v for k, v in cosmology._init_arguments.items()
+              if k not in ("meta",)})
+    m["meta"] = copy.deepcopy(cosmology.meta)
+
+    return m
+
+
+def read_json(filename, key=None, **kwargs):
+    with open(filename, "r") as file:
+        data = file.read()
+    mapping = json.loads(data)  # parse json mappable to dict
+    # deserialize Quantity
+    for k, v in mapping.items():
+        if isinstance(v, dict) and "value" in v and "unit" in v:
+            mapping[k] = u.Quantity(v["value"], v["unit"])
+    return from_mapping(mapping)
+
+
+def write_json(cosmology, file, *, overwrite=False, **kwargs):
+    data = to_mapping(cosmology)  # start by turning into dict
+    data["cosmology"] = data["cosmology"].__name__  # change class field to str
+    # serialize Quantity
+    for k, v in data.items():
+        if isinstance(v, u.Quantity):
+            data[k] = {"value": v.value.tolist(),
+                       "unit": str(v.unit)}
+
+    # check that file exists and whether to overwrite.
+    if os.path.exists(file) and not overwrite:
+        raise IOError(f"{file} exists. Set 'overwrite' to write over.")
+    with open(file, "w") as write_file:
+        json.dump(data, write_file)
+
+
+def json_identify(origin, filepath, fileobj, *args, **kwargs):
+    return filepath is not None and filepath.endswith(".json")
+    
+
+def setup_module(module):
+    """Setup module for tests."""
+    io_registry.register_reader("json", Cosmology, read_json)
+    io_registry.register_writer("json", Cosmology, write_json)
+    io_registry.register_identifier("json", Cosmology, json_identify)
+
+
+def teardown_module(module):
+    """clean up module after tests."""
+    with pytest.warns(FutureWarning):  # idk
+        io_registry.unregister_reader("json", Cosmology)
+        io_registry.unregister_writer("json", Cosmology)
+        io_registry.unregister_identifier("json", Cosmology)
+
+
+###############################################################################
+# Tests
+
+class TestReadWriteCosmology:
+
+    def test_instantiate_read(self):
+        # no error on base class
+        assert isinstance(Cosmology.read, CosmologyRead)
+
+        # Warns when initialized. Cannot be used.
+        with pytest.warns(AstropyUserWarning):
+            assert cosmology.realizations.Planck18.read is NotImplemented
+
+    @pytest.mark.parametrize("format", save_formats)
+    @pytest.mark.parametrize("instance", cosmo_instances)
+    def test_write_then_read_file(self, tmpdir, instance, format):
+        cosmo = getattr(cosmology.realizations, instance)
+        fname = tmpdir / f"{instance}.{format}"
+
+        cosmo.write(str(fname), format=format)
+
+        # Also test kwarg "overwrite"
+        assert os.path.exists(str(fname))  # file exists
+        with pytest.raises(IOError):
+            cosmo.write(str(fname), format=format, overwrite=False)
+
+        assert os.path.exists(str(fname))  # overwrite file existing file
+        cosmo.write(str(fname), format=format, overwrite=True)
+
+        # Read back
+        got = Cosmology.read(tmpdir / f"{instance}.{format}", format=format)
+
+        assert got == cosmo
+        assert got.meta == cosmo.meta

--- a/astropy/cosmology/tests/test_connect.py
+++ b/astropy/cosmology/tests/test_connect.py
@@ -1,8 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import copy
-import os
 import json
+import os
 
 import pytest
 
@@ -10,11 +10,10 @@ import numpy as np
 
 import astropy.units as u
 from astropy import cosmology
-from astropy.cosmology import Cosmology
+from astropy.cosmology import Cosmology, w0wzCDM
 from astropy.cosmology.connect import CosmologyRead
 from astropy.cosmology.core import _COSMOLOGY_CLASSES, Cosmology
 from astropy.io import registry as io_registry
-from astropy.utils.exceptions import AstropyUserWarning
 
 cosmo_instances = cosmology.parameters.available
 save_formats = ["json"]
@@ -27,7 +26,12 @@ def from_mapping(map, **kwargs):
     params = copy.deepcopy(map)  # so can pop
 
     # get cosmology. if string, parse to class
-    cosmology = params.pop("cosmology")
+    # 1st from 'kwargs'. Allows for override of the cosmology, if on file.
+    # 2nd from params. This MUST have the cosmology if 'kwargs' did not.
+    if "cosmology" in kwargs:
+        cosmology = kwargs.pop("cosmology")
+    else:
+        cosmology = params.pop("cosmology")
     if isinstance(cosmology, str):
         cosmology = _COSMOLOGY_CLASSES[cosmology]
 
@@ -59,7 +63,7 @@ def read_json(filename, key=None, **kwargs):
     for k, v in mapping.items():
         if isinstance(v, dict) and "value" in v and "unit" in v:
             mapping[k] = u.Quantity(v["value"], v["unit"])
-    return from_mapping(mapping)
+    return from_mapping(mapping, **kwargs)
 
 
 def write_json(cosmology, file, *, overwrite=False, **kwargs):
@@ -80,7 +84,7 @@ def write_json(cosmology, file, *, overwrite=False, **kwargs):
 
 def json_identify(origin, filepath, fileobj, *args, **kwargs):
     return filepath is not None and filepath.endswith(".json")
-    
+
 
 def setup_module(module):
     """Setup module for tests."""
@@ -102,17 +106,13 @@ def teardown_module(module):
 
 class TestReadWriteCosmology:
 
-    def test_instantiate_read(self):
-        # no error on base class
-        assert isinstance(Cosmology.read, CosmologyRead)
-
-        # Warns when initialized. Cannot be used.
-        with pytest.warns(AstropyUserWarning):
-            assert cosmology.realizations.Planck18.read is NotImplemented
-
     @pytest.mark.parametrize("format", save_formats)
     @pytest.mark.parametrize("instance", cosmo_instances)
-    def test_write_then_read_file(self, tmpdir, instance, format):
+    def test_complete_info(self, tmpdir, instance, format):
+        """
+        Test writing from an instance and reading from the base class.
+        This requires full information.
+        """
         cosmo = getattr(cosmology.realizations, instance)
         fname = tmpdir / f"{instance}.{format}"
 
@@ -127,7 +127,95 @@ class TestReadWriteCosmology:
         cosmo.write(str(fname), format=format, overwrite=True)
 
         # Read back
-        got = Cosmology.read(tmpdir / f"{instance}.{format}", format=format)
+        got = Cosmology.read(fname, format=format)
 
         assert got == cosmo
         assert got.meta == cosmo.meta
+
+    @pytest.mark.parametrize("format", save_formats)
+    @pytest.mark.parametrize("instance", cosmo_instances)
+    def test_from_subclass_complete_info(self, tmpdir, instance, format):
+        """
+        Test writing from an instance and reading from that class, when there's
+        full information saved.
+        """
+        cosmo = getattr(cosmology.realizations, instance)
+        fname = tmpdir / f"{instance}.{format}"
+        cosmo.write(str(fname), format=format)
+
+        # read with the same class that wrote.
+        got = cosmo.__class__.read(fname, format=format)
+        assert got == cosmo
+        assert got.meta == cosmo.meta
+
+        # this should be equivalent to
+        got = Cosmology.read(fname, format=format, cosmology=cosmo.__class__)
+        assert got == cosmo
+        assert got.meta == cosmo.meta
+
+        # and also
+        got = Cosmology.read(fname, format=format, cosmology=cosmo.__class__.__qualname__)
+        assert got == cosmo
+        assert got.meta == cosmo.meta
+
+    @pytest.mark.parametrize("instance", cosmo_instances)
+    def test_from_subclass_partial_info(self, tmpdir, instance):
+        """
+        Test writing from an instance and reading from that class.
+        This requires partial information.
+
+        .. todo::
+
+            generalize over all save formats for this test.
+        """
+        format = "json"
+        cosmo = getattr(cosmology.realizations, instance)
+        fname = tmpdir / f"{instance}.{format}"
+
+        cosmo.write(str(fname), format=format)
+
+        # partial information
+        with open(fname, "r") as file:
+            L = file.readlines()
+        L[0] = L[0][:L[0].index('"cosmology":')]+L[0][L[0].index(', ')+2:]
+        i = L[0].index('"Tcmb0":')  # delete Tcmb0
+        L[0] = L[0][:i] + L[0][L[0].index(', ', i)+2:]
+
+        tempfname = tmpdir / f"{instance}_temp.{format}"
+        with open(tempfname, "w") as file:
+            file.writelines(L)
+
+        # read with the same class that wrote fills in the missing info with
+        # the default value
+        got = cosmo.__class__.read(tempfname, format=format)
+        got2 = Cosmology.read(tempfname, format=format, cosmology=cosmo.__class__)
+        got3 = Cosmology.read(tempfname, format=format, cosmology=cosmo.__class__.__qualname__)
+
+        assert (got == got2) and (got2 == got3)  # internal consistency
+
+        # not equal, because Tcmb0 is changed
+        assert got != cosmo
+        assert got.Tcmb0 == cosmo.__class__._init_signature.parameters["Tcmb0"].default
+        assert got.clone(name=cosmo.name, Tcmb0=cosmo.Tcmb0.value) == cosmo
+        # but the metadata is the same
+        assert got.meta == cosmo.meta
+
+    @pytest.mark.parametrize("format", save_formats)
+    @pytest.mark.parametrize("instance", cosmo_instances)
+    def test_reader_class_mismatch(self, tmpdir, instance, format):
+        """Test when the reader class doesn't match the file."""
+        cosmo = getattr(cosmology.realizations, instance)
+        fname = tmpdir / f"{instance}.{format}"
+        cosmo.write(str(fname), format=format)
+
+        # class mismatch
+        # when reading directly
+        with pytest.raises(TypeError, match="missing 1 required"):
+            w0wzCDM.read(fname, format=format)
+
+        with pytest.raises(TypeError, match="missing 1 required"):
+            Cosmology.read(fname, format=format, cosmology=w0wzCDM)
+
+        # when specifying the class
+        with pytest.raises(ValueError, match="`cosmology` must be either"):
+            w0wzCDM.read(fname, format=format, cosmology="FlatLambdaCDM")

--- a/astropy/cosmology/tests/test_funcs.py
+++ b/astropy/cosmology/tests/test_funcs.py
@@ -10,7 +10,7 @@ import numpy as np
 
 from astropy import units as u
 from astropy.cosmology import core
-from astropy.cosmology.funcs import z_at_value, _z_at_scalar_value
+from astropy.cosmology.funcs import _z_at_scalar_value, z_at_value
 from astropy.cosmology.realizations import WMAP5, WMAP7, WMAP9, Planck13, Planck15, Planck18
 from astropy.units import allclose
 from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa
@@ -234,9 +234,7 @@ def test_z_at_value_roundtrip(cosmo):
     if str(cosmo.name).startswith('WMAP'):
         skip += ('nu_relative_density', )
 
-    # get methods, ignoring warning from ".read"
-    with pytest.warns(AstropyUserWarning, match=r'``Cosmology`` subclasses'):
-        methods = inspect.getmembers(cosmo, predicate=inspect.ismethod)
+    methods = inspect.getmembers(cosmo, predicate=inspect.ismethod)
 
     for name, func in methods:
         if name.startswith('_') or name in skip:

--- a/astropy/cosmology/tests/test_funcs.py
+++ b/astropy/cosmology/tests/test_funcs.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+import inspect
 import sys
 from io import StringIO
 
@@ -233,8 +234,9 @@ def test_z_at_value_roundtrip(cosmo):
     if str(cosmo.name).startswith('WMAP'):
         skip += ('nu_relative_density', )
 
-    import inspect
-    methods = inspect.getmembers(cosmo, predicate=inspect.ismethod)
+    # get methods, ignoring warning from ".read"
+    with pytest.warns(AstropyUserWarning, match=r'``Cosmology`` subclasses'):
+        methods = inspect.getmembers(cosmo, predicate=inspect.ismethod)
 
     for name, func in methods:
         if name.startswith('_') or name in skip:

--- a/docs/changes/cosmology/11948.feature.rst
+++ b/docs/changes/cosmology/11948.feature.rst
@@ -1,0 +1,4 @@
+Added ``read/write`` methods to Cosmology using the Unified I/O registry.
+Now custom file format readers, writers, and format-identifier functions
+can be registered to read, write, and identify, respectively, Cosmology
+objects. Details are discussed in an addition to the docs.

--- a/docs/cosmology/index.rst
+++ b/docs/cosmology/index.rst
@@ -14,6 +14,9 @@ distances, ages, and lookback times corresponding to a measured
 redshift or the transverse separation corresponding to a measured
 angular separation.
 
+For details on reading and writing cosmologies from files,
+see :ref:`read_write_cosmologies`.
+
 
 Getting Started
 ===============
@@ -88,6 +91,14 @@ access the floating point or array values::
 
 Using `astropy.cosmology`
 =========================
+
+More detailed information on using the package is provided on separate pages,
+listed below.
+
+.. toctree::
+   :maxdepth: 1
+
+   Reading and Writing <io>
 
 Most of the functionality is enabled by the `~astropy.cosmology.FLRW`
 object. This represents a homogeneous and isotropic cosmology

--- a/docs/cosmology/io.rst
+++ b/docs/cosmology/io.rst
@@ -22,7 +22,7 @@ An easy way to serialize and deserialize a Cosmology object is using the
    >>> cosmo
 
 However this method has all the attendant drawbacks of :mod:`pickle` — security
-and non-human-readable files.
+vulnerabilities and non-human-readable files.
 
 Solving both these issues, ``astropy`` provides a unified interface for reading
 and writing data in different formats.
@@ -36,7 +36,7 @@ The :class:`~astropy.cosmology.Cosmology` class includes two methods,
 :meth:`~astropy.cosmology.Cosmology.write`, that make it possible to read from
 and write to files.
 
-There are currently no built-in Cosmology readers not writers, but custom
+There are currently no built-in Cosmology readers nor writers, but custom
 ``read`` / ``write`` formats may be registered into the Astropy Cosmology I/O
 framework.
 

--- a/docs/cosmology/io.rst
+++ b/docs/cosmology/io.rst
@@ -40,6 +40,38 @@ There are currently no built-in Cosmology readers nor writers, but custom
 ``read`` / ``write`` formats may be registered into the Astropy Cosmology I/O
 framework.
 
+Writing a cosmology instance requires only the file location and optionally,
+if the file format cannot be inferred, a keyword argument "format". Additional
+positional arguments and keyword arguments are passed to the reader methods.
+::
+
+    >>> from astropy.cosmology import Planck18
+    >>> Planck18.write('[file name]')
+
+Reading back the cosmology is most safely done from ``Cosmology``, the base
+class, as it provides no default information and therefore requires the file
+to have all necessary information to describe a cosmology.
+
+::
+
+    >>> from astropy.cosmology import Cosmology
+    >>> cosmo = Cosmology.read('[file name]')
+    >>> cosmo == Planck18
+    True
+
+When a subclass of ``Cosmology`` is used to read a file, the subclass will
+provide a keyword argument ``cosmology=[class]`` to the registered read
+method. The method uses this cosmology class, regardless of the class
+indicated in the file, and sets parameters' default values from the class'
+signature.
+
+::
+
+    >>> from astropy.cosmology import FlatLambdaCDM
+    >>> cosmo = FlatLambdaCDM.read('[file name]')
+    >>> cosmo == Planck18
+    True
+
 
 .. _custom_cosmology_readers_writers:
 

--- a/docs/cosmology/io.rst
+++ b/docs/cosmology/io.rst
@@ -1,0 +1,82 @@
+.. doctest-skip-all
+
+.. _read_write_cosmologies:
+
+Reading and Writing Cosmology Objects
+*************************************
+
+An easy way to serialize and deserialize a Cosmology object is using the
+:mod:`pickle` module.
+
+.. code-block:: python
+   :emphasize-lines: 1,4,8
+
+   >>> import pickle
+   >>> from astropy.cosmology import Planck18
+   >>> with open("planck18.pkl", mode="wb") as file:
+   ...     pickle.dump(file, Planck18)
+
+   And to read the file back
+   >>> with open("planck18.pkl", mode="rb") as file:
+   >>>     cosmo = pickle.load(file)
+   >>> cosmo
+
+However this method has all the attendant drawbacks of :mod:`pickle` — security
+and non-human-readable files.
+
+Solving both these issues, ``astropy`` provides a unified interface for reading
+and writing data in different formats.
+
+
+Getting Started
+===============
+
+The :class:`~astropy.cosmology.Cosmology` class includes two methods,
+:meth:`~astropy.cosmology.Cosmology.read` and
+:meth:`~astropy.cosmology.Cosmology.write`, that make it possible to read from
+and write to files.
+
+There are currently no built-in Cosmology readers not writers, but custom
+``read`` / ``write`` formats may be registered into the Astropy Cosmology I/O
+framework.
+
+
+.. _custom_cosmology_readers_writers:
+
+Custom Cosmology Readers/Writers
+================================
+
+Custom ``read`` / ``write`` formats may be registered into the Astropy Cosmology
+I/O framework. For details of the framework see :ref:`io_registry`.
+As a quick example, outlining how to make a
+`~astropy.cosmology.Cosmology` <-> JSON serializer:
+
+.. code-block:: python
+
+   import json
+   from astropy.cosmology import Cosmology
+   from astropy.io import registry as io_registry
+
+   def read_json(filename, **kwargs):
+       cosmology = ...  # read and parse file
+       return cosmology
+
+   def write_json(cosmology, file, **kwargs):
+       data = ...  # parse cosmology to dict
+       with open(file, "w") as write_file:
+            json.dump(data, write_file)
+
+   def json_identify(origin, filepath, fileobj, *args, **kwargs):
+       """Identify if object uses the JSON format."""
+       return filepath is not None and filepath.endswith(".json")
+
+   # register the read/write methods 
+   io_registry.register_reader("json", Cosmology, read_json)
+   io_registry.register_writer("json", Cosmology, write_json)
+   io_registry.register_identifier("json", Cosmology, json_identify)
+
+
+Reference/API
+=============
+
+.. automodapi:: astropy.cosmology.connect

--- a/docs/io/registry.rst
+++ b/docs/io/registry.rst
@@ -18,8 +18,8 @@ Introduction
 ============
 
 The I/O registry is a submodule used to define the readers/writers available
-for the :class:`~astropy.table.Table` and
-:class:`~astropy.nddata.NDData` classes.
+for the :class:`~astropy.table.Table`, :class:`~astropy.nddata.NDData`,
+and :class:`~astropy.cosmology.Cosmology` classes.
 
 Using `astropy.io.registry`
 ===========================


### PR DESCRIPTION
### Description

Use the ``UnifiedReadWrite`` architecture with the ``io.registry`` to enable reading and writing Cosmologies. Currently no formats are registered in. See #11559 for a full discussion of the implementation. That PR does a lot, so I'm breaking it apart into a few more atomic pieces. The followup to this PR will be the `to/from_format` method, which will allow me to fully flesh out the examples in the docs.

Fixes #11947
Fixes https://github.com/astropy/astropy/projects/7#card-65851204

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
