### PR TITLE
Changed `format_info` variable name to `broadcasted_shape` in modeling

### DIFF
--- a/astropy/modeling/polynomial.py
+++ b/astropy/modeling/polynomial.py
@@ -399,14 +399,14 @@ class OrthoPolynomialBase(PolynomialBase):
         return self.imhorner(x, y, invcoeff)
 
     def prepare_inputs(self, x, y, **kwargs):
-        inputs, format_info = super().prepare_inputs(x, y, **kwargs)
+        inputs, broadcasted_shapes = super().prepare_inputs(x, y, **kwargs)
 
         x, y = inputs
 
         if x.shape != y.shape:
             raise ValueError("Expected input arrays to have the same shape")
 
-        return (x, y), format_info
+        return (x, y), broadcasted_shapes
 
 
 class Chebyshev1D(_PolyDomainWindow1D):
@@ -484,11 +484,11 @@ class Chebyshev1D(_PolyDomainWindow1D):
         return np.rollaxis(v, 0, v.ndim)
 
     def prepare_inputs(self, x, **kwargs):
-        inputs, format_info = super().prepare_inputs(x, **kwargs)
+        inputs, broadcasted_shapes = super().prepare_inputs(x, **kwargs)
 
         x = inputs[0]
 
-        return (x,), format_info
+        return (x,), broadcasted_shapes
 
     def evaluate(self, x, *coeffs):
         if self.domain is not None:
@@ -591,11 +591,11 @@ class Hermite1D(_PolyDomainWindow1D):
         return np.rollaxis(v, 0, v.ndim)
 
     def prepare_inputs(self, x, **kwargs):
-        inputs, format_info = super().prepare_inputs(x, **kwargs)
+        inputs, broadcasted_shapes = super().prepare_inputs(x, **kwargs)
 
         x = inputs[0]
 
-        return (x,), format_info
+        return (x,), broadcasted_shapes
 
     def evaluate(self, x, *coeffs):
         if self.domain is not None:
@@ -804,11 +804,11 @@ class Legendre1D(_PolyDomainWindow1D):
             model_set_axis=model_set_axis, name=name, meta=meta, **params)
 
     def prepare_inputs(self, x, **kwargs):
-        inputs, format_info = super().prepare_inputs(x, **kwargs)
+        inputs, broadcasted_shapes = super().prepare_inputs(x, **kwargs)
 
         x = inputs[0]
 
-        return (x,), format_info
+        return (x,), broadcasted_shapes
 
     def evaluate(self, x, *coeffs):
         if self.domain is not None:
@@ -908,10 +908,10 @@ class Polynomial1D(_PolyDomainWindow1D):
         self._domain = _validate_domain_window(window or self._default_domain_window['window'])
 
     def prepare_inputs(self, x, **kwargs):
-        inputs, format_info = super().prepare_inputs(x, **kwargs)
+        inputs, broadcasted_shapes = super().prepare_inputs(x, **kwargs)
 
         x = inputs[0]
-        return (x,), format_info
+        return (x,), broadcasted_shapes
 
     def evaluate(self, x, *coeffs):
         if self.domain is not None:
@@ -1034,10 +1034,10 @@ class Polynomial2D(PolynomialModel):
 
     def prepare_inputs(self, x, y, **kwargs):
 
-        inputs, format_info = super().prepare_inputs(x, y, **kwargs)
+        inputs, broadcasted_shapes = super().prepare_inputs(x, y, **kwargs)
 
         x, y = inputs
-        return (x, y), format_info
+        return (x, y), broadcasted_shapes
 
     def evaluate(self, x, y, *coeffs):
         if self.x_domain is not None:

--- a/astropy/modeling/tests/test_input.py
+++ b/astropy/modeling/tests/test_input.py
@@ -918,7 +918,7 @@ def test_more_outputs():
             return a*x, a-x, a+y
 
         def __call__(self, *args, **kwargs):
-            inputs, format_info = super().prepare_inputs(*args, **kwargs)
+            inputs, _ = super().prepare_inputs(*args, **kwargs)
 
             outputs = self.evaluate(*inputs, *self.parameters)
             output_shapes = [out.shape for out in outputs]


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

In @perrygreenfield's [review](https://github.com/astropy/astropy/pull/11931#pullrequestreview-787108669) of #11931 he suggested that we change the term `format_info` to `broadcasted_shape`
as this better conveys what this variable is keeping track of. Unfortunately, #11931 was merged before I could push this commit to that PR. I believe this PR will help make the modeling code slightly more readable. 

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
