### PR TITLE
Expose the data size calculation in Header as well as in HDU

### DIFF
--- a/astropy/io/fits/hdu/base.py
+++ b/astropy/io/fits/hdu/base.py
@@ -374,6 +374,19 @@ class _BaseHDU:
                         checksum=checksum)
 
     @classmethod
+    def size_of_header(cls, header):
+        """
+        Calculate the size of the data of an HDU given a Header object.
+        This allows one to determine the data size of an HDU without
+        having to create the full HDU object.
+
+        Parameters
+        ----------
+        header: FITS Header object
+        """
+        return header.size_of_data()
+
+    @classmethod
     def _from_data(cls, data, header, **kwargs):
         """
         Instantiate the HDU object after guessing the HDU class from the

--- a/astropy/io/fits/hdu/base.py
+++ b/astropy/io/fits/hdu/base.py
@@ -374,19 +374,6 @@ class _BaseHDU:
                         checksum=checksum)
 
     @classmethod
-    def size_of_header(cls, header):
-        """
-        Calculate the size of the data of an HDU given a Header object.
-        This allows one to determine the data size of an HDU without
-        having to create the full HDU object.
-
-        Parameters
-        ----------
-        header: FITS Header object
-        """
-        return header.size_of_data()
-
-    @classmethod
     def _from_data(cls, data, header, **kwargs):
         """
         Instantiate the HDU object after guessing the HDU class from the
@@ -955,18 +942,7 @@ class _ValidHDU(_BaseHDU, _Verify):
         """
         Size (in bytes) of the data portion of the HDU.
         """
-
-        size = 0
-        naxis = self._header.get('NAXIS', 0)
-        if naxis > 0:
-            size = 1
-            for idx in range(naxis):
-                size = size * self._header['NAXIS' + str(idx + 1)]
-            bitpix = self._header['BITPIX']
-            gcount = self._header.get('GCOUNT', 1)
-            pcount = self._header.get('PCOUNT', 0)
-            size = abs(bitpix) * gcount * (pcount + size) // 8
-        return size
+        return self._header.data_size
 
     def filebytes(self):
         """

--- a/astropy/io/fits/header.py
+++ b/astropy/io/fits/header.py
@@ -1648,21 +1648,21 @@ class Header:
                      'TFIELDS'):
             self.remove(name, ignore_missing=True)
 
-    def size_of_data(self):
+    @property
+    def data_size(self):
         """
         Return the size (in bytes) of the data portion following the `Header`.
         """
-        size = 0
-        naxis = self.get('NAXIS', 0)
-        if naxis > 0:
-            size = 1
-            for idx in range(naxis):
-                size = size * self['NAXIS' + str(idx + 1)]
-            bitpix = self['BITPIX']
-            gcount = self.get('GCOUNT', 1)
-            pcount = self.get('PCOUNT', 0)
-            size = abs(bitpix) * gcount * (pcount + size) // 8
-        return size
+        return _hdr_data_size(self)
+
+    @property
+    def data_size_padded(self):
+        """
+        Return the size (in bytes) of the data portion following the `Header`
+        including padding.
+        """
+        size = self.data_size
+        return size + _pad_length(size)
 
     def _update(self, card):
         """
@@ -2060,6 +2060,22 @@ class _BasicHeader(collections.abc.Mapping):
     def index(self, keyword):
         return self._keys.index(keyword)
 
+    @property
+    def data_size(self):
+        """
+        Return the size (in bytes) of the data portion following the `Header`.
+        """
+        return _hdr_data_size(self)
+
+    @property
+    def data_size_padded(self):
+        """
+        Return the size (in bytes) of the data portion following the `Header`
+        including padding.
+        """
+        size = self.data_size
+        return size + _pad_length(size)
+
     @classmethod
     def fromfile(cls, fileobj):
         """The main method to parse a FITS header from a file. The parsing is
@@ -2292,3 +2308,18 @@ def _check_padding(header_str, block_size, is_eof, check_block_size=True):
         actual_len = len(header_str) - block_size + BLOCK_SIZE
         # TODO: Pass this error to validation framework
         raise ValueError(f'Header size is not multiple of {BLOCK_SIZE}: {actual_len}')
+
+
+def _hdr_data_size(header):
+    """Calculate the data size (in bytes) following the given `Header`"""
+    size = 0
+    naxis = header.get('NAXIS', 0)
+    if naxis > 0:
+        size = 1
+        for idx in range(naxis):
+            size = size * header['NAXIS' + str(idx + 1)]
+        bitpix = header['BITPIX']
+        gcount = header.get('GCOUNT', 1)
+        pcount = header.get('PCOUNT', 0)
+        size = abs(bitpix) * gcount * (pcount + size) // 8
+    return size

--- a/astropy/io/fits/header.py
+++ b/astropy/io/fits/header.py
@@ -1648,6 +1648,22 @@ class Header:
                      'TFIELDS'):
             self.remove(name, ignore_missing=True)
 
+    def size_of_data(self):
+        """
+        Return the size (in bytes) of the data portion following the `Header`.
+        """
+        size = 0
+        naxis = self.get('NAXIS', 0)
+        if naxis > 0:
+            size = 1
+            for idx in range(naxis):
+                size = size * self['NAXIS' + str(idx + 1)]
+            bitpix = self['BITPIX']
+            gcount = self.get('GCOUNT', 1)
+            pcount = self.get('PCOUNT', 0)
+            size = abs(bitpix) * gcount * (pcount + size) // 8
+        return size
+
     def _update(self, card):
         """
         The real update code.  If keyword already exists, its value and/or

