### PR TITLE
Fix annotations in py3.8

### DIFF
--- a/astropy/units/_typing.py
+++ b/astropy/units/_typing.py
@@ -3,6 +3,8 @@
 Support for ``typing`` py3.9+ features while min version is py3.8.
 """
 
+from typing import *
+
 try:  # py 3.9+
     from typing import Annotated
 except (ImportError, ModuleNotFoundError):  # optional dependency
@@ -11,5 +13,8 @@ except (ImportError, ModuleNotFoundError):  # optional dependency
     except (ImportError, ModuleNotFoundError):
 
         Annotated = NotImplemented
+
+    else:
+        from typing_extensions import *  # override typing
 
 HAS_ANNOTATED = Annotated is not NotImplemented

--- a/astropy/units/decorators.py
+++ b/astropy/units/decorators.py
@@ -4,14 +4,13 @@
 __all__ = ['quantity_input']
 
 import inspect
-import typing as T
 from numbers import Number
 from collections.abc import Sequence
 from functools import wraps
 
 import numpy as np
 
-from ._typing import Annotated
+from . import _typing as T
 from .core import (Unit, UnitBase, UnitsError,
                    add_enabled_equivalencies, dimensionless_unscaled)
 from .function.core import FunctionUnitBase
@@ -118,7 +117,7 @@ def _parse_annotation(target):
     origin = T.get_origin(target)
     if origin is T.Union:
         return [_parse_annotation(t) for t in T.get_args(target)]
-    elif origin is not Annotated:  # can't be Quantity[]
+    elif origin is not T.Annotated:  # can't be Quantity[]
         return False
 
     # parse type hint
@@ -308,7 +307,7 @@ class QuantityInput:
             ra = wrapped_signature.return_annotation
             valid_empty = (inspect.Signature.empty, None, NoneType, T.NoReturn)
             if ra not in valid_empty:
-                target = (ra if T.get_origin(ra) not in (Annotated, T.Union)
+                target = (ra if T.get_origin(ra) not in (T.Annotated, T.Union)
                           else _parse_annotation(ra))
                 if isinstance(target, str) or not isinstance(target, Sequence):
                     target = [target]

--- a/astropy/units/tests/test_quantity_annotations.py
+++ b/astropy/units/tests/test_quantity_annotations.py
@@ -30,7 +30,6 @@ def test_ignore_generic_type_annotations():
     assert i_str == o_str
 
 
-@pytest.mark.skipif(sys.version_info < (3, 9), reason="temporary fix")
 @pytest.mark.skipif(not HAS_ANNOTATED, reason="need `Annotated`")
 class TestQuantityUnitAnnotations:
     """Test Quantity[Unit] type annotation."""


### PR DESCRIPTION
The functions ``get_origin`` and ``get_args`` behave differently in 3.8 than 3.9 and don't expose the annotation metadata. Fortunately, overriding their behaviour with `typing_extensions` makes py3.8 commensurate with py3.9.

Fixes #12333
Rolls back #12334  

Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
