### PR TITLE
Fix ECSV tests class location

### DIFF
--- a/astropy/cosmology/tests/test_connect.py
+++ b/astropy/cosmology/tests/test_connect.py
@@ -27,7 +27,7 @@ tofrom_formats = [("mapping", dict), ("astropy.table", QTable)]
 ###############################################################################
 
 
-class ReadWriteTestMixin:
+class ReadWriteTestMixin(test_ecsv.ReadWriteECSVTestMixin):
     """
     Tests for a CosmologyRead/Write on a |Cosmology|.
     This class will not be directly called by :mod:`pytest` since its name does
@@ -103,18 +103,6 @@ class ReadWriteTestMixin:
         assert got == cosmo
         assert got.meta == cosmo.meta
 
-    @pytest.mark.skip("TODO: generalize over all save formats for this test.")
-    def test_readwrite_from_subclass_partial_info(self, cosmo, tmpdir):
-        """
-        Test writing from an instance and reading from that class.
-        This requires partial information.
-
-        .. todo::
-
-            - generalize over all save formats for this test.
-            - remove the method defined in subclass
-        """
-
 
 class TestCosmologyReadWrite(ReadWriteTestMixin):
     """Test the classes CosmologyRead/Write."""
@@ -122,6 +110,10 @@ class TestCosmologyReadWrite(ReadWriteTestMixin):
     @pytest.fixture(params=cosmo_instances)
     def cosmo(self, request):
         return getattr(cosmology.realizations, request.param)
+
+    @pytest.fixture
+    def cosmo_cls(self, cosmo):
+        return cosmo.__class__
 
     # ==============================================================
 
@@ -203,14 +195,9 @@ class TestCosmologyReadWrite(ReadWriteTestMixin):
 # To/From_Format Tests
 
 
-class ToFromFormatTestMixin(
-    # convert
-    test_mapping.ToFromMappingTestMixin, test_model.ToFromModelTestMixin,
-    test_row.ToFromRowTestMixin, test_table.ToFromTableTestMixin,
-    test_yaml.ToFromYAMLTestMixin,
-    # read/write
-    test_ecsv.ReadWriteECSVTestMixin,
-):
+class ToFromFormatTestMixin(test_mapping.ToFromMappingTestMixin, test_model.ToFromModelTestMixin,
+                            test_row.ToFromRowTestMixin, test_table.ToFromTableTestMixin,
+                            test_yaml.ToFromYAMLTestMixin):
     """
     Tests for a Cosmology[To/From]Format on a |Cosmology|.
     This class will not be directly called by :mod:`pytest` since its name does


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

I put a test class in the wrong location. No change in coverage or anything, so I'm not sure if it's worth backporting to v5.0.


### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
