### PR TITLE
Updates to `~astropy.modeling.custom_model`

### DIFF
--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -710,6 +710,7 @@ class Model(metaclass=_ModelMeta):
                         self.__dict__[parname] = newpar
 
         self._initialize_constraints(kwargs)
+        kwargs = self._initialize_setters(kwargs)
         # Remaining keyword args are either parameter values or invalid
         # Parameter values must be passed in as keyword arguments in order to
         # distinguish them
@@ -734,6 +735,19 @@ class Model(metaclass=_ModelMeta):
                 # ``n_inputs``, ``n_outputs``, ``inputs`` or ``outputs``.
                 self._inputs = ()
                 self._outputs = ()
+
+    def _initialize_setters(self, kwargs):
+        """
+        This exists to inject defaults for settable properties for models
+        originating from `custom_model`.
+        """
+        if hasattr(self, '_settable_properties'):
+            setters = {name: kwargs.pop(name, default)
+                       for name, default in self._settable_properties.items()}
+            for name, value in setters.items():
+                setattr(self, name, value)
+
+        return kwargs
 
     @property
     def inputs(self):
@@ -3660,6 +3674,50 @@ def custom_model(*args, fit_deriv=None):
             "any).".format(__name__))
 
 
+def _custom_model_inputs(func):
+    """
+    Processes the inputs to the `custom_model`'s function into the appropriate
+    categories.
+
+    Parameters
+    ----------
+    func : callable
+
+    Returns
+    -------
+    inputs : list
+        list of evaluation inputs
+    special_params : dict
+        dictionary of model properties which require special treatment
+    settable_params : dict
+        dictionary of defaults for settable model properties
+    params : dict
+        dictionary of model parameters set by `custom_model`'s function
+    """
+    inputs, parameters = get_inputs_and_params(func)
+
+    special = ['n_outputs']
+    settable = [attr for attr, value in vars(Model).items()
+                if isinstance(value, property) and value.fset is not None]
+    properties = [attr for attr, value in vars(Model).items()
+                  if isinstance(value, property) and value.fset is None and attr not in special]
+
+    special_params = {}
+    settable_params = {}
+    params = {}
+    for param in parameters:
+        if param.name in special:
+            special_params[param.name] = param.default
+        elif param.name in settable:
+            settable_params[param.name] = param.default
+        elif param.name in properties:
+            raise ValueError(f"Parameter '{param.name}' cannot be a model property: {properties}.")
+        else:
+            params[param.name] = param.default
+
+    return inputs, special_params, settable_params, params
+
+
 def _custom_model_wrapper(func, fit_deriv=None):
     """
     Internal implementation `custom_model`.
@@ -3683,21 +3741,15 @@ def _custom_model_wrapper(func, fit_deriv=None):
 
     model_name = func.__name__
 
-    inputs, params = get_inputs_and_params(func)
+    inputs, special_params, settable_params, params = _custom_model_inputs(func)
 
     if (fit_deriv is not None and
             len(fit_deriv.__defaults__) != len(params)):
         raise ModelDefinitionError("derivative function should accept "
                                    "same number of parameters as func.")
 
-    # TODO: Maybe have a clever scheme for default output name?
-    if inputs:
-        output_names = (inputs[0].name,)
-    else:
-        output_names = ('x',)
-
-    params = {param.name: Parameter(param.name, default=param.default)
-              for param in params}
+    params = {param: Parameter(param, default=default)
+              for param, default in params.items()}
 
     mod = find_current_module(2)
     if mod:
@@ -3709,9 +3761,9 @@ def _custom_model_wrapper(func, fit_deriv=None):
         '__module__': str(modname),
         '__doc__': func.__doc__,
         'n_inputs': len(inputs),
-        # tuple(x.name for x in inputs)),
-        'n_outputs': len(output_names),
-        'evaluate': staticmethod(func)
+        'n_outputs': special_params.pop('n_outputs', 1),
+        'evaluate': staticmethod(func),
+        '_settable_properties': settable_params
     }
 
     if fit_deriv is not None:

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -3607,6 +3607,13 @@ def custom_model(*args, fit_deriv=None):
         default values in the model function.  Use `None` as a default argument
         value if you do not want to have a default value for that parameter.
 
+        The standard settable model properties can be configured by default
+        using keyword arguments matching the name of the property; however,
+        these values are not set as model "parameters". Moreover, users
+        cannot use keyword arguments matching non-settable model properties,
+        with the exception of ``n_outputs`` which should be set to the number of
+        outputs of your function.
+
     Parameters
     ----------
     func : function

--- a/astropy/modeling/tests/test_core.py
+++ b/astropy/modeling/tests/test_core.py
@@ -193,7 +193,7 @@ def test_custom_model_n_outputs():
     """
     Test creating a custom_model which has more than one output, which
     requires special handling.
