### PR TITLE
Improve formatting of Table/Column.info()

### DIFF
--- a/astropy/table/info.py
+++ b/astropy/table/info.py
@@ -49,7 +49,7 @@ def table_info(tbl, option='attributes', out=''):
     name mean std min max
     ---- ---- --- --- ---
        a  1.5 0.5   1   2
-       b  1.5 0.5 1.0 2.0
+       b  1.5 0.5   1   2
 
     Parameters
     ----------

--- a/astropy/table/tests/test_info.py
+++ b/astropy/table/tests/test_info.py
@@ -82,7 +82,7 @@ def test_table_info_stats(table_types):
            'name mean std min max',
            '---- ---- --- --- ---',
            '   a  1.5 0.5   1   2',
-           '   b  1.5 0.5 1.0 2.0',
+           '   b  1.5 0.5   1   2',
            '   c   --  --  --  --',
            '   d   --  -- 1.0 2.0']
     assert out.getvalue().splitlines() == exp
@@ -93,8 +93,8 @@ def test_table_info_stats(table_types):
                               'class', 'mean', 'std', 'min', 'max', 'n_bad', 'length']
     assert np.all(tinfo['mean'] == ['1.5', '1.5', '--', '--'])
     assert np.all(tinfo['std'] == ['0.5', '0.5', '--', '--'])
-    assert np.all(tinfo['min'] == ['1', '1.0', '--', '1.0'])
-    assert np.all(tinfo['max'] == ['2', '2.0', '--', '2.0'])
+    assert np.all(tinfo['min'] == ['1', '1', '--', '1.0'])
+    assert np.all(tinfo['max'] == ['2', '2', '--', '2.0'])
 
     out = StringIO()
     t.info('stats', out=out)
@@ -102,7 +102,7 @@ def test_table_info_stats(table_types):
            'name mean std min max',
            '---- ---- --- --- ---',
            '   a  1.5 0.5   1   2',
-           '   b  1.5 0.5 1.0 2.0',
+           '   b  1.5 0.5   1   2',
            '   c   --  --  --  --',
            '   d   --  -- 1.0 2.0']
     assert out.getvalue().splitlines() == exp
@@ -116,8 +116,8 @@ def test_table_info_stats(table_types):
                               'class', 'sum', 'first', 'n_bad', 'length']
     assert np.all(tinfo['name'] == ['a', 'b', 'c', 'd'])
     assert np.all(tinfo['dtype'] == ['int32', 'float32', dtype_info_name('S1'), 'object'])
-    assert np.all(tinfo['sum'] == ['6', '6.0', '--', '--'])
-    assert np.all(tinfo['first'] == ['1', '1.0', 'a', '1.0'])
+    assert np.all(tinfo['sum'] == ['6', '6', '--', '--'])
+    assert np.all(tinfo['first'] == ['1', '1', 'a', '1.0'])
 
 
 def test_data_info():
@@ -162,8 +162,8 @@ def test_data_info():
         assert cinfo == OrderedDict([('name', 'name'),
                                      ('mean', '1.5'),
                                      ('std', '0.5'),
-                                     ('min', '1.0'),
-                                     ('max', '2.0'),
+                                     ('min', '1'),
+                                     ('max', '2'),
                                      ('n_bad', 1),
                                      ('length', 3)])
 

--- a/astropy/table/tests/test_showtable.py
+++ b/astropy/table/tests/test_showtable.py
@@ -30,10 +30,10 @@ def test_stats(capsys):
     showtable.main([os.path.join(FITS_ROOT, 'data/table.fits'), '--stats'])
     out, err = capsys.readouterr()
     expected = ['<Table length=3>',
-                ' name     mean      std    min  max ',
-                '------ --------- --------- ---- ----',
-                'target        --        --   --   --',
-                ' V_mag 12.86666[0-9]? 1.7211105 11.1 15.2']
+                ' name    mean    std   min  max ',
+                '------ ------- ------- ---- ----',
+                'target      --      --   --   --',
+                ' V_mag 12.866[0-9]? 1.72111 11.1 15.2']
 
     out = out.splitlines()
     assert out[:4] == expected[:4]

