### PR TITLE
Add conversion between uncertainty types

### DIFF
--- a/astropy/nddata/nduncertainty.py
+++ b/astropy/nddata/nduncertainty.py
@@ -789,10 +789,8 @@ class StdDevUncertainty(_VariancePropagationMixin, NDUncertainty):
 
     @classmethod
     def _convert_from_variance(cls, var_uncert):
-        new_array = None if var_uncert.array is None else \
-            var_uncert.array ** (1 / 2)
-        new_unit = None if var_uncert.unit is None else \
-            var_uncert.unit ** (1 / 2)
+        new_array = None if var_uncert.array is None else var_uncert.array ** (1 / 2)
+        new_unit = None if var_uncert.unit is None else var_uncert.unit ** (1 / 2)
         return cls(new_array, unit=new_unit)
 
 

--- a/astropy/nddata/nduncertainty.py
+++ b/astropy/nddata/nduncertainty.py
@@ -395,6 +395,40 @@ class NDUncertainty(metaclass=ABCMeta):
     def _propagate_divide(self, other_uncert, result_data, correlation):
         return None
 
+    def represent_as(self, other_uncert):
+        """Convert this uncertainty to a different uncertainty type.
+
+        Parameters
+        ----------
+        other_uncert : `NDUncertainty` subclass
+            The `NDUncertainty` subclass to convert to.
+
+        Returns
+        -------
+        resulting_uncertainty : `NDUncertainty` instance
+            An instance of ``other_uncert`` subclass containing the uncertainty
+            converted to the new uncertainty type.
+
+        Raises
+        ------
+        TypeError
+            If either the initial or final subclasses do not support
+            conversion, a `TypeError` is raised.
+        """
+        as_variance = getattr(self, "_convert_to_variance", None)
+        if as_variance is None:
+            raise TypeError(
+                f"{type(self)} does not support conversion to another "
+                "uncertainty type."
+            )
+        from_variance = getattr(other_uncert, "_convert_from_variance", None)
+        if from_variance is None:
+            raise TypeError(
+                f"{other_uncert.__name__} does not support conversion from "
+                "another uncertainty type."
+            )
+        return from_variance(as_variance())
+
 
 class UnknownUncertainty(NDUncertainty):
     """This class implements any unknown uncertainty type.
@@ -748,6 +782,19 @@ class StdDevUncertainty(_VariancePropagationMixin, NDUncertainty):
     def _data_unit_to_uncertainty_unit(self, value):
         return value
 
+    def _convert_to_variance(self):
+        new_array = None if self.array is None else self.array ** 2
+        new_unit = None if self.unit is None else self.unit ** 2
+        return VarianceUncertainty(new_array, unit=new_unit)
+
+    @classmethod
+    def _convert_from_variance(cls, var_uncert):
+        new_array = None if var_uncert.array is None else \
+            var_uncert.array ** (1 / 2)
+        new_unit = None if var_uncert.unit is None else \
+            var_uncert.unit ** (1 / 2)
+        return cls(new_array, unit=new_unit)
+
 
 class VarianceUncertainty(_VariancePropagationMixin, NDUncertainty):
     """
@@ -833,6 +880,13 @@ class VarianceUncertainty(_VariancePropagationMixin, NDUncertainty):
 
     def _data_unit_to_uncertainty_unit(self, value):
         return value ** 2
+
+    def _convert_to_variance(self):
+        return self
+
+    @classmethod
+    def _convert_from_variance(cls, var_uncert):
+        return var_uncert
 
 
 def _inverse(x):
@@ -933,3 +987,14 @@ class InverseVariance(_VariancePropagationMixin, NDUncertainty):
 
     def _data_unit_to_uncertainty_unit(self, value):
         return 1 / value ** 2
+
+    def _convert_to_variance(self):
+        new_array = None if self.array is None else 1 / self.array
+        new_unit = None if self.unit is None else 1 / self.unit
+        return VarianceUncertainty(new_array, unit=new_unit)
+
+    @classmethod
+    def _convert_from_variance(cls, var_uncert):
+        new_array = None if var_uncert.array is None else 1 / var_uncert.array
+        new_unit = None if var_uncert.unit is None else 1 / var_uncert.unit
+        return cls(new_array, unit=new_unit)

--- a/astropy/nddata/tests/test_nduncertainty.py
+++ b/astropy/nddata/tests/test_nduncertainty.py
@@ -74,14 +74,9 @@ uncertainty_types_to_be_tested = [
 ]
 
 uncertainty_types_with_conversion_support = (
-    StdDevUncertainty,
-    VarianceUncertainty,
-    InverseVariance,
-)
+    StdDevUncertainty, VarianceUncertainty, InverseVariance)
 uncertainty_types_without_conversion_support = (
-    FakeUncertainty,
-    UnknownUncertainty,
-)
+    FakeUncertainty, UnknownUncertainty)
 
 
 @pytest.mark.parametrize(('UncertClass'), uncertainty_types_to_be_tested)
