### PR TITLE
cleanup cosmology realization creation

### DIFF
--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -153,6 +153,7 @@ class Cosmology(metaclass=ABCMeta):
             >>> newcosmo = Planck13.clone(name="Modified Planck 2013", Om0=0.35)
 
         If no name is specified, the new name will note the modification.
+
             >>> Planck13.clone(Om0=0.35).name
             'Planck13 (modified)'
 

--- a/astropy/cosmology/io/mapping.py
+++ b/astropy/cosmology/io/mapping.py
@@ -60,8 +60,9 @@ def from_mapping(map, *, move_to_meta=False, cosmology=None):
         >>> cm
         {'cosmology': <class 'astropy.cosmology.core.FlatLambdaCDM'>,
          'name': 'Planck18', 'H0': <Quantity 67.66 km / (Mpc s)>, 'Om0': 0.30966,
-         'Tcmb0': 2.7255, 'Neff': 3.046, 'm_nu': <Quantity [0. , 0. , 0.06] eV>,
-         'Ob0': 0.04897, 'meta': ...
+         'Tcmb0': <Quantity 2.7255 K>, 'Neff': 3.046,
+         'm_nu': <Quantity [0. , 0. , 0.06] eV>, 'Ob0': 0.04897,
+         'meta': ...
 
     Now this dict can be used to load a new cosmological instance identical
     to the ``Planck18`` cosmology from which it was generated.
@@ -143,8 +144,9 @@ def to_mapping(cosmology, *args):
         >>> Planck18.to_format('mapping')
         {'cosmology': <class 'astropy.cosmology.core.FlatLambdaCDM'>,
          'name': 'Planck18', 'H0': <Quantity 67.66 km / (Mpc s)>, 'Om0': 0.30966,
-         'Tcmb0': 2.7255, 'Neff': 3.046, 'm_nu': <Quantity [0.  , 0.  , 0.06] eV>,
-         'Ob0': 0.04897, 'meta': ...
+         'Tcmb0': <Quantity 2.7255 K>, 'Neff': 3.046,
+         'm_nu': <Quantity [0.  , 0.  , 0.06] eV>, 'Ob0': 0.04897,
+         'meta': ...
 
     """
 

--- a/astropy/cosmology/parameters.py
+++ b/astropy/cosmology/parameters.py
@@ -48,6 +48,8 @@ doi: 10.1088/0067-0049/180/2/330. Table 1 (WMAP + BAO + SN ML).
 
 """
 
+import astropy.units as u
+
 # Note: if you add a new cosmology, please also update the table
 # in the 'Built-in Cosmologies' section of astropy/docs/cosmology/index.rst
 # in addition to the list above.  You also need to add them to the 'available'
@@ -61,16 +63,16 @@ Planck18 = dict(
     Oc0=0.2607,
     Ob0=0.04897,
     Om0=0.30966,
-    H0=67.66,
+    H0=67.66 * (u.km / u.s / u.Mpc),
     n=0.9665,
     sigma8=0.8102,
     tau=0.0561,
     z_reion=7.82,
-    t0=13.787,
-    Tcmb0=2.7255,
+    t0=13.787 * u.Gyr,
+    Tcmb0=2.7255 * u.K,
     Neff=3.046,
     flat=True,
-    m_nu=[0., 0., 0.06],
+    m_nu=[0., 0., 0.06] * u.eV,
     reference=("Planck Collaboration 2018, 2020, A&A, 641, A6  (Paper VI),"
                " Table 2 (TT, TE, EE + lowE + lensing + BAO)")
 )
@@ -82,16 +84,16 @@ Planck18_arXiv_v2 = dict(
     Oc0=0.2607,
     Ob0=0.04897,
     Om0=0.30966,
-    H0=67.66,
+    H0=67.66 * (u.km / u.s / u.Mpc),
     n=0.9665,
     sigma8=0.8102,
     tau=0.0561,
     z_reion=7.82,
-    t0=13.787,
-    Tcmb0=2.7255,
+    t0=13.787 * u.Gyr,
+    Tcmb0=2.7255 * u.K,
     Neff=3.046,
     flat=True,
-    m_nu=[0., 0., 0.06],
+    m_nu=[0., 0., 0.06] * u.eV,
     reference=("DEPRECATED: Planck Collaboration 2018, arXiv:1807.06209 v2 (Paper VI),"
                " Table 2 (TT, TE, EE + lowE + lensing + BAO)")
 )
@@ -102,16 +104,16 @@ Planck15 = dict(
     Oc0=0.2589,
     Ob0=0.04860,
     Om0=0.3075,
-    H0=67.74,
+    H0=67.74 * (u.km / u.s / u.Mpc),
     n=0.9667,
     sigma8=0.8159,
     tau=0.066,
     z_reion=8.8,
-    t0=13.799,
-    Tcmb0=2.7255,
+    t0=13.799 * u.Gyr,
+    Tcmb0=2.7255 * u.K,
     Neff=3.046,
     flat=True,
-    m_nu=[0., 0., 0.06],
+    m_nu=[0., 0., 0.06] * u.eV,
     reference=("Planck Collaboration 2016, A&A, 594, A13 (Paper XIII),"
                " Table 4 (TT, TE, EE + lowP + lensing + ext)")
 )
@@ -122,16 +124,16 @@ Planck13 = dict(
     Oc0=0.25886,
     Ob0=0.048252,
     Om0=0.30712,
-    H0=67.77,
+    H0=67.77 * (u.km / u.s / u.Mpc),
     n=0.9611,
     sigma8=0.8288,
     tau=0.0952,
     z_reion=11.52,
-    t0=13.7965,
-    Tcmb0=2.7255,
+    t0=13.7965 * u.Gyr,
+    Tcmb0=2.7255 * u.K,
     Neff=3.046,
     flat=True,
-    m_nu=[0., 0., 0.06],
+    m_nu=[0., 0., 0.06] * u.eV,
     reference=("Planck Collaboration 2014, A&A, 571, A16 (Paper XVI),"
                " Table 5 (Planck + WP + highL + BAO)")
 )
@@ -142,15 +144,15 @@ WMAP9 = dict(
     Oc0=0.2402,
     Ob0=0.04628,
     Om0=0.2865,
-    H0=69.32,
+    H0=69.32 * (u.km / u.s / u.Mpc),
     n=0.9608,
     sigma8=0.820,
     tau=0.081,
     z_reion=10.1,
-    t0=13.772,
-    Tcmb0=2.725,
+    t0=13.772 * u.Gyr,
+    Tcmb0=2.725 * u.K,
     Neff=3.04,
-    m_nu=0.0,
+    m_nu=0.0 * u.eV,
     flat=True,
     reference=("Hinshaw et al. 2013, ApJS, 208, 19, "
                "doi: 10.1088/0067-0049/208/2/19. "
@@ -162,15 +164,15 @@ WMAP7 = dict(
     Oc0=0.226,
     Ob0=0.0455,
     Om0=0.272,
-    H0=70.4,
+    H0=70.4 * (u.km / u.s / u.Mpc),
     n=0.967,
     sigma8=0.810,
     tau=0.085,
     z_reion=10.3,
-    t0=13.76,
-    Tcmb0=2.725,
+    t0=13.76 * u.Gyr,
+    Tcmb0=2.725 * u.K,
     Neff=3.04,
-    m_nu=0.0,
+    m_nu=0.0 * u.eV,
     flat=True,
     reference=("Komatsu et al. 2011, ApJS, 192, 18, "
                "doi: 10.1088/0067-0049/192/2/18. "
@@ -182,15 +184,15 @@ WMAP5 = dict(
     Oc0=0.231,
     Ob0=0.0459,
     Om0=0.277,
-    H0=70.2,
+    H0=70.2 * (u.km / u.s / u.Mpc),
     n=0.962,
     sigma8=0.817,
     tau=0.088,
     z_reion=11.3,
-    t0=13.72,
-    Tcmb0=2.725,
+    t0=13.72 * u.Gyr,
+    Tcmb0=2.725 * u.K,
     Neff=3.04,
-    m_nu=0.0,
+    m_nu=0.0 * u.eV,
     flat=True,
     reference=("Komatsu et al. 2009, ApJS, 180, 330, "
                "doi: 10.1088/0067-0049/180/2/330. "

--- a/docs/changes/cosmology/12116.api.rst
+++ b/docs/changes/cosmology/12116.api.rst
@@ -1,0 +1,2 @@
+Cosmology parameters in ``cosmology.parameters.py`` now have units,
+where applicable.

--- a/docs/cosmology/io.rst
+++ b/docs/cosmology/io.rst
@@ -209,7 +209,7 @@ Now the registered functions can be used in
     >>> row
     <Row index=0>
       cosmology     name        H0        Om0    Tcmb0    Neff    m_nu [3]    Ob0  
-                           km / (Mpc s)                              eV            
+                           km / (Mpc s)            K                 eV            
         str13       str8     float64    float64 float64 float64   float64   float64
     ------------- -------- ------------ ------- ------- ------- ----------- -------
     FlatLambdaCDM Planck18        67.66 0.30966  2.7255   3.046 0.0 .. 0.06 0.04897
@@ -274,6 +274,9 @@ and which Cosmology class to use. Details of are in
     ...     for k, v in mapping.items():
     ...         if isinstance(v, dict) and "value" in v and "unit" in v:
     ...             mapping[k] = u.Quantity(v["value"], v["unit"])
+    ...     for k, v in mapping.get("meta", {}).items():  # also the metadata
+    ...         if isinstance(v, dict) and "value" in v and "unit" in v:
+    ...             mapping["meta"][k] = u.Quantity(v["value"], v["unit"])
     ...     return Cosmology.from_format(mapping, **kwargs)
 
 
@@ -285,7 +288,7 @@ JSON. In both the ``write`` and ``read`` methods we have to create custom
 parsers.
 
 .. code-block:: python
-    :emphasize-lines: 2,15
+    :emphasize-lines: 2,19
 
     >>> def write_json(cosmology, file, *, overwrite=False, **kwargs):
     ...    data = cosmology.to_format("mapping")  # start by turning into dict
@@ -293,8 +296,10 @@ parsers.
     ...    # serialize Quantity
     ...    for k, v in data.items():
     ...        if isinstance(v, u.Quantity):
-    ...            data[k] = {"value": v.value.tolist(),
-    ...                       "unit": str(v.unit)}
+    ...            data[k] = {"value": v.value.tolist(), "unit": str(v.unit)}
+    ...    for k, v in data.get("meta", {}).items():  # also serialize the metadata
+    ...        if isinstance(v, u.Quantity):
+    ...            data["meta"][k] = {"value": v.value.tolist(), "unit": str(v.unit)}
     ...
     ...    if isinstance(file, (str, bytes, os.PathLike)):
     ...        # check that file exists and whether to overwrite.
@@ -355,6 +360,7 @@ Now the registered functions can be used in
     ...     pass
 
 .. EXAMPLE END
+
 
 Reference/API
 =============


### PR DESCRIPTION
Now that ``to/from_format`` is in, the builtin realizations can be constructed much more easily!
Also, I took the opportunity to enhance the parameters file with units.  The ``parameters`` file is mentioned, so it's only semi-private. As such, I've added a changelog.

- Use cosmology I/O
- Add units to the parameters file

Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
