### PR TITLE
Add registry to IO classes and use in registration

### DIFF
--- a/astropy/cosmology/connect.py
+++ b/astropy/cosmology/connect.py
@@ -4,6 +4,7 @@ import copy
 import warnings
 
 from astropy.io import registry as io_registry
+from astropy.utils.decorators import classproperty
 from astropy.utils.exceptions import AstropyUserWarning
 
 __all__ = ["CosmologyRead", "CosmologyWrite",
@@ -14,7 +15,15 @@ __doctest_skip__ = __all__
 # ==============================================================================
 # Read / Write
 
-class CosmologyRead(io_registry.UnifiedReadWrite):
+class CosmologyIO(io_registry.UnifiedReadWrite):
+
+    @classproperty
+    def registry(cls):
+        """Return I/O registry relevant to Cosmology file I/O."""
+        return io_registry
+
+
+class CosmologyRead(CosmologyIO):
     """Read and parse data to a `~astropy.cosmology.Cosmology`.
 
     This function provides the Cosmology interface to the Astropy unified I/O
@@ -84,11 +93,11 @@ class CosmologyRead(io_registry.UnifiedReadWrite):
                     "keyword argument `cosmology` must be either the class "
                     f"{valid[0]} or its qualified name '{valid[1]}'")
 
-        cosmo = io_registry.read(self._cls, *args, **kwargs)
+        cosmo = self.registry.read(self._cls, *args, **kwargs)
         return cosmo
 
 
-class CosmologyWrite(io_registry.UnifiedReadWrite):
+class CosmologyWrite(CosmologyIO):
     """Write this Cosmology object out in the specified format.
 
     This function provides the Cosmology interface to the astropy unified I/O
@@ -131,14 +140,22 @@ class CosmologyWrite(io_registry.UnifiedReadWrite):
         super().__init__(instance, cls, "write")
 
     def __call__(self, *args, **kwargs):
-        io_registry.write(self._instance, *args, **kwargs)
+        self.registry.write(self._instance, *args, **kwargs)
 
 
 # ==============================================================================
 # Format Interchange
 # for transforming instances, e.g. Cosmology <-> dict
 
-class CosmologyFromFormat(io_registry.UnifiedReadWrite):
+class CosmologyConvert(io_registry.UnifiedReadWrite):
+
+    @classproperty
+    def registry(cls):
+        """Return I/O registry relevant to Cosmology conversion."""
+        return io_registry
+
+
+class CosmologyFromFormat(CosmologyConvert):
     """Transform object to a `~astropy.cosmology.Cosmology`.
 
     This function provides the Cosmology interface to the Astropy unified I/O
@@ -206,11 +223,11 @@ class CosmologyFromFormat(io_registry.UnifiedReadWrite):
                     "keyword argument `cosmology` must be either the class "
                     f"{valid[0]} or its qualified name '{valid[1]}'")
 
-        cosmo = io_registry.read(self._cls, obj, *args, **kwargs)
+        cosmo = self.registry.read(self._cls, obj, *args, **kwargs)
         return cosmo
 
 
-class CosmologyToFormat(io_registry.UnifiedReadWrite):
+class CosmologyToFormat(CosmologyConvert):
     """Transform this Cosmology to another format.
 
     This function provides the Cosmology interface to the astropy unified I/O
@@ -256,5 +273,5 @@ class CosmologyToFormat(io_registry.UnifiedReadWrite):
         super().__init__(instance, cls, "write")
 
     def __call__(self, format, *args, **kwargs):
-        return io_registry.write(self._instance, None, *args, format=format,
-                                 **kwargs)
+        return self.registry.write(self._instance, None, *args, format=format,
+                                   **kwargs)

--- a/astropy/cosmology/io/mapping.py
+++ b/astropy/cosmology/io/mapping.py
@@ -180,6 +180,6 @@ def mapping_identify(origin, format, *args, **kwargs):
 # ===================================================================
 # Register
 
-io_registry.register_reader("mapping", Cosmology, from_mapping)
-io_registry.register_writer("mapping", Cosmology, to_mapping)
-io_registry.register_identifier("mapping", Cosmology, mapping_identify)
+Cosmology.from_format.registry.register_reader("mapping", Cosmology, from_mapping)
+Cosmology.from_format.registry.register_writer("mapping", Cosmology, to_mapping)
+Cosmology.from_format.registry.register_identifier("mapping", Cosmology, mapping_identify)

--- a/docs/changes/cosmology/12259.api.rst
+++ b/docs/changes/cosmology/12259.api.rst
@@ -1,0 +1,1 @@
+Cosmology I/O classes now have a reference to their relevant I/O registry.

--- a/docs/cosmology/io.rst
+++ b/docs/cosmology/io.rst
@@ -186,7 +186,9 @@ implements `astropy.cosmology.Cosmology.to_format`).
     ...     return QTable(params, meta=meta)[0]  # return row
 
 Last we write a function to help with format auto-identification and then
-register everything into `astropy.io.registry`.
+register everything into `astropy.io.registry`. Note that Cosmology has two
+associated registries (one for reading/writing and the other for converting
+between formats) so the functions must be put in the correct registry.
 
 .. code-block:: python
     :emphasize-lines: 11, 12, 13
@@ -201,9 +203,9 @@ register everything into `astropy.io.registry`.
     ...         return isinstance(args[1], Row) and (format in (None, "row"))
     ...     return False
 
