### PR TITLE
ensure in-built realizations can pickle

### DIFF
--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -6,7 +6,6 @@ import warnings
 from abc import ABCMeta, abstractmethod
 from inspect import signature
 from math import acos, cos, exp, floor, log, pi, sin, sqrt
-from types import MappingProxyType
 
 import numpy as np
 
@@ -130,7 +129,7 @@ class Cosmology(metaclass=ABCMeta):
         # bundle and store initialization arguments on the instance
         ba = cls._init_signature.bind_partial(*args, **kwargs)
         ba.apply_defaults()  # and fill in the defaults
-        self._init_arguments = MappingProxyType(ba.arguments)
+        self._init_arguments = ba.arguments
 
         return self
 

--- a/astropy/cosmology/tests/test_pickle.py
+++ b/astropy/cosmology/tests/test_pickle.py
@@ -1,7 +1,10 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+import pickle
+
 import pytest
 
+from astropy import cosmology
 from astropy.cosmology import FLRW
 from astropy.tests.helper import check_pickling_recovery, pickle_protocol
 
@@ -9,9 +12,27 @@ originals = [FLRW]
 xfails = [False]
 
 
-@pytest.mark.parametrize(("original", "xfail"),
-                         zip(originals, xfails))
+@pytest.mark.parametrize(("original", "xfail"), zip(originals, xfails))
 def test_flrw(pickle_protocol, original, xfail):
     if xfail:
         pytest.xfail()
     check_pickling_recovery(original, pickle_protocol)
+
+
+@pytest.mark.parametrize("name", cosmology.parameters.available)
+@pytest.mark.parametrize("protocol", [0, 1, 2, 3, 4])  # add [5] when drop 3.7
+def test_builtin_realizations(name, protocol):
+    """
+    Test in-built realizations can pickle and unpickle.
+    Also a regression test for #12008.
+    """
+    # get class instance
+    original = getattr(cosmology, name)
+
+    # pickle and unpickle
+    f = pickle.dumps(original, protocol=protocol)
+    unpickled = pickle.loads(f)
+
+    # test equality
+    assert unpickled == original
+    assert unpickled.meta == original.meta


### PR DESCRIPTION
Cosmologies used to be pickle-able, then I made a private attribute read-only and they weren't. There wasn't a test for this :(.
The best solution is to just remove the read-only dict protection on the private attribute. It was nice to have, but not worth customizing pickle behavior.  Problem arose from #11817.

Fixes #12008 

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
