### PR TITLE
Remove the last reference to the old blackbody module from the docs

### DIFF
--- a/docs/modeling/physical_models.rst
+++ b/docs/modeling/physical_models.rst
@@ -77,16 +77,6 @@ give the wavelength and frequency of the maximum for :math:`B_\lambda`
 and :math:`B_\nu`, respectively, calculated using `Wien's Law
 <https://en.wikipedia.org/wiki/Wien%27s_displacement_law>`_.
 
-.. _deprecated-blackbody:
-
-Note on old blackbody module
-----------------------------
-
-Prior to v4.0, blackbody functionality was provided by the
-``astropy.modeling.blackbody`` module, which was then removed in v4.3.
-If you are still using the removed ``blackbody`` module, please see
-`Blackbody Module (deprecated capabilities) <https://docs.astropy.org/en/v4.1/modeling/blackbody_deprecated.html>`_.
-
 Drude1D
 =======
 


### PR DESCRIPTION
### Description

This pull request deletes the last reference to the removed `astropy.modeling.blackbody` module from the docs.

Closes #10986.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
