### PR TITLE
TST: Fix weekly cron failures (broken link, xpass)

### DIFF
--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -539,7 +539,7 @@ def poisson_conf_interval(n, interval='root-n', sigma=1, background=0,
 
     The "right" confidence interval to use for Poisson data is a
     matter of debate. The CDF working group `recommends
-    <https://www-cdf.fnal.gov/physics/statistics/notes/pois_eb.txt>`_
+    <https://web.archive.org/web/20210222093249/https://www-cdf.fnal.gov/physics/statistics/notes/pois_eb.txt>`_
     using root-n throughout, largely in the interest of
     comprehensibility, but discusses other possibilities. The ATLAS
     group also `discusses
@@ -569,7 +569,7 @@ def poisson_conf_interval(n, interval='root-n', sigma=1, background=0,
 
     **3. 'pearson'** This is an only-slightly-more-complicated rule
     based on Pearson's chi-squared rule (as `explained
-    <https://www-cdf.fnal.gov/physics/statistics/notes/pois_eb.txt>`_ by
+    <https://web.archive.org/web/20210222093249/https://www-cdf.fnal.gov/physics/statistics/notes/pois_eb.txt>`_ by
     the CDF working group). It also has the nice feature that if your
     theory curve touches an endpoint of the interval, then your data
     point is indeed one sigma away. The interval is

--- a/astropy/stats/jackknife.py
+++ b/astropy/stats/jackknife.py
@@ -33,7 +33,7 @@ def jackknife_resampling(data):
     References
     ----------
     .. [1] McIntosh, Avery. "The Jackknife Estimation Method".
-        <http://people.bu.edu/aimcinto/jackknife.pdf>
+        <https://arxiv.org/abs/1606.00497>
 
     .. [2] Efron, Bradley. "The Jackknife, the Bootstrap, and other
         Resampling Plans". Technical Report No. 63, Division of Biostatistics,

--- a/astropy/units/tests/test_quantity_array_methods.py
+++ b/astropy/units/tests/test_quantity_array_methods.py
@@ -7,7 +7,7 @@ import numpy as np
 from numpy.testing import assert_array_equal
 
 from astropy import units as u
-from astropy.utils.compat import NUMPY_LT_1_22
+from astropy.utils.compat import NUMPY_LT_1_21_1
 
 
 class TestQuantityArrayCopy:
@@ -124,7 +124,7 @@ class TestQuantityReshapeFuncs:
         assert q_swapaxes.unit == q.unit
         assert np.all(q_swapaxes.value == q.value.swapaxes(0, 2))
 
-    @pytest.mark.xfail(sys.byteorder == 'big' and NUMPY_LT_1_22,
+    @pytest.mark.xfail(sys.byteorder == 'big' and NUMPY_LT_1_21_1,
                        reason="Numpy GitHub Issue 19153")
     def test_flat_attributes(self):
         """While ``flat`` doesn't make a copy, it changes the shape."""

--- a/astropy/utils/compat/numpycompat.py
+++ b/astropy/utils/compat/numpycompat.py
@@ -5,11 +5,12 @@ earlier versions of Numpy.
 """
 from astropy.utils import minversion
 
-__all__ = ['NUMPY_LT_1_19', 'NUMPY_LT_1_20', 'NUMPY_LT_1_22']
+__all__ = ['NUMPY_LT_1_19', 'NUMPY_LT_1_20', 'NUMPY_LT_1_21_1', 'NUMPY_LT_1_22']
 
 # TODO: It might also be nice to have aliases to these named for specific
 # features/bugs we're checking for (ex:
 # astropy.table.table._BROKEN_UNICODE_TABLE_SORT)
 NUMPY_LT_1_19 = not minversion('numpy', '1.19')
 NUMPY_LT_1_20 = not minversion('numpy', '1.20')
+NUMPY_LT_1_21_1 = not minversion('numpy', '1.21.1')
 NUMPY_LT_1_22 = not minversion('numpy', '1.22')


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to address these two failures seen in weekly cron:

1. Broken link to http://people.bu.edu/aimcinto/jackknife.pdf (error 404)
2. `[XPASS(strict)] Numpy GitHub Issue 19153` for `TestQuantityReshapeFuncs.test_flat_attributes`; they must have backported the fix for numpy/numpy#19153 to 1.21.1.

p.s. Only `main` branch runs weekly cron, so maybe no need for backport?

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
