### PR TITLE
4.3.1 changelog roll-up from towncrier

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,37 @@
+4.3.1 (unreleased)
+==================
+
+Bug Fixes
+---------
+
+astropy.io.fits
+^^^^^^^^^^^^^^^
+
+- In ``fits.io.getdata`` do not fall back to first non-primary extension when
+  user explicitly specifies an extension. [#11860]
+
+- Ensure multidimensional masked columns round-trip properly to FITS. [#11911]
+
+- Ensure masked times round-trip to FITS, even if multi-dimensional. [#11913]
+
+- Raise ``ValueError`` if an ``np.float32`` NaN/Inf value is assigned to a
+  header keyword. [#11922]
+
+astropy.modeling
+^^^^^^^^^^^^^^^^
+
+- Fixed bug in ``fix_inputs`` handling of bounding boxes. [#11908]
+
+astropy.units
+^^^^^^^^^^^^^
+
+- Ensure that unpickling quantities and units in new sessions does not change
+  hashes and thus cause problems with (de)composition such as getting different
+  answers from the ``.si`` attribute. [#11879]
+
+- Fixed cannot import name imperial from astropy.units namespace. [#11977]
+
+
 4.3 (2021-07-26)
 ================
 

--- a/docs/changes/io.fits/11860.bugfix.rst
+++ b/docs/changes/io.fits/11860.bugfix.rst
@@ -1,2 +1,0 @@
-In ``fits.io.getdata`` do not fall back to first non-primary extension when
-user explicitly specifies an extension.

--- a/docs/changes/io.fits/11911.bugfix.rst
+++ b/docs/changes/io.fits/11911.bugfix.rst
@@ -1,1 +1,0 @@
-Ensure multidimensional masked columns round-trip properly to FITS.

--- a/docs/changes/io.fits/11913.bugfix.rst
+++ b/docs/changes/io.fits/11913.bugfix.rst
@@ -1,1 +1,0 @@
-Ensure masked times round-trip to FITS, even if multi-dimensional.

--- a/docs/changes/io.fits/11922.bugfix.rst
+++ b/docs/changes/io.fits/11922.bugfix.rst
@@ -1,1 +1,0 @@
-Raise ``ValueError`` if an ``np.float32`` NaN/Inf value is assigned to a header keyword.

--- a/docs/changes/modeling/11908.bugfix.rst
+++ b/docs/changes/modeling/11908.bugfix.rst
@@ -1,1 +1,0 @@
-Fixed bug in ``fix_inputs`` handling of bounding boxes.

--- a/docs/changes/units/11879.bugfix.rst
+++ b/docs/changes/units/11879.bugfix.rst
@@ -1,3 +1,0 @@
-Ensure that unpickling quantities and units in new sessions does not change
-hashes and thus cause problems with (de)composition such as getting different
-answers from the ``.si`` attribute.

--- a/docs/changes/units/11977.bugfix.rst
+++ b/docs/changes/units/11977.bugfix.rst
@@ -1,1 +1,0 @@
-Fixed cannot import name imperial from astropy.units namespace.


### PR DESCRIPTION
This is the changelog for 4.3.1 (hopefually) - I'm PRing this to v4.3.x following the plan from #11973 and then it gets forward-ported to `main` post-release.