### PR TITLE
Add docstrings for dynamically created properties of coordinate frames

### DIFF
--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -641,16 +641,14 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
         return repr_info
 
     @classmethod
-    def _create_readonly_property(cls, attr_name, value, docstring=None):
+    def _create_readonly_property(cls, attr_name, value, doc=None):
         private_attr = '_' + attr_name
 
         def getter(self):
             return getattr(self, private_attr)
 
         setattr(cls, private_attr, value)
-        setattr(cls, attr_name, property(getter))
-        if docstring:
-            setattr(getattr(cls, attr_name), '__doc__', docstring)
+        setattr(cls, attr_name, property(getter, doc=doc))
 
     @lazyproperty
     def cache(self):

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -268,10 +268,14 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
         # be read-only to make them immutable after creation.
         # We copy attributes instead of linking to make sure there's no
         # accidental cross-talk between classes
-        cls._create_readonly_property('default_representation', default_repr)
-        cls._create_readonly_property('default_differential', default_diff)
+        cls._create_readonly_property('default_representation', default_repr,
+                                      'Default representation for position data')
+        cls._create_readonly_property('default_differential', default_diff,
+                                      'Default representation for differential data '
+                                      '(e.g., velocity)')
         cls._create_readonly_property('frame_specific_representation_info',
-                                      copy.deepcopy(repr_info))
+                                      copy.deepcopy(repr_info),
+                                      'Mapping for frame-specific component names')
 
         # Set the frame attributes. We first construct the attributes from
         # superclasses, going in reverse order to keep insertion order,
@@ -637,7 +641,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
         return repr_info
 
     @classmethod
-    def _create_readonly_property(cls, attr_name, value):
+    def _create_readonly_property(cls, attr_name, value, docstring=None):
         private_attr = '_' + attr_name
 
         def getter(self):
@@ -645,6 +649,8 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
 
         setattr(cls, private_attr, value)
         setattr(cls, attr_name, property(getter))
+        if docstring:
+            setattr(getattr(cls, attr_name), '__doc__', docstring)
 
     @lazyproperty
     def cache(self):


### PR DESCRIPTION
Subclasses of `BaseCoordinateFrame` have the following dynamically created properties, with none of them having an explicit docstring:

* `frame_specific_representation_info` (returns a `dict` instance)
* `default_representation`
* `default_differential`

These properties are created without any docstring.  With the latest Sphinx (4.1.2), the docstring for `dict` gets used as the docstring for `frame_specific_representation_info`, which is not helpful (this example is from SunPy docs):

![attributes](https://user-images.githubusercontent.com/991759/127886251-fde9e51c-7ad2-4657-99dd-42a4d060150a.png)

Furthermore, Sphinx gets confused by the `**` and raises a warning.

I don't know whether the Sphinx behavior is intentional, but these properties should probably have descriptions anyway.  This PR adds them.