### PR TITLE
Remove the `clobber` argument from `io.fits`

### DIFF
--- a/astropy/io/fits/convenience.py
+++ b/astropy/io/fits/convenience.py
@@ -69,7 +69,6 @@ from .hdu.table import BinTableHDU
 from .header import Header
 from .util import fileobj_closed, fileobj_name, fileobj_mode, _is_int
 from astropy.utils.exceptions import AstropyUserWarning
-from astropy.utils.decorators import deprecated_renamed_argument
 
 try:
     from dask.array import Array as DaskArray
@@ -401,10 +400,6 @@ def delval(filename, keyword, *args, **kwargs):
         hdulist.close(closed=closed)
 
 
-@deprecated_renamed_argument('clobber', 'overwrite', '2.0',
-                             message='"clobber" was deprecated in version 2.0 '
-                                     'and will be removed in version 5.1. Use '
-                                     'argument "overwrite" instead.')
 def writeto(filename, data, header=None, output_verify='exception',
             overwrite=False, checksum=False):
     """
@@ -435,9 +430,6 @@ def writeto(filename, data, header=None, output_verify='exception',
         If ``True``, overwrite the output file if it exists. Raises an
         ``OSError`` if ``False`` and the output file exists. Default is
         ``False``.
-
-        .. versionchanged:: 1.3
-           ``overwrite`` replaces the deprecated ``clobber`` argument.
 
     checksum : bool, optional
         If `True`, adds both ``DATASUM`` and ``CHECKSUM`` cards to the
@@ -914,10 +906,6 @@ def printdiff(inputa, inputb, *args, **kwargs):
         print(FITSDiff(inputa, inputb, **kwargs).report())
 
 
-@deprecated_renamed_argument('clobber', 'overwrite', '2.0',
-                             message='"clobber" was deprecated in version 2.0 '
-                                     'and will be removed in version 5.1. Use '
-                                     'argument "overwrite" instead.')
 def tabledump(filename, datafile=None, cdfile=None, hfile=None, ext=1,
               overwrite=False):
     """
