### PR TITLE
Fix biweight_scale and biweight_midvariance for constant Quantity input

### DIFF
--- a/astropy/stats/biweight.py
+++ b/astropy/stats/biweight.py
@@ -376,7 +376,6 @@ def biweight_midvariance(data, c=9.0, M=None, axis=None,
     >>> print(bivar)    # doctest: +FLOAT_CMP
     1.0484350639638342
     """
-
     median_func, sum_func = _stat_functions(data, ignore_nan=ignore_nan)
 
     if isinstance(data, np.ma.MaskedArray) and ignore_nan:
@@ -396,10 +395,10 @@ def biweight_midvariance(data, c=9.0, M=None, axis=None,
     mad = median_absolute_deviation(data, axis=axis, ignore_nan=ignore_nan)
 
     if axis is None:
-        if mad == 0.:  # data is constant or mostly constant
-            return 0.0
-        if np.isnan(mad):  # data contains NaNs and ignore_nan=False
-            return np.nan
+        # data is constant or mostly constant OR
+        # data contains NaNs and ignore_nan=False
+        if mad == 0. or np.isnan(mad):
+            return mad ** 2  # variance units
     else:
         mad = _expand_dims(mad, axis=axis)  # NUMPY_LT_1_18
 

--- a/astropy/stats/tests/test_biweight.py
+++ b/astropy/stats/tests/test_biweight.py
@@ -9,6 +9,8 @@ from astropy.stats.biweight import (biweight_location, biweight_scale,
                                     biweight_midvariance,
                                     biweight_midcovariance,
                                     biweight_midcorrelation)
+from astropy.tests.helper import assert_quantity_allclose
+import astropy.units as u
 from astropy.utils.misc import NumpyRNGContext
 
 
@@ -553,3 +555,23 @@ def test_biweight_32bit_runtime_warnings():
         data[50] = 30000.
         biweight_scale(data)
         biweight_midvariance(data)
+
+
+def test_biweight_scl_var_constant_units():
+    unit = u.km
+    data = np.ones(10) << unit
+    biwscl = biweight_scale(data)
+    biwvar = biweight_midvariance(data)
+    assert isinstance(biwscl, u.Quantity)
+    assert isinstance(biwvar, u.Quantity)
+    assert_quantity_allclose(biwscl, 0. << unit)
+    assert_quantity_allclose(biwvar, 0. << unit ** 2)
+
+    data = np.ones(10) << unit
+    data[0] = np.nan
+    biwscl = biweight_scale(data)
+    biwvar = biweight_midvariance(data)
+    assert isinstance(biwscl, u.Quantity)
+    assert isinstance(biwvar, u.Quantity)
+    assert_quantity_allclose(biwscl, np.nan << unit)
+    assert_quantity_allclose(biwvar, np.nan << unit ** 2)

--- a/docs/changes/stats/12146.bugfix.rst
+++ b/docs/changes/stats/12146.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed a bug in ``biweight_midvariance`` and ``biweight_scale`` where
+output data units would be dropped for constant data and where the
+result was a scalar NaN.


### PR DESCRIPTION
I discovered a bug in `biweight_scale` and `biweight_midvariance` where they silently drop units for constant data or data that contains `np.nan` (with `ignore_nan=False`).

Examples:
```python
>>> from astropy.stats import biweight_scale, biweight_midvariance
>>> import astropy.units as u
>>> data = np.ones(10) << u.km
>>> biweight_scale(data)
0.0
>>> biweight_midvariance(data)
0.0
```

After this PR:
```python
>>> biweight_scale(data)
<Quantity 0. km>
>>> biweight_midvariance(data)
<Quantity 0. km2>
```


<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->


<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
