### PR TITLE
Close CodeQL critical warnings

### DIFF
--- a/cextern/cfitsio/lib/putkey.c
+++ b/cextern/cfitsio/lib/putkey.c
@@ -1105,24 +1105,25 @@ int ffgstm( char *timestr,   /* O  - returned system date and time string  */
 */
 {
     time_t tp;
+    struct tm now;
     struct tm *ptr;
 
-    if (*status > 0)           /* inherit input status value if > 0 */
+    if (*status > 0)            /* inherit input status value if > 0 */
         return(*status);
 
     time(&tp);
-    ptr = gmtime(&tp);         /* get GMT (= UTC) time */
+    ptr = gmtime_r(&tp, &now);  /* get GMT (= UTC) time */
 
     if (timeref)
     {
         if (ptr)
-            *timeref = 0;   /* returning GMT */
+            *timeref = 0;      /* returning GMT */
         else
-            *timeref = 1;   /* returning local time */
+            *timeref = 1;      /* returning local time */
     }
 
     if (!ptr)                  /* GMT not available on this machine */
-        ptr = localtime(&tp); 
+        ptr = localtime_r(&tp, &now); 
 
     strftime(timestr, 25, "%Y-%m-%dT%H:%M:%S", ptr);
 
@@ -1516,19 +1517,20 @@ int ffgsdt( int *day, int *month, int *year, int *status )
 
 */
    time_t now;
-   struct tm *date;
+   struct tm date;
+   struct tm *ptr;
 
    now = time( NULL );
-   date = gmtime(&now);         /* get GMT (= UTC) time */
+   ptr = gmtime_r(&now, &date);   /* get GMT (= UTC) time */
 
-   if (!date)                  /* GMT not available on this machine */
+   if (!ptr)                     /* GMT not available on this machine */
    {
-       date = localtime(&now); 
+       ptr = localtime_r(&now, &date); 
    }
 
-   *day = date->tm_mday;
-   *month = date->tm_mon + 1;
-   *year = date->tm_year + 1900;  /* tm_year is defined as years since 1900 */
+   *day = date.tm_mday;
+   *month = date.tm_mon + 1;
+   *year = date.tm_year + 1900;  /* tm_year is defined as years since 1900 */
    return( *status );
 }
 /*--------------------------------------------------------------------------*/


### PR DESCRIPTION
Replace library codes with ``_r`` versions, as suggested by https://codeql.github.com/codeql-query-help/cpp/cpp-potentially-dangerous-function/

Note: We don't appear to have a label for security issues.
Also, I don't know how to test the ``cextern`` library locally, so this initial draft will most certainly not succeed. Is it just the normal ``tox``?

Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>


### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
