### PR TITLE
Fix for doctest failure

### DIFF
--- a/docs/development/codeguide.rst
+++ b/docs/development/codeguide.rst
@@ -185,9 +185,9 @@ Coding Style/Conventions
   requires a computationally-expensive operation. The
   :ref:`prop-get-set-example` example below illustrates this guideline.
 
-* Classes should use the builtin :func:`super` function when making calls to
+* Classes should use the builtin `super` function when making calls to
   methods in their super-class(es) unless there are specific reasons not to.
-  :func:`super` should be used consistently in all subclasses since it does not
+  `super` should be used consistently in all subclasses since it does not
   work otherwise. The :ref:`super-vs-direct-example` example below illustrates
   why this is important.
 
@@ -376,7 +376,7 @@ a get/set method. For lengthy or complex calculations, however, use a method::
 super() vs. Direct Calling
 --------------------------
 
-This example shows why the use of :func:`super` leads to a more consistent
+This example shows why the use of `super` leads to a more consistent
 method resolution order than manually calling methods of the super classes in a
 multiple inheritance case::
 
@@ -432,9 +432,9 @@ because both ``B.method()`` and ``C.method()`` call ``A.method()`` unaware of
 the fact that they're being called as part of a chain in a hierarchy.  When
 ``C.method()`` is called it is unaware that it's being called from a subclass
 that inherits from both ``B`` and ``C``, and that ``B.method()`` should be
-called next.  By calling :func:`super` the entire method resolution order for
+called next.  By calling `super` the entire method resolution order for
 ``D`` is precomputed, enabling each superclass to cooperatively determine which
-class should be handed control in the next :func:`super` call::
+class should be handed control in the next `super` call::
 
     # This is safer
 
@@ -469,14 +469,14 @@ class should be handed control in the next :func:`super` call::
 
 As you can see, each superclass's method is entered only once.  For this to
 work it is very important that each method in a class that calls its
-superclass's version of that method use :func:`super` instead of calling the
+superclass's version of that method use `super` instead of calling the
 method directly.  In the most common case of single-inheritance, using
 ``super()`` is functionally equivalent to calling the superclass's method
 directly.  But as soon as a class is used in a multiple-inheritance
 hierarchy it must use ``super()`` in order to cooperate with other classes in
 the hierarchy.
 
-.. note:: For more information on the the benefits of :func:`super`, see
+.. note:: For more information on the the benefits of `super`, see
           https://rhettinger.wordpress.com/2011/05/26/super-considered-super/
 
 .. _import-star-example:


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

Currently the docs build test is failing for most of the new astropy pull requests. This PR attempts to resolve the issues preventing the docs from building.

The issue preventing the docs build test from passing appears to be the way the `codeguide.rst` file was trying to link to the python docs `super()` documentation. This is probably due to some small changes in the python docs with the python 3.10 release.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
