### PR TITLE
Cleanup of recent modeling changes

### DIFF
--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -38,7 +38,7 @@ from astropy.nddata.utils import add_array, extract_array
 from .utils import (combine_labels, make_binary_operator_eval,
                     get_inputs_and_params, _combine_equivalency_dict,
                     _ConstraintsDict, _SpecialOperatorsDict)
-from .bounding_box import BoundingDomain, ModelBoundingBox, CompoundBoundingBox
+from .bounding_box import ModelBoundingBox, CompoundBoundingBox
 from .parameters import (Parameter, InputParameterError,
                          param_repr_oneline, _tofloat)
 
@@ -3963,8 +3963,14 @@ def fix_inputs(modelinstance, values, bounding_boxes=None, selector_args=None):
     return model
 
 
+def bind_bounding_box(modelinstance, bounding_box, order='C'):
+    modelinstance.bounding_box = ModelBoundingBox.validate(modelinstance,
+                                                           bounding_box,
+                                                           order=order)
+
+
 def bind_compound_bounding_box(modelinstance, bounding_boxes, selector_args,
-                               create_selector=None, order=None):
+                               create_selector=None, order='C'):
     modelinstance.bounding_box = CompoundBoundingBox.validate(modelinstance,
                                                               bounding_boxes, selector_args, create_selector,
                                                               order=order)

--- a/astropy/modeling/spline.py
+++ b/astropy/modeling/spline.py
@@ -5,6 +5,7 @@
 
 import warnings
 
+import abc
 import functools
 import numpy as np
 
@@ -172,9 +173,11 @@ class _Spline(FittableModel):
 
         return tuple(names)
 
+    @abc.abstractmethod
     def _init_parameters(self):
         raise NotImplementedError("This needs to be implemented")
 
+    @abc.abstractmethod
     def _init_data(self, knots, coeffs, bounds=None):
         raise NotImplementedError("This needs to be implemented")
 
@@ -554,7 +557,7 @@ class Spline1D(_Spline):
                              f"antiderivative degree will be {nu + self.degree}")
 
 
-class _SplineFitter():
+class _SplineFitter(abc.ABC):
     """
     Base Spline Fitter
     """
@@ -569,8 +572,9 @@ class _SplineFitter():
         self.fit_info['resid'] = spline.get_residual()
         self.fit_info['spline'] = spline
 
+    @abc.abstractmethod
     def _fit_method(self, model, x, y, **kwargs):
-        pass
+        raise NotImplementedError("This has not been implemented for _SplineFitter.")
 
     def __call__(self, model, x, y, z=None, **kwargs):
         model_copy = model.copy()

--- a/astropy/modeling/tests/test_core.py
+++ b/astropy/modeling/tests/test_core.py
@@ -13,7 +13,8 @@ from numpy.testing import assert_allclose, assert_equal
 import astropy
 from astropy.modeling.core import (Model, CompoundModel, custom_model,
                                    SPECIAL_OPERATORS, _add_special_operator,
-                                   bind_compound_bounding_box, fix_inputs)
+                                   bind_bounding_box, bind_compound_bounding_box,
+                                   fix_inputs)
 from astropy.modeling.bounding_box import ModelBoundingBox, CompoundBoundingBox
 from astropy.modeling.separable import separability_matrix
 from astropy.modeling.parameters import Parameter
@@ -1022,6 +1023,23 @@ def test_compound_bounding_box():
     assert model(0.5, with_bounding_box=True) == truth(0.5)
     with pytest.raises(RuntimeError):
         model(0, with_bounding_box=True)
+
+
+def test_bind_bounding_box():
+    model = models.Polynomial2D(3)
+    bbox = ((-1, 1), (-2, 2))
+
+    bind_bounding_box(model, bbox)
+    assert model.get_bounding_box() is not None
+    assert model.bounding_box == bbox
+    assert model.bounding_box['x'] == (-2, 2)
+    assert model.bounding_box['y'] == (-1, 1)
+
+    bind_bounding_box(model, bbox, order='F')
+    assert model.get_bounding_box() is not None
+    assert model.bounding_box == bbox
+    assert model.bounding_box['x'] == (-1, 1)
+    assert model.bounding_box['y'] == (-2, 2)
 
 
 def test_bind_compound_bounding_box_using_with_bounding_box_select():


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This PR cleans up some of the new base classes introduced in the new spline models (PR #11634) and the compound bounding box (PR #11942). In both cases, a base class with subbed out (not implemented) methods was introduced. These methods are necessary for the proper function of their child classes. Thus the `abstractmethod` decorator was added to them. Additionally, `BoundingDomain` was made a private class as it should not really be used by anything external to `modeling`, leaving it as a public class was an oversight in PR #11942.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
