### PR TITLE
move non-cosmology functions to utils

### DIFF
--- a/astropy/cosmology/__init__.py
+++ b/astropy/cosmology/__init__.py
@@ -8,9 +8,10 @@ detailed usage examples and references.
 
 """
 
-from . import core, funcs, realizations
+from . import core, funcs, realizations, utils
 from .core import *
 from .funcs import *
 from .realizations import *
+from .utils import *
 
-__all__ = core.__all__ + realizations.__all__ + funcs.__all__
+__all__ = core.__all__ + realizations.__all__ + funcs.__all__ + utils.__all__

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -14,9 +14,9 @@ from astropy import units as u
 from astropy.utils import isiterable
 from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyUserWarning
 from astropy.utils.metadata import MetaData
-from astropy.utils.state import ScienceState
 
 from . import scalar_inv_efuncs
+from .utils import _float_or_none, inf_like, vectorize_if_needed
 
 # Originally authored by Andrew Becker (becker@astro.washington.edu),
 # and modified by Neil Crighton (neilcrighton@gmail.com) and Roban
@@ -3376,40 +3376,3 @@ class w0wzCDM(FLRW):
         return retstr.format(self._namelead(), self._H0, self._Om0,
                              self._Ode0, self._w0, self._wz, self._Tcmb0,
                              self._Neff, self.m_nu, _float_or_none(self._Ob0))
-
-
-def _float_or_none(x, digits=3):
-    """ Helper function to format a variable that can be a float or None"""
-    if x is None:
-        return str(x)
-    fmtstr = "{0:.{digits}g}".format(x, digits=digits)
-    return fmtstr.format(x)
-
-
-def vectorize_if_needed(func, *x):
-    """ Helper function to vectorize functions on array inputs"""
-    if any(map(isiterable, x)):
-        return np.vectorize(func)(*x)
-    else:
-        return func(*x)
-
-
-def inf_like(x):
-    """Return the shape of x with value infinity and dtype='float'.
-
-    Preserves 'shape' for both array and scalar inputs.
-    But always returns a float array, even if x is of integer type.
-
-    >>> inf_like(0.)  # float scalar
-    inf
-    >>> inf_like(1)  # integer scalar should give float output
-    inf
-    >>> inf_like([0., 1., 2., 3.])  # float list
-    array([inf, inf, inf, inf])
-    >>> inf_like([0, 1, 2, 3])  # integer list should give float output
-    array([inf, inf, inf, inf])
-    """
-    if np.isscalar(x):
-        return np.inf
-    else:
-        return np.full_like(x, np.inf, dtype='float')

--- a/astropy/cosmology/tests/test_utils.py
+++ b/astropy/cosmology/tests/test_utils.py
@@ -1,0 +1,63 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+from math import inf
+
+import pytest
+
+import numpy as np
+
+from astropy.cosmology.utils import _float_or_none, inf_like, vectorize_if_needed
+
+
+@pytest.mark.parametrize("x, digits, expected",
+                         [(None, 1, "None"),
+                          (10.1234, 3, "10.1"),
+                          (10.1234, 7, "10.1234"),  # no more digits
+                          # some edge cases I can think of
+                          (10.0, 0, "1e+01"),  # weird
+                          (10, 5, "10"),  # integer
+                          # errors
+                          (10, None, "missing precision"),
+                          (10, 1.2, "Invalid format specifier"),
+                          (10, -3, "missing precision")])
+def test__float_or_none(x, digits, expected):
+    """Test :func:`astropy.cosmology.utils._float_or_none`."""
+    # handle errors
+    if not isinstance(digits, int) or digits < 0:
+        with pytest.raises(ValueError, match=expected):
+            _float_or_none(x, digits=digits)
+    # normal use cases
+    else:
+        assert _float_or_none(x, digits=digits) == expected
+
+
+def test_vectorize_if_needed():
+    """
+    Test :func:`astropy.cosmology.utils.vectorize_if_needed`.
+    There's no need to test 'veckw' because that is directly pasased to
+    `numpy.vectorize` which thoroughly tests the various inputs.
+
+    """
+    func = lambda x: x ** 2
+
+    # not vectorized
+    assert vectorize_if_needed(func, 2) == 4
+
+    # vectorized
+    assert all(vectorize_if_needed(func, [2, 3]) == [4, 9])
+
+
+@pytest.mark.parametrize("arr, expected",
+                         [(0.0, inf),  # float scalar
+                          (1, inf),  # integer scalar should give float output
+                          ([0.0, 1.0, 2.0, 3.0], (inf, inf, inf, inf)),
+                          ([0, 1, 2, 3], (inf, inf, inf, inf)),  # integer list
+                         ])
+def test_inf_like(arr, expected):
+    """
+    Test :func:`astropy.cosmology.utils.inf_like`.
+    All inputs should give a float output.
+    These tests are also in the docstring, but it's better to have them also
+    in one consolidated location.
+    """
+    assert np.all(inf_like(arr) == expected)

--- a/astropy/cosmology/utils.py
+++ b/astropy/cosmology/utils.py
@@ -1,0 +1,92 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+from math import inf
+
+import numpy as np
+
+from astropy.utils import isiterable
+
+__all__ = []  # nothing is publicly scoped
+
+
+def _float_or_none(x, digits=3):
+    """Helper function to format a variable that can be a float or None.
+
+    Parameters
+    ----------
+    x : float or None
+    digits : int
+        Number of digits to display. This includes left of the decimal place.
+        Must be positive.
+
+    Returns
+    -------
+    str
+
+    Examples
+    --------
+    >>> _float_or_none(None)
+    'None'
+    >>> _float_or_none(10.1234, 3)
+    '10.1'
+    """
+    if x is None:
+        return str(x)
+    fmtstr = "{0:.{digits}g}".format(x, digits=digits)
+    return fmtstr.format(x)
+
+
+def vectorize_if_needed(f, *x, **vkw):
+    """Helper function to vectorize scalar functions on array inputs.
+
+    Parameters
+    ----------
+    f : callable
+        'f' must accept positional arguments and no mandatory keyword
+        arguments.
+    *x
+        Arguments into ``f``.
+    **vkw
+        Keyword arguments into :class:`numpy.vectorize`.
+
+    Examples
+    --------
+    >>> func = lambda x: x ** 2
+    >>> vectorize_if_needed(func, 2)
+    4
+    >>> vectorize_if_needed(func, [2, 3])
+    array([4, 9])
+    """
+    return np.vectorize(f, **vkw)(*x) if any(map(isiterable, x)) else f(*x)
+
+
+def inf_like(x):
+    """Return the shape of x with value infinity and dtype='float'.
+
+    Preserves 'shape' for both array and scalar inputs.
+    But always returns a float array, even if x is of integer type.
+
+    Parameters
+    ----------
+    x : scalar or array-like
+        Must work with functions `numpy.isscalar` and `numpy.full_like` (if `x`
+        is not a scalar`
+
+    Returns
+    -------
+    `math.inf` or ndarray[float] thereof
+        Returns a scalar `~math.inf` if `x` is a scalar, an array of floats
+        otherwise.
+
+    Examples
+    --------
+    >>> inf_like(0.)  # float scalar
+    inf
+    >>> inf_like(1)  # integer scalar should give float output
+    inf
+    >>> inf_like([0., 1., 2., 3.])  # float list
+    array([inf, inf, inf, inf])
+    >>> inf_like([0, 1, 2, 3])  # integer list should give float output
+    array([inf, inf, inf, inf])
+    """
+    return inf if np.isscalar(x) else np.full_like(x, inf, dtype=float)


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

### Description

Cosmology ``core.py`` contains a lot of classes, and also some non-cosmology related functions. These  non-cosmology related functions should probably be moved, and the best place seems to be a new file ``utils.py``. 
As the functions need to be imported into ``core.py``, this doesn't change the namespace, so ``from astropy.cosmology.core import X`` will still work.

Fixes #11959


### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
