### PR TITLE
json.dump of FITS_rec with VLF succeeds but produces unexpected result

### DIFF
--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -2010,6 +2010,9 @@ class _VLF(np.ndarray):
         np.ndarray.__setitem__(self, key, value)
         self.max = max(self.max, len(value))
 
+    def tolist(self):
+        return [list(item) for item in super().tolist()]
+
 
 def _get_index(names, key):
     """

--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -1284,6 +1284,13 @@ class FITS_rec(np.recarray):
         if 'D' in format:
             output_field[:] = output_field.replace(b'E', b'D')
 
+    def tolist(self):
+        # Override .tolist to take care of special case of VLF
+
+        column_lists = [self[name].tolist() for name in self.columns.names]
+
+        return [list(row) for row in zip(*column_lists)]
+
 
 def _get_recarray_field(array, key):
     """

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -2951,6 +2951,22 @@ class TestVLATables(FitsTestCase):
         assert np.array_equal(data['arr'][497], [0, 1, 2, 3, 4])
         hdul.close()
 
+    def test_tolist(self):
+        col = fits.Column(
+            name='var', format='PI()',
+            array=np.array([[1, 2, 3], [11, 12]], dtype=np.object_))
+        hdu = fits.BinTableHDU.from_columns([col])
+        assert hdu.data.tolist() == [[[1, 2, 3]], [[11, 12]]]
+        assert hdu.data['var'].tolist() == [[1, 2, 3], [11, 12]]
+
+    def test_tolist_from_file(self):
+        filename = self.data('variable_length_table.fits')
+
+        with fits.open(filename) as hdul:
+            hdu = hdul[1]
+            assert hdu.data.tolist() == [[[45, 56], [11, 3]], [[11, 12, 13], [12, 4]]]
+            assert hdu.data['var'].tolist() == [[45, 56], [11, 12, 13]]
+
 
 # These are tests that solely test the Column and ColDefs interfaces and
 # related functionality without directly involving full tables; currently there

--- a/astropy/utils/tests/test_misc.py
+++ b/astropy/utils/tests/test_misc.py
@@ -10,6 +10,7 @@ import pytest
 import numpy as np
 
 from astropy.utils import data, misc
+from astropy.io import fits
 
 
 def test_isiterable():
@@ -84,6 +85,24 @@ def test_JsonCustomEncoder():
     newd = json.loads(tmp3)
     tmpd = {"a": {"unit": "erg / s", "value": [0., 1.]}}
     assert newd == tmpd
+
+
+def test_JsonCustomEncoder_FITS_rec_from_files():
+    with fits.open(fits.util.get_testdata_filepath('variable_length_table.fits')) as hdul:
+        assert json.dumps(hdul[1].data, cls=misc.JsonCustomEncoder) == \
+            "[[[45, 56], [11, 3]], [[11, 12, 13], [12, 4]]]"
+
+    with fits.open(fits.util.get_testdata_filepath('btable.fits')) as hdul:
+        assert json.dumps(hdul[1].data, cls=misc.JsonCustomEncoder) == \
+            '[[1, "Sirius", -1.4500000476837158, "A1V"], ' \
+             '[2, "Canopus", -0.7300000190734863, "F0Ib"], ' \
+             '[3, "Rigil Kent", -0.10000000149011612, "G2V"]]'
+
+    with fits.open(fits.util.get_testdata_filepath('table.fits')) as hdul:
+        assert json.dumps(hdul[1].data, cls=misc.JsonCustomEncoder) == \
+            '[["NGC1001", 11.100000381469727], ' \
+             '["NGC1002", 12.300000190734863], ' \
+             '["NGC1003", 15.199999809265137]]'
 
 
 def test_set_locale():

--- a/docs/changes/io.fits/11957.bugfix.rst
+++ b/docs/changes/io.fits/11957.bugfix.rst
@@ -1,0 +1,1 @@
+Enable ``json.dump`` for FITS_rec with variable length (VLF) arrays.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to address jsonification of `FITS_rec` containing variable length arrays, represented as [VLF class](https://github.com/astropy/astropy/blob/81c1d646da98730064a6dc86ccadb7bed9045cf2/astropy/io/fits/column.py#L1963). As it is inherited from `np.recarray`, it jsonifies with custom encoder included in astropy, [JsonCustomEncoder](https://docs.astropy.org/en/stable/api/astropy.utils.misc.JsonCustomEncoder.html).
Which relies on `np.ndarray.tolist`.

However, `VLF` enclosed in `FITS_rec` ends up represented as a different list (containing description of the variable length array - sizes and offsets).
This leads to json dump silently producing undesirable values.

I am not sure if it is anyway wise to rely in this jsonification, but I thought it at least it should not produce something unexpected without an error.

Please see the included test for details.

Looking forward for any feedback!

I am not sure if I should have created an issue first, if yes - sorry.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Fixes #<Issue Number> -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
