### PR TITLE
Remove unneeded print statement in tests

### DIFF
--- a/astropy/cosmology/tests/test_funcs.py
+++ b/astropy/cosmology/tests/test_funcs.py
@@ -239,13 +239,13 @@ def test_z_at_value_roundtrip(cosmo):
     for name, func in methods:
         if name.startswith('_') or name in skip:
             continue
-        print(f'Round-trip testing {name}')
         fval = func(z)
         # we need zmax here to pick the right solution for
         # angular_diameter_distance and related methods.
         # Be slightly more generous with rtol than the default 1e-8
         # used in z_at_value
-        assert allclose(z, z_at_value(func, fval, bracket=[0.3, 1.0], ztol=1e-12), rtol=2e-11)
+        got = z_at_value(func, fval, bracket=[0.3, 1.0], ztol=1e-12)
+        assert allclose(got, z, rtol=2e-11), f'Round-trip testing {name} failed'
 
     # Test distance functions between two redshifts; only for realizations
     if isinstance(cosmo.name, str):


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
