### PR TITLE
Fix bitmask compatibility with numpy 1.21.0 and later

### DIFF
--- a/astropy/nddata/bitmask.py
+++ b/astropy/nddata/bitmask.py
@@ -687,7 +687,7 @@ good_mask_value=False, dtype=numpy.bool_)
     ignore_mask = ignore_mask & _SUPPORTED_FLAGS
 
     # invert the "ignore" mask:
-    ignore_mask = np.bitwise_not(ignore_mask, dtype=bitfield.dtype,
+    ignore_mask = np.bitwise_not(ignore_mask, dtype=bitfield.dtype.type,
                                  casting='unsafe')
 
     mask = np.empty_like(bitfield, dtype=np.bool_)


### PR DESCRIPTION
Currently `numpy 1.21.1` raises an exception (should have been a deprecation warning) when running `bitmask` code due to the following change: https://numpy.org/doc/stable/release/1.21.0-notes.html#changes-to-dtype-and-signature-arguments-in-ufuncs. This PR improves compatibility with `numpy>=1.21.0`.

Also see https://github.com/numpy/numpy/issues/19625