### PR TITLE
Add redshift-distance equivalency

### DIFF
--- a/astropy/cosmology/tests/test_units.py
+++ b/astropy/cosmology/tests/test_units.py
@@ -171,20 +171,20 @@ def test_redshift_hubble():
 
 @pytest.mark.skipif(not HAS_SCIPY, reason="Cosmology needs scipy")
 @pytest.mark.parametrize(
-    "distance_kind",
+    "kind",
     [cu.redshift_distance.__defaults__[-1], "comoving", "lookback", "luminosity"]
 )
-def test_redshift_distance(distance_kind):
+def test_redshift_distance(kind):
     """Test :func:`astropy.cosmology.units.redshift_distance`."""
     z = 15 * cu.redshift
-    d = getattr(Planck13, distance_kind + "_distance")(z)
+    d = getattr(Planck13, kind + "_distance")(z)
 
-    equivalency = cu.redshift_distance(cosmology=Planck13, distance_kind=distance_kind)
+    equivalency = cu.redshift_distance(cosmology=Planck13, kind=kind)
 
     # properties of Equivalency
     assert equivalency.name[0] == "redshift_distance"
     assert equivalency.kwargs[0]["cosmology"] == Planck13
-    assert equivalency.kwargs[0]["distance"] == distance_kind
+    assert equivalency.kwargs[0]["distance"] == kind
 
     # roundtrip
     assert_quantity_allclose(z.to(u.Mpc, equivalency), d)
@@ -193,8 +193,8 @@ def test_redshift_distance(distance_kind):
 
 def test_redshift_distance_wrong_kind():
     """Test :func:`astropy.cosmology.units.redshift_distance` wrong kind."""
-    with pytest.raises(ValueError, match="`distance_kind`"):
-        cu.redshift_distance(distance_kind=None)
+    with pytest.raises(ValueError, match="`kind`"):
+        cu.redshift_distance(kind=None)
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason="Cosmology needs scipy")
@@ -353,7 +353,7 @@ class Test_with_redshift:
 
     def test_distance_wrong_kind(self):
         """Test distance equivalency, but the wrong kind."""
-        with pytest.raises(ValueError, match="`distance_kind`"):
+        with pytest.raises(ValueError, match="`kind`"):
             cu.with_redshift(distance=ValueError)
 
     @pytest.mark.parametrize("kind", ["comoving", "lookback", "luminosity"])

--- a/astropy/cosmology/units.py
+++ b/astropy/cosmology/units.py
@@ -9,10 +9,12 @@ from astropy.units.utils import generate_unit_summary as _generate_unit_summary
 
 __all__ = ["littleh", "redshift",
            # redshift equivalencies
-           "dimensionless_redshift", "with_redshift", "redshift_temperature",
-           "redshift_hubble",
+           "dimensionless_redshift", "with_redshift",
+           "redshift_distance", "redshift_hubble", "redshift_temperature",
            # other equivalencies
            "with_H0"]
+
+__doctest_requires__ = {('with_redshift', 'redshift_distance'): ['scipy']}
 
 _ns = globals()
 
@@ -50,8 +52,8 @@ def dimensionless_redshift():
     return u.Equivalency([(redshift, None)], "dimensionless_redshift")
 
 
-def redshift_temperature(cosmology=None, **atzkw):
-    """Convert quantities between redshift and CMB temperature.
+def redshift_distance(cosmology=None, distance_kind="comoving", **atzkw):
+    """Convert quantities between redshift and distance.
 
     Care should be taken to not misinterpret a relativistic, gravitational, etc
     redshift as a cosmological one.
@@ -62,6 +64,10 @@ def redshift_temperature(cosmology=None, **atzkw):
         A cosmology realization or built-in cosmology's name (e.g. 'Planck18').
         If None, will use the default cosmology
         (controlled by :class:`~astropy.cosmology.default_cosmology`).
