### PR TITLE
Targeted fixes to avoid zero-byte writes

### DIFF
--- a/astropy/io/fits/hdu/base.py
+++ b/astropy/io/fits/hdu/base.py
@@ -623,7 +623,9 @@ class _BaseHDU(metaclass=_BaseHDUMeta):
             if self.data is not None:
                 size += self._writedata_internal(fileobj)
             # pad the FITS data block
-            if size > 0:
+            # to avoid a bug in the lustre filesystem client, don't
+            # write zero-byte objects
+            if size > 0 and _pad_length(size) > 0:
                 padding = _pad_length(size) * self._padding_byte
                 # TODO: Not that this is ever likely, but if for some odd
                 # reason _padding_byte is > 0x80 this will fail; but really if

--- a/astropy/io/fits/hdu/table.py
+++ b/astropy/io/fits/hdu/table.py
@@ -937,7 +937,10 @@ class BinTableHDU(_TableBaseHDU):
                 fileobj.writearray(data)
                 # write out the heap of variable length array columns this has
                 # to be done after the "regular" data is written (above)
-                fileobj.write((data._gap * '\0').encode('ascii'))
+                # to avoid a bug in the lustre filesystem client, don't
+                # write 0-byte objects
+                if data._gap > 0:
+                    fileobj.write((data._gap * '\0').encode('ascii'))
 
             nbytes = data._gap
 

--- a/astropy/io/fits/tests/test_core.py
+++ b/astropy/io/fits/tests/test_core.py
@@ -24,6 +24,8 @@ from astropy.utils.data import conf
 from astropy.utils.exceptions import AstropyUserWarning
 from astropy.utils import data
 
+from astropy.io.tests import safeio
+
 # NOTE: Python can be built without bz2.
 from astropy.utils.compat.optional_deps import HAS_BZ2
 if HAS_BZ2:
@@ -1285,6 +1287,32 @@ class TestFileFunctions(FitsTestCase):
             hdul.writeto(None)
             hdul[0].writeto(None)
             hdul[0].header.tofile(None)
+
+    def test_bintablehdu_zero_bytes(self):
+        """Make sure we don't have any zero-byte writes in BinTableHDU"""
+
+        bright = np.rec.array([(1, 'Sirius', -1.45, 'A1V'),
+                            (2, 'Canopus', -0.73, 'F0Ib'),
+                            (3, 'Rigil Kent', -0.1, 'G2V')],
+                           formats='int16,a20,float32,a10', names='order,name,mag,Sp')
+
+        hdu_non_zero = fits.BinTableHDU(bright)
+        # use safeio, a special file handler meant to fail on zero-byte writes
+        fh = safeio.CatchZeroByteWriter(open('bright.fits', mode='wb'))
+        hdu_non_zero.writeto(fh)
+        fh.close()
+
+    def test_primaryhdu_zero_bytes(self):
+        """
+        Make sure we don't have any zero-byte writes from an ImageHDU
+        `(or other) of `size % BLOCK_SIZE == 0`
+        """
+
+        hdu_img_2880 = fits.PrimaryHDU(data=np.arange(720, dtype='i4'))
+        # use safeio, a special file handler meant to fail on zero-byte writes
+        fh = safeio.CatchZeroByteWriter(open('image.fits', mode='wb'))
+        hdu_img_2880.writeto(fh)
+        fh.close()
 
 
 class TestStreamingFunctions(FitsTestCase):

--- a/astropy/io/fits/tests/test_core.py
+++ b/astropy/io/fits/tests/test_core.py
@@ -1305,7 +1305,7 @@ class TestFileFunctions(FitsTestCase):
     def test_primaryhdu_zero_bytes(self):
         """
         Make sure we don't have any zero-byte writes from an ImageHDU
-        `(or other) of `size % BLOCK_SIZE == 0`
+        (or other) of `size % BLOCK_SIZE == 0`
         """
 
         hdu_img_2880 = fits.PrimaryHDU(data=np.arange(720, dtype='i4'))

