### PR TITLE
Fix bug in sigma clipping return bounds

### DIFF
--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -352,11 +352,11 @@ class SigmaClip:
             data_reshaped = data_reshaped.view(np.ndarray)
             mask = np.broadcast_to(mask, data_reshaped.shape).copy()
 
-        bound_lo, bound_hi = _sigma_clip_fast(data_reshaped, mask,
-                                              self.cenfunc == 'median',
-                                              self.stdfunc == 'mad_std',
-                                              -1 if np.isinf(self.maxiters) else self.maxiters,
-                                              self.sigma_lower, self.sigma_upper, axis=axis)
+        bound_lo, bound_hi = _sigma_clip_fast(
+            data_reshaped, mask, self.cenfunc == 'median',
+            self.stdfunc == 'mad_std',
+            -1 if np.isinf(self.maxiters) else self.maxiters,
+            self.sigma_lower, self.sigma_upper, axis=axis)
 
         with np.errstate(invalid='ignore'):
             mask |= data_reshaped < np.expand_dims(bound_lo, axis)
@@ -416,8 +416,9 @@ class SigmaClip:
             iteration += 1
             size = filtered_data.size
             self._compute_bounds(filtered_data, axis=None)
-            filtered_data = filtered_data[(filtered_data >= self._min_value) &
-                                          (filtered_data <= self._max_value)]
+            filtered_data = filtered_data[
+                (filtered_data >= self._min_value)
+                & (filtered_data <= self._max_value)]
             nchanged = size - filtered_data.size
 
         self._niterations = iteration
@@ -486,7 +487,8 @@ class SigmaClip:
                     # points won't "grow" in that dimension:
                     if n not in axis:
                         dim[dim != cenidx] = size
-            kernel = sum(((idx - cenidx)**2 for idx in indices)) <= self.grow**2
+            kernel = (sum(((idx - cenidx)**2 for idx in indices))
+                      <= self.grow**2)
             del indices
 
         nchanged = 1
@@ -503,8 +505,8 @@ class SigmaClip:
                 # resulting mask contains only newly-rejected pixels and
                 # we can dilate it without growing masked pixels more
                 # than once.
-                new_mask = ((filtered_data < self._min_value) |
-                            (filtered_data > self._max_value))
+                new_mask = ((filtered_data < self._min_value)
+                            | (filtered_data > self._max_value))
             if self.grow:
                 new_mask = self.binary_dilation(new_mask, kernel)
             filtered_data[new_mask] = np.nan
@@ -607,9 +609,9 @@ class SigmaClip:
 
         # Shortcut for common cases where a fast C implementation can be
         # used.
-        if (self.cenfunc in ('mean', 'median') and
-                self.stdfunc in ('std', 'mad_std') and
-                axis is not None and not self.grow):
+        if (self.cenfunc in ('mean', 'median')
+                and self.stdfunc in ('std', 'mad_std')
+                and axis is not None and not self.grow):
             return self._sigmaclip_fast(data, axis=axis, masked=masked,
                                         return_bounds=return_bounds,
                                         copy=copy)

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -602,10 +602,15 @@ class SigmaClip:
         data = np.asanyarray(data)
 
         if data.size == 0:
-            if return_bounds:
-                return data, self._min_value, self._max_value
+            if masked:
+                result = np.ma.MaskedArray(data)
             else:
-                return data
+                result = data
+
+            if return_bounds:
+                return result, self._min_value, self._max_value
+            else:
+                return result
 
         if isinstance(data, np.ma.MaskedArray) and data.mask.all():
             if masked:

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -604,13 +604,21 @@ class SigmaClip:
         data = np.asanyarray(data)
 
         if data.size == 0:
-            return data
+            if return_bounds:
+                return data, self._min_value, self._max_value
+            else:
+                return data
 
         if isinstance(data, np.ma.MaskedArray) and data.mask.all():
             if masked:
-                return data
+                result = data
             else:
-                return np.ma.filled(data.astype(float), fill_value=np.nan)
+                result = np.ma.filled(data.astype(float), fill_value=np.nan)
+
+            if return_bounds:
+                return result, self._min_value, self._max_value
+            else:
+                return result
 
         # Shortcut for common cases where a fast C implementation can be
         # used.

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -245,7 +245,7 @@ class SigmaClip:
         # later than necessary if __call__ needs it:
         if self.grow:
             from scipy.ndimage import binary_dilation