+    distance_kind : {'comoving', 'lookback', 'luminosity'} or None, optional
+        The distance type for the Equivalency.
+        Note this does NOT include the angular diameter distance as this
+        distance measure is not monotonic.
     **atzkw
         keyword arguments for :func:`~astropy.cosmology.z_at_value`
 
@@ -69,6 +75,16 @@ def redshift_temperature(cosmology=None, **atzkw):
     -------
     `~astropy.units.equivalencies.Equivalency`
         Equivalency between redshift and temperature.
+
+    Examples
+    --------
+    >>> import astropy.units as u
+    >>> import astropy.cosmology.units as cu
+    >>> from astropy.cosmology import WMAP9
+
+    >>> z = 1100 * cu.redshift
+    >>> z.to(u.Mpc, cu.redshift_distance(WMAP9, distance="comoving"))  # doctest: +FLOAT_CMP
+    <Quantity 14004.03157418 Mpc>
     """
     from astropy.cosmology import default_cosmology, z_at_value
 
@@ -77,15 +93,23 @@ def redshift_temperature(cosmology=None, **atzkw):
     with default_cosmology.set(cosmology):  # if already cosmo, passes through
         cosmology = default_cosmology.get()
 
-    def z_to_Tcmb(z):
-        return cosmology.Tcmb(z)
+    allowed_distances = ('comoving', 'lookback', 'luminosity')
+    if distance_kind not in allowed_distances:
+        raise ValueError(f"`distance_kind` is not one of {allowed_distances}")
 
-    def Tcmb_to_z(T):
-        return z_at_value(cosmology.Tcmb, T << u.K, **atzkw)
+    method = getattr(cosmology, distance_kind + "_distance")
 
-    return u.Equivalency([(redshift, u.K, z_to_Tcmb, Tcmb_to_z)],
-                         "redshift_temperature",
-                         {'cosmology': cosmology})
+    def z_to_distance(z):
+        """Redshift to distance."""
+        return method(z)
+
+    def distance_to_z(d):
+        """Distance to redshift."""
+        return z_at_value(method, d << u.Mpc, **atzkw)
+
+    return u.Equivalency([(redshift, u.Mpc, z_to_distance, distance_to_z)],
+                         "redshift_distance",
+                         {'cosmology': cosmology, "distance": distance_kind})
 
 
 def redshift_hubble(cosmology=None, **atzkw):
@@ -107,6 +131,21 @@ def redshift_hubble(cosmology=None, **atzkw):
     -------
     `~astropy.units.equivalencies.Equivalency`
         Equivalency between redshift and Hubble parameter and little-h unit.
+
+    Examples
+    --------
+    >>> import astropy.units as u
+    >>> import astropy.cosmology.units as cu
+    >>> from astropy.cosmology import WMAP9
+
+    >>> z = 1100 * cu.redshift
+    >>> equivalency = cu.redshift_hubble(WMAP9)  # construct equivalency
+
+    >>> z.to(u.km / u.s / u.Mpc, equivalency)  # doctest: +FLOAT_CMP
+    <Quantity 1565637.40154275 km / (Mpc s)>
+
+    >>> z.to(cu.littleh, equivalency)  # doctest: +FLOAT_CMP
+    <Quantity 15656.37401543 littleh>
     """
     from astropy.cosmology import default_cosmology, z_at_value
 
@@ -137,8 +176,56 @@ def redshift_hubble(cosmology=None, **atzkw):
                          {'cosmology': cosmology})
 
 
