### PR TITLE
Fix unclosed file warning in `io.ascii` tests for big tables

### DIFF
--- a/astropy/io/ascii/tests/test_c_reader.py
+++ b/astropy/io/ascii/tests/test_c_reader.py
@@ -1005,9 +1005,9 @@ def test_read_big_table(tmpdir):
     t.write(filename, format='ascii.csv', overwrite=True)
     t = None
 
-    print("Counting the number of lines in the csv, it should be {}"
-          " + 1 (header).".format(NB_ROWS))
-    assert sum(1 for line in open(filename)) == NB_ROWS + 1
+    print("Counting the number of lines in the csv, it should be {NB_ROWS} + 1 (header).")
+    with open(filename, 'r') as f:
+        assert sum(1 for line in f) == NB_ROWS + 1
 
     print("Reading the file with astropy.")
     t = Table.read(filename, format='ascii.csv', fast_reader=True)
@@ -1023,20 +1023,20 @@ def test_read_big_table2(tmpdir):
     # (2**32 // 2) : max value for int
     # // 10 : we use a value for rows that have 10 chars (1e9)
     # + 5 : add a few lines so the length cannot be stored by an int
-    NB_ROWS = (2**32 // 2) // 10 + 5
+    NB_ROWS = 2**32 // 2 // 10 + 5
     filename = str(tmpdir.join("big_table.csv"))
 
     print(f"Creating a {NB_ROWS} rows table.")
-    data = np.full(2**32 // 2 // 10 + 5, int(1e9), dtype=np.int32)
+    data = np.full(NB_ROWS, int(1e9), dtype=np.int32)
     t = Table(data=[data], names=['a'], copy=False)
 
     print(f"Saving the table to {filename}")
     t.write(filename, format='ascii.csv', overwrite=True)
     t = None
 
-    print("Counting the number of lines in the csv, it should be {}"
-          " + 1 (header).".format(NB_ROWS))
-    assert sum(1 for line in open(filename)) == NB_ROWS + 1
+    print("Counting the number of lines in the csv, it should be {NB_ROWS} + 1 (header).")
+    with open(filename, 'r') as f:
+        assert sum(1 for line in f) == NB_ROWS + 1
 
     print("Reading the file with astropy.")
     t = Table.read(filename, format='ascii.csv', fast_reader=True)


### PR DESCRIPTION
### Description
Fixes #12352 – the extra file length checks left the file handle open.

Tested without warnings and `TEST_READ_HUGE_FILE` / `TEST_INTENSIVE` set for `open_files=True`. 
Update: also successfully tested using the `tox -e py38-test-intensive` method from #12350.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
