### PR TITLE
setuptools_scm preferences in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,15 @@
 [build-system]
 requires = ["setuptools",
-            "setuptools_scm",
+            "setuptools_scm>=6.2",
             "wheel",
             "cython==0.29.22",
             "jinja2==2.10.3",
             "oldest-supported-numpy",
             "extension-helpers"]
 build-backend = 'setuptools.build_meta'
+
+[tool.setuptools_scm]
+write_to = "astropy/_version.py"
 
 [tool.astropy-bot]
     [tool.astropy-bot.autolabel]

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ classifiers =
 packages = find:
 zip_safe = False
 tests_require = pytest-astropy
+# setup_requires is deprecated in favor of pyproject.toml and will be removed
 setup_requires = setuptools_scm
 install_requires =
     numpy>=1.18

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,8 +24,6 @@ classifiers =
 packages = find:
 zip_safe = False
 tests_require = pytest-astropy
-# setup_requires is deprecated in favor of pyproject.toml and will be removed
-setup_requires = setuptools_scm
 install_requires =
     numpy>=1.18
     pyerfa>=2.0

--- a/setup.py
+++ b/setup.py
@@ -62,8 +62,7 @@ if 'build_docs' in sys.argv or 'build_sphinx' in sys.argv:
 
 # Only import these if the above checks are okay
 # to avoid masking the real problem with import error.
-import os  # noqa
 from setuptools import setup  # noqa
 from extension_helpers import get_extensions  # noqa
 
-setup(use_scm_version=True, ext_modules=get_extensions())
+setup(ext_modules=get_extensions())

--- a/setup.py
+++ b/setup.py
@@ -66,5 +66,4 @@ import os  # noqa
 from setuptools import setup  # noqa
 from extension_helpers import get_extensions  # noqa
 
-setup(use_scm_version={'write_to': os.path.join('astropy', '_version.py')},
-      ext_modules=get_extensions())
+setup(use_scm_version=True, ext_modules=get_extensions())


### PR DESCRIPTION
I'm very much NOT an expert in packaging infrastructure.

This PR does:
1. adds `[tool.setuptools_scm]` to `pyproject.toml`, along with the version write-to location.
2. marks for future removal `setup_requires` in setup.cfg. I don't remove this now because "Many tools, especially those that invoke setup.py for any reason, may continue to rely on setup_requires. For maximum compatibility with those uses, consider also including a setup_requires directive (described below in setup.py usage and setup.cfg)." (https://pypi.org/project/setuptools-scm/). I'm not sure when this no longer applies to Astropy. If it doesn't it would be good to remove.
2. removes stuff from ``setup.py``. Like the above, I think it may be possible to remove ``use_scm_version``, but I'm not sure.

Insight appreciated.

Fixes #12326 

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
