### PR TITLE
Bugfix for truncated outputs when using `with_bounding_box=True`

### DIFF
--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -1027,7 +1027,7 @@ class Model(metaclass=_ModelMeta):
         """
         Model specific post evaluation processing of outputs
         """
-        if not (not isinstance(with_bbox, bool) or with_bbox) and self.n_outputs == 1:
+        if self.get_bounding_box(with_bbox) is None and self.n_outputs == 1:
             outputs = (outputs,)
 
         outputs = self.prepare_outputs(broadcasted_shapes, *outputs, **kwargs)
@@ -3173,7 +3173,7 @@ class CompoundModel(Model):
             All of the _post_evaluate for each component model will be
             performed at the time that the individual model is evaluated.
         """
-        if (not isinstance(with_bbox, bool) or with_bbox) and self.n_outputs == 1:
+        if self.get_bounding_box(with_bbox) is not None and self.n_outputs == 1:
             return outputs[0]
         return outputs
 

--- a/astropy/modeling/tests/test_core.py
+++ b/astropy/modeling/tests/test_core.py
@@ -1255,3 +1255,41 @@ def test_compound_model_mixed_array_scalar_bounding_box():
     value0 = model(x, y, slit_id)
     value1 = model(x, y, slit_id, with_bounding_box=True)
     assert_equal(value0, value1)
+
+
+def test_model_with_bounding_box_true_and_single_output():
+    """Regression test for issue #12373"""
+
+    model = models.Mapping((1,))
+    x = [1, 2]
+    y = [3, 4]
+
+    # Check baseline
+    assert_equal(model(x, y), [3, 4])
+    # Check with_bounding_box=True should be the same
+    assert_equal(model(x, y, with_bounding_box=True), [3, 4])
+
+    model.bounding_box = ((-np.inf, np.inf), (-np.inf, np.inf))
+    # Check baseline
+    assert_equal(model(x, y), [3, 4])
+    # Check with_bounding_box=True should be the same
+    assert_equal(model(x, y, with_bounding_box=True), [3, 4])
+
+
+def test_compound_model_with_bounding_box_true_and_single_output():
+    """Regression test for issue #12373"""
+
+    model = models.Mapping((1,)) | models.Shift(1)
+    x = [1, 2]
+    y = [3, 4]
+
+    # Check baseline
+    assert_equal(model(x, y), [4, 5])
+    # Check with_bounding_box=True should be the same
+    assert_equal(model(x, y, with_bounding_box=True), [4, 5])
+
+    model.bounding_box = ((-np.inf, np.inf), (-np.inf, np.inf))
+    # Check baseline
+    assert_equal(model(x, y), [4, 5])
+    # Check with_bounding_box=True should be the same
+    assert_equal(model(x, y, with_bounding_box=True), [4, 5])


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

For models with `n_outputs=1` sometimes the outputs are truncated to just the first input when using the `with_bounding_box=True` keyword argument. This was fixed by calling on the slightly more sophisticated logic
present in the `get_bounding_box()` method for `Model` instead of a few basic tests on the `with_bounding_box` keyword argument.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #12373

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
