### PR TITLE
Cosmo to/from table row

### DIFF
--- a/astropy/cosmology/io/row.py
+++ b/astropy/cosmology/io/row.py
@@ -1,0 +1,139 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+import copy
+
+import numpy as np
+
+from astropy.table import Row
+from astropy.cosmology.connect import convert_registry
+from astropy.cosmology.core import Cosmology
+
+from .mapping import from_mapping
+
+
+def from_row(row, *, move_to_meta=False, cosmology=None):
+    """Instantiate a `~astropy.cosmology.Cosmology` from a `~astropy.table.Row`.
+
+    Parameters
+    ----------
+    row : `~astropy.table.Row`
+        The object containing the Cosmology information.
+    move_to_meta : bool (optional, keyword-only)
+        Whether to move keyword arguments that are not in the Cosmology class'
+        signature to the Cosmology's metadata. This will only be applied if the
+        Cosmology does NOT have a keyword-only argument (e.g. ``**kwargs``).
+        Arguments moved to the metadata will be merged with existing metadata,
+        preferring specified metadata in the case of a merge conflict
+        (e.g. for ``Cosmology(meta={'key':10}, key=42)``, the ``Cosmology.meta``
+        will be ``{'key': 10}``).
+
+    cosmology : str, `~astropy.cosmology.Cosmology` class, or None (optional, keyword-only)
+        The cosmology class (or string name thereof) to use when constructing
+        the cosmology instance. The class also provides default parameter values,
+        filling in any non-mandatory arguments missing in 'table'.
+
+    Returns
+    -------
+    `~astropy.cosmology.Cosmology` subclass instance
+
+    Examples
+    --------
+    To see loading a `~astropy.cosmology.Cosmology` from a Row with
+    ``from_row``, we will first make a `~astropy.table.Row` using
+    :func:`~astropy.cosmology.Cosmology.to_format`.
+
+        >>> from astropy.cosmology import Cosmology, Planck18
+        >>> cr = Planck18.to_format("astropy.row")
+        >>> cr
+        <Row index=0>
+          cosmology     name        H0        Om0    Tcmb0    Neff    m_nu [3]    Ob0
+                               km / (Mpc s)            K                 eV
+            str13       str8     float64    float64 float64 float64   float64   float64
+        ------------- -------- ------------ ------- ------- ------- ----------- -------
+        FlatLambdaCDM Planck18        67.66 0.30966  2.7255   3.046 0.0 .. 0.06 0.04897
+
+    Now this row can be used to load a new cosmological instance identical
+    to the ``Planck18`` cosmology from which it was generated.
+
+        >>> cosmo = Cosmology.from_format(cr, format="astropy.row")
+        >>> cosmo
+        FlatLambdaCDM(name="Planck18", H0=67.7 km / (Mpc s), Om0=0.31,
+                      Tcmb0=2.725 K, Neff=3.05, m_nu=[0. 0. 0.06] eV, Ob0=0.049)
+    """
+    # special values
+    name = row['name'] if 'name' in row.columns else None  # get name from column
+    meta = copy.deepcopy(row.meta)
+
+    # turn row into mapping, filling cosmo if not in a column
+    mapping = dict(row)
+    mapping["name"] = name
+    mapping.setdefault("cosmology", meta.pop("cosmology", None))
+    mapping["meta"] = meta
+
+    # build cosmology from map
+    return from_mapping(mapping, move_to_meta=move_to_meta, cosmology=cosmology)
+
+
+def to_row(cosmology, *args, cosmology_in_meta=False):
+    """Serialize the cosmology into a `~astropy.table.Row`.
+
+    Parameters
+    ----------
+    cosmology : `~astropy.cosmology.Cosmology` subclass instance
+    *args
+        Not used. Needed for compatibility with
+        `~astropy.io.registry.UnifiedReadWriteMethod`
+    cosmology_in_meta : bool
+        Whether to put the cosmology class in the Table metadata (if `True`) or
+        as the first column (if `False`, default).
+
+    Returns
+    -------
+    `~astropy.table.Row`
+        With columns for the cosmology parameters, and metadata in the Table's
+        ``meta`` attribute. The cosmology class name will either be a column
+        or in ``meta``, depending on 'cosmology_in_meta'.
+
+    Examples
+    --------
+    A Cosmology as a `~astropy.table.Row` will have the cosmology's name and
+    parameters as columns.
+
+        >>> from astropy.cosmology import Planck18
+        >>> cr = Planck18.to_format("astropy.row")
+        >>> cr
+        <Row index=0>
+          cosmology     name        H0        Om0    Tcmb0    Neff    m_nu [3]    Ob0
+                               km / (Mpc s)            K                 eV
+            str13       str8     float64    float64 float64 float64   float64   float64
+        ------------- -------- ------------ ------- ------- ------- ----------- -------
+        FlatLambdaCDM Planck18        67.66 0.30966  2.7255   3.046 0.0 .. 0.06 0.04897
+
+    The cosmological class and other metadata, e.g. a paper reference, are in
+    the Table's metadata.
+    """
+    from .table import to_table
+
+    table = to_table(cosmology, cosmology_in_meta=cosmology_in_meta)
+    return table[0]  # extract row from table
+
+
+def row_identify(origin, format, *args, **kwargs):
+    """Identify if object uses the `~astropy.table.Row` format.
+
+    Returns
+    -------
+    bool
+    """
+    itis = False
+    if origin == "read":
+        itis = isinstance(args[1], Row) and (format in (None, "astropy.row"))
+    return itis
+
+
+# ===================================================================
+# Register
+
+convert_registry.register_reader("astropy.row", Cosmology, from_row)
+convert_registry.register_writer("astropy.row", Cosmology, to_row)
+convert_registry.register_identifier("astropy.row", Cosmology, row_identify)

