### PR TITLE
Cosmology to/from Model

### DIFF
--- a/astropy/cosmology/flrw.py
+++ b/astropy/cosmology/flrw.py
@@ -682,7 +682,7 @@ class FLRW(Cosmology):
         # so it is probably a good idea for subclasses to overload this
         # method if an analytic form is available.
         z = aszarr(z)
-        if hasattr(z, "shape"):  # array/Quantity
+        if not isinstance(z, (Number, np.generic)):  # array/Quantity
             ival = np.array([quad(self._w_integrand, 0, log(1 + redshift))[0]
                              for redshift in z])
             return np.exp(3 * ival)

--- a/astropy/cosmology/io/__init__.py
+++ b/astropy/cosmology/io/__init__.py
@@ -6,4 +6,4 @@ Read/Write/Interchange methods for `astropy.cosmology`. **NOT public API**.
 """
 
 # Import the interchange to register them into the io registry.
-from . import mapping, table  # noqa: F403
+from . import mapping, model, table  # noqa: F403

--- a/astropy/cosmology/io/mapping.py
+++ b/astropy/cosmology/io/mapping.py
@@ -15,9 +15,8 @@ import numpy as np
 
 from astropy.cosmology.core import _COSMOLOGY_CLASSES, Cosmology
 from astropy.cosmology.connect import convert_registry
-from astropy.table import QTable
 
-__all__ = ["from_mapping", "to_mapping"]
+__all__ = []  # nothing is publicly scoped
 
 
 def from_mapping(map, *, move_to_meta=False, cosmology=None):

--- a/astropy/cosmology/io/model.py
+++ b/astropy/cosmology/io/model.py
@@ -1,0 +1,248 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+"""
+The following are private functions, included here **FOR REFERENCE ONLY** since
+the io registry cannot be displayed. These functions are registered into
+:meth:`~astropy.cosmology.Cosmology.to_format` and
+:meth:`~astropy.cosmology.Cosmology.from_format` and should only be accessed
+via these methods.
+"""  # this is shown in the docs.
+
+import abc
+import copy
+import inspect
+
+import numpy as np
+
+from astropy.cosmology.connect import convert_registry
+from astropy.cosmology.core import _COSMOLOGY_CLASSES, Cosmology
+from astropy.modeling import FittableModel, Model
+from astropy.modeling import Parameter as ModelParameter
+from astropy.utils.decorators import classproperty
+
+__all__ = []  # nothing is publicly scoped
+
+
+class CosmologyModel(FittableModel):
+    """Base class for Cosmology redshift-method Models.
+
+    .. note::
+
+        This class is not publicly scoped so should not be used directly.
+        Instead, from a Cosmology instance use ``.to_format("astropy.model")``
+        to create an instance of a subclass of this class.
+
+    `CosmologyModel` (subclasses) wrap a redshift-method of a
+    :class:`~astropy.cosmology.Cosmology` class, converting each
+    |Cosmology| :class:`~astropy.cosmology.Parameter` to a
+    :class:`astropy.modeling.Model` :class:`~astropy.modeling.Parameter`
+    and the redshift-method to the model's ``__call__ / evaluate``.
+
+    See Also
+    --------
+    astropy.cosmology.Cosmology.to_format
+    """
+
+    @abc.abstractmethod
+    def _cosmology_class(self):
+        """Cosmology class as a private attribute. Set in subclasses."""
+
+    @abc.abstractmethod
+    def _method_name(self):
+        """Cosmology method name as a private attribute. Set in subclasses."""
+
+    @classproperty
+    def cosmology_class(cls):
+        """|Cosmology| class."""
+        return cls._cosmology_class
+
+    @property
+    def cosmology(self):
+        """Return |Cosmology| using `~astropy.modeling.Parameter` values."""
+        cosmo = self._cosmology_class(
+            name=self.name,
+            **{k: (v.value if not (v := getattr(self, k)).unit else v.quantity)
+               for k in self.param_names})
+        return cosmo
+
+    @classproperty
+    def method_name(self):
+        """Redshift-method name on |Cosmology| instance."""
+        return self._method_name
+
+    # ---------------------------------------------------------------
+
+    def evaluate(self, *args, **kwargs):
+        """Evaluate method {method!r} of {cosmo_cls!r} Cosmology.
+
+        The Model wraps the :class:`~astropy.cosmology.Cosmology` method,
+        converting each |Cosmology| :class:`~astropy.cosmology.Parameter` to a
+        :class:`astropy.modeling.Model` :class:`~astropy.modeling.Parameter`.
+        Here an instance of the cosmology is created using the current
+        Parameter values and the method is evaluated given the input.
+
+        Parameters
+        ----------
+        *args, **kwargs
+            The first ``n_inputs`` of ``*args`` are for evaluating the method
+            of the cosmology. The remaining args and kwargs are passed to the
+            cosmology class constructor.
+            Any unspecified Cosmology Parameter use the current value of the
+            corresponding Model Parameter.
+
+        Returns
+        -------
+        Any
+            Results of evaluating the Cosmology method.
+        """
+        # create BoundArgument with all available inputs beyond the Parameters,
+        # which will be filled in next
+        ba = self.cosmology_class._init_signature.bind_partial(*args[self.n_inputs:], **kwargs)
+
+        # fill in missing Parameters
+        for k in self.param_names:
+            if k not in ba.arguments:
+                v = getattr(self, k)
+                ba.arguments[k] = v.value if not v.unit else v.quantity
+
+            # unvectorize, since Cosmology is not vectorized
+            # TODO! remove when vectorized
+            if np.shape(ba.arguments[k]):  # only in __call__
+                # m_nu is a special case  # TODO! fix by making it 'structured'
+                if k == "m_nu" and len(ba.arguments[k].shape) == 1:
+                    continue
+                ba.arguments[k] = ba.arguments[k][0]
+
+        # make instance of cosmology
+        cosmo = self._cosmology_class(**ba.arguments)
+        # evaluate method
+        result = getattr(cosmo, self._method_name)(*args[:self.n_inputs])
+
+        return result
+
+
+##############################################################################
+
+
+def from_model(model):
+    """Load |Cosmology| from `~astropy.modeling.Model` object.
+
+    Parameters
+    ----------
+    model : `CosmologyModel` subclass instance
+        See ``Cosmology.to_format.help("astropy.model") for details.
+
+    Returns
+    -------
+    `~astropy.cosmology.Cosmology` subclass instance
+
+    Examples
+    --------
+    >>> from astropy.cosmology import Cosmology, Planck18
+    >>> model = Planck18.to_format("astropy.model", method="lookback_time")
+    >>> Cosmology.from_format(model)
+    FlatLambdaCDM(name="Planck18", H0=67.7 km / (Mpc s), Om0=0.31,
+                  Tcmb0=2.725 K, Neff=3.05, m_nu=[0. 0. 0.06] eV, Ob0=0.049)
+    """
+    if not isinstance(model, CosmologyModel):
+        raise TypeError("`model` must be <CosmologyModel>.")
+
+    cosmology = model.cosmology_class
+    meta = copy.deepcopy(model.meta)
+
+    # assemble the Parameters
+    params = {}
+    for n in model.param_names:
+        p = getattr(model, n)
+        params[p.name] = p.quantity if p.unit else p.value
+        # put all attributes in a dict
+        meta[p.name] = {n: getattr(p, n) for n in dir(p)
+                        if not (n.startswith("_") or callable(getattr(p, n)))}
+
+    ba = cosmology._init_signature.bind(name=model.name, **params, meta=meta)
+    return cosmology(*ba.args, **ba.kwargs)
+
+
+def to_model(cosmology, *_, method):
+    """Convert a `~astropy.cosmology.Cosmology` to a `~astropy.modeling.Model`.
+
+    Parameters
+    ----------
+    cosmology : `~astropy.cosmology.Cosmology` subclass instance
+    method : str, keyword-only
+        The name of the method on the ``cosmology``.
+
+    Returns
+    -------
+    `CosmologyModel` subclass instance
+
+    Examples
+    --------
+    >>> from astropy.cosmology import Planck18
+    >>> model = Planck18.to_format("astropy.model", method="lookback_time")
+    >>> model
+    <FlatLambdaCDMCosmologyLookbackTimeModel(H0=67.66 km / (Mpc s), Om0=0.30966,
+        Tcmb0=2.7255 K, Neff=3.046, m_nu=[0.  , 0.  , 0.06] eV, Ob0=0.04897,
+        name='Planck18')>
+    """
+    method_name = method
+    # get unbound method (& sig) from class
+    method = getattr(cosmology.__class__, method_name)
+    msig = inspect.signature(method)
+
+    # introspect for number of inputs, ignoring "self"
+    n_inputs = len([p for p in tuple(msig.parameters.values())[1:]
+                    if (p.kind in (0, 1))])
+
+    d = {}  # class attributes
+    d["_cosmology_class"] = cosmology.__class__
+    d["_method_name"] = method_name
+    d["n_inputs"] = n_inputs
+    d["n_outputs"] = 1
+
+    params = {}  # Parameters (also class attributes)
+    for n in cosmology.__parameters__:
+        params[n] = ModelParameter(default=getattr(cosmology, n),
+                                   unit=getattr(cosmology.__class__, n).unit,
+                                   **cosmology.meta.get(n, {}))
+
+    # class name is cosmology name + method name + CosmologyModel
+    clsname = (cosmology.__class__.__qualname__.replace(".", "_")
+               + "Cosmology"
+               + method_name.replace("_", " ").title().replace(" ", "")
+               + "Model")
+
+    # make Model class
+    CosmoModel = type(clsname, (CosmologyModel, ), {**d, **params})
+    # override __signature__ and format the doc.
+    setattr(CosmoModel.evaluate, "__signature__", msig)
+    CosmoModel.evaluate.__doc__ = CosmoModel.evaluate.__doc__.format(
+        cosmo_cls=cosmology.__class__.__qualname__,
+        method=method_name)
+
+    # instantiate class using default values
+    model = CosmoModel(name=cosmology.name, meta=copy.deepcopy(cosmology.meta))
+
+    return model
+
+
+def model_identify(origin, format, *args, **kwargs):
+    """Identify if object uses the :class:`~astropy.modeling.Model` format.
+
+    Returns
+    -------
+    bool
+    """
+    itis = False
+    if origin == "read":
+        itis = isinstance(args[1], Model) and (format in (None, "astropy.model"))
+
+    return itis
+
+
+# ===================================================================
+# Register
+
+convert_registry.register_reader("astropy.model", Cosmology, from_model)
+convert_registry.register_writer("astropy.model", Cosmology, to_model)
+convert_registry.register_identifier("astropy.model", Cosmology, model_identify)

--- a/astropy/cosmology/io/table.py
+++ b/astropy/cosmology/io/table.py
@@ -4,9 +4,9 @@ import copy
 
 import numpy as np
 
-from astropy.table import Table, QTable
 from astropy.cosmology.connect import convert_registry
 from astropy.cosmology.core import Cosmology
+from astropy.table import QTable, Table
 
 from .mapping import from_mapping, to_mapping
 

--- a/astropy/cosmology/io/tests/test_mapping.py
+++ b/astropy/cosmology/io/tests/test_mapping.py
@@ -45,7 +45,7 @@ class ToFromMappingTestMixin(IOTestMixinBase):
         params = to_format('mapping', cls=map_cls)
         assert isinstance(params, map_cls)  # test type
 
-    def test_to_from_mapping_instance(self, cosmo, to_format, from_format):
+    def test_tofrom_mapping_instance(self, cosmo, to_format, from_format):
         """Test cosmology -> Mapping -> cosmology."""
         # ------------
         # To Mapping
@@ -82,15 +82,18 @@ class ToFromMappingTestMixin(IOTestMixinBase):
         params.pop("mismatching")
         got = from_format(params, format="mapping")
         assert got == cosmo
+        assert got.meta == cosmo.meta
 
         # and it will also work if the cosmology is a string
         params["cosmology"] = params["cosmology"].__qualname__
         got = from_format(params, format="mapping")
         assert got == cosmo
+        assert got.meta == cosmo.meta
 
         # also it auto-identifies 'format'
         got = from_format(params)
         assert got == cosmo
+        assert got.meta == cosmo.meta
 
     def test_fromformat_subclass_partial_info_mapping(self, cosmo):
         """

