### PR TITLE
Strip correct excess columns in multiple-coordinates tables and clean up hmsdms format

### DIFF
--- a/astropy/io/ascii/mrt.py
+++ b/astropy/io/ascii/mrt.py
@@ -267,18 +267,8 @@ class MrtHeader(cds.CdsHeader):
             # Check if column is MaskedColumn
             col.has_null = isinstance(col, MaskedColumn)
 
-            min_width = None
-            # Check if the column format was set by the passed ``formats`` argument.
-            if col.format is None:
-                if col.info.format is not None:
-                    col.format = col.info.format
-
             if col.format is not None:
-                min_width = re.match(r'^(\+?)(\d+)', col.format)
-                if min_width is None:
-                    col.formatted_width = max([len(sval) for sval in col.str_vals])
-                else:
-                    col.formatted_width = int(min_width.groups()[1])
+                col.formatted_width = max([len(sval) for sval in col.str_vals])
 
             # Set MRTColumn type, size and format.
             if np.issubdtype(col.dtype, np.integer):
@@ -287,7 +277,7 @@ class MrtHeader(cds.CdsHeader):
                 if getattr(col, 'formatted_width', None) is None:  # If ``formats`` not passed.
                     col.formatted_width = max(len(str(col.max)), len(str(col.min)))
                 col.fortran_format = "I" + str(col.formatted_width)
-                if min_width is None:
+                if col.format is None:
                     col.format = ">" + col.fortran_format[1:]
 
             elif np.issubdtype(col.dtype, np.dtype(float).type):

--- a/astropy/io/ascii/mrt.py
+++ b/astropy/io/ascii/mrt.py
@@ -472,8 +472,10 @@ class MrtHeader(cds.CdsHeader):
                                                description=descrip)
                         # Set default number of digits after decimal point for the
                         # second values, and deg-min to (signed) 2-digit zero-padded integer.
-                        if name in ['RAs', 'DEs']:
-                            coord_col.format = '015.12f'
+                        if name == 'RAs':
+                            coord_col.format = '013.10f'
+                        elif name == 'DEs':
+                            coord_col.format = '012.9f'
                         elif name == 'RAh':
                             coord_col.format = '2d'
                         elif name == 'DEd':
@@ -508,7 +510,7 @@ class MrtHeader(cds.CdsHeader):
                 # representations to string valued columns. Those could either be types not
                 # supported yet (e.g. 'helioprojective'), or already present and converted.
                 # If there were any extra ``SkyCoord`` columns of one kind after the first one,
-                # then they have been skipped the decomposition into their component columns.
+                # then their decomposition into their component columns has been skipped.
                 # This is done in order to not create duplicate component columns.
                 # Explicit renaming of the extra coordinate component columns by appending some
                 # suffix to their name, so as to distinguish them, is not yet implemented.

--- a/astropy/io/ascii/tests/test_cds.py
+++ b/astropy/io/ascii/tests/test_cds.py
@@ -16,7 +16,7 @@ from astropy.table import Column, MaskedColumn
 from astropy.coordinates import SkyCoord
 from astropy.time import Time
 from astropy.utils.data import get_pkg_data_filename
