### PR TITLE
Include wcslib errors when parsing fits headers

### DIFF
--- a/astropy/wcs/include/astropy_wcs/pyutil.h
+++ b/astropy/wcs/include/astropy_wcs/pyutil.h
@@ -155,7 +155,7 @@ void
 wcs_to_python_exc(const struct wcsprm *wcs);
 
 void
-wcshdr_err_to_python_exc(int status);
+wcshdr_err_to_python_exc(int status, const struct wcsprm *wcs);
 
 void
 wcserr_fix_to_python_exc(const struct wcserr *err);

--- a/astropy/wcs/src/pyutil.c
+++ b/astropy/wcs/src/pyutil.c
@@ -340,11 +340,21 @@ wcserr_fix_to_python_exc(const struct wcserr *err) {
 }
 
 void
-wcshdr_err_to_python_exc(int status) {
+wcshdr_err_to_python_exc(int status, const struct wcsprm *wcs) {
+  /* Add error to wcslib error buffer */
+  wcsperr(wcs, "");
   if (status > 0 && status != WCSHDRERR_PARSER) {
-    PyErr_SetString(PyExc_MemoryError, "Memory allocation error");
+    PyErr_Format(
+      PyExc_MemoryError,
+      "Memory allocation error (internal details %s)",
+      wcsprintf_buf()
+    );
   } else {
-    PyErr_SetString(PyExc_ValueError, "Internal error in wcslib header parser");
+    PyErr_Format(
+      PyExc_ValueError,
+      "Internal error in wcslib header parser (internal details %s)",
+      wcsprintf_buf()
+    );
   }
 }
 

--- a/astropy/wcs/src/pyutil.c
+++ b/astropy/wcs/src/pyutil.c
@@ -342,17 +342,17 @@ wcserr_fix_to_python_exc(const struct wcserr *err) {
 void
 wcshdr_err_to_python_exc(int status, const struct wcsprm *wcs) {
   /* Add error to wcslib error buffer */
-  wcsperr(wcs, "");
+  wcsperr(wcs, NULL);
   if (status > 0 && status != WCSHDRERR_PARSER) {
     PyErr_Format(
       PyExc_MemoryError,
-      "Memory allocation error (internal details %s)",
+      "Memory allocation error:\n%s",
       wcsprintf_buf()
     );
   } else {
     PyErr_Format(
       PyExc_ValueError,
-      "Internal error in wcslib header parser (internal details %s)",
+      "Internal error in wcslib header parser:\n %s",
       wcsprintf_buf()
     );
   }

--- a/astropy/wcs/src/wcslib_wrap.c
+++ b/astropy/wcs/src/wcslib_wrap.c
@@ -500,7 +500,7 @@ PyWcsprm_init(
 
     if (status != 0) {
       free(colsel_ints);
-      wcshdr_err_to_python_exc(status);
+      wcshdr_err_to_python_exc(status, wcs);
       return -1;
     }
 
@@ -536,7 +536,7 @@ PyWcsprm_init(
     free(colsel_ints);
 
     if (status != 0) {
-      wcshdr_err_to_python_exc(status);
+      wcshdr_err_to_python_exc(status, wcs);
       return -1;
     }
 
@@ -772,7 +772,7 @@ PyWcsprm_find_all_wcs(
   Py_END_ALLOW_THREADS
 
   if (status != 0) {
-    wcshdr_err_to_python_exc(status);
+    wcshdr_err_to_python_exc(status, wcs);
     return NULL;
   }
 
@@ -807,7 +807,7 @@ PyWcsprm_find_all_wcs(
   Py_END_ALLOW_THREADS
 
   if (status != 0) {
-    wcshdr_err_to_python_exc(status);
+    wcshdr_err_to_python_exc(status, wcs);
     return NULL;
   }
 


### PR DESCRIPTION
It appears that errors produced when wcslib is scanning fits headers do not get passed up to the user. This adds them to the raised exception, as that appears to be the simplest way to pass them from C to python.

This is the first of the PRs that come from the discussion on slack around trying to read old INT files. This doesn't touch wcslib (only the astropy wrapper).