### PR TITLE
Build arm64 wheels for MacOS X

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,6 +40,7 @@ variables:
   CIBW_MANYLINUX_X86_64_IMAGE: manylinux2010
   CIBW_MANYLINUX_I686_IMAGE: manylinux2010
   CIBW_ARCHS_LINUX: "auto, aarch64"
+  CIBW_ARCHS_MACOS: "x86_64 arm64"
   CI: true
 
 jobs:
@@ -67,21 +68,34 @@ jobs:
       # Only run one job on PRs, so exclude musllinux here
       - wheels_cp39-manylinux_x86_64
       - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+
         - sdist
+
+        # Linux wheels
         - wheels_cp38-manylinux_i686
         - wheels_cp39-manylinux_i686
         # - wheels_cp310*linux_i686  # We can't build this as PyYAML doesn't have i686 wheels for 3.10 yet so the build takes too long
         - wheels_cp38-manylinux_x86_64
         - wheels_cp310-manylinux_x86_64
+
+        # MacOS X wheels - as noted in https://github.com/astropy/astropy/pull/12379 we deliberately
+        # do not build universal2 wheels. Note that the arm64 wheels are not actually tested so we
+        # rely on local manual testing of these to make sure they are ok.
         - wheels_cp38*macosx_x86_64
         - wheels_cp39*macosx_x86_64
         - wheels_cp310*macosx_x86_64
+        - wheels_cp38*macosx_arm64
+        - wheels_cp39*macosx_arm64
+        - wheels_cp310*macosx_arm64
+
+        # Windows wheels
         - wheels_cp38*win32
         - wheels_cp38*win_amd64
         - wheels_cp39*win32
         - wheels_cp39*win_amd64
         - wheels_cp310*win32
         - wheels_cp310*win_amd64
+
         # TODO: Add support for musllinux here (which seems to be new in cibuildwheel 2.2)
         # This seems to introduce real numerical issues
         # - wheels_cp38-musllinux_x86_64


### PR DESCRIPTION
### Description

This adds universal2 (intel + arm64) and arm64 MacOS X wheels to the wheel build matrix.

Note that for now, the arm64 part is built but cannot be tested in CI (as in the test suite is not runI) as it requires native hardware. However, I think we should still provide these wheels as users can try and pip install from source anyway on ARM macs and we aren't testing that things work fine for them, so this at least makes it so users don't have to all build the package locally, and will make it easier for those of us with ARM macs to then try and pip install the wheel and try it out.

If this works, I'd like to include it in 5.0rc2 and I can test out the ARM wheels locally to see if any issues come up.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
