### PR TITLE
Accept UCD C atoms when parsing UCDs

### DIFF
--- a/astropy/io/votable/tests/ucd_test.py
+++ b/astropy/io/votable/tests/ucd_test.py
@@ -31,6 +31,11 @@ examples = {
          ('ivoa', 'stat.max')],
     'stat.error;phot.mag;em.opt.V':
         [('ivoa', 'stat.error'), ('ivoa', 'phot.mag'), ('ivoa', 'em.opt.V')],
+    'phot.color;em.opt.B;em.opt.V':
+        [('ivoa', 'phot.color'), ('ivoa', 'em.opt.B'), ('ivoa', 'em.opt.V')],
+    'stat.error;phot.color;em.opt.B;em.opt.V':
+        [('ivoa', 'stat.error'), ('ivoa', 'phot.color'), ('ivoa', 'em.opt.B'),
+         ('ivoa', 'em.opt.V')],
 }
 
 

--- a/astropy/io/votable/ucd.py
+++ b/astropy/io/votable/ucd.py
@@ -33,9 +33,9 @@ class UCDWords:
                 type, name, descr = [
                     x.strip() for x in line.split('|')]
                 name_lower = name.lower()
-                if type in 'QPEV':
+                if type in 'QPEVC':
                     self._primary.add(name_lower)
-                if type in 'QSEV':
+                if type in 'QSEVC':
                     self._secondary.add(name_lower)
                 self._descriptions[name_lower] = descr
                 self._capitalization[name_lower] = name

--- a/docs/changes/io.votable/11982.bugfix.rst
+++ b/docs/changes/io.votable/11982.bugfix.rst
@@ -1,0 +1,1 @@
+Now accepting UCDs containing phot.color.


### PR DESCRIPTION
### Description

This pull request is to address the rejection of phot.color (and
possibly other C atoms, if these ever came to exist) UCDs by astropy.

Fixes #11981

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.