### PR TITLE
Clarify LTS vs non-LTS procedure for changelog

### DIFF
--- a/docs/development/releasing.rst
+++ b/docs/development/releasing.rst
@@ -181,6 +181,17 @@ packages that use the full bugfix/maintenance branch approach.)
    Push to GitHub and open a pull request for merging this into the release branch,
    e.g. v5.0.x.
 
+   In cases where an LTS branch and a different release branch are being maintained,
+   the changelog should be rendered on both branches separately, and only the
+   rendering from the non-LTS release branch should be forward-ported to main.
+
+   .. note::
+
+      We render the changelog on the latest release branch and forward-port it
+      rather than rendering on main and backporting, since the latter would
+      render all news fragments into the changelog rather than only the ones
+      intended for the e.g. v5.0.x release branch.
+
 #. Once the changelog pull request is merged, update your release branch to
    match the upstream version, then (on the release branch), tag the merge
    commit for the changelog changes with ``v<version>``, being certain to sign


### PR DESCRIPTION

### Description

This clarifies how I think we want to handle changelog updates when two release branches (including LTS) are active.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
