### PR TITLE
Fix warnings with Python 3.10

### DIFF
--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -29,10 +29,10 @@ jobs:
           # that gives too many false positives due to URL timeouts. We also
           # install all dependencies via pip here so we pick up the latest
           # releases.
-          - name: Python 3.8 with dev version of key dependencies
+          - name: Python 3.10 with dev version of key dependencies
             os: ubuntu-latest
-            python: 3.8
-            toxenv: py38-test-devdeps
+            python: 3.10.0-beta.4
+            toxenv: py310-test-devdeps
 
           - name: Documentation link check
             os: ubuntu-latest

--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -31,7 +31,7 @@ jobs:
           # releases.
           - name: Python 3.10 with dev version of key dependencies
             os: ubuntu-latest
-            python: 3.10.0-rc.1
+            python: '3.10.0-alpha - 3.10.0'
             toxenv: py310-test-devdeps
 
           - name: Documentation link check

--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -31,7 +31,7 @@ jobs:
           # releases.
           - name: Python 3.10 with dev version of key dependencies
             os: ubuntu-latest
-            python: 3.10.0-beta.4
+            python: 3.10.0-rc.1
             toxenv: py310-test-devdeps
 
           - name: Documentation link check

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -58,6 +58,11 @@ jobs:
             python: 3.9
             toxenv: py39-test
 
+          - name: Python 3.10 with minimal dependencies
+            os: ubuntu-latest
+            python: 3.10.0-beta.4
+            toxenv: py39-test
+
           # NOTE: In the build below we also check that tests do not open and
           # leave open any files. This has a performance impact on running the
           # tests, hence why it is not enabled by default.

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -60,7 +60,7 @@ jobs:
 
           - name: Python 3.10 with minimal dependencies
             os: ubuntu-latest
-            python: 3.10.0-rc.1
+            python: '3.10.0-alpha - 3.10.0'
             toxenv: py310-test-devdeps
 
           # NOTE: In the build below we also check that tests do not open and

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -61,7 +61,7 @@ jobs:
           - name: Python 3.10 with minimal dependencies
             os: ubuntu-latest
             python: 3.10.0-beta.4
-            toxenv: py39-test
+            toxenv: py310-test
 
           # NOTE: In the build below we also check that tests do not open and
           # leave open any files. This has a performance impact on running the

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -61,7 +61,7 @@ jobs:
           - name: Python 3.10 with minimal dependencies
             os: ubuntu-latest
             python: 3.10.0-beta.4
-            toxenv: py310-test
+            toxenv: py310-test-devdeps
 
           # NOTE: In the build below we also check that tests do not open and
           # leave open any files. This has a performance impact on running the

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -60,7 +60,7 @@ jobs:
 
           - name: Python 3.10 with minimal dependencies
             os: ubuntu-latest
-            python: 3.10.0-beta.4
+            python: 3.10.0-rc.1
             toxenv: py310-test-devdeps
 
           # NOTE: In the build below we also check that tests do not open and

--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -4,6 +4,7 @@ import warnings
 
 import os
 import ctypes
+import warnings
 from functools import partial
 
 import numpy as np
@@ -22,7 +23,10 @@ from .utils import KernelSizeError, has_even_axis, raise_even_kernel_exception
 LIBRARY_PATH = os.path.dirname(__file__)
 
 try:
-    _convolve = load_library("_convolve", LIBRARY_PATH)
+    with warnings.catch_warnings():
+        # distutils.sysconfig module is deprecated in Python 3.10
+        warnings.simplefilter('ignore', DeprecationWarning)
+        _convolve = load_library("_convolve", LIBRARY_PATH)
 except Exception:
     raise ImportError("Convolution C extension is missing. Try re-building astropy.")
 

--- a/astropy/io/fits/util.py
+++ b/astropy/io/fits/util.py
@@ -210,9 +210,9 @@ def ignore_sigint(func):
     def wrapped(*args, **kwargs):
         # Get the name of the current thread and determine if this is a single
         # threaded application
-        curr_thread = threading.currentThread()
-        single_thread = (threading.activeCount() == 1 and
-                         curr_thread.getName() == 'MainThread')
+        curr_thread = threading.current_thread()
+        single_thread = (threading.active_count() == 1 and
+                         curr_thread.name == 'MainThread')
 
         class SigintHandler:
             def __init__(self):

--- a/astropy/tests/tests/test_imports.py
+++ b/astropy/tests/tests/test_imports.py
@@ -19,7 +19,7 @@ def test_imports():
 
     for imper, nm, ispkg in pkgutil.walk_packages(['astropy'], 'astropy.',
                                                   onerror=onerror):
-        imper.find_module(nm)
+        imper.find_spec(nm)
 
 
 def test_toplevel_namespace():

