### PR TITLE
refactor ``test_connect`` for new test suite

### DIFF
--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -263,7 +263,7 @@ class Cosmology(metaclass=abc.ABCMeta):
 
         return self
 
-    def __init__(self, *args, name=None, meta=None, **kwargs):
+    def __init__(self, name=None, meta=None):
         self._name = name
         self.meta.update(meta or {})
 

--- a/astropy/cosmology/io/tests/test_mapping.py
+++ b/astropy/cosmology/io/tests/test_mapping.py
@@ -12,7 +12,7 @@ from astropy.utils.exceptions import AstropyUserWarning
 
 class CosmologyWithKwargs(Cosmology):
     def __init__(self, name="cosmology with kwargs", meta=None, **kwargs):
-        super().__init__(name=name, meta=meta, **kwargs)
+        super().__init__(name=name, meta=meta)
 
 
 cosmo_instances = [

--- a/astropy/cosmology/tests/conftest.py
+++ b/astropy/cosmology/tests/conftest.py
@@ -5,12 +5,88 @@
 ##############################################################################
 # IMPORTS
 
+# STDLIB
+import json
+import os
+
 import pytest
 
+import astropy.units as u
 from astropy.cosmology import core
+from astropy.cosmology.core import Cosmology
+from astropy.utils.misc import isiterable
 
 ###############################################################################
+# FUNCTIONS
 
+
+def read_json(filename, **kwargs):
+    """Read JSON.
+
+    Parameters
+    ----------
+    filename : str
+    **kwargs
+        Keyword arguments into :meth:`~astropy.cosmology.Cosmology.from_format`
+
+    Returns
+    -------
+    `~astropy.cosmology.Cosmology` instance
+
+    """
+    # read
+    if isinstance(filename, (str, bytes, os.PathLike)):
+        with open(filename, "r") as file:
+            data = file.read()
+    else:  # file-like : this also handles errors in dumping
+        data = filename.read()
+
+    mapping = json.loads(data)  # parse json mappable to dict
+
+    # deserialize Quantity
+    for k, v in mapping.items():
+        if isinstance(v, dict) and "value" in v and "unit" in v:
+            mapping[k] = u.Quantity(v["value"], v["unit"])
+    for k, v in mapping.get("meta", {}).items():  # also the metadata
+        if isinstance(v, dict) and "value" in v and "unit" in v:
+            mapping["meta"][k] = u.Quantity(v["value"], v["unit"])
+
+    return Cosmology.from_format(mapping, **kwargs)
+
+
+def write_json(cosmology, file, *, overwrite=False):
+    """Write Cosmology to JSON.
+
+    Parameters
+    ----------
+    cosmology : `astropy.cosmology.Cosmology` subclass instance
+    file : path-like or file-like
+    overwrite : bool (optional, keyword-only)
+    """
+    data = cosmology.to_format("mapping")  # start by turning into dict
+    data["cosmology"] = data["cosmology"].__qualname__
+
+    # serialize Quantity
+    for k, v in data.items():
+        if isinstance(v, u.Quantity):
+            data[k] = {"value": v.value.tolist(), "unit": str(v.unit)}
+    for k, v in data.get("meta", {}).items():  # also serialize the metadata
+        if isinstance(v, u.Quantity):
+            data["meta"][k] = {"value": v.value.tolist(), "unit": str(v.unit)}
+
+    # check that file exists and whether to overwrite.
+    if os.path.exists(file) and not overwrite:
+        raise IOError(f"{file} exists. Set 'overwrite' to write over.")
+    with open(file, "w") as write_file:
+        json.dump(data, write_file)
+
+
+def json_identify(origin, filepath, fileobj, *args, **kwargs):
+    return filepath is not None and filepath.endswith(".json")
+
+
+###############################################################################
+# FIXTURES
 
 @pytest.fixture
 def clean_registry():

--- a/astropy/cosmology/tests/test_connect.py
+++ b/astropy/cosmology/tests/test_connect.py
@@ -2,112 +2,63 @@
 
 import copy
 import inspect
-import json
 import os
 
 import pytest
 
-import numpy as np
-
-import astropy.units as u
 from astropy import cosmology
 from astropy.cosmology import Cosmology, w0wzCDM
 from astropy.cosmology.connect import CosmologyRead
-from astropy.cosmology.core import _COSMOLOGY_CLASSES, Cosmology
+from astropy.cosmology.core import Cosmology
 from astropy.io import registry as io_registry
+
+from .conftest import json_identify, read_json, write_json
+
+###############################################################################
+# SETUP
 
 cosmo_instances = cosmology.parameters.available
 readwrite_formats = ["json"]
 tofrom_formats = [("mapping", dict)]  # (format, data type)
 
-
 ###############################################################################
-# Setup
-
-def read_json(filename, **kwargs):
-    with open(filename, "r") as file:
-        data = file.read()
-    mapping = json.loads(data)  # parse json mappable to dict
-    # deserialize Quantity
-    for k, v in mapping.items():
-        if isinstance(v, dict) and "value" in v and "unit" in v:
-            mapping[k] = u.Quantity(v["value"], v["unit"])
-    for k, v in mapping.get("meta", {}).items():  # also the metadata
-        if isinstance(v, dict) and "value" in v and "unit" in v:
-            mapping["meta"][k] = u.Quantity(v["value"], v["unit"])
-    return Cosmology.from_format(mapping, **kwargs)
 
 
-def write_json(cosmology, file, *, overwrite=False):
-    """Write Cosmology to JSON.
-
-    Parameters
-    ----------
-    cosmology : `astropy.cosmology.Cosmology` subclass instance
-    file : path-like or file-like
-    overwrite : bool (optional, keyword-only)
+class ReadWriteTestMixin:
     """
-    data = cosmology.to_format("mapping")  # start by turning into dict
-    data["cosmology"] = data["cosmology"].__qualname__  # class -> str
-    # serialize Quantity
-    for k, v in data.items():
-        if isinstance(v, u.Quantity):
-            data[k] = {"value": v.value.tolist(),
-                       "unit": str(v.unit)}
-    for k, v in data.get("meta", {}).items():  # also serialize the metadata
-        if isinstance(v, u.Quantity):
-            data["meta"][k] = {"value": v.value.tolist(),
-                               "unit": str(v.unit)}
+    Tests for a CosmologyRead/Write on a |Cosmology|.
+    This class will not be directly called by :mod:`pytest` since its name does
+    not begin with ``Test``. To activate the contained tests this class must
+    be inherited in a subclass. Subclasses must define a :func:`pytest.fixture`
+    ``cosmo`` that returns/yields an instance of a |Cosmology|.
+    See ``TestReadWriteCosmology`` or ``TestCosmology`` for examples.
+    """
 
-    # check that file exists and whether to overwrite.
-    if os.path.exists(file) and not overwrite:
-        raise IOError(f"{file} exists. Set 'overwrite' to write over.")
-    with open(file, "w") as write_file:
-        json.dump(data, write_file)
+    @pytest.fixture(scope="class", autouse=True)
+    def setup_readwrite(self):
+        """Setup & teardown for read/write tests."""
+        # register
+        io_registry.register_reader("json", Cosmology, read_json)
+        io_registry.register_writer("json", Cosmology, write_json)
+        io_registry.register_identifier("json", Cosmology, json_identify)
 
+        yield  # run all tests in class
 
-def json_identify(origin, filepath, fileobj, *args, **kwargs):
-    return filepath is not None and filepath.endswith(".json")
+        # unregister
+        io_registry.unregister_reader("json", Cosmology)
+        io_registry.unregister_writer("json", Cosmology)
+        io_registry.unregister_identifier("json", Cosmology)
 
-
-def setup_module(module):
-    """Setup module for tests."""
-    io_registry.register_reader("json", Cosmology, read_json)
-    io_registry.register_writer("json", Cosmology, write_json)
-    io_registry.register_identifier("json", Cosmology, json_identify)
-
-
-def teardown_module(module):
-    """clean up module after tests."""
-    io_registry.unregister_reader("json", Cosmology)
-    io_registry.unregister_writer("json", Cosmology)
-    io_registry.unregister_identifier("json", Cosmology)
-
-
-###############################################################################
-# Tests
-
-class TestReadWriteCosmology:
+    # ===============================================================
+    # Method & Attribute Tests
 
     @pytest.mark.parametrize("format", readwrite_formats)
-    def test_write_methods_have_explicit_kwarg_overwrite(self, format):
-        writer = io_registry.get_writer(format, Cosmology)
-        # test in signature
-        sig = inspect.signature(writer)
-        assert "overwrite" in sig.parameters
-
-        # also in docstring
-        assert "overwrite : bool" in writer.__doc__
-
-    @pytest.mark.parametrize("format", readwrite_formats)
-    @pytest.mark.parametrize("instance", cosmo_instances)
-    def test_complete_info(self, tmpdir, instance, format):
+    def test_readwrite_complete_info(self, cosmo, tmpdir, format):
         """
         Test writing from an instance and reading from the base class.
         This requires full information.
         """
-        cosmo = getattr(cosmology.realizations, instance)
-        fname = tmpdir / f"{instance}.{format}"
+        fname = tmpdir / f"{cosmo.name}.{format}"
 
         cosmo.write(str(fname), format=format)
 
@@ -126,14 +77,12 @@ class TestReadWriteCosmology:
         assert got.meta == cosmo.meta
 
     @pytest.mark.parametrize("format", readwrite_formats)
-    @pytest.mark.parametrize("instance", cosmo_instances)
-    def test_from_subclass_complete_info(self, tmpdir, instance, format):
+    def test_readwrite_from_subclass_complete_info(self, cosmo, tmpdir, format):
         """
         Test writing from an instance and reading from that class, when there's
         full information saved.
         """
-        cosmo = getattr(cosmology.realizations, instance)
-        fname = tmpdir / f"{instance}.{format}"
+        fname = tmpdir / f"{cosmo.name}.{format}"
         cosmo.write(str(fname), format=format)
 
         # read with the same class that wrote.
@@ -151,30 +100,64 @@ class TestReadWriteCosmology:
         assert got == cosmo
         assert got.meta == cosmo.meta
 
-    @pytest.mark.parametrize("instance", cosmo_instances)
-    def test_from_subclass_partial_info(self, tmpdir, instance):
+    @pytest.mark.skip("TODO: generalize over all save formats for this test.")
+    def test_readwrite_from_subclass_partial_info(self, cosmo, tmpdir):
         """
         Test writing from an instance and reading from that class.
         This requires partial information.
 
         .. todo::
 
-            generalize over all save formats for this test.
+            - generalize over all save formats for this test.
+            - remove the method defined in subclass
         """
-        format = "json"
+
+
+class TestCosmologyReadWrite(ReadWriteTestMixin):
+    """Test the classes CosmologyRead/Write."""
+
+    @pytest.fixture(params=cosmo_instances)
+    def cosmo(self, request):
+        return getattr(cosmology.realizations, request.param)
+
+    # ==============================================================
+
+    @pytest.mark.parametrize("format", readwrite_formats)
+    def test_write_methods_have_explicit_kwarg_overwrite(self, format):
+        writer = io_registry.get_writer(format, Cosmology)
+        # test in signature
+        sig = inspect.signature(writer)
+        assert "overwrite" in sig.parameters
+
+        # also in docstring
+        assert "overwrite : bool" in writer.__doc__
+
+    # @pytest.mark.parametrize("format", readwrite_formats)
+    @pytest.mark.parametrize("instance", cosmo_instances)
+    def test_readwrite_from_subclass_partial_info(self, instance, tmpdir):
+        """
+        Test writing from an instance and reading from that class.
+        This requires partial information.
+
+        .. todo::
+
+            remove when fix method in super
+        """
         cosmo = getattr(cosmology.realizations, instance)
-        fname = tmpdir / f"{instance}.{format}"
+
+        format = "json"
+        fname = tmpdir / f"{cosmo.name}.{format}"
 
         cosmo.write(str(fname), format=format)
 
         # partial information
         with open(fname, "r") as file:
             L = file.readlines()[0]
-        L = L[:L.index('"cosmology":')]+L[L.index(', ')+2:]  # remove cosmology
+        L = L[: L.index('"cosmology":')] + L[L.index(", ") + 2 :]  # remove cosmology
         i = L.index('"Tcmb0":')  # delete Tcmb0
-        L = L[:i] + L[L.index(', ', L.index(', ', i) + 1)+2:]  # second occurence
+        L = L[:i] + L[L.index(", ", L.index(", ", i) + 1) + 2 :]  # second occurence
 
-        tempfname = tmpdir / f"{instance}_temp.{format}"
+        tempfname = tmpdir / f"{cosmo.name}_temp.{format}"
         with open(tempfname, "w") as file:
             file.writelines([L])
 
@@ -193,12 +176,13 @@ class TestReadWriteCosmology:
         # but the metadata is the same
         assert got.meta == cosmo.meta
 
-    @pytest.mark.parametrize("format", readwrite_formats)
     @pytest.mark.parametrize("instance", cosmo_instances)
-    def test_reader_class_mismatch(self, tmpdir, instance, format):
+    @pytest.mark.parametrize("format", readwrite_formats)
+    def test_readwrite_reader_class_mismatch(self, instance, tmpdir, format):
         """Test when the reader class doesn't match the file."""
         cosmo = getattr(cosmology.realizations, instance)
-        fname = tmpdir / f"{instance}.{format}"
+
+        fname = tmpdir / f"{cosmo.name}.{format}"
         cosmo.write(str(fname), format=format)
 
         # class mismatch
@@ -214,15 +198,24 @@ class TestReadWriteCosmology:
             w0wzCDM.read(fname, format=format, cosmology="FlatLambdaCDM")
 
 
-class TestCosmologyToFromFormat:
-    """Test methods ``astropy.cosmology.Cosmology.to/from_format``."""
+###############################################################################
+# To/From_Format Tests
+
+
+class ToFromFormatTestMixin:
+    """
+    Tests for a Cosmology[To/From]Format on a |Cosmology|.
+    This class will not be directly called by :mod:`pytest` since its name does
+    not begin with ``Test``. To activate the contained tests this class must
+    be inherited in a subclass. Subclasses must define a :func:`pytest.fixture`
+    ``cosmo`` that returns/yields an instance of a |Cosmology|.
+    See ``TestCosmologyToFromFormat`` or ``TestCosmology`` for examples.
+    """
 
     @pytest.mark.parametrize("format_type", tofrom_formats)
-    @pytest.mark.parametrize("instance", cosmo_instances)
-    def test_format_complete_info(self, instance, format_type):
+    def test_tofromformat_complete_info(self, cosmo, format_type):
         """Read tests happen later."""
         format, objtype = format_type
-        cosmo = getattr(cosmology.realizations, instance)
 
         # test to_format
         obj = cosmo.to_format(format)
@@ -238,14 +231,12 @@ class TestCosmologyToFromFormat:
         assert got.meta == cosmo.meta
 
     @pytest.mark.parametrize("format_type", tofrom_formats)
-    @pytest.mark.parametrize("instance", cosmo_instances)
-    def test_from_subclass_complete_info(self, instance, format_type):
+    def test_fromformat_subclass_complete_info(self, cosmo, format_type):
         """
         Test transforming an instance and parsing from that class, when there's
         full information available.
         """
         format, objtype = format_type
-        cosmo = getattr(cosmology.realizations, instance)
 
         # test to_format
         obj = cosmo.to_format(format)
@@ -269,8 +260,7 @@ class TestCosmologyToFromFormat:
         assert got == cosmo
         assert got.meta == cosmo.meta
 
-    @pytest.mark.parametrize("instance", cosmo_instances)
-    def test_from_subclass_partial_info(self, instance):
+    def test_fromformat_subclass_partial_info(self, cosmo):
         """
         Test writing from an instance and reading from that class.
         This requires partial information.
@@ -280,7 +270,6 @@ class TestCosmologyToFromFormat:
             generalize over all formats for this test.
         """
         format, objtype = ("mapping", dict)
-        cosmo = getattr(cosmology.realizations, instance)
 
         # test to_format
         obj = cosmo.to_format(format)
@@ -288,8 +277,8 @@ class TestCosmologyToFromFormat:
 
         # partial information
         tempobj = copy.deepcopy(obj)
-        del tempobj["cosmology"]
-        del tempobj["Tcmb0"]
+        tempobj.pop("cosmology", None)
+        tempobj.pop("Tcmb0", None)
 
         # read with the same class that wrote fills in the missing info with
         # the default value
@@ -306,12 +295,21 @@ class TestCosmologyToFromFormat:
         # but the metadata is the same
         assert got.meta == cosmo.meta
 
+
+class TestCosmologyToFromFormat(ToFromFormatTestMixin):
+    """Test Cosmology[To/From]Format classes."""
+
+    @pytest.fixture(params=cosmo_instances)
+    def cosmo(self, request):
+        return getattr(cosmology.realizations, request.param)
+
+    # ==============================================================
+
     @pytest.mark.parametrize("format_type", tofrom_formats)
     @pytest.mark.parametrize("instance", cosmo_instances)
-    def test_reader_class_mismatch(self, instance, format_type):
-        """Test when the reader class doesn't match the object."""
-        format, objtype = format_type
+    def test_fromformat_class_mismatch(self, instance, format_type):
         cosmo = getattr(cosmology.realizations, instance)
+        format, objtype = format_type
 
         # test to_format
         obj = cosmo.to_format(format)

--- a/astropy/cosmology/tests/test_flrw.py
+++ b/astropy/cosmology/tests/test_flrw.py
@@ -12,6 +12,7 @@ import pytest
 import astropy.units as u
 from astropy.cosmology import (FLRW, FlatLambdaCDM, Flatw0waCDM, FlatwCDM,
                                LambdaCDM, Planck18, w0waCDM, w0wzCDM, wCDM, wpwaCDM)
+from astropy.cosmology.core import _COSMOLOGY_CLASSES
 from astropy.cosmology.flrw import ellipkinc, hyp2f1, quad
 from astropy.utils.compat.optional_deps import HAS_SCIPY
 
@@ -55,7 +56,11 @@ class TestFLRW(CosmologyTest):
         self.cls = SubFLRW
         # H0, Om0, Ode0
         self.cls_args = (70 * u.km / u.s / u.Mpc, 0.27 * u.one, 0.689 * u.one)
-        self.cls_kwargs = dict(Tcmb0=3.0 * u.K, name="test", meta={"a": "b"})
+        self.cls_kwargs = dict(Tcmb0=3.0 * u.K, name=self.__class__.__name__, meta={"a": "b"})
+
+    def teardown_class(self):
+        super().teardown_class(self)
+        _COSMOLOGY_CLASSES.pop("TestFLRW.setup_class.<locals>.SubFLRW", None)
 
     @pytest.fixture
     def nonflatcosmo(self):
@@ -144,7 +149,7 @@ class TestLambdaCDM(FLRWSubclassTest):
         """Setup for testing."""
         self.cls = LambdaCDM
         self.cls_args = (70 * (u.km / u.s / u.Mpc), 0.27, 0.73)  # H0, Om0, Ode0
-        self.cls_kwargs = dict(Tcmb0=3 * u.K, name="test", meta={"a": "b"})
+        self.cls_kwargs = dict(Tcmb0=3 * u.K, name=self.__class__.__name__, meta={"a": "b"})
 
 
 # -----------------------------------------------------------------------------
@@ -157,7 +162,7 @@ class TestFlatLambdaCDM(FlatFLRWMixinTest, TestLambdaCDM):
         """Setup for testing."""
         self.cls = FlatLambdaCDM
         self.cls_args = (70 * (u.km / u.s / u.Mpc), 0.27)  # H0, Om0, Ode0
-        self.cls_kwargs = dict(Tcmb0=3 * u.K, name="test", meta={"a": "b"})
+        self.cls_kwargs = dict(Tcmb0=3 * u.K, name=self.__class__.__name__, meta={"a": "b"})
 
 
 # -----------------------------------------------------------------------------
@@ -170,7 +175,7 @@ class TestwCDM(FLRWSubclassTest):
         """Setup for testing."""
         self.cls = wCDM
         self.cls_args = (70 * (u.km / u.s / u.Mpc), 0.27, 0.73)  # H0, Om0, Ode0
-        self.cls_kwargs = dict(Tcmb0=3 * u.K, name="test", meta={"a": "b"})
+        self.cls_kwargs = dict(Tcmb0=3 * u.K, name=self.__class__.__name__, meta={"a": "b"})
 
 
 # -----------------------------------------------------------------------------
@@ -183,7 +188,7 @@ class TestFlatwCDM(FlatFLRWMixinTest, TestwCDM):
         """Setup for testing."""
         self.cls = FlatwCDM
         self.cls_args = (70 * (u.km / u.s / u.Mpc), 0.27)  # H0, Om0
-        self.cls_kwargs = dict(Tcmb0=3 * u.K, name="test", meta={"a": "b"})
+        self.cls_kwargs = dict(Tcmb0=3 * u.K, name=self.__class__.__name__, meta={"a": "b"})
 
 
 # -----------------------------------------------------------------------------
@@ -196,7 +201,7 @@ class Testw0waCDM(FLRWSubclassTest):
         """Setup for testing."""
         self.cls = w0waCDM
         self.cls_args = (70 * (u.km / u.s / u.Mpc), 0.27, 0.73)  # H0, Om0, Ode0
-        self.cls_kwargs = dict(Tcmb0=3 * u.K, name="test", meta={"a": "b"})
+        self.cls_kwargs = dict(Tcmb0=3 * u.K, name=self.__class__.__name__, meta={"a": "b"})
 
 
 # -----------------------------------------------------------------------------
@@ -209,7 +214,7 @@ class TestFlatw0waCDM(FlatFLRWMixinTest, Testw0waCDM):
         """Setup for testing."""
         self.cls = Flatw0waCDM
         self.cls_args = (70 * (u.km / u.s / u.Mpc), 0.27)  # H0, Om0
-        self.cls_kwargs = dict(Tcmb0=3 * u.K, name="test", meta={"a": "b"})
+        self.cls_kwargs = dict(Tcmb0=3 * u.K, name=self.__class__.__name__, meta={"a": "b"})
 
 
 # -----------------------------------------------------------------------------
@@ -222,7 +227,7 @@ class TestwpwaCDM(FLRWSubclassTest):
         """Setup for testing."""
         self.cls = wpwaCDM
         self.cls_args = (70 * (u.km / u.s / u.Mpc), 0.27, 0.73)  # H0, Om0, Ode0
-        self.cls_kwargs = dict(Tcmb0=3 * u.K, name="test", meta={"a": "b"})
+        self.cls_kwargs = dict(Tcmb0=3 * u.K, name=self.__class__.__name__, meta={"a": "b"})
 
 
 # -----------------------------------------------------------------------------
@@ -235,4 +240,4 @@ class Testw0wzCDM(FLRWSubclassTest):
         """Setup for testing."""
         self.cls = w0wzCDM
         self.cls_args = (70 * (u.km / u.s / u.Mpc), 0.27, 0.73)  # H0, Om0, Ode0
-        self.cls_kwargs = dict(Tcmb0=3 * u.K, name="test", meta={"a": "b"})
+        self.cls_kwargs = dict(Tcmb0=3 * u.K, name=self.__class__.__name__, meta={"a": "b"})

--- a/docs/changes/cosmology/12191.api.rst
+++ b/docs/changes/cosmology/12191.api.rst
@@ -1,0 +1,2 @@
+Cosmology base class constructor now only accepts arguments ``name`` and ``meta``.
+Subclasses should add relevant arguments and not pass them to the base class.


### PR DESCRIPTION
Provides mixins for TestCosmology to test the descriptors.
Now every cosmology will test that it can I/O.
Also the classes in ``connect.py`` have some extra tests built upon the more general tests that each cosmology runs.

Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
