### PR TITLE
Generalize handling of resource-intensive tests

### DIFF
--- a/astropy/io/ascii/tests/test_c_reader.py
+++ b/astropy/io/ascii/tests/test_c_reader.py
@@ -980,15 +980,15 @@ def test_fast_tab_with_names(parallel, read_tab):
     read_tab(content, data_start=1, parallel=parallel, names=head)
 
 
-@pytest.mark.skipif(not os.getenv('TEST_READ_HUGE_FILE'),
-                    reason='Environment variable TEST_READ_HUGE_FILE must be '
+@pytest.mark.skipif(not os.getenv('TEST_INTENSIVE'),
+                    reason='Environment variable TEST_INTENSIVE must be '
                     'defined to run this test')
 def test_read_big_table(tmpdir):
     """Test reading of a huge file.
 
     This test generates a huge CSV file (~2.3Gb) before reading it (see
     https://github.com/astropy/astropy/pull/5319). The test is run only if the
-    environment variable ``TEST_READ_HUGE_FILE`` is defined. Note that running
+    environment variable ``TEST_INTENSIVE`` is defined. Note that running
     the test requires quite a lot of memory (~18Gb when reading the file) !!
 
     """
@@ -1014,8 +1014,8 @@ def test_read_big_table(tmpdir):
     assert len(t) == NB_ROWS
 
 
-@pytest.mark.skipif(not os.getenv('TEST_READ_HUGE_FILE'),
-                    reason='Environment variable TEST_READ_HUGE_FILE must be '
+@pytest.mark.skipif(not os.getenv('TEST_INTENSIVE'),
+                    reason='Environment variable TEST_INTENSIVE must be '
                     'defined to run this test')
 def test_read_big_table2(tmpdir):
     """Test reading of a file with a huge column.

--- a/docs/development/releasing.rst
+++ b/docs/development/releasing.rst
@@ -138,7 +138,7 @@ packages that use the full bugfix/maintenance branch approach.)
    environment::
 
       $ pip install tox --upgrade
-      $ TEST_READ_HUGE_FILE=1 tox -e test-alldeps -- --remote-data=any
+      $ tox -e test-alldeps-intensive -- --remote-data=any
 
 #. Render the changelog with towncrier, and confirm that the fragments can be
    deleted. (Note: update this when doing the next release!)

--- a/docs/development/testguide.rst
+++ b/docs/development/testguide.rst
@@ -437,6 +437,29 @@ temporary directories. This can be done with the
 Python's built-in :ref:`tempfile module <python:tempfile-examples>`.
 
 
+Intensive tests
+===============
+
+In some cases, you may need to write tests that need a lot of resources,
+such as disk, memory, or runtime. Such tests should only be included if
+absolutely necessary, and should include the following ``skipif`` clause::
+
+    @pytest.mark.skipif(not os.getenv('TEST_INTENSIVE'),
+                        reason='Environment variable TEST_INTENSIVE must be '
+                                'defined to run this test')
+
+You can then include these tests when running tests by setting the
+environment variable ``TEST_INTENSIVE`` to e.g. ``1``::
+
+    TEST_INTENSIVE=1 pytest ...
+
+or you can use the ``-intensive`` factor when using tox, e.g.::
+
+    tox -e py39-test-intensive
+
+Tests that have large disk and/or memory requirements
+====================================
+
 Setting up/Tearing down tests
 =============================
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{38,39,310,dev}-test{,-image,-recdeps,-alldeps,-oldestdeps,-devdeps,-numpy118,-numpy119,-numpy120,-numpy121,-mpl311}{,-cov}{,-clocale}
+    py{38,39,310,dev}-test{,-image,-recdeps,-alldeps,-oldestdeps,-devdeps,-numpy118,-numpy119,-numpy120,-numpy121,-mpl311}{,-cov}{,-clocale}{,-intensive}
     build_docs
     linkcheck
     codestyle
@@ -21,7 +21,7 @@ indexserver =
 pypi_filter = https://raw.githubusercontent.com/astropy/ci-helpers/main/pip_pinnings.txt
 
 # Pass through the following environment variables which are needed for the CI
-passenv = HOME WINDIR LC_ALL LC_CTYPE CC CI IS_CRON ARCH_ON_CI TEST_READ_HUGE_FILE
+passenv = HOME WINDIR LC_ALL LC_CTYPE CC CI IS_CRON ARCH_ON_CI TEST_INTENSIVE
 
 # For coverage, we need to pass extra options to the C compiler
 setenv =
@@ -30,6 +30,7 @@ setenv =
     !image: MPLFLAGS =
     clocale: LC_CTYPE = C.ascii
     clocale: LC_ALL = C
+    intensive: TEST_INTENSIVE=1
 
 # Run the tests in a temporary directory to make sure that we don't import
 # astropy from the source tree
@@ -58,6 +59,7 @@ description =
     mpl311: with matplotlib 3.1.1
     mpldev: with the latest developer version of matplotlib
     double: twice in a row to check for global state changes
+    intensive: include tests that have large disk and/or memory requirements
 
 deps =
     numpy118: numpy==1.18.*


### PR DESCRIPTION
### Description

This renames the environment variable for the big table tests to be more general and usable by other tests, and adds a tox option to more easily run these tests without setting an environment variable.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
