### PR TITLE
Warn about mixing git pull and rebase in developer docs

### DIFF
--- a/docs/development/workflow/development_workflow.rst
+++ b/docs/development/workflow/development_workflow.rst
@@ -495,6 +495,13 @@ start make a branch to serve as a backup copy of your work::
 After altering the history, e.g. with ``git rebase``, a normal ``git push``
 is prevented, and a ``git push --force`` will be required.
 
+.. warning::
+
+    Do not update your branch with ``git pull``. Pulling changes from
+    ``astropy/main`` includes merging the branches, which combines them in a
+    way that preserves the commit history of both. The purpose of rebasing is
+    rewriting the commit history of your branch, not preserving it.
+
 .. _howto_rebase:
 
 How to rebase


### PR DESCRIPTION
### Description

This adds a warning about performing `git pull` during rebasing to the developer documentation, as was requested in https://github.com/astropy/astropy/issues/8648#issuecomment-488416424.

Closes #8648.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
