### PR TITLE
Remove deprecated arguments from `astropy.stats`

### DIFF
--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -14,7 +14,6 @@ import math
 import numpy as np
 
 import astropy.units as u
-from astropy.utils.decorators import deprecated_renamed_argument
 from . import _stats
 
 __all__ = ['gaussian_fwhm_to_sigma', 'gaussian_sigma_to_fwhm',
@@ -88,7 +87,6 @@ def _expand_dims(data, axis):
     return data.reshape(shape)
 
 
-@deprecated_renamed_argument('conf', 'confidence_level', '4.0')
 def binom_conf_interval(k, n, confidence_level=0.68269, interval='wilson'):
     r"""Binomial proportion confidence interval given k successes,
     n trials.
@@ -316,7 +314,6 @@ def binom_conf_interval(k, n, confidence_level=0.68269, interval='wilson'):
     return conf_interval
 
 
-@deprecated_renamed_argument('conf', 'confidence_level', '4.0')
 def binned_binom_proportion(x, success, bins=10, range=None,
                             confidence_level=0.68269, interval='wilson'):
     """Binomial proportion and confidence interval in bins of a continuous
@@ -506,7 +503,6 @@ def _check_poisson_conf_inputs(sigma, background, confidence_level, name):
         raise ValueError(f"confidence_level not supported for interval {name}")
 
 
-@deprecated_renamed_argument('conflevel', 'confidence_level', '4.0')
 def poisson_conf_interval(n, interval='root-n', sigma=1, background=0,
                           confidence_level=None):
     r"""Poisson parameter confidence interval given observed counts

--- a/astropy/stats/jackknife.py
+++ b/astropy/stats/jackknife.py
@@ -2,8 +2,6 @@
 
 import numpy as np
 
-from astropy.utils.decorators import deprecated_renamed_argument
-
 __all__ = ['jackknife_resampling', 'jackknife_stats']
 __doctest_requires__ = {'jackknife_stats': ['scipy']}
 
@@ -54,7 +52,6 @@ def jackknife_resampling(data):
     return resamples
 
 
-@deprecated_renamed_argument('conf_lvl', 'confidence_level', '4.0')
 def jackknife_stats(data, statistic, confidence_level=0.95):
     """Performs jackknife estimation on the basis of jackknife resamples.
 

--- a/astropy/stats/tests/test_funcs.py
+++ b/astropy/stats/tests/test_funcs.py
@@ -9,7 +9,6 @@ from astropy.utils.compat.optional_deps import HAS_SCIPY, HAS_MPMATH  # noqa
 
 from astropy.stats import funcs
 from astropy import units as u
-from astropy.utils.exceptions import AstropyDeprecationWarning
 from astropy.utils.misc import NumpyRNGContext
 
 
@@ -160,13 +159,6 @@ def test_binom_conf_interval():
                       [0.36941, 0.52650, 0.65085, 0.75513, 0.84298]])
     assert_allclose(result, table, atol=1.e-3, rtol=0.)
 
-    # Test scalar version
-    with pytest.warns(AstropyDeprecationWarning):
-        result = np.array([funcs.binom_conf_interval(kval, n, conf=conf,
-                                                     interval='flat')
-                           for kval in k]).transpose()
-    assert_allclose(result, table, atol=1.e-3, rtol=0.)
-
     # Test Wald interval
     result = funcs.binom_conf_interval(0, 5, interval='wald')
     assert_allclose(result, 0.)  # conf interval is [0, 0] when k = 0
@@ -233,8 +225,7 @@ def test_binned_binom_proportion():
 
 def test_binned_binom_proportion_exception():
     with pytest.raises(ValueError):
-        with pytest.warns(AstropyDeprecationWarning):
-            funcs.binned_binom_proportion([0], [1, 2], conf=0.75)
+        funcs.binned_binom_proportion([0], [1, 2], confidence_level=0.75)
 
 
 def test_signal_to_noise_oir_ccd():
@@ -677,9 +668,8 @@ def test_poisson_conf_kbn_value_errors():
 @pytest.mark.skipif('HAS_SCIPY or HAS_MPMATH')
 def test_poisson_limit_nodependencies():
     with pytest.raises(ImportError):
-        with pytest.warns(AstropyDeprecationWarning):
-            funcs.poisson_conf_interval(20, interval='kraft-burrows-nousek',
-                                        background=10., conflevel=.95)
+        funcs.poisson_conf_interval(20, interval='kraft-burrows-nousek',
+                                    background=10., confidence_level=.95)
 
 
 @pytest.mark.skipif('not HAS_SCIPY')

--- a/astropy/stats/tests/test_jackknife.py
+++ b/astropy/stats/tests/test_jackknife.py
@@ -5,7 +5,6 @@ import numpy as np
 from numpy.testing import assert_equal, assert_allclose
 
 from astropy.stats.jackknife import jackknife_resampling, jackknife_stats
-from astropy.utils.exceptions import AstropyDeprecationWarning
 from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa
 
 
@@ -51,9 +50,5 @@ def test_jackknife_stats_conf_interval():
 
 
 def test_jackknife_stats_exceptions():
-    with pytest.raises(ValueError):
-        with pytest.warns(AstropyDeprecationWarning):
-            jackknife_stats(np.array([]), np.mean, conf_lvl=0.9)
-
     with pytest.raises(ValueError):
         jackknife_stats(np.arange(2), np.mean, confidence_level=42)

--- a/docs/changes/stats/12200.api.rst
+++ b/docs/changes/stats/12200.api.rst
@@ -1,0 +1,6 @@
+Removed the following deprecated features from ``astropy.stats``:
+
+* ``conf`` argument for ``funcs.binom_conf_interval()`` and
+  ``funcs.binned_binom_proportion()``,
+* ``conflevel`` argument for ``funcs.poisson_conf_interval()``, and
+* ``conf_lvl`` argument for ``jackknife.jackknife_stats()``.


### PR DESCRIPTION
### Description

~~The `bls` and `lombscargle` modules were deprecated in #8591.~~
The keyword arguments removed in this pull request were deprecated in #9408.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