-        Demonstrates issue #11791's `n_outputs` error has been solved
+        Demonstrates issue #11791's ``n_outputs`` error has been solved
     """
 
     @custom_model

--- a/astropy/modeling/tests/test_core.py
+++ b/astropy/modeling/tests/test_core.py
@@ -11,6 +11,7 @@ from numpy.testing import assert_allclose
 
 import astropy
 from astropy.modeling.core import Model, custom_model, SPECIAL_OPERATORS, _add_special_operator
+from astropy.modeling.separable import separability_matrix
 from astropy.modeling.parameters import Parameter
 from astropy.modeling import models
 from astropy.convolution import convolve_models
@@ -186,6 +187,100 @@ def test_custom_model_parametrized_decorator():
     s = sine(2)
     assert_allclose(s(np.pi / 2), 2)
     assert_allclose(s.fit_deriv(0, 2), 2)
+
+
+def test_custom_model_n_outputs():
+    """
+    Test creating a custom_model which has more than one output, which
+    requires special handling.
+        Demonstrates issue #11791's `n_outputs` error has been solved
+    """
+
+    @custom_model
+    def model(x, y, n_outputs=2):
+        return x+1, y+1
+
+    m = model()
+    assert not isinstance(m.n_outputs, Parameter)
+    assert isinstance(m.n_outputs, int)
+    assert m.n_outputs == 2
+    assert m.outputs == ('x0', 'x1')
+    assert (separability_matrix(m) == [[True, True],
+                                       [True, True]]).all()
+
+    @custom_model
+    def model(x, y, z, n_outputs=3):
+        return x+1, y+1, z+1
+
+    m = model()
+    assert not isinstance(m.n_outputs, Parameter)
+    assert isinstance(m.n_outputs, int)
+    assert m.n_outputs == 3
+    assert m.outputs == ('x0', 'x1', 'x2')
+    assert (separability_matrix(m) == [[True, True, True],
+                                       [True, True, True],
+                                       [True, True, True]]).all()
+
+
+def test_custom_model_settable_parameters():
+    """
+    Test creating a custom_model which specifically sets adjustable model
+    parameters.
+        Demonstrates part of issue #11791's notes about what passed parameters
+        should/shouldn't be allowed. In this case, settable parameters
+        should be allowed to have defaults set.
+    """
+    @custom_model
+    def model(x, y, n_outputs=2, bounding_box=((1, 2), (3, 4))):
+        return x+1, y+1
+
+    m = model()
+    assert m.n_outputs == 2
+    assert m.bounding_box == ((1, 2), (3, 4))
+    m.bounding_box = ((9, 10), (11, 12))
+    assert m.bounding_box == ((9, 10), (11, 12))
+    m = model(bounding_box=((5, 6), (7, 8)))
+    assert m.n_outputs == 2
+    assert m.bounding_box == ((5, 6), (7, 8))
+    m.bounding_box = ((9, 10), (11, 12))
+    assert m.bounding_box == ((9, 10), (11, 12))
+
+    @custom_model
+    def model(x, y, n_outputs=2, outputs=('z0', 'z1')):
+        return x+1, y+1
+
+    m = model()
+    assert m.n_outputs == 2
+    assert m.outputs == ('z0', 'z1')
+    m.outputs = ('a0', 'a1')
+    assert m.outputs == ('a0', 'a1')
+    m = model(outputs=('w0', 'w1'))
+    assert m.n_outputs == 2
+    assert m.outputs == ('w0', 'w1')
+    m.outputs = ('a0', 'a1')
+    assert m.outputs == ('a0', 'a1')
+
+
+def test_custom_model_regected_parameters():
+    """
+    Test creating a custom_model which attempts to override non-overridable
+    parameters.
+        Demonstrates part of issue #11791's notes about what passed parameters
+        should/shouldn't be allowed. In this case, non-settable parameters
+        should raise an error (unexpected behavior may occur).
+    """
+
+    with pytest.raises(ValueError,
+                       match=r"Parameter 'n_inputs' cannot be a model property: *"):
+        @custom_model
+        def model(x, y, n_outputs=2, n_inputs=3):
+            return x+1, y+1
+
+    with pytest.raises(ValueError,
+                       match=r"Parameter 'uses_quantity' cannot be a model property: *"):
+        @custom_model
+        def model(x, y, n_outputs=2, uses_quantity=True):
+            return x+1, y+1
 
 
 def test_custom_inverse():

--- a/docs/changes/modeling/11984.feature.rst
+++ b/docs/changes/modeling/11984.feature.rst
@@ -1,0 +1,1 @@
+Improved parameter support for ``astropy.modeling.core.custom_model`` created models.

--- a/docs/modeling/new-model.rst
+++ b/docs/modeling/new-model.rst
@@ -55,10 +55,12 @@ of two Gaussians:
 
 This decorator also supports setting a model's
 `~astropy.modeling.FittableModel.fit_deriv` as well as creating models with
-more than one inputs.  It can also be used as a normal factory function (for
-example ``SumOfGaussians = custom_model(sum_of_gaussians)``) rather than as a
-decorator.  See the `~astropy.modeling.custom_model` documentation for more
-examples.
+more than one inputs.  Note that when creating a model from a function with
+multiple outputs, the keyword argument ``n_outputs`` must be set to the
+number of outputs of the function.  It can also be used as a normal factory
+function (for example ``SumOfGaussians = custom_model(sum_of_gaussians)``)
+rather than as a decorator.  See the `~astropy.modeling.custom_model`
+documentation for more examples.
 
 
 A step by step definition of a 1-D Gaussian model


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request addresses the issues raised in #11791. Namely, what should be done with "parameters" set using `custom_model` which directly relate to the internal workings of `Model`.

In particular, it pointed out that weird behavior occurs when the user tries to set `n_outputs` via the `custom_model` interface. This exposed the fact that `custom_model` assumed that the model generated would always have exactly one output value, which should not be the case.

This PR addresses the question of the banned/reserved list of parameters, by banning use of parameters which share a name with any "non-settable" property used in `Model` and using parameters sharing a name with a "settable" property to set the underlying `Model` property. It also introduces the notion of a `special` parameter, which is a model parameter which is not settable, but maybe one that users may want to manipulate when dynamically creating new models (e.g. `n_outputs`).

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #11791

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
