### PR TITLE
Do not attempt to wrap angles that are NaNs

### DIFF
--- a/astropy/coordinates/angles.py
+++ b/astropy/coordinates/angles.py
@@ -388,6 +388,7 @@ class Angle(u.SpecificTypeQuantity):
         # any more for >= 1.19 (NUMPY_LT_1_19), but former is).
         with np.errstate(invalid='ignore'):
             wraps = (self_angle - wrap_angle_floor) // a360
+            np.nan_to_num(wraps, copy=False)
             if np.any(wraps != 0):
                 self_angle -= wraps*a360
                 # Rounding errors can cause problems.

--- a/astropy/coordinates/tests/test_angles.py
+++ b/astropy/coordinates/tests/test_angles.py
@@ -1032,8 +1032,10 @@ def test_latitude_nan():
 
 
 def test_angle_wrap_at_nan():
-    # Check that passing a NaN to Latitude doesn't raise a warning
-    Angle([0, np.nan, 1] * u.deg).wrap_at(180*u.deg)
+    # Check that no attempt is made to wrap a NaN angle
+    angle = Angle([0, np.nan, 1] * u.deg)
+    angle.flags.writeable = False  # to force an error if a write is attempted
+    angle.wrap_at(180*u.deg, inplace=True)
 
 
 def test_angle_multithreading():

--- a/docs/changes/coordinates/12317.bugfix.rst
+++ b/docs/changes/coordinates/12317.bugfix.rst
@@ -1,0 +1,1 @@
+Wrapping an ``Angle`` array will now ignore NaN values instead of attempting to wrap them, which would produce unexpected warnings/errors when working with coordinates and representations due to internal broadcasting.


### PR DESCRIPTION
(This could be considered an extension of #11568)

The wrapping code for `Angle` currently tries to wrap angles that are NaNs.  This is not a problem in many situations, but can raise unnecessary warnings/errors if the `Angle` array is not freely writeable.  This PR sets the to-be-applied wrapping offset to zero for any NaN angles.  This PR does not prevent true warnings/errors if non-NaN elements of the `Angle` array need to be modified and the array is not freely writeable.

The actual problematic case is subtle:
```python
>>> import warnings
>>> import numpy as np
>>> import astropy.units as u
>>> from astropy.coordinates import SkyCoord, UnitSphericalRepresentation

>>> with warnings.catch_warnings():
>>>    warnings.filterwarnings("error")
>>>    SkyCoord(UnitSphericalRepresentation([np.nan]*u.deg, [0]*u.deg))
...
DeprecationWarning: Numpy has detected that you (may be) writing to an array with
overlapping memory from np.broadcast_arrays. If this is intentional
set the WRITEABLE flag True or make a copy immediately before writing.
...
```
What happens is that the `SkyCoord` constructor takes the `UnitSphericalRepresentation` and represents it without a copy as a `SphericalRepresentation`, with the additional component of the `distance` as the scalar of dimensionless one.  The instantiation of the `SphericalRepresentation` internally calls `np.broadcast_arrays()` on all three components, and because the `distance` is a scalar, broadcasting is performed.  Even though the longitude component didn't need to be broadcasted, it gets flagged with `warn_on_write` (see numpy/numpy#14768).  Later in the constructor, `Longitude(..., copy=False)` is called on the existing longitude component (which incidentally, has already been wrapped), and that triggers the NumPy deprecation warning when it (unnecessarily) wraps the NaN.

A user wouldn't normally see the NumPy deprecation warning at all, but it can get promoted to an error in test suites (e.g., in SunPy).  In the future, the output of `np.broadcast_arrays()` will not be writeable, and thus the above case will be an outright error instead of a hidden warning.