### PR TITLE
fix de-registration of mypackage IO

### DIFF
--- a/astropy/cosmology/tests/mypackage/io/tests/conftest.py
+++ b/astropy/cosmology/tests/mypackage/io/tests/conftest.py
@@ -8,19 +8,19 @@ from mypackage.io import ASTROPY_GE_5
 
 
 @pytest.fixture(scope="session", autouse=True)
-def teardown():
+def teardown_mypackage():
     """Clean up module after tests."""
 
     yield  # to let all tests within the scope run
 
     if ASTROPY_GE_5:
         from astropy.cosmology import Cosmology
-        from astropy.io import registry as io_registry
+        from astropy.cosmology.connect import convert_registry, readwrite_registry
 
-        io_registry.unregister_reader("myformat", Cosmology)
-        io_registry.unregister_writer("myformat", Cosmology)
-        io_registry.unregister_identifier("myformat", Cosmology)
+        readwrite_registry.unregister_reader("myformat", Cosmology)
+        readwrite_registry.unregister_writer("myformat", Cosmology)
+        readwrite_registry.unregister_identifier("myformat", Cosmology)
 
-        io_registry.unregister_reader("mypackage", Cosmology)
-        io_registry.unregister_writer("mypackage", Cosmology)
-        io_registry.unregister_identifier("mypackage", Cosmology)
+        convert_registry.unregister_reader("mypackage", Cosmology)
+        convert_registry.unregister_writer("mypackage", Cosmology)
+        convert_registry.unregister_identifier("mypackage", Cosmology)


### PR DESCRIPTION
Fix the pytest teardown of the ``mypackage`` example formats after the Cosmology I/O registries were separated from the default registry.

I'm seeing the errors in https://github.com/astropy/astropy/runs/4072595260?check_suite_focus=true

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
