### PR TITLE
Fix bug 12082 where can't set constants version

### DIFF
--- a/astropy/__init__.py
+++ b/astropy/__init__.py
@@ -104,7 +104,7 @@ class base_constants_version(ScienceState):
         if 'astropy.constants' in sys.modules:
             raise RuntimeError('astropy.constants is already imported')
 
-        return super().set(cls, value)
+        return super().set(value)
 
 
 class physical_constants(base_constants_version):

--- a/docs/changes/constants/12084.bugfix.rst
+++ b/docs/changes/constants/12084.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed a bug where an older constants version cannot be set directly after
+astropy import.


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

Fixes #12082


### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