--- a/astropy/utils/data_info.py
+++ b/astropy/utils/data_info.py
@@ -116,9 +116,9 @@ def data_info_factory(names, funcs):
     >>> mystats = data_info_factory(names=['min', 'median', 'max'],
     ...                             funcs=[np.min, np.median, np.max])
     >>> c.info(option=mystats)
-    min = 1.0
+    min = 1
     median = 2.5
-    max = 4.0
+    max = 4
     n_bad = 0
     length = 4
 
@@ -145,7 +145,10 @@ def data_info_factory(names, funcs):
             except Exception:
                 outs.append('--')
             else:
-                outs.append(str(out))
+                try:
+                    outs.append(f'{out:g}')
+                except (TypeError, ValueError):
+                    outs.append(str(out))
 
         return OrderedDict(zip(names, outs))
     return func

--- a/docs/changes/table/12022.feature.rst
+++ b/docs/changes/table/12022.feature.rst
@@ -1,0 +1,2 @@
+Formatting of any numerical values in the output of ``Table.info()`` and
+``Column.info()`` has been improved.

--- a/docs/table/access_table.rst
+++ b/docs/table/access_table.rst
@@ -135,19 +135,19 @@ of available options::
 
   >>> t.info('stats')  # doctest: +FLOAT_CMP
   <Table length=5>
-  name mean        std        min max
-  ---- ---- ----------------- --- ---
-     a  6.0 4.242640687119285   0  12
-     b  7.0 4.242640687119285   1  13
-     c  8.0 4.242640687119285   2  14
+  name mean   std   min max
+  ---- ---- ------- --- ---
+     a    6 4.24264   0  12
+     b    7 4.24264   1  13
+     c    8 4.24264   2  14
 
   >>> t.info(['attributes', 'stats'])  # doctest: +FLOAT_CMP
   <Table length=5>
-  name dtype   unit   format       description        mean        std        min max
-  ---- ----- -------- ------ ------------------------ ---- ----------------- --- ---
-     a int32 m sec^-1 {:.3f} unladen swallow velocity  6.0 4.242640687119285   0  12
-     b int32                                           7.0 4.242640687119285   1  13
-     c int32                                           8.0 4.242640687119285   2  14
+  name dtype   unit   format       description        mean   std   min max
+  ---- ----- -------- ------ ------------------------ ---- ------- --- ---
+     a int32 m sec^-1 {:.3f} unladen swallow velocity    6 4.24264   0  12
+     b int32                                             7 4.24264   1  13
+     c int32                                             8 4.24264   2  14
 
 Columns also have an ``info`` property that has the same behavior and
 arguments, but provides information about a single column::
@@ -164,8 +164,8 @@ arguments, but provides information about a single column::
 
   >>> t['a'].info('stats')  # doctest: +FLOAT_CMP
   name = a
-  mean = 6.0
-  std = 4.24264068712
+  mean = 6
+  std = 4.24264
   min = 0
   max = 12
   n_bad = 0


### PR DESCRIPTION
### Description

Suppose you happen to have a `Table` like this:

```python
import numpy as np

from astropy.table import Table


arr = np.arange(15, dtype=np.int32).reshape(5, 3)
t = Table(arr, names=('a', 'b', 'c'))
t['a'].format = '%.3f'
t['b'].format = '.2f'
t['c'].format = '{:.1f}'
```
Currently `Table.info('stats')` ignores the column formats:
```python
>>> t.info('stats')
<Table length=5>
name mean        std        min max
---- ---- ----------------- --- ---
   a  6.0 4.242640687119285   0  12
   b  7.0 4.242640687119285   1  13
   c  8.0 4.242640687119285   2  14
```
With the changes I've made to the code the column formats would be applied to the statistics too:
```python
>>> t.info('stats')
<Table length=5>
name  mean  std   min   max  
---- ----- ----- ----- ------
   a 6.000 4.243 0.000 12.000
   b  7.00  4.24  1.00  13.00
   c   8.0   4.2   2.0   14.0
```

I am opening this pull request as a draft for initial evaluation and to present a proof of concept.

EDIT:

As a result of discussion this pull request does not allow the output of `Table.info('stats')` to be formatted using the `format` attribute of the table columns, but it will apply a better default formatting to numerical values instead.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