--- a/astropy/cosmology/io/tests/test_model.py
+++ b/astropy/cosmology/io/tests/test_model.py
@@ -1,0 +1,162 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+# STDLIB
+import inspect
+import random
+
+# THIRD PARTY
+import pytest
+
+import numpy as np
+
+# LOCAL
+import astropy.units as u
+from astropy import cosmology
+from astropy.cosmology import Cosmology, Planck18, realizations
+from astropy.cosmology.core import _COSMOLOGY_CLASSES, Parameter
+from astropy.cosmology.io.model import CosmologyModel, from_model, to_model
+from astropy.cosmology.parameters import available
+from astropy.modeling import FittableModel
+from astropy.modeling.models import Gaussian1D
+from astropy.utils.compat.optional_deps import HAS_SCIPY
+
+from .base import IOTestMixinBase, ToFromFormatTestBase
+
+cosmo_instances = [getattr(realizations, name) for name in available]
+cosmo_instances.append("TestToFromTable.setup.<locals>.CosmologyWithKwargs")
+
+
+###############################################################################
+
+
+class ToFromModelTestMixin(IOTestMixinBase):
+    """
+    Tests for a Cosmology[To/From]Format with ``format="astropy.model"``.
+    This class will not be directly called by :mod:`pytest` since its name does
+    not begin with ``Test``. To activate the contained tests this class must
+    be inherited in a subclass. Subclasses must define a :func:`pytest.fixture`
+    ``cosmo`` that returns/yields an instance of a |Cosmology|.
+    See ``TestCosmologyToFromFormat`` or ``TestCosmology`` for examples.
+    """
+
+    @pytest.fixture
+    def method_name(self, cosmo):
+        # get methods, ignoring private and dunder
+        methods = {n for n in dir(cosmo)
+                   if (callable(getattr(cosmo, n)) and not n.startswith("_"))}
+        # sieve out incompatible methods
+        for n in tuple(methods):
+            # remove non-introspectable methods
+            try:
+                sig = inspect.signature(getattr(cosmo, n))
+            except ValueError:
+                methods.discard(n)
+                continue
+
+            params = list(sig.parameters.keys())
+            # remove non redshift methods
+            if len(params) == 0 or not params[0].startswith("z"):
+                methods.discard(n)
+                continue
+            # remove instance-only methods
+            elif not hasattr(cosmo.__class__, n):
+                methods.discard(n)
+                continue
+
+            if not HAS_SCIPY:  # dynamically detect optional dependencies
+                args = np.arange(len(params)) + 1
+
+                # remove if doesn't have dependency
+                try:
+                    getattr(cosmo, n)(*args)
+                except ModuleNotFoundError:
+                    methods.discard(n)
+
+        # TODO! pytest doesn't currently allow multiple yields (`cosmo`) so
+        # testing with 1 random method
+        # yield from methods
+        return random.choice(tuple(methods))
+
+    # ===============================================================
+
+    def test_from_model_wrong_cls(self, from_format):
+        """Test when Model is not the correct class."""
+        model = Gaussian1D(amplitude=10, mean=14)
+
+        with pytest.raises(TypeError, match="`model` must be"):
+            from_format(model)
+
+    def test_toformat_model(self, cosmo, to_format, method_name):
+        """Test cosmology -> astropy.model."""
+
+        model = to_format("astropy.model", method=method_name)
+        assert isinstance(model, CosmologyModel)
+
+        # Parameters
+        assert model.param_names == cosmo.__parameters__
+
+        # scalar result
+        args = np.arange(model.n_inputs) + 1
+
+        got = model.evaluate(*args)
+        expected = getattr(cosmo, method_name)(*args)
+        assert np.all(got == expected)
+
+        got = model(*args)
+        expected = getattr(cosmo, method_name)(*args)
+        assert np.all(got == expected)
+
+        # vector result
+        if "scalar" not in method_name:
+
+            args = (np.ones((model.n_inputs, 3)).T + np.arange(model.n_inputs)).T
+
+            got = model.evaluate(*args)
+            expected = getattr(cosmo, method_name)(*args)
+            assert np.all(got == expected)
+
+            got = model(*args)
+            expected = getattr(cosmo, method_name)(*args)
+            assert np.all(got == expected)
+
+    def test_tofrom_model_instance(self, cosmo, to_format, from_format, method_name):
+        """Test cosmology -> astropy.model -> cosmology."""
+        # ------------
+        # To Model
+        # this also serves as a test of all added methods / attributes
+        # in CosmologyModel.
+
+        model = to_format("astropy.model", method=method_name)
+
+        assert isinstance(model, CosmologyModel)
+        assert model.cosmology_class is cosmo.__class__
+        assert model.cosmology == cosmo
+        assert model.method_name == method_name
+
+        # ------------
+        # From Model
+
+        # it won't error if everything matches up
+        got = from_format(model, format="astropy.model")
+        assert got == cosmo
+        assert set(cosmo.meta.keys()).issubset(got.meta.keys())
+        # Note: model adds parameter attributes to the metadata
+
+        # also it auto-identifies 'format'
+        got = from_format(model)
+        assert got == cosmo
+        assert set(cosmo.meta.keys()).issubset(got.meta.keys())
+
+    def test_fromformat_subclass_partial_info_model(self, cosmo):
+        """
+        Test writing from an instance and reading from that class.
+        This works with missing information.
+        """
+        pass  # there's no partial information with a Model
+
+
+class TestToFromModel(ToFromFormatTestBase, ToFromModelTestMixin):
+    """Directly test ``to/from_model``."""
+
+    def setup_class(self):
+        self.functions = {"to": to_model, "from": from_model}

