### PR TITLE
Remove `BaseCoordinateFrame.representation`

### DIFF
--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -111,30 +111,6 @@ def _get_repr_classes(base, **differentials):
     return repr_classes
 
 
-def _representation_deprecation():
-    """
-    Raises a deprecation warning for the "representation" keyword
-    """
-    warnings.warn('The `representation` keyword/property name is deprecated in '
-                  'favor of `representation_type`', AstropyDeprecationWarning)
-
-
-def _normalize_representation_type(kwargs):
-    """ This is added for backwards compatibility: if the user specifies the
-    old-style argument ``representation``, add it back in to the kwargs dict
-    as ``representation_type``.
-    """
-    # TODO: remove this in a future LTS release, along with properties below
-    if 'representation' in kwargs:
-        if 'representation_type' in kwargs:
-            raise ValueError("Both `representation` and `representation_type` "
-                             "were passed to a frame initializer. Please use "
-                             "only `representation_type` (`representation` is "
-                             "now pending deprecation).")
-        _representation_deprecation()
-        kwargs['representation_type'] = kwargs.pop('representation')
-
-
 _RepresentationMappingBase = \
     namedtuple('RepresentationMapping',
                ('reprname', 'framename', 'defaultunit'))
@@ -318,13 +294,6 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
     def __init__(self, *args, copy=True, representation_type=None,
                  differential_type=None, **kwargs):
         self._attr_names_with_defaults = []
-
-        # This is here for backwards compatibility. It should be possible
-        # to use either the kwarg representation_type, or representation.
-        if representation_type is not None:
-            kwargs['representation_type'] = representation_type
-        _normalize_representation_type(kwargs)
-        representation_type = kwargs.pop('representation_type', representation_type)
 
         self._representation = self._infer_representation(representation_type, differential_type)
         self._data = self._infer_data(args, copy, kwargs)  # possibly None.
@@ -777,17 +746,6 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
     @differential_type.setter
     def differential_type(self, value):
         self.set_representation_cls(s=value)
-
-    # TODO: remove this property in a future LTS release
-    @property
-    def representation(self):
-        _representation_deprecation()
-        return self.representation_type
-
-    @representation.setter
-    def representation(self, value):
-        _representation_deprecation()
-        self.representation_type = value
 
     @classmethod
     def _get_representation_info(cls):

--- a/astropy/coordinates/sky_coordinate_parsers.py
+++ b/astropy/coordinates/sky_coordinate_parsers.py
@@ -10,8 +10,7 @@ from astropy.units import Unit, IrreducibleUnit
 from astropy import units as u
 
 from .baseframe import (BaseCoordinateFrame, frame_transform_graph,
-                        _get_repr_cls, _get_diff_cls,
-                        _normalize_representation_type)
+                        _get_repr_cls, _get_diff_cls)
 from .builtin_frames import ICRS
 from .representation import (BaseRepresentation, SphericalRepresentation,
                              UnitSphericalRepresentation)
@@ -196,9 +195,6 @@ def _get_frame_without_data(args, kwargs):
     for attr in frame_cls.frame_attributes:
         if attr in kwargs:
             frame_cls_kwargs[attr] = kwargs.pop(attr)
-
-    # TODO: remove this in a future LTS release
-    _normalize_representation_type(kwargs)
 
     if 'representation_type' in kwargs:
         frame_cls_kwargs['representation_type'] = _get_repr_cls(

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -1337,35 +1337,6 @@ def test_representation_with_multiple_differentials():
         ICRS(rep)
 
 
-def test_representation_arg_backwards_compatibility():
-    # TODO: this test can be removed when the `representation` argument is
-    # removed from the BaseCoordinateFrame initializer.
-
-    c1 = ICRS(x=1*u.pc, y=2*u.pc, z=3*u.pc,
-              representation_type=r.CartesianRepresentation)
-
-    c2 = ICRS(x=1*u.pc, y=2*u.pc, z=3*u.pc,
-              representation_type=r.CartesianRepresentation)
-
-    c3 = ICRS(x=1*u.pc, y=2*u.pc, z=3*u.pc,
-              representation_type='cartesian')
-
-    assert c1.x == c2.x
-    assert c1.y == c2.y
-    assert c1.z == c2.z
-
-    assert c1.x == c3.x
-    assert c1.y == c3.y
-    assert c1.z == c3.z
-
-    assert c1.representation_type == c1.representation_type
-
-    with pytest.raises(ValueError):
-        ICRS(x=1*u.pc, y=2*u.pc, z=3*u.pc,
-             representation_type='cartesian',
-             representation='cartesian')
-
-
 def test_missing_component_error_names():
     """
     This test checks that the component names are frame component names, not

--- a/docs/changes/coordinates/12257.api.rst
+++ b/docs/changes/coordinates/12257.api.rst
@@ -1,0 +1,2 @@
+Removed deprecated ``representation`` attribute from
+``astropy.coordinates.BaseCoordinateFrame`` class.

--- a/docs/coordinates/frames.rst
+++ b/docs/coordinates/frames.rst
@@ -115,18 +115,6 @@ You can get the data in a different representation if needed::
     <CartesianRepresentation (x, y, z) [dimensionless]
          (0.99923861, 0.01744177, 0.0348995)>
 
-.. note::
-
-    Before v3.0, both the frame attribute and the argument to frame classes
-    that are now named ``representation_type`` used to be simply
-    ``representation``. The name of this attribute/argument was confusing as it
-    points to the representation *class*, not the object containing the
-    underlying frame data (which is accessed via the frame attribute
-    ``.data``). To clarify, we have renamed ``representation`` to
-    ``representation_type``. In the current version we will issue a deprecation
-    warning if the old names are used. In v5.0 we will remove the
-    ``.representation`` attribute and ``representation=`` argument.
-
 The representation of the coordinate object can also be changed directly, as
 shown below. This does *nothing* to the object internal data which stores the
 coordinate values, but it changes the external view of that data in two ways:


### PR DESCRIPTION
### Description

The `representation` attribute of the `astropy.coordinates.baseframe.BaseCoordinateFrame` class has been deprecated since #8119.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
