### PR TITLE
Add a note about user questions and Discourse to astropy bot "first issue" comment

### DIFF
--- a/.github/workflows/open_actions.yml
+++ b/.github/workflows/open_actions.yml
@@ -31,6 +31,14 @@ jobs:
             and make sure you've provided the requested details.
 
 
+            GitHub issues in the Astropy repository are used to track bug
+            reports and feature requests; If your issue poses a question about
+            how to use Astropy, please instead raise your question in the
+            [Astropy Discourse user
+            forum](https://community.openastronomy.org/c/astropy/8) and close
+            this issue.
+
+
             If you feel that this issue has not been responded to in a timely
             manner, please leave a comment mentioning our software support
             engineer @embray, or send a message directly to the [development


### PR DESCRIPTION
This adds a new sentence to the astropy-bot comment for users who open a first issue in the Astropy repo.