### PR TITLE
Don't assume MKS constants

### DIFF
--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -63,22 +63,16 @@ __doctest_requires__ = {'*': ['scipy']}
 #
 #  However, the important point is that it is -not- necessary to do this.
 
-# Some conversion constants -- useful to compute them once here
-#  and reuse in the initialization rather than have every object do them
-# Note that the call to cgs is actually extremely expensive,
-#  so we actually skip using the units package directly, and
-#  hardwire the conversion from mks to cgs. This assumes that constants
-#  will always return mks by default -- if this is made faster for simple
-#  cases like this, it should be changed back.
-# Note that the unit tests should catch it if this happens
+# Some conversion constants -- useful to compute them once here and reuse in
+# the initialization rather than have every object do them.
 H0units_to_invs = (u.km / (u.s * u.Mpc)).to(1.0 / u.s)
 sec_to_Gyr = u.s.to(u.Gyr)
 # const in critical density in cgs units (g cm^-3)
-critdens_const = 3. / (8. * pi * const.G.value * 1000)
+critdens_const = (3 / (8 * pi * const.G)).cgs.value
 arcsec_in_radians = pi / (3600. * 180)
 arcmin_in_radians = pi / (60. * 180)
 # Radiation parameter over c^2 in cgs (g cm^-3 K^-4)
-a_B_c2 = 4e-3 * const.sigma_sb.value / const.c.value ** 3
+a_B_c2 = (4 * const.sigma_sb / const.c ** 3).cgs.value
 # Boltzmann constant in eV / K
 kB_evK = const.k_B.to(u.eV / u.K)
 


### PR DESCRIPTION
The unit tests should catch a switch from MKS constants as the default. However, I think the user can change this before importing ``cosmology``, so it actually be problematic? Either way, it's safer to just ask for specific units.

Hi @pllim, if you're doing a drive-by check, all I did was change ``value`` to ``to_value([whatever the unit already was])``.

Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
