### PR TITLE
Cosmological units module

### DIFF
--- a/astropy/cosmology/__init__.py
+++ b/astropy/cosmology/__init__.py
@@ -8,7 +8,7 @@ detailed usage examples and references.
 
 """
 
-from . import core, funcs, realizations, utils
+from . import core, funcs, realizations, units, utils
 from .core import *
 from .funcs import *
 from .realizations import *

--- a/astropy/cosmology/tests/test_units.py
+++ b/astropy/cosmology/tests/test_units.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+
+"""Testing :mod:`astropy.cosmology.units`."""
+
+##############################################################################
+# IMPORTS
+
+import astropy.cosmology.units as cu
+import astropy.units as u
+
+##############################################################################
+# TESTS
+##############################################################################
+
+
+def test_has_expected_units():
+    """
+    Test that this module has the expected set of units. Many of the units are
+    imported from :mod:`astropy.units`, so here we test presence, not usage.
+    Units from :mod:`astropy.units` are tested in that module. Units defined in
+    :mod:`astropy.cosmology` will be tested subsequently.
+    """
+    assert cu.littleh is u.astrophys.littleh
+
+
+def test_has_expected_equivalencies():
+    """
+    Test that this module has the expected set of equivalencies. Many of the
+    equivalencies are imported from :mod:`astropy.units`, so here we test
+    presence, not usage. Equivalencies from :mod:`astropy.units` are tested in
+    that module. Equivalencies defined in :mod:`astropy.cosmology` will be
+    tested subsequently.
+    """
+    assert cu.with_H0 is u.equivalencies.with_H0

--- a/astropy/cosmology/tests/test_units.py
+++ b/astropy/cosmology/tests/test_units.py
@@ -5,8 +5,13 @@
 ##############################################################################
 # IMPORTS
 
+import pytest
+
 import astropy.cosmology.units as cu
 import astropy.units as u
+from astropy.cosmology import default_cosmology
+from astropy.tests.helper import assert_quantity_allclose
+from astropy.utils.compat.optional_deps import HAS_ASDF
 
 ##############################################################################
 # TESTS
@@ -15,12 +20,12 @@ import astropy.units as u
 
 def test_has_expected_units():
     """
-    Test that this module has the expected set of units. Many of the units are
-    imported from :mod:`astropy.units`, so here we test presence, not usage.
-    Units from :mod:`astropy.units` are tested in that module. Units defined in
-    :mod:`astropy.cosmology` will be tested subsequently.
+    Test that this module has the expected set of units. Some of the units are
+    imported from :mod:`astropy.units`, or vice versa. Here we test presence,
+    not usage. Units from :mod:`astropy.units` are tested in that module. Units
+    defined in :mod:`astropy.cosmology` will be tested subsequently.
     """
-    assert cu.littleh is u.astrophys.littleh
+    assert u.astrophys.littleh is cu.littleh
 
 
 def test_has_expected_equivalencies():
@@ -31,4 +36,35 @@ def test_has_expected_equivalencies():
     that module. Equivalencies defined in :mod:`astropy.cosmology` will be
     tested subsequently.
     """
-    assert cu.with_H0 is u.equivalencies.with_H0
+    assert u.equivalencies.with_H0 is cu.with_H0
+
+
+def test_littleh():
+    H0_70 = 70 * u.km / u.s / u.Mpc
+    h70dist = 70 * u.Mpc / cu.littleh
+
+    assert_quantity_allclose(h70dist.to(u.Mpc, cu.with_H0(H0_70)), 100 * u.Mpc)
+
+    # make sure using the default cosmology works
+    cosmodist = default_cosmology.get().H0.value * u.Mpc / cu.littleh
+    assert_quantity_allclose(cosmodist.to(u.Mpc, cu.with_H0()), 100 * u.Mpc)
+
+    # Now try a luminosity scaling
+    h1lum = 0.49 * u.Lsun * cu.littleh ** -2
+    assert_quantity_allclose(h1lum.to(u.Lsun, cu.with_H0(H0_70)), 1 * u.Lsun)
+
+    # And the trickiest one: magnitudes.  Using H0=10 here for the round numbers
+    H0_10 = 10 * u.km / u.s / u.Mpc
+    # assume the "true" magnitude M = 12.
+    # Then M - 5*log_10(h)  = M + 5 = 17
+    withlittlehmag = 17 * (u.mag - u.MagUnit(cu.littleh ** 2))
+    assert_quantity_allclose(withlittlehmag.to(u.mag, cu.with_H0(H0_10)), 12 * u.mag)
+
+
+@pytest.mark.skipif(not HAS_ASDF, reason="requires ASDF")
+@pytest.mark.parametrize('equiv', [cu.with_H0()])
+def test_equivalencies(tmpdir, equiv):
+    from asdf.tests import helpers
+
+    tree = {'equiv': equiv}
+    helpers.assert_roundtrip_tree(tree, tmpdir)

