### PR TITLE
Add a link to `info` description to "Getting Started" section of Table docs

### DIFF
--- a/docs/table/index.rst
+++ b/docs/table/index.rst
@@ -127,7 +127,8 @@ then a formatted version appears::
     5 8.5   z  30.0
 
 
-If you do not like the format of a particular column, you can change it::
+If you do not like the format of a particular column, you can change it through
+:ref:`the 'info' property <mixin_attributes>`::
 
   >>> t['b'].info.format = '7.3f'
   >>> print(t)


### PR DESCRIPTION
### Description

The "Getting Started" section of the `astropy.table` documentation now includes a link to a detailed description of the column `info` property. Examples of using the `info` property were already present.

Closes #5658

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
