### PR TITLE
BlackBody model: fix handling of scale units

### DIFF
--- a/astropy/modeling/physical_models.py
+++ b/astropy/modeling/physical_models.py
@@ -27,7 +27,12 @@ class BlackBody(Fittable1DModel):
         Blackbody temperature.
 
     scale : float or `~astropy.units.Quantity` ['dimensionless']
-        Scale factor
+        Scale factor.  If dimensionless, input units will assumed
+        to be in Hz and output units in (erg / (cm ** 2 * s * Hz * sr).
+        If not dimensionless, must be equivalent to either
+        (erg / (cm ** 2 * s * Hz * sr) or erg / (cm ** 2 * s * AA * sr),
+        in which case the result will be returned in the requested units and
+        the scale will be stripped of units (with the float value applied).
 
     Notes
     -----
@@ -70,11 +75,39 @@ class BlackBody(Fittable1DModel):
     scale = Parameter(default=1.0, min=0, description="Scale factor")
 
     # We allow values without units to be passed when evaluating the model, and
-    # in this case the input x values are assumed to be frequencies in Hz.
+    # in this case the input x values are assumed to be frequencies in Hz or wavelengths
+    # in AA (depending on the choice of output units controlled by units on scale
+    # and stored in self._output_units during init).
     _input_units_allow_dimensionless = True
 
     # We enable the spectral equivalency by default for the spectral axis
     input_units_equivalencies = {'x': u.spectral()}
+
+    # Store the native units returned by B_nu equation
+    _native_units = u.erg / (u.cm ** 2 * u.s * u.Hz * u.sr)
+
+    # Store the base native output units.  If scale is not dimensionless, it
+    # must be equivalent to one of these.  If equivalent to SLAM, then
+    # input_units will expect AA for 'x', otherwise Hz.
+    _native_output_units = {'SNU': u.erg / (u.cm ** 2 * u.s * u.Hz * u.sr),
+                            'SLAM': u.erg / (u.cm ** 2 * u.s * u.AA * u.sr)}
+
+    def __init__(self, *args, **kwargs):
+        scale = kwargs.get('scale', None)
+
+        # Support scale with non-dimensionless unit by stripping the unit and
+        # storing as self._output_units.
+        if hasattr(scale, 'unit') and not scale.unit.is_equivalent(u.dimensionless_unscaled):
+            output_units = scale.unit
+            if not output_units.is_equivalent(self._native_units, u.spectral_density(1*u.AA)):
+                raise ValueError(f"scale units not dimensionless or in surface brightness: {output_units}")
+
+            kwargs['scale'] = scale.value
+            self._output_units = output_units
+        else:
+            self._output_units = self._native_units
+
+        return super().__init__(*args, **kwargs)
 
     def evaluate(self, x, temperature, scale):
         """Evaluate the model.
@@ -83,7 +116,8 @@ class BlackBody(Fittable1DModel):
         ----------
         x : float, `~numpy.ndarray`, or `~astropy.units.Quantity` ['frequency']
             Frequency at which to compute the blackbody. If no units are given,
-            this defaults to Hz.
+            this defaults to Hz (or AA if `scale` was initialized with units
+            equivalent to erg / (cm ** 2 * s * AA * sr)).
 
         temperature : float, `~numpy.ndarray`, or `~astropy.units.Quantity`
             Temperature of the blackbody. If no units are given, this defaults
@@ -119,29 +153,17 @@ class BlackBody(Fittable1DModel):
         else:
             in_temp = temperature
 
+        if not isinstance(x, u.Quantity):
+            # then we assume it has input_units which depends on the
+            # requested output units (either Hz or AA)
+            in_x = u.Quantity(x, self.input_units['x'])
+        else:
+            in_x = x
+
         # Convert to units for calculations, also force double precision
         with u.add_enabled_equivalencies(u.spectral() + u.temperature()):
-            freq = u.Quantity(x, u.Hz, dtype=np.float64)
+            freq = u.Quantity(in_x, u.Hz, dtype=np.float64)
             temp = u.Quantity(in_temp, u.K)
-
-        # check the units of scale and setup the output units
-        bb_unit = u.erg / (u.cm ** 2 * u.s * u.Hz * u.sr)  # default unit
-        # use the scale that was used at initialization for determining the units to return
-        # to support returning the right units when fitting where units are stripped
-        if hasattr(self.scale, "unit") and self.scale.unit is not None:
-            # check that the units on scale are covertable to surface brightness units
-            if not self.scale.unit.is_equivalent(bb_unit, u.spectral_density(x)):
-                raise ValueError(
-                    f"scale units not surface brightness: {self.scale.unit}"
-                )
-            # use the scale passed to get the value for scaling
-            if hasattr(scale, "unit"):
-                mult_scale = scale.value
-            else:
-                mult_scale = scale
-            bb_unit = self.scale.unit
-        else:
-            mult_scale = scale
 
         # Check if input values are physically possible
         if np.any(temp < 0):
@@ -158,7 +180,17 @@ class BlackBody(Fittable1DModel):
         # Calculate blackbody flux
         bb_nu = 2.0 * const.h * freq ** 3 / (const.c ** 2 * boltzm1) / u.sr
 
-        y = mult_scale * bb_nu.to(bb_unit, u.spectral_density(freq))
+        if self.scale.unit is not None:
+            # Will be dimensionless at this point, but may not be dimensionless_unscaled
+            if not hasattr(scale, 'unit'):
+                # during fitting, scale will be passed without units
+                # but we still need to convert from the input dimensionless
+                # to dimensionless unscaled
+                scale = scale * self.scale.unit
+            scale = scale.to(u.dimensionless_unscaled).value
+
+        # NOTE: scale is already stripped of any input units
+        y = scale * bb_nu.to(self._output_units, u.spectral_density(freq))
 
         # If the temperature parameter has no unit, we should return a unitless
         # value. This occurs for instance during fitting, since we drop the
@@ -169,10 +201,13 @@ class BlackBody(Fittable1DModel):
 
     @property
     def input_units(self):
-        # The input units are those of the 'x' value, which should always be
-        # Hz. Because we do this, and because input_units_allow_dimensionless
-        # is set to True, dimensionless values are assumed to be in Hz.
-        return {self.inputs[0]: u.Hz}
+        # The input units are those of the 'x' value, which will depend on the
+        # units compatible with the expected output units.
+        if self._output_units.is_equivalent(self._native_output_units['SNU']):
+            return {self.inputs[0]: u.Hz}
+        else:
+            # only other option is equivalent with SLAM
+            return {self.inputs[0]: u.AA}
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
         return {"temperature": u.K}
@@ -180,9 +215,15 @@ class BlackBody(Fittable1DModel):
     @property
     def bolometric_flux(self):
         """Bolometric flux."""
+        if self.scale.unit is not None:
+            # Will be dimensionless at this point, but may not be dimensionless_unscaled
+            scale = self.scale.quantity.to(u.dimensionless_unscaled)
+        else:
+            scale = self.scale.value
+
         # bolometric flux in the native units of the planck function
         native_bolflux = (
-            self.scale.value * const.sigma_sb * self.temperature ** 4 / np.pi
+            scale * const.sigma_sb * self.temperature ** 4 / np.pi
         )
         # return in more "astro" units
         return native_bolflux.to(u.erg / (u.cm ** 2 * u.s))

--- a/astropy/modeling/tests/test_physical_models.py
+++ b/astropy/modeling/tests/test_physical_models.py
@@ -166,7 +166,13 @@ def test_blackbody_dimensionless():
     scale = np.pi * (r / DL)**2
 
     bb1 = BlackBody(temperature=T, scale=scale)
+    # even though we passed scale with units, we should be able to evaluate with unitless
+    bb1.evaluate(0.5, T.value, scale.to_value(u.dimensionless_unscaled))
+
     bb2 = BlackBody(temperature=T, scale=scale.to_value(u.dimensionless_unscaled))
+    bb2.evaluate(0.5, T.value, scale.to_value(u.dimensionless_unscaled))
+
+    # bolometric flux for both cases should be equivalent
     assert(bb1.bolometric_flux == bb2.bolometric_flux)
 
 

--- a/astropy/modeling/tests/test_physical_models.py
+++ b/astropy/modeling/tests/test_physical_models.py
@@ -170,6 +170,27 @@ def test_blackbody_dimensionless():
     assert(bb1.bolometric_flux == bb2.bolometric_flux)
 
 
+@pytest.mark.skipif("not HAS_SCIPY")
+def test_blackbody_dimensionless_fit():
+    T = 3000 * u.K
+    r = 1e14 * u.cm
+    DL = 100 * u.Mpc
+    scale = np.pi * (r / DL)**2
+
+    bb1 = BlackBody(temperature=T, scale=scale)
+    bb2 = BlackBody(temperature=T, scale=scale.to_value(u.dimensionless_unscaled))
+
+    fitter = LevMarLSQFitter()
+
+    wav = np.array([0.5, 5, 10]) * u.micron
+    fnu = np.array([1, 10, 5]) * u.Jy / u.sr
+
+    bb1_fit = fitter(bb1, wav, fnu, maxiter=1000)
+    bb2_fit = fitter(bb2, wav, fnu, maxiter=1000)
+
+    assert(bb1_fit.temperature == bb2_fit.temperature)
+
+
 @pytest.mark.parametrize("mass", (2.0000000000000E15 * u.M_sun, 3.976819741e+45 * u.kg))
 def test_NFW_evaluate(mass):
     """Evaluation, density, and radii validation of NFW model."""

--- a/astropy/modeling/tests/test_physical_models.py
+++ b/astropy/modeling/tests/test_physical_models.py
@@ -40,6 +40,17 @@ def test_blackbody_sefanboltzman_law():
     assert_quantity_allclose(b.bolometric_flux, 133.02471751812573 * u.W / (u.m * u.m))
 
 
+def test_blackbody_input_units():
+    SLAM = u.erg / (u.cm ** 2 * u.s * u.AA * u.sr)
+    SNU = u.erg / (u.cm ** 2 * u.s * u.Hz * u.sr)
+
+    b_lam = BlackBody(3000*u.K, scale=1*SLAM)
+    assert(b_lam.input_units['x'] == u.AA)
+
+    b_nu = BlackBody(3000*u.K, scale=1*SNU)
+    assert(b_nu.input_units['x'] == u.Hz)
+
+
 def test_blackbody_return_units():
     # return of evaluate has no units when temperature has no units
     b = BlackBody(1000.0 * u.K, scale=1.0)
@@ -145,6 +156,18 @@ def test_blackbody_array_temperature():
     multibb = BlackBody(np.ones(4) * u.K)
     flux = multibb(np.ones((3, 4)) * u.mm)
     assert flux.shape == (3, 4)
+
+
+def test_blackbody_dimensionless():
+    """Test support for dimensionless (but not unscaled) units for scale"""
+    T = 3000 * u.K
+    r = 1e14 * u.cm
+    DL = 100 * u.Mpc
+    scale = np.pi * (r / DL)**2
+
+    bb1 = BlackBody(temperature=T, scale=scale)
+    bb2 = BlackBody(temperature=T, scale=scale.to_value(u.dimensionless_unscaled))
+    assert(bb1.bolometric_flux == bb2.bolometric_flux)
 
 
 @pytest.mark.parametrize("mass", (2.0000000000000E15 * u.M_sun, 3.976819741e+45 * u.kg))

--- a/astropy/modeling/tests/test_physical_models.py
+++ b/astropy/modeling/tests/test_physical_models.py
@@ -72,7 +72,7 @@ def test_blackbody_fit():
     b_fit = fitter(b, wav, fnu, maxiter=1000)
 
     assert_quantity_allclose(b_fit.temperature, 2840.7438355865065 * u.K)
-    assert_quantity_allclose(b_fit.scale, 5.803783292762381e-17 * u.Jy / u.sr)
+    assert_quantity_allclose(b_fit.scale, 5.803783292762381e-17)
 
 
 def test_blackbody_overflow():
@@ -104,10 +104,11 @@ def test_blackbody_exceptions_and_warnings():
     """Test exceptions."""
 
     # Negative temperature
-    with pytest.raises(ValueError) as exc:
+    with pytest.raises(
+            ValueError,
+            match="Temperature should be positive: \\[-100.\\] K"):
         bb = BlackBody(-100 * u.K)
         bb(1.0 * u.micron)
-    assert exc.value.args[0] == "Temperature should be positive: [-100.] K"
 
     bb = BlackBody(5000 * u.K)
 
@@ -121,11 +122,11 @@ def test_blackbody_exceptions_and_warnings():
         bb(-1.0 * u.AA)
     assert len(w) == 1
 
-    # Test that a non surface brightness converatable scale unit
-    with pytest.raises(ValueError) as exc:
+    # Test that a non surface brightness convertible scale unit raises an error
+    with pytest.raises(
+            ValueError,
+            match="scale units not dimensionless or in surface brightness: Jy"):
         bb = BlackBody(5000 * u.K, scale=1.0 * u.Jy)
-        bb(1.0 * u.micron)
-    assert exc.value.args[0] == "scale units not surface brightness: Jy"
 
 
 def test_blackbody_array_temperature():

--- a/docs/changes/modeling/12318.bugfix.rst
+++ b/docs/changes/modeling/12318.bugfix.rst
@@ -1,0 +1,1 @@
+Fix handling of units on ``scale`` parameter in BlackBody model.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request (which is a stripped down version of #12304 that only includes minimal bug fixes and not deprecating support for units in `scale` or introduction of support for flux units) fixes the case where dimensionless (but not unscaled) units are passed to `scale` (#11547) and also changes the expected `input_units` based on the units passed to `scale` (which control the returned units).  This second change is necessary in order to handle fitting `BlackBody(..) + Linear1D(...)` with respect to wavelength, as BlackBody was previously forcing the unitless array to Hz which then failed unit consistency checks with Linear1D.

Note that this does not address the [second example in 11547](https://github.com/astropy/astropy/issues/11547#issuecomment-823772098) and that case remains ambiguous as `scale` is both providing a unitless scale factor _and optionally_ responsible for determining the returned units.  See #12304 for a possible solution to this by requiring `scale` to be dimensionless and handling the request for output units as a separate argument.

Revisiting the first case in #11547:

```
from astropy.modeling.models import BlackBody
from astropy import units as u
import numpy as np

T = 3000 * u.K
r = 1e14 * u.cm
DL = 100 * u.Mpc
scale = np.pi * (r / DL)**2

print(BlackBody(temperature=T, scale=scale).bolometric_flux)
print(BlackBody(temperature=T, scale=scale.to_value(u.dimensionless_unscaled)).bolometric_flux)
```

now returns the expected results (the passed scale with units of `cm ** 2 / Mpc **2` are converted to `dimensionless_unscaled` before being applied):

```
4.823870774433646e-16 erg / (cm2 s)
4.823870774433646e-16 erg / (cm2 s)
```

The following case demonstrates the new treatment of `input_units`:

```
import astropy.units as u
from astropy.modeling import models
from astropy.modeling.fitting import LevMarLSQFitter
import numpy as np

SLAM = u.erg / (u.cm ** 2 * u.s * u.AA * u.sr)
SNU = u.erg / (u.cm ** 2 * u.s * u.Hz * u.sr)

fitter = LevMarLSQFitter()

x_lam = np.linspace(1000, 10000, 1000) * u.AA
x_nu = x_lam.to(u.Hz, u.spectral())

y_lam = np.random.random(x_lam.shape) * SLAM
y_nu = np.random.random(x_nu.shape) * SNU

b_nu = models.BlackBody(3000*u.K, scale=1*SNU)
l_nu = models.Linear1D(intercept=1*SNU, slope=0*SNU/u.Hz)
c_nu = b_nu + l_nu

print(b_nu.input_units, l_nu.input_units, c_nu.input_units)

fitter(c_nu, x_nu, y_nu, maxiter=1000)
```

which shows all models have expected Hz input units and the fitter runs successfully (as previously).  However, the wavelength case:

```
b_lam = models.BlackBody(3000*u.K, scale=1*SLAM)
l_lam = models.Linear1D(intercept=1*SLAM, slope=0*SLAM/u.AA)
c_lam = b_lam + l_lam

print(b_lam.input_units, l_lam.input_units, c_lam.input_units)

fitter(c_lam, x_lam, y_lam, maxiter=1000)
```

used to have x `input_units` of Hz for the BlackBody model (but Angstrom for the other models), causing the following error during fitting: `UnitConversionError: 'erg / (Angstrom2 cm2 s sr)' and 'erg / (Angstrom cm2 Hz s sr)' are not convertible`, but now has expected input units for Angstrom for all models and fitting succeeds without errors.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #11547

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
