### PR TITLE
Improve the error message if the coordinate and differential units of a `SkyCoord` do not match

### DIFF
--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -518,13 +518,25 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
             # NOTE: there is no dimensionless time while lengths can be
             # dimensionless (u.dimensionless_unscaled).
             for comp in representation_data.components:
-                if f'd_{comp}' in differential_data.components:
+                if (diff_comp := f'd_{comp}') in differential_data.components:
                     current_repr_unit = representation_data._units[comp]
-                    current_diff_unit = differential_data._units[f'd_{comp}']
-                    if not current_diff_unit.is_equivalent(current_repr_unit / u.s):
+                    current_diff_unit = differential_data._units[diff_comp]
+                    expected_unit = current_repr_unit / u.s
+                    if not current_diff_unit.is_equivalent(expected_unit):
+                        for key, val in self.get_representation_component_names().items():
+                            if val == comp:
+                                current_repr_name = key
+                                break
+                        for key, val in self.get_representation_component_names('s').items():
+                            if val == diff_comp:
+                                current_diff_name = key
+                                break
                         raise ValueError(
-                            "Differential data units are not compatible with"
-                            "time-derivative of representation data units")
+                            f'{current_repr_name} has unit "{current_repr_unit}" with physical '
+                            f'type "{current_repr_unit.physical_type}", but {current_diff_name} '
+                            f'has incompatible unit "{current_diff_unit}" with physical type '
+                            f'"{current_diff_unit.physical_type}" instead of the expected '
+                            f'"{(expected_unit).physical_type}".')
 
             representation_data = representation_data.with_differentials({'s': differential_data})
 

--- a/astropy/coordinates/tests/test_frames_with_velocity.py
+++ b/astropy/coordinates/tests/test_frames_with_velocity.py
@@ -313,13 +313,15 @@ def test_negative_distance():
 def test_velocity_units():
     """Check that the differential data given has compatible units
     with the time-derivative of representation data"""
-    with pytest.raises(ValueError) as excinfo:
+    msg = ('x has unit "" with physical type "dimensionless", but v_x has '
+           'incompatible unit "" with physical type "dimensionless" instead '
+           r'of the expected "frequency"\.')
+    with pytest.raises(ValueError, match=msg):
         c = ICRS(
             x=1, y=2, z=3,
             v_x=1, v_y=2, v_z=3,
             representation_type=r.CartesianRepresentation,
             differential_type=r.CartesianDifferential)
-    assert "data units are not compatible with" in str(excinfo.value)
 
 
 def test_frame_with_velocity_without_distance_can_be_transformed():


### PR DESCRIPTION
### Description

Suppose you attempt the following:
```python
from astropy import units as u
from astropy.coordinates import SkyCoord
sc = SkyCoord(ra=0*u.deg, dec=0*u.deg, distance=10*u.pc, radial_velocity=10*u.mas/u.yr)
```

Currently the resulting error message is
```
ValueError: Differential data units are not compatible withtime-derivative of representation data units

```
This pull request makes the error message much more informative:
```
ValueError: distance has unit "pc" with physical type "length", but radial_velocity has incompatible unit 
"mas / yr" with physical type "angular frequency/angular speed/angular velocity" instead of the expected 
"speed/velocity".
```

Resolves #12263

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
