### PR TITLE
Cosmo: validating and setting Parameters

### DIFF
--- a/astropy/cosmology/__init__.py
+++ b/astropy/cosmology/__init__.py
@@ -8,16 +8,17 @@ detailed usage examples and references.
 
 """
 
-from . import core, flrw, funcs, units, utils
+from . import core, flrw, funcs, parameter, units, utils
 
 from . import io  # needed before 'realizations'  # isort: split
 from . import realizations
 from .core import *
 from .flrw import *
 from .funcs import *
+from .parameter import Parameter
 from .realizations import *
 from .utils import *
 
 __all__ = (core.__all__ + flrw.__all__       # cosmology classes
            + realizations.__all__            # instances thereof
-           + funcs.__all__ + utils.__all__)  # utils
+           + funcs.__all__ + parameter.__all__ + utils.__all__)  # utils

--- a/astropy/cosmology/__init__.py
+++ b/astropy/cosmology/__init__.py
@@ -15,7 +15,7 @@ from . import realizations
 from .core import *
 from .flrw import *
 from .funcs import *
-from .parameter import Parameter
+from .parameter import *
 from .realizations import *
 from .utils import *
 

--- a/astropy/cosmology/connect.py
+++ b/astropy/cosmology/connect.py
@@ -3,7 +3,9 @@
 import copy
 import warnings
 
+from astropy.cosmology import units as cu
 from astropy.io import registry as io_registry
+from astropy.units import add_enabled_units
 from astropy.utils.exceptions import AstropyUserWarning
 
 __all__ = ["CosmologyRead", "CosmologyWrite",
@@ -87,7 +89,9 @@ class CosmologyRead(io_registry.UnifiedReadWrite):
                     "keyword argument `cosmology` must be either the class "
                     f"{valid[0]} or its qualified name '{valid[1]}'")
 
-        cosmo = self.registry.read(self._cls, *args, **kwargs)
+        with add_enabled_units(cu):
+            cosmo = self.registry.read(self._cls, *args, **kwargs)
+
         return cosmo
 
 

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import abc
-import copy
 import functools
 import inspect
 from types import FunctionType, MappingProxyType
@@ -14,6 +13,7 @@ from astropy.utils.decorators import classproperty
 from astropy.utils.metadata import MetaData
 
 from .connect import CosmologyFromFormat, CosmologyRead, CosmologyToFormat, CosmologyWrite
+from .parameter import Parameter
 
 # Originally authored by Andrew Becker (becker@astro.washington.edu),
 # and modified by Neil Crighton (neilcrighton@gmail.com), Roban Kramer
@@ -22,7 +22,7 @@ from .connect import CosmologyFromFormat, CosmologyRead, CosmologyToFormat, Cosm
 # Many of these adapted from Hogg 1999, astro-ph/9905116
 # and Linder 2003, PRL 90, 91301
 
-__all__ = ["Cosmology", "CosmologyError", "FlatCosmologyMixin", "Parameter"]
+__all__ = ["Cosmology", "CosmologyError", "FlatCosmologyMixin"]
 
 __doctest_requires__ = {}  # needed until __getattr__ removed
 
@@ -32,274 +32,6 @@ _COSMOLOGY_CLASSES = dict()
 
 class CosmologyError(Exception):
     pass
-
-
-class Parameter(property):
-    r"""Cosmological parameter (descriptor).
-
-    Should only be used with a :class:`~astropy.cosmology.Cosmology` subclass.
-
-    Parameters
-    ----------
-    fget : callable[[type], Any] or None, optional
-        Function to get the value from instances of the cosmology class.
-        If None (default) returns the corresponding private attribute.
-        Often not set here, but as a decorator with ``getter``.
-    fset : callable[[object, object, Any], Any] or {'default', 'float'}, optional
-        Function to validate the Parameter value from instances of the
-        cosmology class. If "default", uses default setter to assign units
-        (with equivalencies), if Parameter has units. If "float" will first do
-        units, then take the float value.
-        Often not set here, but as a decorator with ``setter``.
-        See ``Parameter._default_setter`` for an example.
-    doc : str or None, optional
-        Parameter description. If 'doc' is None and 'fget' is not, then 'doc'
-        is taken from ``fget.__doc__``.
-    unit : unit-like or None (optional, keyword-only)
-        The `~astropy.units.Unit` for the Parameter. If None (default) no
-        unit as assumed.
-    equivalencies : `~astropy.units.Equivalency` or sequence thereof
-        Unit equivalencies for this Parameter.
-    fmt : str (optional, keyword-only)
-        `format` specification, used when making string representation
-        of the containing Cosmology.
-        See https://docs.python.org/3/library/string.html#formatspec
-
-    fixed : bool (optional, keyword-only)
-        Whether the Parameter is fixed/'derived', default `False`.
-        Fixed parameters behave similarly to normal parameters, but are not
-        sorted by the |Cosmology| signature (probably not there) and are not
-        included in all methods. For reference, see ``Ode0`` in
-        ``FlatFLRWMixin``, which removes :math:`\Omega_{de,0}`` as an
-        independent parameter (:math:`\Omega_{de,0} \equiv 1 - \Omega_{tot}`).
-
-        Note this is NOT the same as a fixed `~astropy.modeling.Parameter`.
-        To set ``fixed`` if converting a |Cosmology| to a
-        `~astropy.modeling.Model`, set
-        ``cosmology_instance.meta[<param name>] = dict(fixed=True, ...)``.
-
-    Examples
-    --------
-    The most common use case of ``Parameter`` is to access the corresponding
-    private attribute.
-
-        >>> from astropy.cosmology import LambdaCDM
-        >>> from astropy.cosmology.core import Parameter
-        >>> class Example1(LambdaCDM):
-        ...     param = Parameter(doc="example parameter", unit=u.m)
-        ...     def __init__(self, param=15 * u.m):
-        ...         super().__init__(70, 0.3, 0.7)
-        ...         self._param = param << self.__class__.param.unit
-        >>> Example1.param
-        <Parameter 'param' at ...
-        >>> Example1.param.unit
-        Unit("m")
-
-        >>> ex = Example1(param=12357)
-        >>> ex.param
-        <Quantity 12357. m>
-
-    ``Parameter`` also supports custom ``setter`` methods.
-    :attr:`~astropy.cosmology.FLRW.m_nu` is a good example for the former.
-
-        >>> import astropy.units as u
-        >>> class Example2(LambdaCDM):
-        ...     param = Parameter(doc="example parameter", unit="m")
-        ...     def __init__(self, param=15):
-        ...         super().__init__(70, 0.3, 0.7)
-        ...         self.param = param
-        ...     @param.setter
-        ...     def param(self, param, value):
-        ...         return (value << param.unit).to(u.km)
-
-        >>> ex2 = Example2(param=12357)
-        >>> ex2.param
-        <Quantity 12.357 km>
-
-    .. doctest::
-       :hide:
-
-       >>> from astropy.cosmology.core import _COSMOLOGY_CLASSES
-       >>> _ = _COSMOLOGY_CLASSES.pop(Example1.__qualname__)
-       >>> _ = _COSMOLOGY_CLASSES.pop(Example2.__qualname__)
-    """
-
-    def __init__(self, fget=None, fset="default", doc=None, *,
-                 unit=None, equivalencies=[], fmt=".3g", fixed=False):
-        # parse registered fset
-        if callable(fset):
-            pass
-        elif fset == "default":
-            fset = self._default_setter
-        elif fset == "float":
-            fset = self._set_to_float
-        elif fset == "scalar":
-            fset = self._set_to_scalar
-        elif isinstance(fset, str):
-            raise ValueError("fset if str, must be in {'default', 'float'}")
-        else:
-            raise TypeError("fset must be a function or {'default', 'float'}")
-
-        # modeled after https://docs.python.org/3/howto/descriptor.html#properties
-        super().__init__(fget=fget if not hasattr(fget, "fget") else fget.__get__,
-                         fset=self._default_setter if fset is None else fset)
-        # TODO! better detection if `fget` is a descriptor.
-        # Note: setting here b/c @propert(doc=) is broken in subclasses
-        self.__doc__ = fget.__doc__ if (doc is None and fget is not None) else doc
-
-        # units stuff
-        self._unit = u.Unit(unit) if unit is not None else None
-        self._equivalencies = equivalencies
-
-        # misc
-        self._fmt = str(fmt)
-        self._fixed = fixed
-
-        # nested descriptor decorator compatibility
-        self.__wrapped__ = fget  # so always have access to `fget`
-        self.__name__ = getattr(fget, "__name__", None)  # compat with other descriptors
-
-    def __set_name__(self, cosmo_cls, name):
-        # attribute name
-        self._attr_name = name
-        self._attr_name_private = "_" + name
-
-        # update __name__, if not already set
-        self.__name__ = self.__name__ or name
-
-    @property
-    def name(self):
-        """Parameter name."""
-        return self._attr_name
-
-    @property
-    def unit(self):
-        """Parameter unit."""
-        return self._unit
-
-    @property
-    def equivalencies(self):
-        """Equivalencies used when initializing Parameter."""
-        return self._equivalencies
-
-    @property
-    def format_spec(self):
-        """String format specification."""
-        return self._fmt
-
-    @property
-    def fixed(self):
-        """Whether the Parameter is fixed; true parameters are not."""
-        return self._fixed
-
-    # -------------------------------------------
-    # 'property' descriptor overrides
-
-    def getter(self, fget):
-        raise AttributeError("can't create custom Parameter getter.")
-
-    def setter(self, fset):
-        """Make new Parameter with custom ``fset``.
-
-        Note: ``Parameter.setter`` must be the top-most descriptor decorator.
-
-        Parameters
-        ----------
-        fset : callable[[type, type, Any], Any]
-
-        Returns
-        -------
-        `~astropy.cosmology.Parameter`
-            Copy of this Parameter but with custom ``fset``.
-        """
-        desc = type(self)(fget=self.fget, fset=fset,
-                          doc=self.__doc__, fmt=self.format_spec,
-                          unit=self.unit, equivalencies=self.equivalencies,
-                          fixed=self.fixed)
-        # TODO? need to override __wrapped__?
-        return desc
-
-    def deleter(self, fdel):
-        raise AttributeError("can't create custom Parameter deleter.")
-
-    # -------------------------------------------
-    # descriptor methods
-
-    def __get__(self, cosmology, cosmo_cls=None):
-        # get from class
-        if cosmology is None:
-            return self
-        return getattr(cosmology, self._attr_name_private)
-
-    def __set__(self, cosmology, value):
-        """Allows attribute setting once. Raises AttributeError subsequently.
-
-        .. warning::
-
-           Caution if using a custom ``getter``.
-           can't know if getter draws from ``_attr_name_private``
-
-        """
-        # raise error if setting 2nd time.
-        if hasattr(cosmology, self._attr_name_private):
-            raise AttributeError("can't set attribute")
-
-        # validate value, generally setting units if present
-        value = self.set(cosmology, value)
-        setattr(cosmology, self._attr_name_private, value)
-
-    # -------------------------------------------
-    # set value
-
-    def set(self, cosmology, value):
-        """Run the setter on this Parameter.
-
-        Note this setter doesn't actually set the value, but returns the value
-        that *should* be set.
-
-        Parameters
-        ----------
-        cosmology : `~astropy.cosmology.Cosmology` instance
-        value : Any
-            The object to validate and set.
-
-        Returns
-        -------
-        Any
-            The output of calling ``fset(cosmology, self, value)``
-            (yes, that parameter order).
-        """
-        return self.fset(cosmology, self, value)
-
-    @staticmethod
-    def _default_setter(cosmology, param, value):
-        """
-        Default Parameter value setter.
-        Adds/converts units if Parameter has a unit.
-        """
-        if param.unit is not None:
-            with u.add_enabled_equivalencies(param.equivalencies):
-                value = u.Quantity(value, param.unit)
-        return value
-
-    @staticmethod
-    def _set_to_float(cosmology, param, value):
-        """Parameter value setter with units, and converted to float."""
-        value = param._default_setter(cosmology, param, value)
-        return float(value)
-
-    @staticmethod
-    def _set_to_scalar(cosmology, param, value):
-        """"""
-        value = param._default_setter(cosmology, param, value)
-        if not value.isscalar:
-            raise ValueError(f"{param.name} is a non-scalar quantity")
-        return value
-
-    # -------------------------------------------
-
-    def __repr__(self):
-        return f"<Parameter {self._attr_name!r} at {hex(id(self))}>"
 
 
 class Cosmology(metaclass=abc.ABCMeta):
@@ -363,17 +95,17 @@ class Cosmology(metaclass=abc.ABCMeta):
 
         # Get parameters that are still Parameters, either in this class or above.
         parameters = []
-        fixed_parameters = []
+        derived_parameters = []
         for n in cls.__parameters__:
             p = getattr(cls, n)
             if isinstance(p, Parameter):
-                fixed_parameters.append(n) if p.fixed else parameters.append(n)
+                derived_parameters.append(n) if p.derived else parameters.append(n)
 
         # Add new parameter definitions
         for n, v in cls.__dict__.items():
             if n in parameters or n.startswith("_") or not isinstance(v, Parameter):
                 continue
-            fixed_parameters.append(n) if v.fixed else parameters.append(n)
+            derived_parameters.append(n) if v.derived else parameters.append(n)
 
         # reorder to match signature
         ordered = [parameters.pop(parameters.index(n))
@@ -381,7 +113,7 @@ class Cosmology(metaclass=abc.ABCMeta):
                    if n in parameters]
         parameters = ordered + parameters  # place "unordered" at the end
         cls.__parameters__ = tuple(parameters)
-        cls.__all_parameters__ = cls.__parameters__ + tuple(fixed_parameters)
+        cls.__all_parameters__ = cls.__parameters__ + tuple(derived_parameters)
 
         # -------------------
         # register as a Cosmology subclass

--- a/astropy/cosmology/flrw.py
+++ b/astropy/cosmology/flrw.py
@@ -246,9 +246,8 @@ class FLRW(Cosmology):
             self._Tnu0 = 0.0 * u.K
             self._Onu0 = 0.0
 
-        # now set m_nu Parameter (Note the value is calculated and not
-        # influenced by this value)
-        self.m_nu = m_nu
+        # now set m_nu Parameter (Note the value is calculated by the validator)
+        self.m_nu = ...
 
         # -------------------
 

--- a/astropy/cosmology/flrw.py
+++ b/astropy/cosmology/flrw.py
@@ -127,7 +127,6 @@ class FLRW(Cosmology):
     def __init__(self, H0, Om0, Ode0, Tcmb0=0.0*u.K, Neff=3.04, m_nu=0.0*u.eV,
                  Ob0=None, *, name=None, meta=None):
         super().__init__(name=name, meta=meta)
-        cls = self.__class__
 
         # all densities are in units of the critical density
         self.Om0 = float(Om0)
@@ -187,8 +186,8 @@ class FLRW(Cosmology):
         if self._nneutrinos > 0 and self._Tcmb0.value > 0:
             self._neff_per_nu = self._Neff / self._nneutrinos
 
-            with u.add_enabled_equivalencies(cls.m_nu.equivalencies):
-                m_nu = m_nu << cls.m_nu.unit
+            # validate value to Quantity using equivalencies
+            m_nu = self.__class__.m_nu.validate(self, m_nu)
 
             # Now, figure out if we have massive neutrinos to deal with,
             # and, if so, get the right number of masses
@@ -2794,7 +2793,7 @@ class wpwaCDM(FLRW):
                          m_nu=m_nu, Ob0=Ob0, name=name, meta=meta)
         self.wp = float(wp)
         self.wa = float(wa)
-        self.zp = zp << self.__class__.zp.unit
+        self.zp = zp
 
         # Please see :ref:`astropy-cosmology-fast-integrals` for discussion
         # about what is being done here.

--- a/astropy/cosmology/flrw.py
+++ b/astropy/cosmology/flrw.py
@@ -16,7 +16,7 @@ from astropy.utils.exceptions import AstropyUserWarning
 from . import scalar_inv_efuncs
 from . import units as cu
 from .core import Cosmology, FlatCosmologyMixin, Parameter
-from .parameter import _set_non_negative, _set_with_unit
+from .parameter import _validate_non_negative, _validate_with_unit
 from .utils import aszarr, vectorize_redshift_method
 
 # isort: split
@@ -115,14 +115,14 @@ class FLRW(Cosmology):
     """
 
     H0 = Parameter(doc="Hubble constant as an `~astropy.units.Quantity` at z=0.",
-                   unit="km/(s Mpc)", fset="scalar")
+                   unit="km/(s Mpc)", fvalidate="scalar")
     Om0 = Parameter(doc="Omega matter; matter density/critical density at z=0.",
-                    fset="non-negative")
+                    fvalidate="non-negative")
     Ode0 = Parameter(doc="Omega dark energy; dark energy density/critical density at z=0.",
-                     fset="float")
+                     fvalidate="float")
     Tcmb0 = Parameter(doc="Temperature of the CMB as `~astropy.units.Quantity` at z=0.",
-                      unit="Kelvin", fmt="0.4g", fset="scalar")
-    Neff = Parameter(doc="Number of effective neutrino species.", fset="non-negative")
+                      unit="Kelvin", fmt="0.4g", fvalidate="scalar")
+    Neff = Parameter(doc="Number of effective neutrino species.", fvalidate="non-negative")
     m_nu = Parameter(doc="Mass of neutrino species.",
                      unit="eV", equivalencies=u.mass_energy(), fmt="")
     Ob0 = Parameter(doc="Omega baryon; baryonic matter density/critical density at z=0.")
@@ -171,7 +171,7 @@ class FLRW(Cosmology):
         self._massivenu = False
         if self._nneutrinos > 0 and self._Tcmb0.value > 0:
             # not set yet, just validated
-            m_nu = _set_with_unit(self, self.__class__.m_nu, m_nu)
+            m_nu = _validate_with_unit(self, self.__class__.m_nu, m_nu)
 
             self._neff_per_nu = self._Neff / self._nneutrinos
 
@@ -263,7 +263,7 @@ class FLRW(Cosmology):
     # ---------------------------------------------------------------
     # Parameter details
 
-    @m_nu.setter
+    @m_nu.validator
     def m_nu(self, param, _):
         """Mass of neutrino species. Returns None if no neutrinos."""
         if self._nneutrinos == 0 or self._Tnu0.value == 0:
@@ -278,13 +278,13 @@ class FLRW(Cosmology):
                           self._massivenu_mass.value)
         return m << param.unit
 
-    @Ob0.setter
+    @Ob0.validator
     def Ob0(self, param, value):
         """Validate baryon density to None or positive float > matter density."""
         if value is None:
             return value
 
-        value = _set_non_negative(self, param, value)
+        value = _validate_non_negative(self, param, value)
         if value > self.Om0:
             raise ValueError("baryonic density can not be larger than "
                              "total matter density.")
@@ -2204,7 +2204,7 @@ class wCDM(FLRW):
     >>> dc = cosmo.comoving_distance(z)
     """
 
-    w0 = Parameter(doc="Dark energy equation of state.", fset="float")
+    w0 = Parameter(doc="Dark energy equation of state.", fvalidate="float")
 
     def __init__(self, H0, Om0, Ode0, w0=-1.0, Tcmb0=0.0*u.K, Neff=3.04,
                  m_nu=0.0*u.eV, Ob0=None, *, name=None, meta=None):
@@ -2532,9 +2532,9 @@ class w0waCDM(FLRW):
            Universe. Phys. Rev. Lett., 90, 091301.
     """
 
-    w0 = Parameter(doc="Dark energy equation of state at z=0.", fset="float")
+    w0 = Parameter(doc="Dark energy equation of state at z=0.", fvalidate="float")
     wa = Parameter(doc="Negative derivative of dark energy equation of state w.r.t. a.",
-                   fset="float")
+                   fvalidate="float")
 
     def __init__(self, H0, Om0, Ode0, w0=-1.0, wa=0.0, Tcmb0=0.0*u.K, Neff=3.04,
                  m_nu=0.0*u.eV, Ob0=None, *, name=None, meta=None):
@@ -2798,9 +2798,9 @@ class wpwaCDM(FLRW):
            of Merit Science Working Group. arXiv e-prints, arXiv:0901.0721.
     """
 
-    wp = Parameter(doc="Dark energy equation of state at the pivot redshift zp.", fset="float")
+    wp = Parameter(doc="Dark energy equation of state at the pivot redshift zp.", fvalidate="float")
     wa = Parameter(doc="Negative derivative of dark energy equation of state w.r.t. a.",
-                   fset="float")
+                   fvalidate="float")
     zp = Parameter(doc="The pivot redshift, where w(z) = wp.", unit=cu.redshift)
 
     def __init__(self, H0, Om0, Ode0, wp=-1.0, wa=0.0, zp=0.0 * cu.redshift,
@@ -2959,8 +2959,8 @@ class w0wzCDM(FLRW):
     >>> dc = cosmo.comoving_distance(z)
     """
 
-    w0 = Parameter(doc="Dark energy equation of state at z=0.", fset="float")
-    wz = Parameter(doc="Derivative of the dark energy equation of state w.r.t. z.", fset="float")
+    w0 = Parameter(doc="Dark energy equation of state at z=0.", fvalidate="float")
+    wz = Parameter(doc="Derivative of the dark energy equation of state w.r.t. z.", fvalidate="float")
 
     def __init__(self, H0, Om0, Ode0, w0=-1.0, wz=0.0, Tcmb0=0.0*u.K, Neff=3.04,
                  m_nu=0.0*u.eV, Ob0=None, *, name=None, meta=None):

--- a/astropy/cosmology/io/tests/test_ecsv.py
+++ b/astropy/cosmology/io/tests/test_ecsv.py
@@ -4,6 +4,7 @@
 import pytest
 
 # LOCAL
+import astropy.cosmology.units as cu
 import astropy.units as u
 from astropy import cosmology
 from astropy.cosmology import Cosmology, realizations
@@ -29,6 +30,14 @@ class ReadWriteECSVTestMixin(IOTestMixinBase):
     ``cosmo`` that returns/yields an instance of a |Cosmology|.
     See ``TestCosmology`` for an example.
     """
+
+    @pytest.fixture
+    def add_cu(self):
+        # TODO! autoenable 'cu' if cosmology is imported?
+        with u.add_enabled_units(cu):
+            yield
+
+    # ===============================================================
 
     def test_to_ecsv_bad_index(self, read, write, tmp_path):
         """Test if argument ``index`` is incorrect"""
@@ -61,7 +70,7 @@ class ReadWriteECSVTestMixin(IOTestMixinBase):
     # -----------------------
 
     @pytest.mark.parametrize("in_meta", [True, False])
-    def test_to_ecsv_in_meta(self, cosmo_cls, write, in_meta, tmp_path):
+    def test_to_ecsv_in_meta(self, cosmo_cls, write, in_meta, tmp_path, add_cu):
         """Test where the cosmology class is placed."""
         fp = tmp_path / "test_to_ecsv_in_meta.ecsv"
         write(fp, format='ascii.ecsv', cosmology_in_meta=in_meta)
@@ -77,7 +86,7 @@ class ReadWriteECSVTestMixin(IOTestMixinBase):
 
     # -----------------------
 
-    def test_tofrom_ecsv_instance(self, cosmo_cls, cosmo, read, write, tmp_path):
+    def test_tofrom_ecsv_instance(self, cosmo_cls, cosmo, read, write, tmp_path, add_cu):
         """Test cosmology -> ascii.ecsv -> cosmology."""
         fp = tmp_path / "test_tofrom_ecsv_instance.ecsv"
 
@@ -132,7 +141,8 @@ class ReadWriteECSVTestMixin(IOTestMixinBase):
         got = read(fp)
         assert got == cosmo
 
-    def test_fromformat_ecsv_subclass_partial_info(self, cosmo_cls, cosmo, read, write, tmp_path):
+    def test_fromformat_ecsv_subclass_partial_info(self, cosmo_cls, cosmo, read, write,
+                                                   tmp_path, add_cu):
         """
         Test writing from an instance and reading from that class.
         This works with missing information.
@@ -163,7 +173,7 @@ class ReadWriteECSVTestMixin(IOTestMixinBase):
         # but the metadata is the same
         assert got.meta == cosmo.meta
 
-    def test_tofrom_ecsv_mutlirow(self, cosmo, read, write, tmp_path):
+    def test_tofrom_ecsv_mutlirow(self, cosmo, read, write, tmp_path, add_cu):
         """Test if table has multiple rows."""
         fp = tmp_path / "test_tofrom_ecsv_mutlirow.ecsv"
 

--- a/astropy/cosmology/parameter.py
+++ b/astropy/cosmology/parameter.py
@@ -17,8 +17,7 @@ class Parameter:
         Function to validate the Parameter value from instances of the
         cosmology class. If "default", uses default validator to assign units
         (with equivalencies), if Parameter has units.
-        For other valid string options,
-        see :attr:`~astropy.cosmology.Parameter.registered_validators`.
+        For other valid string options, see ``Parameter._registry_validators``.
         'fvalidate' can also be set through a decorator with
         :meth:`~astropy.cosmology.Parameter.validator`.
     doc : str or None, optional
@@ -208,11 +207,6 @@ class Parameter:
             return fvalidate
 
         return register
-
-    @classproperty
-    def registered_validators(cls):
-        """Return keys view of registered validators."""
-        return cls._registry_validators.keys()
 
     # -------------------------------------------
 

--- a/astropy/cosmology/parameter.py
+++ b/astropy/cosmology/parameter.py
@@ -1,0 +1,326 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+import astropy.units as u
+
+# Originally authored by Andrew Becker (becker@astro.washington.edu),
+# and modified by Neil Crighton (neilcrighton@gmail.com), Roban Kramer
+# (robanhk@gmail.com), and Nathaniel Starkman (n.starkman@mail.utoronto.ca).
+
+# Many of these adapted from Hogg 1999, astro-ph/9905116
+# and Linder 2003, PRL 90, 91301
+
+__all__ = ["Parameter"]
+
+# registry of cosmology classes with {key=name : value=class}
+_COSMOLOGY_CLASSES = dict()
+
+
+class Parameter(property):
+    r"""Cosmological parameter (descriptor).
+
+    Should only be used with a :class:`~astropy.cosmology.Cosmology` subclass.
+
+    Parameters
+    ----------
+    fget : callable[[type], Any] or None, optional
+        Function to get the value from instances of the cosmology class.
+        If None (default) returns the corresponding private attribute.
+        Often not set here, but as a decorator with ``getter``.
+    fset : callable[[object, object, Any], Any] or {'default', 'float'}, optional
+        Function to validate the Parameter value from instances of the
+        cosmology class. If "default", uses default setter to assign units
+        (with equivalencies), if Parameter has units. If "float" will first do
+        units, then take the float value.
+        Often not set here, but as a decorator with ``setter``.
+    doc : str or None, optional
+        Parameter description. If 'doc' is None and 'fget' is not, then 'doc'
+        is taken from ``fget.__doc__``.
+    unit : unit-like or None (optional, keyword-only)
+        The `~astropy.units.Unit` for the Parameter. If None (default) no
+        unit as assumed.
+    equivalencies : `~astropy.units.Equivalency` or sequence thereof
+        Unit equivalencies for this Parameter.
+    fmt : str (optional, keyword-only)
+        `format` specification, used when making string representation
+        of the containing Cosmology.
+        See https://docs.python.org/3/library/string.html#formatspec
+
+    derived : bool (optional, keyword-only)
+        Whether the Parameter is 'derived', default `False`.
+        Fixed parameters behave similarly to normal parameters, but are not
+        sorted by the |Cosmology| signature (probably not there) and are not
+        included in all methods. For reference, see ``Ode0`` in
+        ``FlatFLRWMixin``, which removes :math:`\Omega_{de,0}`` as an
+        independent parameter (:math:`\Omega_{de,0} \equiv 1 - \Omega_{tot}`).
+
+    Examples
+    --------
+    The most common use case of ``Parameter`` is to access the corresponding
+    private attribute.
+
+        >>> from astropy.cosmology import LambdaCDM
+        >>> from astropy.cosmology.core import Parameter
+        >>> class Example1(LambdaCDM):
+        ...     param = Parameter(doc="example parameter", unit=u.m)
+        ...     def __init__(self, param=15 * u.m):
+        ...         super().__init__(70, 0.3, 0.7)
+        ...         self._param = param << self.__class__.param.unit
+        >>> Example1.param
+        <Parameter 'param' at ...
+        >>> Example1.param.unit
+        Unit("m")
+
+        >>> ex = Example1(param=12357)
+        >>> ex.param
+        <Quantity 12357. m>
+
+    ``Parameter`` also supports custom ``setter`` methods.
+    :attr:`~astropy.cosmology.FLRW.m_nu` is a good example for the former.
+
+        >>> import astropy.units as u
+        >>> class Example2(LambdaCDM):
+        ...     param = Parameter(doc="example parameter", unit="m")
+        ...     def __init__(self, param=15):
+        ...         super().__init__(70, 0.3, 0.7)
+        ...         self.param = param
+        ...     @param.setter
+        ...     def param(self, param, value):
+        ...         return (value << param.unit).to(u.km)
+
+        >>> ex2 = Example2(param=12357)
+        >>> ex2.param
+        <Quantity 12.357 km>
+
+    .. doctest::
+       :hide:
+
+       >>> from astropy.cosmology.core import _COSMOLOGY_CLASSES
+       >>> _ = _COSMOLOGY_CLASSES.pop(Example1.__qualname__)
+       >>> _ = _COSMOLOGY_CLASSES.pop(Example2.__qualname__)
+    """
+
+    _registry_setters = {}
+
+    def __init__(self, fget=None, fset="default", doc=None, *,
+                 unit=None, equivalencies=[], fmt=".3g", derived=False):
+        # parse registered fset
+        if callable(fset):
+            pass
+        elif fset in self._registry_setters:
+            fset = self._registry_setters[fset]
+        elif isinstance(fset, str):
+            raise ValueError(f"`fset` if str, must be in {self._registry_setters.keys()}")
+        else:
+            raise TypeError(f"`fset` must be a function or {self._registry_setters.keys()}")
+
+        # modeled after https://docs.python.org/3/howto/descriptor.html#properties
+        super().__init__(fget=fget if not hasattr(fget, "fget") else fget.__get__,
+                         fset=fset)
+        # TODO! better detection if `fget` is a descriptor.
+        # Note: setting here b/c @propert(doc=) is broken in subclasses
+        self.__doc__ = fget.__doc__ if (doc is None and fget is not None) else doc
+
+        # units stuff
+        self._unit = u.Unit(unit) if unit is not None else None
+        self._equivalencies = equivalencies
+
+        # misc
+        self._fmt = str(fmt)
+        self._derived = derived
+
+        # nested descriptor decorator compatibility
+        self.__wrapped__ = fget  # so always have access to `fget`
+        self.__name__ = getattr(fget, "__name__", None)  # compat with other descriptors
+
+    def __set_name__(self, cosmo_cls, name):
+        # attribute name
+        self._attr_name = name
+        self._attr_name_private = "_" + name
+
+        # update __name__, if not already set
+        self.__name__ = self.__name__ or name
+
+    @property
+    def name(self):
+        """Parameter name."""
+        return self._attr_name
+
+    @property
+    def unit(self):
+        """Parameter unit."""
+        return self._unit
+
+    @property
+    def equivalencies(self):
+        """Equivalencies used when initializing Parameter."""
+        return self._equivalencies
+
+    @property
+    def format_spec(self):
+        """String format specification."""
+        return self._fmt
+
+    @property
+    def derived(self):
+        """Whether the Parameter is derived; true parameters are not."""
+        return self._derived
+
+    # -------------------------------------------
+    # descriptor methods
+
+    def __get__(self, cosmology, cosmo_cls=None):
+        # get from class
+        if cosmology is None:
+            return self
+        return getattr(cosmology, self._attr_name_private)
+
+    def __set__(self, cosmology, value):
+        """Allows attribute setting once. Raises AttributeError subsequently."""
+        # raise error if setting 2nd time.
+        if hasattr(cosmology, self._attr_name_private):
+            raise AttributeError("can't set attribute")
+
+        # validate value, generally setting units if present
+        value = self.set(cosmology, value)
+        setattr(cosmology, self._attr_name_private, value)
+
+    # -------------------------------------------
+    # 'property' descriptor overrides
+
+    def getter(self, fget):
+        raise AttributeError("can't create custom Parameter getter.")
+
+    def setter(self, fset):
+        """Make new Parameter with custom ``fset``.
+
+        Note: ``Parameter.setter`` must be the top-most descriptor decorator.
+
+        Parameters
+        ----------
+        fset : callable[[type, type, Any], Any]
+
+        Returns
+        -------
+        `~astropy.cosmology.Parameter`
+            Copy of this Parameter but with custom ``fset``.
+        """
+        desc = type(self)(fget=self.fget, fset=fset,
+                          doc=self.__doc__, fmt=self.format_spec,
+                          unit=self.unit, equivalencies=self.equivalencies,
+                          derived=self.derived)
+        # TODO? need to override __wrapped__?
+        return desc
+
+    def deleter(self, fdel):
+        raise AttributeError("can't create custom Parameter deleter.")
+
+    # -------------------------------------------
+    # set value
+
+    def set(self, cosmology, value):
+        """Run the setter on this Parameter.
+
+        Note this setter doesn't actually set the value, but returns the value
+        that *should* be set.
+
+        Parameters
+        ----------
+        cosmology : `~astropy.cosmology.Cosmology` instance
+        value : Any
+            The object to validate and set.
+
+        Returns
+        -------
+        Any
+            The output of calling ``fset(cosmology, self, value)``
+            (yes, that parameter order).
+        """
+        return self.fset(cosmology, self, value)
+
+    @classmethod
+    def register_setter(cls, key, setter=None):
+        """Decorator to register setter function.
+
+        Parameters
+        ----------
+        key : str
+        setter : callable[[object, object, Any], Any] or None, optional
+            Value setter / validation function.
+
+        Returns
+        -------
+        ``setter`` or callable[``setter``]
+            if setter is None returns a function that takes and registers a
+            setter. This allows ``register_setter`` to be used as a decorator.
+        """
+        if key in cls._registry_setters:
+            raise KeyError(f"setter {key!r} already registered with Parameter.")
+
+        # setter directly passed
+        if setter is not None:
+            cls._registry_setters[key] = setter
+            return setter
+
+        # for use as a decorator
+        def register(setter):
+            """Register setter function.
+
+            Parameters
+            ----------
+            setter : callable[[object, object, Any], Any]
+                Value setter / validation function.
+
+            Returns
+            -------
+            ``setter``
+            """
+            cls._registry_setters[key] = setter
+            return setter
+
+        return register
+
+    # -------------------------------------------
+
+    def __repr__(self):
+        return f"<Parameter {self._attr_name!r} at {hex(id(self))}>"
+
+
+# ===================================================================
+# Built-in setters
+
+
+@Parameter.register_setter("default")
+def _set_with_unit(cosmology, param, value):
+    """
+    Default Parameter value setter.
+    Adds/converts units if Parameter has a unit.
+    """
+    if param.unit is not None:
+        with u.add_enabled_equivalencies(param.equivalencies):
+            value = u.Quantity(value, param.unit)
+    return value
+
+
+@Parameter.register_setter("float")
+def _set_to_float(cosmology, param, value):
+    """Parameter value setter with units, and converted to float."""
+    value = _set_with_unit(cosmology, param, value)
+    return float(value)
+
+
+@Parameter.register_setter("scalar")
+def _set_to_scalar(cosmology, param, value):
+    """"""
+    value = _set_with_unit(cosmology, param, value)
+    if not value.isscalar:
+        raise ValueError(f"{param.name} is a non-scalar quantity")
+    return value
+
+
+@Parameter.register_setter("non-negative")
+def _set_non_negative(cosmology, param, value):
+    """Parameter value setter where value is a positive float."""
+    value = _set_to_float(cosmology, param, value)
+    if value < 0.0:
+        raise ValueError(f"{param.name} can not be negative.")
+    return value

--- a/astropy/cosmology/tests/conftest.py
+++ b/astropy/cosmology/tests/conftest.py
@@ -12,6 +12,7 @@ import os
 import pytest
 
 import astropy.units as u
+import astropy.cosmology.units as cu
 from astropy.cosmology import core
 from astropy.cosmology.core import Cosmology
 from astropy.utils.misc import isiterable
@@ -44,12 +45,13 @@ def read_json(filename, **kwargs):
     mapping = json.loads(data)  # parse json mappable to dict
 
     # deserialize Quantity
-    for k, v in mapping.items():
-        if isinstance(v, dict) and "value" in v and "unit" in v:
-            mapping[k] = u.Quantity(v["value"], v["unit"])
-    for k, v in mapping.get("meta", {}).items():  # also the metadata
-        if isinstance(v, dict) and "value" in v and "unit" in v:
-            mapping["meta"][k] = u.Quantity(v["value"], v["unit"])
+    with u.add_enabled_units(cu.redshift):
+        for k, v in mapping.items():
+            if isinstance(v, dict) and "value" in v and "unit" in v:
+                mapping[k] = u.Quantity(v["value"], v["unit"])
+        for k, v in mapping.get("meta", {}).items():  # also the metadata
+            if isinstance(v, dict) and "value" in v and "unit" in v:
+                mapping["meta"][k] = u.Quantity(v["value"], v["unit"])
 
     return Cosmology.from_format(mapping, **kwargs)
 

--- a/astropy/cosmology/tests/conftest.py
+++ b/astropy/cosmology/tests/conftest.py
@@ -11,8 +11,8 @@ import os
 
 import pytest
 
-import astropy.units as u
 import astropy.cosmology.units as cu
+import astropy.units as u
 from astropy.cosmology import core
 from astropy.cosmology.core import Cosmology
 from astropy.utils.misc import isiterable

--- a/astropy/cosmology/tests/test_core.py
+++ b/astropy/cosmology/tests/test_core.py
@@ -40,7 +40,7 @@ class TestParameter:
         #  with getter and validator
         class Example2(Example1):
             def __init__(self, param=15 * u.m):
-                self._param = self.__class__.param.validate(self, param)
+                self.param = param
 
             @Example1.param.getter
             def param(self):
@@ -59,21 +59,21 @@ class TestParameter:
 
     @pytest.fixture(params=["Example1", "Example2"])
     def cosmo_cls(self, request):
-        yield self.classes[request.param]
+        return self.classes[request.param]
 
     @pytest.fixture
     def cosmo(self, cosmo_cls):
-        yield cosmo_cls()
+        return cosmo_cls()
 
     @pytest.fixture
     def parameter(self, cosmo_cls):
-        yield cosmo_cls.param
+        return cosmo_cls.param
 
     # ==============================================================
 
     def test_has_expected_attributes(self, parameter):
         # property
-        assert hasattr(parameter, "_fget")  # None or callable
+        assert hasattr(parameter, "fget")  # None or callable
         assert parameter.__doc__ == "example parameter"
 
         # property-esque
@@ -145,8 +145,6 @@ class TestParameter:
 
     def test_fget(self, cosmo, parameter):
         """Test :attr:`astropy.cosmology.Parameter.fget`."""
-        assert parameter.fget is parameter._fget
-
         if parameter.fget is not None:
             value = parameter.fget(cosmo)
             assert value  == 0.015 * u.km
@@ -155,6 +153,24 @@ class TestParameter:
         """Test :meth:`astropy.cosmology.Parameter.getter`."""
         newparam = parameter.getter("NOT NONE")
         assert newparam.fget == "NOT NONE"
+
+    def test_fset(self, cosmo, parameter):
+        """Test :attr:`astropy.cosmology.Parameter.fset`."""
+        assert parameter.fset is None
+
+    def test_setter_method(self, parameter):
+        """Test :meth:`astropy.cosmology.Parameter.setter`."""
+        with pytest.raises(AttributeError, match="can't create custom Parameter setter."):
+            parameter.setter(None)
+
+    def test_fdel(self, cosmo, parameter):
+        """Test :attr:`astropy.cosmology.Parameter.fdel`."""
+        assert parameter.fdel is None
+
+    def test_deleter_method(self, parameter):
+        """Test :meth:`astropy.cosmology.Parameter.deleter`."""
+        with pytest.raises(AttributeError, match="can't create custom Parameter deleter."):
+            parameter.deleter(None)
 
     # -------------------------------------------
     # validation

--- a/astropy/cosmology/tests/test_flrw.py
+++ b/astropy/cosmology/tests/test_flrw.py
@@ -83,10 +83,10 @@ class TestFLRW(CosmologyTest):
         assert cosmo_cls.H0.unit == u.Unit("km/(s Mpc)")
 
         # validation
-        assert cosmo_cls.H0.validate(cosmo, 1) == 1 * u.Unit("km/(s Mpc)")
-        assert cosmo_cls.H0.validate(cosmo, 10 * u.Unit("km/(s Mpc)")) == 10 * u.Unit("km/(s Mpc)")
+        assert cosmo_cls.H0.set(cosmo, 1) == 1 * u.Unit("km/(s Mpc)")
+        assert cosmo_cls.H0.set(cosmo, 10 * u.Unit("km/(s Mpc)")) == 10 * u.Unit("km/(s Mpc)")
         with pytest.raises(ValueError, match="H0 is a non-scalar quantity"):
-            cosmo_cls.H0.validate(cosmo, [1, 2])
+            cosmo_cls.H0.set(cosmo, [1, 2])
 
         # on the instance
         assert cosmo.H0 is cosmo._H0
@@ -100,14 +100,14 @@ class TestFLRW(CosmologyTest):
         assert cosmo_cls.Tcmb0.format_spec == "0.4g"
 
         # validation
-        assert cosmo_cls.Om0.validate(cosmo, 1) == 1
-        assert cosmo_cls.Om0.validate(cosmo, 10 * u.one) == 10
+        assert cosmo_cls.Om0.set(cosmo, 1) == 1
+        assert cosmo_cls.Om0.set(cosmo, 10 * u.one) == 10
         with pytest.raises(ValueError, match="matter density can not be negative"):
-            cosmo_cls.Om0.validate(cosmo, -1)
+            cosmo_cls.Om0.set(cosmo, -1)
 
         # on the instance
         assert cosmo.Om0 is cosmo._Om0
-        assert isinstance(cosmo.Om0, float)  # from fvalidate
+        assert isinstance(cosmo.Om0, float)  # from fset
         assert cosmo.Om0 == 0.27
 
     def test_Ode0(self, cosmo_cls, cosmo):
@@ -117,12 +117,12 @@ class TestFLRW(CosmologyTest):
         assert "Omega dark energy" in cosmo_cls.Ode0.__doc__
 
         # validation
-        assert cosmo_cls.Ode0.validate(cosmo, 1) == 1
-        assert cosmo_cls.Ode0.validate(cosmo, 10 * u.one) == 10
+        assert cosmo_cls.Ode0.set(cosmo, 1) == 1
+        assert cosmo_cls.Ode0.set(cosmo, 10 * u.one) == 10
 
         # on the instance
         assert cosmo.Ode0 is cosmo._Ode0
-        assert isinstance(cosmo.Ode0, float)  # from validator
+        assert isinstance(cosmo.Ode0, float)  # from setter
 
     def test_Tcmb0(self, cosmo_cls, cosmo):
         """Test Parameter ``Tcmb0``."""
@@ -132,10 +132,10 @@ class TestFLRW(CosmologyTest):
         assert cosmo_cls.Tcmb0.unit == u.K
 
         # validation
-        assert cosmo_cls.Tcmb0.validate(cosmo, 1) == 1 * u.K
-        assert cosmo_cls.Tcmb0.validate(cosmo, 10 * u.K) == 10 * u.K
+        assert cosmo_cls.Tcmb0.set(cosmo, 1) == 1 * u.K
+        assert cosmo_cls.Tcmb0.set(cosmo, 10 * u.K) == 10 * u.K
         with pytest.raises(ValueError, match="Tcmb0 is a non-scalar quantity"):
-            cosmo_cls.Tcmb0.validate(cosmo, [1, 2])
+            cosmo_cls.Tcmb0.set(cosmo, [1, 2])
 
         # on the instance
         assert cosmo.Tcmb0 is cosmo._Tcmb0
@@ -148,10 +148,10 @@ class TestFLRW(CosmologyTest):
         assert "Number of effective neutrino species" in cosmo_cls.Neff.__doc__
 
         # validation
-        assert cosmo_cls.Neff.validate(cosmo, 1) == 1
-        assert cosmo_cls.Neff.validate(cosmo, 10 * u.one) == 10
+        assert cosmo_cls.Neff.set(cosmo, 1) == 1
+        assert cosmo_cls.Neff.set(cosmo, 10 * u.one) == 10
         with pytest.raises(ValueError, match="effective number of neutrinos can not be negative"):
-            cosmo_cls.Neff.validate(cosmo, -1)
+            cosmo_cls.Neff.set(cosmo, -1)
 
         # on the instance
         assert cosmo.Neff is cosmo._Neff
@@ -188,13 +188,13 @@ class TestFLRW(CosmologyTest):
         assert "Omega baryon;" in cosmo_cls.Ob0.__doc__
 
         # validation
-        assert cosmo_cls.Ob0.validate(cosmo, None) is None
-        assert cosmo_cls.Ob0.validate(cosmo, 0.1) == 0.1
-        assert cosmo_cls.Ob0.validate(cosmo, 0.1 * u.one) == 0.1
+        assert cosmo_cls.Ob0.set(cosmo, None) is None
+        assert cosmo_cls.Ob0.set(cosmo, 0.1) == 0.1
+        assert cosmo_cls.Ob0.set(cosmo, 0.1 * u.one) == 0.1
         with pytest.raises(ValueError, match="baryonic density can not be negative"):
-            cosmo_cls.Ob0.validate(cosmo, -1)
+            cosmo_cls.Ob0.set(cosmo, -1)
         with pytest.raises(ValueError, match="baryonic density can not be larger"):
-            cosmo_cls.Ob0.validate(cosmo, cosmo.Om0 + 1)
+            cosmo_cls.Ob0.set(cosmo, cosmo.Om0 + 1)
 
         # on the instance
         assert cosmo.Ob0 is cosmo._Ob0

--- a/astropy/cosmology/tests/test_flrw.py
+++ b/astropy/cosmology/tests/test_flrw.py
@@ -87,10 +87,10 @@ class TestFLRW(CosmologyTest):
         assert cosmo_cls.H0.unit == u.Unit("km/(s Mpc)")
 
         # validation
-        assert cosmo_cls.H0.set(cosmo, 1) == 1 * u.Unit("km/(s Mpc)")
-        assert cosmo_cls.H0.set(cosmo, 10 * u.Unit("km/(s Mpc)")) == 10 * u.Unit("km/(s Mpc)")
+        assert cosmo_cls.H0.validate(cosmo, 1) == 1 * u.Unit("km/(s Mpc)")
+        assert cosmo_cls.H0.validate(cosmo, 10 * u.Unit("km/(s Mpc)")) == 10 * u.Unit("km/(s Mpc)")
         with pytest.raises(ValueError, match="H0 is a non-scalar quantity"):
-            cosmo_cls.H0.set(cosmo, [1, 2])
+            cosmo_cls.H0.validate(cosmo, [1, 2])
 
         # on the instance
         assert cosmo.H0 is cosmo._H0
@@ -104,10 +104,10 @@ class TestFLRW(CosmologyTest):
         assert cosmo_cls.Tcmb0.format_spec == "0.4g"
 
         # validation
-        assert cosmo_cls.Om0.set(cosmo, 1) == 1
-        assert cosmo_cls.Om0.set(cosmo, 10 * u.one) == 10
+        assert cosmo_cls.Om0.validate(cosmo, 1) == 1
+        assert cosmo_cls.Om0.validate(cosmo, 10 * u.one) == 10
         with pytest.raises(ValueError, match="Om0 can not be negative"):
-            cosmo_cls.Om0.set(cosmo, -1)
+            cosmo_cls.Om0.validate(cosmo, -1)
 
         # on the instance
         assert cosmo.Om0 is cosmo._Om0
@@ -121,8 +121,8 @@ class TestFLRW(CosmologyTest):
         assert "Omega dark energy" in cosmo_cls.Ode0.__doc__
 
         # validation
-        assert cosmo_cls.Ode0.set(cosmo, 1) == 1
-        assert cosmo_cls.Ode0.set(cosmo, 10 * u.one) == 10
+        assert cosmo_cls.Ode0.validate(cosmo, 1) == 1
+        assert cosmo_cls.Ode0.validate(cosmo, 10 * u.one) == 10
 
         # on the instance
         assert cosmo.Ode0 is cosmo._Ode0
@@ -136,10 +136,10 @@ class TestFLRW(CosmologyTest):
         assert cosmo_cls.Tcmb0.unit == u.K
 
         # validation
-        assert cosmo_cls.Tcmb0.set(cosmo, 1) == 1 * u.K
-        assert cosmo_cls.Tcmb0.set(cosmo, 10 * u.K) == 10 * u.K
+        assert cosmo_cls.Tcmb0.validate(cosmo, 1) == 1 * u.K
+        assert cosmo_cls.Tcmb0.validate(cosmo, 10 * u.K) == 10 * u.K
         with pytest.raises(ValueError, match="Tcmb0 is a non-scalar quantity"):
-            cosmo_cls.Tcmb0.set(cosmo, [1, 2])
+            cosmo_cls.Tcmb0.validate(cosmo, [1, 2])
 
         # on the instance
         assert cosmo.Tcmb0 is cosmo._Tcmb0
@@ -152,10 +152,10 @@ class TestFLRW(CosmologyTest):
         assert "Number of effective neutrino species" in cosmo_cls.Neff.__doc__
 
         # validation
-        assert cosmo_cls.Neff.set(cosmo, 1) == 1
-        assert cosmo_cls.Neff.set(cosmo, 10 * u.one) == 10
+        assert cosmo_cls.Neff.validate(cosmo, 1) == 1
+        assert cosmo_cls.Neff.validate(cosmo, 10 * u.one) == 10
         with pytest.raises(ValueError, match="Neff can not be negative"):
-            cosmo_cls.Neff.set(cosmo, -1)
+            cosmo_cls.Neff.validate(cosmo, -1)
 
         # on the instance
         assert cosmo.Neff is cosmo._Neff
@@ -174,7 +174,7 @@ class TestFLRW(CosmologyTest):
         # assert cosmo.m_nu is cosmo._m_nu
         assert u.allclose(cosmo.m_nu, [0.0, 0.0, 0.0] * u.eV)
 
-        # getter
+        # set differently depending on the other inputs
         if cosmo.Tnu0.value == 0:
             assert cosmo.m_nu is None
         elif not cosmo._massivenu:  # only massless
@@ -192,13 +192,13 @@ class TestFLRW(CosmologyTest):
         assert "Omega baryon;" in cosmo_cls.Ob0.__doc__
 
         # validation
-        assert cosmo_cls.Ob0.set(cosmo, None) is None
-        assert cosmo_cls.Ob0.set(cosmo, 0.1) == 0.1
-        assert cosmo_cls.Ob0.set(cosmo, 0.1 * u.one) == 0.1
+        assert cosmo_cls.Ob0.validate(cosmo, None) is None
+        assert cosmo_cls.Ob0.validate(cosmo, 0.1) == 0.1
+        assert cosmo_cls.Ob0.validate(cosmo, 0.1 * u.one) == 0.1
         with pytest.raises(ValueError, match="Ob0 can not be negative"):
-            cosmo_cls.Ob0.set(cosmo, -1)
+            cosmo_cls.Ob0.validate(cosmo, -1)
         with pytest.raises(ValueError, match="baryonic density can not be larger"):
-            cosmo_cls.Ob0.set(cosmo, cosmo.Om0 + 1)
+            cosmo_cls.Ob0.validate(cosmo, cosmo.Om0 + 1)
 
         # on the instance
         assert cosmo.Ob0 is cosmo._Ob0

--- a/astropy/cosmology/tests/test_flrw.py
+++ b/astropy/cosmology/tests/test_flrw.py
@@ -72,6 +72,136 @@ class TestFLRW(CosmologyTest):
     # ===============================================================
     # Method & Attribute Tests
 
+    # ---------------------------------------------------------------
+    # Parameters
+
+    def test_H0(self, cosmo_cls, cosmo):
+        """Test Parameter ``H0``."""
+        # on the class
+        assert isinstance(cosmo_cls.H0, Parameter)
+        assert "Hubble constant" in cosmo_cls.H0.__doc__
+        assert cosmo_cls.H0.unit == u.Unit("km/(s Mpc)")
+
+        # validation
+        assert cosmo_cls.H0.validate(cosmo, 1) == 1 * u.Unit("km/(s Mpc)")
+        assert cosmo_cls.H0.validate(cosmo, 10 * u.Unit("km/(s Mpc)")) == 10 * u.Unit("km/(s Mpc)")
+        with pytest.raises(ValueError, match="H0 is a non-scalar quantity"):
+            cosmo_cls.H0.validate(cosmo, [1, 2])
+
+        # on the instance
+        assert cosmo.H0 is cosmo._H0
+        assert cosmo.H0 == 70 * (u.km / u.s / u.Mpc)
+
+    def test_Om0(self, cosmo_cls, cosmo):
+        """Test Parameter ``Om0``."""
+        # on the class
+        assert isinstance(cosmo_cls.Om0, Parameter)
+        assert "Omega matter" in cosmo_cls.Om0.__doc__
+        assert cosmo_cls.Tcmb0.format_spec == "0.4g"
+
+        # validation
+        assert cosmo_cls.Om0.validate(cosmo, 1) == 1
+        assert cosmo_cls.Om0.validate(cosmo, 10 * u.one) == 10
+        with pytest.raises(ValueError, match="matter density can not be negative"):
+            cosmo_cls.Om0.validate(cosmo, -1)
+
+        # on the instance
+        assert cosmo.Om0 is cosmo._Om0
+        assert isinstance(cosmo.Om0, float)  # from fvalidate
+        assert cosmo.Om0 == 0.27
+
+    def test_Ode0(self, cosmo_cls, cosmo):
+        """Test Parameter ``Ode0``."""
+        # on the class
+        assert isinstance(cosmo_cls.Ode0, Parameter)
+        assert "Omega dark energy" in cosmo_cls.Ode0.__doc__
+
+        # validation
+        assert cosmo_cls.Ode0.validate(cosmo, 1) == 1
+        assert cosmo_cls.Ode0.validate(cosmo, 10 * u.one) == 10
+
+        # on the instance
+        assert cosmo.Ode0 is cosmo._Ode0
+        assert isinstance(cosmo.Ode0, float)  # from validator
+
+    def test_Tcmb0(self, cosmo_cls, cosmo):
+        """Test Parameter ``Tcmb0``."""
+        # on the class
+        assert isinstance(cosmo_cls.Tcmb0, Parameter)
+        assert "Temperature of the CMB" in cosmo_cls.Tcmb0.__doc__
+        assert cosmo_cls.Tcmb0.unit == u.K
+
+        # validation
+        assert cosmo_cls.Tcmb0.validate(cosmo, 1) == 1 * u.K
+        assert cosmo_cls.Tcmb0.validate(cosmo, 10 * u.K) == 10 * u.K
+        with pytest.raises(ValueError, match="Tcmb0 is a non-scalar quantity"):
+            cosmo_cls.Tcmb0.validate(cosmo, [1, 2])
+
+        # on the instance
+        assert cosmo.Tcmb0 is cosmo._Tcmb0
+        assert cosmo.Tcmb0 == 3 * u.K
+
+    def test_Neff(self, cosmo_cls, cosmo):
+        """Test Parameter ``Neff``."""
+        # on the class
+        assert isinstance(cosmo_cls.Neff, Parameter)
+        assert "Number of effective neutrino species" in cosmo_cls.Neff.__doc__
+
+        # validation
+        assert cosmo_cls.Neff.validate(cosmo, 1) == 1
+        assert cosmo_cls.Neff.validate(cosmo, 10 * u.one) == 10
+        with pytest.raises(ValueError, match="effective number of neutrinos can not be negative"):
+            cosmo_cls.Neff.validate(cosmo, -1)
+
+        # on the instance
+        assert cosmo.Neff is cosmo._Neff
+        assert cosmo.Neff == 3.04
+
+    def test_m_nu(self, cosmo_cls, cosmo):
+        """Test Parameter ``m_nu``."""
+        # on the class
+        assert isinstance(cosmo_cls.m_nu, Parameter)
+        assert "Mass of neutrino species" in cosmo_cls.m_nu.__doc__
+        assert cosmo_cls.m_nu.unit == u.eV
+        assert cosmo_cls.m_nu.equivalencies == u.mass_energy()
+        assert cosmo_cls.m_nu.format_spec == ""
+
+        # on the instance
+        # assert cosmo.m_nu is cosmo._m_nu
+        assert u.allclose(cosmo.m_nu, [0.0, 0.0, 0.0] * u.eV)
+
+        # getter
+        if cosmo.Tnu0.value == 0:
+            assert cosmo.m_nu is None
+        elif not cosmo._massivenu:  # only massless
+            assert u.allclose(cosmo.m_nu, 0 * u.eV)
+        elif self._nmasslessnu == 0:  # only massive
+            assert cosmo.m_nu == cosmo._massivenu_mass
+        else:  # a mix -- the most complicated case
+            assert u.allclose(cosmo.m_nu[:self._nmasslessnu], 0 * u.eV)
+            assert u.allclose(cosmo.m_nu[self._nmasslessnu], cosmo._massivenu_mass)
+
+    def test_Ob0(self, cosmo_cls, cosmo):
+        """Test Parameter ``Ob0``."""
+        # on the class
+        assert isinstance(cosmo_cls.Ob0, Parameter)
+        assert "Omega baryon;" in cosmo_cls.Ob0.__doc__
+
+        # validation
+        assert cosmo_cls.Ob0.validate(cosmo, None) is None
+        assert cosmo_cls.Ob0.validate(cosmo, 0.1) == 0.1
+        assert cosmo_cls.Ob0.validate(cosmo, 0.1 * u.one) == 0.1
+        with pytest.raises(ValueError, match="baryonic density can not be negative"):
+            cosmo_cls.Ob0.validate(cosmo, -1)
+        with pytest.raises(ValueError, match="baryonic density can not be larger"):
+            cosmo_cls.Ob0.validate(cosmo, cosmo.Om0 + 1)
+
+        # on the instance
+        assert cosmo.Ob0 is cosmo._Ob0
+        assert cosmo.Ob0 is None
+
+    # ---------------------------------------------------------------
+
     def test_init(self, cosmo_cls):
         """Test initialization."""
         super().test_init(cosmo_cls)

--- a/astropy/cosmology/tests/test_flrw.py
+++ b/astropy/cosmology/tests/test_flrw.py
@@ -106,7 +106,7 @@ class TestFLRW(CosmologyTest):
         # validation
         assert cosmo_cls.Om0.validate(cosmo, 1) == 1
         assert cosmo_cls.Om0.validate(cosmo, 10 * u.one) == 10
-        with pytest.raises(ValueError, match="Om0 can not be negative"):
+        with pytest.raises(ValueError, match="Om0 cannot be negative"):
             cosmo_cls.Om0.validate(cosmo, -1)
 
         # on the instance
@@ -154,7 +154,7 @@ class TestFLRW(CosmologyTest):
         # validation
         assert cosmo_cls.Neff.validate(cosmo, 1) == 1
         assert cosmo_cls.Neff.validate(cosmo, 10 * u.one) == 10
-        with pytest.raises(ValueError, match="Neff can not be negative"):
+        with pytest.raises(ValueError, match="Neff cannot be negative"):
             cosmo_cls.Neff.validate(cosmo, -1)
 
         # on the instance
@@ -195,7 +195,7 @@ class TestFLRW(CosmologyTest):
         assert cosmo_cls.Ob0.validate(cosmo, None) is None
         assert cosmo_cls.Ob0.validate(cosmo, 0.1) == 0.1
         assert cosmo_cls.Ob0.validate(cosmo, 0.1 * u.one) == 0.1
-        with pytest.raises(ValueError, match="Ob0 can not be negative"):
+        with pytest.raises(ValueError, match="Ob0 cannot be negative"):
             cosmo_cls.Ob0.validate(cosmo, -1)
         with pytest.raises(ValueError, match="baryonic density can not be larger"):
             cosmo_cls.Ob0.validate(cosmo, cosmo.Om0 + 1)

--- a/astropy/cosmology/tests/test_parameter.py
+++ b/astropy/cosmology/tests/test_parameter.py
@@ -1,0 +1,488 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+"""Testing :mod:`astropy.cosmology.parameter`."""
+
+##############################################################################
+# IMPORTS
+
+# STDLIB
+import inspect
+
+# THIRD PARTY
+import pytest
+
+import numpy as np
+
+# LOCAL
+import astropy.units as u
+from astropy.cosmology import Cosmology
+from astropy.cosmology.core import _COSMOLOGY_CLASSES
+from astropy.cosmology.parameter import Parameter, _set_to_float, _set_with_unit
+
+##############################################################################
+# TESTS
+##############################################################################
+
+
+class ParameterTestMixin:
+    """Tests for a :class:`astropy.cosmology.Parameter` on a Cosmology.
+
+    :class:`astropy.cosmology.Parameter` is a descriptor and this test suite
+    tests descriptors by class inheritance, so ``ParameterTestMixin`` is mixed
+    into ``TestCosmology`` (tests :class:`astropy.cosmology.Cosmology`).
+    """
+
+    @pytest.fixture
+    def parameter(self, cosmo_cls):
+        """Cosmological Parameters"""
+        # I wish this would work
+        # yield from {getattr(cosmo_cls, n) for n in cosmo_cls.__parameters__}
+
+        # just return one parameter at random
+        yield getattr(cosmo_cls, set(cosmo_cls.__parameters__).pop())
+
+    @pytest.fixture
+    def all_parameter(self, cosmo_cls):
+        """Cosmological All Parameter instances"""
+        # I wish this would work
+        # yield from {getattr(cosmo_cls, n) for n in cosmo_cls.__all_parameters__}
+
+        # just return one parameter at random
+        yield getattr(cosmo_cls, set(cosmo_cls.__all_parameters__).pop())
+
+    # ===============================================================
+    # Method Tests
+
+    def test_Parameter_class_attributes(self, all_parameter):
+        """Test :class:`astropy.cosmology.Parameter` attributes on class."""
+        # _registry_setters
+        assert hasattr(all_parameter, "_registry_setters")
+        assert isinstance(all_parameter._registry_setters, dict)
+        assert all(isinstance(k, str) for k in all_parameter._registry_setters.keys())
+        assert all(callable(v) for v in all_parameter._registry_setters.values())
+
+    def test_Parameter_init(self):
+        """Test :class:`astropy.cosmology.Parameter` instantiation."""
+        # defaults
+        parameter = Parameter()
+        assert parameter.fget is None
+        assert parameter.fset is _set_with_unit
+        assert parameter.unit is None
+        assert parameter.equivalencies == []
+        assert parameter.format_spec == ".3g"
+        assert parameter.derived is False
+        assert parameter.__wrapped__ is parameter.fget
+        assert parameter.__name__ is None
+
+        # setting all kwargs
+        parameter = Parameter(fget=lambda x: x, fset="float", doc="DOCSTRING",
+                              unit="km", equivalencies=[u.mass_energy()],
+                              fmt=".4f", derived=True)
+        assert parameter.fget(2) == 2
+        assert parameter.fset is _set_to_float
+        assert parameter.unit is u.km
+        assert parameter.equivalencies == [u.mass_energy()]
+        assert parameter.format_spec == ".4f"
+        assert parameter.derived is True
+        assert parameter.__wrapped__ is parameter.fget
+        assert parameter.__name__ == "<lambda>"
+
+    def test_Parameter_instance_attributes(self, all_parameter):
+        """Test :class:`astropy.cosmology.Parameter` attributes from init."""
+        # property
+        assert hasattr(all_parameter, "fget")
+        assert all_parameter.fget is None or callable(all_parameter.fget)
+
+        assert hasattr(all_parameter, "fset")
+        assert callable(all_parameter.fset)
+
+        assert hasattr(all_parameter, "fdel")
+        assert all_parameter.fdel is None
+
+        assert hasattr(all_parameter, "__doc__")
+
+        # Parameter
+        assert hasattr(all_parameter, "_unit")
+        assert hasattr(all_parameter, "_equivalencies")
+        assert hasattr(all_parameter, "_fmt")
+        assert hasattr(all_parameter, "_derived")
+        assert hasattr(all_parameter, "__wrapped__")
+        assert hasattr(all_parameter, "__name__")
+
+        # __set_name__
+        assert hasattr(all_parameter, "_attr_name")
+        assert hasattr(all_parameter, "_attr_name_private")
+
+    def test_Parameter_fget(self, all_parameter):
+        """Test :attr:`astropy.cosmology.Parameter.fget`."""
+        assert hasattr(all_parameter, "fget")
+        assert callable(all_parameter.fget) or all_parameter.fget is None
+
+    def test_Parameter_fset(self, all_parameter):
+        """Test :attr:`astropy.cosmology.Parameter.fset`."""
+        assert hasattr(all_parameter, "fset")
+        assert callable(all_parameter.fset)
+
+    def test_Parameter_fdel(self, all_parameter):
+        """Test :attr:`astropy.cosmology.Parameter.fdel`."""
+        assert all_parameter.fdel is None
+
+    def test_Parameter_name(self, all_parameter):
+        """Test :attr:`astropy.cosmology.Parameter.name`."""
+        assert hasattr(all_parameter, "name")
+        assert isinstance(all_parameter.name, str)
+        assert all_parameter.name is all_parameter._attr_name
+
+    def test_Parameter_unit(self, all_parameter):
+        """Test :attr:`astropy.cosmology.Parameter.unit`."""
+        assert hasattr(all_parameter, "unit")
+        assert isinstance(all_parameter.unit, (u.UnitBase, type(None)))
+        assert all_parameter.unit is all_parameter._unit
+
+    def test_Parameter_equivalencies(self, all_parameter):
+        """Test :attr:`astropy.cosmology.Parameter.equivalencies`."""
+        assert hasattr(all_parameter, "equivalencies")
+        assert isinstance(all_parameter.equivalencies, (list, u.Equivalency))
+        assert all_parameter.equivalencies is all_parameter._equivalencies
+
+    def test_Parameter_format_spec(self, all_parameter):
+        """Test :attr:`astropy.cosmology.Parameter.format_spec`."""
+        assert hasattr(all_parameter, "format_spec")
+        assert isinstance(all_parameter.format_spec, str)
+        assert all_parameter.format_spec is all_parameter._fmt
+
+    def test_Parameter_derived(self, cosmo_cls, all_parameter):
+        """Test :attr:`astropy.cosmology.Parameter.derived`."""
+        assert hasattr(all_parameter, "derived")
+        assert isinstance(all_parameter.derived, bool)
+        assert all_parameter.derived is all_parameter._derived
+
+        # test value
+        if all_parameter.name in cosmo_cls.__parameters__:
+            assert all_parameter.derived is False
+        else:
+            assert all_parameter.derived is True
+
+    # -------------------------------------------
+    # descriptor methods
+
+    def test_Parameter_descriptor_get(self, cosmo_cls, cosmo, all_parameter):
+        """Test :attr:`astropy.cosmology.Parameter.__get__`."""
+        # from class
+        parameter = getattr(cosmo_cls, all_parameter.name)
+        assert isinstance(parameter, Parameter)
+        assert parameter is all_parameter
+
+        # from instance
+        parameter = getattr(cosmo, all_parameter.name)
+        assert np.all(parameter == getattr(cosmo, all_parameter._attr_name_private))
+
+    def test_Parameter_descriptor_set(self, cosmo, all_parameter):
+        """Test :attr:`astropy.cosmology.Parameter.__set__`."""
+        # test it's already set
+        assert hasattr(cosmo, all_parameter._attr_name_private)
+
+        # and raises an error if set again
+        with pytest.raises(AttributeError, match="can't set attribute"):
+            setattr(cosmo, all_parameter._attr_name, None)
+
+    def test_Parameter_descriptor_delete(self, cosmo, all_parameter):
+        """Test :attr:`astropy.cosmology.Parameter.__delete__`."""
+        with pytest.raises(AttributeError, match="can't delete attribute"):
+            assert delattr(cosmo, all_parameter._attr_name)
+
+    # -------------------------------------------
+    # 'property' descriptor overrides
+
+    # def test_Parameter_getter(self, cosmo):
+    # def test_Parameter_setter(self, cosmo):
+    # def test_Parameter_deleter(self, cosmo):
+
+    # -------------------------------------------
+    # set value
+    # tested later.
+
+    # -------------------------------------------
+
+    def test_Parameter_repr(self, cosmo_cls, all_parameter):
+        """Test Parameter repr."""
+        r = repr(getattr(cosmo_cls, all_parameter.name))
+
+        assert all_parameter._attr_name in r
+        assert hex(id(all_parameter)) in r
+
+    # ===============================================================
+    # Usage Tests
+
+    def test_Parameter_listed(self, cosmo_cls, all_parameter):
+        """Test each `astropy.cosmology.Parameter` attached to Cosmology."""
+        # just double check that each entry is a Parameter
+        assert isinstance(all_parameter, Parameter)
+
+        # the reverse: check that if it is a Parameter, it's listed.
+        # note have to check the more inclusive ``__all_parameters__``
+        assert all_parameter.name in cosmo_cls.__all_parameters__
+        if not all_parameter.derived:
+            assert all_parameter.name in cosmo_cls.__parameters__
+
+    def test_parameter_related_attributes_on_Cosmology(self, cosmo_cls):
+        """Test `astropy.cosmology.Parameter`-related on Cosmology."""
+        # establish has expected attribute
+        assert hasattr(cosmo_cls, "__parameters__")
+        assert hasattr(cosmo_cls, "__all_parameters__")
+
+    def test_Parameter_not_unique(self, cosmo_cls, clean_registry):
+        """Cosmology Parameter not unique to class when subclass defined."""
+
+        # define subclass to show param is same
+        class ExampleBase(cosmo_cls):
+            param = Parameter()
+
+        class Example(ExampleBase): pass
+
+        assert Example.param is ExampleBase.param
+        assert Example.__parameters__ == ExampleBase.__parameters__
+
+    def test_Parameters_reorder_by_signature(self, cosmo_cls, clean_registry):
+        """Test parameters are reordered."""
+
+        class Example(cosmo_cls):
+            param = Parameter()
+
+            def __init__(self, param, *, name=None, meta=None):
+                pass  # never actually initialized
+
+        # param should be 1st, all other parameters next
+        Example.__parameters__[0] == "param"
+        # Check the other parameters are as expected.
+        # only run this test if "param" is not already on the cosmology
+        if cosmo_cls.__parameters__[0] != "param":
+            assert set(Example.__parameters__[1:]) == set(cosmo_cls.__parameters__)
+
+    def test_make_from_Parameter(self, cosmo_cls, clean_registry):
+        """Test the parameter creation process. Uses ``__set__``."""
+
+        class Example(cosmo_cls):
+            param = Parameter(unit=u.eV, equivalencies=u.mass_energy())
+
+            def __init__(self, param, *, name=None, meta=None):
+                self.param = param
+
+        assert Example(1).param == 1 * u.eV
+        assert Example(1 * u.eV).param == 1 * u.eV
+        assert Example(1 * u.J).param == (1 * u.J).to(u.eV)
+        assert Example(1 * u.kg).param == (1 * u.kg).to(u.eV, u.mass_energy())
+
+
+# ========================================================================
+
+
+class TestParameter(ParameterTestMixin):
+    """
+    Test `astropy.cosmology.Parameter` directly. Adds a lot of specific tests
+    that wouldn't be covered by the per-cosmology tests.
+    """
+
+    def setup_class(self):
+        class Example1(Cosmology):
+            param = Parameter(doc="example parameter",
+                              unit=u.m, equivalencies=u.mass_energy())
+
+            def __init__(self, param=15):
+                self.param = param
+
+        # with setter
+        class Example2(Example1):
+            def __init__(self, param=15 * u.m):
+                self.param = param
+
+            @Example1.param.setter
+            def param(self, param, value):
+                return value.to(u.km)
+
+        # attributes
+        self.classes = {"Example1": Example1, "Example2": Example2}
+
+    def teardown_class(self):
+        for cls in self.classes.values():
+            _COSMOLOGY_CLASSES.pop(cls.__qualname__)
+
+    @pytest.fixture(params=["Example1", "Example2"])
+    def cosmo_cls(self, request):
+        """Cosmology class."""
+        return self.classes[request.param]
+
+    @pytest.fixture
+    def cosmo(self, cosmo_cls):
+        """Cosmology instance"""
+        return cosmo_cls()
+
+    @pytest.fixture
+    def param(self, cosmo_cls):
+        """Get Parameter 'param' from cosmology class."""
+        return cosmo_cls.param
+
+    # ==============================================================
+
+    def test_Parameter_instance_attributes(self, param):
+        """Test :class:`astropy.cosmology.Parameter` attributes from init."""
+        super().test_Parameter_instance_attributes(param)
+
+        # property
+        assert param.__doc__ == "example parameter"
+
+        # custom from init
+        assert param._unit == u.m
+        assert param._equivalencies == u.mass_energy()
+        assert param._fmt == ".3g"
+        assert param._derived == False
+
+        # custom from set_name
+        assert param._attr_name == "param"
+        assert param._attr_name_private == "_param"
+        assert hasattr(param, "__wrapped__")
+        assert hasattr(param, "__name__")
+
+    def test_Parameter_fset(self, cosmo, param):
+        """Test :attr:`astropy.cosmology.Parameter.fset`."""
+        super().test_Parameter_fset(param)
+
+        value = param.fset(cosmo, param, 1000 * u.m)
+        assert value == 1 * u.km
+
+    def test_Parameter_name(self, param):
+        """Test :attr:`astropy.cosmology.Parameter.name`."""
+        super().test_Parameter_name(param)
+
+        assert param.name == "param"
+
+    def test_Parameter_unit(self, param):
+        """Test :attr:`astropy.cosmology.Parameter.unit`."""
+        super().test_Parameter_unit(param)
+
+        assert param.unit == u.m
+
+    def test_Parameter_equivalencies(self, param):
+        """Test :attr:`astropy.cosmology.Parameter.equivalencies`."""
+        super().test_Parameter_equivalencies(param)
+
+        assert param.equivalencies == u.mass_energy()
+
+    def test_Parameter_format_spec(self, param):
+        """Test :attr:`astropy.cosmology.Parameter.format_spec`."""
+        super().test_Parameter_format_spec(param)
+
+        assert param.format_spec == ".3g"
+
+    def test_Parameter_derived(self, cosmo_cls, param):
+        """Test :attr:`astropy.cosmology.Parameter.derived`."""
+        super().test_Parameter_derived(cosmo_cls, param)
+
+        assert param.derived is False
+
+    # -------------------------------------------
+    # descriptor methods
+
+    def test_Parameter_descriptor_get(self, cosmo_cls, cosmo, param):
+        """Test :meth:`astropy.cosmology.Parameter.__get__`."""
+        super().test_Parameter_descriptor_get(cosmo_cls, cosmo, param)
+
+        # from instance
+        value = getattr(cosmo, param.name)
+        assert value == 15 * u.m
+
+    # -------------------------------------------
+    # property-style methods
+
+    def test_Parameter_getter(self, param):
+        """Test :meth:`astropy.cosmology.Parameter.getter`."""
+        with pytest.raises(AttributeError, match="can't create custom Parameter getter."):
+            param.getter(None)
+
+    def test_Parameter_setter(self, param):
+        """Test :meth:`astropy.cosmology.Parameter.setter`."""
+        for k in Parameter._registry_setters:
+            newparam = param.setter(k)
+            assert newparam.fset == newparam._registry_setters[k]
+
+        # error for non-registered str
+        with pytest.raises(ValueError, match="`fset` if str"):
+            Parameter(fset="NOT REGISTERED")
+
+        # error if wrong type
+        with pytest.raises(TypeError, match="`fset` must be a function or"):
+            Parameter(fset=object())
+
+    def test_Parameter_deleter(self, param):
+        """Test :meth:`astropy.cosmology.Parameter.deleter`."""
+        with pytest.raises(AttributeError, match="can't create custom Parameter deleter."):
+            param.deleter(None)
+
+    # -------------------------------------------
+    # validation
+
+    def test_Parameter_set(self, cosmo, param):
+        """Test :meth:`astropy.cosmology.Parameter.set`."""
+        value = param.set(cosmo, 1000 * u.m)
+
+        # whether has custom setter
+        if param.fset is param._registry_setters["default"]:
+            assert value.unit == u.m
+            assert value.value == 1000
+        else:
+            assert value.unit == u.km
+            assert value.value == 1
+
+    def test_Parameter_register_setter(self, param):
+        """Test :meth:`astropy.cosmology.Parameter.register_setter`."""
+        # already registered
+        with pytest.raises(KeyError, match="setter 'default' already"):
+            param.__class__.register_setter("default", None)
+
+        # setter not None
+        try:
+            func = lambda x: x
+            setter = param.__class__.register_setter("newsetter", func)
+            assert setter is func
+        finally:
+            param.__class__._registry_setters.pop("newsetter", None)
+
+        # used as decorator
+        try:
+            @param.__class__.register_setter("newsetter")
+            def func(cosmology, param, value):
+                return value
+
+            assert param.__class__._registry_setters["newsetter"] is func
+        finally:
+            param.__class__._registry_setters.pop("newsetter", None)
+
+    # ==============================================================
+
+    def test_Parameter_doesnt_change_with_generic_class(self):
+        """Descriptors are initialized once and not updated on subclasses."""
+
+        class ExampleBase:
+            def __init__(self, param=15):
+                self._param = param
+
+            sig = inspect.signature(__init__)
+            _init_signature = sig.replace(parameters=list(sig.parameters.values())[1:])
+
+            param = Parameter(doc="example parameter")
+
+        class Example(ExampleBase): pass
+
+        assert Example.param is ExampleBase.param
+
+    def test_Parameter_doesnt_change_with_cosmology(self, cosmo_cls):
+        """Cosmology reinitializes all descriptors when a subclass is defined."""
+
+        # define subclass to show param is same
+        class Example(cosmo_cls): pass
+
+        assert Example.param is cosmo_cls.param
+
+        # unregister
+        _COSMOLOGY_CLASSES.pop(Example.__qualname__)
+        assert Example.__qualname__ not in _COSMOLOGY_CLASSES

--- a/astropy/cosmology/tests/test_parameter.py
+++ b/astropy/cosmology/tests/test_parameter.py
@@ -65,32 +65,24 @@ class ParameterTestMixin:
         """Test :class:`astropy.cosmology.Parameter` instantiation."""
         # defaults
         parameter = Parameter()
-        assert parameter.fget is None
         assert parameter.fvalidate is _validate_with_unit
         assert parameter.unit is None
         assert parameter.equivalencies == []
         assert parameter.format_spec == ".3g"
         assert parameter.derived is False
-        assert parameter.__wrapped__ is parameter.fget
 
         # setting all kwargs
-        parameter = Parameter(fget=lambda x: x, fvalidate="float", doc="DOCSTRING",
+        parameter = Parameter(fvalidate="float", doc="DOCSTRING",
                               unit="km", equivalencies=[u.mass_energy()],
                               fmt=".4f", derived=True)
-        assert parameter.fget(2) == 2
         assert parameter.fvalidate is _validate_to_float
         assert parameter.unit is u.km
         assert parameter.equivalencies == [u.mass_energy()]
         assert parameter.format_spec == ".4f"
         assert parameter.derived is True
-        assert parameter.__wrapped__ is parameter.fget
 
     def test_Parameter_instance_attributes(self, all_parameter):
         """Test :class:`astropy.cosmology.Parameter` attributes from init."""
-        # property
-        assert hasattr(all_parameter, "fget")
-        assert all_parameter.fget is None or callable(all_parameter.fget)
-
         assert hasattr(all_parameter, "fvalidate")
         assert callable(all_parameter.fvalidate)
 
@@ -101,16 +93,10 @@ class ParameterTestMixin:
         assert hasattr(all_parameter, "_equivalencies")
         assert hasattr(all_parameter, "_fmt")
         assert hasattr(all_parameter, "_derived")
-        assert hasattr(all_parameter, "__wrapped__")
 
         # __set_name__
         assert hasattr(all_parameter, "_attr_name")
         assert hasattr(all_parameter, "_attr_name_private")
-
-    def test_Parameter_fget(self, all_parameter):
-        """Test :attr:`astropy.cosmology.Parameter.fget`."""
-        assert hasattr(all_parameter, "fget")
-        assert callable(all_parameter.fget) or all_parameter.fget is None
 
     def test_Parameter_fvalidate(self, all_parameter):
         """Test :attr:`astropy.cosmology.Parameter.fvalidate`."""
@@ -318,7 +304,6 @@ class TestParameter(ParameterTestMixin):
         # custom from set_name
         assert param._attr_name == "param"
         assert param._attr_name_private == "_param"
-        assert hasattr(param, "__wrapped__")
 
     def test_Parameter_fvalidate(self, cosmo, param):
         """Test :attr:`astropy.cosmology.Parameter.fvalidate`."""
@@ -420,6 +405,13 @@ class TestParameter(ParameterTestMixin):
             assert param.__class__._registry_validators["newvalidator"] is func
         finally:
             param.__class__._registry_validators.pop("newvalidator", None)
+
+    def test_Parameter_registered_validators(self, param):
+        """
+        Test :attr:`astropy.cosmology.Parameter.registered_validators`
+        is just a keys view of the validators registry.
+        """
+        assert param.registered_validators == param._registry_validators.keys()
 
     # ==============================================================
 

--- a/astropy/cosmology/tests/test_parameter.py
+++ b/astropy/cosmology/tests/test_parameter.py
@@ -406,13 +406,6 @@ class TestParameter(ParameterTestMixin):
         finally:
             param.__class__._registry_validators.pop("newvalidator", None)
 
-    def test_Parameter_registered_validators(self, param):
-        """
-        Test :attr:`astropy.cosmology.Parameter.registered_validators`
-        is just a keys view of the validators registry.
-        """
-        assert param.registered_validators == param._registry_validators.keys()
-
     # ==============================================================
 
     def test_Parameter_doesnt_change_with_generic_class(self):

--- a/docs/changes/cosmology/12190.feature.rst
+++ b/docs/changes/cosmology/12190.feature.rst
@@ -1,3 +1,3 @@
-Cosmology parameters now allow for custom value validators.
-If not specified, the default validator is used, which will assign units
+Cosmology parameters now allow for custom value setters.
+If not specified, the default setter is used, which will assign units
 using the Parameters ``units`` and ``equivalencies`` (if present)

--- a/docs/changes/cosmology/12190.feature.rst
+++ b/docs/changes/cosmology/12190.feature.rst
@@ -1,3 +1,6 @@
-Cosmology parameters now allow for custom value setters.
+Cosmology Parameters allow for custom value setters.
+Values can be set once, but will error if set a second time.
 If not specified, the default setter is used, which will assign units
-using the Parameters ``units`` and ``equivalencies`` (if present)
+using the Parameters ``units`` and ``equivalencies`` (if present).
+Alternate setters may be registered with Parameter to be specified by a str,
+not a decorator on the Cosmology.

--- a/docs/changes/cosmology/12190.feature.rst
+++ b/docs/changes/cosmology/12190.feature.rst
@@ -1,0 +1,3 @@
+Cosmology parameters now allow for custom value validators.
+If not specified, the default validator is used, which will assign units
+using the Parameters ``units`` and ``equivalencies`` (if present)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -141,6 +141,7 @@ numpydoc_xref_param_type = True
 # name. The base set comes from sphinx-astropy. We add more here.
 numpydoc_xref_ignore.update({
     "mixin",
+    "Any",  # aka something that would be annotated with `typing.Any`
     # needed in subclassing numpy  # TODO! revisit
     "Arguments", "Path",
     # TODO! not need to ignore.

--- a/docs/cosmology/dev.rst
+++ b/docs/cosmology/dev.rst
@@ -109,12 +109,11 @@ the definition of :class:`~astropy.cosmology.FLRW`.
             self.H0 = H0
             ...  # for each Parameter in turn
 
-        @m_nu.getter
-        @lazyproperty  # so only does expensive computation once
-        def m_nu(self):
-            """ Mass of neutrino species"""
+        @m_nu.setter
+        def m_nu(self, param, value):
+            """Mass of neutrino species."""
             ...
-            return u.Quantity(numass, self.__class__.m_nu.unit)
+            return u.Quantity(value, param.unit)
 
 First note that all the parameters are also arguments in ``__init__``. This is
 not strictly necessary, but is good practice. If the parameter has units (and
@@ -122,25 +121,17 @@ related equivalencies) these must be specified on the Parameter, as seen in
 :attr:`~astropy.cosmology.FLRW.H0` and :attr:`~astropy.cosmology.FLRW.m_nu`.
 
 The next important thing to note is how the parameter value is set, in
-``__init__``. Without a custom ``getter``, |Parameter| returns the
-corresponding private attribute: so the value for "H0" is set on "._H0".
-However |Parameter| allows for a value to be set once (before auto-locking),
-so ``self.H0 = H0`` will use this setter and put the value on "._H0". The
-advantage of this method over direct assignment to the private attribute is
-the use of validators. |Parameter| allows for custom value validators, using
-the method-decorator ``validator``, that can check a values validity and even
-modify the value, e.g to assign units. If no custom ``validator`` is specified
-the default is to check if the |Parameter| has defined units and if so, return
-the value as a |Quantity| with those units, using all enabled + the parameter's
-unit equivalencies.
+``__init__``. |Parameter| allows for a value to be set once (before
+auto-locking), so ``self.H0 = H0`` will use this setter and put the value on
+"._H0". The advantage of this method over direct assignment to the private
+attribute is the use of setters / validators. |Parameter| allows for custom
+value setters, using the method-decorator ``setter``, that can check a values
+validity and modify the value, e.g to assign units. If no custom ``setter`` is
+specified the default is to check if the |Parameter| has defined units and if
+so, return the value as a |Quantity| with those units, using all enabled and
+the parameter's unit equivalencies.
 
-When a Parameter uses :meth:`~astropy.cosmology.Parameter.getter`, the
-value may be stored anywhere, anyhow. For instance
-:attr:`~astropy.cosmology.FLRW.m_nu` is declared a Parameter with all the rest,
-but has a custom ``getter``. On instances of FLRW its value depends on
-:attr:`~astropy.cosmology.FLRW.Neff` and :attr:`~astropy.cosmology.FLRW.Tcmb0`,
-so is not neatly stored in an attribute ``_m_nu``.
-Note: ``Parameter.getter`` must be the top-most decorator.
+Note: ``Parameter.setter`` must be the top-most decorator.
 
 The last thing to note is pretty formatting for the |Cosmology|. Each
 |Parameter| defaults to the `format specification

--- a/docs/cosmology/dev.rst
+++ b/docs/cosmology/dev.rst
@@ -76,7 +76,7 @@ Parameters
 An astropy |Cosmology| is characterized by 1) its class, which encodes the
 physics, and 2) its free parameter(s), which specify a cosmological realization.
 When defining the former, all parameters must be declared using |Parameter| and
-should have values assigned at instantiation (or appropriate ``getter`` methods).
+should have values assigned at instantiation.
 
 A |Parameter| is a `descriptor <https://docs.python.org/3/howto/descriptor.html>`_.
 When accessed from a class it transparently stores information, like the units

--- a/docs/cosmology/dev.rst
+++ b/docs/cosmology/dev.rst
@@ -114,7 +114,9 @@ the definition of :class:`~astropy.cosmology.FLRW`.
             """Validate baryon density to None or positive float > matter density."""
             if value is None:
                 return value
-            ...
+            value = _validate_non_negative(self, param, value)
+            if value > self.Om0:
+                raise ValueError("baryonic density can not be larger than total matter density.")
             return value
 
 First note that all the parameters are also arguments in ``__init__``. This is
@@ -127,7 +129,7 @@ The next important thing to note is how the parameter value is set, in
 auto-locking), so ``self.H0 = H0`` will use this setter and put the value on
 "._H0". The advantage of this method over direct assignment to the private
 attribute is the use of validators. |Parameter| allows for custom value
-validators, using the method-decorator ``validator``, that can check a values
+validators, using the method-decorator ``validator``, that can check a value's
 validity and modify the value, e.g to assign units. If no custom ``validator``
 is specified the default is to check if the |Parameter| has defined units and
 if so, return the value as a |Quantity| with those units, using all enabled and

--- a/docs/cosmology/dev.rst
+++ b/docs/cosmology/dev.rst
@@ -75,9 +75,8 @@ Parameters
 
 An astropy |Cosmology| is characterized by 1) its class, which encodes the
 physics, and 2) its free parameter(s), which specify a cosmological realization.
-When defining the former, all parameters must be declared using
-|Parameter| and should have values assigned at instantiation (or appropriate
-``getter`` methods).
+When defining the former, all parameters must be declared using |Parameter| and
+should have values assigned at instantiation (or appropriate ``getter`` methods).
 
 A |Parameter| is a `descriptor <https://docs.python.org/3/howto/descriptor.html>`_.
 When accessed from a class it transparently stores information, like the units
@@ -107,8 +106,7 @@ the definition of :class:`~astropy.cosmology.FLRW`.
 
         def __init__(self, H0, Om0, Ode0, Tcmb0=0.0*u.K, Neff=3.04, m_nu=0.0*u.eV,
                      Ob0=None, *, name=None, meta=None):
-            cls = self.__class__
-            self._H0 = H0 << cls.H0.unit
+            self.H0 = H0
             ...  # for each Parameter in turn
 
         @m_nu.getter
@@ -126,6 +124,15 @@ related equivalencies) these must be specified on the Parameter, as seen in
 The next important thing to note is how the parameter value is set, in
 ``__init__``. Without a custom ``getter``, |Parameter| returns the
 corresponding private attribute: so the value for "H0" is set on "._H0".
+However |Parameter| allows for a value to be set once (before auto-locking),
+so ``self.H0 = H0`` will use this setter and put the value on "._H0". The
+advantage of this method over direct assignment to the private attribute is
+the use of validators. |Parameter| allows for custom value validators, using
+the method-decorator ``validator``, that can check a values validity and even
+modify the value, e.g to assign units. If no custom ``validator`` is specified
+the default is to check if the |Parameter| has defined units and if so, return
+the value as a |Quantity| with those units, using all enabled + the parameter's
+unit equivalencies.
 
 When a Parameter uses :meth:`~astropy.cosmology.Parameter.getter`, the
 value may be stored anywhere, anyhow. For instance

--- a/docs/cosmology/io.rst
+++ b/docs/cosmology/io.rst
@@ -237,7 +237,6 @@ class to use. Details about metadata treatment are in
 ``Cosmology.from_format.help("mapping")``.
 
 .. code-block:: python
-    :emphasize-lines: 12,13
 
     >>> import copy
     >>> from astropy.cosmology import Cosmology
@@ -261,7 +260,6 @@ cosmology object and a ``*args`` to absorb unneeded information passed by
 :meth:`astropy.cosmology.Cosmology.to_format`).
 
 .. code-block:: python
-    :emphasize-lines: 4
 
     >>> from astropy.table import QTable
 
@@ -277,7 +275,6 @@ Last we write a function to help with format auto-identification and then
 register everything into `astropy.io.registry`.
 
 .. code-block:: python
-    :emphasize-lines: 11, 12, 13
 
     >>> from astropy.cosmology import Cosmology
     >>> from astropy.cosmology.connect import convert_registry
@@ -353,7 +350,6 @@ which Cosmology class to use. Details of are in
 ``Cosmology.from_format.help("mapping")``.
 
 .. code-block:: python
-    :emphasize-lines: 9,12,17
 
     >>> import json, os
     >>> import astropy.units as u
@@ -384,7 +380,6 @@ boolean flag "overwrite" to set behavior for existing files. Note that
 ``read`` methods we have to create custom parsers.
 
 .. code-block:: python
-    :emphasize-lines: 2,19
 
     >>> def write_json(cosmology, file, *, overwrite=False, **kwargs):
     ...    data = cosmology.to_format("mapping")  # start by turning into dict
@@ -410,7 +405,6 @@ Last we write a function to help with format auto-identification and then
 register everything into :mod:`astropy.io.registry`.
 
 .. code-block:: python
-    :emphasize-lines: 7,8,9
 
     >>> from astropy.cosmology.connect import readwrite_registry
 


### PR DESCRIPTION
Parameter value validation and allowing parameters to be "fixed"/derived, e.g. setting ``Ode0`` in ``FlatFLRWMixin``.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
