### PR TITLE
Fix for Parquet v2.0 being deprecated

### DIFF
--- a/astropy/io/misc/parquet.py
+++ b/astropy/io/misc/parquet.py
@@ -18,11 +18,6 @@ from astropy.utils.misc import NOT_OVERWRITING_MSG
 
 from astropy.utils import minversion
 
-if minversion('pyarrow', '6.0.0'):
-    writer_version = '2.4'
-else:
-    writer_version = '2.0'
-
 
 PARQUET_SIGNATURE = b'PAR1'
 
@@ -120,7 +115,7 @@ def read_table_parquet(input, include_names=None, exclude_names=None,
         Table will have zero rows and only metadata information
         if schema_only is True.
     """
-    pa, parquet = get_pyarrow()
+    pa, parquet, _ = get_pyarrow()
 
     if not isinstance(input, (str, os.PathLike)):
         # The 'read' attribute is the key component of a generic
@@ -269,7 +264,7 @@ def write_table_parquet(table, output, overwrite=False):
     from astropy.table import meta, serialize
     from astropy.utils.data_info import serialize_context_as
 
-    pa, parquet = get_pyarrow()
+    pa, parquet, writer_version = get_pyarrow()
 
     if not isinstance(output, (str, os.PathLike)):
         raise TypeError(f'`output` should be a string or path-like, not {output}')
@@ -361,4 +356,10 @@ def get_pyarrow():
         from pyarrow import parquet
     except ImportError:
         raise Exception("pyarrow is required to read and write parquet files")
-    return pa, parquet
+
+    if minversion('pyarrow', '6.0.0'):
+        writer_version = '2.4'
+    else:
+        writer_version = '2.0'
+
+    return pa, parquet, writer_version

--- a/astropy/io/misc/tests/test_parquet.py
+++ b/astropy/io/misc/tests/test_parquet.py
@@ -11,7 +11,7 @@ from astropy import units as u
 from astropy.coordinates import (SkyCoord, Latitude, Longitude, Angle, EarthLocation,
                                  SphericalRepresentation, CartesianRepresentation,
                                  SphericalCosLatDifferential)
-from astropy.io.misc.parquet import parquet_identify, writer_version
+from astropy.io.misc.parquet import parquet_identify, get_pyarrow
 from astropy.time import Time, TimeDelta
 from astropy.units import allclose as quantity_allclose
 from astropy.units.quantity import QuantityInfo
@@ -642,7 +642,7 @@ def test_parquet_read_generic(tmpdir):
                  for name in names]
     schema = pyarrow.schema(type_list)
 
-    from pyarrow import parquet
+    _, parquet, writer_version = get_pyarrow()
     # We use version='2.0' for full support of datatypes including uint32.
     with parquet.ParquetWriter(filename, schema, version=writer_version) as writer:
         arrays = [pyarrow.array(t1[name].data)
@@ -671,6 +671,7 @@ def test_parquet_read_pandas(tmpdir):
 
     df = t1.to_pandas()
     # We use version='2.0' for full support of datatypes including uint32.
+    _, _, writer_version = get_pyarrow()
     df.to_parquet(filename, version=writer_version)
 
     with pytest.warns(AstropyUserWarning, match='No table::len'):


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This is a possible fix for Parquet v2.0 being depreciated.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #12298 

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
