### PR TITLE
Fixed two coordinate-transformation bugs

### DIFF
--- a/astropy/coordinates/builtin_frames/intermediate_rotation_transforms.py
+++ b/astropy/coordinates/builtin_frames/intermediate_rotation_transforms.py
@@ -244,9 +244,9 @@ def precessedgeo_to_gcrs(from_coo, to_frame):
     pmat = gcrs_precession_mat(from_coo.equinox)
     crepr = from_coo.cartesian.transform(matrix_transpose(pmat))
     gcrs_coo = GCRS(crepr,
-                    obstime=to_frame.obstime,
-                    obsgeoloc=to_frame.obsgeoloc,
-                    obsgeovel=to_frame.obsgeovel)
+                    obstime=from_coo.obstime,
+                    obsgeoloc=from_coo.obsgeoloc,
+                    obsgeovel=from_coo.obsgeovel)
 
     # then move to the GCRS that's actually desired
     return gcrs_coo.transform_to(to_frame)

--- a/astropy/coordinates/builtin_frames/intermediate_rotation_transforms.py
+++ b/astropy/coordinates/builtin_frames/intermediate_rotation_transforms.py
@@ -254,22 +254,31 @@ def precessedgeo_to_gcrs(from_coo, to_frame):
 
 @frame_transform_graph.transform(FunctionTransformWithFiniteDifference, TEME, ITRS)
 def teme_to_itrs(teme_coo, itrs_frame):
-    # first get us to TEME at the target obstime
-    # TODO: self transform?
-    teme_coo2 = teme_coo.transform_to(TEME(obstime=itrs_frame.obstime))
+    # use the pmatrix to transform to ITRS in the source obstime
+    pmat = teme_to_itrs_mat(teme_coo.obstime)
+    crepr = teme_coo.cartesian.transform(pmat)
+    itrs = ITRS(crepr, obstime=teme_coo.obstime)
 
-    # now get the pmatrix
-    pmat = teme_to_itrs_mat(itrs_frame.obstime)
-    crepr = teme_coo2.cartesian.transform(pmat)
-    return itrs_frame.realize_frame(crepr)
+    # transform the ITRS coordinate to the target obstime
+    return itrs.transform_to(itrs_frame)
 
 
 @frame_transform_graph.transform(FunctionTransformWithFiniteDifference, ITRS, TEME)
 def itrs_to_teme(itrs_coo, teme_frame):
-    # compute the pmatrix, and then multiply by its transpose
-    pmat = teme_to_itrs_mat(itrs_coo.obstime)
-    newrepr = itrs_coo.cartesian.transform(matrix_transpose(pmat))
-    teme = TEME(newrepr, obstime=itrs_coo.obstime)
+    # transform the ITRS coordinate to the target obstime
+    itrs_coo2 = itrs_coo.transform_to(ITRS(obstime=teme_frame.obstime))
 
-    # now do any needed offsets (no-op if same obstime)
-    return teme.transform_to(teme_frame)
+    # compute the pmatrix, and then multiply by its transpose
+    pmat = teme_to_itrs_mat(teme_frame.obstime)
+    newrepr = itrs_coo2.cartesian.transform(matrix_transpose(pmat))
+    return teme_frame.realize_frame(newrepr)
+
+
+@frame_transform_graph.transform(FunctionTransformWithFiniteDifference, TEME, TEME)
+def teme_to_teme(from_coo, to_frame):
+    if np.all(from_coo.obstime == to_frame.obstime):
+        return to_frame.realize_frame(from_coo.data)
+    else:
+        # this self-transform goes through ITRS right now, which implicitly also
+        # goes back to ICRS
+        return from_coo.transform_to(ITRS(obstime=from_coo.obstime)).transform_to(to_frame)

--- a/astropy/coordinates/tests/test_intermediate_transformations.py
+++ b/astropy/coordinates/tests/test_intermediate_transformations.py
@@ -600,6 +600,20 @@ def test_teme_itrf():
     )
 
 