--- a/astropy/utils/console.py
+++ b/astropy/utils/console.py
@@ -121,7 +121,7 @@ def isatty(file):
     ttys.
     """
     if (multiprocessing.current_process().name != 'MainProcess' or
-            threading.current_thread().getName() != 'MainThread'):
+            threading.current_thread().name != 'MainThread'):
         return False
 
     if hasattr(file, 'isatty'):

--- a/docs/changes/11962.other.rst
+++ b/docs/changes/11962.other.rst
@@ -1,0 +1,1 @@
+Fix deprecation warnings with Python 3.10

--- a/setup.cfg
+++ b/setup.cfg
@@ -143,10 +143,11 @@ filterwarnings =
     # Ignore a warning we emit about not supporting the parallel
     # reading option for now, can be removed once the issue is fixed
     ignore:parallel reading does not currently work, so falling back to serial
-    # RuntimeWarning from convolution, lombscargle, modeling
-    ignore:invalid value encountered in true_divide:RuntimeWarning
-    # RuntimeWarning from units, lombscargle
-    ignore:divide by zero encountered in:RuntimeWarning
+    ignore:divide by zero encountered in true_divide:RuntimeWarning:astropy.modeling.functional_models
+    ignore:divide by zero encountered in true_divide:RuntimeWarning:astropy.timeseries.periodograms.lombscargle
+    ignore:divide by zero encountered in true_divide:RuntimeWarning:astropy.units.quantity
+    ignore:invalid value encountered in true_divide:RuntimeWarning:astropy.convolution.convolve
+    ignore:invalid value encountered in true_divide:RuntimeWarning:astropy.modeling.functional_models
 doctest_norecursedirs =
     */setup_package.py
 doctest_subpackage_requires =

--- a/setup.cfg
+++ b/setup.cfg
@@ -143,6 +143,10 @@ filterwarnings =
     # Ignore a warning we emit about not supporting the parallel
     # reading option for now, can be removed once the issue is fixed
     ignore:parallel reading does not currently work, so falling back to serial
+    # RuntimeWarning from convolution, lombscargle, modeling
+    ignore:invalid value encountered in true_divide:RuntimeWarning
+    # RuntimeWarning from units, lombscargle
+    ignore:divide by zero encountered in:RuntimeWarning
 doctest_norecursedirs =
     */setup_package.py
 doctest_subpackage_requires =

--- a/setup.cfg
+++ b/setup.cfg
@@ -143,11 +143,6 @@ filterwarnings =
     # Ignore a warning we emit about not supporting the parallel
     # reading option for now, can be removed once the issue is fixed
     ignore:parallel reading does not currently work, so falling back to serial
-    ignore:divide by zero encountered in true_divide:RuntimeWarning:astropy.modeling.functional_models
-    ignore:divide by zero encountered in true_divide:RuntimeWarning:astropy.timeseries.periodograms.lombscargle
-    ignore:divide by zero encountered in true_divide:RuntimeWarning:astropy.units.quantity
-    ignore:invalid value encountered in true_divide:RuntimeWarning:astropy.convolution.convolve
-    ignore:invalid value encountered in true_divide:RuntimeWarning:astropy.modeling.functional_models
 doctest_norecursedirs =
     */setup_package.py
 doctest_subpackage_requires =

--- a/tox.ini
+++ b/tox.ini
@@ -87,8 +87,7 @@ deps =
 
     # The devdeps factor is intended to be used to install the latest developer version
     # or nightly wheel of key dependencies.
-    # devdeps: :NIGHTLY:numpy
-    devdeps: git+https://github.com/numpy/numpy.git#egg=numpy
+    devdeps: :NIGHTLY:numpy
     devdeps,mpldev: git+https://github.com/matplotlib/matplotlib.git#egg=matplotlib
     devdeps: git+https://github.com/spacetelescope/asdf.git#egg=asdf
     devdeps: git+https://github.com/liberfa/pyerfa.git#egg=pyerfa

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{38,39,dev}-test{,-image,-recdeps,-alldeps,-oldestdeps,-devdeps,-numpy118,-numpy119,-numpy120,-numpy121,-mpl311}{,-cov}{,-clocale}
+    py{38,39,310,dev}-test{,-image,-recdeps,-alldeps,-oldestdeps,-devdeps,-numpy118,-numpy119,-numpy120,-numpy121,-mpl311}{,-cov}{,-clocale}
     build_docs
     linkcheck
     codestyle

--- a/tox.ini
+++ b/tox.ini
@@ -87,7 +87,8 @@ deps =
 
     # The devdeps factor is intended to be used to install the latest developer version
     # or nightly wheel of key dependencies.
-    devdeps: :NIGHTLY:numpy
+    # devdeps: :NIGHTLY:numpy
+    devdeps: git+https://github.com/numpy/numpy.git#egg=numpy
     devdeps,mpldev: git+https://github.com/matplotlib/matplotlib.git#egg=matplotlib
     devdeps: git+https://github.com/spacetelescope/asdf.git#egg=asdf
     devdeps: git+https://github.com/liberfa/pyerfa.git#egg=pyerfa


### PR DESCRIPTION
Closes  #11821, tests run locally, not sure when we will be able to add a job on Actions.

Fix the deprecation warnings and ignore new `RuntimeWarning` raised in convolution, lombscargle, modeling and units. We should probably address those by either fixing the code or catching them in tests but there are many of them (except for units, only 1 IIRC). So probably to address those when we have a 3.10 job.

What should be the milestone, probably 4.3 ?

<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to address ...

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