+def redshift_temperature(cosmology=None, **atzkw):
+    """Convert quantities between redshift and CMB temperature.
+
+    Care should be taken to not misinterpret a relativistic, gravitational, etc
+    redshift as a cosmological one.
+
+    Parameters
+    ----------
+    cosmology : `~astropy.cosmology.Cosmology`, str, or None, optional
+        A cosmology realization or built-in cosmology's name (e.g. 'Planck18').
+        If None, will use the default cosmology
+        (controlled by :class:`~astropy.cosmology.default_cosmology`).
+    **atzkw
+        keyword arguments for :func:`~astropy.cosmology.z_at_value`
+
+    Returns
+    -------
+    `~astropy.units.equivalencies.Equivalency`
+        Equivalency between redshift and temperature.
+
+    Examples
+    --------
+    >>> import astropy.units as u
+    >>> import astropy.cosmology.units as cu
+    >>> from astropy.cosmology import WMAP9
+
+    >>> z = 1100 * cu.redshift
+    >>> z.to(u.K, cu.redshift_temperature(WMAP9))
+    <Quantity 3000.225 K>
+    """
+    from astropy.cosmology import default_cosmology, z_at_value
+
+    # get cosmology: None -> default and process str / class
+    cosmology = cosmology if cosmology is not None else default_cosmology.get()
+    with default_cosmology.set(cosmology):  # if already cosmo, passes through
+        cosmology = default_cosmology.get()
+
+    def z_to_Tcmb(z):
+        return cosmology.Tcmb(z)
+
+    def Tcmb_to_z(T):
+        return z_at_value(cosmology.Tcmb, T << u.K, **atzkw)
+
+    return u.Equivalency([(redshift, u.K, z_to_Tcmb, Tcmb_to_z)],
+                         "redshift_temperature",
+                         {'cosmology': cosmology})
+
+
 def with_redshift(cosmology=None, *,
-                  Tcmb=True, hubble=True,
+                  distance="comoving", hubble=True, Tcmb=True,
                   atzkw=None):
     """Convert quantities between measures of cosmological distance.
 
@@ -150,15 +237,18 @@ def with_redshift(cosmology=None, *,
     ----------
     cosmology : `~astropy.cosmology.Cosmology`, str, or None, optional
         A cosmology realization or built-in cosmology's name (e.g. 'Planck18').
-        If None, will use the default cosmology
+        If `None`, will use the default cosmology
         (controlled by :class:`~astropy.cosmology.default_cosmology`).
 
-    Tcmb : bool (optional, keyword-only)
-        Whether to create a CMB temperature <-> redshift equivalency, using
-        ``Cosmology.Tcmb``. Default is `True`.
+    distance : {'comoving', 'lookback', 'luminosity'} or None (optional, keyword-only)
+        The type of distance equivalency to create or `None`.
+        Default is 'comoving'.
     hubble : bool (optional, keyword-only)
         Whether to create a Hubble parameter <-> redshift equivalency, using
         ``Cosmology.H``. Default is `True`.
+    Tcmb : bool (optional, keyword-only)
+        Whether to create a CMB temperature <-> redshift equivalency, using
+        ``Cosmology.Tcmb``. Default is `True`.
 
     atzkw : dict or None (optional, keyword-only)
         keyword arguments for :func:`~astropy.cosmology.z_at_value`
@@ -166,7 +256,34 @@ def with_redshift(cosmology=None, *,
     Returns
     -------
     `~astropy.units.equivalencies.Equivalency`
-        With equivalencies between redshift and temperature / Hubble.
+        With equivalencies between redshift and distance / Hubble / temperature.
+
+    Examples
+    --------
+    >>> import astropy.units as u
+    >>> import astropy.cosmology.units as cu
+    >>> from astropy.cosmology import WMAP9
+
+    >>> equivalency = cu.with_redshift(WMAP9)
+    >>> z = 1100 * cu.redshift
+
+    Redshift to (comoving) distance:
+
+    >>> z.to(u.Mpc, equivalency)  # doctest: +FLOAT_CMP
+    <Quantity 14004.03157418 Mpc>
+
+    Redshift to the Hubble parameter:
+
+    >>> z.to(u.km / u.s / u.Mpc, equivalency)  # doctest: +FLOAT_CMP
+    <Quantity 1565637.40154275 km / (Mpc s)>
+
+    >>> z.to(cu.littleh, equivalency)  # doctest: +FLOAT_CMP
+    <Quantity 15656.37401543 littleh>
+
+    Redshift to CMB temperature:
+
+    >>> z.to(u.K, equivalency)
+    <Quantity 3000.225 K>
     """
     from astropy.cosmology import default_cosmology, z_at_value
 
