### PR TITLE
Backport PR #12203: Avoid unnecessary transform via CIRS for AltAz and use ICRS as intermediate frame instead, fixes 12196

### DIFF
--- a/astropy/coordinates/builtin_frames/cirs_observed_transforms.py
+++ b/astropy/coordinates/builtin_frames/cirs_observed_transforms.py
@@ -76,10 +76,3 @@ def altaz_to_cirs(altaz_coo, cirs_frame):
 
     # this final transform may be a no-op if the obstimes and locations are the same
     return cirs_at_aa_time.transform_to(cirs_frame)
-
-
-@frame_transform_graph.transform(FunctionTransformWithFiniteDifference, AltAz, AltAz)
-def altaz_to_altaz(from_coo, to_frame):
-    # for now we just implement this through CIRS to make sure we get everything
-    # covered
-    return from_coo.transform_to(CIRS(obstime=from_coo.obstime)).transform_to(to_frame)

--- a/astropy/coordinates/builtin_frames/icrs_observed_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_observed_transforms.py
@@ -84,3 +84,17 @@ def altaz_to_icrs(altaz_coo, icrs_frame):
         icrs_srepr = newrepr.represent_as(SphericalRepresentation)
 
     return icrs_frame.realize_frame(icrs_srepr)
+
+
+@frame_transform_graph.transform(FunctionTransformWithFiniteDifference, AltAz, AltAz)
+def observed_to_observed(from_coo, to_frame):
+    if from_coo.is_equivalent_frame(to_frame):  # loopback to the same frame
+        return to_frame.realize_frame(from_coo.data)
+
+    # for now we just implement this through ICRS to make sure we get everything
+    # covered
+    # Before, this was using CIRS as intermediate frame, however this is much
+    # slower than the direct observed<->ICRS transform added in 4.3
+    # due to how the frame attribute broadcasting works, see
+    # https://github.com/astropy/astropy/pull/10994#issuecomment-722617041
+    return from_coo.transform_to(ICRS()).transform_to(to_frame)

--- a/docs/changes/coordinates/12203.bugfix.rst
+++ b/docs/changes/coordinates/12203.bugfix.rst
@@ -1,0 +1,2 @@
+Avoid unnecessary transforms through CIRS for AltAz and
+use ICRS as intermediate frame for these transformations instead.


### PR DESCRIPTION
Backport of #12203 for 4.3.x

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
