### PR TITLE
Change `BoundingBox` to `ModelBoundingBox`

### DIFF
--- a/astropy/io/misc/asdf/tags/transform/basic.py
+++ b/astropy/io/misc/asdf/tags/transform/basic.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from asdf.versioning import AsdfVersion
 
-from astropy.modeling.bounding_box import BoundingBox, CompoundBoundingBox
+from astropy.modeling.bounding_box import ModelBoundingBox, CompoundBoundingBox
 from astropy.modeling import mappings
 from astropy.modeling import functional_models
 from astropy.modeling.core import CompoundModel
@@ -84,7 +84,7 @@ class TransformType(AstropyAsdfType):
         except NotImplementedError:
             bb = None
 
-        if isinstance(bb, BoundingBox):
+        if isinstance(bb, ModelBoundingBox):
             bb = bb.bounding_box(order='C')
 
             if model.n_inputs == 1:

--- a/astropy/io/misc/asdf/tags/transform/tabular.py
+++ b/astropy/io/misc/asdf/tags/transform/tabular.py
@@ -7,7 +7,7 @@ from numpy.testing import assert_array_equal
 from astropy import modeling
 from astropy import units as u
 from .basic import TransformType
-from astropy.modeling.bounding_box import BoundingBox
+from astropy.modeling.bounding_box import ModelBoundingBox
 
 __all__ = ['TabularType']
 
@@ -62,10 +62,10 @@ class TabularType(TransformType):
             assert u.allclose(a.lookup_table, b.lookup_table)
             assert u.allclose(a.points, b.points)
             a_box = a.bounding_box
-            if isinstance(a_box, BoundingBox):
+            if isinstance(a_box, ModelBoundingBox):
                 a_box = a_box.bounding_box()
             b_box = b.bounding_box
-            if isinstance(b_box, BoundingBox):
+            if isinstance(b_box, ModelBoundingBox):
                 b_box = b_box.bounding_box()
             for i in range(len(a_box)):
                 assert u.allclose(a_box[i], b_box[i])
@@ -73,10 +73,10 @@ class TabularType(TransformType):
             assert_array_equal(a.lookup_table, b.lookup_table)
             assert_array_equal(a.points, b.points)
             a_box = a.bounding_box
-            if isinstance(a_box, BoundingBox):
+            if isinstance(a_box, ModelBoundingBox):
                 a_box = a_box.bounding_box()
             b_box = b.bounding_box
-            if isinstance(b_box, BoundingBox):
+            if isinstance(b_box, ModelBoundingBox):
                 b_box = b_box.bounding_box()
             assert_array_equal(a_box, b_box)
         assert (a.method == b.method)

--- a/astropy/modeling/tabular.py
+++ b/astropy/modeling/tabular.py
@@ -180,7 +180,7 @@ class _Tabular(Model):
         >>> from astropy.modeling.models import Tabular1D, Tabular2D
         >>> t1 = Tabular1D(points=[1, 2, 3], lookup_table=[10, 20, 30])
         >>> t1.bounding_box
