### PR TITLE
transfer `test_efunc_vs_invefunc`

### DIFF
--- a/astropy/cosmology/tests/test_cosmology.py
+++ b/astropy/cosmology/tests/test_cosmology.py
@@ -12,8 +12,7 @@ from astropy.cosmology import Cosmology, flrw, funcs
 from astropy.cosmology.realizations import Planck13, Planck18, default_cosmology
 from astropy.units import allclose
 from astropy.utils.compat.optional_deps import HAS_SCIPY
-from astropy.utils.exceptions import (AstropyDeprecationWarning,
-                                      AstropyUserWarning)
+from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyUserWarning
 
 
 def test_flrw_moved_deprecation():
@@ -693,48 +692,6 @@ def test_tnu():
     # Test for integers
     z = [0, 1, 2, 3]
     assert allclose(cosmo.Tnu(z), expected, rtol=1e-6)
-
-
-def test_efunc_vs_invefunc():
-    """ Test that efunc and inv_efunc give inverse values"""
-
-    # Note that all of the subclasses here don't need
-    #  scipy because they don't need to call de_density_scale
-    # The test following this tests the case where that is needed.
-
-    z0 = 0.5
-    z = np.array([0.5, 1.0, 2.0, 5.0])
-
-    # Below are the 'standard' included cosmologies
-    # We do the non-standard case in test_efunc_vs_invefunc_flrw,
-    # since it requires scipy
-    cosmo = flrw.LambdaCDM(70, 0.3, 0.5)
-    assert allclose(cosmo.efunc(z0), 1.0 / cosmo.inv_efunc(z0))
-    assert allclose(cosmo.efunc(z), 1.0 / cosmo.inv_efunc(z))
-    cosmo = flrw.LambdaCDM(70, 0.3, 0.5, m_nu=u.Quantity(0.01, u.eV))
-    assert allclose(cosmo.efunc(z0), 1.0 / cosmo.inv_efunc(z0))
-    assert allclose(cosmo.efunc(z), 1.0 / cosmo.inv_efunc(z))
-    cosmo = flrw.FlatLambdaCDM(50.0, 0.27)
-    assert allclose(cosmo.efunc(z0), 1.0 / cosmo.inv_efunc(z0))
-    assert allclose(cosmo.efunc(z), 1.0 / cosmo.inv_efunc(z))
-    cosmo = flrw.wCDM(60.0, 0.27, 0.6, w0=-0.8)
-    assert allclose(cosmo.efunc(z0), 1.0 / cosmo.inv_efunc(z0))
-    assert allclose(cosmo.efunc(z), 1.0 / cosmo.inv_efunc(z))
-    cosmo = flrw.FlatwCDM(65.0, 0.27, w0=-0.6)
-    assert allclose(cosmo.efunc(z0), 1.0 / cosmo.inv_efunc(z0))
-    assert allclose(cosmo.efunc(z), 1.0 / cosmo.inv_efunc(z))
-    cosmo = flrw.w0waCDM(60.0, 0.25, 0.4, w0=-0.6, wa=0.1)
-    assert allclose(cosmo.efunc(z0), 1.0 / cosmo.inv_efunc(z0))
-    assert allclose(cosmo.efunc(z), 1.0 / cosmo.inv_efunc(z))
-    cosmo = flrw.Flatw0waCDM(55.0, 0.35, w0=-0.9, wa=-0.2)
-    assert allclose(cosmo.efunc(z0), 1.0 / cosmo.inv_efunc(z0))
-    assert allclose(cosmo.efunc(z), 1.0 / cosmo.inv_efunc(z))
-    cosmo = flrw.wpwaCDM(50.0, 0.3, 0.3, wp=-0.9, wa=-0.2, zp=0.3)
-    assert allclose(cosmo.efunc(z0), 1.0 / cosmo.inv_efunc(z0))
-    assert allclose(cosmo.efunc(z), 1.0 / cosmo.inv_efunc(z))
-    cosmo = flrw.w0wzCDM(55.0, 0.4, 0.8, w0=-1.05, wz=-0.2)
-    assert allclose(cosmo.efunc(z0), 1.0 / cosmo.inv_efunc(z0))
-    assert allclose(cosmo.efunc(z), 1.0 / cosmo.inv_efunc(z))
 
 
 @pytest.mark.skipif('not HAS_SCIPY')

--- a/astropy/cosmology/tests/test_flrw.py
+++ b/astropy/cosmology/tests/test_flrw.py
@@ -9,6 +9,8 @@ import abc
 
 import pytest
 
+import numpy as np
+
 import astropy.units as u
 from astropy.cosmology import (FLRW, FlatLambdaCDM, Flatw0waCDM, FlatwCDM,
                                LambdaCDM, Planck18, w0waCDM, w0wzCDM, wCDM, wpwaCDM)
@@ -88,6 +90,19 @@ class TestFLRW(CosmologyTest):
             assert not cosmo.is_equivalent(Planck18)
             assert not Planck18.is_equivalent(cosmo)
 
+    def test_efunc_vs_invefunc(self, cosmo):
+        """
+        Test that efunc and inv_efunc give inverse values.
+        Here they just fail b/c no ``w(z)`` or no scipy.
+        """
+        exception = NotImplementedError if HAS_SCIPY else ModuleNotFoundError
+
+        with pytest.raises(exception):
+            cosmo.efunc(0.5)
+
+        with pytest.raises(exception):
+            cosmo.inv_efunc(0.5)
+
 
 class FLRWSubclassTest(TestFLRW):
     """
@@ -100,6 +115,21 @@ class FLRWSubclassTest(TestFLRW):
     def setup_class(self):
         """Setup for testing."""
         pass
+
+    # ===============================================================
+
+    def test_efunc_vs_invefunc(self, cosmo):
+        """Test that ``efunc`` and ``inv_efunc`` give inverse values.
+
+        Note that the test doesn't need scipy because it doesn't need to call
+        ``de_density_scale``.
+        """
+        # super().test_efunc_vs_invefunc(cosmo)  # NOT b/c abstract `w(z)`
+        z0 = 0.5
+        z = np.array([0.5, 1.0, 2.0, 5.0])
+
+        assert np.allclose(cosmo.efunc(z0), 1.0 / cosmo.inv_efunc(z0))
+        assert np.allclose(cosmo.efunc(z), 1.0 / cosmo.inv_efunc(z))
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Move `test_efunc_vs_invefunc` from ``test_cosmology.py`` to new test suite. Now it tests `FLRW` + all subclasses and can is more easily extended to new Cosmology classes (because of the new test framework framework).

Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
