### PR TITLE
add len to quantity iterator

### DIFF
--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -110,6 +110,9 @@ class QuantityIterator:
 
     next = __next__
 
+    def __len__(self):
+        return len(self._dataiter)
+
     #### properties and methods to match `numpy.ndarray.flatiter` ####
 
     @property

--- a/astropy/units/tests/test_quantity_array_methods.py
+++ b/astropy/units/tests/test_quantity_array_methods.py
@@ -130,6 +130,8 @@ class TestQuantityReshapeFuncs:
         """While ``flat`` doesn't make a copy, it changes the shape."""
         q = np.arange(6.).reshape(3, 1, 2) * u.m
         qf = q.flat
+        # flat shape is same as before reshaping
+        assert len(qf) == 6
         # see TestQuantityArrayCopy.test_flat for tests of iteration
         # and slicing and setting. Here we test the properties and methods to
         # match `numpy.ndarray.flatiter`


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

Further method compatibility between numpy flatiter and QuantityIterator

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
