### PR TITLE
Fixing flawed bounding box tests and skipped modeling tests

### DIFF
--- a/astropy/modeling/tests/example_models.py
+++ b/astropy/modeling/tests/example_models.py
@@ -71,7 +71,8 @@ models_1D = {
         'x_values': [0, np.sqrt(2), -np.sqrt(2)],
         'y_values': [1.0, 0.367879, 0.367879],
         'x_lim': [-10, 10],
-        'integral': np.sqrt(2 * np.pi)
+        'integral': np.sqrt(2 * np.pi),
+        'bbox_peak': True
     },
 
     Sine1D: {
@@ -87,7 +88,8 @@ models_1D = {
         'x_values': [-5, 5, 0, -10, 10],
         'y_values': [1, 1, 1, 0, 0],
         'x_lim': [-10, 10],
-        'integral': 10
+        'integral': 10,
+        'bbox_peak': True
     },
 
     Linear1D: {
@@ -103,7 +105,8 @@ models_1D = {
         'x_values': [0, -1, 1, 0.5, -0.5],
         'y_values': [1., 0.2, 0.2, 0.5, 0.5],
         'x_lim': [-10, 10],
-        'integral': 1
+        'integral': 1,
+        'bbox_peak': True
     },
 
     RickerWavelet1D: {
@@ -111,7 +114,8 @@ models_1D = {
         'x_values': [0, 1, -1, 3, -3],
         'y_values': [1.0, 0.0, 0.0, -0.088872, -0.088872],
         'x_lim': [-20, 20],
-        'integral': 0
+        'integral': 0,
+        'bbox_peak': True
     },
 
     Trapezoid1D: {
@@ -119,7 +123,8 @@ models_1D = {
         'x_values': [0, 1, -1, 1.5, -1.5, 2, 2],
         'y_values': [1, 1, 1, 0.5, 0.5, 0, 0],
         'x_lim': [-10, 10],
-        'integral': 3
+        'integral': 3,
+        'bbox_peak': True
     },
 
     Const1D: {
@@ -219,6 +224,7 @@ models_1D = {
         'y_values': [0.30557281, 0.30011069, 0.2, 0.1113258],
         'x_lim': [0, 10],
         'y_lim': [0, 10],
+        'bbox_peak': True
     },
 
     Drude1D: {
@@ -226,7 +232,8 @@ models_1D = {
         'x_values': [7.0, 8.0, 9.0, 10.0],
         'y_values': [0.17883212, 1.0, 0.21891892, 0.07163324],
         'x_lim': [1.0, 20.0],
-        'y_lim': [0.0, 10.0]
+        'y_lim': [0.0, 10.0],
+        'bbox_peak': True
     },
 
     Plummer1D: {
@@ -266,7 +273,8 @@ models_2D = {
         'y_lim': [-10, 10],
         'integral': 2 * np.pi,
         'deriv_parameters': [137., 5.1, 5.4, 1.5, 2., np.pi/4],
-        'deriv_initial': [10, 5, 5, 4, 4, .5]
+        'deriv_initial': [10, 5, 5, 4, 4, .5],
+        'bbox_peak': True
     },
 
     Const2D: {
@@ -286,7 +294,8 @@ models_2D = {
         'z_values': [1, 1, 1, 1, 1, 0, 0],
         'x_lim': [-10, 10],
         'y_lim': [-10, 10],
-        'integral': 100
+        'integral': 100,
+        'bbox_peak': True
     },
 
     RickerWavelet2D: {
@@ -306,7 +315,8 @@ models_2D = {
         'y_values': [0, 0.5, 1.5, 0],
         'z_values': [1, 1, 0.5, 0.5],
         'x_lim': [-3, 3],
-        'y_lim': [-3, 3]
+        'y_lim': [-3, 3],
+        'bbox_peak': True
     },
 
     AiryDisk2D: {
@@ -344,7 +354,8 @@ models_2D = {
         'z_values': [0, 0, 1, 1, 1, 0, 0],
         'x_lim': [-10, 10],
         'y_lim': [-10, 10],
-        'integral': np.pi * 5 ** 2
+        'integral': np.pi * 5 ** 2,
+        'bbox_peak': True
     },
 
     Ring2D: {
@@ -354,7 +365,8 @@ models_2D = {
         'z_values': [1, 1, 1, 1, 0, 0, 0],
         'x_lim': [-10, 10],
         'y_lim': [-10, 10],
-        'integral': np.pi * (10 ** 2 - 5 ** 2)
+        'integral': np.pi * (10 ** 2 - 5 ** 2),
+        'bbox_peak': True
     },
 
     Sersic2D: {

--- a/astropy/modeling/tests/test_models.py
+++ b/astropy/modeling/tests/test_models.py
@@ -280,10 +280,8 @@ class Fittable2DModelTester:
         x_lim = test_parameters['x_lim']
         y_lim = test_parameters['y_lim']
 
-        if model_class.fit_deriv is None:
-            pytest.skip("Derivative function is not defined for model.")
-        if issubclass(model_class, PolynomialBase):
-            pytest.skip("Skip testing derivative of polynomials.")
+        if model_class.fit_deriv is None or issubclass(model_class, PolynomialBase):
+            return
 
         if "log_fit" in test_parameters:
             if test_parameters['log_fit']:
@@ -473,10 +471,8 @@ class Fittable1DModelTester:
 
         x_lim = test_parameters['x_lim']
 
-        if model_class.fit_deriv is None:
-            pytest.skip("Derivative function is not defined for model.")
-        if issubclass(model_class, PolynomialBase):
-            pytest.skip("Skip testing derivative of polynomials.")
+        if model_class.fit_deriv is None or issubclass(model_class, PolynomialBase):
+            return
 
         if "log_fit" in test_parameters:
             if test_parameters['log_fit']:

--- a/astropy/modeling/tests/test_polynomial.py
+++ b/astropy/modeling/tests/test_polynomial.py
@@ -235,8 +235,7 @@ class TestFitting:
 
 
 @pytest.mark.parametrize('model_class',
-                         [cls for cls in list(linear1d) + list(linear2d)
-                          if isinstance(cls, PolynomialBase)])
+                         [cls for cls in list(linear1d) + list(linear2d)])
 def test_polynomial_init_with_constraints(model_class):
     """
     Test that polynomial models can be instantiated with constraints, but no
@@ -252,6 +251,9 @@ def test_polynomial_init_with_constraints(model_class):
         param = 'c0'
     else:
         param = 'c0_0'
+
+    if issubclass(model_class, Linear1D):
+        param = 'intercept'
 
     if issubclass(model_class, OrthoPolynomialBase):
         degree = (2, 2)


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

As pointed out in issue #12182 the bounding box tests being performed were not testing bounding boxes properly. Instead those tests were testing that the "peak" described by the bounding box accounted for > 1% of the integral of the model (checking that integration over the bounding box accounted for most of the area). Conceptually this is not what the bounding box was intended to do, instead it was meant to filter out "bad" input values, e.g. points outside the domain of the model.

This refactors the bounding box test into two tests. One which tests the bounding box as a domain for which values are tested as in or outside, and an additional test which tests the peak property that was originally tested for only for models which where actually being tested for this peak property. This means that adding models with bounding boxes that fail to have the peak property (such as those whose bounding box describes the entire domain of the model, causing the peak property test) will no longer create a mysterious test failure.

Note that this PR also fixes how `astropy/modeling/tests/test_models.py` was handling tests of properties for models that do not have them. Before, the test was being marked as skipped. I do not believe this should be the case the model implicitly should pass those tests rather than listing a test which will always be marked down as skipped.

Finally, while looking at skipped tests throughout `astropy.modeling` I noticed that a polynomial test was being skipped due to a malformed test parameterization, which caused an empty list of test parameters to be passed to the test. I resolved this issue so that the test would become useful once again.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #12182

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
