### PR TITLE
Fix exponential notation of scale factors in format='vounit' representation

### DIFF
--- a/astropy/units/format/vounit.py
+++ b/astropy/units/format/vounit.py
@@ -224,17 +224,7 @@ class VOUnit(generic.Generic):
                     .format(unit.scale))
             s = ''
             if unit.scale != 1:
-                m, ex = utils.split_mantissa_exponent(unit.scale)
-                parts = []
-                if m:
-                    parts.append(m)
-                if ex:
-                    fex = '10'
-                    if not ex.startswith('-'):
-                        fex += '+'
-                    fex += ex
-                    parts.append(fex)
-                s += ' '.join(parts)
+                s += f'{unit.scale:.8g}'
 
             pairs = list(zip(unit.bases, unit.powers))
             pairs.sort(key=operator.itemgetter(1), reverse=True)

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -514,6 +514,20 @@ def test_vounit_details():
         assert new_flam == flam
 
 
+@pytest.mark.parametrize('unit, vounit, number, scale, voscale',
+                         [('nm', 'nm', 0.1, '10^-1', '0.1'),
+                          ('fm', 'fm', 100.0, '10+2', '100'),
+                          ('m^2', 'm**2', 100.0, '100.0', '100'),
+                          ('cm', 'cm', 2.54, '2.54', '2.54'),
+                          ('kg', 'kg', 1.898124597e27, '1.898124597E27', '1.8981246e+27'),
+                          ('m/s', 'm.s**-1', 299792458.0, '299792458', '2.9979246e+08'),
+                          ('cm2', 'cm**2', 1.e-20, '10^(-20)', '1e-20')])
+def test_vounit_scale_factor(unit, vounit, number, scale, voscale):
+    x = u.Unit(f'{scale} {unit}')
+    assert x == number * u.Unit(unit)
+    assert x.to_string(format='vounit') == voscale + vounit
+
+
 def test_vounit_custom():
     x = u.Unit("'foo' m", format='vounit')
     x_vounit = x.to_string('vounit')


### PR DESCRIPTION
### Description
Follow-up to https://github.com/astropy/astropy/pull/11565#issuecomment-951277019 to fix the `VOUnit.to_string()` output for units with scale factors; these produce output strings like
```python
>>> u.Unit('1.898e27 kg').to_string('vounit')
'1.898 10+27kg'
```
which conflict with standard's specification for the `VOUFLOAT` format in Appendix C.4 as either of
- `0\.[0-9]+([eE][+-]?[0-9]+)?`
- `[1-9][0-9]*(\.[0-9]+)?([eE][+-]?[0-9]+)?`

or for the above example of Jupiter mass as `1.898E27kg` in § 2.10, as well as with the rules of avoiding blank spaces and using `.` for multiplication.

Setting the milestone to 5.0 to accompany #11565; not sure about the changelog. The output is definitely changed, though I cannot imagine anyone has used the previous form without filing a bug report.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