--- a/astropy/cosmology/io/tests/test_table.py
+++ b/astropy/cosmology/io/tests/test_table.py
@@ -6,11 +6,11 @@ import pytest
 # LOCAL
 import astropy.units as u
 from astropy import cosmology
-from astropy.cosmology import Cosmology, realizations, Planck18
+from astropy.cosmology import Cosmology, Planck18, realizations
 from astropy.cosmology.core import _COSMOLOGY_CLASSES, Parameter
 from astropy.cosmology.io.table import from_table, to_table
-from astropy.table import Table, QTable, vstack
 from astropy.cosmology.parameters import available
+from astropy.table import QTable, Table, vstack
 
 from .base import IOTestMixinBase, ToFromFormatTestBase
 

--- a/astropy/cosmology/tests/test_connect.py
+++ b/astropy/cosmology/tests/test_connect.py
@@ -10,7 +10,7 @@ from astropy import cosmology
 from astropy.cosmology import Cosmology, w0wzCDM
 from astropy.cosmology.connect import CosmologyRead, readwrite_registry
 from astropy.cosmology.core import Cosmology
-from astropy.cosmology.io.tests import test_mapping, test_table
+from astropy.cosmology.io.tests import test_mapping, test_model, test_table
 from astropy.table import QTable
 
 from .conftest import json_identify, read_json, write_json