+def test_teme_loopback():
+    from_coo = TEME(1*u.AU, 2*u.AU, 3*u.AU, obstime='2001-01-01')
+    to_frame = TEME(obstime='2001-06-30')
+
+    explicit_coo = from_coo.transform_to(ICRS()).transform_to(to_frame)
+    implicit_coo = from_coo.transform_to(to_frame)
+
+    # Confirm that the explicit transformation changes the coordinate
+    assert not allclose(explicit_coo.cartesian.xyz, from_coo.cartesian.xyz, rtol=1e-10)
+
+    # Confirm that the loopback matches the explicit transformation
+    assert_allclose(explicit_coo.cartesian.xyz, implicit_coo.cartesian.xyz, rtol=1e-10)
+
+
 @pytest.mark.remote_data
 def test_earth_orientation_table(monkeypatch):
     """Check that we can set the IERS table used as Earth Reference.

--- a/astropy/coordinates/tests/test_intermediate_transformations.py
+++ b/astropy/coordinates/tests/test_intermediate_transformations.py
@@ -347,6 +347,27 @@ def test_precessed_geocentric():
     assert_allclose(gcrs_coo.distance, gcrs2_roundtrip.distance)
 
 
+def test_precessed_geocentric_different_obstime():
+    # Create two PrecessedGeocentric frames with different obstime
+    precessedgeo1 = PrecessedGeocentric(obstime='2021-09-07')
+    precessedgeo2 = PrecessedGeocentric(obstime='2021-06-07')
+
+    # GCRS->PrecessedGeocentric should give different results for the two frames
+    gcrs_coord = GCRS(10*u.deg, 20*u.deg, 3*u.AU, obstime=precessedgeo1.obstime)
+    pg_coord1 = gcrs_coord.transform_to(precessedgeo1)
+    pg_coord2 = gcrs_coord.transform_to(precessedgeo2)
+    assert not pg_coord1.is_equivalent_frame(pg_coord2)
+    assert not allclose(pg_coord1.cartesian.xyz, pg_coord2.cartesian.xyz)
+
+    # Looping back to GCRS should return the original coordinate
+    loopback1 = pg_coord1.transform_to(gcrs_coord)
+    loopback2 = pg_coord2.transform_to(gcrs_coord)
+    assert loopback1.is_equivalent_frame(gcrs_coord)
+    assert loopback2.is_equivalent_frame(gcrs_coord)
+    assert_allclose(loopback1.cartesian.xyz, gcrs_coord.cartesian.xyz)
+    assert_allclose(loopback2.cartesian.xyz, gcrs_coord.cartesian.xyz)
+
+
 # shared by parametrized tests below.  Some use the whole AltAz, others use just obstime
 totest_frames = [AltAz(location=EarthLocation(-90*u.deg, 65*u.deg),
                        obstime=Time('J2000')),  # J2000 is often a default so this might work when others don't

--- a/docs/changes/coordinates/12152.bugfix.1.rst
+++ b/docs/changes/coordinates/12152.bugfix.1.rst
@@ -1,0 +1,2 @@
+Fixed a bug with the transformation from ``PrecessedGeocentric`` to ``GCRS`` where changes in ``obstime``, ``obsgeoloc``, or ``obsgeovel`` were ignored.
+This bug would also affect loopback transformations from one ``PrecessedGeocentric`` frame to another ``PrecessedGeocentric`` frame.

--- a/docs/changes/coordinates/12152.bugfix.2.rst
+++ b/docs/changes/coordinates/12152.bugfix.2.rst
@@ -1,0 +1,1 @@
+Fixed a bug with the transformations between ``TEME`` and ``ITRS`` or between ``TEME`` and itself where a change in ``obstime`` was ignored.


### PR DESCRIPTION
These fixes are pulled out of #10909 because they should be backported:

- The `PrecessedGeocentric`->`GCRS` transformation mistakenly ignores any change in `obstime`/`obsgeoloc`/`obsgeovel`.
- The `TEME`<->`ITRS` transformations mistakenly ignore any change in `obstime` because they are written assuming the existence of an explicit `TEME`<->`TEME` loopback.  The straightforward way to write the `TEME`<->`TEME` loopback is to loop through `ITRS`, so this PR implements the `TEME`<->`ITRS` transformations without needing a `TEME`<->`TEME` loopback.