### PR TITLE
Allow CompImageHDU header argument to contain very few cards

### DIFF
--- a/astropy/io/fits/hdu/compressed.py
+++ b/astropy/io/fits/hdu/compressed.py
@@ -882,10 +882,14 @@ class CompImageHDU(BinTableHDU):
             if bzero != 0.0:
                 self._header.set('BZERO', bzero, after=after_keyword)
 
+        try:
             bitpix_comment = image_header.comments['BITPIX']
-            naxis_comment = image_header.comments['NAXIS']
-        else:
+        except (AttributeError, KeyError):
             bitpix_comment = 'data type of original image'
+
+        try:
+            naxis_comment = image_header.comments['NAXIS']
+        except (AttributeError, KeyError):
             naxis_comment = 'dimension of original image'
 
         # Set the label for the first column in the table

--- a/astropy/io/fits/tests/test_image.py
+++ b/astropy/io/fits/tests/test_image.py
@@ -1786,6 +1786,19 @@ class TestCompressedImage(FitsTestCase):
 
         assert len(hdu._header._keyword_indices['EXTNAME']) == 1
 
+    def test_compressed_header_minimal(self):
+        """
+        Regression test for https://github.com/astropy/astropy/issues/11694
+
+        Tests that CompImageHDU can be initialized with a Header that
+        contains few or no cards, and doesn't require specific cards
+        such as 'BITPIX' or 'NAXIS'.
+        """
+        fits.CompImageHDU(data=np.arange(10), header=fits.Header())
+        header = fits.Header({'HELLO': 'world'})
+        hdu = fits.CompImageHDU(data=np.arange(10), header=header)
+        assert hdu.header['HELLO'] == 'world'
+
     @pytest.mark.parametrize(
         ('keyword', 'dtype', 'expected'),
         [('BSCALE', np.uint8, np.float32), ('BSCALE', np.int16, np.float32),

--- a/docs/changes/io.fits/12061.bugfix.rst
+++ b/docs/changes/io.fits/12061.bugfix.rst
@@ -1,0 +1,1 @@
+Ensure header passed to ``astropy.io.fits.CompImageHDU`` does not need to contain standard cards that can be automatically generated, such as `BITPIX` and `NAXIS`.

--- a/docs/changes/io.fits/12061.bugfix.rst
+++ b/docs/changes/io.fits/12061.bugfix.rst
@@ -1,1 +1,1 @@
-Ensure header passed to ``astropy.io.fits.CompImageHDU`` does not need to contain standard cards that can be automatically generated, such as `BITPIX` and `NAXIS`.
+Ensure header passed to ``astropy.io.fits.CompImageHDU`` does not need to contain standard cards that can be automatically generated, such as ``BITPIX`` and ``NAXIS``.


### PR DESCRIPTION


<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request allows for `BITPIX` and `NAXIS` comments to be missing from the `image_header` argument of `astropy.io.fits.CompImageHDU._update_header_data`. Now e.g. `hdu = fits.CompImageHDU(np.random.random((10,10)), header=fits.Header({'HELLO': 'world'}))` uses default values instead of raising a `KeyError`.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #11694 

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
