### PR TITLE
Use __init_subclass__ instead of metaclass in time formats

### DIFF
--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -76,37 +76,7 @@ def _regexify_subfmts(subfmts):
     return tuple(new_subfmts)
 
 
-class TimeFormatMeta(type):
-    """
-    Metaclass that adds `TimeFormat` and `TimeDeltaFormat` to the
-    `TIME_FORMATS` and `TIME_DELTA_FORMATS` registries, respectively.
-    """
-
-    _registry = TIME_FORMATS
-
-    def __new__(mcls, name, bases, members):
-        cls = super().__new__(mcls, name, bases, members)
-
-        # Register time formats that have a name, but leave out astropy_time since
-        # it is not a user-accessible format and is only used for initialization into
-        # a different format.
-        if 'name' in members and cls.name != 'astropy_time':
-            # FIXME: check here that we're not introducing a collision with
-            # an existing method or attribute; problem is it could be either
-            # astropy.time.Time or astropy.time.TimeDelta, and at the point
-            # where this is run neither of those classes have necessarily been
-            # constructed yet.
-            if 'value' in members and not hasattr(members['value'], "fget"):
-                raise ValueError("If defined, 'value' must be a property")
-            mcls._registry[cls.name] = cls
-
-        if 'subfmts' in members:
-            cls.subfmts = _regexify_subfmts(members['subfmts'])
-
-        return cls
-
-
-class TimeFormat(metaclass=TimeFormatMeta):
+class TimeFormat:
     """
     Base class for time representations.
 
@@ -131,6 +101,7 @@ class TimeFormat(metaclass=TimeFormatMeta):
 
     _default_scale = 'utc'  # As of astropy 0.4
     subfmts = ()
+    _registry = TIME_FORMATS
 
     def __init__(self, val1, val2, scale, precision,
                  in_subfmt, out_subfmt, from_jd=False):
@@ -147,6 +118,27 @@ class TimeFormat(metaclass=TimeFormatMeta):
         else:
             val1, val2 = self._check_val_type(val1, val2)
             self.set_jds(val1, val2)
+
+    def __init_subclass__(cls, **kwargs):
+        # Register time formats that define a name, but leave out astropy_time since
+        # it is not a user-accessible format and is only used for initialization into
+        # a different format.
+        if 'name' in cls.__dict__ and cls.name != 'astropy_time':
+            # FIXME: check here that we're not introducing a collision with
+            # an existing method or attribute; problem is it could be either
+            # astropy.time.Time or astropy.time.TimeDelta, and at the point
+            # where this is run neither of those classes have necessarily been
+            # constructed yet.
+            if 'value' in cls.__dict__ and not hasattr(cls.value, "fget"):
+                raise ValueError("If defined, 'value' must be a property")
+
+            cls._registry[cls.name] = cls
+
+        # If this class defines its own subfmts, preprocess the definitions.
+        if 'subfmts' in cls.__dict__:
+            cls.subfmts = _regexify_subfmts(cls.subfmts)
+
+        return super().__init_subclass__(**kwargs)
 
     @classmethod
     def _get_allowed_subfmt(cls, subfmt):
@@ -457,7 +449,7 @@ class TimeNumeric(TimeFormat):
         Subclasses that require ``parent`` or to adjust the jds should
         override this method.
         """
-        # TODO: do this in metaclass.
+        # TODO: do this in __init_subclass__?
         if self.__class__.value.fget is not self.__class__.to_value:
             return self.value
 
@@ -1827,12 +1819,10 @@ class TimeJulianEpochString(TimeEpochDateString):
     epoch_prefix = 'J'
 
 
-class TimeDeltaFormatMeta(TimeFormatMeta):
-    _registry = TIME_DELTA_FORMATS
-
-
-class TimeDeltaFormat(TimeFormat, metaclass=TimeDeltaFormatMeta):
+class TimeDeltaFormat(TimeFormat):
     """Base class for time delta representations"""
+
+    _registry = TIME_DELTA_FORMATS
 
     def _check_scale(self, scale):
         """


### PR DESCRIPTION
#7144 happened to float on top when sorting by last-updated, and I saw that `astropy.time` was mentioned as a place where we could replace a metaclass with the somewhat more readable `__init_subclass__` method. This seemed like a good idea and was indeed simple.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
