### PR TITLE
Remove constants.set_enabled_constants

### DIFF
--- a/astropy/constants/__init__.py
+++ b/astropy/constants/__init__.py
@@ -14,10 +14,8 @@ A typical use case might be::
 
 """
 import warnings
-from contextlib import contextmanager
 
 from astropy.utils import find_current_module
-from astropy.utils.decorators import deprecated
 
 # Hack to make circular imports with units work
 from astropy import units
@@ -51,58 +49,8 @@ if __doc__ is not None:
     __doc__ += '\n'.join(_lines)
 
 
-@deprecated('4.0', alternative="Use 'astropy.physical_constants' and 'astropy.astronomical_constants'")  # noqa
-@contextmanager
-def set_enabled_constants(modname):
-    """
-    Context manager to temporarily set values in the ``constants``
-    namespace to an older version.
-    See :ref:`astropy:astropy-constants-prior` for usage.
-
-    Parameters
-    ----------
-    modname : {'astropyconst13', 'astropyconst20'}
-        Name of the module containing an older version.
-
-    """
-
-    # Re-import here because these were deleted from namespace on init.
-    import importlib
-    import warnings
-    from astropy.utils import find_current_module
-    from . import utils as _utils
-
-    try:
-        modmodule = importlib.import_module('.constants.' + modname, 'astropy')
-        codata_context = modmodule.codata
-        iaudata_context = modmodule.iaudata
-    except ImportError as exc:
-        exc.args += (f'Context manager does not currently handle {modname}',)
-        raise
-
-    module = find_current_module()
-
-    # Ignore warnings about "Constant xxx already has a definition..."
-    with warnings.catch_warnings():
-        warnings.filterwarnings('ignore',
-                                'Constant .*already has a definition')
-        _utils._set_c(codata_context, iaudata_context, module,
-                      not_in_module_only=False, set_class=True)
-
-    try:
-        yield
-    finally:
-        with warnings.catch_warnings():
-            warnings.filterwarnings('ignore',
-                                    'Constant .*already has a definition')
-            _utils._set_c(codata, iaudata, module,
-                          not_in_module_only=False, set_class=True)
-
-
 # Clean up namespace
 del find_current_module
-del deprecated
 del warnings
-del contextmanager
 del _utils
 del _lines

--- a/astropy/constants/tests/test_prior_version.py
+++ b/astropy/constants/tests/test_prior_version.py
@@ -7,7 +7,6 @@ import numpy as np
 
 from astropy.constants import Constant
 from astropy.units import Quantity as Q
-from astropy.utils.exceptions import AstropyDeprecationWarning
 
 
 def test_c():
@@ -187,25 +186,3 @@ def test_view():
 
     c4 = Q(c, subok=True, copy=False)
     assert c4 is c
-
-
-def test_context_manager():
-    from astropy import constants as const
-
-    with pytest.warns(AstropyDeprecationWarning,
-                      match="Use 'astropy.physical_constants'"):
-        with const.set_enabled_constants('astropyconst13'):
-            assert const.h.value == 6.62606957e-34  # CODATA2010
-
-    with pytest.warns(AstropyDeprecationWarning,
-                      match="Use 'astropy.physical_constants'"):
-        with const.set_enabled_constants('astropyconst20'):
-            assert const.h.value == 6.626070040e-34  # CODATA2014
-
-    assert const.h.value == 6.62607015e-34  # CODATA2018
-
-    with pytest.raises(ImportError):
-        with pytest.warns(AstropyDeprecationWarning,
-                          match="Use 'astropy.physical_constants'"):
-            with const.set_enabled_constants('notreal'):
-                const.h

--- a/docs/changes/constants/12105.api.rst
+++ b/docs/changes/constants/12105.api.rst
@@ -1,0 +1,1 @@
+Removed deprecated ``astropy.constants.set_enabled_constants`` context manager.


### PR DESCRIPTION
It has been deprecated since #9025.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