--- a/astropy/cosmology/tests/test_units.py
+++ b/astropy/cosmology/tests/test_units.py
@@ -12,6 +12,7 @@ import astropy.units as u
 from astropy.cosmology import default_cosmology
 from astropy.tests.helper import assert_quantity_allclose
 from astropy.utils.compat.optional_deps import HAS_ASDF
+from astropy.utils.exceptions import AstropyDeprecationWarning
 
 ##############################################################################
 # TESTS
@@ -25,7 +26,8 @@ def test_has_expected_units():
     not usage. Units from :mod:`astropy.units` are tested in that module. Units
     defined in :mod:`astropy.cosmology` will be tested subsequently.
     """
-    assert u.astrophys.littleh is cu.littleh
+    with pytest.warns(AstropyDeprecationWarning, match="`littleh`"):
+        assert u.astrophys.littleh is cu.littleh
 
 
 def test_has_expected_equivalencies():
@@ -36,7 +38,8 @@ def test_has_expected_equivalencies():
     that module. Equivalencies defined in :mod:`astropy.cosmology` will be
     tested subsequently.
     """
-    assert u.equivalencies.with_H0 is cu.with_H0
+    with pytest.warns(AstropyDeprecationWarning, match="`with_H0`"):
+        assert u.equivalencies.with_H0 is cu.with_H0
 
 
 def test_littleh():
@@ -67,4 +70,6 @@ def test_equivalencies(tmpdir, equiv):
     from asdf.tests import helpers
 
     tree = {'equiv': equiv}
-    helpers.assert_roundtrip_tree(tree, tmpdir)
+
+    with pytest.warns(AstropyDeprecationWarning, match="`with_H0`"):
+        helpers.assert_roundtrip_tree(tree, tmpdir)

--- a/astropy/cosmology/units.py
+++ b/astropy/cosmology/units.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+"""Cosmological units and equivalencies.
+"""  # (needed for unit summary)
+
+__all__ = ["littleh", "with_H0"]
+
+from astropy.units.utils import generate_unit_summary as _generate_unit_summary
+
+###############################################################################
+# Cosmological Units
+# isort: split
+
+from astropy.units.astrophys import littleh
+
+###############################################################################
+# Equivalencies
+# isort: split
+
+from astropy.units.equivalencies import with_H0
+
+# =============================================================================
+# DOCSTRING
+
+# This generates a docstring for this module that describes all of the
+# standard units defined here.
+if __doc__ is not None:
+    __doc__ += _generate_unit_summary(globals())