--- a/astropy/cosmology/io/table.py
+++ b/astropy/cosmology/io/table.py
@@ -8,7 +8,8 @@ from astropy.cosmology.connect import convert_registry
 from astropy.cosmology.core import Cosmology
 from astropy.table import QTable, Table
 
-from .mapping import from_mapping, to_mapping
+from .mapping import to_mapping
+from .row import from_row
 
 
 def from_table(table, index=None, *, move_to_meta=False, cosmology=None):
@@ -136,18 +137,7 @@ def from_table(table, index=None, *, move_to_meta=False, cosmology=None):
     # ------------------
     # parse row to cosmo
 
-    # special values
-    name = row['name'] if 'name' in row.columns else None  # get name from column
-    meta = copy.deepcopy(row.meta)
-
-    # turn row into mapping, filling cosmo if not in a column
-    mapping = dict(row)
-    mapping["name"] = name
-    mapping.setdefault("cosmology", meta.pop("cosmology", None))
-    mapping["meta"] = meta
-
-    # build cosmology from map
-    return from_mapping(mapping, move_to_meta=move_to_meta, cosmology=cosmology)
+    return from_row(row, move_to_meta=move_to_meta, cosmology=cosmology)
 
 
 def to_table(cosmology, *args, cls=QTable, cosmology_in_meta=True):

