### PR TITLE
Support table join on different keys

### DIFF
--- a/astropy/table/operations.py
+++ b/astropy/table/operations.py
@@ -355,7 +355,7 @@ def join(left, right, keys=None, join_type='inner', *,
         Default is to use all columns which are common to both tables.
     join_type : str
         Join type ('inner' | 'outer' | 'left' | 'right' | 'cartesian'), default is 'inner'
-    keys_left : str or list of str of list of column-like, optional
+    keys_left : str or list of str or list of column-like, optional
         Left column(s) used to match rows instead of ``keys`` arg. This can be
         be a single left table column name or list of column names, or a list of
         column-like values with the same lengths as the left table.
@@ -1132,12 +1132,12 @@ def _join(left, right, keys=None, join_type='inner',
         left, right, keys = _join_keys_left_right(
             left, right, keys, keys_left, keys_right, join_funcs)
 
-    # If we have a single key, put it in a tuple
     if keys is None:
         keys = tuple(name for name in left.colnames if name in right.colnames)
         if len(keys) == 0:
             raise TableMergeError('No keys in common between left and right tables')
     elif isinstance(keys, str):
+        # If we have a single key, put it in a tuple
         keys = (keys,)
 
     # Check the key columns

--- a/docs/changes/table/11954.api.rst
+++ b/docs/changes/table/11954.api.rst
@@ -1,0 +1,3 @@
+The table ``join`` function now accepts only the first four arguments ``left``,
+``right``, ``keys``, and ``join_type`` as positional arguments. All other
+arguments must be supplied as keyword arguments.

--- a/docs/changes/table/11954.feature.rst
+++ b/docs/changes/table/11954.feature.rst
@@ -1,0 +1,5 @@
+Added new keyword arguments ``keys_left`` and ``keys_right`` to the table ``join``
+function to support joining tables on key columns with different names. In
+addition the new keywords can accept a list of column-like objects which are
+used as the match keys. This allows joining on arbitrary data which are not part
+of the tables being joined.

--- a/docs/table/operations.rst
+++ b/docs/table/operations.rst
@@ -855,40 +855,27 @@ Non-Identical Key Column Names
 
 .. EXAMPLE START: Joining Tables with Unique Key Column Names
 
-The |join| function requires the key column names to be identical in the
-two tables. However, in the following, one table has a ``'name'`` column
-while the other has an ``'obj_id'`` column::
+To use the |join| function with non-identical key column names, use the
+``keys_left`` and ``keys_right`` arguments. In the following example one table
+has a ``'name'`` column while the other has an ``'obj_id'`` column::
 
   >>> optical = Table.read("""name    obs_date    mag_b  mag_v
   ...                         M31     2012-01-02  17.0   16.0
   ...                         M82     2012-10-29  16.2   15.2
   ...                         M101    2012-10-31  15.1   15.5""", format='ascii')
-  >>> xray_1 = Table.read("""   obj_id    obs_date    logLx
-  ...                           NGC3516 2011-11-11  42.1
-  ...                           M31     1999-01-05  43.1
-  ...                           M82     2012-10-29  45.0""", format='ascii')
+  >>> xray = Table.read("""   obj_id    obs_date    logLx
+  ...                         NGC3516 2011-11-11  42.1
+  ...                         M31     1999-01-05  43.1
+  ...                         M82     2012-10-29  45.0""", format='ascii')
 
-In order to perform a match based on the names of the objects, you have to
-temporarily rename one of the columns mentioned above, right before creating
-the new table::
+In order to perform a match based on the names of the objects, do the
+following::
 
-  >>> xray_1.rename_column('obj_id', 'name')
-  >>> opt_xray_1 = join(optical, xray_1, keys='name')
-  >>> xray_1.rename_column('name', 'obj_id')
-  >>> print(opt_xray_1)
-  name obs_date_1 mag_b mag_v obs_date_2 logLx
-  ---- ---------- ----- ----- ---------- -----
-  M31 2012-01-02  17.0  16.0 1999-01-05  43.1
-  M82 2012-10-29  16.2  15.2 2012-10-29  45.0
+  >>> print(join(optical, xray, keys_left='name', keys_right='obj_id'))
 
-The original ``xray_1`` table remains unchanged after the operation::
-
-  >>> print(xray_1)
-  obj_id  obs_date  logLx
-  ------- ---------- -----
-  NGC3516 2011-11-11  42.1
-      M31 1999-01-05  43.1
-      M82 2012-10-29  45.0
+The ``keys_left`` and ``keys_right`` arguments can also take a list of column
+names or even a list of column-like objects. The latter case allows specifying
+the matching key column values independent of the tables being joined.
 
 .. EXAMPLE END
 

--- a/docs/table/operations.rst
+++ b/docs/table/operations.rst
@@ -863,15 +863,19 @@ has a ``'name'`` column while the other has an ``'obj_id'`` column::
   ...                         M31     2012-01-02  17.0   16.0
   ...                         M82     2012-10-29  16.2   15.2
   ...                         M101    2012-10-31  15.1   15.5""", format='ascii')
-  >>> xray = Table.read("""   obj_id    obs_date    logLx
-  ...                         NGC3516 2011-11-11  42.1
-  ...                         M31     1999-01-05  43.1
-  ...                         M82     2012-10-29  45.0""", format='ascii')
+  >>> xray_1 = Table.read("""obj_id    obs_date    logLx
+  ...                        NGC3516 2011-11-11  42.1
+  ...                        M31     1999-01-05  43.1
+  ...                        M82     2012-10-29  45.0""", format='ascii')
 
 In order to perform a match based on the names of the objects, do the
 following::
 
-  >>> print(join(optical, xray, keys_left='name', keys_right='obj_id'))
+  >>> print(join(optical, xray_1, keys_left='name', keys_right='obj_id'))
+  name obs_date_1 mag_b mag_v obj_id obs_date_2 logLx
+  ---- ---------- ----- ----- ------ ---------- -----
+   M31 2012-01-02  17.0  16.0    M31 1999-01-05  43.1
+   M82 2012-10-29  16.2  15.2    M82 2012-10-29  45.0
 
 The ``keys_left`` and ``keys_right`` arguments can also take a list of column
 names or even a list of column-like objects. The latter case allows specifying


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to allow doing a table join on table columns that have different names. It also allows doing a join on arbitrary column-like data which serve as the join values. The API is inspired by `left_on` and `right_on` in [pandas merge](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.merge.html#pandas.DataFrame.merge).

This also introduces a small API change by requiring keyword-only args after `left, right, keys, join_type`. I think that after this it is unlikely that much external code is using positional args. The next arg was previously `uniq_col_name`.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #3752

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