--- a/astropy/cosmology/units.py
+++ b/astropy/cosmology/units.py
@@ -2,23 +2,56 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 """Cosmological units and equivalencies.
-"""  # (needed for unit summary)
+"""  # (newline needed for unit summary)
+
+import astropy.units as u
+from astropy.units.utils import generate_unit_summary as _generate_unit_summary
 
 __all__ = ["littleh", "with_H0"]
 
-from astropy.units.utils import generate_unit_summary as _generate_unit_summary
+_ns = globals()
 
 ###############################################################################
 # Cosmological Units
-# isort: split
 
-from astropy.units.astrophys import littleh
+# This is not formally a unit, but is used in that way in many contexts, and
+# an appropriate equivalency is only possible if it's treated as a unit (see
+# https://arxiv.org/pdf/1308.4150.pdf for more)
+# Also note that h or h100 or h_100 would be a better name, but they either
+# conflict or have numbers in them, which is disallowed
+littleh = u.def_unit(['littleh'], namespace=_ns, prefixes=False,
+                     doc='Reduced/"dimensionless" Hubble constant',
+                     format={'latex': r'h_{100}'})
+
 
 ###############################################################################
 # Equivalencies
-# isort: split
 
-from astropy.units.equivalencies import with_H0
+def with_H0(H0=None):
+    """
+    Convert between quantities with little-h and the equivalent physical units.
+
+    Parameters
+    ----------
+    H0 : None or `~astropy.units.Quantity` ['frequency']
+        The value of the Hubble constant to assume. If a
+        `~astropy.units.Quantity`, will assume the quantity *is* ``H0``. If
+        `None` (default), use the ``H0`` attribute from
+        :mod:`~astropy.cosmology.default_cosmology`.
+
+    References
+    ----------
+    For an illuminating discussion on why you may or may not want to use
+    little-h at all, see https://arxiv.org/pdf/1308.4150.pdf
+    """
+    if H0 is None:
+        from .realizations import default_cosmology
+        H0 = default_cosmology.get().H0
+
+    h100_val_unit = u.Unit(100/(H0.to_value((u.km/u.s)/u.Mpc)) * littleh)
+
+    return u.Equivalency([(h100_val_unit, None)], "with_H0", kwargs={"H0": H0})
+
 
 # =============================================================================
 # DOCSTRING
@@ -26,4 +59,4 @@ from astropy.units.equivalencies import with_H0
 # This generates a docstring for this module that describes all of the
 # standard units defined here.
 if __doc__ is not None:
-    __doc__ += _generate_unit_summary(globals())
+    __doc__ += _generate_unit_summary(_ns)

--- a/astropy/io/misc/asdf/tags/unit/tests/test_equivalency.py
+++ b/astropy/io/misc/asdf/tags/unit/tests/test_equivalency.py
@@ -21,7 +21,7 @@ def get_equivalencies():
             eq.spectral_density(350 * u.nm), eq.spectral(),
             eq.brightness_temperature(500 * u.GHz),
             eq.brightness_temperature(500 * u.GHz, beam_area=23 * u.sr),
-            eq.with_H0(), eq.temperature_energy(), eq.temperature(),
+            eq.temperature_energy(), eq.temperature(),
             eq.thermodynamic_temperature(300 * u.Hz),
             eq.thermodynamic_temperature(140 * u.GHz, Planck15.Tcmb0),
             eq.beam_angular_area(3 * u.sr), eq.mass_energy(),

--- a/astropy/units/__init__.py
+++ b/astropy/units/__init__.py
@@ -45,3 +45,16 @@ del bases
 # Imperial units.
 
 set_enabled_units([si, cgs, astrophys, function_units, misc, photometric])
+
+
+# -------------------------------------------------------------------------
+
+def __getattr__(attr):
+    if attr == "littleh":
+        from astropy.units.astrophys import littleh
+        return littleh
+    elif attr == "with_H0":
+        from astropy.units.equivalencies import with_H0
+        return with_H0
+
+    raise AttributeError(f"module {__name__!r} has no attribute {attr!r}.")

--- a/astropy/units/astrophys.py
+++ b/astropy/units/astrophys.py
@@ -145,6 +145,13 @@ def __getattr__(attr):
     if attr == "littleh":
         import warnings
         from astropy.cosmology.units import littleh
+        from astropy.utils.exceptions import AstropyDeprecationWarning
+
+        warnings.warn(
+            ("`littleh` is deprecated from module `astropy.units.astrophys` "
+             "since astropy 5.0 and may be removed in a future version. "
+             "Use `astropy.cosmology.units.littleh` instead."),
+            AstropyDeprecationWarning)
 
         return littleh
 

--- a/astropy/units/astrophys.py
+++ b/astropy/units/astrophys.py
@@ -120,14 +120,6 @@ def_unit(['bin'], namespace=_ns, prefixes=True)
 def_unit(['beam'], namespace=_ns, prefixes=True)
 def_unit(['electron'], doc="Number of electrons", namespace=_ns,
          format={'latex': r'e^{-}', 'unicode': 'e⁻'})
-# This is not formally a unit, but is used in that way in many contexts, and
-# an appropriate equivalency is only possible if it's treated as a unit (see
-# https://arxiv.org/pdf/1308.4150.pdf for more)
-# Also note that h or h100 or h_100 would be a better name, but they either
-# conflict or have numbers in them, which is apparently disallowed
-def_unit(['littleh'], namespace=_ns, prefixes=False,
-         doc="Reduced/\"dimensionless\" Hubble constant",
-         format={'latex': r'h_{100}'})
 
 ###########################################################################
 # CLEANUP
@@ -145,3 +137,15 @@ del si
 from .utils import generate_unit_summary as _generate_unit_summary
 if __doc__ is not None:
     __doc__ += _generate_unit_summary(globals())
+
+
+# -------------------------------------------------------------------------
+
+def __getattr__(attr):
+    if attr == "littleh":
+        import warnings
+        from astropy.cosmology.units import littleh
+
+        return littleh
+
+    raise AttributeError(f"module {__name__!r} has no attribute {attr!r}.")

--- a/astropy/units/equivalencies.py
+++ b/astropy/units/equivalencies.py
@@ -800,6 +800,13 @@ def __getattr__(attr):
     if attr == "with_H0":
         import warnings
         from astropy.cosmology.units import with_H0
+        from astropy.utils.exceptions import AstropyDeprecationWarning
+
+        warnings.warn(
+            ("`with_H0` is deprecated from `astropy.units.equivalencies` "
+             "since astropy 5.0 and may be removed in a future version. "
+             "Use `astropy.cosmology.units.with_H0` instead."),
+            AstropyDeprecationWarning)
 
         return with_H0
 

--- a/astropy/units/equivalencies.py
+++ b/astropy/units/equivalencies.py
@@ -25,7 +25,7 @@ __all__ = ['parallax', 'spectral', 'spectral_density', 'doppler_radio',
            'brightness_temperature', 'thermodynamic_temperature',
            'beam_angular_area', 'dimensionless_angles', 'logarithmic',
            'temperature', 'temperature_energy', 'molar_mass_amu',
-           'pixel_scale', 'plate_scale', 'with_H0', "Equivalency"]
+           'pixel_scale', 'plate_scale', "Equivalency"]
 
 
 class Equivalency(UserList):
@@ -794,27 +794,13 @@ def plate_scale(platescale):
                        "plate_scale", {'platescale': platescale})
 
 
-def with_H0(H0=None):
-    """
-    Convert between quantities with little-h and the equivalent physical units.
+# -------------------------------------------------------------------------
 