@@ -202,7 +202,8 @@ class TestCosmologyReadWrite(ReadWriteTestMixin):
 # To/From_Format Tests
 
 
-class ToFromFormatTestMixin(test_mapping.ToFromMappingTestMixin, test_table.ToFromTableTestMixin):
+class ToFromFormatTestMixin(test_mapping.ToFromMappingTestMixin,
+                            test_model.ToFromModelTestMixin, test_table.ToFromTableTestMixin):
     """
     Tests for a Cosmology[To/From]Format on a |Cosmology|.
     This class will not be directly called by :mod:`pytest` since its name does

--- a/astropy/modeling/physical_models.py
+++ b/astropy/modeling/physical_models.py
@@ -10,7 +10,6 @@ import numpy as np
 
 from astropy import constants as const
 from astropy import units as u
-from astropy import cosmology
 from astropy.utils.exceptions import AstropyUserWarning
 from .core import Fittable1DModel
 from .parameters import Parameter, InputParameterError
@@ -439,7 +438,10 @@ class NFW(Fittable1DModel):
                  massfactor=("critical", 200), cosmo=None,  **kwargs):
         # Set default cosmology
         if cosmo is None:
-            cosmo = cosmology.default_cosmology.get()
+            # LOCAL
+            from astropy.cosmology import default_cosmology
+
+            cosmo = default_cosmology.get()
 
         # Set mass overdensity type and factor
         self._density_delta(massfactor, cosmo, redshift)

--- a/docs/changes/cosmology/12269.feature.rst
+++ b/docs/changes/cosmology/12269.feature.rst
@@ -1,0 +1,2 @@
+Register Astropy Model into Cosmology's ``to/from_format`` I/O, allowing
+a Cosmology instance to be parsed from or converted to a Model instance.

--- a/docs/cosmology/io.rst
+++ b/docs/cosmology/io.rst
@@ -98,6 +98,7 @@ To see the a list of the available conversion formats:
     >>> Cosmology.to_format.list_formats()
         Format    Read Write Auto-identify
     ------------- ---- ----- -------------
+    astropy.model  Yes   Yes           Yes
     astropy.table  Yes   Yes           Yes
           mapping  Yes   Yes           Yes
         mypackage  Yes   Yes           Yes
@@ -112,7 +113,7 @@ is from an `example 3rd-party package
 another python object. This can be useful for e.g., iterating through an MCMC
 of cosmological parameters or printing out a cosmological model to a journal
 format, like latex or HTML. When 3rd party cosmology packages register with
-Astropy' Cosmology I/O, ``to/from_format`` can be used to convert cosmology
+Astropy's Cosmology I/O, ``to/from_format`` can be used to convert cosmology
 instances between packages!
 
 .. EXAMPLE START: Planck18 to mapping and back
@@ -186,6 +187,26 @@ and ``html`` formats, which can be copied into journal articles and websites,
 respectively.
 
 .. EXAMPLE END
+
+.. EXAMPLE START: Planck18 to Model and back
+
+Using ``format="astropy.model`` any redshift(s) method of a cosmology may be
+turned into a :class:`astropy.modeling.Model`. Each |Cosmology|
+:class:`~astropy.cosmology.Parameter` is converted to a
+:class:`astropy.modeling.Model` :class:`~astropy.modeling.Parameter`
+and the redshift-method to the model's ``__call__ / evaluate``.
+Now you can fit cosmologies with data!
+
+.. code-block::
+
+    >>> model = Planck18.to_format("astropy.model", method="lookback_time")
+    >>> model
+    <FlatLambdaCDMCosmologyLookbackTimeModel(H0=67.66 km / (Mpc s), Om0=0.30966,
+        Tcmb0=2.7255 K, Neff=3.046, m_nu=[0.  , 0.  , 0.06] eV, Ob0=0.04897,
+        name='Planck18')>
+
+Like for the other formats, the ``Planck18`` cosmology can be recovered with
+`~astropy.cosmology.Cosmology.from_format`.
 
 
 .. _custom_cosmology_converters:

--- a/docs/whatsnew/5.0.rst
+++ b/docs/whatsnew/5.0.rst
@@ -33,7 +33,7 @@ Currently no file formats are registered, but the syntax is as follows:
     True
 
 
-The transformations between ``Cosmology`` and `dict`/``QTable`` are
+The transformations between ``Cosmology`` and `dict`/``QTable``/``Model`` are
 pre-registered, e.g. enabling::
 
     >>> from astropy.cosmology import Cosmology, Planck18
@@ -67,6 +67,14 @@ pre-registered, e.g. enabling::
     -------- ------------ ------- ------- ------- ----------- -------
     Planck18        67.66 0.30966  2.7255   3.046 0.0 .. 0.06 0.04897
 
+    Models can be created from any redshift method of a Cosmology:
+
+    >>> model = Planck18.to_format("astropy.model", method="lookback_time")
+    >>> model
+    <FlatLambdaCDMCosmologyLookbackTimeModel(H0=67.66 km / (Mpc s), Om0=0.30966,
+        Tcmb0=2.7255 K, Neff=3.046, m_nu=[0.  , 0.  , 0.06] eV, Ob0=0.04897,
+        name='Planck18')>
+
     All the format conversions can be reversed:
 
     >>> cosmo = Cosmology.from_format(cm, format="mapping")
@@ -75,6 +83,10 @@ pre-registered, e.g. enabling::
                   Tcmb0=2.725 K, Neff=3.05, m_nu=[0. 0. 0.06] eV, Ob0=0.049)
 
     >>> cosmo = Cosmology.from_format(ct, format="astropy.table")
+    >>> cosmo == Planck18
+    True
+
+    >>> cosmo = Cosmology.from_format(model, format="astropy.modeling")
     >>> cosmo == Planck18
     True
 


### PR DESCRIPTION
Register Astropy Model into Cosmology's ``to/from_format`` I/O, allowing
a Cosmology instance to be parsed from or converted to a Model instance.

~Requires #12213.  Sorry kind of a PR stack while dev'ing all the Cosmology I/O.~
~@nden @perrygreenfield all the diffs for this PR are in 1 commit, so hopefully that makes reviewing easier!~
Merged. So this is a normal PR now.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
