### PR TITLE
Deprecate the pedantic option for VOTables

### DIFF
--- a/astropy/io/votable/exceptions.py
+++ b/astropy/io/votable/exceptions.py
@@ -266,8 +266,8 @@ class W01(VOTableSpecWarning):
         encoded as multiple numbers separated by whitespace.
 
     Many VOTable files in the wild use commas as a separator instead,
-    and ``astropy.io.votable`` supports this convention when not in
-    :ref:`astropy:pedantic-mode`.
+    and ``astropy.io.votable`` can support this convention depending on the
+    :ref:`astropy:verifying-votables` setting.
 
     ``astropy.io.votable`` always outputs files using only spaces, regardless of
     how they were input.

--- a/astropy/io/votable/table.py
+++ b/astropy/io/votable/table.py
@@ -60,6 +60,10 @@ def parse(source, columns=None, invalid='exception', verify=None,
         for more information. When not provided, uses the configuration setting
         ``astropy.io.votable.verify``, which defaults to 'ignore'.
 
+        .. versionchanged:: 4.0
+           ``verify`` replaces the ``pedantic`` argument, which will be
+           deprecated in future.
+
     chunk_size : int, optional
         The number of rows to read before converting to an array.
         Higher numbers are likely to be faster, but will consume more

--- a/astropy/io/votable/table.py
+++ b/astropy/io/votable/table.py
@@ -18,7 +18,6 @@ from . import tree
 from astropy.utils.xml import iterparser
 from astropy.utils import data
 from astropy.utils.decorators import deprecated_renamed_argument
-from astropy.utils.exceptions import AstropyDeprecationWarning
 
 __all__ = ['parse', 'parse_single_table', 'from_table', 'writeto', 'validate',
            'reset_vo_warnings']
@@ -26,7 +25,7 @@ __all__ = ['parse', 'parse_single_table', 'from_table', 'writeto', 'validate',
 VERIFY_OPTIONS = ['ignore', 'warn', 'exception']
 
 
-@deprecated_renamed_argument('pedantic', 'verify', pending=True, since='4.0')
+@deprecated_renamed_argument('pedantic', 'verify', since='5.0')
 def parse(source, columns=None, invalid='exception', verify=None,
           chunk_size=tree.DEFAULT_CHUNK_SIZE, table_number=None,
           table_id=None, filename=None, unit_format=None,
@@ -60,10 +59,6 @@ def parse(source, columns=None, invalid='exception', verify=None,
         mechanisms.  See the `warnings` module in the Python standard library
         for more information. When not provided, uses the configuration setting
         ``astropy.io.votable.verify``, which defaults to 'ignore'.
-
-        .. versionchanged:: 4.0
-           ``verify`` replaces the ``pedantic`` argument, which will be
-           deprecated in future.
 
     chunk_size : int, optional
         The number of rows to read before converting to an array.
@@ -120,15 +115,7 @@ def parse(source, columns=None, invalid='exception', verify=None,
 
     if verify is None:
 
-        # NOTE: since the pedantic argument isn't fully deprecated yet, we need
-        # to catch the deprecation warning that occurs when accessing the
-        # configuration item, but only if it is for the pedantic option in the
-        # [io.votable] section.
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore",
-                                    r"Config parameter \'pedantic\' in section \[io.votable\]",
-                                    AstropyDeprecationWarning)
-            conf_verify_lowercase = conf.verify.lower()
+        conf_verify_lowercase = conf.verify.lower()
 
         # We need to allow verify to be booleans as strings since the
         # configuration framework doesn't make it easy/possible to have mixed

--- a/astropy/io/votable/tests/table_test.py
+++ b/astropy/io/votable/tests/table_test.py
@@ -234,16 +234,17 @@ class TestVerifyOptions:
         with pytest.raises(VOWarning):
             parse(get_pkg_data_filename('data/gemini.xml'), verify='exception')
 
-    # Make sure the pedantic option still works for now (pending deprecation)
+    # Make sure the deprecated pedantic option still works for now
 
     def test_pedantic_false(self):
         with pytest.warns(VOWarning) as w:
             parse(get_pkg_data_filename('data/gemini.xml'), pedantic=False)
-        assert len(w) == 24
+        assert len(w) == 25
 
     def test_pedantic_true(self):
-        with pytest.raises(VOWarning):
-            parse(get_pkg_data_filename('data/gemini.xml'), pedantic=True)
+        with pytest.raises(AstropyDeprecationWarning):
+            with pytest.raises(VOWarning):
+                parse(get_pkg_data_filename('data/gemini.xml'), pedantic=True)
 
     # Make sure that the default behavior can be set via configuration items
 
@@ -275,7 +276,7 @@ class TestVerifyOptions:
 
             with pytest.warns(VOWarning) as w:
                 parse(get_pkg_data_filename('data/gemini.xml'))
-            assert len(w) == 24
+            assert len(w) == 25
 
     def test_conf_pedantic_true(self, tmpdir):
 
@@ -286,5 +287,6 @@ class TestVerifyOptions:
 
             reload_config('astropy.io.votable')
 
-            with pytest.raises(VOWarning):
-                parse(get_pkg_data_filename('data/gemini.xml'))
+            with pytest.raises(AstropyDeprecationWarning):
+                with pytest.raises(VOWarning):
+                    parse(get_pkg_data_filename('data/gemini.xml'))

--- a/docs/changes/io.votable/12129.api.rst
+++ b/docs/changes/io.votable/12129.api.rst
@@ -1,0 +1,3 @@
+Deprecated the ``pedantic`` keyword argument in the
+``astropy.io.votable.table.parse`` function and the corresponding configuration
+setting. It has been replaced by the ``verify`` option.

--- a/docs/io/votable/index.rst
+++ b/docs/io/votable/index.rst
@@ -247,7 +247,8 @@ Version 1.1
 and `Version 1.4
 <https://www.ivoa.net/documents/VOTable/20191021/REC-VOTable-1.4-20191021.html>`_.
 Some flexibility is provided to support the 1.0 draft version and
-other nonstandard usage in the wild, see :ref:`pedantic-mode` for more details.
+other nonstandard usage in the wild, see :ref:`verifying-votables` for more
+details.
 
 .. note::
 
@@ -258,14 +259,14 @@ other nonstandard usage in the wild, see :ref:`pedantic-mode` for more details.
 Output always conforms to the 1.1, 1.2, 1.3, or 1.4 spec, depending on the
 input.
 
-.. _pedantic-mode:
+.. _verifying-votables:
 
 Verifying VOTables
 ^^^^^^^^^^^^^^^^^^
 
 Many VOTable files in the wild do not conform to the VOTable specification. You
 can set what should happen when a violation is encountered with the ``verify``
-argument, which can take three values:
+keyword, which can take three values:
 
     * ``'ignore'`` - Attempt to parse the VOTable silently. This is the default
       setting.
@@ -274,11 +275,11 @@ argument, which can take three values:
       same type to a maximum value using the
       `astropy.io.votable.exceptions.conf.max_warnings
       <astropy.io.votable.exceptions.Conf.max_warnings>` item in the
-      :ref:`astropy_config`
+      :ref:`astropy_config`.
     * ``'exception'`` - Do not parse the VOTable and raise an exception.
 
-The ``verify`` argument can be used with the :func:`~astropy.io.votable.parse` or
-:func:`~astropy.io.votable.parse_single_table` functions::
+The ``verify`` keyword can be used with the :func:`~astropy.io.votable.parse`
+or :func:`~astropy.io.votable.parse_single_table` functions::
 
   from astropy.io.votable import parse
   votable = parse("votable.xml", verify='warn')

--- a/docs/io/votable/index.rst
+++ b/docs/io/votable/index.rst
@@ -247,8 +247,7 @@ Version 1.1
 and `Version 1.4
 <https://www.ivoa.net/documents/VOTable/20191021/REC-VOTable-1.4-20191021.html>`_.
 Some flexibility is provided to support the 1.0 draft version and
-other nonstandard usage in the wild. To support these cases, set the
-keyword argument ``pedantic`` to ``False`` when parsing.
+other nonstandard usage in the wild, see :ref:`pedantic-mode` for more details.
 
 .. note::
 
@@ -261,26 +260,40 @@ input.
 
 .. _pedantic-mode:
 
-Pedantic mode
-^^^^^^^^^^^^^
+Verifying VOTables
+^^^^^^^^^^^^^^^^^^
 
-Many VOTable files in the wild do not conform to the VOTable
-specification. If reading one of these files causes exceptions, you
-may turn off pedantic mode in `astropy.io.votable` by passing
-``pedantic=False`` to the `~astropy.io.votable.parse` or
-`~astropy.io.votable.parse_single_table` functions::
+Many VOTable files in the wild do not conform to the VOTable specification. You
+can set what should happen when a violation is encountered with the ``verify``
+argument, which can take three values:
+
+    * ``'ignore'`` - Attempt to parse the VOTable silently. This is the default
+      setting.
+    * ``'warn'`` - Attempt to parse the VOTable, but raise appropriate
+      :ref:`warnings`. It is possible to limit the number of warnings of the
+      same type to a maximum value using the
+      `astropy.io.votable.exceptions.conf.max_warnings
+      <astropy.io.votable.exceptions.Conf.max_warnings>` item in the
+      :ref:`astropy_config`
+    * ``'exception'`` - Do not parse the VOTable and raise an exception.
+
+The ``verify`` argument can be used with the :func:`~astropy.io.votable.parse` or
+:func:`~astropy.io.votable.parse_single_table` functions::
 
   from astropy.io.votable import parse
-  votable = parse("votable.xml", pedantic=False)
+  votable = parse("votable.xml", verify='warn')
 
-Note, however, that it is good practice to report these errors to the
-author of the application that generated the VOTable file to bring the
-file into compliance with the specification.
+It is possible to change the default ``verify`` value through the
+`astropy.io.votable.conf.verify <astropy.io.votable.Conf.verify>` item in the
+:ref:`astropy_config`.
 
-Even with ``pedantic`` turned off, many warnings may still be omitted.
-These warnings are all of the type
-`~astropy.io.votable.exceptions.VOTableSpecWarning` and can be turned
-off using the standard Python `warnings` module.
+Note that ``'ignore'`` or ``'warn'``  mean that ``astropy`` will attempt to
+parse the VOTable, but if the specification has been violated then success
+cannot be guaranteed.
+
+It is good practice to report any errors to the author of the application that
+generated the VOTable file to bring the file into compliance with the
+specification.
 
 Missing Values
 --------------


### PR DESCRIPTION
Closes #8887

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