@@ -186,10 +303,14 @@ def with_redshift(cosmology=None, *,
     if Tcmb:
         equivs.extend(redshift_temperature(cosmology, **atzkw))
 
+    # Distance <-> Redshift, but need to choose which distance
+    if distance is not None:
+        equivs.extend(redshift_distance(cosmology, distance_kind=distance, **atzkw))
+
     # -----------
     return u.Equivalency(equivs, "with_redshift",
                          {'cosmology': cosmology,
-                          'hubble': hubble, 'Tcmb': Tcmb})
+                          'distance': distance, 'hubble': hubble, 'Tcmb': Tcmb})
 
 
 # ===================================================================

--- a/astropy/cosmology/units.py
+++ b/astropy/cosmology/units.py
@@ -52,7 +52,7 @@ def dimensionless_redshift():
     return u.Equivalency([(redshift, None)], "dimensionless_redshift")
 
 
-def redshift_distance(cosmology=None, distance_kind="comoving", **atzkw):
+def redshift_distance(cosmology=None, kind="comoving", **atzkw):
     """Convert quantities between redshift and distance.
 
     Care should be taken to not misinterpret a relativistic, gravitational, etc
@@ -64,7 +64,7 @@ def redshift_distance(cosmology=None, distance_kind="comoving", **atzkw):
         A cosmology realization or built-in cosmology's name (e.g. 'Planck18').
         If None, will use the default cosmology
         (controlled by :class:`~astropy.cosmology.default_cosmology`).
-    distance_kind : {'comoving', 'lookback', 'luminosity'} or None, optional
+    kind : {'comoving', 'lookback', 'luminosity'} or None, optional
         The distance type for the Equivalency.
         Note this does NOT include the angular diameter distance as this
         distance measure is not monotonic.
@@ -83,7 +83,7 @@ def redshift_distance(cosmology=None, distance_kind="comoving", **atzkw):
     >>> from astropy.cosmology import WMAP9
 
     >>> z = 1100 * cu.redshift
-    >>> z.to(u.Mpc, cu.redshift_distance(WMAP9, distance="comoving"))  # doctest: +FLOAT_CMP
+    >>> z.to(u.Mpc, cu.redshift_distance(WMAP9, kind="comoving"))  # doctest: +FLOAT_CMP
     <Quantity 14004.03157418 Mpc>
     """
     from astropy.cosmology import default_cosmology, z_at_value
@@ -93,11 +93,11 @@ def redshift_distance(cosmology=None, distance_kind="comoving", **atzkw):
     with default_cosmology.set(cosmology):  # if already cosmo, passes through
         cosmology = default_cosmology.get()
 
-    allowed_distances = ('comoving', 'lookback', 'luminosity')
-    if distance_kind not in allowed_distances:
-        raise ValueError(f"`distance_kind` is not one of {allowed_distances}")
+    allowed_kinds = ('comoving', 'lookback', 'luminosity')
+    if kind not in allowed_kinds:
+        raise ValueError(f"`kind` is not one of {allowed_kinds}")
 
-    method = getattr(cosmology, distance_kind + "_distance")
+    method = getattr(cosmology, kind + "_distance")
 
     def z_to_distance(z):
         """Redshift to distance."""
@@ -109,7 +109,7 @@ def redshift_distance(cosmology=None, distance_kind="comoving", **atzkw):
 
     return u.Equivalency([(redshift, u.Mpc, z_to_distance, distance_to_z)],
                          "redshift_distance",
-                         {'cosmology': cosmology, "distance": distance_kind})
+                         {'cosmology': cosmology, "distance": kind})
 
 
 def redshift_hubble(cosmology=None, **atzkw):