-        BoundingBox(
+        ModelBoundingBox(
             intervals={
                 x: Interval(lower=1, upper=3)
             }
@@ -190,7 +190,7 @@ class _Tabular(Model):
         >>> t2 = Tabular2D(points=[[1, 2, 3], [2, 3, 4]],
         ...                lookup_table=[[10, 20, 30], [20, 30, 40]])
         >>> t2.bounding_box
-        BoundingBox(
+        ModelBoundingBox(
             intervals={
                 x: Interval(lower=1, upper=3)
                 y: Interval(lower=2, upper=4)

--- a/astropy/modeling/tests/test_bounding_box.py
+++ b/astropy/modeling/tests/test_bounding_box.py
@@ -5,7 +5,7 @@ import numpy as np
 import unittest.mock as mk
 
 from astropy.modeling.bounding_box import (_BaseInterval, Interval, _ignored_interval,
-                                           BoundingDomain, BoundingBox,
+                                           BoundingDomain, ModelBoundingBox,
                                            _BaseSelectorArgument, SelectorArgument, SelectorArguments,
                                            CompoundBoundingBox)
 from astropy.modeling.models import Gaussian1D, Gaussian2D, Shift, Scale, Identity
@@ -453,11 +453,11 @@ class TestBoundingDomain:
                         assert mkUnits.call_args_list == [mk.call()]
 
 
-class TestBoundingBox:
+class TestModelBoundingBox:
     def test_create(self):
         intervals = ()
         model = mk.MagicMock()
-        bounding_box = BoundingBox(intervals, model)
+        bounding_box = ModelBoundingBox(intervals, model)
 
         assert isinstance(bounding_box, BoundingDomain)
         assert bounding_box._intervals == {}
@@ -468,7 +468,7 @@ class TestBoundingBox:
         # Set optional
         intervals = {}
         model = mk.MagicMock()
-        bounding_box = BoundingBox(intervals, model, order='test')
+        bounding_box = ModelBoundingBox(intervals, model, order='test')
 
         assert isinstance(bounding_box, BoundingDomain)
         assert bounding_box._intervals == {}
@@ -481,7 +481,7 @@ class TestBoundingBox:
         model = mk.MagicMock()
         model.n_inputs = 1
         model.inputs = ['x']
-        bounding_box = BoundingBox(intervals, model)
+        bounding_box = ModelBoundingBox(intervals, model)
 
         assert isinstance(bounding_box, BoundingDomain)
         assert bounding_box._intervals == {0: (1, 2)}
@@ -492,7 +492,7 @@ class TestBoundingBox:
         model = mk.MagicMock()
         model.n_inputs = 2
         model.inputs = ['x', 'y']
-        bounding_box = BoundingBox(intervals, model, ignored=[1])
+        bounding_box = ModelBoundingBox(intervals, model, ignored=[1])
 
         assert isinstance(bounding_box, BoundingDomain)
         assert bounding_box._intervals == {0: (1, 2)}
@@ -503,7 +503,7 @@ class TestBoundingBox:
         model = mk.MagicMock()
         model.n_inputs = 3
         model.inputs = ['x', 'y', 'z']
-        bounding_box = BoundingBox(intervals, model, ignored=[2], order='F')
+        bounding_box = ModelBoundingBox(intervals, model, ignored=[2], order='F')
 
         assert isinstance(bounding_box, BoundingDomain)
         assert bounding_box._intervals == {0: (1, 2), 1: (3, 4)}
@@ -512,7 +512,7 @@ class TestBoundingBox:
         assert bounding_box._order == 'F'
 
     def test_copy(self):
-        bounding_box = BoundingBox.validate(Gaussian2D(), ((-4.5, 4.5), (-1.4, 1.4)))
+        bounding_box = ModelBoundingBox.validate(Gaussian2D(), ((-4.5, 4.5), (-1.4, 1.4)))
         copy = bounding_box.copy()
 
         assert bounding_box == copy
@@ -549,7 +549,7 @@ class TestBoundingBox:
         model = mk.MagicMock()
         model.n_inputs = 1
         model.inputs = ['x']
-        bounding_box = BoundingBox(intervals, model)
+        bounding_box = ModelBoundingBox(intervals, model)
 
         assert bounding_box._intervals == intervals
         assert bounding_box.intervals == intervals
@@ -557,7 +557,7 @@ class TestBoundingBox:
     def test_order(self):
         intervals = {}
         model = mk.MagicMock()
-        bounding_box = BoundingBox(intervals, model, order='test')
+        bounding_box = ModelBoundingBox(intervals, model, order='test')
 
         assert bounding_box._order == 'test'
         assert bounding_box.order == 'test'
@@ -567,7 +567,7 @@ class TestBoundingBox:
         model = mk.MagicMock()
         model.n_inputs = 1
         model.inputs = ['x']
-        bounding_box = BoundingBox({}, model, ignored=ignored)
+        bounding_box = ModelBoundingBox({}, model, ignored=ignored)
 
         assert bounding_box._ignored == ignored
         assert bounding_box.ignored == ignored
@@ -577,7 +577,7 @@ class TestBoundingBox:
         model = mk.MagicMock()
         model.n_inputs = 1
         model.inputs = ['x']
-        bounding_box = BoundingBox(intervals, model)
+        bounding_box = ModelBoundingBox(intervals, model)
 
         index = mk.MagicMock()
         name = mk.MagicMock()
@@ -591,7 +591,7 @@ class TestBoundingBox:
         model = mk.MagicMock()
         model.n_inputs = 4
         model.inputs = [mk.MagicMock() for _ in range(4)]
-        bounding_box = BoundingBox(intervals, model)
+        bounding_box = ModelBoundingBox(intervals, model)
 
         named = bounding_box.named_intervals
         assert isinstance(named, dict)
@@ -609,7 +609,7 @@ class TestBoundingBox:
         ignored = list(range(4, 8))
         model.n_inputs = 8
         model.inputs = [mk.MagicMock() for _ in range(8)]
-        bounding_box = BoundingBox(intervals, model, ignored=ignored)
+        bounding_box = ModelBoundingBox(intervals, model, ignored=ignored)
 
         inputs = bounding_box.ignored_inputs
         assert isinstance(inputs, list)
@@ -625,10 +625,10 @@ class TestBoundingBox:
     def test___repr__(self):
         intervals = {0: Interval(-1, 1), 1: Interval(-4, 4)}
         model = Gaussian2D()
-        bounding_box = BoundingBox.validate(model, intervals)
+        bounding_box = ModelBoundingBox.validate(model, intervals)
 
         assert bounding_box.__repr__() ==\
-            "BoundingBox(\n" +\
+            "ModelBoundingBox(\n" +\
             "    intervals={\n" +\
             "        x: Interval(lower=-1, upper=1)\n" +\
             "        y: Interval(lower=-4, upper=4)\n" +\
@@ -639,10 +639,10 @@ class TestBoundingBox:
 
         intervals = {0: Interval(-1, 1)}
         model = Gaussian2D()
-        bounding_box = BoundingBox.validate(model, intervals, ignored=['y'])
+        bounding_box = ModelBoundingBox.validate(model, intervals, ignored=['y'])
 
         assert bounding_box.__repr__() ==\
-            "BoundingBox(\n" +\
+            "ModelBoundingBox(\n" +\
             "    intervals={\n" +\
             "        x: Interval(lower=-1, upper=1)\n" +\
             "    }\n" +\
@@ -654,7 +654,7 @@ class TestBoundingBox:
     def test__get_index(self):
         intervals = {0: Interval(-1, 1), 1: Interval(-4, 4)}
         model = Gaussian2D()
-        bounding_box = BoundingBox.validate(model, intervals)
+        bounding_box = ModelBoundingBox.validate(model, intervals)
 
         # Pass input name
         assert bounding_box._get_index('x') == 0
@@ -699,7 +699,7 @@ class TestBoundingBox:
 
     def test__validate_ignored(self):
         model = Gaussian2D()
-        bounding_box = BoundingBox({}, model)
+        bounding_box = ModelBoundingBox({}, model)
 
         # Pass
         assert bounding_box._validate_ignored(None) == []
@@ -722,12 +722,12 @@ class TestBoundingBox:
     def test___len__(self):
         intervals = {0: Interval(-1, 1)}
         model = Gaussian1D()
-        bounding_box = BoundingBox.validate(model, intervals)
+        bounding_box = ModelBoundingBox.validate(model, intervals)
         assert len(bounding_box) == 1 == len(bounding_box._intervals)
 
         intervals = {0: Interval(-1, 1), 1: Interval(-4, 4)}
         model = Gaussian2D()
-        bounding_box = BoundingBox.validate(model, intervals)
+        bounding_box = ModelBoundingBox.validate(model, intervals)
         assert len(bounding_box) == 2 == len(bounding_box._intervals)
 
         bounding_box._intervals = {}
@@ -736,7 +736,7 @@ class TestBoundingBox:
     def test___contains__(self):
         intervals = {0: Interval(-1, 1), 1: Interval(-4, 4)}
         model = Gaussian2D()
-        bounding_box = BoundingBox.validate(model, intervals)
+        bounding_box = ModelBoundingBox.validate(model, intervals)
 
         # Contains with keys
         assert 'x' in bounding_box
@@ -767,7 +767,7 @@ class TestBoundingBox:
     def test___getitem__(self):
         intervals = {0: Interval(-1, 1), 1: Interval(-4, 4)}
         model = Gaussian2D()
-        bounding_box = BoundingBox.validate(model, intervals)
+        bounding_box = ModelBoundingBox.validate(model, intervals)
 
         # Get using input key
         assert bounding_box['x'] == (-1, 1)
@@ -805,7 +805,7 @@ class TestBoundingBox:
     def test__get_order(self):
         intervals = {0: Interval(-1, 1)}
         model = Gaussian1D()
-        bounding_box = BoundingBox.validate(model, intervals)
+        bounding_box = ModelBoundingBox.validate(model, intervals)
 
         # Success (default 'C')
         assert bounding_box._order == 'C'
@@ -831,7 +831,7 @@ class TestBoundingBox:
     def test_bounding_box(self):
         # 0D
         model = Gaussian1D()
-        bounding_box = BoundingBox.validate(model, {}, ignored=['x'])
+        bounding_box = ModelBoundingBox.validate(model, {}, ignored=['x'])
         assert bounding_box.bounding_box() == (-np.inf, np.inf)
         assert bounding_box.bounding_box('C') == (-np.inf, np.inf)
         assert bounding_box.bounding_box('F') == (-np.inf, np.inf)
@@ -839,14 +839,14 @@ class TestBoundingBox:
         # 1D
         intervals = {0: Interval(-1, 1)}
         model = Gaussian1D()
-        bounding_box = BoundingBox.validate(model, intervals)
+        bounding_box = ModelBoundingBox.validate(model, intervals)
         assert bounding_box.bounding_box() == (-1, 1)
         assert bounding_box.bounding_box(mk.MagicMock()) == (-1, 1)
 
         # > 1D
         intervals = {0: Interval(-1, 1), 1: Interval(-4, 4)}
         model = Gaussian2D()
-        bounding_box = BoundingBox.validate(model, intervals)
+        bounding_box = ModelBoundingBox.validate(model, intervals)
         assert bounding_box.bounding_box() == ((-4, 4), (-1, 1))
         assert bounding_box.bounding_box('C') == ((-4, 4), (-1, 1))
         assert bounding_box.bounding_box('F') == ((-1, 1), (-4, 4))
@@ -854,21 +854,21 @@ class TestBoundingBox:
     def test___eq__(self):
         intervals = {0: Interval(-1, 1)}
         model = Gaussian1D()
-        bounding_box = BoundingBox.validate(model.copy(), intervals.copy())
+        bounding_box = ModelBoundingBox.validate(model.copy(), intervals.copy())
 
         assert bounding_box == bounding_box
-        assert bounding_box == BoundingBox.validate(model.copy(), intervals.copy())
+        assert bounding_box == ModelBoundingBox.validate(model.copy(), intervals.copy())
         assert bounding_box == (-1, 1)
 
         assert not (bounding_box == mk.MagicMock())
         assert not (bounding_box == (-2, 2))
-        assert not (bounding_box == BoundingBox.validate(model, {0: Interval(-2, 2)}))
+        assert not (bounding_box == ModelBoundingBox.validate(model, {0: Interval(-2, 2)}))
 
         # Respect ordering
         intervals = {0: Interval(-1, 1), 1: Interval(-4, 4)}
         model = Gaussian2D()
-        bounding_box_1 = BoundingBox.validate(model, intervals)
-        bounding_box_2 = BoundingBox.validate(model, intervals, order='F')
+        bounding_box_1 = ModelBoundingBox.validate(model, intervals)
+        bounding_box_2 = ModelBoundingBox.validate(model, intervals, order='F')
         assert bounding_box_1._order == 'C'
         assert bounding_box_1 == ((-4, 4), (-1, 1))
         assert not (bounding_box_1 == ((-1, 1), (-4, 4)))
@@ -888,7 +888,7 @@ class TestBoundingBox:
 
     def test__setitem__(self):
         model = Gaussian2D()
-        bounding_box = BoundingBox.validate(model, {}, ignored=[0, 1])
+        bounding_box = ModelBoundingBox.validate(model, {}, ignored=[0, 1])
         assert bounding_box._ignored == [0, 1]
 
         # USING Intervals directly
@@ -972,7 +972,7 @@ class TestBoundingBox:
 
         # Model set support
         model = Gaussian1D([0.1, 0.2], [0, 0], [5, 7], n_models=2)
-        bounding_box = BoundingBox({}, model)
+        bounding_box = ModelBoundingBox({}, model)
         # USING Intervals directly
         # Set interval using key
         assert 'x' not in bounding_box
@@ -1010,7 +1010,7 @@ class TestBoundingBox:
     def test___delitem__(self):
         intervals = {0: Interval(-1, 1), 1: Interval(-4, 4)}
         model = Gaussian2D()
-        bounding_box = BoundingBox.validate(model, intervals)
+        bounding_box = ModelBoundingBox.validate(model, intervals)
 
         # Using index
         assert 0 in bounding_box.intervals
@@ -1048,7 +1048,7 @@ class TestBoundingBox:
 
     def test__validate_dict(self):
         model = Gaussian2D()
-        bounding_box = BoundingBox({}, model)
+        bounding_box = ModelBoundingBox({}, model)
 
         # Input name keys
         intervals = {'x': Interval(-1, 1), 'y': Interval(-4, 4)}
@@ -1075,7 +1075,7 @@ class TestBoundingBox:
 
         # Model set support
         model = Gaussian1D([0.1, 0.2], [0, 0], [5, 7], n_models=2)
-        bounding_box = BoundingBox({}, model)
+        bounding_box = ModelBoundingBox({}, model)
         # name keys
         intervals = {'x': Interval(np.array([-1, -2]), np.array([1, 2]))}
         assert 'x' not in bounding_box
@@ -1094,7 +1094,7 @@ class TestBoundingBox:
 
     def test__validate_sequence(self):
         model = Gaussian2D()
-        bounding_box = BoundingBox({}, model)
+        bounding_box = ModelBoundingBox({}, model)
 
         # Default order
         assert 'x' not in bounding_box
@@ -1143,14 +1143,14 @@ class TestBoundingBox:
         model = Gaussian2D()
 
         intervals = {0: Interval(-1, 1), 1: Interval(-4, 4)}
-        bounding_box = BoundingBox.validate(model, intervals)
+        bounding_box = ModelBoundingBox.validate(model, intervals)
         assert bounding_box._n_inputs == 2
 
         intervals = {0: Interval(-1, 1)}
-        bounding_box = BoundingBox.validate(model, intervals, ignored=['y'])
+        bounding_box = ModelBoundingBox.validate(model, intervals, ignored=['y'])
         assert bounding_box._n_inputs == 1
 
-        bounding_box = BoundingBox.validate(model, {}, ignored=['x', 'y'])
+        bounding_box = ModelBoundingBox.validate(model, {}, ignored=['x', 'y'])
         assert bounding_box._n_inputs == 0
 
         bounding_box._ignored = ['x', 'y', 'z']
@@ -1158,7 +1158,7 @@ class TestBoundingBox:
 
     def test__validate_iterable(self):
         model = Gaussian2D()
-        bounding_box = BoundingBox({}, model)
+        bounding_box = ModelBoundingBox({}, model)
 
         # Pass sequence Default order
         assert 'x' not in bounding_box
@@ -1233,7 +1233,7 @@ class TestBoundingBox:
 
     def test__validate(self):
         model = Gaussian2D()
-        bounding_box = BoundingBox({}, model)
+        bounding_box = ModelBoundingBox({}, model)
 
         # Pass sequence Default order
         assert 'x' not in bounding_box
@@ -1270,7 +1270,7 @@ class TestBoundingBox:
 
         # Pass single with ignored
         intervals = {0: Interval(-1, 1)}
-        bounding_box = BoundingBox({}, model, ignored=[1])
+        bounding_box = ModelBoundingBox({}, model, ignored=[1])
 
         assert 0 not in bounding_box.intervals
         assert 1 not in bounding_box.intervals
@@ -1282,7 +1282,7 @@ class TestBoundingBox:
 
         # Pass single
         model = Gaussian1D()
-        bounding_box = BoundingBox({}, model)
+        bounding_box = ModelBoundingBox({}, model)
 
         assert 'x' not in bounding_box
         bounding_box._validate((-1, 1))
@@ -1292,7 +1292,7 @@ class TestBoundingBox:
 
         # Model set support
         model = Gaussian1D([0.1, 0.2], [0, 0], [5, 7], n_models=2)
-        bounding_box = BoundingBox({}, model)
+        bounding_box = ModelBoundingBox({}, model)
         sequence = (np.array([-1, -2]), np.array([1, 2]))
         assert 'x' not in bounding_box
         bounding_box._validate(sequence)
@@ -1305,7 +1305,7 @@ class TestBoundingBox:
         kwargs = {'test': mk.MagicMock()}
 
         # Pass sequence Default order
-        bounding_box = BoundingBox.validate(model, ((-4, 4), (-1, 1)), **kwargs)
+        bounding_box = ModelBoundingBox.validate(model, ((-4, 4), (-1, 1)), **kwargs)
         assert (bounding_box._model.parameters == model.parameters).all()
         assert 'x' in bounding_box
         assert bounding_box['x'] == (-1, 1)
@@ -1314,7 +1314,7 @@ class TestBoundingBox:
         assert len(bounding_box.intervals) == 2
 
         # Pass sequence
-        bounding_box = BoundingBox.validate(model, ((-4, 4), (-1, 1)), order='F', **kwargs)
+        bounding_box = ModelBoundingBox.validate(model, ((-4, 4), (-1, 1)), order='F', **kwargs)
         assert (bounding_box._model.parameters == model.parameters).all()
         assert 'x' in bounding_box
         assert bounding_box['x'] == (-4, 4)
@@ -1324,7 +1324,7 @@ class TestBoundingBox:
 
         # Pass Dict
         intervals = {0: Interval(-1, 1), 1: Interval(-4, 4)}
-        bounding_box = BoundingBox.validate(model, intervals, order='F', **kwargs)
+        bounding_box = ModelBoundingBox.validate(model, intervals, order='F', **kwargs)
         assert (bounding_box._model.parameters == model.parameters).all()
         assert 0 in bounding_box
         assert bounding_box[0] == (-1, 1)
@@ -1333,9 +1333,9 @@ class TestBoundingBox:
         assert len(bounding_box.intervals) == 2
         assert bounding_box.order == 'F'
 
-        # Pass BoundingBox
+        # Pass ModelBoundingBox
         bbox = bounding_box
-        bounding_box = BoundingBox.validate(model, bbox, **kwargs)
+        bounding_box = ModelBoundingBox.validate(model, bbox, **kwargs)
         assert (bounding_box._model.parameters == model.parameters).all()
         assert 0 in bounding_box
         assert bounding_box[0] == (-1, 1)
@@ -1346,7 +1346,7 @@ class TestBoundingBox:
 
         # Pass single ignored
         intervals = {0: Interval(-1, 1)}
-        bounding_box = BoundingBox.validate(model, intervals, ignored=['y'], **kwargs)
+        bounding_box = ModelBoundingBox.validate(model, intervals, ignored=['y'], **kwargs)
         assert (bounding_box._model.parameters == model.parameters).all()
         assert 'x' in bounding_box
         assert bounding_box['x'] == (-1, 1)
@@ -1355,7 +1355,7 @@ class TestBoundingBox:
         assert len(bounding_box.intervals) == 1
 
         # Pass single
-        bounding_box = BoundingBox.validate(Gaussian1D(), (-1, 1), **kwargs)
+        bounding_box = ModelBoundingBox.validate(Gaussian1D(), (-1, 1), **kwargs)
         assert (bounding_box._model.parameters == Gaussian1D().parameters).all()
         assert 'x' in bounding_box
         assert bounding_box['x'] == (-1, 1)
@@ -1364,13 +1364,13 @@ class TestBoundingBox:
         # Model set support
         model = Gaussian1D([0.1, 0.2], [0, 0], [5, 7], n_models=2)
         sequence = (np.array([-1, -2]), np.array([1, 2]))
-        bounding_box = BoundingBox.validate(model, sequence, **kwargs)
+        bounding_box = ModelBoundingBox.validate(model, sequence, **kwargs)
         assert 'x' in bounding_box
         assert (bounding_box['x'].lower == np.array([-1, -2])).all()
         assert (bounding_box['x'].upper == np.array([1, 2])).all()
 
     def test_fix_inputs(self):
-        bounding_box = BoundingBox.validate(Gaussian2D(), ((-4, 4), (-1, 1)))
+        bounding_box = ModelBoundingBox.validate(Gaussian2D(), ((-4, 4), (-1, 1)))
 
         # keep_ignored = False (default)
         new_bounding_box = bounding_box.fix_inputs(Gaussian1D(), {1: mk.MagicMock()})
@@ -1399,12 +1399,12 @@ class TestBoundingBox:
     def test_dimension(self):
         intervals = {0: Interval(-1, 1)}
         model = Gaussian1D()
-        bounding_box = BoundingBox.validate(model, intervals)
+        bounding_box = ModelBoundingBox.validate(model, intervals)
         assert bounding_box.dimension == 1 == len(bounding_box._intervals)
 
         intervals = {0: Interval(-1, 1), 1: Interval(-4, 4)}
         model = Gaussian2D()
-        bounding_box = BoundingBox.validate(model, intervals)
+        bounding_box = ModelBoundingBox.validate(model, intervals)
         assert bounding_box.dimension == 2 == len(bounding_box._intervals)
 
         bounding_box._intervals = {}
@@ -1413,7 +1413,7 @@ class TestBoundingBox:
     def test_domain(self):
         intervals = {0: Interval(-1, 1), 1: Interval(0, 2)}
         model = Gaussian2D()
-        bounding_box = BoundingBox.validate(model, intervals)
+        bounding_box = ModelBoundingBox.validate(model, intervals)
 
         # test defaults
         assert (np.array(bounding_box.domain(0.25)) ==
@@ -1435,7 +1435,7 @@ class TestBoundingBox:
     def test__outside(self):
         intervals = {0: Interval(-1, 1), 1: Interval(0, 2)}
         model = Gaussian2D()
-        bounding_box = BoundingBox.validate(model, intervals)
+        bounding_box = ModelBoundingBox.validate(model, intervals)
 
         # Normal array input, all inside
         x = np.linspace(-1, 1, 13)
@@ -1484,7 +1484,7 @@ class TestBoundingBox:
     def test__valid_index(self):
         intervals = {0: Interval(-1, 1), 1: Interval(0, 2)}
         model = Gaussian2D()
-        bounding_box = BoundingBox.validate(model, intervals)
+        bounding_box = ModelBoundingBox.validate(model, intervals)
 
         # Normal array input, all inside
         x = np.linspace(-1, 1, 13)
@@ -1535,7 +1535,7 @@ class TestBoundingBox:
     def test_prepare_inputs(self):
         intervals = {0: Interval(-1, 1), 1: Interval(0, 2)}
         model = Gaussian2D()
-        bounding_box = BoundingBox.validate(model, intervals)
+        bounding_box = ModelBoundingBox.validate(model, intervals)
 
         # Normal array input, all inside
         x = np.linspace(-1, 1, 13)
@@ -2030,7 +2030,7 @@ class TestCompoundBoundingBox:
         for _selector, bbox in bounding_box._bounding_boxes.items():
             assert _selector in bounding_boxes
             assert bounding_boxes[_selector] == bbox
-            assert isinstance(bbox, BoundingBox)
+            assert isinstance(bbox, ModelBoundingBox)
         assert bounding_box._bounding_boxes == bounding_boxes
         assert bounding_box._create_selector == create_selector
         assert bounding_box._order == 'test'
@@ -2115,14 +2115,14 @@ class TestCompoundBoundingBox:
         assert bounding_box.__repr__() ==\
             "CompoundBoundingBox(\n" + \
             "    bounding_boxes={\n" + \
-            "        (1,) = BoundingBox(\n" + \
+            "        (1,) = ModelBoundingBox(\n" + \
             "                intervals={\n" + \
             "                    x: Interval(lower=-1, upper=1)\n" + \
             "                }\n" + \
             "                model=Gaussian2D(inputs=('x', 'y'))\n" + \
             "                order='C'\n" + \
             "            )\n" + \
-            "        (2,) = BoundingBox(\n" + \
+            "        (2,) = ModelBoundingBox(\n" + \
             "                intervals={\n" + \
             "                    x: Interval(lower=-2, upper=2)\n" + \
             "                }\n" + \
@@ -2202,7 +2202,7 @@ class TestCompoundBoundingBox:
         bounding_box[(15, )] = (-15, 15)
         assert len(bounding_box.bounding_boxes) == 1
         assert (15,) in bounding_box._bounding_boxes
-        assert isinstance(bounding_box._bounding_boxes[(15,)], BoundingBox)
+        assert isinstance(bounding_box._bounding_boxes[(15,)], ModelBoundingBox)
         assert bounding_box._bounding_boxes[(15,)] == (-15, 15)
         assert bounding_box._bounding_boxes[(15,)].order == 'F'
         # Invalid key
@@ -2227,7 +2227,7 @@ class TestCompoundBoundingBox:
         bounding_box[(15, )] = ((-15, 15), (-6, 6))
         assert len(bounding_box.bounding_boxes) == 1
         assert (15,) in bounding_box._bounding_boxes
-        assert isinstance(bounding_box._bounding_boxes[(15,)], BoundingBox)
+        assert isinstance(bounding_box._bounding_boxes[(15,)], ModelBoundingBox)
         assert bounding_box._bounding_boxes[(15,)] == ((-15, 15), (-6, 6))
         assert bounding_box._bounding_boxes[(15,)].order == 'F'
         # Invalid key
@@ -2259,7 +2259,7 @@ class TestCompoundBoundingBox:
         for _selector, bbox in bounding_box._bounding_boxes.items():
             assert _selector in bounding_boxes
             assert bounding_boxes[_selector] == bbox
-            assert isinstance(bbox, BoundingBox)
+            assert isinstance(bbox, ModelBoundingBox)
         assert bounding_box._bounding_boxes == bounding_boxes
 
     def test___eq__(self):
@@ -2347,11 +2347,11 @@ class TestCompoundBoundingBox:
         create_selector.return_value = ((-15, 15), (-23, 23))
         assert len(bounding_box._bounding_boxes) == 0
         bbox = bounding_box._create_bounding_box((7,))
-        assert isinstance(bbox, BoundingBox)
+        assert isinstance(bbox, ModelBoundingBox)
         assert bbox == ((-15, 15), (-23, 23))
         assert len(bounding_box._bounding_boxes) == 1
         assert (7,) in bounding_box
-        assert isinstance(bounding_box[(7,)], BoundingBox)
+        assert isinstance(bounding_box[(7,)], ModelBoundingBox)
         assert bounding_box[(7,)] == bbox
 
         # Create is unsuccessful
@@ -2366,13 +2366,13 @@ class TestCompoundBoundingBox:
         bounding_box = CompoundBoundingBox(bounding_boxes, model, selector_args)
 
         # already exists
-        assert isinstance(bounding_box[1], BoundingBox)
+        assert isinstance(bounding_box[1], ModelBoundingBox)
         assert bounding_box[1] == (-1, 1)
-        assert isinstance(bounding_box[(2,)], BoundingBox)
+        assert isinstance(bounding_box[(2,)], ModelBoundingBox)
         assert bounding_box[2] == (-2, 2)
-        assert isinstance(bounding_box[(1,)], BoundingBox)
+        assert isinstance(bounding_box[(1,)], ModelBoundingBox)
         assert bounding_box[(1,)] == (-1, 1)
-        assert isinstance(bounding_box[(2,)], BoundingBox)
+        assert isinstance(bounding_box[(2,)], ModelBoundingBox)
         assert bounding_box[(2,)] == (-2, 2)
 
         # no selector
@@ -2413,7 +2413,7 @@ class TestCompoundBoundingBox:
         bounding_box = CompoundBoundingBox(bounding_boxes, model, selector_args)
 
         input_shape = mk.MagicMock()
-        with mk.patch.object(BoundingBox, 'prepare_inputs',
+        with mk.patch.object(ModelBoundingBox, 'prepare_inputs',
                              autospec=True) as mkPrepare:
             assert bounding_box.prepare_inputs(input_shape, [1, 2, 3]) == mkPrepare.return_value
             assert mkPrepare.call_args_list == \
@@ -2435,7 +2435,7 @@ class TestCompoundBoundingBox:
             assert isinstance(matching, dict)
             assert () in matching
             bbox = matching[()]
-            assert isinstance(bbox, BoundingBox)
+            assert isinstance(bbox, ModelBoundingBox)
             assert (bbox._model.parameters == Gaussian2D().parameters).all()
             assert 'x' in bbox
             assert 'x' in bbox.ignored_inputs
@@ -2454,7 +2454,7 @@ class TestCompoundBoundingBox:
             assert isinstance(matching, dict)
             assert (4 - value,) in matching
             bbox = matching[(4 - value,)]
-            assert isinstance(bbox, BoundingBox)
+            assert isinstance(bbox, ModelBoundingBox)
             assert (bbox._model.parameters == Gaussian2D().parameters).all()
             assert 'x' in bbox
             assert 'x' in bbox.ignored_inputs
@@ -2467,7 +2467,7 @@ class TestCompoundBoundingBox:
             assert isinstance(matching, dict)
             assert (4 - value,) in matching
             bbox = matching[(4 - value,)]
-            assert isinstance(bbox, BoundingBox)
+            assert isinstance(bbox, ModelBoundingBox)
             assert (bbox._model.parameters == Gaussian2D().parameters).all()
             assert 'y' in bbox
             assert 'y' in bbox.ignored_inputs
@@ -2486,7 +2486,7 @@ class TestCompoundBoundingBox:
         assert isinstance(matching, dict)
         assert () in matching
         bbox = matching[()]
-        assert isinstance(bbox, BoundingBox)
+        assert isinstance(bbox, ModelBoundingBox)
         assert (bbox._model.parameters == model.parameters).all()
         assert bbox.ignored_inputs == ['slit_id']
         assert bbox.named_intervals == {'x': (-0.5, 1047.5),
@@ -2497,7 +2497,7 @@ class TestCompoundBoundingBox:
         assert isinstance(matching, dict)
         assert () in matching
         bbox = matching[()]
-        assert isinstance(bbox, BoundingBox)
+        assert isinstance(bbox, ModelBoundingBox)
         assert (bbox._model.parameters == model.parameters).all()
         assert bbox.ignored_inputs == ['slit_id']
         assert bbox.named_intervals == {'x': (-0.5, 3047.5),
@@ -2518,7 +2518,7 @@ class TestCompoundBoundingBox:
 
         for value in [1, 2, 3]:
             bbox = bounding_box._fix_input_selector_arg('x', value)
-            assert isinstance(bbox, BoundingBox)
+            assert isinstance(bbox, ModelBoundingBox)
             assert (bbox._model.parameters == Gaussian2D().parameters).all()
             assert 'x' in bbox
             assert 'x' in bbox.ignored_inputs
@@ -2539,7 +2539,7 @@ class TestCompoundBoundingBox:
             assert bbox.selector_args == ((1, False),)
             assert (4 - value,) in bbox
             bbox_selector = bbox[(4 - value,)]
-            assert isinstance(bbox_selector, BoundingBox)
+            assert isinstance(bbox_selector, ModelBoundingBox)
             assert (bbox_selector._model.parameters == Gaussian2D().parameters).all()
             assert 'x' in bbox_selector
             assert 'x' in bbox_selector.ignored_inputs
@@ -2554,7 +2554,7 @@ class TestCompoundBoundingBox:
             assert bbox.selector_args == ((0, False),)
             assert (4 - value,) in bbox
             bbox_selector = bbox[(4 - value,)]
-            assert isinstance(bbox_selector, BoundingBox)
+            assert isinstance(bbox_selector, ModelBoundingBox)
             assert (bbox_selector._model.parameters == Gaussian2D().parameters).all()
             assert 'y' in bbox_selector
             assert 'y' in bbox_selector.ignored_inputs
@@ -2570,7 +2570,7 @@ class TestCompoundBoundingBox:
         bounding_box = CompoundBoundingBox.validate(model, bounding_boxes, selector_args=[('slit_id', True)], order='F')
 
         bbox = bounding_box._fix_input_selector_arg('slit_id', 0)
-        assert isinstance(bbox, BoundingBox)
+        assert isinstance(bbox, ModelBoundingBox)
         assert (bbox._model.parameters == model.parameters).all()
         assert bbox.ignored_inputs == ['slit_id']
         assert bbox.named_intervals == {'x': (-0.5, 1047.5),
@@ -2578,7 +2578,7 @@ class TestCompoundBoundingBox:
         assert bbox.order == 'F'
 
         bbox = bounding_box._fix_input_selector_arg('slit_id', 1)
-        assert isinstance(bbox, BoundingBox)
+        assert isinstance(bbox, ModelBoundingBox)
         assert (bbox._model.parameters == model.parameters).all()
         assert bbox.ignored_inputs == ['slit_id']
         assert bbox.named_intervals == {'x': (-0.5, 3047.5),
@@ -2619,7 +2619,7 @@ class TestCompoundBoundingBox:
         # Fix selector argument
         new_model = fix_inputs(model, {'slit_id': 0})
         bbox = new_model.bounding_box
-        assert isinstance(bbox, BoundingBox)
+        assert isinstance(bbox, ModelBoundingBox)
         assert (bbox._model.parameters == new_model.parameters).all()
         assert bbox.ignored_inputs == []
         assert bbox.named_intervals == {'x': (-0.5, 1047.5),
@@ -2653,14 +2653,14 @@ class TestCompoundBoundingBox:
         # Fix selector argument and a bounding_box field
         new_model = fix_inputs(model, {'slit_id': 0, 'x': 5})
         bbox = new_model.bounding_box
-        assert isinstance(bbox, BoundingBox)
+        assert isinstance(bbox, ModelBoundingBox)
         assert (bbox._model.parameters == new_model.parameters).all()
         assert bbox.ignored_inputs == []
         assert bbox.named_intervals == {'y': (-0.5, 2047.5)}
         assert bbox.order == 'F'
         new_model = fix_inputs(model, {'y': 5, 'slit_id': 1})
         bbox = new_model.bounding_box
-        assert isinstance(bbox, BoundingBox)
+        assert isinstance(bbox, ModelBoundingBox)
         assert (bbox._model.parameters == new_model.parameters).all()
         assert bbox.ignored_inputs == []
         assert bbox.named_intervals == {'x': (-0.5, 3047.5)}

--- a/astropy/modeling/tests/test_core.py
+++ b/astropy/modeling/tests/test_core.py
@@ -14,7 +14,7 @@ import astropy
 from astropy.modeling.core import (Model, CompoundModel, custom_model,
                                    SPECIAL_OPERATORS, _add_special_operator,
                                    bind_compound_bounding_box, fix_inputs)
-from astropy.modeling.bounding_box import BoundingBox, CompoundBoundingBox
+from astropy.modeling.bounding_box import ModelBoundingBox, CompoundBoundingBox
 from astropy.modeling.separable import separability_matrix
 from astropy.modeling.parameters import Parameter
 from astropy.modeling import models
@@ -1098,7 +1098,7 @@ def test_fix_inputs_compound_bounding_box():
 
 def test_model_copy_with_bounding_box():
     model = models.Polynomial2D(2)
-    bbox = BoundingBox.validate(model, ((-0.5, 1047.5), (-0.5, 2047.5)), order='F')
+    bbox = ModelBoundingBox.validate(model, ((-0.5, 1047.5), (-0.5, 2047.5)), order='F')
 
     # No bbox
     model_copy = model.copy()
@@ -1125,7 +1125,7 @@ def test_model_copy_with_bounding_box():
 def test_compound_model_copy_with_bounding_box():
     model = models.Shift(1) & models.Shift(2) & models.Identity(1)
     model.inputs = ('x', 'y', 'slit_id')
-    bbox = BoundingBox.validate(model, ((-0.5, 1047.5), (-0.5, 2047.5), (-np.inf, np.inf)), order='F')
+    bbox = ModelBoundingBox.validate(model, ((-0.5, 1047.5), (-0.5, 2047.5), (-np.inf, np.inf)), order='F')
 
     # No bbox
     model_copy = model.copy()
@@ -1214,7 +1214,7 @@ def test_compound_model_copy_with_compound_bounding_box():
 
 def test_model_mixed_array_scalar_bounding_box():
     model = models.Gaussian2D()
-    bbox = BoundingBox.validate(model, ((-1, 1), (-np.inf, np.inf)), order='F')
+    bbox = ModelBoundingBox.validate(model, ((-1, 1), (-np.inf, np.inf)), order='F')
     model.bounding_box = bbox
 
     x = np.array([-0.5, 0.5])
@@ -1227,7 +1227,7 @@ def test_model_mixed_array_scalar_bounding_box():
 def test_compound_model_mixed_array_scalar_bounding_box():
     model = models.Shift(1) & models.Shift(2) & models.Identity(1)
     model.inputs = ('x', 'y', 'slit_id')
-    bbox = BoundingBox.validate(model, ((-0.5, 1047.5), (-0.5, 2047.5), (-np.inf, np.inf)), order='F')
+    bbox = ModelBoundingBox.validate(model, ((-0.5, 1047.5), (-0.5, 2047.5), (-np.inf, np.inf)), order='F')
     model.bounding_box = bbox
     x = np.array([1000, 1001])
     y = np.array([2000, 2001])

--- a/astropy/modeling/tests/test_models.py
+++ b/astropy/modeling/tests/test_models.py
@@ -15,7 +15,7 @@ from numpy.testing import assert_allclose, assert_equal
 from astropy import units as u
 from astropy.modeling import fitting, models
 from astropy.modeling.models import Gaussian2D
-from astropy.modeling.bounding_box import BoundingBox
+from astropy.modeling.bounding_box import ModelBoundingBox
 from astropy.modeling.core import FittableModel
 from astropy.modeling.parameters import Parameter
 from astropy.modeling.polynomial import PolynomialBase
@@ -422,7 +422,7 @@ class Fittable1DModelTester:
             rtol = 1e-7
             ddx = 1
 
-        if isinstance(bbox, BoundingBox):
+        if isinstance(bbox, ModelBoundingBox):
             bbox = bbox.bounding_box()
 
         dx = np.diff(bbox) / 2

--- a/astropy/modeling/tests/test_models_quantities.py
+++ b/astropy/modeling/tests/test_models_quantities.py
@@ -29,7 +29,7 @@ from astropy.modeling.powerlaws import (
 from astropy.modeling.polynomial import Polynomial1D, Polynomial2D
 
 from astropy.modeling.fitting import LevMarLSQFitter
-from astropy.modeling.bounding_box import BoundingBox
+from astropy.modeling.bounding_box import ModelBoundingBox
 
 from astropy.modeling.parameters import InputParameterError
 
@@ -367,7 +367,7 @@ def test_models_bounding_box(model):
         # values one by one.
         for i in range(len(model['bounding_box'])):
             bbox = m.bounding_box
-            if isinstance(bbox, BoundingBox):
+            if isinstance(bbox, ModelBoundingBox):
                 bbox = bbox.bounding_box()
             assert_quantity_allclose(bbox[i], model['bounding_box'][i])
 

--- a/docs/modeling/models.rst
+++ b/docs/modeling/models.rst
@@ -239,7 +239,7 @@ with `~astropy.modeling.custom_model` or as a `~astropy.modeling.core.CompoundMo
     ...
     >>> model = Ellipsoid3D()
     >>> model.bounding_box
-    BoundingBox(
+    ModelBoundingBox(
         intervals={
             x0: Interval(lower=-2.0, upper=2.0)
             x1: Interval(lower=-3.0, upper=3.0)


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

The astropy regions coordinated package also has a very different "BoundingBox" class (https://astropy-regions.readthedocs.io/en/stable/api/regions.BoundingBox.html). The regions package will eventually be merged into astropy core as a new astropy.regions subpackage.  Having two different classes in the core package with the same name isn't ideal. Therefore, it has been suggested that `modeling` rename it's `BoundingBox` class to `ModelBoundingBox`, while regions rename it's `BoundingBox` class to `RegionBoundingBox`.  This PR accomplishes this requested renaming for the `modeling` subpackage.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
