### PR TITLE
Update astropy.io.fits.CompImageHDU header when setting data

### DIFF
--- a/astropy/io/fits/hdu/compressed.py
+++ b/astropy/io/fits/hdu/compressed.py
@@ -1467,6 +1467,14 @@ class CompImageHDU(BinTableHDU):
             raise TypeError('CompImageHDU data has incorrect type:{}; '
                             'dtype.fields = {}'.format(
                     type(data), data.dtype.fields))
+        if hasattr(self, '_data_first_run') and not self._data_first_run:
+            # Update header
+            self.__dict__['data'] = data
+            self.update_header()
+            # returning the data signals to lazyproperty that we've already handled
+            # setting self.__dict__['data']
+            return data
+        self._data_first_run = False
 
     @lazyproperty
     def compressed_data(self):

--- a/astropy/io/fits/hdu/compressed.py
+++ b/astropy/io/fits/hdu/compressed.py
@@ -1410,6 +1410,13 @@ class CompImageHDU(BinTableHDU):
             for _ in range(required_blanks - table_blanks):
                 self._header.append()
 
+    def update_header(self):
+        """
+        Update the header keywords to agree with the data.
+        """
+        self._update_header_data(self.header)
+        del self.header  # delete cached header
+
     @lazyproperty
     def data(self):
         # The data attribute is the image data (not the table data).


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to address the following unexpected behaviours:

1. If a HDU is created with e.g. `hdu = astropy.io.fits.CompImageHDU()`, when new data is set (e.g. `hdu.data = np.random.rand(10, 20, 30)`) `hdu.header` does not match the shape of the new data. However, with `astropy.io.fits.ImageHDU` it would.

2. If the header is updated with the `astropy.io.fits.CompImageHDU._update_header_data` method, `hdu.header` is still not always updated. This is because `astropy.io.fits.CompImageHDU.header` is a `@lazyproperty` that caches its first return value.

The first commit in this PR implements an `astropy.io.fits.CompImageHDU.update_header` method (for symmetry with `astropy.io.fits.ImageHDU.update_header`). This method calls the `_update_header_data` method and clears the cached `@lazyproperty`. This resolves the second unexpected behaviour above.

The second commit in this PR calls the new `astropy.io.fits.CompImageHDU.update_header` method in the `astropy.io.fits.CompImageHDU.data` setter method (just like in `astropy.io.fits.ImageHDU`). This resolves the first unexpected behaviour above.

- [ ] While these updates fix the issues I was having, eight of the `astropy/io/fits/tests/test_checksum.py` and `astropy/io/fits/tests/test_image.py` tests are failing when the header is updated while setting data. I'm pretty sure some of these are failing because tests are not expecting manually removed headers such as `ZNAXIS` to be re-added when the data attribute is updated. Before I investigate this further, does what I'm trying to do here make sense?*

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
