### PR TITLE
Attempt to fix 32-bit CI

### DIFF
--- a/astropy/time/tests/test_precision.py
+++ b/astropy/time/tests/test_precision.py
@@ -34,8 +34,10 @@ dt_tiny = TimeDelta(tiny, format='jd')
 
 def setup_module():
     # Pre-load leap seconds table to avoid flakiness in hypothesis runs.
-    # See https://github.com/astropy/astropy/issues/11030
-    Time('2020-01-01').ut1
+    # See https://github.com/astropy/astropy/issues/11030. In some cases,
+    # the auto_download setting in conftest.py is not picked up, so we
+    with iers.conf.set_temp('auto_download', False):
+        Time('2020-01-01').ut1
 
 
 @pytest.fixture(scope='module')


### PR DESCRIPTION
For some reason the 32-bit CI is failing as the auto_download setting from conftest.py is not being taken into account. This is an attempt to fix this although does not address the root cause. But given that this works on main and LTS is soon reaching end of life, it might not be worth investigating since it's mainly a CI issue and not an issue for users.