-from .common import assert_equal, assert_almost_equal
+from .common import assert_almost_equal
 
 
 test_dat = ['names e d s i',
@@ -123,6 +123,7 @@ def test_write_readme_with_default_options():
 
 def test_write_empty_table():
     out = StringIO()
+    import pytest
     with pytest.raises(NotImplementedError):
         Table().write(out, format='ascii.mrt')
 
@@ -194,18 +195,18 @@ exp_coord_cols_output = dict(generic=[
     '33-35  I3     ---    i       [-30/67] Description of i         ',
     '37-39  F3.1   ---    sameF   [5.0/5.0] Description of sameF    ',
     '41-42  I2     ---    sameI   [20] Description of sameI         ',
-    '44-47  F4.1   h      RAh     Right Ascension (hour)            ',
-    '49-52  F4.1   min    RAm     Right Ascension (minute)          ',
-    '54-68  F15.12 s      RAs     Right Ascension (second)          ',
-    '   70  A1     ---    DE-     Sign of Declination               ',
-    '71-74  F5.1   deg    DEd     Declination (degree)              ',
-    '76-79  F4.1   arcmin DEm     Declination (arcmin)              ',
-    '81-95  F15.12 arcsec DEs     Declination (arcsec)              ',
+    '44-45  I2     h      RAh     Right Ascension (hour)            ',
+    '47-48  I2     min    RAm     Right Ascension (minute)          ',
+    '50-64  F15.12 s      RAs     Right Ascension (second)          ',
+    '   66  A1     ---    DE-     Sign of Declination               ',
+    '67-68  I2     deg    DEd     Declination (degree)              ',
+    '70-71  I2     arcmin DEm     Declination (arcmin)              ',
+    '73-87  F15.12 arcsec DEs     Declination (arcsec)              ',
     '--------------------------------------------------------------------------------',
     'Notes:',
     '--------------------------------------------------------------------------------',
-    'HD81809  1e-07  22.25608   2e+00  67 5.0 20 22.0  2.0 15.450000000007 -61.0 39.0 34.599996000001',  # noqa
-    'HD103095 -3e+06 27.25000  -9e+34 -30 5.0 20 12.0 48.0 15.224407200005  17.0 46.0 26.496624000004'],  # noqa
+    'HD81809  1e-07  22.25608   2e+00  67 5.0 20 22 02 15.450000000007 -61 39 34.599996000001',
+    'HD103095 -3e+06 27.25000  -9e+34 -30 5.0 20 12 48 15.224407200005 +17 46 26.496624000004'],
 
     positive_de=[
         '================================================================================',
@@ -220,17 +221,18 @@ exp_coord_cols_output = dict(generic=[
         '33-35  I3     ---    i       [-30/67] Description of i         ',
         '37-39  F3.1   ---    sameF   [5.0/5.0] Description of sameF    ',
         '41-42  I2     ---    sameI   [20] Description of sameI         ',
-        '44-47  F4.1   h      RAh     Right Ascension (hour)            ',
-        '49-52  F4.1   min    RAm     Right Ascension (minute)          ',
-        '54-68  F15.12 s      RAs     Right Ascension (second)          ',
-        '70-73  F4.1   deg    DEd     Declination (degree)              ',
-        '75-78  F4.1   arcmin DEm     Declination (arcmin)              ',
-        '80-94  F15.12 arcsec DEs     Declination (arcsec)              ',
+        '44-45  I2     h      RAh     Right Ascension (hour)            ',
+        '47-48  I2     min    RAm     Right Ascension (minute)          ',
+        '50-64  F15.12 s      RAs     Right Ascension (second)          ',
+        '   66  A1     ---    DE-     Sign of Declination               ',
+        '67-68  I2     deg    DEd     Declination (degree)              ',
+        '70-71  I2     arcmin DEm     Declination (arcmin)              ',
+        '73-87  F15.12 arcsec DEs     Declination (arcsec)              ',
         '--------------------------------------------------------------------------------',
         'Notes:',
         '--------------------------------------------------------------------------------',
-        'HD81809  1e-07  22.25608   2e+00  67 5.0 20 12.0 48.0 15.224407200005 17.0 46.0 26.496624000004',  # noqa
-        'HD103095 -3e+06 27.25000  -9e+34 -30 5.0 20 12.0 48.0 15.224407200005 17.0 46.0 26.496624000004'],  # noqa
+        'HD81809  1e-07  22.25608   2e+00  67 5.0 20 12 48 15.224407200005 +17 46 26.496624000004',
+        'HD103095 -3e+06 27.25000  -9e+34 -30 5.0 20 12 48 15.224407200005 +17 46 26.496624000004'],
 
     galactic=[
         '================================================================================',
@@ -327,21 +329,21 @@ def test_write_byte_by_byte_bytes_col_format():
         '--------------------------------------------------------------------------------',
         ' Bytes Format Units  Label     Explanations',
         '--------------------------------------------------------------------------------',
-        '  1-  8  A8     ---    names         Description of names              ',
-        ' 10- 21  E12.6  ---    e             [-3160000.0/0.01] Description of e',
-        ' 23- 30  F8.5   ---    d             [22.25/27.25] Description of d    ',
-        ' 32- 38  E7.1   ---    s             [-9e+34/2.0] Description of s     ',
-        ' 40- 42  I3     ---    i             [-30/67] Description of i         ',
-        ' 44- 46  F3.1   ---    sameF         [5.0/5.0] Description of sameF    ',
-        ' 48- 49  I2     ---    sameI         [20] Description of sameI         ',
-        '     51  I1     ---    singleByteCol [2] Description of singleByteCol  ',
-        ' 53- 56  F4.1   h      RAh           Right Ascension (hour)            ',
-        ' 58- 60  F3.1   min    RAm           Right Ascension (minute)          ',
-        ' 62- 76  F15.12 s      RAs           Right Ascension (second)          ',
-        '     78  A1     ---    DE-           Sign of Declination               ',
-        ' 79- 82  F5.1   deg    DEd           Declination (degree)              ',
-        ' 84- 87  F4.1   arcmin DEm           Declination (arcmin)              ',
-        ' 89-103  F15.12 arcsec DEs           Declination (arcsec)              ',
+        ' 1- 8  A8     ---    names         Description of names              ',
+        '10-21  E12.6  ---    e             [-3160000.0/0.01] Description of e',
+        '23-30  F8.5   ---    d             [22.25/27.25] Description of d    ',
+        '32-38  E7.1   ---    s             [-9e+34/2.0] Description of s     ',
+        '40-42  I3     ---    i             [-30/67] Description of i         ',
+        '44-46  F3.1   ---    sameF         [5.0/5.0] Description of sameF    ',
+        '48-49  I2     ---    sameI         [20] Description of sameI         ',
+        '   51  I1     ---    singleByteCol [2] Description of singleByteCol  ',
+        '53-54  I2     h      RAh           Right Ascension (hour)            ',
+        '56-57  I2     min    RAm           Right Ascension (minute)          ',
+        '59-73  F15.12 s      RAs           Right Ascension (second)          ',
+        '   75  A1     ---    DE-           Sign of Declination               ',
+        '76-77  I2     deg    DEd           Declination (degree)              ',
+        '79-80  I2     arcmin DEm           Declination (arcmin)              ',
+        '82-96  F15.12 arcsec DEs           Declination (arcsec)              ',
         '--------------------------------------------------------------------------------']
     t = ascii.read(test_dat)
     t.add_column([5.0, 5.0], name='sameF')
@@ -437,7 +439,7 @@ def test_write_mixin_and_broken_cols():
     assert lines == exp_output
 
 
-def test_write_extra_SkyCoord_cols():
+def test_write_extra_skycoord_cols():
     """
     Tests output for cases when table contains multiple ``SkyCoord`` columns.
     """
@@ -473,7 +475,7 @@ HD81809 22 02 15.450000000007 -61 39 34.599996000001 330.564 -61.66
 
     lines = out.getvalue().splitlines()
     i_bbb = lines.index('=' * 80)
-    lines = lines[i_bbb:]  # Select Byte-By-Byte section and later lines.
+    lines = lines[i_bbb:]  # Select Byte-By-Byte section and following lines.
     # Check the written table.
     assert lines[:-2] == exp_output.splitlines()[:-2]
 

--- a/astropy/io/ascii/tests/test_cds.py
+++ b/astropy/io/ascii/tests/test_cds.py
@@ -16,6 +16,7 @@ from astropy.table import Column, MaskedColumn
 from astropy.coordinates import SkyCoord
 from astropy.time import Time
 from astropy.utils.data import get_pkg_data_filename
+from astropy.utils.exceptions import AstropyWarning
 from .common import assert_almost_equal
 
 
@@ -197,16 +198,16 @@ exp_coord_cols_output = dict(generic=[
     '41-42  I2     ---    sameI   [20] Description of sameI         ',
     '44-45  I2     h      RAh     Right Ascension (hour)            ',
     '47-48  I2     min    RAm     Right Ascension (minute)          ',
-    '50-64  F15.12 s      RAs     Right Ascension (second)          ',
-    '   66  A1     ---    DE-     Sign of Declination               ',
-    '67-68  I2     deg    DEd     Declination (degree)              ',
-    '70-71  I2     arcmin DEm     Declination (arcmin)              ',
-    '73-87  F15.12 arcsec DEs     Declination (arcsec)              ',
+    '50-62  F13.10 s      RAs     Right Ascension (second)          ',
+    '   64  A1     ---    DE-     Sign of Declination               ',
+    '65-66  I2     deg    DEd     Declination (degree)              ',
+    '68-69  I2     arcmin DEm     Declination (arcmin)              ',
+    '71-82  F12.9  arcsec DEs     Declination (arcsec)              ',
     '--------------------------------------------------------------------------------',
     'Notes:',
     '--------------------------------------------------------------------------------',
-    'HD81809  1e-07  22.25608   2e+00  67 5.0 20 22 02 15.450000000007 -61 39 34.599996000001',
-    'HD103095 -3e+06 27.25000  -9e+34 -30 5.0 20 12 48 15.224407200005 +17 46 26.496624000004'],
+    'HD81809  1e-07  22.25608   2e+00  67 5.0 20 22 02 15.4500000000 -61 39 34.599996000',
+    'HD103095 -3e+06 27.25000  -9e+34 -30 5.0 20 12 48 15.2244072000 +17 46 26.496624000'],
 
     positive_de=[
         '================================================================================',
@@ -223,16 +224,16 @@ exp_coord_cols_output = dict(generic=[
         '41-42  I2     ---    sameI   [20] Description of sameI         ',
         '44-45  I2     h      RAh     Right Ascension (hour)            ',
         '47-48  I2     min    RAm     Right Ascension (minute)          ',
-        '50-64  F15.12 s      RAs     Right Ascension (second)          ',
-        '   66  A1     ---    DE-     Sign of Declination               ',
-        '67-68  I2     deg    DEd     Declination (degree)              ',
-        '70-71  I2     arcmin DEm     Declination (arcmin)              ',
-        '73-87  F15.12 arcsec DEs     Declination (arcsec)              ',
+        '50-62  F13.10 s      RAs     Right Ascension (second)          ',
+        '   64  A1     ---    DE-     Sign of Declination               ',
+        '65-66  I2     deg    DEd     Declination (degree)              ',
+        '68-69  I2     arcmin DEm     Declination (arcmin)              ',
+        '71-82  F12.9  arcsec DEs     Declination (arcsec)              ',
         '--------------------------------------------------------------------------------',
         'Notes:',
         '--------------------------------------------------------------------------------',
-        'HD81809  1e-07  22.25608   2e+00  67 5.0 20 12 48 15.224407200005 +17 46 26.496624000004',
-        'HD103095 -3e+06 27.25000  -9e+34 -30 5.0 20 12 48 15.224407200005 +17 46 26.496624000004'],
+        'HD81809  1e-07  22.25608   2e+00  67 5.0 20 12 48 15.2244072000 +17 46 26.496624000',
+        'HD103095 -3e+06 27.25000  -9e+34 -30 5.0 20 12 48 15.2244072000 +17 46 26.496624000'],
 
     galactic=[
         '================================================================================',
@@ -339,11 +340,11 @@ def test_write_byte_by_byte_bytes_col_format():
         '   51  I1     ---    singleByteCol [2] Description of singleByteCol  ',
         '53-54  I2     h      RAh           Right Ascension (hour)            ',
         '56-57  I2     min    RAm           Right Ascension (minute)          ',
-        '59-73  F15.12 s      RAs           Right Ascension (second)          ',
-        '   75  A1     ---    DE-           Sign of Declination               ',
-        '76-77  I2     deg    DEd           Declination (degree)              ',
-        '79-80  I2     arcmin DEm           Declination (arcmin)              ',
-        '82-96  F15.12 arcsec DEs           Declination (arcsec)              ',
+        '59-71  F13.10 s      RAs           Right Ascension (second)          ',
+        '   73  A1     ---    DE-           Sign of Declination               ',
+        '74-75  I2     deg    DEd           Declination (degree)              ',
+        '77-78  I2     arcmin DEm           Declination (arcmin)              ',
+        '80-91  F12.9  arcsec DEs           Declination (arcsec)              ',
         '--------------------------------------------------------------------------------']
     t = ascii.read(test_dat)
     t.add_column([5.0, 5.0], name='sameF')
@@ -452,17 +453,17 @@ Byte-by-byte Description of file: table.dat
  1- 7  A7     ---    name    Description of name     
  9-10  I2     h      RAh     Right Ascension (hour)  
 12-13  I2     min    RAm     Right Ascension (minute)
-15-29  F15.12 s      RAs     Right Ascension (second)
-   31  A1     ---    DE-     Sign of Declination     
-32-33  I2     deg    DEd     Declination (degree)    
-35-36  I2     arcmin DEm     Declination (arcmin)    
-38-52  F15.12 arcsec DEs     Declination (arcsec)    
-54-67  A14    ---    coord2  Description of coord2   
+15-27  F13.10 s      RAs     Right Ascension (second)
+   29  A1     ---    DE-     Sign of Declination     
+30-31  I2     deg    DEd     Declination (degree)    
+33-34  I2     arcmin DEm     Declination (arcmin)    
+36-47  F12.9  arcsec DEs     Declination (arcsec)    
+49-62  A14    ---    coord2  Description of coord2   
 --------------------------------------------------------------------------------
 Notes:
 --------------------------------------------------------------------------------
-HD4760   0 49 39.900000000000 +06 24 07.999200000000 12.4163 6.407 
-HD81809 22 02 15.450000000007 -61 39 34.599996000001 330.564 -61.66
+HD4760   0 49 39.9000000000 +06 24 07.999200000 12.4163 6.407 
+HD81809 22 02 15.4500000000 -61 39 34.599996000 330.564 -61.66
 '''  # noqa: W291
     t = Table()
     t['name'] = ['HD4760', 'HD81809']
@@ -483,3 +484,45 @@ HD81809 22 02 15.450000000007 -61 39 34.599996000001 330.564 -61.66
         assert a[:18] == b[:18]
         assert a[30:42] == b[30:42]
         assert_almost_equal(np.fromstring(a[2:], sep=' '), np.fromstring(b[2:], sep=' '))
+
+
+def test_write_skycoord_with_format():
+    """
+    Tests output with custom setting for ``SkyCoord`` (second) columns.
+    """
+    exp_output = '''\
+================================================================================
+Byte-by-byte Description of file: table.dat
+--------------------------------------------------------------------------------
+ Bytes Format Units  Label     Explanations
+--------------------------------------------------------------------------------
+ 1- 7  A7     ---    name    Description of name     
+ 9-10  I2     h      RAh     Right Ascension (hour)  
+12-13  I2     min    RAm     Right Ascension (minute)
+15-19  F5.2   s      RAs     Right Ascension (second)
+   21  A1     ---    DE-     Sign of Declination     
+22-23  I2     deg    DEd     Declination (degree)    
+25-26  I2     arcmin DEm     Declination (arcmin)    
+28-31  F4.1   arcsec DEs     Declination (arcsec)    
+--------------------------------------------------------------------------------
+Notes:
+--------------------------------------------------------------------------------
+HD4760   0 49 39.90 +06 24 08.0
+HD81809 22 02 15.45 -61 39 34.6
+'''  # noqa: W291
+    t = Table()
+    t['name'] = ['HD4760', 'HD81809']
+    t['coord'] = SkyCoord([12.41625, 330.564375], [6.402222, -61.65961111], unit=u.deg)
+
+    out = StringIO()
+    # This will raise a warning because `formats` is checked before the writer creating the
+    # final list of columns is called.
+    with pytest.warns(AstropyWarning, match=r"The key.s. {'[RD][AE]s', '[RD][AE]s'} specified in "
+                                            r"the formats argument do not match a column name."):
+        t.write(out, format='ascii.mrt', formats={'RAs': '05.2f', 'DEs': '04.1f'})
+
+    lines = out.getvalue().splitlines()
+    i_bbb = lines.index('=' * 80)
+    lines = lines[i_bbb:]  # Select Byte-By-Byte section and following lines.
+    # Check the written table.
+    assert lines == exp_output.splitlines()

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -825,7 +825,7 @@ def write(table, output=None, format=None, Writer=None, fast_writer=True, *,
 
     if diff_format_with_names:
         warnings.warn(
-            'The keys {} specified in the formats argument does not match a column name.'
+            'The key(s) {} specified in the formats argument do not match a column name.'
             .format(diff_format_with_names), AstropyWarning)
 
     if table.has_mixin_columns:

--- a/docs/changes/io.ascii/12302.feature.rst
+++ b/docs/changes/io.ascii/12302.feature.rst
@@ -1,0 +1,3 @@
+Added a new ``astropy.io.ascii.Mrt`` class to write tables in the American
+Astronomical Society Machine-Readable Table format,
+including documentation and tests for the same.

--- a/docs/io/ascii/write.rst
+++ b/docs/io/ascii/write.rst
@@ -310,7 +310,7 @@ copy of the table. The new coordinate component columns are appended to the end 
 
 It should be noted that the default precision of the latitude, longitude and seconds (of arc)
 columns is set at a default number of 12, 10 and 9 digits after the decimal for ``deg``, ``sec``
-and ``arcsec`` values, repsectively. This default is set to match a machine precision of 1e-15
+and ``arcsec`` values, respectively. This default is set to match a machine precision of 1e-15
 relative to the original ``SkyCoord`` those columns were extracted from.
 As all other columns, the format can be expliclty set by passing the ``formats`` keyword to the
 ``write`` function or by setting the ``format`` attribute of individual columns (the latter

--- a/docs/io/ascii/write.rst
+++ b/docs/io/ascii/write.rst
@@ -302,15 +302,14 @@ values that are such objects are recognized as such, and some predefined labels 
 description is used for them. Coordinate columns that have `~astropy.coordinates.SphericalRepresentation`
 are additionally sub-divided into their coordinate component columns. Representations that have
 ``ra`` and ``dec`` components are divided into their ``hour``-``min``-``sec``
-and ``deg``-``arcmin``-``arcsec`` components respectively. Whereas, columns with
+and ``deg``-``arcmin``-``arcsec`` components respectively. Whereas columns with
 ``SkyCoord`` objects in the ``Galactic`` or any of the ``Ecliptic`` frames are divided
 into their latitude(``ELAT``/``GLAT``) and longitude components (``ELON``/``GLAT``) only.
-The original table remains accessible as such, while the file is written from a
-modified copy of the table. The new coordinate component columns are added at the end
-of the table.
+The original table remains accessible as such, while the file is written from a modified
+copy of the table. The new coordinate component columns are appended to the end of the table.
 
 It should be noted that the precision of the latitude and longitude and ``sec``, ``arcsec``
-columns is set at a default number of 12 digits after the decimal. Since, these component
+columns is set at a default number of 12 digits after the decimal. Since these component
 columns are obtained by dividing up ``SkyCoord`` columns, this precision is internally set,
 and cannot be changed. For all other columns though, the format can be set by passing the
 ``formats`` keyword to the ``write`` function or by setting the ``format`` attribute of
@@ -336,20 +335,20 @@ After execution, the contents of ``coords_cols.dat`` will be::
   --------------------------------------------------------------------------------
    Bytes Format Units  Label     Explanations
   --------------------------------------------------------------------------------
-    1-11  A11     ---    Name        Description of Name
-   13-23  E11.6   keV    Temperature [0.0/0.01] Description of Temperature
-   25-30  F6.4    10+22  nH          [0.01/0.03] Description of nH
-   32-36  F5.3   10+12Jy Flux        ? Description of Flux
-   38-42  E5.1    mag    magnitude   [0.0/3981.08] Description of magnitude
-   44-49  F6.1    ---    Obs         [2019.0/2019.0] Time of Observation
-   51-53  I3      s      Cadence     [100] Description of Cadence
-   55-56  I2     h      RAh           Right Ascension (hour)
-   58-59  I2     min    RAm           Right Ascension (minute)
-   61-75  F15.12 s      RAs           Right Ascension (second)
-      77  A1     ---    DE-           Sign of Declination
-   78-79  I2     deg    DEd           Declination (degree)
-   81-82  I2     arcmin DEm           Declination (arcmin)
-   84-98  F15.12 arcsec DEs           Declination (arcsec)
+   1-11  A11     ---    Name        Description of Name
+  13-23  E11.6   keV    Temperature [0.0/0.01] Description of Temperature
+  25-30  F6.4    10+22  nH          [0.01/0.03] Description of nH
+  32-36  F5.3   10+12Jy Flux        ? Description of Flux
+  38-42  E5.1    mag    magnitude   [0.0/3981.08] Description of magnitude
+  44-49  F6.1    ---    Obs         [2019.0/2019.0] Time of Observation
+  51-53  I3      s      Cadence     [100] Description of Cadence
+  55-56  I2     h      RAh           Right Ascension (hour)
+  58-59  I2     min    RAm           Right Ascension (minute)
+  61-75  F15.12 s      RAs           Right Ascension (second)
+     77  A1     ---    DE-           Sign of Declination
+  78-79  I2     deg    DEd           Declination (degree)
+  81-82  I2     arcmin DEm           Declination (arcmin)
+  84-98  F15.12 arcsec DEs           Declination (arcsec)
   --------------------------------------------------------------------------------
   Notes:
   --------------------------------------------------------------------------------
@@ -366,15 +365,15 @@ And the file ``ecliptic_cols.dat`` will look like::
   --------------------------------------------------------------------------------
    Bytes Format Units  Label     Explanations
   --------------------------------------------------------------------------------
-    1- 11  A11     ---    Name        Description of Name
-   13- 23  E11.6   keV    Temperature [0.0/0.01] Description of Temperature
-   25- 30  F6.4    10+22  nH          [0.01/0.03] Description of nH
-   32- 36  F5.3   10+12Jy Flux        ? Description of Flux
-   38- 42  E5.1    mag    magnitude   [0.0/3981.08] Description of magnitude
-   44- 49  F6.1    ---    Obs         [2019.0/2019.0] Time of Observation
-   51- 53  I3      s      Cadence     [100] Description of Cadence
-   55- 70  F16.12  deg    ELON        Ecliptic Longitude (geocentrictrueecliptic)
-   72- 87  F16.12  deg    ELAT        Ecliptic Latitude (geocentrictrueecliptic)
+   1- 11  A11     ---    Name        Description of Name
+  13- 23  E11.6   keV    Temperature [0.0/0.01] Description of Temperature
+  25- 30  F6.4    10+22  nH          [0.01/0.03] Description of nH
+  32- 36  F5.3   10+12Jy Flux        ? Description of Flux
+  38- 42  E5.1    mag    magnitude   [0.0/3981.08] Description of magnitude
+  44- 49  F6.1    ---    Obs         [2019.0/2019.0] Time of Observation
+  51- 53  I3      s      Cadence     [100] Description of Cadence
+  55- 70  F16.12  deg    ELON        Ecliptic Longitude (geocentrictrueecliptic)
+  72- 87  F16.12  deg    ELAT        Ecliptic Latitude (geocentrictrueecliptic)
   --------------------------------------------------------------------------------
   Notes:
   --------------------------------------------------------------------------------
@@ -407,16 +406,16 @@ The following example shows a similar situation, using the option to send the ou
   --------------------------------------------------------------------------------
    Bytes Format Units  Label     Explanations
   --------------------------------------------------------------------------------
-    1- 11  A11     ---    Name        Description of Name
-   13- 18  F6.1    ---    Obs         [2019.0/2019.0] Time of Observation
-   20- 22  I3      s      Cadence     [100] Description of Cadence
-   24- 29  F6.4    10+22  nH          [0.01/0.03] Description of nH
-   31- 35  E5.1    mag    magnitude   [0.0/3981.08] Description of magnitude
-   37- 47  E11.6   keV    Temperature [0.0/0.01] Description of Temperature
-   49- 53  F5.3   10+12Jy Flux        ? Description of Flux
-   55- 61  F7.1    Jy     e_Flux      [450.0/10000.0] Description of e_Flux
-   63- 78  F16.12  deg    ELON        Ecliptic Longitude (geocentrictrueecliptic)
-   80- 95  F16.12  deg    ELAT        Ecliptic Latitude (geocentrictrueecliptic)
+   1- 11  A11     ---    Name        Description of Name
+  13- 18  F6.1    ---    Obs         [2019.0/2019.0] Time of Observation
+  20- 22  I3      s      Cadence     [100] Description of Cadence
+  24- 29  F6.4    10+22  nH          [0.01/0.03] Description of nH
+  31- 35  E5.1    mag    magnitude   [0.0/3981.08] Description of magnitude
+  37- 47  E11.6   keV    Temperature [0.0/0.01] Description of Temperature
+  49- 53  F5.3   10+12Jy Flux        ? Description of Flux
+  55- 61  F7.1    Jy     e_Flux      [450.0/10000.0] Description of e_Flux
+  63- 78  F16.12  deg    ELON        Ecliptic Longitude (geocentrictrueecliptic)
+  80- 95  F16.12  deg    ELAT        Ecliptic Latitude (geocentrictrueecliptic)
   --------------------------------------------------------------------------------
   Notes:
   --------------------------------------------------------------------------------
@@ -428,9 +427,10 @@ The following example shows a similar situation, using the option to send the ou
 
 .. attention::
 
-    The MRT writer supports automatic writing of a single coordinate
-    column in ``Tables``. For tables with more
-    than one coordinate columns, only the first found coordinate column will be
-    converted to its component columns and the rest of the coordinate columns will
-    be converted to string columns. Thus you should take care that the additional
-    coordinate columns are dealt with before using ``SkyCoord`` methods.
+    The MRT writer currently supports automatic writing of a single coordinate column
+    in ``Tables``. For tables with more than one coordinate column of a given kind
+    (e.g. equatorial, galactic or ecliptic), only the first found coordinate column
+    will be decomposed into its component columns, and the rest of the coordinate
+    columns will be converted to string columns. Thus users should take care that the
+    additional coordinate columns are dealt with (e.g. by converting them into unique
+    ``float``-valued columns) before using ``SkyCoord`` methods.

--- a/docs/io/ascii/write.rst
+++ b/docs/io/ascii/write.rst
@@ -336,25 +336,25 @@ After execution, the contents of ``coords_cols.dat`` will be::
   --------------------------------------------------------------------------------
    Bytes Format Units  Label     Explanations
   --------------------------------------------------------------------------------
-    1- 11  A11     ---    Name        Description of Name
-   13- 23  E11.6   keV    Temperature [0.0/0.01] Description of Temperature
-   25- 30  F6.4    10+22  nH          [0.01/0.03] Description of nH
-   32- 36  F5.3   10+12Jy Flux        ? Description of Flux
-   38- 42  E5.1    mag    magnitude   [0.0/3981.08] Description of magnitude
-   44- 49  F6.1    ---    Obs         [2019.0/2019.0] Time of Observation
-   51- 53  I3      s      Cadence     [100] Description of Cadence
-   55- 58  F4.1    h      RAh         Right Ascension (hour)
-   60- 63  F4.1    min    RAm         Right Ascension (minute)
-   65- 79  F15.12  s      RAs         Right Ascension (second)
-       81  A1      ---    DE-         Sign of Declination
-   82- 85  F5.1    deg    DEd         Declination (degree)
-   87- 90  F4.1    arcmin DEm         Declination (arcmin)
-   92-106  F15.12  arcsec DEs         Declination (arcsec)
+    1-11  A11     ---    Name        Description of Name
+   13-23  E11.6   keV    Temperature [0.0/0.01] Description of Temperature
+   25-30  F6.4    10+22  nH          [0.01/0.03] Description of nH
+   32-36  F5.3   10+12Jy Flux        ? Description of Flux
+   38-42  E5.1    mag    magnitude   [0.0/3981.08] Description of magnitude
+   44-49  F6.1    ---    Obs         [2019.0/2019.0] Time of Observation
+   51-53  I3      s      Cadence     [100] Description of Cadence
+   55-56  I2     h      RAh           Right Ascension (hour)
+   58-59  I2     min    RAm           Right Ascension (minute)
+   61-75  F15.12 s      RAs           Right Ascension (second)
+      77  A1     ---    DE-           Sign of Declination
+   78-79  I2     deg    DEd           Declination (degree)
+   81-82  I2     arcmin DEm           Declination (arcmin)
+   84-98  F15.12 arcsec DEs           Declination (arcsec)
   --------------------------------------------------------------------------------
   Notes:
   --------------------------------------------------------------------------------
-  ASASSN-15lh 2.87819e-09 0.0250       1e-10 2019.0 100 22.0  2.0 15.450000000007 -61.0 39.0 34.599996000001
-  ASASSN-14li 2.55935e-08 0.0188 2.044 4e+03 2019.0 100 12.0 48.0 15.224407200005  17.0 46.0 26.496624000004
+  ASASSN-15lh 2.87819e-09 0.0250       1e-10 2019.0 100 22 02 15.450000000007 -61 39 34.599996000001
+  ASASSN-14li 2.55935e-08 0.0188 2.044 4e+03 2019.0 100 12 48 15.224407200005 +17 46 26.496624000004
 
 And the file ``ecliptic_cols.dat`` will look like::
 

--- a/docs/io/ascii/write.rst
+++ b/docs/io/ascii/write.rst
@@ -308,12 +308,18 @@ into their latitude(``ELAT``/``GLAT``) and longitude components (``ELON``/``GLAT
 The original table remains accessible as such, while the file is written from a modified
 copy of the table. The new coordinate component columns are appended to the end of the table.
 
-It should be noted that the precision of the latitude and longitude and ``sec``, ``arcsec``
-columns is set at a default number of 12 digits after the decimal. Since these component
-columns are obtained by dividing up ``SkyCoord`` columns, this precision is internally set,
-and cannot be changed. For all other columns though, the format can be set by passing the
-``formats`` keyword to the ``write`` function or by setting the ``format`` attribute of
-individual columns.
+It should be noted that the default precision of the latitude, longitude and seconds (of arc)
+columns is set at a default number of 12, 10 and 9 digits after the decimal for ``deg``, ``sec``
+and ``arcsec`` values, repsectively. This default is set to match a machine precision of 1e-15
+relative to the original ``SkyCoord`` those columns were extracted from.
+As all other columns, the format can be expliclty set by passing the ``formats`` keyword to the
+``write`` function or by setting the ``format`` attribute of individual columns (the latter
+will only work for columns that are not decomposed).
+To customize the number of significant digits, presicions should therefore be specified in the
+``formats`` dictionary for the *output* column names, such as
+``formats={'RAs': '07.4f', 'DEs': '06.3f'}`` or ``formats={'GLAT': '+10.6f', 'GLON': '9.6f'}``
+for milliarcsecond accuracy. Note that the forms with leading zeros for the seconds and
+including the sign for latitudes are recommended for better consistency and readability.
 
 The following code illustrates the above.
 
@@ -344,16 +350,16 @@ After execution, the contents of ``coords_cols.dat`` will be::
   51-53  I3      s      Cadence     [100] Description of Cadence
   55-56  I2     h      RAh           Right Ascension (hour)
   58-59  I2     min    RAm           Right Ascension (minute)
-  61-75  F15.12 s      RAs           Right Ascension (second)
-     77  A1     ---    DE-           Sign of Declination
-  78-79  I2     deg    DEd           Declination (degree)
-  81-82  I2     arcmin DEm           Declination (arcmin)
-  84-98  F15.12 arcsec DEs           Declination (arcsec)
+  61-73  F13.10 s      RAs           Right Ascension (second)
+     75  A1     ---    DE-           Sign of Declination
+  76-77  I2     deg    DEd           Declination (degree)
+  79-80  I2     arcmin DEm           Declination (arcmin)
+  82-93  F12.9  arcsec DEs           Declination (arcsec)
   --------------------------------------------------------------------------------
   Notes:
   --------------------------------------------------------------------------------
-  ASASSN-15lh 2.87819e-09 0.0250       1e-10 2019.0 100 22 02 15.450000000007 -61 39 34.599996000001
-  ASASSN-14li 2.55935e-08 0.0188 2.044 4e+03 2019.0 100 12 48 15.224407200005 +17 46 26.496624000004
+  ASASSN-15lh 2.87819e-09 0.0250       1e-10 2019.0 100 22 02 15.4500000000 -61 39 34.599996000
+  ASASSN-14li 2.55935e-08 0.0188 2.044 4e+03 2019.0 100 12 48 15.2244072000 +17 46 26.496624000
 
 And the file ``ecliptic_cols.dat`` will look like::
 
@@ -431,6 +437,6 @@ The following example shows a similar situation, using the option to send the ou
     in ``Tables``. For tables with more than one coordinate column of a given kind
     (e.g. equatorial, galactic or ecliptic), only the first found coordinate column
     will be decomposed into its component columns, and the rest of the coordinate
-    columns will be converted to string columns. Thus users should take care that the
-    additional coordinate columns are dealt with (e.g. by converting them into unique
-    ``float``-valued columns) before using ``SkyCoord`` methods.
+    columns of the same type will be converted to string columns. Thus users should take
+    care that the additional coordinate columns are dealt with (e.g. by converting them
+    to unique ``float``-valued columns) before using ``SkyCoord`` methods.


### PR DESCRIPTION
### Description
Fixes #12299

A core problem seems to have been `pop`ing the columns in forward order, messing up the indices of the remaining columns in the process, so instead of the extra `SkyCoord` column e.g. the following `RAh` column would be stripped.
Also this was only done after the fact of already adding the duplicate `RAh RAm...` columns to `self.cols`.
In addition I found a number of problems with the coordinate formatting, so listing the declination sign in the header would depend on perchance having a negative value in the first row or not. An example with positive declination would look like this:
```
Byte-by-byte Description of file: table.dat
--------------------------------------------------------------------------------
 Bytes Format Units  Label     Explanations
--------------------------------------------------------------------------------
  1-  7  A7     ---    name    Description of name     
  9- 12  F4.1   h      RAh     Right Ascension (hour)  
 14- 17  F4.1   min    RAm     Right Ascension (minute)
 19- 33  F15.12 s      RAs     Right Ascension (second)
 35- 39  F5.1   deg    DEd     Declination (degree)    
 41- 44  F4.1   arcmin DEm     Declination (arcmin)    
 46- 60  F15.12 arcsec DEs     Declination (arcsec)    
 62- 65  F4.1   h      RAh     Right Ascension (hour)  
 67- 70  F4.1   min    RAm     Right Ascension (minute)
 72- 86  F15.12 s      RAs     Right Ascension (second)
 88- 92  F5.1   deg    DEd     Declination (degree)    
 94- 97  F4.1   arcmin DEm     Declination (arcmin)    
 99-113  F15.12 arcsec DEs     Declination (arcsec)    
--------------------------------------------------------------------------------
Notes:
--------------------------------------------------------------------------------
HD4760   0.0 49.0 39.900000000000   6.0 24.0 25.999992000001  0.0 49.0 39.900000000000   6.0 24.0 28.800000000001
HD81809 22.0  2.0 15.450000000007 -61.0 39.0 34.599996000001 22.0  2.0 15.600000000012 -61.0 39.0 35.999999999988
```
Moreover the hour-deg-minute columns were formatted in floating-point format despite being of integer type.
So in addition to stripping the excess column hopefully correctly, I have changed those formats to fixed `I2` width, plus leading zeros in the minutes/seconds for better readability and consistency with examples on http://vizier.u-strasbg.fr/doc/catstd-3.htx or
https://github.com/cds-astro/cds.pyreadme/blob/b84fc8b8b44b12d323eef3446e5084c52b9d7c39/tests/table.ascii#L1-L3

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
