### PR TITLE
Fix for kernels allowing silent overwritting of arrays.

### DIFF
--- a/astropy/convolution/core.py
+++ b/astropy/convolution/core.py
@@ -216,9 +216,11 @@ class Kernel1D(Kernel):
 
     def __init__(self, model=None, x_size=None, array=None, **kwargs):
         # Initialize from model
-        if array is None:
-            if self._model is None:
-                raise TypeError("Must specify either array or model.")
+        if self._model:
+            if array is not None:
+                # Reject "array" keyword for kernel models, to avoid them not being
+                # populated as expected.
+                raise TypeError("Array argument not allowed for kernel models.")
 
             if x_size is None:
                 x_size = self._default_size
@@ -235,8 +237,8 @@ class Kernel1D(Kernel):
             array = discretize_model(self._model, x_range, **kwargs)
 
         # Initialize from array
-        elif array is not None:
-            self._model = None
+        elif array is None:
+            raise TypeError("Must specify either array or model.")
 
         super().__init__(array)
 
@@ -280,10 +282,11 @@ class Kernel2D(Kernel):
     def __init__(self, model=None, x_size=None, y_size=None, array=None, **kwargs):
 
         # Initialize from model
-        if array is None:
-            if self._model is None:
-                raise TypeError("Must specify either array or model.")
-
+        if self._model:
+            if array is not None:
+                # Reject "array" keyword for kernel models, to avoid them not being
+                # populated as expected.
+                raise TypeError("Array argument not allowed for kernel models.")
             if x_size is None:
                 x_size = self._default_size
             elif x_size != int(x_size):
@@ -309,8 +312,8 @@ class Kernel2D(Kernel):
             array = discretize_model(self._model, x_range, y_range, **kwargs)
 
         # Initialize from array
-        elif array is not None:
-            self._model = None
+        elif array is None:
+            raise TypeError("Must specify either array or model.")
 
         super().__init__(array)
 

--- a/astropy/convolution/tests/test_kernel_class.py
+++ b/astropy/convolution/tests/test_kernel_class.py
@@ -545,3 +545,23 @@ class TestKernels:
         """
         with pytest.raises(TypeError):
             Kernel2D()
+
+    def test_array_keyword_not_allowed(self):
+        """
+        Regression test for issue #10439
+        """
+        x = np.ones([10,10])
+        with pytest.raises(TypeError, match=r".* allowed .*"):
+            AiryDisk2DKernel(2, array=x)
+            Box1DKernel(2, array=x)
+            Box2DKernel(2, array=x)
+            Gaussian1DKernel(2, array=x)
+            Gaussian2DKernel(2, array=x)
+            RickerWavelet1DKernel(2, array=x)
+            RickerWavelet2DKernel(2, array=x)
+            Model1DKernel(Gaussian1D(1, 0, 2), array=x)
+            Model2DKernel(Gaussian2D(1, 0, 0, 2, 2), array=x)
+            Ring2DKernel(9, 8, array=x)
+            Tophat2DKernel(2, array=x)
+            Trapezoid1DKernel(2, array=x)
+            Trapezoid1DKernel(2, array=x)

--- a/docs/changes/convolution/11969.bugfix.rst
+++ b/docs/changes/convolution/11969.bugfix.rst
@@ -1,1 +1,1 @@
-Passing an ``array`` argument for any Kernel1D or Kernel2D subclasses (with the exception of CustomKernel) will now raise a `TypeError``. 
+Passing an ``array`` argument for any Kernel1D or Kernel2D subclasses (with the exception of CustomKernel) will now raise a ``TypeError``. 

--- a/docs/changes/convolution/11969.bugfix.rst
+++ b/docs/changes/convolution/11969.bugfix.rst
@@ -1,0 +1,1 @@
+Passing an ``array`` argument for any Kernel1D or Kernel2D subclasses (with the exception of CustomKernel) will now raise a `TypeError``. 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request aims to fix the bug that allows `Kernel1D` or `Kernel2D`'s subclasses accept `array` argument when initialized, therefore silently becoming essentialy another type of kernel.

In order to address this I slightly changed the checks in `__init__` functions of their base classes `Kernel1D` and `Kernel2D`. As for now, in order to initialize a kernel model, `__init__` checks if `array` has a value. If it has, kernel will be initialized from array, no matter if it was intended to be a kernel model. In other words, design is prioritizing array initialization over model initialization.

In this version I propose, `__init__` first checks if the kernel has a `_model`. If so, there is a second check for if `array` argument exists. This will raise an error if so. If not, kernel will be initialized from model. There is another last check for if no model nor array has been specified. Array initialization would be the default flow.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #10439 

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