--- a/astropy/io/tests/safeio.py
+++ b/astropy/io/tests/safeio.py
@@ -1,0 +1,13 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+import io
+
+
+class CatchZeroByteWriter(io.BufferedWriter):
+    """File handle to intercept 0-byte writes"""
+
+    def write(self, buffer):
+        nbytes = super().write(buffer)
+        if nbytes == 0:
+            raise ValueError("This writer does not allow empty writes")
+        return nbytes

--- a/docs/changes/io.fits/11955.bugfix.rst
+++ b/docs/changes/io.fits/11955.bugfix.rst
@@ -1,0 +1,2 @@
+Prevent zero-byte writes for FITS binary tables to
+speed up writes on the Lustre filesystem.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This is a WIP PR to document some work today during the SciPy 2021 sprints with @dhomeier and @mwcraig (thank you very much for your help!) towards addressing #11696 opened by @weaverba137. 

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

The goal of this PR is to address the zero-byte writes that occur when writing binary tables. (These zero-byte writes can cause problems for the Lustre filesystem client and can result in very long write times.) We have found and fixed two of these places and found that they do speed up writes on Lustre considerably! We have not yet determined a good strategy for testing, however, and are marking this PR as WIP. 

We performed some testing on the NERSC Cori Lustre filesystem, comparing this PR to astropy 4.2.1. We ran this test for both versions after fixing the padding in `hdu/table.py`:

```
import astropy.io.fits
import numpy as np

bright = np.rec.array(
    [(1, 'Serius', -1.45, 'A1V'),
     (2, 'Canopys', -0.73, 'F0Ib'),
     (3, 'Rigil Kent', -0.1, 'G2V')],
    formats='int16,a20,float32,a10',
    names='order,name,mag,Sp')
hdu_non_zero = astropy.io.fits.BinTableHDU(bright)

test = hdu_non_zero.writeto('test.fits', overwrite=True)
```

This test ran in approximately 30 seconds with astropy 4.2.1 and approximately one second in with change in this PR. I believe the interpretation of this result is that the value of `data._gap` will always be zero for regular tables, so this case would probably occur frequently. 

We also performed this test to try to write 2880 byte blocks:

```
import astropy.io.fits
import numpy as np

bright = np.rec.array(
    [(1, 'Serius', -1.45, 'A1V'),
     (2, 'Canopys', -0.73, 'F0Ib'),
     (3, 'Rigil Kent', -0.1, 'G2V')],
    formats='int16,a20,float32,a10',
    names='order,name,mag,Sp')
hdu_non_zero = astropy.io.fits.BinTableHDU(bright.repeat(28)[:80])

test = hdu_non_zero.writeto('test.fits', overwrite=True)
```

We found that by fixing some additional padding in `hdu/base.py`, we were able to speed up this as well. In astropy 4.2.1 it runs in about 20-30 seconds, but in this PR, it runs in less than one second. 

Lastly, @dhomeier and I discussed how we might test that zero-byte writes do not happen, but this is a difficult problem. One suggestion was to look at the `atime` and `mtime`:

```
statinfo = os.stat('test.fits')

atime = statinfo.st_atime
print('atime', atime)

mtime = statinfo.st_mtime
print('mtime', mtime)

dtime = mtime - atime
print('dtime', dtime)
```

I did test this (on our non-lustre filesystem) and found:

For astropy 4.2.1:

```
atime 1626567387.653371
mtime 1626567387.6561396
dtime 0.0027685165405273438
```

and for the version in this PR:

```
atime 1626567404.457559
mtime 1626567404.4616377
dtime 0.00407862663269043
```

So there are some differences, but I think these times will vary widely depending on the system. I'm not sure how we could decide on a reasonably universal threshold. 

Another suggestion would be to try to use a custom file handler to determine the write size of the file, although at the moment we don't have any concrete ideas about how to make this work. 


<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #11696

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
