### PR TITLE
Allow deprecated_renamed_argument custom messages

### DIFF
--- a/astropy/utils/tests/test_decorators.py
+++ b/astropy/utils/tests/test_decorators.py
@@ -317,6 +317,14 @@ def test_deprecated_argument():
             method(1, clobber=2)
 
 
+def test_deprecated_argument_custom_message():
+    @deprecated_renamed_argument('foo', 'bar', '4.0', message='Custom msg')
+    def test(bar=0):
+        pass
+    with pytest.warns(AstropyDeprecationWarning, match='Custom msg'):
+        test(foo=0)
+
+
 def test_deprecated_argument_in_kwargs():
     # To rename an argument that is consumed by "kwargs" the "arg_in_kwargs"
     # parameter is used.

--- a/docs/changes/utils/12305.feature.rst
+++ b/docs/changes/utils/12305.feature.rst
@@ -1,0 +1,2 @@
+The ``astropy.utils.deprecated_renamed_argument()`` decorator now supports
+custom warning messages.


### PR DESCRIPTION
### Description

Many deprecation decorators in `astropy.utils.decorators` allow the user to specify a custom warning message. This pull request adds the possibility of using custom warning messages in `deprecated_renamed_argument()` too.
### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.