### PR TITLE
Cosmo: process array-like inputs

### DIFF
--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -9,7 +9,6 @@ import numpy as np
 
 import astropy.units as u
 from astropy.io.registry import UnifiedReadWriteMethod
-from astropy.utils import isiterable
 from astropy.utils.decorators import classproperty
 from astropy.utils.metadata import MetaData
 

--- a/astropy/cosmology/funcs.py
+++ b/astropy/cosmology/funcs.py
@@ -41,13 +41,13 @@ def _z_at_scalar_value(func, fval, zmin=1e-8, zmax=1000, ztol=1e-8, maxfun=500,
     # guarantee it has a unique solution, but for Standard Cosmological
     # quantities normally should (being monotonic or having a single extremum).
     # In these cases keep solver from returning solutions outside of bracket.
-    fval_zmin, fval_zmax = func((zmin, zmax))
+    fval_zmin, fval_zmax = func(zmin), func(zmax)
     nobracket = False
     if np.sign(fval - fval_zmin) != np.sign(fval_zmax - fval):
         if bracket is None:
             nobracket = True
         else:
-            fval_brac = func(bracket)
+            fval_brac = func(np.asanyarray(bracket))
             if np.sign(fval - fval_brac[0]) != np.sign(fval_brac[-1] - fval):
                 nobracket = True
             else:

--- a/astropy/cosmology/tests/test_cosmology.py
+++ b/astropy/cosmology/tests/test_cosmology.py
@@ -12,7 +12,8 @@ from astropy.cosmology import Cosmology, flrw, funcs
 from astropy.cosmology.realizations import Planck13, Planck18, default_cosmology
 from astropy.units import allclose
 from astropy.utils.compat.optional_deps import HAS_SCIPY
-from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyUserWarning
+from astropy.utils.exceptions import (AstropyDeprecationWarning,
+                                      AstropyUserWarning)
 
 
 def test_flrw_moved_deprecation():

--- a/astropy/cosmology/utils.py
+++ b/astropy/cosmology/utils.py
@@ -1,10 +1,14 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 from math import inf
+from numbers import Number
 
 import numpy as np
 
+from astropy.units import Quantity
 from astropy.utils import isiterable
+
+from . import units as cu
 
 __all__ = []  # nothing is publicly scoped
 
@@ -63,3 +67,18 @@ def inf_like(x):
     array([inf, inf, inf, inf])
     """
     return inf if np.isscalar(x) else np.full_like(x, inf, dtype=float)
+
+
+def aszarr(z):
+    """
+    Redshift as a `~numbers.Number` or `~numpy.ndarray` / |Quantity|.
+    Allows for any ndarray ducktype by checking for attribute "shape".
+    """
+    if isinstance(z, Number):
+        return z
+    elif hasattr(z, "shape"):
+        if hasattr(z, "unit"):  # Quantity
+            return z.to_value(cu.redshift)
+        return z
+    # not one of the preferred types: Number / array ducktype
+    return Quantity(z, cu.redshift).value

--- a/docs/cosmology/index.rst
+++ b/docs/cosmology/index.rst
@@ -66,8 +66,9 @@ redshifts as input:
 
 .. doctest-requires:: scipy
 
+  >>> import numpy as np
   >>> from astropy.cosmology import WMAP9 as cosmo
-  >>> cosmo.comoving_distance([0.5, 1.0, 1.5])  # doctest: +FLOAT_CMP
+  >>> cosmo.comoving_distance(np.array([0.5, 1.0, 1.5]))  # doctest: +FLOAT_CMP
   <Quantity [1916.06941724, 3363.07062107, 4451.7475201 ] Mpc>
 
 You can create your own FLRW-like cosmology using one of the cosmology
@@ -166,8 +167,9 @@ They also accept arrays of redshifts:
 
 .. doctest-requires:: scipy
 
-  >>> cosmo.age([0.5, 1, 1.5]).value  # doctest: +FLOAT_CMP
-  array([8.42128013, 5.74698021, 4.19645373])
+  >>> import astropy.cosmology.units as cu
+  >>> cosmo.age([0.5, 1, 1.5] * cu.redshift)  # doctest: +FLOAT_CMP
+  <Quantity [8.42128013, 5.74698021, 4.19645373] Gyr>
 
 See the `~astropy.cosmology.FLRW` and
 `~astropy.cosmology.FlatLambdaCDM` object docstring for all of the
@@ -191,10 +193,12 @@ parameters already defined are also available
 
 You can see how the density parameters evolve with redshift as well::
 
+  >>> import numpy as np
   >>> from astropy.cosmology import WMAP7   # WMAP 7-year cosmology
-  >>> WMAP7.Om([0, 1.0, 2.0]), WMAP7.Ode([0., 1.0, 2.0])  # doctest: +FLOAT_CMP
-  (array([0.272     , 0.74898522, 0.90905234]),
-   array([0.72791572, 0.2505506 , 0.0901026 ]))
+  >>> WMAP7.Om(np.array([0, 1.0, 2.0]))  # doctest: +FLOAT_CMP
+  array([0.272     , 0.74898522, 0.90905234])
+  >>> WMAP7.Ode(np.array([0., 1.0, 2.0]))  # doctest: +FLOAT_CMP
+  array([0.72791572, 0.2505506 , 0.0901026 ])
 
 Note that these do not quite add up to one, even though WMAP7 assumes a
 flat universe, because photons and neutrinos are included. Also note
@@ -421,7 +425,7 @@ can be found as a function of redshift::
   >>> from astropy.cosmology import WMAP7   # WMAP 7-year cosmology
   >>> WMAP7.Ogamma0, WMAP7.Onu0  # Current epoch values  # doctest: +FLOAT_CMP
   (4.985694972799396e-05, 3.442154948307989e-05)
-  >>> z = [0, 1.0, 2.0]
+  >>> z = np.array([0, 1.0, 2.0])
   >>> WMAP7.Ogamma(z), WMAP7.Onu(z)  # doctest: +FLOAT_CMP
   (array([4.98603986e-05, 2.74593395e-04, 4.99915942e-04]),
    array([3.44239306e-05, 1.89580995e-04, 3.45145089e-04]))
@@ -441,9 +445,9 @@ Universe) but setting ``Neff`` to 0::
 
   >>> from astropy.cosmology import FlatLambdaCDM
   >>> cos = FlatLambdaCDM(70.4, 0.272, Tcmb0=2.725, Neff=0)
-  >>> cos.Ogamma([0, 1, 2])  # Photons are still present  # doctest: +FLOAT_CMP
+  >>> cos.Ogamma(np.array([0, 1, 2]))  # Photons are still present  # doctest: +FLOAT_CMP
   array([4.98603986e-05, 2.74642208e-04, 5.00086413e-04])
-  >>> cos.Onu([0, 1, 2])  # But not neutrinos  # doctest: +FLOAT_CMP
+  >>> cos.Onu(np.array([0, 1, 2]))  # But not neutrinos  # doctest: +FLOAT_CMP
   array([0., 0., 0.])
 
 The number of neutrino species is assumed to be the floor of ``Neff``,
@@ -469,7 +473,7 @@ value is provided, all of the species are assumed to have the same mass.
   True
   >>> cosmo.m_nu  # doctest: +FLOAT_CMP
   <Quantity [0.  , 0.05, 0.1 ] eV>
-  >>> cosmo.Onu([0, 1.0, 15.0])  # doctest: +FLOAT_CMP
+  >>> cosmo.Onu(np.array([0, 1.0, 15.0]))  # doctest: +FLOAT_CMP
   array([0.00327011, 0.00896845, 0.01257946])
   >>> cosmo.Onu(1) * cosmo.critical_density(1)  # doctest: +FLOAT_CMP
   <Quantity 2.444380380370406e-31 g / cm3>


### PR DESCRIPTION
Summary:

The preferred input types to Cosmology methods are 1) numbers (e.g. float) and 2) ndarray / Quantity / ndarray ducktypes.
All other input types are converted to an ndarray.

Also did ``1 + z`` -> ``z + 1`` to avoid ``int.__add__`` failure triggering ``int.__radd__``. Now it starts with the passing ``ndarray.__add__``.

Motivation:
speed, simplicity, supporting ducktypes, and eventual vectorization.


### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