-            self.binary_dilation = binary_dilation
+            self._binary_dilation = binary_dilation
 
     def __repr__(self):
         return ('SigmaClip(sigma={}, sigma_lower={}, sigma_upper={}, '
@@ -395,8 +395,7 @@ class SigmaClip:
     def _sigmaclip_noaxis(self, data, masked=True, return_bounds=False,
                           copy=True):
         """
-        Sigma clip the data when ``axis`` is None and ``grow`` is not
-        >0.
+        Sigma clip when ``axis`` is None and ``grow`` is not >0.
 
         In this simple case, we remove clipped elements from the
         flattened array during each iteration.
@@ -513,7 +512,7 @@ class SigmaClip:
                 new_mask = ((filtered_data < self._min_value)
                             | (filtered_data > self._max_value))
             if self.grow:
-                new_mask = self.binary_dilation(new_mask, kernel)
+                new_mask = self._binary_dilation(new_mask, kernel)
             filtered_data[new_mask] = np.nan
             nchanged = np.count_nonzero(new_mask)
             del new_mask
@@ -558,9 +557,8 @@ class SigmaClip:
 
         masked : bool, optional
             If `True`, then a `~numpy.ma.MaskedArray` is returned, where
-            the mask is `True` for clipped values. If `False`, then
-            a `~numpy.ndarray` and the minimum and maximum clipping
-            thresholds are returned. The default is `True`.
+            the mask is `True` for clipped values. If `False`, then a
+            `~numpy.ndarray` is returned. The default is `True`.
 
         return_bounds : bool, optional
             If `True`, then the minimum and maximum clipping bounds are
@@ -613,7 +611,7 @@ class SigmaClip:
             if masked:
                 result = data
             else:
-                result = np.ma.filled(data.astype(float), fill_value=np.nan)
+                result = np.full(data.shape, np.nan)
 
             if return_bounds:
                 return result, self._min_value, self._max_value

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -236,6 +236,9 @@ class SigmaClip:
         self.stdfunc = stdfunc
         self._cenfunc_parsed = self._parse_cenfunc(cenfunc)
         self._stdfunc_parsed = self._parse_stdfunc(stdfunc)
+        self._min_value = np.nan
+        self._max_value = np.nan
+        self._niterations = 0
         self.grow = grow
 
         # This just checks that SciPy is available, to avoid failing
@@ -258,7 +261,8 @@ class SigmaClip:
             lines.append(f'    {attr}: {getattr(self, attr)}')
         return '\n'.join(lines)
 
-    def _parse_cenfunc(self, cenfunc):
+    @staticmethod
+    def _parse_cenfunc(cenfunc):
         if isinstance(cenfunc, str):
             if cenfunc == 'median':
                 if HAS_BOTTLENECK:
@@ -277,7 +281,8 @@ class SigmaClip:
 
         return cenfunc
 
-    def _parse_stdfunc(self, stdfunc):
+    @staticmethod
+    def _parse_stdfunc(stdfunc):
         if isinstance(stdfunc, str):
             if stdfunc == 'std':
                 if HAS_BOTTLENECK:

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -23,9 +23,8 @@ def _move_tuple_axes_first(array, axis):
     """
     Bottleneck can only take integer axis, not tuple, so this function
     takes all the axes to be operated on and combines them into the
-    first dimension of the array so that we can then use axis=0
+    first dimension of the array so that we can then use axis=0.
     """
-
     # Figure out how many axes we are operating over
     naxis = len(axis)
 
@@ -35,11 +34,12 @@ def _move_tuple_axes_first(array, axis):
     # The new position of each axis is just in order
     destination = tuple(range(array.ndim))
 
-    # Reorder the array so that the axes being operated on are at the beginning
+    # Reorder the array so that the axes being operated on are at the
+    # beginning
     array_new = np.moveaxis(array, axis, destination)
 
-    # Collapse the dimensions being operated on into a single dimension so that
-    # we can then use axis=0 with the bottleneck functions
+    # Collapse the dimensions being operated on into a single dimension
+    # so that we can then use axis=0 with the bottleneck functions
     array_new = array_new.reshape((-1,) + array_new.shape[naxis:])
 
     return array_new
@@ -100,8 +100,13 @@ class SigmaClip:
 
     Clipped (rejected) pixels are those where::
 
-        data < cenfunc(data [,axis=int]) - (sigma_lower * stdfunc(data [,axis=int]))
-        data > cenfunc(data [,axis=int]) + (sigma_upper * stdfunc(data [,axis=int]))
+        data < center - (sigma_lower * std)
+        data > center + (sigma_upper * std)
+
+    where::
+
+        center = cenfunc(data [, axis=])
+        std = stdfunc(data [, axis=])
 
     Invalid data values (i.e., NaN or inf) are automatically clipped.
 
@@ -109,15 +114,15 @@ class SigmaClip:
     :func:`sigma_clip`.
 
     .. note::
-        `scipy.stats.sigmaclip`
-        provides a subset of the functionality in this class.  Also, its
-        input data cannot be a masked array and it does not handle data
-        that contains invalid values (i.e., NaN or inf).  Also note that
-        it uses the mean as the centering function.
+        `scipy.stats.sigmaclip` provides a subset of the functionality
+        in this class. Also, its input data cannot be a masked array
+        and it does not handle data that contains invalid values (i.e.,
+        NaN or inf). Also note that it uses the mean as the centering
+        function.
 
-        If your data is a `~numpy.ndarray` with no invalid values and
-        you want to use the mean as the centering function with
-        ``axis=None`` and iterate to convergence, then
+        If your data is a `~numpy.ndarray` with no invalid values
+        and you want to use the mean as the centering function
+        with ``axis=None`` and iterate to convergence, then
         `scipy.stats.sigmaclip` is ~25-30% faster than the equivalent
         settings here (``s = SigmaClip(cenfunc='mean', maxiters=None);
         s(data, axis=None)``).
@@ -125,69 +130,70 @@ class SigmaClip:
     Parameters
     ----------
     sigma : float, optional
-        The number of standard deviations to use for both the lower and
-        upper clipping limit.  These limits are overridden by
-        ``sigma_lower`` and ``sigma_upper``, if input.  The default is
-        3.
+        The number of standard deviations to use for both the lower
+        and upper clipping limit. These limits are overridden by
+        ``sigma_lower`` and ``sigma_upper``, if input. The default is 3.
 
     sigma_lower : float or None, optional
         The number of standard deviations to use as the lower bound for
-        the clipping limit.  If `None` then the value of ``sigma`` is
-        used.  The default is `None`.
+        the clipping limit. If `None` then the value of ``sigma`` is
+        used. The default is `None`.
 
     sigma_upper : float or None, optional
         The number of standard deviations to use as the upper bound for
-        the clipping limit.  If `None` then the value of ``sigma`` is
-        used.  The default is `None`.
+        the clipping limit. If `None` then the value of ``sigma`` is
+        used. The default is `None`.
 
     maxiters : int or None, optional
         The maximum number of sigma-clipping iterations to perform or
         `None` to clip until convergence is achieved (i.e., iterate
-        until the last iteration clips nothing).  If convergence is
+        until the last iteration clips nothing). If convergence is
         achieved prior to ``maxiters`` iterations, the clipping
-        iterations will stop.  The default is 5.
+        iterations will stop. The default is 5.
 
     cenfunc : {'median', 'mean'} or callable, optional
-        The statistic or callable function/object used to compute the
-        center value for the clipping. If using a callable function/object and
-        the ``axis`` keyword is used, then it must be able to ignore
-        NaNs (e.g., `numpy.nanmean`) and has an ``axis`` keyword to return an
-        array with axis dimension(s) removed.  The default is ``'median'``.
+        The statistic or callable function/object used to compute
+        the center value for the clipping. If using a callable
+        function/object and the ``axis`` keyword is used, then it must
+        be able to ignore NaNs (e.g., `numpy.nanmean`) and it must have
+        an ``axis`` keyword to return an array with axis dimension(s)
+        removed. The default is ``'median'``.
 
     stdfunc : {'std', 'mad_std'} or callable, optional
         The statistic or callable function/object used to compute the
         standard deviation about the center value. If using a callable
         function/object and the ``axis`` keyword is used, then it must
-        be able to ignore NaNs (e.g., `numpy.nanstd`) and has
+        be able to ignore NaNs (e.g., `numpy.nanstd`) and it must have
         an ``axis`` keyword to return an array with axis dimension(s)
-        removed.  The default is ``'std'``.
+        removed. The default is ``'std'``.
 
     grow : float or `False`, optional
-        Radius within which to mask the neighbouring pixels of those that
-        fall outwith the clipping limits (only applied along ``axis``, if
-        specified). As an example, for a 2D image a value of 1 will mask the
-        nearest pixels in a cross pattern around each deviant pixel, while
-        1.5 will also reject the nearest diagonal neighbours and so on.
-
-    Notes
-    -----
-
-    The best performance will typically be obtained by setting ``cenfunc`` and
-    ``stdfunc`` to one of the built-in functions specified as as string. If one of
-    the options is set to a string while the other has a custom callable, you may in some
-    cases see better performance if you have the `bottleneck`_ package installed.
-
-    .. _bottleneck:  https://github.com/pydata/bottleneck
+        Radius within which to mask the neighbouring pixels of those
+        that fall outwith the clipping limits (only applied along
+        ``axis``, if specified). As an example, for a 2D image a value
+        of 1 will mask the nearest pixels in a cross pattern around each
+        deviant pixel, while 1.5 will also reject the nearest diagonal
+        neighbours and so on.
 
     See Also
     --------
     sigma_clip, sigma_clipped_stats
 
+    Notes
+    -----
+    The best performance will typically be obtained by setting
+    ``cenfunc`` and ``stdfunc`` to one of the built-in functions
+    specified as as string. If one of the options is set to a string
+    while the other has a custom callable, you may in some cases see
+    better performance if you have the `bottleneck`_ package installed.
+
+    .. _bottleneck:  https://github.com/pydata/bottleneck
+
     Examples
     --------
     This example uses a data array of random variates from a Gaussian
-    distribution.  We clip all points that are more than 2 sample
-    standard deviations from the median.  The result is a masked array,
+    distribution. We clip all points that are more than 2 sample
+    standard deviations from the median. The result is a masked array,
     where the mask is `True` for clipped data::
 
         >>> from astropy.stats import SigmaClip
@@ -196,8 +202,8 @@ class SigmaClip:
         >>> sigclip = SigmaClip(sigma=2, maxiters=5)
         >>> filtered_data = sigclip(randvar)
 
-    This example clips all points that are more than 3 sigma relative to
-    the sample *mean*, clips until convergence, returns an unmasked
+    This example clips all points that are more than 3 sigma relative
+    to the sample *mean*, clips until convergence, returns an unmasked
     `~numpy.ndarray`, and modifies the data in-place::
 
         >>> from astropy.stats import SigmaClip
@@ -222,7 +228,6 @@ class SigmaClip:
 
     def __init__(self, sigma=3., sigma_lower=None, sigma_upper=None,
                  maxiters=5, cenfunc='median', stdfunc='std', grow=False):
-
         self.sigma = sigma
         self.sigma_lower = sigma_lower or sigma
         self.sigma_upper = sigma_upper or sigma
@@ -233,8 +238,8 @@ class SigmaClip:
         self._stdfunc_parsed = self._parse_stdfunc(stdfunc)
         self.grow = grow
 
-        # This just checks that SciPy is available, to avoid failing later
-        # than necessary if __call__ needs it:
+        # This just checks that SciPy is available, to avoid failing
+        # later than necessary if __call__ needs it:
         if self.grow:
             from scipy.ndimage import binary_dilation
 
@@ -299,9 +304,8 @@ class SigmaClip:
                         masked=True, return_bounds=False,
                         copy=True):
         """
-        Fast C implementation for simple use cases
+        Fast C implementation for simple use cases.
         """
-
         if isinstance(data, Quantity):
             data, unit = data.value, data.unit
         else:
@@ -385,12 +389,12 @@ class SigmaClip:
     def _sigmaclip_noaxis(self, data, masked=True, return_bounds=False,
                           copy=True):
         """
-        Sigma clip the data when ``axis`` is None and ``grow`` is not >0.
+        Sigma clip the data when ``axis`` is None and ``grow`` is not
+        >0.
 
         In this simple case, we remove clipped elements from the
         flattened array during each iteration.
         """
-
         filtered_data = data.ravel()
 
         # remove masked values and convert to ndarray
@@ -440,7 +444,6 @@ class SigmaClip:
         In this case, we replace clipped values with NaNs as placeholder
         values.
         """
-
         # float array type is needed to insert nans into the array
         filtered_data = data.astype(float)    # also makes a copy
 
@@ -471,16 +474,17 @@ class SigmaClip:
         if self.grow:
             from scipy.ndimage import binary_dilation
 
-            # Construct a growth kernel from the specified radius in pixels
-            # (consider caching this for re-use by subsequent calls?):
+            # Construct a growth kernel from the specified radius in
+            # pixels (consider caching this for re-use by subsequent
+            # calls?):
             cenidx = int(self.grow)
             size = 2 * cenidx + 1
             indices = np.mgrid[(slice(0, size),) * data.ndim]
             if axis is not None:
                 for n, dim in enumerate(indices):
-                    # For any axes that we're not clipping over, set their
-                    # indices outside the growth radius, so masked points won't
-                    # "grow" in that dimension:
+                    # For any axes that we're not clipping over, set
+                    # their indices outside the growth radius, so masked
+                    # points won't "grow" in that dimension:
                     if n not in axis:
                         dim[dim != cenidx] = size
             kernel = sum(((idx - cenidx)**2 for idx in indices)) <= self.grow**2
@@ -497,8 +501,9 @@ class SigmaClip:
 
             with np.errstate(invalid='ignore'):
                 # Since these comparisons are always False for NaNs, the
-                # resulting mask contains only newly-rejected pixels and we
-                # can dilate it without growing masked pixels more than once.
+                # resulting mask contains only newly-rejected pixels and
+                # we can dilate it without growing masked pixels more
+                # than once.
                 new_mask = ((filtered_data < self._min_value) |
                             (filtered_data > self._max_value))
             if self.grow:
@@ -540,22 +545,23 @@ class SigmaClip:
             The data to be sigma clipped.
 
         axis : None or int or tuple of int, optional
-            The axis or axes along which to sigma clip the data.  If `None`,
-            then the flattened data will be used.  ``axis`` is passed
-            to the ``cenfunc`` and ``stdfunc``.  The default is `None`.
+            The axis or axes along which to sigma clip the data. If
+            `None`, then the flattened data will be used. ``axis`` is
+            passed to the ``cenfunc`` and ``stdfunc``. The default is
+            `None`.
 
         masked : bool, optional
             If `True`, then a `~numpy.ma.MaskedArray` is returned, where
-            the mask is `True` for clipped values.  If `False`, then a
-            `~numpy.ndarray` and the minimum and maximum clipping
-            thresholds are returned.  The default is `True`.
+            the mask is `True` for clipped values. If `False`, then
+            a `~numpy.ndarray` and the minimum and maximum clipping
+            thresholds are returned. The default is `True`.
 
         return_bounds : bool, optional
             If `True`, then the minimum and maximum clipping bounds are
             also returned.
 
         copy : bool, optional
-            If `True`, then the ``data`` array will be copied.  If
+            If `True`, then the ``data`` array will be copied. If
             `False` and ``masked=True``, then the returned masked array
             data will contain the same array as the input ``data`` (if
             ``data`` is a `~numpy.ndarray` or `~numpy.ma.MaskedArray`).
@@ -575,21 +581,20 @@ class SigmaClip:
             array or array above, the minimum and maximum clipping
             bounds are returned.
 
-            If ``masked=False`` and ``axis=None``, then the output array
-            is a flattened 1D `~numpy.ndarray` where the clipped values
-            have been removed.  If ``return_bounds=True`` then the
+            If ``masked=False`` and ``axis=None``, then the output
+            array is a flattened 1D `~numpy.ndarray` where the clipped
+            values have been removed. If ``return_bounds=True`` then the
             returned minimum and maximum thresholds are scalars.
 
             If ``masked=False`` and ``axis`` is specified, then the
             output `~numpy.ndarray` will have the same shape as the
             input ``data`` and contain ``np.nan`` where values were
-            clipped.  If the input ``data`` was a masked array, then the
+            clipped. If the input ``data`` was a masked array, then the
             output `~numpy.ndarray` will also contain ``np.nan`` where
-            the input mask was `True`.  If ``return_bounds=True`` then
+            the input mask was `True`. If ``return_bounds=True`` then
             the returned minimum and maximum clipping thresholds will be
             be `~numpy.ndarray`\\s.
         """
-
         data = np.asanyarray(data)
 
         if data.size == 0:
@@ -601,7 +606,8 @@ class SigmaClip:
             else:
                 return np.ma.filled(data.astype(float), fill_value=np.nan)
 
-        # Shortcut for common cases where a fast C implementation can be used.
+        # Shortcut for common cases where a fast C implementation can be
+        # used.
         if (self.cenfunc in ('mean', 'median') and
                 self.stdfunc in ('std', 'mad_std') and
                 axis is not None and not self.grow):
@@ -609,9 +615,10 @@ class SigmaClip:
                                         return_bounds=return_bounds,
                                         copy=copy)
 
-        # These two cases are treated separately because when ``axis=None``
-        # we can simply remove clipped values from the array.  This is not
-        # possible when ``axis`` or ``grow`` is specified.
+        # These two cases are treated separately because when
+        # ``axis=None`` we can simply remove clipped values from the
+        # array. This is not possible when ``axis`` or ``grow`` is
+        # specified.
         if axis is None and not self.grow:
             return self._sigmaclip_noaxis(data, masked=masked,
                                           return_bounds=return_bounds,
@@ -634,8 +641,13 @@ def sigma_clip(data, sigma=3, sigma_lower=None, sigma_upper=None, maxiters=5,
 
     Clipped (rejected) pixels are those where::
 
-        data < cenfunc(data [,axis=int]) - (sigma_lower * stdfunc(data [,axis=int]))
-        data > cenfunc(data [,axis=int]) + (sigma_upper * stdfunc(data [,axis=int]))
+        data < center - (sigma_lower * std)
+        data > center + (sigma_upper * std)
+
+    where::
+
+        center = cenfunc(data [, axis=])
+        std = stdfunc(data [, axis=])
 
     Invalid data values (i.e., NaN or inf) are automatically clipped.
 
@@ -643,15 +655,15 @@ def sigma_clip(data, sigma=3, sigma_lower=None, sigma_upper=None, maxiters=5,
     :class:`SigmaClip`.
 
     .. note::
-        `scipy.stats.sigmaclip`
-        provides a subset of the functionality in this class.  Also, its
-        input data cannot be a masked array and it does not handle data
-        that contains invalid values (i.e., NaN or inf).  Also note that
-        it uses the mean as the centering function.
+        `scipy.stats.sigmaclip` provides a subset of the functionality
+        in this class. Also, its input data cannot be a masked array
+        and it does not handle data that contains invalid values (i.e.,
+        NaN or inf). Also note that it uses the mean as the centering
+        function.
 
-        If your data is a `~numpy.ndarray` with no invalid values and
-        you want to use the mean as the centering function with
-        ``axis=None`` and iterate to convergence, then
+        If your data is a `~numpy.ndarray` with no invalid values
+        and you want to use the mean as the centering function
+        with ``axis=None`` and iterate to convergence, then
         `scipy.stats.sigmaclip` is ~25-30% faster than the equivalent
         settings here (``sigma_clip(data, cenfunc='mean', maxiters=None,
         axis=None)``).
@@ -662,72 +674,73 @@ def sigma_clip(data, sigma=3, sigma_lower=None, sigma_upper=None, maxiters=5,
         The data to be sigma clipped.
 
     sigma : float, optional
-        The number of standard deviations to use for both the lower and
-        upper clipping limit.  These limits are overridden by
-        ``sigma_lower`` and ``sigma_upper``, if input.  The default is
-        3.
+        The number of standard deviations to use for both the lower
+        and upper clipping limit. These limits are overridden by
+        ``sigma_lower`` and ``sigma_upper``, if input. The default is 3.
 
     sigma_lower : float or None, optional
         The number of standard deviations to use as the lower bound for
-        the clipping limit.  If `None` then the value of ``sigma`` is
-        used.  The default is `None`.
+        the clipping limit. If `None` then the value of ``sigma`` is
+        used. The default is `None`.
 
     sigma_upper : float or None, optional
         The number of standard deviations to use as the upper bound for
-        the clipping limit.  If `None` then the value of ``sigma`` is
-        used.  The default is `None`.
+        the clipping limit. If `None` then the value of ``sigma`` is
+        used. The default is `None`.
 
     maxiters : int or None, optional
         The maximum number of sigma-clipping iterations to perform or
         `None` to clip until convergence is achieved (i.e., iterate
-        until the last iteration clips nothing).  If convergence is
+        until the last iteration clips nothing). If convergence is
         achieved prior to ``maxiters`` iterations, the clipping
-        iterations will stop.  The default is 5.
+        iterations will stop. The default is 5.
 
     cenfunc : {'median', 'mean'} or callable, optional
-        The statistic or callable function/object used to compute the
-        center value for the clipping. If using a callable function/object and
-        the ``axis`` keyword is used, then it must be able to ignore
-        NaNs (e.g., `numpy.nanmean`) and has an ``axis`` keyword to return an
-        array with axis dimension(s) removed.  The default is ``'median'``.
+        The statistic or callable function/object used to compute
+        the center value for the clipping. If using a callable
+        function/object and the ``axis`` keyword is used, then it must
+        be able to ignore NaNs (e.g., `numpy.nanmean`) and it must have
+        an ``axis`` keyword to return an array with axis dimension(s)
+        removed. The default is ``'median'``.
 
     stdfunc : {'std', 'mad_std'} or callable, optional
         The statistic or callable function/object used to compute the
         standard deviation about the center value. If using a callable
         function/object and the ``axis`` keyword is used, then it must
-        be able to ignore NaNs (e.g., `numpy.nanstd`) and has
+        be able to ignore NaNs (e.g., `numpy.nanstd`) and it must have
         an ``axis`` keyword to return an array with axis dimension(s)
-        removed.  The default is ``'std'``.
+        removed. The default is ``'std'``.
 
     axis : None or int or tuple of int, optional
-        The axis or axes along which to sigma clip the data.  If `None`,
-        then the flattened data will be used.  ``axis`` is passed to the
-        ``cenfunc`` and ``stdfunc``.  The default is `None`.
+        The axis or axes along which to sigma clip the data. If `None`,
+        then the flattened data will be used. ``axis`` is passed to the
+        ``cenfunc`` and ``stdfunc``. The default is `None`.
 
     masked : bool, optional
-        If `True`, then a `~numpy.ma.MaskedArray` is returned, where the
-        mask is `True` for clipped values.  If `False`, then a
+        If `True`, then a `~numpy.ma.MaskedArray` is returned, where
+        the mask is `True` for clipped values. If `False`, then a
         `~numpy.ndarray` and the minimum and maximum clipping thresholds
-        are returned.  The default is `True`.
+        are returned. The default is `True`.
 
     return_bounds : bool, optional
         If `True`, then the minimum and maximum clipping bounds are also
         returned.
 
     copy : bool, optional
-        If `True`, then the ``data`` array will be copied.  If
-        `False` and ``masked=True``, then the returned masked array
-        data will contain the same array as the input ``data`` (if
-        ``data`` is a `~numpy.ndarray` or `~numpy.ma.MaskedArray`).
-        If `False` and ``masked=False``, the input data is modified
-        in-place. The default is `True`.
+        If `True`, then the ``data`` array will be copied. If `False`
+        and ``masked=True``, then the returned masked array data will
+        contain the same array as the input ``data`` (if ``data`` is a
+        `~numpy.ndarray` or `~numpy.ma.MaskedArray`). If `False` and
+        ``masked=False``, the input data is modified in-place. The
+        default is `True`.
 
     grow : float or `False`, optional
-        Radius within which to mask the neighbouring pixels of those that
-        fall outwith the clipping limits (only applied along ``axis``, if
-        specified). As an example, for a 2D image a value of 1 will mask the
-        nearest pixels in a cross pattern around each deviant pixel, while
-        1.5 will also reject the nearest diagonal neighbours and so on.
+        Radius within which to mask the neighbouring pixels of those
+        that fall outwith the clipping limits (only applied along
+        ``axis``, if specified). As an example, for a 2D image a value
+        of 1 will mask the nearest pixels in a cross pattern around each
+        deviant pixel, while 1.5 will also reject the nearest diagonal
+        neighbours and so on.
 
     Returns
     -------
@@ -742,38 +755,38 @@ def sigma_clip(data, sigma=3, sigma_lower=None, sigma_upper=None, maxiters=5,
         or array above, the minimum and maximum clipping bounds are
         returned.
 
-        If ``masked=False`` and ``axis=None``, then the output array is
-        a flattened 1D `~numpy.ndarray` where the clipped values have
-        been removed.  If ``return_bounds=True`` then the returned
+        If ``masked=False`` and ``axis=None``, then the output array
+        is a flattened 1D `~numpy.ndarray` where the clipped values
+        have been removed. If ``return_bounds=True`` then the returned
         minimum and maximum thresholds are scalars.
 
         If ``masked=False`` and ``axis`` is specified, then the output
         `~numpy.ndarray` will have the same shape as the input ``data``
-        and contain ``np.nan`` where values were clipped.  If the input
+        and contain ``np.nan`` where values were clipped. If the input
         ``data`` was a masked array, then the output `~numpy.ndarray`
         will also contain ``np.nan`` where the input mask was `True`.
         If ``return_bounds=True`` then the returned minimum and maximum
         clipping thresholds will be be `~numpy.ndarray`\\s.
 
-    Notes
-    -----
-
-    The best performance will typically be obtained by setting ``cenfunc`` and
-    ``stdfunc`` to one of the built-in functions specified as as string. If one of
-    the options is set to a string while the other has a custom callable, you may in some
-    cases see better performance if you have the `bottleneck`_ package installed.
-
-    .. _bottleneck:  https://github.com/pydata/bottleneck
-
     See Also
     --------
     SigmaClip, sigma_clipped_stats
 
+    Notes
+    -----
+    The best performance will typically be obtained by setting
+    ``cenfunc`` and ``stdfunc`` to one of the built-in functions
+    specified as as string. If one of the options is set to a string
+    while the other has a custom callable, you may in some cases see
+    better performance if you have the `bottleneck`_ package installed.
+
+    .. _bottleneck:  https://github.com/pydata/bottleneck
+
     Examples
     --------
     This example uses a data array of random variates from a Gaussian
-    distribution.  We clip all points that are more than 2 sample
-    standard deviations from the median.  The result is a masked array,
+    distribution. We clip all points that are more than 2 sample
+    standard deviations from the median. The result is a masked array,
     where the mask is `True` for clipped data::
 
         >>> from astropy.stats import sigma_clip
@@ -781,8 +794,8 @@ def sigma_clip(data, sigma=3, sigma_lower=None, sigma_upper=None, maxiters=5,
         >>> randvar = randn(10000)
         >>> filtered_data = sigma_clip(randvar, sigma=2, maxiters=5)
 
-    This example clips all points that are more than 3 sigma relative to
-    the sample *mean*, clips until convergence, returns an unmasked
+    This example clips all points that are more than 3 sigma relative
+    to the sample *mean*, clips until convergence, returns an unmasked
     `~numpy.ndarray`, and does not copy the data::
 
         >>> from astropy.stats import sigma_clip
@@ -803,7 +816,6 @@ def sigma_clip(data, sigma=3, sigma_lower=None, sigma_upper=None, maxiters=5,
     Note that along the other axis, no points would be clipped, as the
     standard deviation is higher.
     """
-
     sigclip = SigmaClip(sigma=sigma, sigma_lower=sigma_lower,
                         sigma_upper=sigma_upper, maxiters=maxiters,
                         cenfunc=cenfunc, stdfunc=stdfunc, grow=grow)
@@ -831,72 +843,73 @@ def sigma_clipped_stats(data, mask=None, mask_value=None, sigma=3.0,
 
     mask_value : float, optional
         A data value (e.g., ``0.0``) that is ignored when computing the
-        statistics.  ``mask_value`` will be masked in addition to any
+        statistics. ``mask_value`` will be masked in addition to any
         input ``mask``.
 
     sigma : float, optional
-        The number of standard deviations to use for both the lower and
-        upper clipping limit.  These limits are overridden by
-        ``sigma_lower`` and ``sigma_upper``, if input.  The default is
-        3.
+        The number of standard deviations to use for both the lower
+        and upper clipping limit. These limits are overridden by
+        ``sigma_lower`` and ``sigma_upper``, if input. The default is 3.
 
     sigma_lower : float or None, optional
         The number of standard deviations to use as the lower bound for
-        the clipping limit.  If `None` then the value of ``sigma`` is
-        used.  The default is `None`.
+        the clipping limit. If `None` then the value of ``sigma`` is
+        used. The default is `None`.
 
     sigma_upper : float or None, optional
         The number of standard deviations to use as the upper bound for
-        the clipping limit.  If `None` then the value of ``sigma`` is
-        used.  The default is `None`.
+        the clipping limit. If `None` then the value of ``sigma`` is
+        used. The default is `None`.
 
     maxiters : int or None, optional
         The maximum number of sigma-clipping iterations to perform or
         `None` to clip until convergence is achieved (i.e., iterate
-        until the last iteration clips nothing).  If convergence is
+        until the last iteration clips nothing). If convergence is
         achieved prior to ``maxiters`` iterations, the clipping
-        iterations will stop.  The default is 5.
+        iterations will stop. The default is 5.
 
     cenfunc : {'median', 'mean'} or callable, optional
-        The statistic or callable function/object used to compute the
-        center value for the clipping. If using a callable function/object and
-        the ``axis`` keyword is used, then it must be able to ignore
-        NaNs (e.g., `numpy.nanmean`) and has an ``axis`` keyword to return an
-        array with axis dimension(s) removed.  The default is ``'median'``.
+        The statistic or callable function/object used to compute
+        the center value for the clipping. If using a callable
+        function/object and the ``axis`` keyword is used, then it must
+        be able to ignore NaNs (e.g., `numpy.nanmean`) and it must have
+        an ``axis`` keyword to return an array with axis dimension(s)
+        removed. The default is ``'median'``.
 
     stdfunc : {'std', 'mad_std'} or callable, optional
         The statistic or callable function/object used to compute the
         standard deviation about the center value. If using a callable
         function/object and the ``axis`` keyword is used, then it must
-        be able to ignore NaNs (e.g., `numpy.nanstd`) and has
+        be able to ignore NaNs (e.g., `numpy.nanstd`) and it must have
         an ``axis`` keyword to return an array with axis dimension(s)
-        removed.  The default is ``'std'``.
+        removed. The default is ``'std'``.
 
     std_ddof : int, optional
         The delta degrees of freedom for the standard deviation
-        calculation.  The divisor used in the calculation is ``N -
-        std_ddof``, where ``N`` represents the number of elements.  The
+        calculation. The divisor used in the calculation is ``N -
+        std_ddof``, where ``N`` represents the number of elements. The
         default is 0.
 
     axis : None or int or tuple of int, optional
-        The axis or axes along which to sigma clip the data.  If `None`,
-        then the flattened data will be used.  ``axis`` is passed
-        to the ``cenfunc`` and ``stdfunc``.  The default is `None`.
+        The axis or axes along which to sigma clip the data. If `None`,
+        then the flattened data will be used. ``axis`` is passed to the
+        ``cenfunc`` and ``stdfunc``. The default is `None`.
 
     grow : float or `False`, optional
-        Radius within which to mask the neighbouring pixels of those that
-        fall outwith the clipping limits (only applied along ``axis``, if
-        specified). As an example, for a 2D image a value of 1 will mask the
-        nearest pixels in a cross pattern around each deviant pixel, while
-        1.5 will also reject the nearest diagonal neighbours and so on.
+        Radius within which to mask the neighbouring pixels of those
+        that fall outwith the clipping limits (only applied along
+        ``axis``, if specified). As an example, for a 2D image a value
+        of 1 will mask the nearest pixels in a cross pattern around each
+        deviant pixel, while 1.5 will also reject the nearest diagonal
+        neighbours and so on.
 
     Notes
     -----
-
-    The best performance will typically be obtained by setting ``cenfunc`` and
-    ``stdfunc`` to one of the built-in functions specified as as string. If one of
-    the options is set to a string while the other has a custom callable, you may in some
-    cases see better performance if you have the `bottleneck`_ package installed.
+    The best performance will typically be obtained by setting
+    ``cenfunc`` and ``stdfunc`` to one of the built-in functions
+    specified as as string. If one of the options is set to a string
+    while the other has a custom callable, you may in some cases see
+    better performance if you have the `bottleneck`_ package installed.
 
     .. _bottleneck:  https://github.com/pydata/bottleneck
 
@@ -910,7 +923,6 @@ def sigma_clipped_stats(data, mask=None, mask_value=None, sigma=3.0,
     --------
     SigmaClip, sigma_clip
     """
-
     if mask is not None:
         data = np.ma.MaskedArray(data, mask)
     if mask_value is not None:

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -242,6 +242,7 @@ class SigmaClip:
         # later than necessary if __call__ needs it:
         if self.grow:
             from scipy.ndimage import binary_dilation
+            self.binary_dilation = binary_dilation
 
     def __repr__(self):
         return ('SigmaClip(sigma={}, sigma_lower={}, sigma_upper={}, '
@@ -472,8 +473,6 @@ class SigmaClip:
                            for dim, size in enumerate(filtered_data.shape))
 
         if self.grow:
-            from scipy.ndimage import binary_dilation
-
             # Construct a growth kernel from the specified radius in
             # pixels (consider caching this for re-use by subsequent
             # calls?):
@@ -507,7 +506,7 @@ class SigmaClip:
                 new_mask = ((filtered_data < self._min_value) |
                             (filtered_data > self._max_value))
             if self.grow:
-                new_mask = binary_dilation(new_mask, kernel)
+                new_mask = self.binary_dilation(new_mask, kernel)
             filtered_data[new_mask] = np.nan
             nchanged = np.count_nonzero(new_mask)
             del new_mask

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -118,14 +118,11 @@ class SigmaClip:
         in this class. Also, its input data cannot be a masked array
         and it does not handle data that contains invalid values (i.e.,
         NaN or inf). Also note that it uses the mean as the centering
-        function.
+        function. The equivalent settings to `scipy.stats.sigmaclip`
+        are::
 
-        If your data is a `~numpy.ndarray` with no invalid values
-        and you want to use the mean as the centering function
-        with ``axis=None`` and iterate to convergence, then
-        `scipy.stats.sigmaclip` is ~25-30% faster than the equivalent
-        settings here (``s = SigmaClip(cenfunc='mean', maxiters=None);
-        s(data, axis=None)``).
+            sigclip = SigmaClip(sigma=4., cenfunc='mean', maxiters=None)
+            sigclip(data, axis=None, masked=False, return_bounds=True)
 
     Parameters
     ----------
@@ -676,14 +673,11 @@ def sigma_clip(data, sigma=3, sigma_lower=None, sigma_upper=None, maxiters=5,
         in this class. Also, its input data cannot be a masked array
         and it does not handle data that contains invalid values (i.e.,
         NaN or inf). Also note that it uses the mean as the centering
-        function.
+        function. The equivalent settings to `scipy.stats.sigmaclip`
+        are::
 
-        If your data is a `~numpy.ndarray` with no invalid values
-        and you want to use the mean as the centering function
-        with ``axis=None`` and iterate to convergence, then
-        `scipy.stats.sigmaclip` is ~25-30% faster than the equivalent
-        settings here (``sigma_clip(data, cenfunc='mean', maxiters=None,
-        axis=None)``).
+            sigma_clip(sigma=4., cenfunc='mean', maxiters=None, axis=None,
+            ...        masked=False, return_bounds=True)
 
     Parameters
     ----------

--- a/astropy/stats/tests/test_sigma_clipping.py
+++ b/astropy/stats/tests/test_sigma_clipping.py
@@ -247,8 +247,8 @@ def test_sigmaclip_fully_masked():
 
 def test_sigmaclip_empty_masked():
     """
-    Make sure a empty masked array is returned when sigma clipping an empty
-    masked array.
+    Make sure an empty masked array is returned when sigma clipping an
+    empty masked array.
     """
     data = np.ma.MaskedArray(data=[], mask=[])
     clipped_data = sigma_clip(data)
@@ -262,7 +262,7 @@ def test_sigmaclip_empty_masked():
 
 def test_sigmaclip_empty():
     """
-    Make sure a empty array is returned when sigma clipping an empty
+    Make sure an empty array is returned when sigma clipping an empty
     array.
     """
     data = np.array([])

--- a/astropy/stats/tests/test_sigma_clipping.py
+++ b/astropy/stats/tests/test_sigma_clipping.py
@@ -226,10 +226,10 @@ def test_sigmaclip_negative_axis():
 
 
 def test_sigmaclip_fully_masked():
-    """Make sure a fully masked array is returned when sigma clipping a fully
-    masked array.
     """
-
+    Make sure a fully masked array is returned when sigma clipping a
+    fully masked array.
+    """
     data = np.ma.MaskedArray(data=[[1., 0.], [0., 1.]],
                              mask=[[True, True], [True, True]])
     clipped_data = sigma_clip(data)
@@ -239,30 +239,45 @@ def test_sigmaclip_fully_masked():
     assert not isinstance(clipped_data, np.ma.MaskedArray)
     assert np.all(np.isnan(clipped_data))
 
+    clipped_data, low, high = sigma_clip(data, return_bounds=True)
+    assert np.ma.allequal(data, clipped_data)
+    assert np.isnan(low)
+    assert np.isnan(high)
+
 
 def test_sigmaclip_empty_masked():
-    """Make sure a empty masked array is returned when sigma clipping an empty
+    """
+    Make sure a empty masked array is returned when sigma clipping an empty
     masked array.
     """
-
     data = np.ma.MaskedArray(data=[], mask=[])
     clipped_data = sigma_clip(data)
     assert np.ma.allequal(data, clipped_data)
 
+    clipped_data, low, high = sigma_clip(data, return_bounds=True)
+    assert np.ma.allequal(data, clipped_data)
+    assert np.isnan(low)
+    assert np.isnan(high)
+
 
 def test_sigmaclip_empty():
-    """Make sure a empty array is returned when sigma clipping an empty array.
     """
-
+    Make sure a empty array is returned when sigma clipping an empty
+    array.
+    """
     data = np.array([])
     clipped_data = sigma_clip(data)
     assert_equal(data, clipped_data)
+
+    clipped_data, low, high = sigma_clip(data, return_bounds=True)
+    assert_equal(data, clipped_data)
+    assert np.isnan(low)
+    assert np.isnan(high)
 
 
 def test_sigma_clip_axis_tuple_3D():
     """Test sigma clipping over a subset of axes (issue #7227).
     """
-
     data = np.sin(0.78 * np.arange(27)).reshape(3, 3, 3)
     mask = np.zeros_like(data, dtype=np.bool_)
 

--- a/astropy/stats/tests/test_sigma_clipping.py
+++ b/astropy/stats/tests/test_sigma_clipping.py
@@ -267,7 +267,8 @@ def test_sigmaclip_empty():
     """
     data = np.array([])
     clipped_data = sigma_clip(data)
-    assert_equal(data, clipped_data)
+    assert isinstance(clipped_data, np.ma.MaskedArray)
+    assert_equal(data, clipped_data.data)
 
     clipped_data, low, high = sigma_clip(data, return_bounds=True)
     assert_equal(data, clipped_data)

--- a/docs/changes/stats/11994.bugfix.rst
+++ b/docs/changes/stats/11994.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed a bug in sigma clipping where the bounds would not be returned for
+completely empty or masked data.


### PR DESCRIPTION
### Description

This PR fixes a bug in sigma clipping where the bounds would not be returned for completely empty or masked data.  Some documentation improvements and PEP8 fixes came along for the ride.

Fixes #11992
Fixes #11850

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