-    Parameters
-    ----------
-    H0 : None or `~astropy.units.Quantity` ['frequency']
-        The value of the Hubble constant to assume. If a `~astropy.units.Quantity`,
-        will assume the quantity *is* ``H0``.  If `None` (default), use the
-        ``H0`` attribute from the default `astropy.cosmology` cosmology.
+def __getattr__(attr):
+    if attr == "with_H0":
+        import warnings
+        from astropy.cosmology.units import with_H0
 
-    References
-    ----------
-    For an illuminating discussion on why you may or may not want to use
-    little-h at all, see https://arxiv.org/pdf/1308.4150.pdf
-    """
+        return with_H0
 
-    if H0 is None:
-        from astropy import cosmology
-        H0 = cosmology.default_cosmology.get().H0
-
-    h100_val_unit = Unit(100/(H0.to_value((si.km/si.s)/astrophys.Mpc)) * astrophys.littleh)
-
-    return Equivalency([(h100_val_unit, None)], "with_H0", kwargs={"H0": H0})
+    raise AttributeError(f"module {__name__!r} has no attribute {attr!r}.")

--- a/astropy/units/tests/test_equivalencies.py
+++ b/astropy/units/tests/test_equivalencies.py
@@ -10,7 +10,7 @@ from numpy.testing import assert_allclose
 # LOCAL
 from astropy import units as u
 from astropy.units.equivalencies import Equivalency
-from astropy import constants, cosmology
+from astropy import constants
 from astropy.tests.helper import assert_quantity_allclose
 from astropy.utils.exceptions import AstropyDeprecationWarning
 
@@ -835,28 +835,6 @@ def test_plate_scale():
 
     assert_quantity_allclose(asec.to(u.mm, u.plate_scale(platescale)), mm)
     assert_quantity_allclose(asec.to(u.mm, u.plate_scale(platescale2)), mm)
-
-
-def test_littleh():
-    H0_70 = 70*u.km/u.s/u.Mpc
-    h70dist = 70 * u.Mpc/u.littleh
-
-    assert_quantity_allclose(h70dist.to(u.Mpc, u.with_H0(H0_70)), 100*u.Mpc)
-
-    # make sure using the default cosmology works
-    cosmodist = cosmology.default_cosmology.get().H0.value * u.Mpc/u.littleh
-    assert_quantity_allclose(cosmodist.to(u.Mpc, u.with_H0()), 100*u.Mpc)
-
-    # Now try a luminosity scaling
-    h1lum = .49 * u.Lsun * u.littleh**-2
-    assert_quantity_allclose(h1lum.to(u.Lsun, u.with_H0(H0_70)), 1*u.Lsun)
-
-    # And the trickiest one: magnitudes.  Using H0=10 here for the round numbers
-    H0_10 = 10*u.km/u.s/u.Mpc
-    # assume the "true" magnitude M = 12.
-    # Then M - 5*log_10(h)  = M + 5 = 17
-    withlittlehmag = 17 * (u.mag - u.MagUnit(u.littleh**2))
-    assert_quantity_allclose(withlittlehmag.to(u.mag, u.with_H0(H0_10)), 12*u.mag)
 
 
 def test_equivelency():

--- a/astropy/utils/compat/optional_deps.py
+++ b/astropy/utils/compat/optional_deps.py
@@ -9,9 +9,9 @@ import warnings
 # TODO: This list is a duplicate of the dependencies in setup.cfg "all", but
 # some of the package names are different from the pip-install name (e.g.,
 # beautifulsoup4 -> bs4).
-_optional_deps = ['bleach', 'bottleneck', 'bs4', 'bz2', 'h5py', 'html5lib',
-                  'IPython', 'jplephem', 'lxml', 'matplotlib', 'mpmath',
-                  'pandas', 'PIL', 'pytz', 'scipy', 'skyfield',
+_optional_deps = ['asdf', 'bleach', 'bottleneck', 'bs4', 'bz2', 'h5py',
+                  'html5lib', 'IPython', 'jplephem', 'lxml', 'matplotlib',
+                  'mpmath', 'pandas', 'PIL', 'pytz', 'scipy', 'skyfield',
                   'sortedcontainers', 'lzma']
 _formerly_optional_deps = ['yaml']  # for backward compatibility
 _deps = {k.upper(): k for k in _optional_deps + _formerly_optional_deps}

--- a/docs/changes/cosmology/12092.feature.rst
+++ b/docs/changes/cosmology/12092.feature.rst
@@ -1,0 +1,2 @@
+Added units module for defining and collecting cosmological units and
+equivalencies.

--- a/docs/changes/units/12092.api.rst
+++ b/docs/changes/units/12092.api.rst
@@ -1,0 +1,2 @@
+Unit ``littleh`` and equivalency ``with_H0`` have been moved to the
+``cosmology`` module.

--- a/docs/changes/units/12092.api.rst
+++ b/docs/changes/units/12092.api.rst
@@ -1,2 +1,2 @@
 Unit ``littleh`` and equivalency ``with_H0`` have been moved to the
-``cosmology`` module.
+``cosmology`` module and are deprecated from ``astropy.units``.

--- a/docs/cosmology/index.rst
+++ b/docs/cosmology/index.rst
@@ -7,12 +7,16 @@ Cosmological Calculations (`astropy.cosmology`)
 Introduction
 ============
 
-The `astropy.cosmology` sub-package contains classes for representing
+The :mod:`astropy.cosmology` sub-package contains classes for representing
 cosmologies and utility functions for calculating commonly used
 quantities that depend on a cosmological model. This includes
 distances, ages, and lookback times corresponding to a measured
 redshift or the transverse separation corresponding to a measured
 angular separation.
+
+:mod:`astropy.cosmology.units` extends the :mod:`astropy.units` sub-package,
+adding and collecting cosmological units and equivalencies, like :math:`h` for
+keeping track of (dimensionless) factors of the Hubble constant.
 
 For details on reading and writing cosmologies from files,
 see :ref:`read_write_cosmologies`.
@@ -101,6 +105,8 @@ listed below.
    :maxdepth: 1
 
    Reading and Writing <io>
+   Units and Equivalencies <units>
+
 
 Most of the functionality is enabled by the `~astropy.cosmology.FLRW`
 object. This represents a homogeneous and isotropic cosmology

--- a/docs/cosmology/units.rst
+++ b/docs/cosmology/units.rst
@@ -67,8 +67,8 @@ the ``H0`` from the current default :ref:`cosmology <astropy-cosmology>`:
 
 .. code-block:: python
 
-    >>> distance = 100 * (u.Mpc/u.littleh)
-    >>> distance.to(u.Mpc, u.with_H0())  # doctest: +FLOAT_CMP
+    >>> distance = 100 * (u.Mpc/cu.littleh)
+    >>> distance.to(u.Mpc, cu.with_H0())  # doctest: +FLOAT_CMP
     <Quantity 147.79781259 Mpc>
 
 This equivalency also allows a common magnitude formulation of little h
@@ -76,10 +76,10 @@ scaling:
 
 .. code-block:: python
 
-    >>> mag_quantity = 12 * (u.mag - u.MagUnit(u.littleh**2))
+    >>> mag_quantity = 12 * (u.mag - u.MagUnit(cu.littleh**2))
     >>> mag_quantity  # doctest: +FLOAT_CMP
     <Magnitude 12. mag(1 / littleh2)>
-    >>> mag_quantity.to(u.mag, u.with_H0(H0_70))  # doctest: +FLOAT_CMP
+    >>> mag_quantity.to(u.mag, cu.with_H0(H0_70))  # doctest: +FLOAT_CMP
     <Quantity 11.2254902 mag>
 
 .. EXAMPLE END
@@ -90,5 +90,3 @@ Reference/API
 
 .. automodapi:: astropy.cosmology.units
    :inherited-members:
-   :include-all-objects:
-   :allowed-package-names: astropy.units

--- a/docs/cosmology/units.rst
+++ b/docs/cosmology/units.rst
@@ -1,0 +1,31 @@
+.. _astropy-cosmology-units-and-equivalencies:
+
+************************************
+Cosmological Units and Equivalencies
+************************************
+
+.. currentmodule:: astropy.cosmology.units
+
+This package defines and collects cosmological units and equivalencies.
+Many of the units and equivalencies are also available in the
+:mod:`astropy.units` namespace.
+
+We suggest importing this units package as
+
+    >>> import astropy.cosmology.units as cu
+
+
+To enable the main :mod:`astropy.units` to access these units when searching
+for unit conversions and equivalencies, use
+:func:`~astropy.units.add_enabled_units`.
+
+    >>> u.add_enabled_units(cu)  # doctest: +SKIP
+
+
+Reference/API
+=============
+
+.. automodapi:: astropy.cosmology.units
+   :inherited-members:
+   :include-all-objects:
+   :allowed-package-names: astropy.units

--- a/docs/cosmology/units.rst
+++ b/docs/cosmology/units.rst
@@ -22,6 +22,69 @@ for unit conversions and equivalencies, use
     >>> u.add_enabled_units(cu)  # doctest: +SKIP
 
 
+About the Units
+===============
+
+.. _littleh-and-H0-equivalency:
+
+Reduced Hubble Constant and "little-h" Equivalency
+--------------------------------------------------
+
+The dimensionless version of the Hubble constant — often known as "little h" —
+is a frequently used quantity in extragalactic astrophysics. It is also widely
+known as the bane of beginners' existence in such fields (See e.g., the title
+of `this paper <https://doi.org/10.1017/pasa.2013.31>`__, which also provides
+valuable advice on the use of little h). ``astropy`` provides the
+:func:`~astropy.cosmology.units.with_H0` equivalency that helps keep this
+straight in at least some of these cases, by providing a way to convert to/from
+physical to "little h" units.
+
+Examples
+^^^^^^^^
+
+.. EXAMPLE START: Using the "little h" Equivalency
+
+To convert to or from physical to "little h" units:
+
+.. code-block:: python
+
+    >>> import astropy.units as u
+    >>> import astropy.cosmology.units as cu
+    >>> H0_70 = 70 * u.km/u.s/u.Mpc
+    >>> distance = 70 * (u.Mpc/cu.littleh)
+    >>> distance.to(u.Mpc, cu.with_H0(H0_70))  # doctest: +FLOAT_CMP
+    <Quantity 100.0 Mpc>
+    >>> luminosity = 0.49 * u.Lsun * cu.littleh**-2
+    >>> luminosity.to(u.Lsun, cu.with_H0(H0_70))  # doctest: +FLOAT_CMP
+    <Quantity 1.0 solLum>
+
+Note the unit name ``littleh``: while this unit is usually expressed in the
+literature as just ``h``, here it is ``littleh`` to avoid confusion with
+"hours."
+
+If no argument is given (or the argument is `None`), this equivalency assumes
+the ``H0`` from the current default :ref:`cosmology <astropy-cosmology>`:
+
+.. code-block:: python
+
+    >>> distance = 100 * (u.Mpc/u.littleh)
+    >>> distance.to(u.Mpc, u.with_H0())  # doctest: +FLOAT_CMP
+    <Quantity 147.79781259 Mpc>
+
+This equivalency also allows a common magnitude formulation of little h
+scaling:
+
+.. code-block:: python
+
+    >>> mag_quantity = 12 * (u.mag - u.MagUnit(u.littleh**2))
+    >>> mag_quantity  # doctest: +FLOAT_CMP
+    <Magnitude 12. mag(1 / littleh2)>
+    >>> mag_quantity.to(u.mag, u.with_H0(H0_70))  # doctest: +FLOAT_CMP
+    <Quantity 11.2254902 mag>
+
+.. EXAMPLE END
+
+
 Reference/API
 =============
 

--- a/docs/cosmology/units.rst
+++ b/docs/cosmology/units.rst
@@ -63,7 +63,7 @@ literature as just ``h``, here it is ``littleh`` to avoid confusion with
 "hours."
 
 If no argument is given (or the argument is `None`), this equivalency assumes
-the ``H0`` from the current default :ref:`cosmology <astropy-cosmology>`:
+the ``H0`` from the current default :class:`~astropy.cosmology.Cosmology`:
 
 .. code-block:: python
 

--- a/docs/units/equivalencies.rst
+++ b/docs/units/equivalencies.rst
@@ -461,57 +461,6 @@ point of 3631.1 Jy::
 
 .. EXAMPLE END
 
-.. _H0-equivalency:
-
-Reduced Hubble Constant and "little-h" Equivalency
---------------------------------------------------
-
-The dimensionless version of the Hubble constant — often known as "little h" —
-is a frequently used quantity in extragalactic astrophysics. It is also widely
-known as the bane of beginners' existence in such fields (See e.g., the title
-of `this paper <https://doi.org/10.1017/pasa.2013.31>`__, which also provides
-valuable advice on the use of little h). ``astropy`` provides the
-:func:`~astropy.units.equivalencies.with_H0` equivalency that helps keep this
-straight in at least some of these cases, by providing a way to convert to/from
-physical to "little h" units.
-
-Examples
-^^^^^^^^
-
-.. EXAMPLE START: Using the "little h" Equivalency
-
-To convert to or from physical to "little h" units:
-
-    >>> H0_70 = 70 * u.km/u.s / u.Mpc
-    >>> distance = 70 * (u.Mpc/u.littleh)
-    >>> distance.to(u.Mpc, u.with_H0(H0_70))  # doctest: +FLOAT_CMP
-    <Quantity 100.0 Mpc>
-    >>> luminosity = 0.49 * u.Lsun * u.littleh**-2
-    >>> luminosity.to(u.Lsun, u.with_H0(H0_70))  # doctest: +FLOAT_CMP
-    <Quantity 1.0 solLum>
-
-Note the unit name ``littleh``: while this unit is usually expressed in the
-literature as just ``h``, here it is ``littleh`` to avoid confusion with
-"hours."
-
-If no argument is given (or the argument is `None`), this equivalency assumes
-the ``H0`` from the current default :ref:`cosmology <astropy-cosmology>`::
-
-    >>> distance = 100 * (u.Mpc/u.littleh)
-    >>> distance.to(u.Mpc, u.with_H0())  # doctest: +FLOAT_CMP
-    <Quantity 147.79781259 Mpc>
-
-This equivalency also allows a common magnitude formulation of little h
-scaling:
-
-    >>> mag_quantity = 12 * (u.mag - u.MagUnit(u.littleh**2))
-    >>> mag_quantity  # doctest: +FLOAT_CMP
-    <Magnitude 12. mag(1 / littleh2)>
-    >>> mag_quantity.to(u.mag, u.with_H0(H0_70))  # doctest: +FLOAT_CMP
-    <Quantity 11.2254902 mag>
-
-.. EXAMPLE END
-
 Temperature Equivalency
 -----------------------
 


### PR DESCRIPTION
Adds a new module to Cosmology — ``units`` —  for defining and collecting cosmological units and
equivalencies.
@eteq, though I advocated for it, I'm holding off from actually moving ``littleh`` and ``with_H0`` for now. The latter will be easy to move, but moving ``littleh`` and having it be imported into ``units/astrophys`` is a nightmare of circular imports.
It would be much easier to just deprecate it from ``units/astrophys``, but I'd want some discussion on that, and since it's a low priority, I'll save it for a followup. Thanks!

Necessary For : #11784 
Fixes: #12093 

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
