### PR TITLE
Adding TRF fitter to astropy modeling

### DIFF
--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -1306,7 +1306,7 @@ class _NLLSQFitter(_NonLinearLSQFitter):
         - Trust Region Reflective
         - dogbox
         - Levenberg-Marqueardt
-    algorithms using theleast squares statistic.
+    algorithms using the least squares statistic.
 
     Parameters
     ----------
@@ -1356,7 +1356,7 @@ class _NLLSQFitter(_NonLinearLSQFitter):
 
         init_values, _, bounds = model_to_fit_params(model)
 
-        # Note, if check_bounds is True we are defaulting to enfocing bounds
+        # Note, if check_bounds is True we are defaulting to enforcing bounds
         # using the old method employed by LevMarLSQFitter, this is different
         # from the method that optimize.least_squares employs to enforce bounds
         # thus we override the bounds being passed to optimize.least_squares so
@@ -1817,7 +1817,8 @@ def fitter_to_model_params(model, fps, check_bounds=True):
     Constructs the full list of model parameters from the fitted and
     constrained parameters.
 
-    Parameters:
+    Parameters
+    ----------
     model :
         The model being fit
     fps :

--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -41,9 +41,10 @@ from .spline import (
 from .statistic import leastsquare
 from .utils import _combine_equivalency_dict, poly_map_domain
 
-__all__ = ['LinearLSQFitter', 'LevMarLSQFitter', 'FittingWithOutlierRemoval',
-           'SLSQPLSQFitter', 'SimplexLSQFitter', 'JointFitter', 'Fitter',
-           "ModelLinearityError", "ModelsError"]
+__all__ = ['LinearLSQFitter', 'LevMarLSQFitter', 'TRFLSQFitter',
+           'DogBoxLSQFitter', 'LMLSQFitter',
+           'FittingWithOutlierRemoval', 'SLSQPLSQFitter', 'SimplexLSQFitter',
+           'JointFitter', 'Fitter', 'ModelLinearityError', "ModelsError"]
 
 
 # Statistic functions implemented in `astropy.modeling.statistic.py
@@ -543,7 +544,7 @@ class LinearLSQFitter(metaclass=_FitterMeta):
 
         model_copy = model.copy()
         model_copy.sync_constraints = False
-        _, fitparam_indices = model_to_fit_params(model_copy)
+        _, fitparam_indices, _ = model_to_fit_params(model_copy)
 
         if model_copy.n_inputs == 2 and z is None:
             raise ValueError("Expected x, y and z for a 2 dimensional model.")
@@ -1027,30 +1028,19 @@ class FittingWithOutlierRemoval:
         return fitted_model, filtered_data.mask
 
 
-class LevMarLSQFitter(metaclass=_FitterMeta):
+class _NonLinearLSQFitter(metaclass=_FitterMeta):
     """
-    Levenberg-Marquardt algorithm and least squares statistic.
+    Base class for Non-Linear least-squares fitters
 
-    Attributes
+    Parameters
     ----------
-    fit_info : dict
-        The `scipy.optimize.leastsq` result for the most recent fit (see
-        notes).
-
-    Notes
-    -----
-    The ``fit_info`` dictionary contains the values returned by
-    `scipy.optimize.leastsq` for the most recent fit, including the values from
-    the ``infodict`` dictionary it returns. See the `scipy.optimize.leastsq`
-    documentation for details on the meaning of these values. Note that the
-    ``x`` return value is *not* included (as it is instead the parameter values
-    of the returned model).
-    Additionally, one additional element of ``fit_info`` is computed whenever a
-    model is fit, with the key 'param_cov'. The corresponding value is the
-    covariance matrix of the parameters as a 2D numpy array.  The order of the
-    matrix elements matches the order of the parameters in the fitted model
-    (i.e., the same order as ``model.param_names``).
-
+    calc_uncertainties : bool
+        If the covarience matrix should be computed and set in the fit_info.
+        Default: False
+    check_bounds : bool
+        If the set parameter bounds for a model will be enforced each given
+        parameter while fitting via a simple min/max condition.
+        Default: True
     """
 
     supported_constraints = ['fixed', 'tied', 'bounds']
@@ -1058,17 +1048,10 @@ class LevMarLSQFitter(metaclass=_FitterMeta):
     The constraint types supported by this fitter type.
     """
 
-    def __init__(self, calc_uncertainties=False):
-        self.fit_info = {'nfev': None,
-                         'fvec': None,
-                         'fjac': None,
-                         'ipvt': None,
-                         'qtf': None,
-                         'message': None,
-                         'ierr': None,
-                         'param_jac': None,
-                         'param_cov': None}
-        self._calc_uncertainties=calc_uncertainties
+    def __init__(self, calc_uncertainties=False, check_bounds=True):
+        self.fit_info = None
+        self._calc_uncertainties = calc_uncertainties
+        self._check_bounds = check_bounds
         super().__init__()
 
     def objective_function(self, fps, *args):
@@ -1086,7 +1069,7 @@ class LevMarLSQFitter(metaclass=_FitterMeta):
 
         model = args[0]
         weights = args[1]
-        fitter_to_model_params(model, fps)
+        fitter_to_model_params(model, fps, self._check_bounds)
         meas = args[-1]
 
         if weights is None:
@@ -1111,91 +1094,6 @@ class LevMarLSQFitter(metaclass=_FitterMeta):
 
         model.cov_matrix = Covariance(cov_matrix, free_param_names)
         model.stds = StandardDeviations(cov_matrix, free_param_names)
-
-    @fitter_unit_support
-    def __call__(self, model, x, y, z=None, weights=None,
-                 maxiter=DEFAULT_MAXITER, acc=DEFAULT_ACC,
-                 epsilon=DEFAULT_EPS, estimate_jacobian=False):
-        """
-        Fit data to this model.
-
-        Parameters
-        ----------
-        model : `~astropy.modeling.FittableModel`
-            model to fit to x, y, z
-        x : array
-           input coordinates
-        y : array
-           input coordinates
-        z : array, optional
-           input coordinates
-        weights : array, optional
-            Weights for fitting.
-            For data with Gaussian uncertainties, the weights should be
-            1/sigma.
-        maxiter : int
-            maximum number of iterations
-        acc : float
-            Relative error desired in the approximate solution
-        epsilon : float
-            A suitable step length for the forward-difference
-            approximation of the Jacobian (if model.fjac=None). If
-            epsfcn is less than the machine precision, it is
-            assumed that the relative errors in the functions are
-            of the order of the machine precision.
-        estimate_jacobian : bool
-            If False (default) and if the model has a fit_deriv method,
-            it will be used. Otherwise the Jacobian will be estimated.
-            If True, the Jacobian will be estimated in any case.
-        equivalencies : list or None, optional, keyword-only
-            List of *additional* equivalencies that are should be applied in
-            case x, y and/or z have units. Default is None.
-
-        Returns
-        -------
-        model_copy : `~astropy.modeling.FittableModel`
-            a copy of the input model with parameters set by the fitter
-
-        """
-        from scipy import optimize
-
-        model_copy = _validate_model(model, self.supported_constraints)
-        model_copy.sync_constraints = False
-        farg = (model_copy, weights, ) + _convert_input(x, y, z)
-        if model_copy.fit_deriv is None or estimate_jacobian:
-            dfunc = None
-        else:
-            dfunc = self._wrap_deriv
-        init_values, _ = model_to_fit_params(model_copy)
-        fitparams, cov_x, dinfo, mess, ierr = optimize.leastsq(
-            self.objective_function, init_values, args=farg, Dfun=dfunc,
-            col_deriv=model_copy.col_fit_deriv, maxfev=maxiter, epsfcn=epsilon,
-            xtol=acc, full_output=True)
-        fitter_to_model_params(model_copy, fitparams)
-        self.fit_info.update(dinfo)
-        self.fit_info['cov_x'] = cov_x
-        self.fit_info['message'] = mess
-        self.fit_info['ierr'] = ierr
-        if ierr not in [1, 2, 3, 4]:
-            warnings.warn("The fit may be unsuccessful; check "
-                          "fit_info['message'] for more information.",
-                          AstropyUserWarning)
-
-        # now try to compute the true covariance matrix
-        if (len(y) > len(init_values)) and cov_x is not None:
-            sum_sqrs = np.sum(self.objective_function(fitparams, *farg)**2)
-            dof = len(y) - len(init_values)
-            self.fit_info['param_cov'] = cov_x * sum_sqrs / dof
-        else:
-            self.fit_info['param_cov'] = None
-
-        if self._calc_uncertainties is True:
-            if self.fit_info['param_cov'] is not None:
-                self._add_fitting_uncertainties(model_copy,
-                                               self.fit_info['param_cov'])
-
-        model_copy.sync_constraints = True
-        return model_copy
 
     @staticmethod
     def _wrap_deriv(params, model, weights, x, y, z=None):
@@ -1256,6 +1154,311 @@ class LevMarLSQFitter(metaclass=_FitterMeta):
                     return [np.ravel(_) for _ in
                             (np.ravel(weights) * np.array(model.fit_deriv(x, y, *params)).T).T]
                 return [np.ravel(_) for _ in weights * np.array(model.fit_deriv(x, y, *params))]
+
+    def _compute_param_cov(self, model, y, init_values, cov_x, fitparams, farg):
+        # now try to compute the true covariance matrix
+        if (len(y) > len(init_values)) and cov_x is not None:
+            sum_sqrs = np.sum(self.objective_function(fitparams, *farg)**2)
+            dof = len(y) - len(init_values)
+            self.fit_info['param_cov'] = cov_x * sum_sqrs / dof
+        else:
+            self.fit_info['param_cov'] = None
+
+        if self._calc_uncertainties is True:
+            if self.fit_info['param_cov'] is not None:
+                self._add_fitting_uncertainties(model,
+                                                self.fit_info['param_cov'])
+
+    def _run_fitter(self, model, farg, maxiter, acc, epsilon, estimate_jacobian):
+        return None, None, None
+
+    @fitter_unit_support
+    def __call__(self, model, x, y, z=None, weights=None,
+                 maxiter=DEFAULT_MAXITER, acc=DEFAULT_ACC,
+                 epsilon=DEFAULT_EPS, estimate_jacobian=False):
+        """
+        Fit data to this model.
+
+        Parameters
+        ----------
+        model : `~astropy.modeling.FittableModel`
+            model to fit to x, y, z
+        x : array
+           input coordinates
+        y : array
+           input coordinates
+        z : array, optional
+           input coordinates
+        weights : array, optional
+            Weights for fitting.
+            For data with Gaussian uncertainties, the weights should be
+            1/sigma.
+        maxiter : int
+            maximum number of iterations
+        acc : float
+            Relative error desired in the approximate solution
+        epsilon : float
+            A suitable step length for the forward-difference
+            approximation of the Jacobian (if model.fjac=None). If
+            epsfcn is less than the machine precision, it is
+            assumed that the relative errors in the functions are
+            of the order of the machine precision.
+        estimate_jacobian : bool
+            If False (default) and if the model has a fit_deriv method,
+            it will be used. Otherwise the Jacobian will be estimated.
+            If True, the Jacobian will be estimated in any case.
+        equivalencies : list or None, optional, keyword-only
+            List of *additional* equivalencies that are should be applied in
+            case x, y and/or z have units. Default is None.
+
+        Returns
+        -------
+        model_copy : `~astropy.modeling.FittableModel`
+            a copy of the input model with parameters set by the fitter
+
+        """
+
+        model_copy = _validate_model(model, self.supported_constraints)
+        model_copy.sync_constraints = False
+        farg = (model_copy, weights, ) + _convert_input(x, y, z)
+
+        init_values, fitparams, cov_x = self._run_fitter(model_copy, farg,
+                                                         maxiter, acc, epsilon, estimate_jacobian)
+
+        self._compute_param_cov(model_copy, y, init_values, cov_x, fitparams, farg)
+
+        model.sync_constraints = True
+        return model_copy
+
+
+class LevMarLSQFitter(_NonLinearLSQFitter):
+    """
+    Levenberg-Marquardt algorithm and least squares statistic.
+
+    Parameters
+    ----------
+    calc_uncertainties : bool
+        If the covarience matrix should be computed and set in the fit_info.
+        Default: False
+
+    Attributes
+    ----------
+    fit_info : dict
+        The `scipy.optimize.leastsq` result for the most recent fit (see
+        notes).
+
+    Notes
+    -----
+    The ``fit_info`` dictionary contains the values returned by
+    `scipy.optimize.leastsq` for the most recent fit, including the values from
+    the ``infodict`` dictionary it returns. See the `scipy.optimize.leastsq`
+    documentation for details on the meaning of these values. Note that the
+    ``x`` return value is *not* included (as it is instead the parameter values
+    of the returned model).
+    Additionally, one additional element of ``fit_info`` is computed whenever a
+    model is fit, with the key 'param_cov'. The corresponding value is the
+    covariance matrix of the parameters as a 2D numpy array.  The order of the
+    matrix elements matches the order of the parameters in the fitted model
+    (i.e., the same order as ``model.param_names``).
+
+    """
+
+    def __init__(self, calc_uncertainties=False):
+        super().__init__(calc_uncertainties)
+        self.fit_info = {'nfev': None,
+                         'fvec': None,
+                         'fjac': None,
+                         'ipvt': None,
+                         'qtf': None,
+                         'message': None,
+                         'ierr': None,
+                         'param_jac': None,
+                         'param_cov': None}
+
+    def _run_fitter(self, model, farg, maxiter, acc, epsilon, estimate_jacobian):
+        from scipy import optimize
+
+        if model.fit_deriv is None or estimate_jacobian:
+            dfunc = None
+        else:
+            dfunc = self._wrap_deriv
+        init_values, _, _ = model_to_fit_params(model)
+        fitparams, cov_x, dinfo, mess, ierr = optimize.leastsq(
+            self.objective_function, init_values, args=farg, Dfun=dfunc,
+            col_deriv=model.col_fit_deriv, maxfev=maxiter, epsfcn=epsilon,
+            xtol=acc, full_output=True)
+        fitter_to_model_params(model, fitparams)
+        self.fit_info.update(dinfo)
+        self.fit_info['cov_x'] = cov_x
+        self.fit_info['message'] = mess
+        self.fit_info['ierr'] = ierr
+        if ierr not in [1, 2, 3, 4]:
+            warnings.warn("The fit may be unsuccessful; check "
+                          "fit_info['message'] for more information.",
+                          AstropyUserWarning)
+
+        return init_values, fitparams, cov_x
+
+
+class _NLLSQFitter(_NonLinearLSQFitter):
+    """
+    Wrapper class for `scipy.optimize.least_squares` method, which provides:
+        - Trust Region Reflective
+        - dogbox
+        - Levenberg-Marqueardt
+    algorithms using theleast squares statistic.
+
+    Parameters
+    ----------
+    method : str
+        ‘trf’ :  Trust Region Reflective algorithm, particularly suitable
+            for large sparse problems with bounds. Generally robust method.
+        ‘dogbox’ : dogleg algorithm with rectangular trust regions, typical
+            use case is small problems with bounds. Not recommended for
+            problems with rank-deficient Jacobian.
+        ‘lm’ : Levenberg-Marquardt algorithm as implemented in MINPACK.
+            Doesn’t handle bounds and sparse Jacobians. Usually the most
+            efficient method for small unconstrained problems.
+    calc_uncertainties : bool
+        If the covarience matrix should be computed and set in the fit_info.
+        Default: False
+    check_bounds : bool
+        If the set parameter bounds for a model will be enforced each given
+        parameter while fitting via a simple min/max condition. A True setting
+        will replicate how LevMarLSQFitter enforces bounds.
+        Default: False
+
+    Attributes
+    ----------
+    fit_info :
+        A `scipy.optimize.OptimizeResult` class which contains all of
+        the most recent fit information
+    """
+
+    def __init__(self, method, calc_uncertainties=False, check_bounds=False):
+        super().__init__(calc_uncertainties, check_bounds)
+        self._method = method
+
+    def _run_fitter(self, model, farg, maxiter, acc, epsilon, estimate_jacobian):
+        from scipy import optimize
+        from scipy.linalg import svd
+
+        if model.fit_deriv is None or estimate_jacobian:
+            dfunc = '2-point'
+        else:
+            def _dfunc(params, model, weights, x, y, z=None):
+                if model.col_fit_deriv:
+                    return np.transpose(self._wrap_deriv(params, model, weights, x, y, z))
+                else:
+                    return self._wrap_deriv(params, model, weights, x, y, z)
+
+            dfunc = _dfunc
+
+        init_values, _, bounds = model_to_fit_params(model)
+
+        # Note, if check_bounds is True we are defaulting to enfocing bounds
+        # using the old method employed by LevMarLSQFitter, this is different
+        # from the method that optimize.least_squares employs to enforce bounds
+        # thus we override the bounds being passed to optimize.least_squares so
+        # that it will not enforce any bounding.
+        if self._check_bounds:
+            bounds = (-np.inf, np.inf)
+
+        self.fit_info = optimize.least_squares(
+            self.objective_function, init_values, args=farg, jac=dfunc,
+            max_nfev=maxiter, diff_step=np.sqrt(epsilon), xtol=acc,
+            method=self._method, bounds=bounds
+        )
+
+        # Adapted from ~scipy.optimize.minpack, see:
+        # https://github.com/scipy/scipy/blob/47bb6febaa10658c72962b9615d5d5aa2513fa3a/scipy/optimize/minpack.py#L795-L816
+        # Do Moore-Penrose inverse discarding zero singular values.
+        _, s, VT = svd(self.fit_info.jac, full_matrices=False)
+        threshold = np.finfo(float).eps * max(self.fit_info.jac.shape) * s[0]
+        s = s[s > threshold]
+        VT = VT[:s.size]
+        cov_x = np.dot(VT.T / s**2, VT)
+
+        fitter_to_model_params(model, self.fit_info.x, False)
+        if not self.fit_info.success:
+            warnings.warn("The fit may be unsuccessful; check: \n"
+                          f"    {self.fit_info.message}",
+                          AstropyUserWarning)
+
+        return init_values, self.fit_info.x, cov_x
+
+
+class TRFLSQFitter(_NLLSQFitter):
+    """
+    Trust Region Reflective algorithm and least squares statistic.
+
+    Parameters
+    ----------
+    calc_uncertainties : bool
+        If the covarience matrix should be computed and set in the fit_info.
+        Default: False
+    check_bounds : bool
+        If the set parameter bounds for a model will be enforced each given
+        parameter while fitting via a simple min/max condition. A True setting
+        will replicate how LevMarLSQFitter enforces bounds.
+        Default: False
+
+    Attributes
+    ----------
+    fit_info :
+        A `scipy.optimize.OptimizeResult` class which contains all of
+        the most recent fit information
+    """
+
+    def __init__(self, calc_uncertainties=False, check_bounds=False):
+        super().__init__('trf', calc_uncertainties, check_bounds)
+
+
+class DogBoxLSQFitter(_NLLSQFitter):
+    """
+    DogBox algorithm and least squares statistic.
+
+    Parameters
+    ----------
+    calc_uncertainties : bool
+        If the covarience matrix should be computed and set in the fit_info.
+        Default: False
+    check_bounds : bool
+        If the set parameter bounds for a model will be enforced each given
+        parameter while fitting via a simple min/max condition. A True setting
+        will replicate how LevMarLSQFitter enforces bounds.
+        Default: False
+
+    Attributes
+    ----------
+    fit_info :
+        A `scipy.optimize.OptimizeResult` class which contains all of
+        the most recent fit information
+    """
+
+    def __init__(self, calc_uncertainties=False, check_bounds=False):
+        super().__init__('dogbox', calc_uncertainties, check_bounds)
+
+
+class LMLSQFitter(_NLLSQFitter):
+    """
+    `scipy.optimize.least_squares` Levenberg-Marquardt algorithm and least squares statistic.
+
+    Parameters
+    ----------
+    calc_uncertainties : bool
+        If the covarience matrix should be computed and set in the fit_info.
+        Default: False
+
+    Attributes
+    ----------
+    fit_info :
+        A `scipy.optimize.OptimizeResult` class which contains all of
+        the most recent fit information
+    """
+
+    def __init__(self, calc_uncertainties=False):
+        super().__init__('lm', calc_uncertainties, True)
 
 
 class SLSQPLSQFitter(Fitter):
@@ -1326,7 +1529,7 @@ class SLSQPLSQFitter(Fitter):
         model_copy.sync_constraints = False
         farg = _convert_input(x, y, z)
         farg = (model_copy, weights, ) + farg
-        init_values, _ = model_to_fit_params(model_copy)
+        init_values, _, _ = model_to_fit_params(model_copy)
         fitparams, self.fit_info = self._opt_method(
             self.objective_function, init_values, farg, **kwargs)
         fitter_to_model_params(model_copy, fitparams)
@@ -1394,7 +1597,7 @@ class SimplexLSQFitter(Fitter):
         farg = _convert_input(x, y, z)
         farg = (model_copy, weights, ) + farg
 
-        init_values, _ = model_to_fit_params(model_copy)
+        init_values, _, _ = model_to_fit_params(model_copy)
 
         fitparams, self.fit_info = self._opt_method(
             self.objective_function, init_values, farg, **kwargs)
@@ -1609,13 +1812,23 @@ def _convert_input(x, y, z=None, n_models=1, model_set_axis=0):
 # its own versions of these)
 # TODO: Most of this code should be entirely rewritten; it should not be as
 # inefficient as it is.
-def fitter_to_model_params(model, fps):
+def fitter_to_model_params(model, fps, check_bounds=True):
     """
     Constructs the full list of model parameters from the fitted and
     constrained parameters.
+
+    Parameters:
+    model :
+        The model being fit
+    fps :
+        The fit parameter values to be assigned
+    check_bounds : bool
+        If the set parameter bounds for model will be enforced on each
+        parameter with bounds.
+        Default: True
     """
 
-    _, fit_param_indices = model_to_fit_params(model)
+    _, fit_param_indices, _ = model_to_fit_params(model)
 
     has_tied = any(model.tied.values())
     has_fixed = any(model.fixed.values())
@@ -1643,7 +1856,7 @@ def fitter_to_model_params(model, fps):
         values = fps[offset:offset + size]
 
         # Check bounds constraints
-        if model.bounds[name] != (None, None):
+        if model.bounds[name] != (None, None) and check_bounds:
             _min, _max = model.bounds[name]
             if _min is not None:
                 values = np.fmax(values, _min)
@@ -1688,16 +1901,33 @@ def model_to_fit_params(model):
     """
 
     fitparam_indices = list(range(len(model.param_names)))
+    model_params = model.parameters
+    model_bounds = list(model.bounds.values())
     if any(model.fixed.values()) or any(model.tied.values()):
-        params = list(model.parameters)
+        params = list(model_params)
         param_metrics = model._param_metrics
         for idx, name in list(enumerate(model.param_names))[::-1]:
             if model.fixed[name] or model.tied[name]:
                 slice_ = param_metrics[name]['slice']
                 del params[slice_]
+                del model_bounds[slice_]
                 del fitparam_indices[idx]
-        return (np.array(params), fitparam_indices)
-    return (model.parameters, fitparam_indices)
+        model_params = np.array(params)
+
+    for idx, bound in enumerate(model_bounds):
+        if bound[0] is None:
+            lower = -np.inf
+        else:
+            lower = bound[0]
+
+        if bound[1] is None:
+            upper = np.inf
+        else:
+            upper = bound[1]
+
+        model_bounds[idx] = (lower, upper)
+    model_bounds = tuple(zip(*model_bounds))
+    return model_params, fitparam_indices, model_bounds
 
 
 @deprecated('5.1', 'private method: _model_to_fit_params has been made public now')

--- a/astropy/modeling/tests/test_functional_models.py
+++ b/astropy/modeling/tests/test_functional_models.py
@@ -11,6 +11,8 @@ from astropy.modeling import InputParameterError, fitting, models
 from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa
 from astropy.utils.exceptions import AstropyUserWarning
 
+fitters = [fitting.LevMarLSQFitter, fitting.TRFLSQFitter, fitting.LMLSQFitter, fitting.DogBoxLSQFitter]
+
 
 def test_sigma_constant():
     """
@@ -295,15 +297,16 @@ def test_Shift_inverse_bounding_box():
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
-def test_Shift_model_levmar_fit():
+@pytest.mark.parametrize('fitter', fitters)
+def test_Shift_model_levmar_fit(fitter):
     """Test fitting Shift model with LevMarLSQFitter (issue #6103)."""
+    fitter = fitter()
 
     init_model = models.Shift()
 
     x = np.arange(10)
     y = x + 0.1
 
-    fitter = fitting.LevMarLSQFitter()
     with pytest.warns(AstropyUserWarning,
                       match='Model is linear in parameters'):
         fitted_model = fitter(init_model, x, y)
@@ -434,12 +437,14 @@ def test_Ring2D_rout():
 
 
 @pytest.mark.skipif("not HAS_SCIPY")
-def test_Voigt1D():
+@pytest.mark.parametrize('fitter', fitters)
+def test_Voigt1D(fitter):
+    fitter = fitter()
+
     voi = models.Voigt1D(amplitude_L=-0.5, x_0=1.0, fwhm_L=5.0, fwhm_G=5.0)
     xarr = np.linspace(-5.0, 5.0, num=40)
     yarr = voi(xarr)
     voi_init = models.Voigt1D(amplitude_L=-1.0, x_0=1.0, fwhm_L=5.0, fwhm_G=5.0)
-    fitter = fitting.LevMarLSQFitter()
     voi_fit = fitter(voi_init, xarr, yarr)
     assert_allclose(voi_fit.param_sets, voi.param_sets)
 
@@ -483,12 +488,14 @@ def test_Voigt1D_hum2(doppler):
 
 
 @pytest.mark.skipif("not HAS_SCIPY")
-def test_KingProjectedAnalytic1D_fit():
+@pytest.mark.parametrize('fitter', fitters)
+def test_KingProjectedAnalytic1D_fit(fitter):
+    fitter = fitter()
+
     km = models.KingProjectedAnalytic1D(amplitude=1, r_core=1, r_tide=2)
     xarr = np.linspace(0.1, 2, 10)
     yarr = km(xarr)
     km_init = models.KingProjectedAnalytic1D(amplitude=1, r_core=1, r_tide=1)
-    fitter = fitting.LevMarLSQFitter()
     km_fit = fitter(km_init, xarr, yarr)
     assert_allclose(km_fit.param_sets, km.param_sets)
     assert_allclose(km_fit.concentration, 0.30102999566398136)

--- a/astropy/modeling/tests/test_input.py
+++ b/astropy/modeling/tests/test_input.py
@@ -26,6 +26,8 @@ model2d_params = [
     (models.Chebyshev2D, [1, 2])
 ]
 
+fitters = [fitting.LevMarLSQFitter, fitting.TRFLSQFitter, fitting.LMLSQFitter, fitting.DogBoxLSQFitter]
+
 
 class TestInputType:
     """
@@ -164,47 +166,51 @@ class TestFitting:
         assert_allclose(model.param_sets, expected, atol=10 ** (-7))
 
     @pytest.mark.skipif('not HAS_SCIPY')
-    def test_nonlinear_lsqt_1set_1d(self):
+    @pytest.mark.parametrize('fitter', fitters)
+    def test_nonlinear_lsqt_1set_1d(self, fitter):
         """1 set 1D x, 1 set 1D y, 1 pset NonLinearFitter"""
+        fitter = fitter()
 
         g1 = models.Gaussian1D(10, mean=3, stddev=.2)
         y1 = g1(self.x1)
-        gfit = fitting.LevMarLSQFitter()
-        model = gfit(g1, self.x1, y1)
+        model = fitter(g1, self.x1, y1)
         assert_allclose(model.parameters, [10, 3, .2])
 
     @pytest.mark.skipif('not HAS_SCIPY')
-    def test_nonlinear_lsqt_Nset_1d(self):
+    @pytest.mark.parametrize('fitter', fitters)
+    def test_nonlinear_lsqt_Nset_1d(self, fitter):
         """1 set 1D x, 1 set 1D y, 2 param_sets, NonLinearFitter"""
+        fitter = fitter()
 
         with pytest.raises(ValueError):
             g1 = models.Gaussian1D([10.2, 10], mean=[3, 3.2], stddev=[.23, .2],
                                    n_models=2)
             y1 = g1(self.x1, model_set_axis=False)
-            gfit = fitting.LevMarLSQFitter()
-            model = gfit(g1, self.x1, y1)
+            _ = fitter(g1, self.x1, y1)
 
     @pytest.mark.skipif('not HAS_SCIPY')
-    def test_nonlinear_lsqt_1set_2d(self):
+    @pytest.mark.parametrize('fitter', fitters)
+    def test_nonlinear_lsqt_1set_2d(self, fitter):
         """1 set 2d x, 1set 2D y, 1 pset, NonLinearFitter"""
+        fitter = fitter()
 
         g2 = models.Gaussian2D(10, x_mean=3, y_mean=4, x_stddev=.3,
                                y_stddev=.2, theta=0)
         z = g2(self.x, self.y)
-        gfit = fitting.LevMarLSQFitter()
-        model = gfit(g2, self.x, self.y, z)
+        model = fitter(g2, self.x, self.y, z)
         assert_allclose(model.parameters, [10, 3, 4, .3, .2, 0])
 
     @pytest.mark.skipif('not HAS_SCIPY')
-    def test_nonlinear_lsqt_Nset_2d(self):
+    @pytest.mark.parametrize('fitter', fitters)
+    def test_nonlinear_lsqt_Nset_2d(self, fitter):
         """1 set 2d x, 1set 2D y, 2 param_sets, NonLinearFitter"""
+        fitter = fitter()
 
         with pytest.raises(ValueError):
             g2 = models.Gaussian2D([10, 10], [3, 3], [4, 4], x_stddev=[.3, .3],
                                    y_stddev=[.2, .2], theta=[0, 0], n_models=2)
             z = g2(self.x.flatten(), self.y.flatten())
-            gfit = fitting.LevMarLSQFitter()
-            model = gfit(g2, self.x, self.y, z)
+            _ = fitter(g2, self.x, self.y, z)
 
 
 class TestEvaluation:

--- a/docs/changes/modeling/12051.feature.rst
+++ b/docs/changes/modeling/12051.feature.rst
@@ -1,5 +1,6 @@
 Add new fitters based on ``scipy.optimize.least_squares`` method of non-linear
-least-squares optiomization:
+least-squares optimization:
+
     - ``TRFLSQFitter`` using the Trust Region Reflective algorithm.
     - ``LMLSQFitter`` using the Levenburg-Marquardt algorithm (implemented by ``scipy.optimize.least_squares``).
     - ``DogBoxLSQFitter`` using the dogleg algorithm.

--- a/docs/changes/modeling/12051.feature.rst
+++ b/docs/changes/modeling/12051.feature.rst
@@ -1,0 +1,5 @@
+Add new fitters based on ``scipy.optimize.least_squares`` method of non-linear
+least-squares optiomization:
+    - ``TRFLSQFitter`` using the Trust Region Reflective algorithm.
+    - ``LMLSQFitter`` using the Levenburg-Marquardt algorithm (implemented by ``scipy.optimize.least_squares``).
+    - ``DogBoxLSQFitter`` using the dogleg algorithm.

--- a/docs/changes/modeling/12051.feature.rst
+++ b/docs/changes/modeling/12051.feature.rst
@@ -2,5 +2,5 @@ Add new fitters based on ``scipy.optimize.least_squares`` method of non-linear
 least-squares optimization:
 
     - ``TRFLSQFitter`` using the Trust Region Reflective algorithm.
-    - ``LMLSQFitter`` using the Levenburg-Marquardt algorithm (implemented by ``scipy.optimize.least_squares``).
+    - ``LMLSQFitter`` using the Levenberg-Marquardt algorithm (implemented by ``scipy.optimize.least_squares``).
     - ``DogBoxLSQFitter`` using the dogleg algorithm.

--- a/docs/modeling/fitting.rst
+++ b/docs/modeling/fitting.rst
@@ -29,6 +29,42 @@ The rules for passing input to fitters are:
   `~astropy.modeling.polynomial.Chebyshev2D` but not compound models that map
   ``x, y -> x', y'``).
 
+.. _modeling-getting-started-nonlinear-notes:
+
+Notes on Non-linear fitting
+---------------------------
+
+There are several non-linear fitters, which rely on several different optimization
+algorithms now. Choice of algorithm is problem dependent. The main non-linear
+fitters are:
+
+* :class:`~astropy.modeling.fitting.LevMarLSQFitter`, which uses the Levenberg-Marquardt
+  algorithm via the scipy legacy function `scipy.optimize.leastsq`. This fitter supports
+  parameter bounds via an unsophisticated min/max condition which can cause parameters
+  to "stick" to one of the bounds if during the fitting process the parameter gets close
+  to the bound during some of the intermediate fitting operations.
+
+* :class:`~astropy.modeling.fitting.TRFLSQFitter`, which uses the Trust Region Reflective
+  (TRF) algorithm that is particularly suitable for large sparse problems with bounds, see
+  `scipy.optimize.least_squares` for more details. Note that this fitter supports parameter
+  bounds in a sophisticated fashion which prevents fitting from "sticking" to one of the
+  bounds provided. This fitter can be switched over to using the min/max bound method
+  by setting ``check_bounds=False`` when initializing the fitter. This is the recommended
+  algorithm by scipy.
+
+* :class:`~astropy.modeling.fitting.DogBoxLSQFitter`, which uses the dogleg algorithm
+  with rectangular trust regions, typical use case is small problems with bounds. Not
+  recommended for problems with rank-deficient Jacobian, see `scipy.optimize.least_squares`
+  for more details. This fitter supports bounds in the same fashion that
+  :class:`~astropy.modeling.fitting.TRFLSQFitter` does.
+
+* :class:`~astropy.modeling.fitting.LMLSQFitter`, which uses the Levenberg-Marquardt (LM)
+  algorithm as implemented by `scipy.optimize.least_squares`. Doesn’t handle bounds and/or
+  sparse Jacobians. Usually the most efficient method for small unconstrained problems.
+  If a Levenberg-Marquardt algorithm is desired for your problem, it is now recommended that
+  you use this fitter instead of :class:`~astropy.modeling.fitting.LevMarLSQFitter` as it
+  makes use of the recommended version of this algorithm in scipy.
+
 .. _modeling-getting-started-1d-fitting:
 
 Simple 1-D model fitting
@@ -124,39 +160,3 @@ background in an image.
     plt.imshow(z - p(x, y), origin='lower', interpolation='nearest', vmin=-1e4,
                vmax=5e4)
     plt.title("Residual")
-
-.. _modeling-getting-started-nonlinear-notes:
-
-Notes on Non-linear fitting
----------------------------
-
-There are several non-linear fitters, which rely on several different optimization
-algorithms now. Choice of algorithm is problem dependent. The main non-linear
-fitters are:
-
-* :class:`~astropy.modeling.fitting.LevMarLSQFitter`, which uses the Levenberg-Marquardt
-  algorithm via the scipy legacy function `scipy.optimize.leastsq`. This fitter supports
-  parameter bounds via an unsophisticated min/max condition which can cause parameters
-  to "stick" to one of the bounds if during the fitting process the parameter gets close
-  to the bound during some of the intermediate fitting operations.
-
-* :class:`~astropy.modeling.fitting.TRFLSQFitter`, which uses the Trust Region Reflective
-  (TRF) algorithm that is particularly suitable for large sparse problems with bounds, see
-  `scipy.optimize.least_squares` for more details. Note that this fitter supports parameter
-  bounds in a sophisticated fashion which prevents fitting from "sticking" to one of the
-  bounds provided. This fitter can be switched over to using the min/max bound method
-  by setting ``check_bounds=False`` when initializing the fitter. This is the recommended
-  algorithm by scipy.
-
-* :class: `~astropy.modeling.fitting.DobBoxLSQFitter`, which uses the dogleg algorithm
-  with rectangular trust regions, typical use case is small problems with bounds. Not
-  recommended for problems with rank-deficient Jacobian, see `scipy.optimize.least_squares`
-  for more details. This fitter supports bounds in the same fashion that
-  :class:`~astropy.modeling.fitting.TRFLSQFitter` does.
-
-* :class: `~astropy.modeling.fitting.LMLSQFitter`, which uses the Levenberg-Marquardt (LM)
-  algorithm as implemented by `scipy.optimize.least_squares`. Doesn’t handle bounds and/or
-  sparse Jacobians. Usually the most efficient method for small unconstrained problems.
-  If a Levenberg-Marquardt algorithm is desired for your problem, it is now recommended that
-  you use this fitter instead of :class:`~astropy.modeling.fitting.LevMarLSQFitter` as it
-  makes use of the recommended version of this algorithm in scipy.

--- a/docs/modeling/fitting.rst
+++ b/docs/modeling/fitting.rst
@@ -49,7 +49,7 @@ fitters are:
   `scipy.optimize.least_squares` for more details. Note that this fitter supports parameter
   bounds in a sophisticated fashion which prevents fitting from "sticking" to one of the
   bounds provided. This fitter can be switched over to using the min/max bound method
-  by setting ``check_bounds=False`` when initializing the fitter. This is the recommended
+  by setting ``use_min_max_bounds=False`` when initializing the fitter. This is the recommended
   algorithm by scipy.
 
 * :class:`~astropy.modeling.fitting.DogBoxLSQFitter`, which uses the dogleg algorithm

--- a/docs/modeling/fitting.rst
+++ b/docs/modeling/fitting.rst
@@ -9,8 +9,8 @@ instance of `~astropy.modeling.FittableModel` as input and modify its
 users to easily add other fitters.
 
 Linear fitting is done using Numpy's `numpy.linalg.lstsq` function.  There are
-currently two non-linear fitters which use `scipy.optimize.leastsq` and
-`scipy.optimize.fmin_slsqp`.
+currently non-linear fitters which use `scipy.optimize.leastsq`,
+`scipy.optimize.least_squares`, and `scipy.optimize.fmin_slsqp`.
 
 The rules for passing input to fitters are:
 
@@ -124,3 +124,39 @@ background in an image.
     plt.imshow(z - p(x, y), origin='lower', interpolation='nearest', vmin=-1e4,
                vmax=5e4)
     plt.title("Residual")
+
+.. _modeling-getting-started-nonlinear-notes:
+
+Notes on Non-linear fitting
+---------------------------
+
+There are several non-linear fitters, which rely on several different optimization
+algorithms now. Choice of algorithm is problem dependent. The main non-linear
+fitters are:
+
+* :class:`~astropy.modeling.fitting.LevMarLSQFitter`, which uses the Levenberg-Marquardt
+  algorithm via the scipy legacy function `scipy.optimize.leastsq`. This fitter supports
+  parameter bounds via an unsophisticated min/max condition which can cause parameters
+  to "stick" to one of the bounds if during the fitting process the parameter gets close
+  to the bound during some of the intermediate fitting operations.
+
+* :class:`~astropy.modeling.fitting.TRFLSQFitter`, which uses the Trust Region Reflective
+  (TRF) algorithm that is particularly suitable for large sparse problems with bounds, see
+  `scipy.optimize.least_squares` for more details. Note that this fitter supports parameter
+  bounds in a sophisticated fashion which prevents fitting from "sticking" to one of the
+  bounds provided. This fitter can be switched over to using the min/max bound method
+  by setting ``check_bounds=False`` when initializing the fitter. This is the recommended
+  algorithm by scipy.
+
+* :class: `~astropy.modeling.fitting.DobBoxLSQFitter`, which uses the dogleg algorithm
+  with rectangular trust regions, typical use case is small problems with bounds. Not
+  recommended for problems with rank-deficient Jacobian, see `scipy.optimize.least_squares`
+  for more details. This fitter supports bounds in the same fashion that
+  :class:`~astropy.modeling.fitting.TRFLSQFitter` does.
+
+* :class: `~astropy.modeling.fitting.LMLSQFitter`, which uses the Levenberg-Marquardt (LM)
+  algorithm as implemented by `scipy.optimize.least_squares`. Doesn’t handle bounds and/or
+  sparse Jacobians. Usually the most efficient method for small unconstrained problems.
+  If a Levenberg-Marquardt algorithm is desired for your problem, it is now recommended that
+  you use this fitter instead of :class:`~astropy.modeling.fitting.LevMarLSQFitter` as it
+  makes use of the recommended version of this algorithm in scipy.

--- a/docs/modeling/fitting.rst
+++ b/docs/modeling/fitting.rst
@@ -31,7 +31,7 @@ The rules for passing input to fitters are:
 
 .. _modeling-getting-started-nonlinear-notes:
 
-Notes on Non-linear fitting
+Notes on non-linear fitting
 ---------------------------
 
 There are several non-linear fitters, which rely on several different optimization

--- a/docs/modeling/fitting.rst
+++ b/docs/modeling/fitting.rst
@@ -59,7 +59,7 @@ fitters are:
   :class:`~astropy.modeling.fitting.TRFLSQFitter` does.
 
 * :class:`~astropy.modeling.fitting.LMLSQFitter`, which uses the Levenberg-Marquardt (LM)
-  algorithm as implemented by `scipy.optimize.least_squares`. Doesn’t handle bounds and/or
+  algorithm as implemented by `scipy.optimize.least_squares`. Does not handle bounds and/or
   sparse Jacobians. Usually the most efficient method for small unconstrained problems.
   If a Levenberg-Marquardt algorithm is desired for your problem, it is now recommended that
   you use this fitter instead of :class:`~astropy.modeling.fitting.LevMarLSQFitter` as it

--- a/docs/whatsnew/5.1.rst
+++ b/docs/whatsnew/5.1.rst
@@ -114,8 +114,8 @@ least-squares optimization algorithm from scipy. These new fitters are:
 
 * :class:`~astropy.modeling.fitting.TRFLSQFitter`, which uses the Trust Region Reflective (TRF)
   algorithm.
-* :class:`~astropy.modeling.fitting.LMLSQFitter`, which uses the Levenburg-Marquardt (LM) algorithm,
-  via the :func:`scipy.optimize.lease_squares` function.
+* :class:`~astropy.modeling.fitting.LMLSQFitter`, which uses the Levenberg-Marquardt (LM) algorithm,
+  via the `scipy.optimize.least_squares` function.
 * :class:`~astropy.modeling.fitting.DogBoxLSQFitter`, which uses the dogleg algorithm.
 
 Full change log

--- a/docs/whatsnew/5.1.rst
+++ b/docs/whatsnew/5.1.rst
@@ -16,6 +16,7 @@ In particular, this release includes:
 * :ref:`whatsnew-doppler-redshift-eq`
 * :ref:`whatsnew-io-ascii-converters`
 * :ref:`whatsnew-structured-columns`
+* :ref:`whatsnew-fitters`
 
 .. _whatsnew-5.1-cosmology:
 
@@ -101,6 +102,21 @@ effectively allowing tables within tables. This applies to |Column|,
 |MaskedColumn|, and |Quantity| columns, and includes possible structured
 units. These structured data columns can be stored in ECSV, FITS, and HDF5
 formats.
+
+.. _whatsnew-fitters:
+
+New fitters have been added
+===========================
+
+New fitters have been added to :mod:`~astropy.modeling.fitting` based around the available
+algorithms provided by `scipy.optimize.least_squares`, which is now the recommended
+least-squares optimization algorithm from scipy. These new fitters are:
+
+* :class:`~astropy.modeling.fitting.TRFLSQFitter`, which uses the Trust Region Reflective (TRF)
+  algorithm.
+* :class:`~astropy.modeling.fitting.LMLSQFitter`, which uses the Levenburg-Marquardt (LM) algorithm,
+  via the :func:`scipy.optimize.lease_squares` function.
+* :class:`~astropy.modeling.fitting.DogBoxLSQFitter`, which uses the dogleg algorithm.
 
 Full change log
 ===============

--- a/docs/whatsnew/5.1.rst
+++ b/docs/whatsnew/5.1.rst
@@ -105,8 +105,8 @@ formats.
 
 .. _whatsnew-fitters:
 
-New fitters have been added
-===========================
+New model fitters have been added
+=================================
 
 New fitters have been added to :mod:`~astropy.modeling.fitting` based around the available
 algorithms provided by `scipy.optimize.least_squares`, which is now the recommended


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

Currently, the standard non-linear least-squares fitter, `LevMarLSQFitter`, supports fitting bounded parameters by forcing the parameters to stay within the prescribed bounds within the objective function. It was noted in issue #11946 that this method of enforcing parameter bounds while employing the Levenberg-Marquardt (LevMar) can cause problems with the fit, such as causing the parameter to "stick" to one of the bounds. The Trust Region Reflective (TRF) algorithm is an alternative algorithm for non-linear least-squares fitting which can accommodate parameter bounds directly within the algorithm, in a way which prevents the issues with LevMar detailed in issue #11946.

The [`~scipy.optimize.least_squares`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.least_squares.html#scipy.optimize.least_squares) method implements the TRF with bounded parameters, this method was wrapped into a new astropy fitter: `TRFLSQFitter`. 

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #11946

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
