### PR TITLE
MAINT: guard __warningregistry__ deletion with try/except

### DIFF
--- a/astropy/io/votable/table.py
+++ b/astropy/io/votable/table.py
@@ -415,5 +415,7 @@ def reset_vo_warnings():
     #  warning out of this, we have to delete all of them first. #
     # -----------------------------------------------------------#
     for module in (converters, exceptions, tree, xmlutil):
-        if hasattr(module, '__warningregistry__'):
+        try:
             del module.__warningregistry__
+        except AttributeError:
+            pass

--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -222,9 +222,11 @@ def treat_deprecations_as_exceptions():
     for module in list(sys.modules.values()):
         # We don't want to deal with six.MovedModules, only "real"
         # modules. FIXME: we no more use six, this should be useless ?
-        if (isinstance(module, types.ModuleType) and
-                hasattr(module, '__warningregistry__')):
-            del module.__warningregistry__
+        if isinstance(module, types.ModuleType):
+            try:
+                del module.__warningregistry__
+            except AttributeError:
+                pass
 
     if not _deprecations_as_exceptions:
         return

--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -220,13 +220,10 @@ def treat_deprecations_as_exceptions():
     # this iteration thus we copy the original state to a list to iterate
     # on. See https://github.com/astropy/astropy/pull/5513.
     for module in list(sys.modules.values()):
-        # We don't want to deal with six.MovedModules, only "real"
-        # modules. FIXME: we no more use six, this should be useless ?
-        if isinstance(module, types.ModuleType):
-            try:
-                del module.__warningregistry__
-            except AttributeError:
-                pass
+        try:
+            del module.__warningregistry__
+        except AttributeError:
+            pass
 
     if not _deprecations_as_exceptions:
         return


### PR DESCRIPTION
### Description
I encountered a strange error in `treat_deprecations_as_exceptions` where the statement `del module.__warningregistry__` raised an `AttributeError` for the module `matplotlib.style.core`, even though the `hasattr` test had passed.

I don't know why this is, but replacing the `hasattr` test with a `try`/`except` block should fix it, and is in any case more Pythonic because it follows the principle of [EAFP](https://docs.python.org/3.9/glossary.html#term-eafp).

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
