### PR TITLE
Add WMAP1 and WMAP3 to built in cosmologies.

### DIFF
--- a/astropy/cosmology/parameters.py
+++ b/astropy/cosmology/parameters.py
@@ -46,6 +46,16 @@ doi: 10.1088/0067-0049/192/2/18. Table 1 (WMAP + BAO + H0 ML).
 WMAP 5 year (WMAP5) parameters from Komatsu et al. 2009, ApJS, 180, 330,
 doi: 10.1088/0067-0049/180/2/330. Table 1 (WMAP + BAO + SN ML).
 
+WMAP 3 year (WMAP3) parameters from Spergel et al. 2007, ApJS, 170, 377,
+doi:  10.1086/513700. Table 6. (WMAP + SNGold) Obtained from https://lambda.gsfc.nasa.gov/product/map/dr2/params/lcdm_wmap_sngold.cfm
+Tcmb0 and Neff are the standard values as also used for WMAP5, 7, 9.
+Pending WMAP team approval and subject to change.
+
+WMAP 1 year (WMAP1) parameters from Spergel et al. 2003, ApJS, 148, 175,
+doi:  10.1086/377226. Table 7 (WMAP + CBI + ACBAR + 2dFGRS + Lya)
+Tcmb0 and Neff are the standard values as also used for WMAP5, 7, 9.
+Pending WMAP team approval and subject to change.
+
 """
 
 import astropy.units as u
@@ -199,6 +209,50 @@ WMAP5 = dict(
                "Table 1 (WMAP + BAO + SN ML).")
 )
 
+WMAP3 = dict(
+    cosmology="FlatLambdaCDM",
+    Oc0=0.230,
+    Ob0=0.0454,
+    Om0=0.276,
+    H0=70.1 * (u.km / u.s / u.Mpc),
+    n=0.946,
+    sigma8=0.784,
+    tau=0.079,
+    z_reion=10.3,
+    t0=13.78 * u.Gyr,
+    Tcmb0=2.725 * u.K,
+    Neff=3.04,
+    m_nu=0.0 * u.eV,
+    flat=True,
+    reference=("Spergel et al. 2007, ApJS, 170, 377, "
+               "doi:  10.1086/513700. "
+               "Table 6 (WMAP + SNGold) "
+               "obtained from: https://lambda.gsfc.nasa.gov/product/map/dr2/params/lcdm_wmap_sngold.cfm"
+               "\nPending WMAP team approval and subject to change.")
+)
+
+WMAP1 = dict(
+    cosmology="FlatLambdaCDM",
+    Oc0=0.213,
+    Ob0=0.0436,
+    Om0=0.257,
+    H0=72. * (u.km / u.s / u.Mpc),
+    n=0.96,
+    sigma8=0.75,
+    tau=0.117,
+    z_reion=17.0,  # Only from WMAP1. Does not exist in the combined analysis.
+    t0=13.4 * u.Gyr,
+    Tcmb0=2.725 * u.K,
+    Neff=3.04,
+    m_nu=0.0 * u.eV,
+    flat=True,
+    reference=("Spergel et al. 2003, ApJS, 148, 175, "
+               "doi:  10.1086/377226. "
+               "Table 7 (WMAP + CBI + ACBAR + 2dFGRS + Lya)."
+               "\nPending WMAP team approval and subject to change.")
+)
+
+
 # If new parameters are added, this list must be updated
 available = ['Planck18', 'Planck18_arXiv_v2', 'Planck15', 'Planck13',
-             'WMAP9', 'WMAP7', 'WMAP5']
+             'WMAP9', 'WMAP7', 'WMAP5', 'WMAP3', 'WMAP1']

--- a/astropy/cosmology/tests/test_funcs.py
+++ b/astropy/cosmology/tests/test_funcs.py
@@ -11,7 +11,7 @@ import numpy as np
 from astropy import units as u
 from astropy.cosmology import core, flrw
 from astropy.cosmology.funcs import _z_at_scalar_value, z_at_value
-from astropy.cosmology.realizations import WMAP5, WMAP7, WMAP9, Planck13, Planck15, Planck18
+from astropy.cosmology.realizations import WMAP1, WMAP3, WMAP5, WMAP7, WMAP9, Planck13, Planck15, Planck18
 from astropy.units import allclose
 from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa
 from astropy.utils.exceptions import AstropyUserWarning
@@ -212,7 +212,7 @@ def test_z_at_value_unconverged(method):
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
-@pytest.mark.parametrize('cosmo', [Planck13, Planck15, Planck18, WMAP5, WMAP7, WMAP9,
+@pytest.mark.parametrize('cosmo', [Planck13, Planck15, Planck18, WMAP1, WMAP3, WMAP5, WMAP7, WMAP9,
                                    flrw.LambdaCDM, flrw.FlatLambdaCDM, flrw.wpwaCDM, flrw.w0wzCDM,
                                    flrw.wCDM, flrw.FlatwCDM, flrw.w0waCDM, flrw.Flatw0waCDM])
 def test_z_at_value_roundtrip(cosmo):

--- a/docs/changes/cosmology/12248.feature.rst
+++ b/docs/changes/cosmology/12248.feature.rst
@@ -1,0 +1,1 @@
+The WMAP1 and WMAP3 are accessible as builtin cosmologies.

--- a/docs/cosmology/index.rst
+++ b/docs/cosmology/index.rst
@@ -323,6 +323,8 @@ A full list of the predefined cosmologies is given by
 ========  ============================== ====  ===== =======
 Name      Source                         H0    Om    Flat
 ========  ============================== ====  ===== =======
+WMAP1     Spergel et al. 2003            72.0  0.257 Yes
+WMAP3     Spergel et al. 2007            70.1  0.276 Yes
 WMAP5     Komatsu et al. 2009            70.2  0.277 Yes
 WMAP7     Komatsu et al. 2011            70.4  0.272 Yes
 WMAP9     Hinshaw et al. 2013            69.3  0.287 Yes


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->



<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request adds WMAP1 and WMAP3 as built in cosmologies to cosmology.py. It also modifies the cosmology docs to add these as options to the table there. The docs change is a separate commit with [ci_skip] appended, I don't know if that matters. This is my first code contribution to astropy so please excuse me if I have done something wrong. The tests ran fine on my machine after the commits.

**Some details of the chosen cosmology**
I have used the papers listed in the issue and in the docstring. For WMAP1, the z_reion parameter is only given for WMAP1, and not the combined analysis. Since WMAP 5,7, and 9 used some form of combined analysis, I went with using the combined analysis values for all parameters, except that z_reion is only from WMAP1. This value has an error bar of +/- 10 and is not very useful anyway for WMAP1.

For WMAP3, I had to make a choice in which combined analysis to use, as the combination of WMAP3 + BAO + Supernova did not exist, as was used for WMAP 5. I chose to use the WMAP3 + SNGold sample combination, since WMAP5 also uses SN data, but BAO could have been chosen as well. Let me know if cosmology people have an opinion. There is an 'all' option that combines a large number of data sources, but the paper warns against using it and several parameters are not available for this 'all' option. There is a [Table provided by Goddard](https://lambda.gsfc.nasa.gov/product/map/dr2/parameters.cfm) where one can pick the combination, but you can only pick WMAP3 + 1 other source, OR "all".

I used the same effective neutrino species number as the other WMAPs as well as the same CMB temperature. The power spectrum goes beyond the precision we give for the TCMB parameter anyway. WMAP1 paper technically pushes for a non-standard sliding spectral index model, but I thought it was better to stick with the flat lambda-CDM one as used in all the other ready-made cosmologies. It's also much simpler to implement this way.


<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #12228 and fixes #12227 

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
