### PR TITLE
`Planck18_arXiv_v2` is removed

### DIFF
--- a/astropy/cosmology/parameters.py
+++ b/astropy/cosmology/parameters.py
@@ -28,9 +28,6 @@ The list of cosmologies available are given by the tuple
 Planck 2018 (Planck18) parameters from Planck Collaboration 2020,
  A&A, 641, A6 (Paper VI), Table 2 (TT, TE, EE + lowE + lensing + BAO)
 
-Planck 2018 (Planck18_arXiv_v2) parameters from Planck Collaboration 2018,
- arXiv:1807.06209v2 (Paper VI), Table 2 (TT, TE, EE + lowE + lensing + BAO)
-
 Planck 2015 (Planck15) parameters from Planck Collaboration 2016, A&A, 594, A13
  (Paper XIII), Table 4 (TT, TE, EE + lowP + lensing + ext)
 
@@ -88,27 +85,6 @@ Planck18 = MappingProxyType(dict(
     flat=True,
     m_nu=[0., 0., 0.06] * u.eV,
     reference=("Planck Collaboration 2018, 2020, A&A, 641, A6  (Paper VI),"
-               " Table 2 (TT, TE, EE + lowE + lensing + BAO)")
-))
-
-# Planck 2018 paper VI v2.  Identical to Planck18 above.
-# Warning: deprecated and will be removed in future versions.
-Planck18_arXiv_v2 = MappingProxyType(dict(
-    cosmology="FlatLambdaCDM",
-    Oc0=0.2607,
-    Ob0=0.04897,
-    Om0=0.30966,
-    H0=67.66 * (u.km / u.s / u.Mpc),
-    n=0.9665,
-    sigma8=0.8102,
-    tau=0.0561,
-    z_reion=7.82,
-    t0=13.787 * u.Gyr,
-    Tcmb0=2.7255 * u.K,
-    Neff=3.046,
-    flat=True,
-    m_nu=[0., 0., 0.06] * u.eV,
-    reference=("DEPRECATED: Planck Collaboration 2018, arXiv:1807.06209 v2 (Paper VI),"
                " Table 2 (TT, TE, EE + lowE + lensing + BAO)")
 ))
 
@@ -258,5 +234,5 @@ WMAP1 = MappingProxyType(dict(
 
 
 # If new parameters are added, this list must be updated
-available = ('Planck18', 'Planck18_arXiv_v2', 'Planck15', 'Planck13',
+available = ('Planck18', 'Planck15', 'Planck13',
              'WMAP9', 'WMAP7', 'WMAP5', 'WMAP3', 'WMAP1')

--- a/astropy/cosmology/realizations.py
+++ b/astropy/cosmology/realizations.py
@@ -73,11 +73,6 @@ class default_cosmology(ScienceState):
         if value is None:
             value = "Planck18"
         if isinstance(value, str):
-            if value == "Planck18_arXiv_v2":
-                warnings.warn(
-                    f"{value} is deprecated in astropy 4.2, use Planck18 instead",
-                    AstropyDeprecationWarning,
-                )
             return cls.get_cosmology_from_string(value)
         elif isinstance(value, Cosmology):
             return value

--- a/astropy/cosmology/tests/test_realizations.py
+++ b/astropy/cosmology/tests/test_realizations.py
@@ -6,7 +6,7 @@ from astropy.cosmology import parameters, realizations
 from astropy.cosmology.realizations import Planck13, default_cosmology
 from astropy.utils.exceptions import AstropyDeprecationWarning
 
-cosmo_realz = [s for s in parameters.available if s != "Planck18_arXiv_v2"]
+cosmo_realz = parameters.available
 
 
 class Test_default_cosmology(object):
@@ -29,11 +29,6 @@ class Test_default_cosmology(object):
         """Test method ``validate`` for specific values."""
         value = default_cosmology.validate(None)
         assert value is realizations.Planck18
-
-        with pytest.warns(AstropyDeprecationWarning) as e:
-            value = default_cosmology.validate("Planck18_arXiv_v2")
-        assert "use Planck18 instead" in str(e.list[0].message)
-        assert value is realizations.Planck18_arXiv_v2
 
         with pytest.raises(TypeError) as e:
             default_cosmology.validate(TypeError)

--- a/docs/changes/cosmology/12354.api.rst
+++ b/docs/changes/cosmology/12354.api.rst
@@ -1,0 +1,2 @@
+The already deprecated ``Planck18_arXiv_v2`` has been removed.
+Use ``Planck18`` instead


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

Deprecated for v4.2. Removed in v5.1, as warned in v5.0.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
