### PR TITLE
cosmo: deprecate `inf_like`

### DIFF
--- a/astropy/cosmology/flrw.py
+++ b/astropy/cosmology/flrw.py
@@ -2,7 +2,7 @@
 
 import warnings
 from abc import abstractmethod
-from math import acos, cos, exp, floor, log, pi, sin, sqrt
+from math import acos, cos, exp, floor, inf, log, pi, sin, sqrt
 from numbers import Number
 
 import numpy as np
@@ -16,7 +16,7 @@ from astropy.utils.exceptions import AstropyUserWarning
 from . import scalar_inv_efuncs
 from . import units as cu
 from .core import Cosmology, FlatCosmologyMixin, Parameter
-from .utils import inf_like, vectorize_if_needed, aszarr
+from .utils import vectorize_if_needed, aszarr
 
 # isort: split
 if HAS_SCIPY:
@@ -1822,7 +1822,8 @@ class LambdaCDM(FLRW):
         t : `~astropy.units.Quantity` ['time']
             The age of the universe in Gyr at each input redshift.
         """
-        return self._hubble_time * inf_like(z)
+        t = (inf if isinstance(z, Number) else np.full_like(z, inf, dtype=float))
+        return self._hubble_time * t
 
     def _EdS_age(self, z):
         r"""Age of the universe in Gyr at redshift ``z``.

--- a/astropy/cosmology/tests/test_utils.py
+++ b/astropy/cosmology/tests/test_utils.py
@@ -7,6 +7,7 @@ import pytest
 import numpy as np
 
 from astropy.cosmology.utils import inf_like, vectorize_if_needed
+from astropy.utils.exceptions import AstropyDeprecationWarning
 
 
 def test_vectorize_if_needed():
@@ -38,4 +39,5 @@ def test_inf_like(arr, expected):
     These tests are also in the docstring, but it's better to have them also
     in one consolidated location.
     """
-    assert np.all(inf_like(arr) == expected)
+    with pytest.warns(AstropyDeprecationWarning):
+        assert np.all(inf_like(arr) == expected)

--- a/astropy/cosmology/utils.py
+++ b/astropy/cosmology/utils.py
@@ -40,7 +40,11 @@ def vectorize_if_needed(f, *x, **vkw):
     return np.vectorize(f, **vkw)(*x) if any(map(isiterable, x)) else f(*x)
 
 
-@deprecated("5.0")
+@deprecated(
+    since="5.0",
+    message="inf_like has been removed because it duplicates functionality provided by numpy.full_like()",
+    alternative="Use numpy.full_like(z, numpy.inf) instead for a target array 'z'"
+)
 def inf_like(x):
     """Return the shape of x with value infinity and dtype='float'.
 

--- a/astropy/cosmology/utils.py
+++ b/astropy/cosmology/utils.py
@@ -7,10 +7,13 @@ import numpy as np
 
 from astropy.units import Quantity
 from astropy.utils import isiterable
+from astropy.utils.decorators import deprecated
 
 from . import units as cu
 
 __all__ = []  # nothing is publicly scoped
+
+__doctest_skip__ = ["inf_like"]
 
 
 def vectorize_if_needed(f, *x, **vkw):
@@ -37,6 +40,7 @@ def vectorize_if_needed(f, *x, **vkw):
     return np.vectorize(f, **vkw)(*x) if any(map(isiterable, x)) else f(*x)
 
 
+@deprecated("5.0")
 def inf_like(x):
     """Return the shape of x with value infinity and dtype='float'.
 

--- a/docs/changes/cosmology/12175.api.rst
+++ b/docs/changes/cosmology/12175.api.rst
@@ -1,0 +1,1 @@
+The function ``astropy.cosmology.utils.inf_like()`` is deprecated.


### PR DESCRIPTION
It's not public and used only once. I just moved the code into the one function that used ``inf_like``

Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>


### Checklist for package maintainer(s)

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
