### PR TITLE
Cosmo FLRW output types

### DIFF
--- a/astropy/cosmology/__init__.py
+++ b/astropy/cosmology/__init__.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-""" astropy.cosmology contains classes and functions for cosmological
+""":mod:`astropy.cosmology` contains classes and functions for cosmological
 distance measures and other cosmology-related calculations.
 
 See the `Astropy documentation

--- a/astropy/cosmology/tests/test_cosmology.py
+++ b/astropy/cosmology/tests/test_cosmology.py
@@ -169,11 +169,11 @@ def test_distance_broadcast():
     for method in methods:
         g = getattr(cosmo, method)
         value_flat = g(z)
-        assert value_flat.shape == z.shape
+        assert value_flat.shape in (z.shape, ())
         value_2d = g(z_reshape2d)
-        assert value_2d.shape == z_reshape2d.shape
+        assert value_2d.shape in (z_reshape2d.shape, ())
         value_3d = g(z_reshape3d)
-        assert value_3d.shape == z_reshape3d.shape
+        assert value_3d.shape in (z_reshape3d.shape, ())
         assert value_flat.unit == value_2d.unit
         assert value_flat.unit == value_3d.unit
         assert allclose(value_flat, value_2d.flatten())
@@ -186,11 +186,11 @@ def test_distance_broadcast():
     for method in methods:
         g = getattr(cosmo, method)
         value_flat = g(z)
-        assert value_flat.shape == z.shape
+        assert value_flat.shape in (z.shape, ())
         value_2d = g(z_reshape2d)
-        assert value_2d.shape == z_reshape2d.shape
+        assert value_2d.shape in (z_reshape2d.shape, ())
         value_3d = g(z_reshape3d)
-        assert value_3d.shape == z_reshape3d.shape
+        assert value_3d.shape in (z_reshape3d.shape, ())
         assert allclose(value_flat, value_2d.flatten())
         assert allclose(value_flat, value_3d.flatten())
 
@@ -205,11 +205,11 @@ def test_distance_broadcast():
         for method in methods:
             g = getattr(cosmo, method)
             value_flat = g(z)
-            assert value_flat.shape == z.shape
+            assert value_flat.shape in (z.shape, ())
             value_2d = g(z_reshape2d)
-            assert value_2d.shape == z_reshape2d.shape
+            assert value_2d.shape in (z_reshape2d.shape, ())
             value_3d = g(z_reshape3d)
-            assert value_3d.shape == z_reshape3d.shape
+            assert value_3d.shape in (z_reshape3d.shape, ())
             assert allclose(value_flat, value_2d.flatten())
             assert allclose(value_flat, value_3d.flatten())
 

--- a/docs/changes/cosmology/12206.api.rst
+++ b/docs/changes/cosmology/12206.api.rst
@@ -1,0 +1,1 @@
+Many FLRW methods return a scalar when possible.

--- a/docs/cosmology/index.rst
+++ b/docs/cosmology/index.rst
@@ -448,7 +448,7 @@ Universe) but setting ``Neff`` to 0::
   >>> cos.Ogamma(np.array([0, 1, 2]))  # Photons are still present  # doctest: +FLOAT_CMP
   array([4.98603986e-05, 2.74642208e-04, 5.00086413e-04])
   >>> cos.Onu(np.array([0, 1, 2]))  # But not neutrinos  # doctest: +FLOAT_CMP
-  array([0., 0., 0.])
+  array(0.)
 
 The number of neutrino species is assumed to be the floor of ``Neff``,
 which in the default case is ``Neff=3``. Therefore, if non-zero neutrino masses


### PR DESCRIPTION
Followup to #12169 
This PR simplifies output types, returning scalars where possible.
All outputs are shape-compatible with the input, just the minimum possible size.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