@@ -366,9 +361,7 @@ def test_assigning_uncertainty_with_bad_unit_to_parent_fails(NDClass,
         ndd.uncertainty = v
 
 
-@pytest.mark.parametrize(
-    'UncertClass', uncertainty_types_with_conversion_support
-)
+@pytest.mark.parametrize('UncertClass', uncertainty_types_with_conversion_support)
 def test_self_conversion_via_variance_supported(UncertClass):
     uncert = np.arange(1, 11).reshape(2, 5) * u.adu
     start_uncert = UncertClass(uncert)
@@ -392,9 +385,7 @@ def test_conversion_to_from_variance_supported(UncertClass, to_variance_func):
     assert start_uncert.unit == final_uncert.unit
 
 
-@pytest.mark.parametrize(
-    'UncertClass', uncertainty_types_without_conversion_support
-)
+@pytest.mark.parametrize('UncertClass', uncertainty_types_without_conversion_support)
 def test_self_conversion_via_variance_not_supported(UncertClass):
     uncert = np.arange(1, 11).reshape(2, 5) * u.adu
     start_uncert = UncertClass(uncert)

--- a/astropy/nddata/tests/test_nduncertainty.py
+++ b/astropy/nddata/tests/test_nduncertainty.py
@@ -4,7 +4,7 @@ import pickle
 
 import pytest
 import numpy as np
-from numpy.testing import assert_array_equal
+from numpy.testing import assert_array_equal, assert_allclose
 
 from astropy.nddata.nduncertainty import (StdDevUncertainty,
                              VarianceUncertainty,
@@ -378,13 +378,16 @@ def test_self_conversion_via_variance_supported(UncertClass):
 
 
 @pytest.mark.parametrize(
-    'UncertClass', uncertainty_types_with_conversion_support
+    'UncertClass,to_variance_func',
+    zip(uncertainty_types_with_conversion_support,
+    (lambda x: x ** 2, lambda x: x, lambda x: 1 / x))
 )
-def test_conversion_to_from_variance_supported(UncertClass):
+def test_conversion_to_from_variance_supported(UncertClass, to_variance_func):
     uncert = np.arange(1, 11).reshape(2, 5) * u.adu
     start_uncert = UncertClass(uncert)
     var_uncert = start_uncert.represent_as(VarianceUncertainty)
     final_uncert = var_uncert.represent_as(UncertClass)
+    assert_allclose(to_variance_func(start_uncert.array), var_uncert.array)
     assert_array_equal(start_uncert.array, final_uncert.array)
     assert start_uncert.unit == final_uncert.unit
 

--- a/docs/changes/nddata/12057.feature.rst
+++ b/docs/changes/nddata/12057.feature.rst
@@ -1,0 +1,4 @@
+Add support for converting between uncertainty types. This uncertainty
+conversion system uses a similar flow to the coordinate subsystem, where
+Cartesian is used as the common system. In this case, variance is used as the
+common system.

--- a/docs/nddata/nddata.rst
+++ b/docs/nddata/nddata.rst
@@ -234,7 +234,7 @@ Examples
 Like the other properties the ``uncertainty`` can be set during
 initialization::
 
-    >>> from astropy.nddata import StdDevUncertainty
+    >>> from astropy.nddata import StdDevUncertainty, InverseVariance
     >>> array = np.array([10, 7, 12, 22])
     >>> uncert = StdDevUncertainty(np.sqrt(array))
     >>> ndd = NDData(array, uncertainty=uncert)
@@ -254,6 +254,11 @@ But it will print an info message if there is no ``uncertainty_type``::
     INFO: uncertainty should have attribute uncertainty_type. [astropy.nddata.nddata]
     >>> ndd.uncertainty
     UnknownUncertainty([ 5,  1,  2, 10])
+
+It is also possible to convert between uncertainty types::
+
+    >>> uncert.represent_as(InverseVariance)
+    InverseVariance([0.1       , 0.14285714, 0.08333333, 0.04545455])
 
 ..
   EXAMPLE END

--- a/docs/whatsnew/5.1.rst
+++ b/docs/whatsnew/5.1.rst
@@ -157,8 +157,8 @@ variance into the desired uncertainty. A simple example of this is::
     >>> from astropy.nddata import InverseVariance, StdDevUncertainty
     >>> StdDevUncertainty(np.arange(1, 10)).represent_as(InverseVariance)
     InverseVariance([1.        , 0.25      , 0.11111111, 0.0625    ,
-                 0.04      , 0.02777778, 0.02040816, 0.015625  ,
-                 0.01234568])
+                     0.04      , 0.02777778, 0.02040816, 0.015625  ,
+                     0.01234568])
 
 .. _whatsnew-schechter1d-model:
 

--- a/docs/whatsnew/5.1.rst
+++ b/docs/whatsnew/5.1.rst
@@ -18,6 +18,7 @@ In particular, this release includes:
 * :ref:`whatsnew-structured-columns`
 * :ref:`whatsnew-fitters`
 * :ref:`whatsnew-iers-handling`
+* :ref:`whatsnew-uncertainty-represent`
 * :ref:`whatsnew-schechter1d-model`
 
 .. _whatsnew-5.1-cosmology:
@@ -141,6 +142,23 @@ when times are outside the range of available IERS data. The options are
 In addition, the logic for auto-downloads was changed to guarantee that no matter
 what happens with the IERS download operations, only warnings will be issued.
 These warnings can be ignored if desired.
+
+.. _whatsnew-uncertainty-represent:
+
+Uncertainty classes can be transformed into each other
+======================================================
+
+Subclasses of :class:`astropy.nddata.NDUncertainty` can now be
+converted between each other. This is done via transforming the original
+uncertainty values into a variance (if possible), and then transforming the
+variance into the desired uncertainty. A simple example of this is::
+
+    >>> import numpy as np
+    >>> from astropy.nddata import InverseVariance, StdDevUncertainty
+    >>> StdDevUncertainty(np.arange(1, 10)).represent_as(InverseVariance)
+    InverseVariance([1.        , 0.25      , 0.11111111, 0.0625    ,
+                 0.04      , 0.02777778, 0.02040816, 0.015625  ,
+                 0.01234568])
 
 .. _whatsnew-schechter1d-model:
 


### PR DESCRIPTION
We assume that uncertainty types can be converted via variance, similar to the coordinate system where Cartesian is used as the path to convert via.

Closes #11862.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.