### PR TITLE
Restrict matplotlib version check for failing test

### DIFF
--- a/astropy/visualization/wcsaxes/tests/test_misc.py
+++ b/astropy/visualization/wcsaxes/tests/test_misc.py
@@ -25,7 +25,7 @@ ft_version = Version(matplotlib.ft2font.__freetype_version__)
 FREETYPE_261 = ft_version == Version("2.6.1")
 TEX_UNAVAILABLE = not matplotlib.checkdep_usetex(True)
 
-MATPLOTLIB_GT_3_4_2 = Version(matplotlib.__version__) > Version('3.4.2')
+MATPLOTLIB_GT_3_4_3 = Version(matplotlib.__version__) > Version('3.4.3 ')
 
 
 def teardown_function(function):
@@ -79,7 +79,7 @@ def test_no_numpy_warnings(ignore_matplotlibrc, tmpdir, grid_type):
     ax.imshow(np.zeros((100, 200)))
     ax.coords.grid(color='white', grid_type=grid_type)
 
-    if MATPLOTLIB_GT_3_4_2 and grid_type == 'contours':
+    if MATPLOTLIB_GT_3_4_3 and grid_type == 'contours':
         ctx = pytest.raises(AttributeError, match='dpi')
     else:
         ctx = nullcontext()


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

Restrict the version check to the relevant matplotlib version.

Fixes #12050

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
