### PR TITLE
Let WCS slice accept integer types other than just int

### DIFF
--- a/astropy/wcs/wcsapi/wrappers/sliced_wcs.py
+++ b/astropy/wcs/wcsapi/wrappers/sliced_wcs.py
@@ -214,7 +214,7 @@ class SlicedLowLevelWCS(BaseWCSWrapper):
         pixel_arrays_new = []
         ipix_curr = -1
         for ipix in range(self._wcs.pixel_n_dim):
-            if isinstance(self._slices_pixel[ipix], int):
+            if isinstance(self._slices_pixel[ipix], numbers.Integral):
                 pixel_arrays_new.append(self._slices_pixel[ipix])
             else:
                 ipix_curr += 1

--- a/astropy/wcs/wcsapi/wrappers/tests/test_sliced_wcs.py
+++ b/astropy/wcs/wcsapi/wrappers/tests/test_sliced_wcs.py
@@ -890,3 +890,12 @@ def test_dropped_dimensions_4d(cube_4d_fitswcs):
 
     assert wao_classes['spectral'][0:3] == (u.Quantity, (), {})
     assert wao_classes['time'][0:3] == (Time, (), {})
+
+
+def test_pixel_to_world_values_different_int_types():
+    int_sliced = SlicedLowLevelWCS(WCS_SPECTRAL_CUBE, np.s_[:, 0, :])
+    np64_sliced = SlicedLowLevelWCS(WCS_SPECTRAL_CUBE, np.s_[:, np.int64(0), :])
+    pixel_arrays = ([0, 1], [0, 1])
+    for int_coord, np64_coord in zip(int_sliced.pixel_to_world_values(*pixel_arrays),
+                                     np64_sliced.pixel_to_world_values(*pixel_arrays)):
+        assert all(int_coord == np64_coord)

--- a/docs/changes/wcs/11980.bugfix.rst
+++ b/docs/changes/wcs/11980.bugfix.rst
@@ -1,0 +1,1 @@
+Enabled ``SlicedLowLevelWCS.pixel_to_world_values`` to handle slices including non- ``int`` integers, e.g. ``numpy.int64``.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This PR fixes an `isinstance` check when slicing `WCS`.  While in all other locations in that submodule the check is done using `isinstance(var, numbers.Integral)`, there was one location where the check was done against `int`.  This caused WCS slicing to crash if a non-`int` integer type was given, e.g. `numpy.int64`.  This PR corrects this.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
