### PR TITLE
move scipy imports

### DIFF
--- a/astropy/cosmology/flrw.py
+++ b/astropy/cosmology/flrw.py
@@ -21,9 +21,16 @@ from .utils import inf_like, vectorize_if_needed
 # isort: split
 if HAS_SCIPY:
     from scipy.integrate import quad
+    from scipy.special import ellipkinc, hyp2f1
 else:
     def quad(*args, **kwargs):
         raise ModuleNotFoundError("No module named 'scipy.integrate'")
+
+    def ellipkinc(*args, **kwargs):
+        raise ModuleNotFoundError("No module named 'scipy.special'")
+
+    def hyp2f1(*args, **kwargs):
+        raise ModuleNotFoundError("No module named 'scipy.special'")
 
 
 __all__ = ["FLRW", "LambdaCDM", "FlatLambdaCDM", "wCDM", "FlatwCDM",
@@ -1689,7 +1696,6 @@ class LambdaCDM(FLRW):
         .. [1] Kantowski, R., Kao, J., & Thomas, R. (2000). Distance-Redshift
                in Inhomogeneous FLRW. arXiv e-prints, astro-ph/0002334.
         """
-        from scipy.special import ellipkinc
         try:
             z1, z2 = np.broadcast_arrays(z1, z2)
         except ValueError as e:
@@ -1853,7 +1859,6 @@ class LambdaCDM(FLRW):
            expressions and numerical evaluation of the luminosity distance
            in a flat cosmology. MNRAS, 468(1), 927-930.
         """
-        from scipy.special import hyp2f1
         return 2 * np.sqrt(x) * hyp2f1(1./6, 1./2, 7./6, -x**3)
 
     def _dS_age(self, z):

--- a/astropy/cosmology/tests/test_flrw.py
+++ b/astropy/cosmology/tests/test_flrw.py
@@ -12,12 +12,30 @@ import pytest
 import astropy.units as u
 from astropy.cosmology import (FLRW, FlatLambdaCDM, Flatw0waCDM, FlatwCDM,
                                LambdaCDM, Planck18, w0waCDM, w0wzCDM, wCDM, wpwaCDM)
+from astropy.cosmology.flrw import ellipkinc, hyp2f1, quad
+from astropy.utils.compat.optional_deps import HAS_SCIPY
 
-from .test_core import FlatCosmologyMixinTest
 from .test_core import CosmologySubclassTest as CosmologyTest
+from .test_core import FlatCosmologyMixinTest
 
 ##############################################################################
 # TESTS
+##############################################################################
+
+
+@pytest.mark.skipif(HAS_SCIPY, reason="scipy is installed")
+def test_optional_deps_functions():
+    """Test stand-in functions when optional dependencies not installed."""
+    with pytest.raises(ModuleNotFoundError, match="No module named 'scipy.integrate'"):
+        quad()
+
+    with pytest.raises(ModuleNotFoundError, match="No module named 'scipy.special'"):
+        ellipkinc()
+
+    with pytest.raises(ModuleNotFoundError, match="No module named 'scipy.special'"):
+        hyp2f1()
+
+
 ##############################################################################
 
 
@@ -83,7 +101,6 @@ class FLRWSubclassTest(TestFLRW):
 
 
 class FlatFLRWMixinTest(FlatCosmologyMixinTest):
-
     def test_init(self, cosmo_cls):
         super().test_init(cosmo_cls)
 


### PR DESCRIPTION
Don't import every time the function is called.

Edit:  this is mostly a stylistic change (as the import is fairly inexpensive), but this implementation is better because it separates the logic of optional dependencies from the actual physics.

Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>


### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