-    >>> io_registry.register_reader("row", Cosmology, from_table_row)
-    >>> io_registry.register_writer("row", Cosmology, to_table_row)
-    >>> io_registry.register_identifier("row", Cosmology, row_identify)
+    >>> Cosmology.to_format.registry.register_reader("row", Cosmology, from_table_row)
+    >>> Cosmology.to_format.registry.register_writer("row", Cosmology, to_table_row)
+    >>> Cosmology.to_format.registry.register_identifier("row", Cosmology, row_identify)
 
 Now the registered functions can be used in
 :meth:`astropy.cosmology.Cosmology.from_format` and
@@ -229,11 +231,11 @@ Now the registered functions can be used in
 .. doctest::
     :hide:
 
-    >>> io_registry.unregister_reader("row", Cosmology)
-    >>> io_registry.unregister_writer("row", Cosmology)
-    >>> io_registry.unregister_identifier("row", Cosmology)
+    >>> Cosmology.to_format.registry.unregister_reader("row", Cosmology)
+    >>> Cosmology.to_format.registry.unregister_writer("row", Cosmology)
+    >>> Cosmology.to_format.registry.unregister_identifier("row", Cosmology)
     >>> try:
-    ...     io_registry.get_reader("row", Cosmology)
+    ...     Cosmology.to_format.registry.get_reader("row", Cosmology)
     ... except io_registry.IORegistryError:
     ...     pass
 
@@ -318,7 +320,9 @@ parsers.
     ...        json.dump(data, file)
 
 Last we write a function to help with format auto-identification and then
-register everything into `astropy.io.registry`.
+register everything into `astropy.io.registry`.  Note that Cosmology has two
+associated registries (one for reading/writing and the other for converting
+between formats) so the functions must be put in the correct registry.
 
 .. code-block:: python
     :emphasize-lines: 7,8,9
@@ -329,10 +333,10 @@ register everything into `astropy.io.registry`.
     ...     """Identify if object uses the JSON format."""
     ...     return filepath is not None and filepath.endswith(".json")
 
-    >>> io_registry.register_reader("json", Cosmology, read_json)
-    >>> io_registry.register_writer("json", Cosmology, write_json)
-    >>> io_registry.register_identifier("json", Cosmology, json_identify)
-    
+    >>> Cosmology.read.registry.register_reader("json", Cosmology, read_json)
+    >>> Cosmology.read.registry.register_writer("json", Cosmology, write_json)
+    >>> Cosmology.read.registry.register_identifier("json", Cosmology, json_identify)
+
 Now the registered functions can be used in
 :meth:`astropy.cosmology.Cosmology.read` and
 :meth:`astropy.cosmology.Cosmology.write`.
@@ -358,11 +362,11 @@ Now the registered functions can be used in
 .. doctest::
     :hide:
 
-    >>> io_registry.unregister_reader("json", Cosmology)
-    >>> io_registry.unregister_writer("json", Cosmology)
-    >>> io_registry.unregister_identifier("json", Cosmology)
+    >>> Cosmology.read.registry.unregister_reader("json", Cosmology)
+    >>> Cosmology.read.registry.unregister_writer("json", Cosmology)
+    >>> Cosmology.read.registry.unregister_identifier("json", Cosmology)
     >>> try:
-    ...     io_registry.get_reader("json", Cosmology)
+    ...     Cosmology.read.registry.get_reader("json", Cosmology)
     ... except io_registry.IORegistryError:
     ...     pass
 

--- a/docs/cosmology/mypackage/io/astropy_convert.py
+++ b/docs/cosmology/mypackage/io/astropy_convert.py
@@ -136,6 +136,6 @@ def mypackage_identify(origin, format, *args, **kwargs):
 # -------------------------------------------------------------------
 # Register to/from_format & identify methods with Astropy Unified I/O
 
-io_registry.register_reader("mypackage", Cosmology, from_mypackage)
-io_registry.register_writer("mypackage", Cosmology, to_mypackage)
-io_registry.register_identifier("mypackage", Cosmology, mypackage_identify)
+Cosmology.from_format.registry.register_reader("mypackage", Cosmology, from_mypackage)
+Cosmology.from_format.registry.register_writer("mypackage", Cosmology, to_mypackage)
+Cosmology.from_format.registry.register_identifier("mypackage", Cosmology, mypackage_identify)

--- a/docs/cosmology/mypackage/io/astropy_io.py
+++ b/docs/cosmology/mypackage/io/astropy_io.py
@@ -83,6 +83,6 @@ def myformat_identify(origin, filepath, fileobj, *args, **kwargs):
 # -------------------------------------------------------------------
 # Register read/write/identify methods with Astropy Unified I/O
 
-io_registry.register_reader("myformat", Cosmology, read_myformat)
-io_registry.register_writer("myformat", Cosmology, write_myformat)
-io_registry.register_identifier("myformat", Cosmology, myformat_identify)
+Cosmology.read.registry.register_reader("myformat", Cosmology, read_myformat)
+Cosmology.read.registry.register_writer("myformat", Cosmology, write_myformat)
+Cosmology.read.registry.register_identifier("myformat", Cosmology, myformat_identify)


### PR DESCRIPTION
The two Cosmology IO types will eventually use separate registries, so it's important to establish the separation before people start registering their own custom IO functions.

This will be superseded by #12015, but that will almost certainly not make it into v5.0
Users should not have to refactor when #12015 is merged.

Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
