### PR TITLE
Fix failing exact float comparisons in tests

### DIFF
--- a/astropy/coordinates/tests/test_angular_separation.py
+++ b/astropy/coordinates/tests/test_angular_separation.py
@@ -71,7 +71,7 @@ def test_proj_separations():
     # returns an Angle object
     assert isinstance(sep, Angle)
 
-    assert sep.degree == 1
+    assert_allclose(sep.degree, 1.)
     assert_allclose(sep.arcminute, 60.)
 
     # these operations have ambiguous interpretations for points on a sphere

--- a/astropy/coordinates/tests/test_api_ape5.py
+++ b/astropy/coordinates/tests/test_api_ape5.py
@@ -210,7 +210,7 @@ def test_frame_api():
     coo1 = ICRS(ra=0*u.hour, dec=0*u.deg)
     coo2 = ICRS(ra=0*u.hour, dec=1*u.deg)
     # `separation` is the on-sky separation
-    assert coo1.separation(coo2).degree == 1.0
+    assert_allclose(coo1.separation(coo2).degree, 1.0)
 
     # while `separation_3d` includes the 3D distance information
     coo3 = ICRS(ra=0*u.hour, dec=0*u.deg, distance=1*u.kpc)

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -663,7 +663,7 @@ def test_sep():
     i2 = ICRS(ra=0*u.deg, dec=2*u.deg)
 
     sep = i1.separation(i2)
-    assert sep.deg == 1
+    assert_allclose(sep.deg, 1.)
 
     i3 = ICRS(ra=[1, 2]*u.deg, dec=[3, 4]*u.deg, distance=[5, 6]*u.kpc)
     i4 = ICRS(ra=[1, 2]*u.deg, dec=[3, 4]*u.deg, distance=[4, 5]*u.kpc)

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -2066,7 +2066,7 @@ def test_unitphysics(unitphysics):
 
     asphys = obj.represent_as(PhysicsSphericalRepresentation)
     assert asphys.phi == obj.phi
-    assert asphys.theta == obj.theta
+    assert_allclose(asphys.theta, obj.theta)
     assert_allclose_quantity(asphys.r, 1*u.dimensionless_unscaled)
 
     assph = obj.represent_as(SphericalRepresentation)

--- a/astropy/visualization/wcsaxes/tests/test_images.py
+++ b/astropy/visualization/wcsaxes/tests/test_images.py
@@ -687,7 +687,7 @@ class TestBasic(BaseImageTests):
         # the input(center) is a tuple or a SkyCoord object.
         assert (r1.get_xy() == r2.get_xy()).all()
         assert np.allclose(r1.get_xy(), r3.get_xy())
-        assert (r2.get_xy()[0] == [266.4, -29.25]).all()
+        assert np.allclose(r2.get_xy()[0], [266.4, -29.25])
 
         return fig
 


### PR DESCRIPTION
### Description

This fixes the float comparisons that are causing test failures in multiple pull requests right now.

EDIT (AFTER MERGING):

The update to `astropy/visualization/wcsaxes/tests/test_images.py` fixes #12036.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
