### PR TITLE
Fix ASDF serialization of model inputs and outputs

### DIFF
--- a/astropy/io/misc/asdf/tags/transform/basic.py
+++ b/astropy/io/misc/asdf/tags/transform/basic.py
@@ -25,16 +25,10 @@ class TransformType(AstropyAsdfType):
             model.name = node['name']
 
         if "inputs" in node:
-            if model.n_inputs == 1:
-                model.inputs = (node["inputs"],)
-            else:
-                model.inputs = tuple(node["inputs"])
+            model.inputs = tuple(node["inputs"])
 
         if "outputs" in node:
-            if model.n_outputs == 1:
-                model.outputs = (node["outputs"],)
-            else:
-                model.outputs = tuple(node["outputs"])
+            model.outputs = tuple(node["outputs"])
 
         if 'bounding_box' in node:
             model.bounding_box = node['bounding_box']
@@ -75,9 +69,8 @@ class TransformType(AstropyAsdfType):
         if model.name is not None:
             node['name'] = model.name
 
-        if type(model.__class__.inputs) != property:
-            node['inputs'] = model.inputs
-            node['outputs'] = model.outputs
+        node['inputs'] = list(model.inputs)
+        node['outputs'] = list(model.outputs)
 
         try:
             bb = model.bounding_box
@@ -132,6 +125,8 @@ class TransformType(AstropyAsdfType):
         # TODO: Assert inverses are the same
         # assert the bounding_boxes are the same
         assert a.get_bounding_box() == b.get_bounding_box()
+        assert a.inputs == b.inputs
+        assert a.outputs == b.outputs
 
 
 class IdentityType(TransformType):

--- a/astropy/io/misc/asdf/tags/transform/tests/test_transform.py
+++ b/astropy/io/misc/asdf/tags/transform/tests/test_transform.py
@@ -31,6 +31,13 @@ def custom_and_analytical_inverse():
     return m1
 
 
+def custom_inputs_outputs():
+    m = astmodels.Gaussian2D()
+    m.inputs = ('a', 'b')
+    m.outputs = ('c',)
+    return m
+
+
 test_models = [
     astmodels.Identity(2), astmodels.Polynomial1D(2, c0=1, c1=2, c2=3),
     astmodels.Polynomial2D(1, c0_0=1, c0_1=2, c1_0=3),
@@ -86,7 +93,9 @@ test_models = [
     astmodels.LogParabola1D(amplitude=10, x_0=0.5, alpha=2., beta=3.,),
     astmodels.PowerLaw1D(amplitude=10., x_0=0.5, alpha=2.0),
     astmodels.SmoothlyBrokenPowerLaw1D(amplitude=10., x_break=5.0, alpha_1=2.0, alpha_2=3.0, delta=0.5),
-    custom_and_analytical_inverse()]
+    custom_and_analytical_inverse(),
+    custom_inputs_outputs(),
+]
 
 
 math_models = []

--- a/docs/changes/io.misc/12381.bugfix.rst
+++ b/docs/changes/io.misc/12381.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ASDF serialization of model inputs and outputs and add relevant assertion to test helper.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address a bug in ASDF serialization of models that prevents input and output names from being written to the file.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
