### PR TITLE
Remove the `overwrite=None` option for `ascii.write()`

### DIFF
--- a/astropy/io/ascii/docs.py
+++ b/astropy/io/ascii/docs.py
@@ -160,12 +160,9 @@ WRITE_DOCSTRING = """
         if available), `False` (do not use fast writer), or ``'force'`` (use
         fast writer and fail if not available, mostly for testing).
     overwrite : bool
-        If ``overwrite=None`` (default) and the file exists, then a
-        warning will be issued. In a future release this will instead
-        generate an exception. If ``overwrite=False`` and the file
-        exists, then an exception is raised.
-        This parameter is ignored when the ``output`` arg is not a string
-        (e.g., a file object).
+        If ``overwrite=False`` (default) and the file exists, then an OSError
+        is raised. This parameter is ignored when the ``output`` arg is not a
+        string (e.g., a file object).
 
     """
 # Specify allowed types for core write() keyword arguments.  Each entry

--- a/astropy/io/ascii/tests/test_write.py
+++ b/astropy/io/ascii/tests/test_write.py
@@ -12,7 +12,7 @@ import numpy as np
 from astropy.io import ascii
 from astropy import table
 from astropy.table.table_helpers import simple_table
-from astropy.utils.exceptions import AstropyWarning, AstropyDeprecationWarning
+from astropy.utils.exceptions import AstropyWarning
 from astropy.utils.compat.optional_deps import HAS_BS4
 from astropy import units as u
 
@@ -694,24 +694,14 @@ def test_write_overwrite_ascii(format, fast_writer, tmpdir):
     t = table.Table([['Hello', ''], ['', '']], dtype=['S10', 'S10'])
 
     with pytest.raises(OSError) as err:
-        t.write(filename, overwrite=False, format=format,
-                fast_writer=fast_writer)
-    assert str(err.value).endswith('already exists')
-
-    with pytest.warns(
-            AstropyDeprecationWarning,
-            match=r".* Automatically overwriting ASCII files is deprecated. "
-            "Use the argument 'overwrite=True' in the future.") as warning:
         t.write(filename, format=format, fast_writer=fast_writer)
-    assert len(warning) == 1
+    assert str(err.value).endswith('already exists')
 
     t.write(filename, overwrite=True, format=format,
             fast_writer=fast_writer)
 
     # If the output is a file object, overwrite is ignored
     with open(filename, 'w') as fp:
-        t.write(fp, format=format,
-                fast_writer=fast_writer)
         t.write(fp, overwrite=False, format=format,
                 fast_writer=fast_writer)
         t.write(fp, overwrite=True, format=format,

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -38,7 +38,7 @@ from .docs import READ_KWARG_TYPES, WRITE_KWARG_TYPES
 
 from astropy.table import Table, MaskedColumn
 from astropy.utils.data import get_readable_fileobj
-from astropy.utils.exceptions import AstropyWarning, AstropyDeprecationWarning
+from astropy.utils.exceptions import AstropyWarning
 
 _read_trace = []
 
@@ -782,22 +782,15 @@ def get_writer(Writer=None, fast_writer=True, **kwargs):
 
 
 def write(table, output=None, format=None, Writer=None, fast_writer=True, *,
-          overwrite=None, **kwargs):
+          overwrite=False, **kwargs):
     # Docstring inserted below
 
     _validate_read_write_kwargs('write', format=format, fast_writer=fast_writer,
                                 overwrite=overwrite, **kwargs)
 
     if isinstance(output, str):
-        if os.path.lexists(output):
-            if overwrite is None:
-                warnings.warn(
-                    "{} already exists. "
-                    "Automatically overwriting ASCII files is deprecated. "
-                    "Use the argument 'overwrite=True' in the future.".format(
-                        output), AstropyDeprecationWarning)
-            elif not overwrite:
-                raise OSError(f"{output} already exists")
+        if not overwrite and os.path.lexists(output):
+            raise OSError(f"{output} already exists")
 
     if output is None:
         output = sys.stdout

--- a/docs/changes/io.ascii/12171.api.rst
+++ b/docs/changes/io.ascii/12171.api.rst
@@ -1,0 +1,3 @@
+Removed deprecated ``overwrite=None`` option for
+``astropy.io.ascii.ui.write()``. Overwriting existing files now only happens if
+``overwrite=True``.


### PR DESCRIPTION
### Description

It has been deprecated since #5007. Replacing an already existing file now only happens if `overwrite=True`.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
