### PR TITLE
BlackBody model: deprecate non-dimensionless scale and add support for flux units

### DIFF
--- a/astropy/modeling/physical_models.py
+++ b/astropy/modeling/physical_models.py
@@ -31,7 +31,7 @@ class BlackBody(Fittable1DModel):
         Scale factor
 
     output_units: `~astropy.units.CompositeUnit` or string
-        Desired output units when evaluating.  If a unit object, 
+        Desired output units when evaluating.  If a unit object,
         must be equivalent to one of erg / (cm ** 2 * s * Hz * sr)
         or erg / (cm ** 2 * s * AA * sr) for surface brightness
         or erg / (cm ** 2 * s * Hz) or erg / (cm ** 2 * s * AA) for
@@ -265,7 +265,7 @@ class BlackBody(Fittable1DModel):
         if isinstance(unit, str) and unit in ['SNU', 'SLAM', 'FNU', 'FLAM']:
             # let's provide some convenience for passing these as strings
             unit = self._native_output_units.get(unit)
-        
+
         if unit is None:
             pass
         elif isinstance(unit, u.UnitBase):

--- a/astropy/modeling/physical_models.py
+++ b/astropy/modeling/physical_models.py
@@ -95,8 +95,15 @@ class BlackBody(Fittable1DModel):
                 # NOTE: output_units will have to pass validation when assigned below
                 # so we don't need to duplicate the checks here
                 output_units = scale.unit
-                
-                # if the scale had FNU or FLAM units, then the scale quantity INCLUDES
+
+                # NOTE: if the scale units are equivalent (but not identical) to the
+                # "native" output units, this may result in confusing behavior (as the
+                # float value of the scale is adopted directly).  We keep this behavior
+                # for backwards compatibility as the ambiguity is removed by deprecating
+                # non-dimensionless support.
+                # See https://github.com/astropy/astropy/issues/11547#issuecomment-823772098
+
+                # If the scale had FNU or FLAM units, then the scale quantity INCLUDES
                 # pi*u.sr.  We need to remove the pi when passing the dimensionless 
                 # scale as it will be re-added later in evaluate.
                 if output_units.is_equivalent(self._native_units*u.sr, u.spectral_density(1*u.Hz)):

--- a/astropy/modeling/physical_models.py
+++ b/astropy/modeling/physical_models.py
@@ -11,7 +11,7 @@ import numpy as np
 from astropy import constants as const
 from astropy import units as u
 from astropy import cosmology
-from astropy.utils.exceptions import AstropyUserWarning
+from astropy.utils.exceptions import AstropyUserWarning, AstropyDeprecationWarning
 from .core import Fittable1DModel
 from .parameters import Parameter, InputParameterError
 
@@ -150,7 +150,7 @@ class BlackBody(Fittable1DModel):
                 warnings.warn(
                     f"Support for scale with units is deprecated in favor of passing output_units. "
                     f"Adopting scale={kwargs['scale']} and output_units={output_units}.",
-                    AstropyUserWarning,
+                    AstropyDeprecationWarning,
                 )
             else:
                 # Do not allow passing scale with unit AND output_units

--- a/astropy/modeling/physical_models.py
+++ b/astropy/modeling/physical_models.py
@@ -255,13 +255,13 @@ class BlackBody(Fittable1DModel):
         
         if unit is None:
             pass
-        elif isinstance(unit, u.CompositeUnit):
+        elif isinstance(unit, u.UnitBase):
             # support SNU, SLAM, FNU, FLAM output units (and equivalent)
             if not (unit.is_equivalent(self._native_units, u.spectral_density(1*u.AA)) or
                     unit.is_equivalent(self._native_units*u.sr, u.spectral_density(1*u.AA))):
                 raise ValueError(f"output_units not in surface brightness or flux density: {unit}")
         else:
