### PR TITLE
Add more diagnostic output from wcspih

### DIFF
--- a/cextern/wcslib/C/wcspih.l
+++ b/cextern/wcslib/C/wcspih.l
@@ -255,6 +255,7 @@ static int wcspih_timepixr(double timepixr);
 	
 	// Return here via longjmp() invoked by yy_fatal_error().
 	if (setjmp(yyextra->abort_jmp_env)) {
+	  wcsfprintf(stderr, "Failed with yy_fatal_error");
 	  return WCSHDRERR_PARSER;
 	}
 	
@@ -2541,6 +2542,7 @@ int wcspih_init1(
   if (*nwcs) {
     // Allocate memory for the required number of wcsprm structs.
     if ((*wcs = calloc(*nwcs, sizeof(struct wcsprm))) == 0x0) {
+      wcsfprintf(stderr, "Failed to allocate memory for wcspm structs");
       return WCSHDRERR_MEMORY;
     }
 
@@ -2895,6 +2897,7 @@ int wcspih_final(
 
       // Read the control parameters.
       if ((wp = strchr(wat[i], '"')) == 0x0) {
+        wcsfprintf(stderr, "Did not find double quotes for control parameters (first)");
         return WCSHDRERR_PARSER;
       }
       wp++;
@@ -2902,6 +2905,7 @@ int wcspih_final(
       for (int m = 0; m < 4; m++) {
         sscanf(wp, "%d", wctrl+m);
         if ((wp = strchr(wp, ' ')) == 0x0) {
+          wcsfprintf(stderr, "Failed to read control parameters (first)");
           return WCSHDRERR_PARSER;
         }
         wp++;
@@ -2943,6 +2947,7 @@ int wcspih_final(
 
       // Read the control parameters.
       if ((wp = strchr(wat[i], '"')) == 0x0) {
+        wcsfprintf(stderr, "Did not find double quotes for control parameters (actual read)");
         return WCSHDRERR_PARSER;
       }
       wp++;
@@ -2950,6 +2955,7 @@ int wcspih_final(
       for (int m = 0; m < 4; m++) {
         sscanf(wp, "%d", wctrl+m);
         if ((wp = strchr(wp, ' ')) == 0x0) {
+          wcsfprintf(stderr, "Failed to read control parameters (actual read)");
           return WCSHDRERR_PARSER;
         }
         wp++;
@@ -2980,6 +2986,7 @@ int wcspih_final(
         dpfill(disp->dp+(idp++), "DQ", field, i+1, 1, 0, wval);
 
         if ((wp = strchr(wp, ' ')) == 0x0) {
+          wcsfprintf(stderr, "Failed to read scaling parameters");
           return WCSHDRERR_PARSER;
         }
         wp++;
@@ -3001,6 +3008,7 @@ int wcspih_final(
           dpfill(disp->dp+(idp++), "DQ", field, i+1, 1, 0, wval);
 
           if ((wp = strchr(wp, ' ')) == 0x0) {
+            wcsfprintf(stderr, "Failed to read coefficients");
             return WCSHDRERR_PARSER;
           }
           wp++;


### PR DESCRIPTION
N.B. This is a change to wcslib, there didn't seem to be consensus on slack on what the best path to getting this added to wcslib is, happy to treat this as effectively an issue tracking its inclusion upstream (rather than a actual PR).

Previously wcspih would return 4 (parser error) for any parsing issue, whether it happened during the header scan, or the extraction of the various parameters that the header may have stored (including those stored as multiline cards). This adds some diagnostic output to wcspih to help locate at which state of the process the parser failed at, to hopefully make finding the cause of the parser error.

It does look like the other parser functions had more return values or diagnostic output than wcspih, so similar changes were not made to those parsers.

This is the second (and most likely final) PR related to the WCS issues referred to the slack conversation referenced in #12047. I was going to include some more changes to the astropy wrapper, but looking at the code again, I suspect a better way would be to wire up wcslib's logging to python, rather than try to provide different compilation flags to control the output.

Finally on the wording of the printed errors: happy to change them, that was what I quickly typed while trying to debug the wcs issue.