@@ -951,9 +939,6 @@ def tabledump(filename, datafile=None, cdfile=None, hfile=None, ext=1,
         If ``True``, overwrite the output file if it exists. Raises an
         ``OSError`` if ``False`` and the output file exists. Default is
         ``False``.
-
-        .. versionchanged:: 1.3
-           ``overwrite`` replaces the deprecated ``clobber`` argument.
 
     Notes
     -----

--- a/astropy/io/fits/diff.py
+++ b/astropy/io/fits/diff.py
@@ -23,7 +23,6 @@ from astropy import __version__
 
 from .card import Card, BLANK_CARD
 from .header import Header
-from astropy.utils.decorators import deprecated_renamed_argument
 # HDUList is used in one of the doctests
 from .hdu.hdulist import fitsopen, HDUList  # pylint: disable=W0611
 from .hdu.table import _TableLikeHDU
@@ -121,11 +120,6 @@ class _BaseDiff:
         return not any(getattr(self, attr) for attr in self.__dict__
                        if attr.startswith('diff_'))
 
-    @deprecated_renamed_argument('clobber', 'overwrite', '2.0',
-                                 message='"clobber" was deprecated in version '
-                                         '2.0 and will be removed in version '
-                                         '5.1. Use argument "overwrite" '
-                                         'instead.')
     def report(self, fileobj=None, indent=0, overwrite=False):
         """
         Generates a text report on the differences (if any) between two
@@ -147,9 +141,6 @@ class _BaseDiff:
             If ``True``, overwrite the output file if it exists. Raises an
             ``OSError`` if ``False`` and the output file exists. Default is
             ``False``.
-
-            .. versionchanged:: 1.3
-               ``overwrite`` replaces the deprecated ``clobber`` argument.
 
         Returns
         -------

--- a/astropy/io/fits/file.py
+++ b/astropy/io/fits/file.py
@@ -21,7 +21,7 @@ from .util import (isreadable, iswritable, isfile, fileobj_open, fileobj_name,
                    fileobj_closed, fileobj_mode, _array_from_file,
                    _array_to_file, _write_string)
 from astropy.utils.data import download_file, _is_url
-from astropy.utils.decorators import classproperty, deprecated_renamed_argument
+from astropy.utils.decorators import classproperty
 from astropy.utils.exceptions import AstropyUserWarning
 from astropy.utils.misc import NOT_OVERWRITING_MSG
 
@@ -104,11 +104,6 @@ class _File:
     Represents a FITS file on disk (or in some other file-like object).
     """
 
-    @deprecated_renamed_argument('clobber', 'overwrite', '2.0',
-                                 message='"clobber" was deprecated in version '
-                                         '2.0 and will be removed in version '
-                                         '5.1. Use argument "overwrite" '
-                                         'instead.')
     def __init__(self, fileobj=None, mode=None, memmap=None, overwrite=False,
                  cache=True):
         self.strict_memmap = bool(memmap)

--- a/astropy/io/fits/hdu/base.py
+++ b/astropy/io/fits/hdu/base.py
@@ -21,7 +21,6 @@ from astropy.io.fits.verify import _Verify, _ErrList
 
 from astropy.utils import lazyproperty
 from astropy.utils.exceptions import AstropyUserWarning
-from astropy.utils.decorators import deprecated_renamed_argument
 
 
 __all__ = [
@@ -338,11 +337,6 @@ class _BaseHDU:
         fileobj.seek(hdu._data_offset + hdu._data_size, os.SEEK_SET)
         return hdu
 
-    @deprecated_renamed_argument('clobber', 'overwrite', '2.0',
-                                 message='"clobber" was deprecated in version '
-                                         '2.0 and will be removed in version '
-                                         '5.1. Use argument "overwrite" '
-                                         'instead.')
     def writeto(self, name, output_verify='exception', overwrite=False,
                 checksum=False):
         """
@@ -367,9 +361,6 @@ class _BaseHDU:
             If ``True``, overwrite the output file if it exists. Raises an
             ``OSError`` if ``False`` and the output file exists. Default is
             ``False``.
-
-            .. versionchanged:: 1.3
-               ``overwrite`` replaces the deprecated ``clobber`` argument.
 
         checksum : bool
             When `True` adds both ``DATASUM`` and ``CHECKSUM`` cards
@@ -1572,20 +1563,12 @@ class ExtensionHDU(_ValidHDU):
 
         raise NotImplementedError
 
-    @deprecated_renamed_argument('clobber', 'overwrite', '2.0',
-                                 message='"clobber" was deprecated in version '
-                                         '2.0 and will be removed in version '
-                                         '5.1. Use argument "overwrite" '
-                                         'instead.')
     def writeto(self, name, output_verify='exception', overwrite=False,
                 checksum=False):
         """
         Works similarly to the normal writeto(), but prepends a default
         `PrimaryHDU` are required by extension HDUs (which cannot stand on
         their own).
-
-        .. versionchanged:: 1.3
-           ``overwrite`` replaces the deprecated ``clobber`` argument.
         """
 
         from .hdulist import HDUList

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -22,7 +22,6 @@ from astropy.io.fits.util import (_free_space_check, _get_array_mmap, _is_int,
 from astropy.io.fits.verify import _Verify, _ErrList, VerifyError, VerifyWarning
 from astropy.utils import indent
 from astropy.utils.exceptions import AstropyUserWarning
-from astropy.utils.decorators import deprecated_renamed_argument
 
 # NOTE: Python can be built without bz2.
 from astropy.utils.compat.optional_deps import HAS_BZ2
@@ -893,11 +892,6 @@ class HDUList(list, _Verify):
                 n = hdr['NAXIS']
                 hdr.set('EXTEND', True, after='NAXIS' + str(n))
 
-    @deprecated_renamed_argument('clobber', 'overwrite', '2.0',
-                                 message='"clobber" was deprecated in version '
-                                         '2.0 and will be removed in version '
-                                         '5.1. Use argument "overwrite" '
-                                         'instead.')
     def writeto(self, fileobj, output_verify='exception', overwrite=False,
                 checksum=False):
         """
@@ -920,9 +914,6 @@ class HDUList(list, _Verify):
             If ``True``, overwrite the output file if it exists. Raises an
             ``OSError`` if ``False`` and the output file exists. Default is
             ``False``.
-
-            .. versionchanged:: 1.3
-               ``overwrite`` replaces the deprecated ``clobber`` argument.
 
         checksum : bool
             When `True` adds both ``DATASUM`` and ``CHECKSUM`` cards

--- a/astropy/io/fits/hdu/table.py
+++ b/astropy/io/fits/hdu/table.py
@@ -29,7 +29,6 @@ from astropy.io.fits.util import _is_int, _str_to_num
 
 from astropy.utils import lazyproperty
 from astropy.utils.exceptions import AstropyDeprecationWarning
-from astropy.utils.decorators import deprecated_renamed_argument
 
 
 class FITSTableDumpDialect(csv.excel):
@@ -1052,11 +1051,6 @@ class BinTableHDU(_TableBaseHDU):
           image.
       """)
 
-    @deprecated_renamed_argument('clobber', 'overwrite', '2.0',
-                                 message='"clobber" was deprecated in version '
-                                         '2.0 and will be removed in version '
-                                         '5.1. Use argument "overwrite" '
-                                         'instead.')
     def dump(self, datafile=None, cdfile=None, hfile=None, overwrite=False):
         """
         Dump the table HDU to a file in ASCII format.  The table may be dumped
@@ -1082,9 +1076,6 @@ class BinTableHDU(_TableBaseHDU):
             If ``True``, overwrite the output file if it exists. Raises an
             ``OSError`` if ``False`` and the output file exists. Default is
             ``False``.
-
-            .. versionchanged:: 1.3
-               ``overwrite`` replaces the deprecated ``clobber`` argument.
 
         Notes
         -----

--- a/astropy/io/fits/header.py
+++ b/astropy/io/fits/header.py
@@ -15,7 +15,6 @@ from ._utils import parse_header
 
 from astropy.utils import isiterable
 from astropy.utils.exceptions import AstropyUserWarning
-from astropy.utils.decorators import deprecated_renamed_argument
 
 
 BLOCK_SIZE = 2880  # the FITS block size
@@ -701,11 +700,6 @@ class Header:
             s += ' ' * _pad_length(len(s))
         return s
 
-    @deprecated_renamed_argument('clobber', 'overwrite', '2.0',
-                                 message='"clobber" was deprecated in version '
-                                         '2.0 and will be removed in version '
-                                         '5.1. Use argument "overwrite" '
-                                         'instead.')
     def tofile(self, fileobj, sep='', endcard=True, padding=True,
                overwrite=False):
         r"""
@@ -738,9 +732,6 @@ class Header:
             If ``True``, overwrite the output file if it exists. Raises an
             ``OSError`` if ``False`` and the output file exists. Default is
             ``False``.
-
-            .. versionchanged:: 1.3
-               ``overwrite`` replaces the deprecated ``clobber`` argument.
         """
 
         close_file = fileobj_closed(fileobj)
@@ -782,11 +773,6 @@ class Header:
 
         return cls.fromfile(fileobj, sep='\n', endcard=endcard, padding=False)
 
-    @deprecated_renamed_argument('clobber', 'overwrite', '2.0',
-                                 message='"clobber" was deprecated in version '
-                                         '2.0 and will be removed in version '
-                                         '5.1. Use argument "overwrite" '
-                                         'instead.')
     def totextfile(self, fileobj, endcard=False, overwrite=False):
         """
         Write the header as text to a file or a file-like object.
@@ -795,9 +781,6 @@ class Header:
 
             >>> Header.tofile(fileobj, sep='\\n', endcard=False,
             ...               padding=False, overwrite=overwrite)
-
-        .. versionchanged:: 1.3
-           ``overwrite`` replaces the deprecated ``clobber`` argument.
 
         See Also
         --------

--- a/astropy/io/fits/tests/test_diff.py
+++ b/astropy/io/fits/tests/test_diff.py
@@ -10,7 +10,6 @@ from astropy.io.fits.hdu.base import NonstandardExtHDU
 from astropy.io.fits.hdu.table import BinTableHDU
 from astropy.io.fits.header import Header
 
-from astropy.utils.exceptions import AstropyDeprecationWarning
 from astropy.utils.misc import _NOT_OVERWRITING_MSG_MATCH
 from astropy.io import fits
 
@@ -805,20 +804,6 @@ class TestDiff(FitsTestCase):
         with open(outpath) as fout:
             assert fout.read() == report_as_string, (
                 "overwritten output file is not identical to report string")
-
-    def test_file_output_overwrite_vs_clobber(self):
-        """Verify uses of clobber and overwrite."""
-
-        outpath = self.temp('diff_output.txt')
-        ha = Header([('A', 1), ('B', 2), ('C', 3)])
-        hb = ha.copy()
-        hb['C'] = 4
-        diffobj = HeaderDiff(ha, hb)
-        diffobj.report(fileobj=outpath)
-        with pytest.warns(AstropyDeprecationWarning, match=r'"clobber" was '
-                          r'deprecated in version 2\.0 and will be removed in '
-                          r'version 5\.1\. Use argument "overwrite" instead\.'):
-            diffobj.report(fileobj=outpath, clobber=True)
 
     def test_rawdatadiff_nodiff(self):
         a = np.arange(100, dtype='uint8').reshape(10, 10)

--- a/astropy/io/fits/tests/test_hdulist.py
+++ b/astropy/io/fits/tests/test_hdulist.py
@@ -13,7 +13,7 @@ import numpy as np
 from astropy.io.fits.hdu.base import _ValidHDU, _NonstandardHDU
 from astropy.io.fits.verify import VerifyError, VerifyWarning
 from astropy.io import fits
-from astropy.utils.exceptions import AstropyUserWarning, AstropyDeprecationWarning
+from astropy.utils.exceptions import AstropyUserWarning
 from astropy.utils.data import get_pkg_data_filenames
 
 from . import FitsTestCase
@@ -891,14 +891,10 @@ class TestHDUListFunctions(FitsTestCase):
             assert hdulist[0] in hdulist
             assert fits.ImageHDU() not in hdulist
 
-    def test_overwrite_vs_clobber(self):
+    def test_overwrite(self):
         hdulist = fits.HDUList([fits.PrimaryHDU()])
         hdulist.writeto(self.temp('test_overwrite.fits'))
         hdulist.writeto(self.temp('test_overwrite.fits'), overwrite=True)
-        with pytest.warns(AstropyDeprecationWarning, match=r'"clobber" was '
-                          r'deprecated in version 2\.0 and will be removed in '
-                          r'version 5\.1\. Use argument "overwrite" instead\.'):
-            hdulist.writeto(self.temp('test_overwrite.fits'), clobber=True)
 
     def test_invalid_hdu_key_in_contains(self):
         """

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -2662,7 +2662,7 @@ class TestTableFunctions(FitsTestCase):
             t3.teardown_class()
         del t3
 
-    def test_dump_clobber_vs_overwrite(self):
+    def test_dump_overwrite(self):
         with fits.open(self.data('table.fits')) as hdul:
             tbhdu = hdul[1]
             datafile = self.temp('data.txt')
@@ -2675,10 +2675,6 @@ class TestTableFunctions(FitsTestCase):
             with pytest.raises(OSError, match=msg):
                 tbhdu.dump(datafile, cdfile, hfile)
             tbhdu.dump(datafile, cdfile, hfile, overwrite=True)
-            with pytest.warns(AstropyDeprecationWarning, match=r'"clobber" was '
-                              r'deprecated in version 2\.0 and will be removed in '
-                              r'version 5\.1\. Use argument "overwrite" instead\.'):
-                tbhdu.dump(datafile, cdfile, hfile, clobber=True)
 
     def test_pseudo_unsigned_ints(self):
         """

--- a/docs/changes/io.fits/12258.api.rst
+++ b/docs/changes/io.fits/12258.api.rst
@@ -1,0 +1,1 @@
+Removed deprecated ``clobber`` argument from functions in ``astropy.io.fits``.


### PR DESCRIPTION
### Description

The  `clobber` argument has been deprecated since #6203.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
