### PR TITLE
Fix calculation of DATASUM for >1D CompImageHDU

### DIFF
--- a/astropy/io/fits/tests/test_checksum.py
+++ b/astropy/io/fits/tests/test_checksum.py
@@ -224,6 +224,17 @@ class TestChecksumFunctions(FitsTestCase):
                 assert 'DATASUM' in h2[1].header
                 assert h2[1].header['DATASUM'] == '113055149'
 
+    def test_failing_compressed_datasum(self):
+        """
+        Regression test for https://github.com/astropy/astropy/issues/4587
+        """
+        n = np.ones((10, 10), dtype='float32')
+        comp_hdu = fits.CompImageHDU(n)
+        comp_hdu.writeto(self.temp('tmp.fits'), checksum=True)
+
+        with fits.open(self.temp('tmp.fits'), checksum=True) as hdul:
+            assert np.all(hdul[1].data == comp_hdu.data)
+
     def test_compressed_image_data_int16(self):
         n = np.arange(100, dtype='int16')
         hdu = fits.ImageHDU(n)


### PR DESCRIPTION
I am sorry for this atrocity.

Someone with a deeper understanding of FITS binary tables or a lot more time might be able to come up with an actual fix to the way BinTableHDU calculates the datasum from the data in memory. I have neither of these things, so I came up with the easiest path to a fix I could find.

My main reservation about this approach is that for large files it's going to be pretty memory inefficient. Given that this bug only occurs when you construct a `CompImageHDU` in memory this is likely only to be an issue when people are trying to compress and save out a memmap or something. When doing this I assume that saving to disk will only read a tile at a time from the input array and compress it, whereas this will read the whole lot into a nice bytes array in memory.

We could use a tempfile instead as a buffer to alleviate this concern.

Fixes #4587 

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