--- a/astropy/cosmology/io/tests/test_row.py
+++ b/astropy/cosmology/io/tests/test_row.py
@@ -1,0 +1,117 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+# THIRD PARTY
+import pytest
+
+# LOCAL
+import astropy.units as u
+from astropy import cosmology
+from astropy.cosmology import Cosmology, realizations, Planck18
+from astropy.cosmology.core import _COSMOLOGY_CLASSES, Parameter
+from astropy.cosmology.io.row import from_row, to_row
+from astropy.table import Row
+from astropy.cosmology.parameters import available
+
+from .base import IOTestMixinBase, IOFormatTestBase
+
+cosmo_instances = [getattr(realizations, name) for name in available]
+cosmo_instances.append("TestToFromRow.setup.<locals>.CosmologyWithKwargs")
+
+###############################################################################
+
+
+class ToFromRowTestMixin(IOTestMixinBase):
+    """
+    Tests for a Cosmology[To/From]Format with ``format="astropy.row"``.
+    This class will not be directly called by :mod:`pytest` since its name does
+    not begin with ``Test``. To activate the contained tests this class must
+    be inherited in a subclass. Subclasses must define a :func:`pytest.fixture`
+    ``cosmo`` that returns/yields an instance of a |Cosmology|.
+    See ``TestCosmologyToFromFormat`` or ``TestCosmology`` for examples.
+    """
+
+    @pytest.mark.parametrize("in_meta", [True, False])
+    def test_to_row_in_meta(self, cosmo, in_meta):
+        """Test where the cosmology class is placed."""
+        row = cosmo.to_format('astropy.row', cosmology_in_meta=in_meta)
+
+        # if it's in metadata, it's not a column. And vice versa.
+        if in_meta:
+            assert row.meta["cosmology"] == cosmo.__class__.__qualname__
+            assert "cosmology" not in row.colnames  # not also a column
+        else:
+            assert row["cosmology"] == cosmo.__class__.__qualname__
+            assert "cosmology" not in row.meta
+
+    # -----------------------
+
+    def test_tofrom_row_instance(self, cosmo, to_format, from_format):
+        """Test cosmology -> astropy.row -> cosmology."""
+        # ------------
+        # To Row
+
+        row = to_format("astropy.row")
+        assert isinstance(row, Row)
+        assert row["cosmology"] == cosmo.__class__.__qualname__
+        assert row["name"] == cosmo.name
+
+        # ------------
+        # From Row
+
+        row.table["mismatching"] = "will error"
+
+        # tests are different if the last argument is a **kwarg
+        if tuple(cosmo._init_signature.parameters.values())[-1].kind == 4:
+            got = from_format(row, format="astropy.row")
+
+            assert got.__class__ is cosmo.__class__
+            assert got.name == cosmo.name
+            assert "mismatching" not in got.meta
+
+            return  # don't continue testing
+
+        # read with mismatching parameters errors
+        with pytest.raises(TypeError, match="there are unused parameters"):
+            from_format(row, format="astropy.row")
+
+        # unless mismatched are moved to meta
+        got = from_format(row, format="astropy.row", move_to_meta=True)
+        assert got == cosmo
+        assert got.meta["mismatching"] == "will error"
+
+        # it won't error if everything matches up
+        row.table.remove_column("mismatching")
+        got = from_format(row, format="astropy.row")
+        assert got == cosmo
+
+        # and it will also work if the cosmology is a class
+        # Note this is not the default output of ``to_format``.
+        cosmology = _COSMOLOGY_CLASSES[row["cosmology"]]
+        row.table.remove_column("cosmology")
+        row.table["cosmology"] = cosmology
+        got = from_format(row, format="astropy.row")
+        assert got == cosmo
+
+        # also it auto-identifies 'format'
+        got = from_format(row)
+        assert got == cosmo
+
+    def test_fromformat_row_subclass_partial_info(self, cosmo):
+        """
+        Test writing from an instance and reading from that class.
+        This works with missing information.
+        """
+        pass  # there are no partial info options
+
+
+class TestToFromTable(IOFormatTestBase, ToFromRowTestMixin):
+    """
+    Directly test ``to/from_row``.
+    These are not public API and are discouraged from use, in favor of
+    ``Cosmology.to/from_format(..., format="astropy.row")``, but should be
+    tested regardless b/c 3rd party packages might use these in their Cosmology
+    I/O. Also, it's cheap to test.
+    """
+
+    def setup_class(self):
+        self.functions = {"to": to_row, "from": from_row}

--- a/astropy/cosmology/tests/test_connect.py
+++ b/astropy/cosmology/tests/test_connect.py
@@ -10,7 +10,7 @@ from astropy import cosmology
 from astropy.cosmology import Cosmology, w0wzCDM
 from astropy.cosmology.connect import CosmologyRead, readwrite_registry
 from astropy.cosmology.core import Cosmology
-from astropy.cosmology.io.tests import test_ecsv, test_mapping, test_model, test_table
+from astropy.cosmology.io.tests import test_ecsv, test_mapping, test_model, test_row, test_table
 from astropy.table import QTable
 
 from .conftest import json_identify, read_json, write_json