--- a/astropy/io/fits/tests/test_core.py
+++ b/astropy/io/fits/tests/test_core.py
@@ -561,6 +561,18 @@ class TestCore(FitsTestCase):
                                         hdu.header[:len(hdu2.header)])
                             assert np.all(hdu.data == hdu2.data)
 
+    def test_hdu_size_of_header(self):
+        """
+        Tests the calculation of data size given a Header to
+        the HDU classmethod.
+        """
+        header = fits.Header()
+        header['BITPIX'] = 32
+        header['NAXIS'] = 2
+        header['NAXIS1'] = 100
+        header['NAXIS2'] = 100
+        assert fits.PrimaryHDU.size_of_header(header) == 40000
+
 
 class TestConvenienceFunctions(FitsTestCase):
     def test_writeto(self):

--- a/astropy/io/fits/tests/test_core.py
+++ b/astropy/io/fits/tests/test_core.py
@@ -561,18 +561,6 @@ class TestCore(FitsTestCase):
                                         hdu.header[:len(hdu2.header)])
                             assert np.all(hdu.data == hdu2.data)
 
-    def test_hdu_size_of_header(self):
-        """
-        Tests the calculation of data size given a Header to
-        the HDU classmethod.
-        """
-        header = fits.Header()
-        header['BITPIX'] = 32
-        header['NAXIS'] = 2
-        header['NAXIS1'] = 100
-        header['NAXIS2'] = 100
-        assert fits.PrimaryHDU.size_of_header(header) == 40000
-
 
 class TestConvenienceFunctions(FitsTestCase):
     def test_writeto(self):

--- a/astropy/io/fits/tests/test_header.py
+++ b/astropy/io/fits/tests/test_header.py
@@ -2515,6 +2515,20 @@ class TestHeaderFunctions(FitsTestCase):
         assert header[('C', np.int16(0))] == 'BAZ'
         assert header[('C', np.uint32(1))] == 'BAZBAZ'
 
+    def test_header_data_size(self):
+        """
+        Tests data size calculation given a Header.
+        """
+        hdu = fits.PrimaryHDU()
+        header = hdu.header
+        assert header.size_of_data() == 0
+
+        header['BITPIX'] = 32
+        header['NAXIS'] = 2
+        header['NAXIS1'] = 100
+        header['NAXIS2'] = 100
+        assert header.size_of_data() == 40000
+
 
 class TestRecordValuedKeywordCards(FitsTestCase):
     """

--- a/astropy/io/fits/tests/test_header.py
+++ b/astropy/io/fits/tests/test_header.py
@@ -2517,17 +2517,18 @@ class TestHeaderFunctions(FitsTestCase):
 
     def test_header_data_size(self):
         """
-        Tests data size calculation given a Header.
+        Tests data size calculation (w/o padding) given a Header.
         """
         hdu = fits.PrimaryHDU()
         header = hdu.header
-        assert header.size_of_data() == 0
+        assert header.data_size == 0
 
         header['BITPIX'] = 32
         header['NAXIS'] = 2
         header['NAXIS1'] = 100
         header['NAXIS2'] = 100
-        assert header.size_of_data() == 40000
+        assert header.data_size == 40000
+        assert header.data_size_padded == 40320
 
 
 class TestRecordValuedKeywordCards(FitsTestCase):

--- a/docs/changes/io.fits/12110.feature.rst
+++ b/docs/changes/io.fits/12110.feature.rst
@@ -1,0 +1,3 @@
+``astropy.io.fits.Header`` now has a method to calculate the size
+(in bytes) of the data portion (with or without padding) following
+that header.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address the addition of a FITS ``Header`` method to calculate data size as well as an ``HDU`` classmethod for the same. I have added tests and verified them locally. I am not sure if the way I have dealt with this Feature request/API change is what is expected. @embray, please let me know if this is what you were looking for!

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #11105

Things to do:

- [x] Add a changelog
- [ ] Potentially update docs (?) -- don't know if this part is necessary for this PR.
### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
