### PR TITLE
patch to fix double registration of example package

### DIFF
--- a/astropy/cosmology/tests/mypackage/io/astropy_convert.py
+++ b/astropy/cosmology/tests/mypackage/io/astropy_convert.py
@@ -136,6 +136,6 @@ def mypackage_identify(origin, format, *args, **kwargs):
 # -------------------------------------------------------------------
 # Register to/from_format & identify methods with Astropy Unified I/O
 
-convert_registry.register_reader("mypackage", Cosmology, from_mypackage)
-convert_registry.register_writer("mypackage", Cosmology, to_mypackage)
-convert_registry.register_identifier("mypackage", Cosmology, mypackage_identify)
+convert_registry.register_reader("mypackage", Cosmology, from_mypackage, force=True)
+convert_registry.register_writer("mypackage", Cosmology, to_mypackage, force=True)
+convert_registry.register_identifier("mypackage", Cosmology, mypackage_identify, force=True)

--- a/astropy/cosmology/tests/mypackage/io/astropy_io.py
+++ b/astropy/cosmology/tests/mypackage/io/astropy_io.py
@@ -83,6 +83,6 @@ def myformat_identify(origin, filepath, fileobj, *args, **kwargs):
 # -------------------------------------------------------------------
 # Register read/write/identify methods with Astropy Unified I/O
 
-readwrite_registry.register_reader("myformat", Cosmology, read_myformat)
-readwrite_registry.register_writer("myformat", Cosmology, write_myformat)
-readwrite_registry.register_identifier("myformat", Cosmology, myformat_identify)
+readwrite_registry.register_reader("myformat", Cosmology, read_myformat, force=True)
+readwrite_registry.register_writer("myformat", Cosmology, write_myformat, force=True)
+readwrite_registry.register_identifier("myformat", Cosmology, myformat_identify, force=True)


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

Not entirely sure what's sourcing the error as the code only appears once.
It may be related to some ``.. literalinclude::`` in the docs...
But this should fix the errors for now.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
