### PR TITLE
Add FlatwpwaCDM and Flatw0wzCDM

### DIFF
--- a/astropy/cosmology/flrw/scalar_inv_efuncs.pyx
+++ b/astropy/cosmology/flrw/scalar_inv_efuncs.pyx
@@ -176,6 +176,31 @@ def wpwacdm_inv_efunc(double z, double Om0, double Ode0, double Ok0,
   cdef Odescl = opz**(3. * (1. + wp + apiv * wa)) * exp(-3. * wa * z / opz)
   return pow((((opz * Or0 + Om0) * opz) + Ok0) * opz**2 + Ode0 * Odescl, -0.5)
 
+######## FlatwpwaCDM
+# No relativistic species
+def fwpwacdm_inv_efunc_norel(double z, double Om0, double Ode0,
+    double wp, double apiv, double wa):
+  cdef double opz = 1.0 + z
+  cdef Odescl = opz**(3. * (1. + wp + apiv * wa)) * exp(-3. * wa * z / opz)
+  return pow(opz**3 * Om0 + Ode0 * Odescl, -0.5)
+
+# Massless neutrinos
+def fwpwacdm_inv_efunc_nomnu(double z, double Om0, double Ode0,
+    double Or0, double wp, double apiv, double wa):
+  cdef double opz = 1.0 + z
+  cdef Odescl = opz**(3. * (1. + wp + apiv * wa)) * exp(-3. * wa * z / opz)
+  return pow((opz * Or0 + Om0) * opz**3 + Ode0 * Odescl, -0.5)
+
+# With massive neutrinos
+def fwpwacdm_inv_efunc(double z, double Om0, double Ode0,
+    double Ogamma0, double NeffPerNu, int nmasslessnu, list nu_y, double wp,
+    double apiv, double wa):
+
+  cdef double opz = 1.0 + z
+  cdef double Or0 = Ogamma0 * (1.0 + nufunc(opz, NeffPerNu, nmasslessnu, nu_y))
+  cdef Odescl = opz**(3. * (1. + wp + apiv * wa)) * exp(-3. * wa * z / opz)
+  return pow((opz * Or0 + Om0) * opz**3 + Ode0 * Odescl, -0.5)
+
 ######## w0wzCDM
 # No relativistic species
 def w0wzcdm_inv_efunc_norel(double z, double Om0, double Ode0, double Ok0,
@@ -201,6 +226,31 @@ def w0wzcdm_inv_efunc(double z, double Om0, double Ode0, double Ok0,
   cdef double Or0 = Ogamma0 * (1.0 + nufunc(opz, NeffPerNu, nmasslessnu, nu_y))
   cdef Odescl = opz**(3. * (1. + w0 - wz)) * exp(-3. * wz * z)
   return pow((((opz * Or0 + Om0) * opz) + Ok0) * opz**2 + Ode0 * Odescl, -0.5)
+
+######## Flatw0wzCDM
+# No relativistic species
+def fw0wzcdm_inv_efunc_norel(double z, double Om0, double Ode0,
+    double w0, double wz):
+  cdef double opz = 1.0 + z
+  cdef Odescl = opz**(3. * (1. + w0 - wz)) * exp(-3. * wz * z)
+  return pow(opz**3 * Om0 + Ode0 * Odescl, -0.5)
+
+# Massless neutrinos
+def fw0wzcdm_inv_efunc_nomnu(double z, double Om0, double Ode0,
+    double Or0, double w0, double wz):
+  cdef double opz = 1.0 + z
+  cdef Odescl = opz**(3. * (1. + w0 - wz)) * exp(-3. * wz * z)
+  return pow((opz * Or0 + Om0) * opz**3 + Ode0 * Odescl, -0.5)
+
+# With massive neutrinos
+def fw0wzcdm_inv_efunc(double z, double Om0, double Ode0,
+    double Ogamma0, double NeffPerNu, int nmasslessnu, list nu_y, double w0,
+    double wz):
+
+  cdef double opz = 1.0 + z
+  cdef double Or0 = Ogamma0 * (1.0 + nufunc(opz, NeffPerNu, nmasslessnu, nu_y))
+  cdef Odescl = opz**(3. * (1. + w0 - wz)) * exp(-3. * wz * z)
+  return pow((opz * Or0 + Om0) * opz**3 + Ode0 * Odescl, -0.5)
 
 ######## Neutrino relative density function
 # Scalar equivalent to FLRW.nu_realative_density in core.py

--- a/astropy/cosmology/flrw/w0wzcdm.py
+++ b/astropy/cosmology/flrw/w0wzcdm.py
@@ -266,8 +266,8 @@ class Flatw0wzCDM(FlatFLRWMixin, w0wzCDM):
 
     The comoving distance in Mpc at redshift z:
 
-    >>> z = 0.5
-    >>> dc = cosmo.comoving_distance(z)
+    >>> cosmo.comoving_distance(0.5)
+    <Quantity 1982.66012926 Mpc>
     """
 
     def __init__(

--- a/astropy/cosmology/flrw/w0wzcdm.py
+++ b/astropy/cosmology/flrw/w0wzcdm.py
@@ -7,9 +7,9 @@ from astropy.cosmology.parameter import Parameter
 from astropy.cosmology.utils import aszarr
 
 from . import scalar_inv_efuncs
-from .base import FLRW
+from .base import FLRW, FlatFLRWMixin
 
-__all__ = ["w0wzCDM"]
+__all__ = ["w0wzCDM", "Flatw0wzCDM"]
 
 __doctest_requires__ = {"*": ["scipy"]}
 
@@ -203,3 +203,124 @@ class w0wzCDM(FLRW):
         z = aszarr(z)
         zp1 = z + 1.0  # (converts z [unit] -> z [dimensionless])
         return zp1 ** (3.0 * (1.0 + self._w0 - self._wz)) * exp(-3.0 * self._wz * z)
+
+
+class Flatw0wzCDM(FlatFLRWMixin, w0wzCDM):
+    """
+    FLRW cosmology with a variable dark energy equation of state and no curvature.
+
+    The equation for the dark energy equation of state uses the simple form:
+    :math:`w(z) = w_0 + w_z z`.
+
+    This form is not recommended for z > 1.
+
+    Parameters
+    ----------
+    H0 : float or scalar quantity-like ['frequency']
+        Hubble constant at z = 0. If a float, must be in [km/sec/Mpc].
+
+    Om0 : float
+        Omega matter: density of non-relativistic matter in units of the
+        critical density at z=0.
+
+    w0 : float, optional
+        Dark energy equation of state at z=0. This is pressure/density for
+        dark energy in units where c=1.
+
+    wz : float, optional
+        Derivative of the dark energy equation of state with respect to z.
+        A cosmological constant has w0=-1.0 and wz=0.0.
+
+    Tcmb0 : float or scalar quantity-like ['temperature'], optional
+        Temperature of the CMB z=0. If a float, must be in [K]. Default: 0 [K].
+        Setting this to zero will turn off both photons and neutrinos
+        (even massive ones).
+
+    Neff : float, optional
+        Effective number of Neutrino species. Default 3.04.
+
+    m_nu : quantity-like ['energy', 'mass'] or array-like, optional
+        Mass of each neutrino species in [eV] (mass-energy equivalency enabled).
+        If this is a scalar Quantity, then all neutrino species are assumed to
+        have that mass. Otherwise, the mass of each species. The actual number
+        of neutrino species (and hence the number of elements of m_nu if it is
+        not scalar) must be the floor of Neff. Typically this means you should
+        provide three neutrino masses unless you are considering something like
+        a sterile neutrino.
+
+    Ob0 : float or None, optional
+        Omega baryons: density of baryonic matter in units of the critical
+        density at z=0.  If this is set to None (the default), any computation
+        that requires its value will raise an exception.
+
+    name : str or None (optional, keyword-only)
+        Name for this cosmological object.
+
+    meta : mapping or None (optional, keyword-only)
+        Metadata for the cosmology, e.g., a reference.
+
+    Examples
+    --------
+    >>> from astropy.cosmology import Flatw0wzCDM
+    >>> cosmo = Flatw0wzCDM(H0=70, Om0=0.3, w0=-0.9, wz=0.2)
+
+    The comoving distance in Mpc at redshift z:
+
+    >>> z = 0.5
+    >>> dc = cosmo.comoving_distance(z)
+    """
+
+    def __init__(
+        self,
+        H0,
+        Om0,
+        w0=-1.0,
+        wz=0.0,
+        Tcmb0=0.0 * u.K,
+        Neff=3.04,
+        m_nu=0.0 * u.eV,
+        Ob0=None,
+        *,
+        name=None,
+        meta=None
+    ):
+        super().__init__(
+            H0=H0,
+            Om0=Om0,
+            Ode0=0.0,
+            w0=w0,
+            wz=wz,
+            Tcmb0=Tcmb0,
+            Neff=Neff,
+            m_nu=m_nu,
+            Ob0=Ob0,
+            name=name,
+            meta=meta,
+        )
+
+        # Please see :ref:`astropy-cosmology-fast-integrals` for discussion
+        # about what is being done here.
+        if self._Tcmb0.value == 0:
+            self._inv_efunc_scalar = scalar_inv_efuncs.fw0wzcdm_inv_efunc_norel
+            self._inv_efunc_scalar_args = (self._Om0, self._Ode0, self._w0, self._wz)
+        elif not self._massivenu:
+            self._inv_efunc_scalar = scalar_inv_efuncs.fw0wzcdm_inv_efunc_nomnu
+            self._inv_efunc_scalar_args = (
+                self._Om0,
+                self._Ode0,
+                self._Ogamma0 + self._Onu0,
+                self._w0,
+                self._wz,
+            )
+        else:
+            self._inv_efunc_scalar = scalar_inv_efuncs.fw0wzcdm_inv_efunc
+            self._inv_efunc_scalar_args = (
+                self._Om0,
+                self._Ode0,
+                self._Ogamma0,
+                self._neff_per_nu,
+                self._nmasslessnu,
+                self._nu_y_list,
+                self._w0,
+                self._wz,
+            )

--- a/astropy/cosmology/flrw/wpwazpcdm.py
+++ b/astropy/cosmology/flrw/wpwazpcdm.py
@@ -8,9 +8,9 @@ from astropy.cosmology.parameter import Parameter
 from astropy.cosmology.utils import aszarr
 
 from . import scalar_inv_efuncs
-from .base import FLRW
+from .base import FLRW, FlatFLRWMixin
 
-__all__ = ["wpwaCDM"]
+__all__ = ["wpwaCDM", "FlatwpwaCDM"]
 
 __doctest_requires__ = {"*": ["scipy"]}
 
@@ -236,3 +236,151 @@ class wpwaCDM(FLRW):
         return zp1 ** (3.0 * (1.0 + self._wp + apiv * self._wa)) * exp(
             -3.0 * self._wa * z / zp1
         )
+
+
+class FlatwpwaCDM(FlatFLRWMixin, wpwaCDM):
+    r"""
+    FLRW cosmology with a CPL dark energy equation of state, a pivot redshift,
+    and no curvature.
+
+    The equation for the dark energy equation of state uses the CPL form as
+    described in Chevallier & Polarski [1]_ and Linder [2]_, but modified to
+    have a pivot redshift as in the findings of the Dark Energy Task Force
+    [3]_: :math:`w(a) = w_p + w_a (a_p - a) = w_p + w_a( 1/(1+zp) - 1/(1+z) )`.
+
+    Parameters
+    ----------
+    H0 : float or scalar quantity-like ['frequency']
+        Hubble constant at z = 0. If a float, must be in [km/sec/Mpc].
+
+    Om0 : float
+        Omega matter: density of non-relativistic matter in units of the
+        critical density at z=0.
+
+    wp : float, optional
+        Dark energy equation of state at the pivot redshift zp. This is
+        pressure/density for dark energy in units where c=1.
+
+    wa : float, optional
+        Negative derivative of the dark energy equation of state with respect
+        to the scale factor. A cosmological constant has wp=-1.0 and wa=0.0.
+
+    zp : float or quantity-like ['redshift'], optional
+        Pivot redshift -- the redshift where w(z) = wp
+
+    Tcmb0 : float or scalar quantity-like ['temperature'], optional
+        Temperature of the CMB z=0. If a float, must be in [K]. Default: 0 [K].
+        Setting this to zero will turn off both photons and neutrinos
+        (even massive ones).
+
+    Neff : float, optional
+        Effective number of Neutrino species. Default 3.04.
+
+    m_nu : quantity-like ['energy', 'mass'] or array-like, optional
+        Mass of each neutrino species in [eV] (mass-energy equivalency enabled).
+        If this is a scalar Quantity, then all neutrino species are assumed to
+        have that mass. Otherwise, the mass of each species. The actual number
+        of neutrino species (and hence the number of elements of m_nu if it is
+        not scalar) must be the floor of Neff. Typically this means you should
+        provide three neutrino masses unless you are considering something like
+        a sterile neutrino.
+
+    Ob0 : float or None, optional
+        Omega baryons: density of baryonic matter in units of the critical
+        density at z=0.  If this is set to None (the default), any computation
+        that requires its value will raise an exception.
+
+    name : str or None (optional, keyword-only)
+        Name for this cosmological object.
+
+    meta : mapping or None (optional, keyword-only)
+        Metadata for the cosmology, e.g., a reference.
+
+    Examples
+    --------
+    >>> from astropy.cosmology import FlatwpwaCDM
+    >>> cosmo = FlatwpwaCDM(H0=70, Om0=0.3, wp=-0.9, wa=0.2, zp=0.4)
+
+    The comoving distance in Mpc at redshift z:
+
+    >>> z = 0.5
+    >>> dc = cosmo.comoving_distance(z)
+
+    References
+    ----------
+    .. [1] Chevallier, M., & Polarski, D. (2001). Accelerating Universes with
+        Scaling Dark Matter. International Journal of Modern Physics D,
+        10(2), 213-223.
+    .. [2] Linder, E. (2003). Exploring the Expansion History of the
+        Universe. Phys. Rev. Lett., 90, 091301.
+    .. [3] Albrecht, A., Amendola, L., Bernstein, G., Clowe, D., Eisenstein,
+        D., Guzzo, L., Hirata, C., Huterer, D., Kirshner, R., Kolb, E., &
+        Nichol, R. (2009). Findings of the Joint Dark Energy Mission Figure
+        of Merit Science Working Group. arXiv e-prints, arXiv:0901.0721.
+    """
+
+    def __init__(
+        self,
+        H0,
+        Om0,
+        wp=-1.0,
+        wa=0.0,
+        zp=0.0,
+        Tcmb0=0.0 * u.K,
+        Neff=3.04,
+        m_nu=0.0 * u.eV,
+        Ob0=None,
+        *,
+        name=None,
+        meta=None
+    ):
+        super().__init__(
+            H0=H0,
+            Om0=Om0,
+            Ode0=0.0,
+            wp=wp,
+            wa=wa,
+            zp=zp,
+            Tcmb0=Tcmb0,
+            Neff=Neff,
+            m_nu=m_nu,
+            Ob0=Ob0,
+            name=name,
+            meta=meta,
+        )
+
+        # Please see :ref:`astropy-cosmology-fast-integrals` for discussion
+        # about what is being done here.
+        apiv = 1.0 / (1.0 + self._zp)
+        if self._Tcmb0.value == 0:
+            self._inv_efunc_scalar = scalar_inv_efuncs.fwpwacdm_inv_efunc_norel
+            self._inv_efunc_scalar_args = (
+                self._Om0,
+                self._Ode0,
+                self._wp,
+                apiv,
+                self._wa,
+            )
+        elif not self._massivenu:
+            self._inv_efunc_scalar = scalar_inv_efuncs.fwpwacdm_inv_efunc_nomnu
+            self._inv_efunc_scalar_args = (
+                self._Om0,
+                self._Ode0,
+                self._Ogamma0 + self._Onu0,
+                self._wp,
+                apiv,
+                self._wa,
+            )
+        else:
+            self._inv_efunc_scalar = scalar_inv_efuncs.fwpwacdm_inv_efunc
+            self._inv_efunc_scalar_args = (
+                self._Om0,
+                self._Ode0,
+                self._Ogamma0,
+                self._neff_per_nu,
+                self._nmasslessnu,
+                self._nu_y_list,
+                self._wp,
+                apiv,
+                self._wa,
+            )

--- a/astropy/cosmology/flrw/wpwazpcdm.py
+++ b/astropy/cosmology/flrw/wpwazpcdm.py
@@ -303,8 +303,8 @@ class FlatwpwaCDM(FlatFLRWMixin, wpwaCDM):
 
     The comoving distance in Mpc at redshift z:
 
-    >>> z = 0.5
-    >>> dc = cosmo.comoving_distance(z)
+    >>> cosmo.comoving_distance(0.5)
+    <Quantity 1868.68474438 Mpc>
 
     References
     ----------

--- a/docs/changes/cosmology/12353.feature.rst
+++ b/docs/changes/cosmology/12353.feature.rst
@@ -1,0 +1,2 @@
+Two new cosmologies have been added, ``FlatwpwaCDM`` and ``Flatw0wzCDM``, which are the
+flat variants of ``wpwaCDM`` and ``w0wzCDM``, respectively.

--- a/docs/whatsnew/5.3.rst
+++ b/docs/whatsnew/5.3.rst
@@ -22,6 +22,22 @@ By the numbers:
 * X pull requests have been merged since v4.2
 * X distinct people have contributed code
 
+.. _whatsnew-5.3-cosmology:
+
+New flat :mod:`astropy.cosmology` classes
+=========================================
+
+Two new cosmologies have been added, :class:`~astropy.cosmology.FlatwpwaCDM` and
+:class:`~astropy.cosmology.Flatw0wzCDM`, which are the flat variants of
+:class:`~astropy.cosmology.wpwaCDM` and :class:`~astropy.cosmology.w0wzCDM`,
+respectively.
+
+    >>> from astropy.cosmology import Flatw0wzCDM
+    >>> cosmo = Flatw0wzCDM(H0=70, Om0=0.3, w0=-0.9, wz=0.2)
+    >>> cosmo.comoving_distance(0.5)  # doctest: +SKIP
+    <Quantity 1982.66012926 Mpc>
+
+
 Full change log
 ===============
 


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

Add `FlatwpwaCDM` and `Flatw0wzCDM` to fill out all the flat cosmos.

todo:
- [x] tests
- [x] changelog
- [x] whatsnew
- [x] docs

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
