### PR TITLE
merge `get_cosmology_from_string` with `get`

### DIFF
--- a/astropy/cosmology/realizations.py
+++ b/astropy/cosmology/realizations.py
@@ -152,6 +152,7 @@ class default_cosmology(ScienceState):
         if isinstance(value, str):
             value = cls.get(value)
         elif not isinstance(value, Cosmology):
-            raise TypeError("default_cosmology must be a string or Cosmology instance.")
+            raise TypeError("default_cosmology must be a string or Cosmology instance, "
+                            f"not {value}.")
 
         return value

--- a/astropy/cosmology/tests/test_realizations.py
+++ b/astropy/cosmology/tests/test_realizations.py
@@ -13,7 +13,7 @@ class Test_default_cosmology(object):
     """Tests for :class:`~astropy.cosmology.realizations.default_cosmology`."""
 
     @staticmethod
-    def test_get_cosmology_from_string():
+    def test_get_cosmology_from_string(recwarn):
         """Test method ``get_cosmology_from_string``."""
         cosmo = default_cosmology.get_cosmology_from_string("no_default")
         assert cosmo is None

--- a/astropy/cosmology/tests/test_realizations.py
+++ b/astropy/cosmology/tests/test_realizations.py
@@ -3,17 +3,43 @@
 import pytest
 
 from astropy.cosmology import parameters, realizations
-from astropy.cosmology.realizations import Planck13, default_cosmology
+from astropy.cosmology.realizations import default_cosmology, Planck13
 from astropy.utils.exceptions import AstropyDeprecationWarning
-
-cosmo_realz = parameters.available
 
 
 class Test_default_cosmology(object):
     """Tests for :class:`~astropy.cosmology.realizations.default_cosmology`."""
 
-    @staticmethod
-    def test_get_cosmology_from_string(recwarn):
+    # -----------------------------------------------------
+    # Get
+
+    def test_get_fail(self):
+        """Test bad inputs to :meth:`astropy.cosmology.default_cosmology.get`."""
+        # a not-valid option, but still a str
+        with pytest.raises(ValueError, match="Unknown cosmology"):
+            cosmo = default_cosmology.get("fail!")
+
+        # a not-valid type
+        with pytest.raises(TypeError, match="'key' must be must be"):
+            cosmo = default_cosmology.get(object())
+
+    def test_get_current(self):
+        """Test :meth:`astropy.cosmology.default_cosmology.get` current value."""
+        cosmo = default_cosmology.get(None)
+        assert cosmo is default_cosmology.get(default_cosmology._value)
+
+    def test_get_none(self):
+        """Test :meth:`astropy.cosmology.default_cosmology.get` to `None`."""
+        cosmo = default_cosmology.get("no_default")
+        assert cosmo is None
+
+    @pytest.mark.parametrize("name", parameters.available)
+    def test_get_valid(self, name):
+        """Test :meth:`astropy.cosmology.default_cosmology.get` from str."""
+        cosmo = default_cosmology.get(name)
+        assert cosmo is getattr(realizations, name)
+
+    def test_get_cosmology_from_string(self, recwarn):
         """Test method ``get_cosmology_from_string``."""
         cosmo = default_cosmology.get_cosmology_from_string("no_default")
         assert cosmo is None
@@ -24,23 +50,27 @@ class Test_default_cosmology(object):
         with pytest.raises(ValueError):
             cosmo = default_cosmology.get_cosmology_from_string("fail!")
 
-    @staticmethod
-    def test_validate_specific():
+    # -----------------------------------------------------
+    # Validate
+
+    def test_validate_fail(self):
+        """Test :meth:`astropy.cosmology.default_cosmology.validate`."""
+        # bad input type
+        with pytest.raises(TypeError, match="must be a string or Cosmology"):
+            default_cosmology.validate(TypeError)
+
+    def test_validate_default(self):
         """Test method ``validate`` for specific values."""
         value = default_cosmology.validate(None)
         assert value is realizations.Planck18
 
-        with pytest.raises(TypeError) as e:
-            default_cosmology.validate(TypeError)
-        assert "string or Cosmology instance" in str(e.value)
-
-    @pytest.mark.parametrize("name", cosmo_realz)
+    @pytest.mark.parametrize("name", parameters.available)
     def test_validate_str(self, name):
         """Test method ``validate`` for string input."""
         value = default_cosmology.validate(name)
         assert value is getattr(realizations, name)
 
-    @pytest.mark.parametrize("name", cosmo_realz)
+    @pytest.mark.parametrize("name", parameters.available)
     def test_validate_cosmo(self, name):
         """Test method ``validate`` for cosmology instance input."""
         cosmo = getattr(realizations, name)

--- a/docs/changes/cosmology/12375.api.rst
+++ b/docs/changes/cosmology/12375.api.rst
@@ -1,0 +1,3 @@
+``default_cosmology.get_cosmology_from_string`` is deprecated and will be
+removed in two minor versions.
+Use ``default_cosmology.get(<str>)`` instead.


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

~Not yet sure if this is a good idea!~

``get()`` with no arguments gets the current ScienceState value. ``get(name)`` gets the cosmology of that name.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
