### PR TITLE
BUG: Fix cfgtype list serialization, fix table.jsviewer.conf.css_urls cfgtype

### DIFF
--- a/astropy/config/configuration.py
+++ b/astropy/config/configuration.py
@@ -673,7 +673,7 @@ def generate_config(pkgname='astropy', filename=None, verbose=False):
                 fp.write(wrapper.fill(item.description) + '\n')
                 if isinstance(item.defaultvalue, (tuple, list)):
                     if len(item.defaultvalue) == 0:
-                        fp.write(f'# {item.name} =\n\n')
+                        fp.write(f'# {item.name} = ,\n\n')
                     elif len(item.defaultvalue) == 1:
                         fp.write(f'# {item.name} = {item.defaultvalue[0]},\n\n')
                     else:

--- a/astropy/config/configuration.py
+++ b/astropy/config/configuration.py
@@ -671,7 +671,15 @@ def generate_config(pkgname='astropy', filename=None, verbose=False):
                     print_module = False
 
                 fp.write(wrapper.fill(item.description) + '\n')
-                fp.write(f'# {item.name} = {item.defaultvalue}\n\n')
+                if isinstance(item.defaultvalue, (tuple, list)):
+                    if len(item.defaultvalue) == 0:
+                        fp.write(f'# {item.name} =\n\n')
+                    elif len(item.defaultvalue) == 1:
+                        fp.write(f'# {item.name} = {item.defaultvalue[0]},\n\n')
+                    else:
+                        fp.write(f'# {item.name} = {",".join(map(str, item.defaultvalue))}\n\n')
+                else:
+                    fp.write(f'# {item.name} = {item.defaultvalue}\n\n')
 
 
 def reload_config(packageormod=None, rootname=None):

--- a/astropy/config/tests/test_configs.py
+++ b/astropy/config/tests/test_configs.py
@@ -149,6 +149,8 @@ def check_config(conf):
     # test that the output contains some lines that we expect
     assert '# unicode_output = False' in conf
     assert '[io.fits]' in conf
+    assert '[table.jsviewer]' in conf
+    assert '# css_urls = https://cdn.datatables.net/1.10.12/css/jquery.dataTables.css,' in conf
     assert '[visualization.wcsaxes]' in conf
     assert '## Whether to log exceptions before raising them.' in conf
     assert '# log_exceptions = False' in conf

--- a/astropy/config/tests/test_configs.py
+++ b/astropy/config/tests/test_configs.py
@@ -149,6 +149,8 @@ def check_config(conf):
     # test that the output contains some lines that we expect
     assert '# unicode_output = False' in conf
     assert '[io.fits]' in conf
+    assert '[table]' in conf
+    assert '# replace_warnings = ,' in conf
     assert '[table.jsviewer]' in conf
     assert '# css_urls = https://cdn.datatables.net/1.10.12/css/jquery.dataTables.css,' in conf
     assert '[visualization.wcsaxes]' in conf

--- a/astropy/table/__init__.py
+++ b/astropy/table/__init__.py
@@ -33,7 +33,7 @@ class Conf(_config.ConfigNamespace):  # noqa
         'List of conditions for issuing a warning when replacing a table '
         "column using setitem, e.g. t['a'] = value.  Allowed options are "
         "'always', 'slice', 'refcount', 'attributes'.",
-        'list')
+        'string_list')
     replace_inplace = _config.ConfigItem(
         False,
         'Always use in-place update of a table column when using setitem, '

--- a/astropy/table/jsviewer.py
+++ b/astropy/table/jsviewer.py
@@ -24,7 +24,7 @@ class Conf(_config.ConfigNamespace):
 
     css_urls = _config.ConfigItem(
         ['https://cdn.datatables.net/1.10.12/css/jquery.dataTables.css'],
-        'The URLs to the css file(s) to include.', cfgtype='list')
+        'The URLs to the css file(s) to include.', cfgtype='string_list')
 
 
 conf = Conf()

--- a/docs/changes/config/12037.bugfix.rst
+++ b/docs/changes/config/12037.bugfix.rst
@@ -1,0 +1,1 @@
+``generate_config`` no longer outputs wrong syntax for list type.

--- a/docs/changes/table/12037.bugfix.rst
+++ b/docs/changes/table/12037.bugfix.rst
@@ -1,1 +1,1 @@
-``table.jsviewer.conf.css_urls`` configuration item now has correct ``'string_list'`` type.
+``table.conf.replace_warnings`` and ``table.jsviewer.conf.css_urls`` configuration items now have correct ``'string_list'`` type.

--- a/docs/changes/table/12037.bugfix.rst
+++ b/docs/changes/table/12037.bugfix.rst
@@ -1,0 +1,1 @@
+``table.jsviewer.conf.css_urls`` configuration item now has correct ``'string_list'`` type.

--- a/docs/config/index.rst
+++ b/docs/config/index.rst
@@ -269,12 +269,16 @@ each sub-package that has configuration items)::
             1, 'Description of some_setting')
         another_setting = _config.ConfigItem(
             'string value', 'Description of another_setting')
+        some_list = _config.ConfigItem(
+            [], 'Description of some_list', cfgtype='list')
+        another_list = _config.ConfigItem(
+            ['value'], 'Description of another_setting', cfgtype='list')
     # Create an instance for the user
     conf = Conf()
 
     ... implementation ...
     def some_func():
-        #to get the value of these options, I might do:
+        # to get the value of some of these options, I might do:
         something = conf.some_setting + 2
         return conf.another_setting + ' Also, I added text.'
 
@@ -293,8 +297,14 @@ following content would be added to the config file template:
     ## Description of another_setting
     # another_setting = foo
 
+    ## Description of some_list
+    # some_list = ,
+
+    ## Description of another_setting
+    # another_list = value,
+
 Note that the key/value pairs are commented out. This will allow for
-changing the default values in a future version of ``astropy`` without
+changing the default values in a future version of the package without
 requiring the user to edit their configuration file to take advantage
 of the new defaults. By convention, the descriptions of each
 parameter are in comment lines starting with two hash characters


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to fix two things:

1. `cfgtype='list'` does not serialize properly to `astropy.cfg`.
2. `table.jsviewer.conf.css_urls` can only be a list of string but not defined as such.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #12033 

Needs #10877, so cannot backport all the way to LTS.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
