### PR TITLE
Fixed the representation constructor mutating input provided as a longitude component

### DIFF
--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -227,7 +227,7 @@ class BaseRepresentationOrDifferential(ShapedLikeNDArray):
                 raise TypeError(f'unexpected keyword arguments: {kwargs}')
 
         # Pass attributes through the required initializing classes.
-        attrs = [self.attr_classes[component](attr, copy=False, subok=True)
+        attrs = [self.attr_classes[component](attr, copy=copy, subok=True)
                  for component, attr in zip(components, attrs)]
         try:
             attrs = np.broadcast_arrays(*attrs, subok=True)

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -141,6 +141,17 @@ class TestSphericalRepresentation:
         assert isinstance(s3.lat, Latitude)
         assert isinstance(s3.distance, Distance)
 
+    def test_init_no_mutate_input(self):
+
+        lon = -1 * u.hourangle
+        s = SphericalRepresentation(lon=lon, lat=-1 * u.deg, distance=1 * u.kpc, copy=True)
+
+        # The longitude component should be wrapped at 24 hours
+        assert_allclose_quantity(s.lon, 23 * u.hourangle)
+
+        # The input should not have been mutated by the constructor
+        assert_allclose_quantity(lon, -1 * u.hourangle)
+
     def test_init_lonlat(self):
 
         s2 = SphericalRepresentation(Longitude(8, u.hour),

--- a/docs/changes/coordinates/12307.bugfix.rst
+++ b/docs/changes/coordinates/12307.bugfix.rst
@@ -1,1 +1,2 @@
-Fixed a bug where instantiating a representation with a longitude component could mutate input provided for that component even when copying is specified.
+Fixed a bug where instantiating a representation with a longitude component
+could mutate input provided for that component even when copying is specified.

--- a/docs/changes/coordinates/12307.bugfix.rst
+++ b/docs/changes/coordinates/12307.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug where instantiating a representation with a longitude component could mutate input provided for that component even when copying is specified.


### PR DESCRIPTION
This PR fixes a bug where a representation with a longitude component could mutate input provided for that component even when it is supposed to copy the inputs.  Example:
```python
>>> import astropy.units as u
>>> from astropy.coordinates import UnitSphericalRepresentation
>>> test = -1*u.deg
>>> UnitSphericalRepresentation(test, 0*u.deg, copy=True)
<UnitSphericalRepresentation (lon, lat) in deg
    (359., 0.)>
>>> test
<Quantity 359. deg>
```
After this PR:
```python
...
>>> test
<Quantity -1. deg>
```
This bug occurs because the longitude input is turned into a `Longitude` instance with an explicit `copy=False`, and thus the wrapping is imposed back on the input.

Note that this PR fixes this bug in the simplest way by always making an additional copy when `copy=True`, even though this isn't necessary in many situations.  Also note that the components get copied again ~10 lines later, after a potential broadcasting, so there's probably some way to have the code copy only once, but I couldn't get that to work when I tried.