### PR TITLE
Clarify the `--set-upstream` git option in developer documentation

### DIFF
--- a/docs/development/workflow/development_workflow.rst
+++ b/docs/development/workflow/development_workflow.rst
@@ -236,8 +236,9 @@ At this point you have made and checked out a new branch, but `git`_ does not
 know it should be connected to your fork on GitHub. You need that connection
 for your proposed changes to be managed by the Astropy maintainers on GitHub.
 
-To connect your local branch to GitHub, you `git push`_ this new branch up to
-your GitHub repo with the ``--set-upstream`` option::
+The most convenient way for connecting your local branch to GitHub is to `git
+push`_ this new branch up to your GitHub repo with the ``--set-upstream``
+option::
 
    git push --set-upstream your-github-username my-new-feature
 
@@ -245,7 +246,9 @@ From now on git will know that ``my-new-feature`` is related to the
 ``your-github-username/my-new-feature`` branch in your GitHub fork of Astropy.
 
 You will still need to ``git push`` your changes to GitHub periodically. The
-setup in this section will make that easier.
+setup in this section will make that easier because any following pushes of
+this branch can be performed without having to write out the remote and branch
+names.
 
 .. _install-branch:
 
@@ -395,9 +398,15 @@ names and the like is encouraged.
 Copy your changes to GitHub
 ***************************
 
-This step is easy because of the way you created the feature branch. Just::
+If you followed the instructions to `Connect the branch to GitHub`_ then you
+can simply use::
 
     git push
+
+If you skipped that step then you need to write out the remote and branch
+names::
+
+    git push your-github-username my-new-feature
 
 .. _pull-request:
 


### PR DESCRIPTION
### Description

The docs are now clearer about how pushing with and without the `--set-upstream` option differ.

Closes #4296.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