@@ -205,7 +205,7 @@ class TestCosmologyReadWrite(ReadWriteTestMixin):
 class ToFromFormatTestMixin(
     # convert
     test_mapping.ToFromMappingTestMixin, test_model.ToFromModelTestMixin,
-    test_table.ToFromTableTestMixin,
+    test_row.ToFromRowTestMixin, test_table.ToFromTableTestMixin,
     # read/write
     test_ecsv.ReadWriteECSVTestMixin,
 ):

--- a/docs/changes/cosmology/12313.feature.rst
+++ b/docs/changes/cosmology/12313.feature.rst
@@ -1,0 +1,2 @@
+Register "astropy.row" into Cosmology's to/from format I/O, allowing a
+Cosmology instance to be parse from or converted to an Astropy Table Row.

--- a/docs/cosmology/io.rst
+++ b/docs/cosmology/io.rst
@@ -102,6 +102,7 @@ To see the a list of the available conversion formats:
         Format    Read Write Auto-identify
     ------------- ---- ----- -------------
     astropy.model  Yes   Yes           Yes
+      astropy.row  Yes   Yes           Yes
     astropy.table  Yes   Yes           Yes
           mapping  Yes   Yes           Yes
         mypackage  Yes   Yes           Yes
@@ -249,6 +250,7 @@ class to use. Details about metadata treatment are in
     ...     # turn row into mapping (dict of the arguments)
     ...     mapping = dict(row)
     ...     mapping['name'] = name
+    ...     mapping.setdefault("cosmology", meta.pop("cosmology", None))
     ...     mapping["meta"] = meta
     ...     # build cosmology from map
     ...     return Cosmology.from_format(mapping, move_to_meta=move_to_meta,
@@ -286,12 +288,13 @@ register everything into `astropy.io.registry`.
     >>> def row_identify(origin, format, *args, **kwargs):
     ...     """Identify if object uses the Table format."""
     ...     if origin == "read":
-    ...         return isinstance(args[1], Row) and (format in (None, "row"))
+    ...         return isinstance(args[1], Row) and (format in (None, "astropy.row"))
     ...     return False
 
-    >>> convert_registry.register_reader("row", Cosmology, from_table_row)
-    >>> convert_registry.register_writer("row", Cosmology, to_table_row)
-    >>> convert_registry.register_identifier("row", Cosmology, row_identify)
+    >>> # These exact functions are already registered in astropy
+    >>> # convert_registry.register_reader("astropy.row", Cosmology, from_table_row)
+    >>> # convert_registry.register_writer("astropy.row", Cosmology, to_table_row)
+    >>> # convert_registry.register_identifier("astropy.row", Cosmology, row_identify)
 
 Now the registered functions can be used in
 :meth:`astropy.cosmology.Cosmology.from_format` and
@@ -300,7 +303,7 @@ Now the registered functions can be used in
 .. code-block:: python
 
     >>> from astropy.cosmology import Planck18
-    >>> row = Planck18.to_format("row")
+    >>> row = Planck18.to_format("astropy.row")
     >>> row
     <Row index=0>
       cosmology     name        H0        Om0    Tcmb0    Neff    m_nu [3]    Ob0
@@ -312,19 +315,6 @@ Now the registered functions can be used in
     >>> cosmo = Cosmology.from_format(row)
     >>> cosmo == Planck18  # test it round-trips
     True
-
-
-.. doctest::
-    :hide:
-
-    >>> from astropy.io.registry import IORegistryError
-    >>> convert_registry.unregister_reader("row", Cosmology)
-    >>> convert_registry.unregister_writer("row", Cosmology)
-    >>> convert_registry.unregister_identifier("row", Cosmology)
-    >>> try:
-    ...     convert_registry.get_reader("row", Cosmology)
-    ... except IORegistryError:
-    ...     pass
 
 .. EXAMPLE END
 


### PR DESCRIPTION
### Description

Register "astropy.table.Row" with Cosmology I/O.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
