### PR TITLE
Create section for developers in Cosmology docs

### DIFF
--- a/docs/changes/cosmology/12100.other.rst
+++ b/docs/changes/cosmology/12100.other.rst
@@ -1,0 +1,1 @@
+Developer notes in the code and docs are moved to a dedicated page.

--- a/docs/cosmology/dev.rst
+++ b/docs/cosmology/dev.rst
@@ -1,0 +1,48 @@
+.. _astropy-cosmology-for-developers:
+
+Cosmology For Developers
+************************
+
+Cosmologies in Functions
+========================
+
+It is often useful to assume a default cosmology so that the exact
+cosmology does not have to be specified every time a function or method
+is called. In this case, it is possible to specify a "default"
+cosmology.
+
+You can set the default cosmology to a predefined value by using the
+"default_cosmology" option in the ``[cosmology.core]`` section of the
+configuration file (see :ref:`astropy_config`). Alternatively, you can
+use the :meth:`~astropy.cosmology.default_cosmology.set` function of
+:func:`~astropy.cosmology.default_cosmology` to set a cosmology for the current
+Python session. If you have not set a default cosmology using one of the
+methods described above, then the cosmology module will default to using the
+``default_cosmology._value`` parameters.
+
+It is strongly recommended that you use the default cosmology through
+the :class:`~astropy.cosmology.default_cosmology` science state object. An
+override option can then be provided using something like the
+following:
+
+.. code-block:: python
+
+    from astropy.cosmology import default_cosmology
+
+    def myfunc(..., cosmo=None):
+        if cosmo is None:
+            cosmo = default_cosmology.get()
+
+        ... function code here ...
+
+This ensures that all code consistently uses the default cosmology
+unless explicitly overridden.
+
+.. note::
+
+    In general it is better to use an explicit cosmology (for example
+    ``WMAP9.H(0)`` instead of
+    ``cosmology.default_cosmology.get().H(0)``). Use of the default
+    cosmology should generally be reserved for code that will be
+    included in the ``astropy`` core or an affiliated package.
+

--- a/docs/cosmology/dev.rst
+++ b/docs/cosmology/dev.rst
@@ -46,3 +46,37 @@ unless explicitly overridden.
     cosmology should generally be reserved for code that will be
     included in the ``astropy`` core or an affiliated package.
 
+
+.. _astropy-cosmology-fast-integrals:
+
+Speeding up Integrals in Custom Cosmologies
+===========================================
+
+The supplied cosmology classes use a few tricks to speed up distance and time
+integrals.  It is not necessary for anyone subclassing
+:class:`~astropy.cosmology.FLRW` to use these tricks -- but if they do, such
+calculations may be a lot faster.
+
+The first, more basic, idea is that, in many
+cases, it's a big deal to provide explicit formulae for
+:meth:`~astropy.cosmology.FLRW.inv_efunc` rather than simply setting up
+``de_energy_scale`` -- assuming there is a nice expression. As noted above,
+almost all of the provided classes do this, and that template can pretty much
+be followed directly with the appropriate formula changes.
+
+The second, and more advanced, option is to also explicitly provide a
+scalar only version of :meth:`~astropy.cosmology.FLRW.inv_efunc`. This results
+in a fairly large speedup (>10x in most cases) in the distance and age
+integrals, even if only done in python, because testing whether the inputs are
+iterable or pure scalars turns out to be rather expensive. To take advantage of
+this, the key thing is to explicitly set the instance variables
+``self._inv_efunc_scalar`` and ``self._inv_efunc_scalar_args`` in the
+constructor for the subclass, where the latter are all the arguments except
+``z`` to ``_inv_efunc_scalar``. The provided classes do use this optimization,
+and in fact go even further and provide optimizations for no radiation, and for
+radiation with massless neutrinos coded in cython. Consult the 
+:class:`~astropy.cosmology.FLRW` subclasses for details, and
+``scalar_inv_efuncs`` for the details.
+
+However, the important point is that it is *not* necessary to do this.
+

--- a/docs/cosmology/index.rst
+++ b/docs/cosmology/index.rst
@@ -17,6 +17,8 @@ angular separation.
 For details on reading and writing cosmologies from files,
 see :ref:`read_write_cosmologies`.
 
+For developer notes see :ref:`astropy-cosmology-for-developers`.
+
 
 Getting Started
 ===============
@@ -470,51 +472,6 @@ the above examples also apply for all of the other cosmology classes.
 ..
   EXAMPLE END
 
-For Developers: Using `astropy.cosmology` Inside ``astropy``
-============================================================
-
-If you are writing code for the ``astropy`` core or an affiliated package,
-it is often useful to assume a default cosmology so that the exact
-cosmology does not have to be specified every time a function or method
-is called. In this case, it is possible to specify a "default"
-cosmology.
-
-You can set the default cosmology to a predefined value by using the
-"default_cosmology" option in the ``[cosmology.core]`` section of the
-configuration file (see :ref:`astropy_config`). Alternatively, you can
-use the ``set`` function of `~astropy.cosmology.default_cosmology` to
-set a cosmology for the current Python session. If you have not set a
-default cosmology using one of the methods described above, then the
-cosmology module will default to using the nine-year WMAP parameters.
-
-It is strongly recommended that you use the default cosmology through
-the `~astropy.cosmology.default_cosmology` science state object. An
-override option can then be provided using something like the
-following::
-
-    def myfunc(..., cosmo=None):
-	from astropy.cosmology import default_cosmology
-
-	if cosmo is None:
-	    cosmo = default_cosmology.get()
-
-	... your code here ...
-
-This ensures that all code consistently uses the default cosmology
-unless explicitly overridden.
-
-.. note::
-    In general it is better to use an explicit cosmology (for example
-    ``WMAP9.H(0)`` instead of
-    ``cosmology.default_cosmology.get().H(0)``). Use of the default
-    cosmology should generally be reserved for code that will be
-    included in the ``astropy`` core or an affiliated package.
-
-.. note that if this section gets too long, it should be moved to a separate
-   doc page - see the top of performance.inc.rst for the instructions on how to do
-   that
-.. include:: performance.inc.rst
-
 See Also
 ========
 
@@ -556,4 +513,15 @@ the fact that five digits are quoted in the papers.
 Reference/API
 =============
 
+More detailed information on using the package is provided on separate pages,
+listed below.
+
+.. toctree::
+   :maxdepth: 1
+
+   Reading and Writing <io>
+   For Developers <dev>
+
+
 .. automodapi:: astropy.cosmology
+   :inherited-members:


### PR DESCRIPTION
Developer notes in the code and docs are moved to a dedicated page.
Followup will be adding a section explaining how a 3rd party package can plug into astropy's cosmology IO.

Fixes #12099 


### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