-            raise ValueError("output_units must be of type CompositeUnit, None, "
+            raise ValueError("output_units must be of type Unit, None, "
                              "or one of 'SNU', 'SLAM', 'FNU', 'FLAM'")
 
         self._output_units = unit

--- a/astropy/modeling/tests/test_physical_models.py
+++ b/astropy/modeling/tests/test_physical_models.py
@@ -159,7 +159,7 @@ def test_blackbody_exceptions_and_warnings():
     # or when passing in output_units instead of scale
     bb = BlackBody(5000 * u.K, scale=1.0, output_units=u.Jy)
     assert(bb.scale == 1.0)
-    
+
 
 def test_blackbody_array_temperature():
     """Regression test to make sure that the temperature can be an array."""

--- a/astropy/modeling/tests/test_physical_models.py
+++ b/astropy/modeling/tests/test_physical_models.py
@@ -145,11 +145,12 @@ def test_blackbody_exceptions_and_warnings():
         bb = BlackBody(5000 * u.K, scale=1.0 * u.Jy)
         bb.bolometric_flux
     assert len(w) == 2
-    # and that passing flux units to scale also divides internal scale by pi
-    # (since units include steradians)
-    assert(bb.scale == 1.0/np.pi)
+    # and that passing flux units to scale both converts to native units AND
+    # divides internal scale by pi (since units include steradians)
+    assert(bb.scale == 1.0*u.Jy.to(u.erg / (u.cm ** 2 * u.s * u.Hz))/np.pi)
     assert(bb.output_units == u.Jy)
-    # ... but not for surface brightness
+    # ... but surface brightness is not divided by pi (and in this case have
+    # native units passed)
     with pytest.warns(AstropyUserWarning, match='deprecated') as w:
         bb = BlackBody(5000 * u.K, scale=1.0 * u.erg / (u.cm ** 2 * u.s * u.AA * u.sr))
         bb.bolometric_flux

--- a/docs/changes/modeling/12304.api.rst
+++ b/docs/changes/modeling/12304.api.rst
@@ -1,0 +1,1 @@
+BlackBody model: deprecate support for non-dimensionless units on ``scale`` parameter, and add support for flux-units with introduction of new `output_units` argument.

--- a/docs/changes/modeling/12304.api.rst
+++ b/docs/changes/modeling/12304.api.rst
@@ -1,1 +1,1 @@
-BlackBody model: deprecate support for non-dimensionless units on ``scale`` parameter, and add support for flux-units with introduction of new `output_units` argument.
+BlackBody model: deprecate support for non-dimensionless units on ``scale`` parameter, and add support for flux-units with introduction of new ``output_units`` argument.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request deprecates non-dimensionless `scale` in `models.BlackBody` and replaces the functionality with `output_units`, with added support for flux (density) units.  This also fixes the case where dimensionless (but not unscaled) units are passed to `scale`.

Until support for non-dimensionless `scale` is removed in the future, a warning is raised at both `__init__` and future calls to `bolometric_flux` (both warning about deprecation and the possible ambiguous treatment).  The input `scale` quantity is first converted to one of the supported native output units and stored internally as a float, with the originally passed units being passed to the new `output_units` parameter.  In doing so, this also "fixes" the case mentioned in https://github.com/astropy/astropy/issues/11547#issuecomment-823772098... although the expected behavior is still ambiguous (thus the deprecation).  If the units on `scale` are flux units, then pi is also removed as it is added internally within `evaluate` (see example below).

Revisiting the cases in #11547:

```
from astropy.modeling.models import BlackBody
from astropy import units as u
import numpy as np

T = 3000 * u.K
r = 1e14 * u.cm
DL = 100 * u.Mpc
scale = np.pi * (r / DL)**2

print(BlackBody(temperature=T, scale=scale).bolometric_flux)
print(BlackBody(temperature=T, scale=scale.to_value(u.dimensionless_unscaled)).bolometric_flux)
```

now returns the expected output (the passed scale with units of cm ** 2 / Mpc **2 are converted to dimensionless_unscaled before being applied):

```
4.823870774433646e-16 erg / (cm2 s)
4.823870774433646e-16 erg / (cm2 s)
```

The [second example](https://github.com/astropy/astropy/issues/11547#issuecomment-823772098) now gives the expected results (change from previous behavior) with deprecation warnings for passing non-dimensionless quantities to `scale`:

```
from astropy.modeling.models import BlackBody
from astropy import units as u
from matplotlib import pyplot as plt
import numpy as np

nu = np.geomspace(0.1, 10) * u.micron
bb1 = BlackBody(temperature=3000*u.K, scale=1*u.erg/(u.cm ** 2 * u.s * u.Hz * u.sr))
bb2 = BlackBody(temperature=3000*u.K, scale=1*u.J/(u.cm ** 2 * u.s * u.Hz * u.sr))
bb3 = BlackBody(temperature=3000*u.K, scale=1e7*u.erg/(u.cm ** 2 * u.s * u.Hz * u.sr))

fig, ax = plt.subplots()
ax.set_xscale('log')
ax.set_yscale('log')
ax.plot(nu.value, bb1(nu).to_value(u.erg/(u.cm ** 2 * u.s * u.Hz * u.sr)), lw=4, label='bb1')
ax.plot(nu.value, bb2(nu).to_value(u.erg/(u.cm ** 2 * u.s * u.Hz * u.sr)), lw=4, label='bb2')
ax.plot(nu.value, bb3(nu).to_value(u.erg/(u.cm ** 2 * u.s * u.Hz * u.sr)), label='bb3')
ax.legend()
fig.savefig('test.png')
```

![test](https://user-images.githubusercontent.com/877591/139100378-136812bb-30c0-43f9-b9fd-91a69c137730.png)

The new preferred (non-ambiguous) version of this same example would be:

```
from astropy.modeling.models import BlackBody
from astropy import units as u
from matplotlib import pyplot as plt
import numpy as np

nu = np.geomspace(0.1, 10) * u.micron
bb1 = BlackBody(temperature=3000*u.K, scale=1.0, output_units=u.erg/(u.cm ** 2 * u.s * u.Hz * u.sr))
bb2 = BlackBody(temperature=3000*u.K, scale=1*u.J/u.erg, output_units=u.J/(u.cm ** 2 * u.s * u.Hz * u.sr))
bb3 = BlackBody(temperature=3000*u.K, scale=1e7, output_units=u.erg/(u.cm ** 2 * u.s * u.Hz * u.sr))

fig, ax = plt.subplots()
ax.set_xscale('log')
ax.set_yscale('log')
ax.plot(nu.value, bb1(nu).to_value(u.erg/(u.cm ** 2 * u.s * u.Hz * u.sr)), lw=4, label='bb1')
ax.plot(nu.value, bb2(nu).to_value(u.erg/(u.cm ** 2 * u.s * u.Hz * u.sr)), lw=4, label='bb2')
ax.plot(nu.value, bb3(nu).to_value(u.erg/(u.cm ** 2 * u.s * u.Hz * u.sr)), label='bb3')
ax.legend()
fig.savefig('test2.png')
```

![test2](https://user-images.githubusercontent.com/877591/139100479-ba7955e8-a997-4988-b8a7-bdc74b0cb8a2.png)

and the previous (unexpected) behavior can now be reproduced with (note the difference in `scale` passed to `bb2`: one with unit conversion, the other without):

```
from astropy.modeling.models import BlackBody
from astropy import units as u
from matplotlib import pyplot as plt
import numpy as np

nu = np.geomspace(0.1, 10) * u.micron
bb1 = BlackBody(temperature=3000*u.K, scale=1.0, output_units=u.erg/(u.cm ** 2 * u.s * u.Hz * u.sr))
bb2 = BlackBody(temperature=3000*u.K, scale=1.0, output_units=u.J/(u.cm ** 2 * u.s * u.Hz * u.sr))
bb3 = BlackBody(temperature=3000*u.K, scale=1e7, output_units=u.erg/(u.cm ** 2 * u.s * u.Hz * u.sr))

fig, ax = plt.subplots()
ax.set_xscale('log')
ax.set_yscale('log')
ax.plot(nu.value, bb1(nu).to_value(u.erg/(u.cm ** 2 * u.s * u.Hz * u.sr)), lw=4, label='bb1')
ax.plot(nu.value, bb2(nu).to_value(u.erg/(u.cm ** 2 * u.s * u.Hz * u.sr)), label='bb2')
ax.plot(nu.value, bb3(nu).to_value(u.erg/(u.cm ** 2 * u.s * u.Hz * u.sr)), label='bb3')
ax.legend()
fig.savefig('test3.png')
```

![test3](https://user-images.githubusercontent.com/877591/139100565-f3dc83ba-2e16-4f1f-8efd-3734e770658d.png)

Additionally, flux units are now supported by passing valid flux units to `output_units`, with a factor of `pi` multiplied in addition to the dimensionless `scale`:

```
from astropy.modeling import models
import astropy.units as u

import numpy as np

nu = np.geomspace(0.1, 10) * u.micron

bb = models.BlackBody(temperature=3000*u.K, scale=1.0, output_units=u.erg / (u.cm ** 2 * u.s * u.Hz))
bb(nu)
```

To be consistent, passing flux units to `scale` are temporarily supported (with a deprecation warning), in which case the units are converted as above but a factor of `pi` is removed (as solid angle are in the units):

```
from astropy.modeling import models
import astropy.units as u

import numpy as np

nu = np.geomspace(0.1, 10) * u.micron

bb = models.BlackBody(temperature=3000*u.K, scale=np.pi*u.erg / (u.cm ** 2 * u.s * u.Hz))
bb(nu)
print(bb.scale) # set internally as 1.0
```

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #11547

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