@@ -305,7 +305,7 @@ def with_redshift(cosmology=None, *,
 
     # Distance <-> Redshift, but need to choose which distance
     if distance is not None:
-        equivs.extend(redshift_distance(cosmology, distance_kind=distance, **atzkw))
+        equivs.extend(redshift_distance(cosmology, kind=distance, **atzkw))
 
     # -----------
     return u.Equivalency(equivs, "with_redshift",

--- a/docs/changes/cosmology/12212.feature.rst
+++ b/docs/changes/cosmology/12212.feature.rst
@@ -1,0 +1,3 @@
+A new equivalency is added between redshift and distance -- comoving, lookback,
+and luminosity. This equivalency is also available in the catch-all equivalency
+``with_redshift``.

--- a/docs/cosmology/units.rst
+++ b/docs/cosmology/units.rst
@@ -95,11 +95,18 @@ enabling redshift to be converted to other units, like CMB temperature:
 
 or the Hubble parameter:
 
-    >>> z.to(u.km / u.s / u.Mpc, cu.with_redshift(WMAP9))
+    >>> z.to(u.km / u.s / u.Mpc, cu.with_redshift(WMAP9))  # doctest: +FLOAT_CMP
     <Quantity 1565637.40154275 km / (Mpc s)>
 
-    >>> z.to(cu.littleh, cu.with_redshift(WMAP9))
+    >>> z.to(cu.littleh, cu.with_redshift(WMAP9))  # doctest: +FLOAT_CMP
     <Quantity 15656.37401543 littleh>
+
+or a physical distance (comoving, lookback, or luminosity):
+
+.. doctest-requires:: scipy
+
+    >>> z.to(u.Mpc, cu.with_redshift(WMAP9, distance="luminosity"))  # doctest: +FLOAT_CMP
+    <Quantity 15418438.76317008 Mpc>
 
 These conversions are cosmology dependent, so if the cosmology changes,
 so too will the conversions.

--- a/docs/whatsnew/5.0.rst
+++ b/docs/whatsnew/5.0.rst
@@ -92,7 +92,8 @@ A new unit, ``redshift``, is added for tracking factors of cosmological redshift
 As this is a pseudo-unit an equivalency ``dimensionless_redshift`` is added
 (and enabled by default) to allow for redshift - dimensionless conversions.
 To convert between redshift and other cosmological distance measures, e.g.
-CMB temperature, the equivalency ``with_redshift`` is also added.
+CMB temperature or comoving distance, the equivalency ``with_redshift`` is
+also added.
 
     >>> import astropy.units as u
     >>> import astropy.cosmology.units as cu
@@ -103,6 +104,7 @@ CMB temperature, the equivalency ``with_redshift`` is also added.
 
     >>> from astropy.cosmology import WMAP9
     >>> equivalency = cu.with_redshift(WMAP9)  # construct equivalency
+
     >>> z.to(u.K, equivalency)
     <Quantity 3000.225 K>
 
@@ -111,6 +113,13 @@ CMB temperature, the equivalency ``with_redshift`` is also added.
 
     >>> z.to(cu.littleh, equivalency)
     <Quantity 15656.37401543 littleh>
+
+    >>> z.to(u.Mpc, equivalency)
+    <Quantity 14004.03157418 Mpc>
+
+``with_redshift`` is actually a composite of other equivalencies:
+``redshift_distance``, ``redshift_hubble``, and ``redshift_temperature``,
+which may be used separately.
 
 Further details are available in an addition to the docs.
 


### PR DESCRIPTION
A new equivalency is added between redshift and distance -- comoving, lookback,
and luminosity. This equivalency is also available in the catch-all equivalency
``with_redshift``.

Note I am not adding a redshift - angular diameter distance equivalency since that is not monotonic with redshift.

Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
