### PR TITLE
Get wcslib-7.7 from bullseye-backports for non-x86 CI tests

### DIFF
--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -104,6 +104,7 @@ jobs:
           shell: /bin/bash
 
           install: |
+            echo "deb http://deb.debian.org/debian bullseye-backports main" >> /etc/apt/sources.list
             apt-get update -q -y
             apt-get install -q -y git \
                                   g++ \
@@ -114,7 +115,8 @@ jobs:
                                   python3-ply \
                                   python3-venv \
                                   cython3 \
-                                  wcslib-dev \
+                                  libwcs7/bullseye-backports \
+                                  wcslib-dev/bullseye-backports \
                                   libcfitsio-dev \
                                   liberfa1
 


### PR DESCRIPTION
### Description

wcslib backports are now [built on many platforms](https://buildd.debian.org/status/logs.php?pkg=wcslib&ver=7.7%2Bds-1%7Ebpo11%2B1&suite=bullseye-backports) (except for MIPS, which is not used here, right?). This PR installs this wcslib on the weekly (non-x86) CI tests, like 0ff2f4f4bb2493195df42a674f349a8e8fa16edf.

Fixes #12144 

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
