### PR TITLE
Remove an obsolete fixture from coordinate tests

### DIFF
--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -1433,18 +1433,7 @@ def test_component_names_repr():
     assert repr(frame).count("JUSTONCE") == 1
 
 
-@pytest.fixture
-def reset_galactocentric_defaults():
-    # TODO: this can be removed, along with the "warning" test below, once we
-    # switch the default to 'latest' in v4.1
-
-    # Resets before each test, and after (the yield is pytest magic)
-    galactocentric_frame_defaults.set('v4.0')
-    yield
-    galactocentric_frame_defaults.set('v4.0')
-
-
-def test_galactocentric_defaults(reset_galactocentric_defaults):
+def test_galactocentric_defaults():
 
     with galactocentric_frame_defaults.set('pre-v4.0'):
         galcen_pre40 = Galactocentric()
@@ -1491,7 +1480,7 @@ def test_galactocentric_defaults(reset_galactocentric_defaults):
     )
 
 
-def test_galactocentric_references(reset_galactocentric_defaults):
+def test_galactocentric_references():
     # references in the "scientific paper"-sense
 
     with galactocentric_frame_defaults.set('pre-v4.0'):


### PR DESCRIPTION
### Description

The warning test mentioned in a comment in the fixture was already removed in f61a9600f1aad8b435b8ad39af70a07b2845f7ba.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
