### PR TITLE
Enable direct usage of bounding box ignore function

### DIFF
--- a/astropy/modeling/bounding_box.py
+++ b/astropy/modeling/bounding_box.py
@@ -194,6 +194,10 @@ class _BoundingDomain(abc.ABC):
         self._order = self._get_order(order)
 
     @property
+    def model(self):
+        return self._model
+
+    @property
     def order(self) -> str:
         return self._order
 

--- a/astropy/modeling/bounding_box.py
+++ b/astropy/modeling/bounding_box.py
@@ -160,8 +160,9 @@ class _BoundingDomain(abc.ABC):
         on the inputs and returns a complete output.
     """
 
-    def __init__(self, model):
+    def __init__(self, model, order):
         self._model = model
+        self._order = order
 
     def __call__(self, *args, **kwargs):
         raise NotImplementedError(
@@ -540,8 +541,7 @@ class ModelBoundingBox(_BoundingDomain):
 
     def __init__(self, intervals: Dict[int, _Interval], model,
                  ignored: List[int] = None, order: str = 'C'):
-        super().__init__(model)
-        self._order = order
+        super().__init__(model, order)
 
         self._ignored = self._validate_ignored(ignored)
 
@@ -1307,8 +1307,7 @@ class CompoundBoundingBox(_BoundingDomain):
     """
     def __init__(self, bounding_boxes: Dict[Any, ModelBoundingBox], model,
                  selector_args: _SelectorArguments, create_selector: Callable = None, order: str = 'C'):
-        super().__init__(model)
-        self._order = order
+        super().__init__(model, order)
 
         self._create_selector = create_selector
         self._selector_args = _SelectorArguments.validate(model, selector_args)

--- a/astropy/modeling/bounding_box.py
+++ b/astropy/modeling/bounding_box.py
@@ -160,9 +160,27 @@ class _BoundingDomain(abc.ABC):
         on the inputs and returns a complete output.
     """
 
-    def __init__(self, model, order):
+    def __init__(self, model, order: str = 'C'):
         self._model = model
-        self._order = order
+        self._order = self._get_order(order)
+
+    @property
+    def order(self) -> str:
+        return self._order
+
+    def _get_order(self, order: str = None) -> str:
+        """
+        Get if bounding_box is C/python ordered or Fortran/mathematically
+        ordered
+        """
+        if order is None:
+            order = self._order
+
+        if order not in ('C', 'F'):
+            raise ValueError("order must be either 'C' (C/python order) or "
+                             f"'F' (Fortran/mathematical order), got: {order}.")
+
+        return order
 
     def __call__(self, *args, **kwargs):
         raise NotImplementedError(
@@ -566,10 +584,6 @@ class ModelBoundingBox(_BoundingDomain):
         return self._intervals
 
     @property
-    def order(self) -> str:
-        return self._order
-
-    @property
     def ignored(self) -> List[int]:
         return self._ignored
 
@@ -640,20 +654,6 @@ class ModelBoundingBox(_BoundingDomain):
             return _ignored_interval
         else:
             return self._intervals[self._get_index(key)]
-
-    def _get_order(self, order: str = None) -> str:
-        """
-        Get if bounding_box is C/python ordered or Fortran/mathematically
-        ordered
-        """
-        if order is None:
-            order = self._order
-
-        if order not in ('C', 'F'):
-            raise ValueError("order must be either 'C' (C/python order) or "
-                             f"'F' (Fortran/mathematical order), got: {order}.")
-
-        return order
 
     def bounding_box(self, order: str = None):
         """
@@ -1366,10 +1366,6 @@ class CompoundBoundingBox(_BoundingDomain):
     @property
     def create_selector(self):
         return self._create_selector
-
-    @property
-    def order(self) -> str:
-        return self._order
 
     @staticmethod
     def _get_selector_key(key):

--- a/astropy/modeling/bounding_box.py
+++ b/astropy/modeling/bounding_box.py
@@ -744,7 +744,7 @@ class ModelBoundingBox(_BoundingDomain):
 
     @classmethod
     def validate(cls, model, bounding_box,
-                 ignored: list = None, order: str = 'C', **kwargs):
+                 ignored: list = None, order: str = 'C', _preserve_ignore: bool = False, **kwargs):
         """
         Construct a valid bounding box for a model.
 
@@ -760,6 +760,8 @@ class ModelBoundingBox(_BoundingDomain):
         """
         if isinstance(bounding_box, ModelBoundingBox):
             order = bounding_box.order
+            if _preserve_ignore:
+                ignored = bounding_box.ignored
             bounding_box = bounding_box.intervals
 
         new = cls({}, model, ignored=ignored, order=order)
@@ -1400,7 +1402,7 @@ class CompoundBoundingBox(_BoundingDomain):
 
     @classmethod
     def validate(cls, model, bounding_box: dict, selector_args=None, create_selector=None,
-                 order: str = 'C'):
+                 order: str = 'C', **kwarg):
         """
         Construct a valid compound bounding box for a model.
 

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -4115,7 +4115,7 @@ def bind_bounding_box(modelinstance, bounding_box, ignored=None, order='C'):
 
 
 def bind_compound_bounding_box(modelinstance, bounding_boxes, selector_args,
-                               create_selector=None, order='C'):
+                               create_selector=None, ignored=None, order='C'):
     """
     Add a validated compound bounding box to a model instance.
 
@@ -4140,9 +4140,9 @@ def bind_compound_bounding_box(modelinstance, bounding_boxes, selector_args,
         ``'F'``.
     """
     modelinstance.bounding_box = CompoundBoundingBox.validate(modelinstance,
-                                                              bounding_boxes,
-                                                              selector_args,
-                                                              create_selector,
+                                                              bounding_boxes, selector_args,
+                                                              create_selector=create_selector,
+                                                              ignored=ignored,
                                                               order=order)
 
 

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -286,7 +286,7 @@ class _ModelMeta(abc.ABCMeta):
             # See if it's a hard-coded bounding_box (as a sequence) and
             # normalize it
             try:
-                bounding_box = ModelBoundingBox.validate(cls, bounding_box)
+                bounding_box = ModelBoundingBox.validate(cls, bounding_box, _preserve_ignore=True)
             except ValueError as exc:
                 raise ModelDefinitionError(exc.args[0])
         else:
@@ -1450,7 +1450,7 @@ class Model(metaclass=_ModelMeta):
 
         if cls is not None:
             try:
-                bounding_box = cls.validate(self, bounding_box)
+                bounding_box = cls.validate(self, bounding_box, _preserve_ignore=True)
             except ValueError as exc:
                 raise ValueError(exc.args[0])
 
@@ -4087,11 +4087,14 @@ def fix_inputs(modelinstance, values, bounding_boxes=None, selector_args=None):
         bbox = CompoundBoundingBox.validate(modelinstance, bounding_boxes, selector_args)
         _selector = bbox.selector_args.get_fixed_values(modelinstance, values)
 
-        model.bounding_box = bbox[_selector]
+        new_bbox = bbox[_selector]
+        new_bbox = new_bbox.__class__.validate(model, new_bbox)
+
+        model.bounding_box = new_bbox
     return model
 
 
-def bind_bounding_box(modelinstance, bounding_box, order='C'):
+def bind_bounding_box(modelinstance, bounding_box, ignored=None, order='C'):
     """
     Set a validated bounding box to a model instance.
 
@@ -4107,6 +4110,7 @@ def bind_bounding_box(modelinstance, bounding_box, order='C'):
     """
     modelinstance.bounding_box = ModelBoundingBox.validate(modelinstance,
                                                            bounding_box,
+                                                           ignored=ignored,
                                                            order=order)
 
 

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -4104,6 +4104,8 @@ def bind_bounding_box(modelinstance, bounding_box, ignored=None, order='C'):
         This is the model that the validated bounding box will be set on.
     bounding_box : tuple
         A bounding box tuple, see :ref:`astropy:bounding-boxes` for details
+    ignored : list
+        List of the inputs to be ignored by the bounding box.
     order : str, optional
         The ordering of the bounding box tuple, can be either ``'C'`` or
         ``'F'``.
@@ -4135,6 +4137,8 @@ def bind_compound_bounding_box(modelinstance, bounding_boxes, selector_args,
         there is no bounding box in the compound bounding box listed under
         that selector value. Default is ``None``, meaning new bounding
         box entries will not be automatically generated.
+    ignored : list
+        List of the inputs to be ignored by the bounding box.
     order : str, optional
         The ordering of the bounding box tuple, can be either ``'C'`` or
         ``'F'``.

--- a/astropy/modeling/tests/test_bounding_box.py
+++ b/astropy/modeling/tests/test_bounding_box.py
@@ -213,12 +213,14 @@ class Test_BoundingDomain:
 
     def test_create(self):
         model = mk.MagicMock()
-        bounding_box = self.BoundingDomain(model)
+        order = mk.MagicMock()
+        bounding_box = self.BoundingDomain(model, order)
 
         assert bounding_box._model == model
+        assert bounding_box._order == order
 
     def test___call__(self):
-        bounding_box = self.BoundingDomain(mk.MagicMock())
+        bounding_box = self.BoundingDomain(mk.MagicMock(), mk.MagicMock())
 
         args = tuple([mk.MagicMock() for _ in range(3)])
         kwargs = {f"test{idx}": mk.MagicMock() for idx in range(3)}
@@ -230,7 +232,7 @@ class Test_BoundingDomain:
             "adjustable parameters."
 
     def test_fix_inputs(self):
-        bounding_box = self.BoundingDomain(mk.MagicMock())
+        bounding_box = self.BoundingDomain(mk.MagicMock(), mk.MagicMock())
         model = mk.MagicMock()
         fixed_inputs = mk.MagicMock()
 
@@ -240,7 +242,7 @@ class Test_BoundingDomain:
             "This should be implemented by a child class."
 
     def test__prepare_inputs(self):
-        bounding_box = self.BoundingDomain(mk.MagicMock())
+        bounding_box = self.BoundingDomain(mk.MagicMock(), mk.MagicMock())
 
         with pytest.raises(NotImplementedError) as err:
             bounding_box.prepare_inputs(mk.MagicMock(), mk.MagicMock())
@@ -248,7 +250,7 @@ class Test_BoundingDomain:
             "This has not been implemented for BoundingDomain."
 
     def test__base_ouput(self):
-        bounding_box = self.BoundingDomain(mk.MagicMock())
+        bounding_box = self.BoundingDomain(mk.MagicMock(), mk.MagicMock())
 
         # Simple shape
         input_shape = (13,)
@@ -276,7 +278,7 @@ class Test_BoundingDomain:
 
     def test__all_out_output(self):
         model = mk.MagicMock()
-        bounding_box = self.BoundingDomain(model)
+        bounding_box = self.BoundingDomain(model, mk.MagicMock())
 
         # Simple shape
         model.n_outputs = 1
@@ -295,7 +297,7 @@ class Test_BoundingDomain:
         assert output_unit is None
 
     def test__modify_output(self):
-        bounding_box = self.BoundingDomain(mk.MagicMock())
+        bounding_box = self.BoundingDomain(mk.MagicMock(), mk.MagicMock())
         valid_index = mk.MagicMock()
         input_shape = mk.MagicMock()
         fill_value = mk.MagicMock()
@@ -315,7 +317,7 @@ class Test_BoundingDomain:
             assert mkBase.call_args_list == [mk.call(input_shape, fill_value)]
 
     def test__prepare_outputs(self):
-        bounding_box = self.BoundingDomain(mk.MagicMock())
+        bounding_box = self.BoundingDomain(mk.MagicMock(), mk.MagicMock())
         valid_index = mk.MagicMock()
         input_shape = mk.MagicMock()
         fill_value = mk.MagicMock()
@@ -332,7 +334,7 @@ class Test_BoundingDomain:
 
     def test_prepare_outputs(self):
         model = mk.MagicMock()
-        bounding_box = self.BoundingDomain(model)
+        bounding_box = self.BoundingDomain(model, mk.MagicMock())
 
         valid_outputs = mk.MagicMock()
         valid_index = mk.MagicMock()
@@ -356,7 +358,7 @@ class Test_BoundingDomain:
                 [mk.call(bounding_box, valid_outputs, valid_index, input_shape, fill_value)]
 
     def test__get_valid_outputs_unit(self):
-        bounding_box = self.BoundingDomain(mk.MagicMock())
+        bounding_box = self.BoundingDomain(mk.MagicMock(), mk.MagicMock())
 
         # Don't get unit
         assert bounding_box._get_valid_outputs_unit(mk.MagicMock(), False) is None
@@ -368,7 +370,7 @@ class Test_BoundingDomain:
         assert bounding_box._get_valid_outputs_unit(25 * u.m, True) == u.m
 
     def test__evaluate_model(self):
-        bounding_box = self.BoundingDomain(mk.MagicMock())
+        bounding_box = self.BoundingDomain(mk.MagicMock(), mk.MagicMock())
 
         evaluate = mk.MagicMock()
         valid_inputs = mk.MagicMock()
@@ -394,7 +396,7 @@ class Test_BoundingDomain:
                     [mk.call(valid_inputs)]
 
     def test__evaluate(self):
-        bounding_box = self.BoundingDomain(mk.MagicMock())
+        bounding_box = self.BoundingDomain(mk.MagicMock(), mk.MagicMock())
 
         evaluate = mk.MagicMock()
         inputs = mk.MagicMock()
@@ -437,7 +439,7 @@ class Test_BoundingDomain:
                         [mk.call(bounding_box, input_shape, inputs)]
 
     def test__set_outputs_unit(self):
-        bounding_box = self.BoundingDomain(mk.MagicMock())
+        bounding_box = self.BoundingDomain(mk.MagicMock(), mk.MagicMock())
 
         # set no unit
         assert 27 == bounding_box._set_outputs_unit(27, None)
@@ -446,7 +448,7 @@ class Test_BoundingDomain:
         assert 27 * u.m == bounding_box._set_outputs_unit(27, u.m)
 
     def test_evaluate(self):
-        bounding_box = self.BoundingDomain(Gaussian2D())
+        bounding_box = self.BoundingDomain(Gaussian2D(), mk.MagicMock())
 
         evaluate = mk.MagicMock()
         inputs = mk.MagicMock()

--- a/astropy/modeling/tests/test_bounding_box.py
+++ b/astropy/modeling/tests/test_bounding_box.py
@@ -231,6 +231,12 @@ class Test_BoundingDomain:
         with pytest.raises(ValueError):
             self.BoundingDomain(model, order=mk.MagicMock())
 
+    def test_model(self):
+        model = mk.MagicMock()
+        bounding_box = self.BoundingDomain(model)
+        assert bounding_box._model == model
+        assert bounding_box.model == model
+
     def test_order(self):
         bounding_box = self.BoundingDomain(mk.MagicMock(), order='C')
         assert bounding_box._order == 'C'

--- a/astropy/modeling/tests/test_bounding_box.py
+++ b/astropy/modeling/tests/test_bounding_box.py
@@ -214,13 +214,18 @@ class Test_BoundingDomain:
     def test_create(self):
         model = mk.MagicMock()
         bounding_box = self.BoundingDomain(model)
-
         assert bounding_box._model == model
+        assert bounding_box._ignored == []
         assert bounding_box._order == 'C'
 
         bounding_box = self.BoundingDomain(model, order='F')
         assert bounding_box._model == model
+        assert bounding_box._ignored == []
         assert bounding_box._order == 'F'
+
+        bounding_box = self.BoundingDomain(Gaussian2D(), ['x'])
+        assert bounding_box._ignored == [0]
+        assert bounding_box._order == 'C'
 
         # Error
         with pytest.raises(ValueError):
@@ -237,6 +242,16 @@ class Test_BoundingDomain:
 
         bounding_box._order = 'test'
         assert bounding_box.order == 'test'
+
+    def test_ignored(self):
+        ignored = [0]
+        model = mk.MagicMock()
+        model.n_inputs = 1
+        model.inputs = ['x']
+        bounding_box = self.BoundingDomain(model, ignored=ignored)
+
+        assert bounding_box._ignored == ignored
+        assert bounding_box.ignored == ignored
 
     def test__get_order(self):
         bounding_box = self.BoundingDomain(mk.MagicMock())
@@ -261,6 +276,102 @@ class Test_BoundingDomain:
         assert str(err.value) ==\
             "order must be either 'C' (C/python order) or " +\
             f"'F' (Fortran/mathematical order), got: {order}."
+
+    def test__get_index(self):
+        bounding_box = self.BoundingDomain(Gaussian2D())
+
+        # Pass input name
+        assert bounding_box._get_index('x') == 0
+        assert bounding_box._get_index('y') == 1
+
+        # Pass invalid input name
+        with pytest.raises(ValueError) as err:
+            bounding_box._get_index('z')
+        assert str(err.value) ==\
+            "'z' is not one of the inputs: ('x', 'y')."
+
+        # Pass valid index
+        assert bounding_box._get_index(0) == 0
+        assert bounding_box._get_index(1) == 1
+        assert bounding_box._get_index(np.int32(0)) == 0
+        assert bounding_box._get_index(np.int32(1)) == 1
+        assert bounding_box._get_index(np.int64(0)) == 0
+        assert bounding_box._get_index(np.int64(1)) == 1
+
+        # Pass invalid index
+        MESSAGE = "Integer key: 2 must be non-negative and < 2."
+        with pytest.raises(IndexError) as err:
+            bounding_box._get_index(2)
+        assert str(err.value) == MESSAGE
+        with pytest.raises(IndexError) as err:
+            bounding_box._get_index(np.int32(2))
+        assert str(err.value) == MESSAGE
+        with pytest.raises(IndexError) as err:
+            bounding_box._get_index(np.int64(2))
+        assert str(err.value) == MESSAGE
+        with pytest.raises(IndexError) as err:
+            bounding_box._get_index(-1)
+        assert str(err.value) ==\
+            "Integer key: -1 must be non-negative and < 2."
+
+        # Pass invalid key
+        value = mk.MagicMock()
+        with pytest.raises(ValueError) as err:
+            bounding_box._get_index(value)
+        assert str(err.value) ==\
+            f"Key value: {value} must be string or integer."
+
+    def test__get_name(self):
+        model = mk.MagicMock()
+        model.n_inputs = 1
+        model.inputs = ['x']
+        bounding_box = self.BoundingDomain(model)
+
+        index = mk.MagicMock()
+        name = mk.MagicMock()
+        model.inputs = mk.MagicMock()
+        model.inputs.__getitem__.return_value = name
+        assert bounding_box._get_name(index) == name
+        assert model.inputs.__getitem__.call_args_list == [mk.call(index)]
+
+    def test_ignored_inputs(self):
+        model = mk.MagicMock()
+        ignored = list(range(4, 8))
+        model.n_inputs = 8
+        model.inputs = [mk.MagicMock() for _ in range(8)]
+        bounding_box = self.BoundingDomain(model, ignored=ignored)
+
+        inputs = bounding_box.ignored_inputs
+        assert isinstance(inputs, list)
+        for index, _input in enumerate(inputs):
+            assert _input in model.inputs
+            assert model.inputs[index + 4] == _input
+        for index, _input in enumerate(model.inputs):
+            if _input in inputs:
+                assert inputs[index - 4] == _input
+            else:
+                assert index < 4
+
+    def test__validate_ignored(self):
+        bounding_box = self.BoundingDomain(Gaussian2D())
+
+        # Pass
+        assert bounding_box._validate_ignored(None) == []
+        assert bounding_box._validate_ignored(['x', 'y']) == [0, 1]
+        assert bounding_box._validate_ignored([0, 1]) == [0, 1]
+        assert bounding_box._validate_ignored([np.int32(0), np.int64(1)]) == [0, 1]
+
+        # Fail
+        with pytest.raises(ValueError):
+            bounding_box._validate_ignored([mk.MagicMock()])
+        with pytest.raises(ValueError):
+            bounding_box._validate_ignored(['z'])
+        with pytest.raises(IndexError):
+            bounding_box._validate_ignored([3])
+        with pytest.raises(IndexError):
+            bounding_box._validate_ignored([np.int32(3)])
+        with pytest.raises(IndexError):
+            bounding_box._validate_ignored([np.int64(3)])
 
     def test___call__(self):
         bounding_box = self.BoundingDomain(mk.MagicMock())
@@ -620,30 +731,6 @@ class TestModelBoundingBox:
         assert bounding_box._intervals == intervals
         assert bounding_box.intervals == intervals
 
-    def test_ignored(self):
-        ignored = [0]
-        model = mk.MagicMock()
-        model.n_inputs = 1
-        model.inputs = ['x']
-        bounding_box = ModelBoundingBox({}, model, ignored=ignored)
-
-        assert bounding_box._ignored == ignored
-        assert bounding_box.ignored == ignored
-
-    def test__get_name(self):
-        intervals = {0: _Interval(1, 2)}
-        model = mk.MagicMock()
-        model.n_inputs = 1
-        model.inputs = ['x']
-        bounding_box = ModelBoundingBox(intervals, model)
-
-        index = mk.MagicMock()
-        name = mk.MagicMock()
-        model.inputs = mk.MagicMock()
-        model.inputs.__getitem__.return_value = name
-        assert bounding_box._get_name(index) == name
-        assert model.inputs.__getitem__.call_args_list == [mk.call(index)]
-
     def test_named_intervals(self):
         intervals = {idx: _Interval(idx, idx + 1) for idx in range(4)}
         model = mk.MagicMock()
@@ -660,25 +747,6 @@ class TestModelBoundingBox:
             assert index in intervals
             assert name in named
             assert intervals[index] == named[name]
-
-    def test_ignored_inputs(self):
-        intervals = {idx: _Interval(idx, idx + 1) for idx in range(4)}
-        model = mk.MagicMock()
-        ignored = list(range(4, 8))
-        model.n_inputs = 8
-        model.inputs = [mk.MagicMock() for _ in range(8)]
-        bounding_box = ModelBoundingBox(intervals, model, ignored=ignored)
-
-        inputs = bounding_box.ignored_inputs
-        assert isinstance(inputs, list)
-        for index, _input in enumerate(inputs):
-            assert _input in model.inputs
-            assert model.inputs[index + 4] == _input
-        for index, _input in enumerate(model.inputs):
-            if _input in inputs:
-                assert inputs[index - 4] == _input
-            else:
-                assert index < 4
 
     def test___repr__(self):
         intervals = {0: _Interval(-1, 1), 1: _Interval(-4, 4)}
@@ -708,74 +776,6 @@ class TestModelBoundingBox:
             "    model=Gaussian2D(inputs=('x', 'y'))\n" +\
             "    order='C'\n" +\
             ")"
-
-    def test__get_index(self):
-        intervals = {0: _Interval(-1, 1), 1: _Interval(-4, 4)}
-        model = Gaussian2D()
-        bounding_box = ModelBoundingBox.validate(model, intervals)
-
-        # Pass input name
-        assert bounding_box._get_index('x') == 0
-        assert bounding_box._get_index('y') == 1
-
-        # Pass invalid input name
-        with pytest.raises(ValueError) as err:
-            bounding_box._get_index('z')
-        assert str(err.value) ==\
-            "'z' is not one of the inputs: ('x', 'y')."
-
-        # Pass valid index
-        assert bounding_box._get_index(0) == 0
-        assert bounding_box._get_index(1) == 1
-        assert bounding_box._get_index(np.int32(0)) == 0
-        assert bounding_box._get_index(np.int32(1)) == 1
-        assert bounding_box._get_index(np.int64(0)) == 0
-        assert bounding_box._get_index(np.int64(1)) == 1
-
-        # Pass invalid index
-        MESSAGE = "Integer key: 2 must be non-negative and < 2."
-        with pytest.raises(IndexError) as err:
-            bounding_box._get_index(2)
-        assert str(err.value) == MESSAGE
-        with pytest.raises(IndexError) as err:
-            bounding_box._get_index(np.int32(2))
-        assert str(err.value) == MESSAGE
-        with pytest.raises(IndexError) as err:
-            bounding_box._get_index(np.int64(2))
-        assert str(err.value) == MESSAGE
-        with pytest.raises(IndexError) as err:
-            bounding_box._get_index(-1)
-        assert str(err.value) ==\
-            "Integer key: -1 must be non-negative and < 2."
-
-        # Pass invalid key
-        value = mk.MagicMock()
-        with pytest.raises(ValueError) as err:
-            bounding_box._get_index(value)
-        assert str(err.value) ==\
-            f"Key value: {value} must be string or integer."
-
-    def test__validate_ignored(self):
-        model = Gaussian2D()
-        bounding_box = ModelBoundingBox({}, model)
-
-        # Pass
-        assert bounding_box._validate_ignored(None) == []
-        assert bounding_box._validate_ignored(['x', 'y']) == [0, 1]
-        assert bounding_box._validate_ignored([0, 1]) == [0, 1]
-        assert bounding_box._validate_ignored([np.int32(0), np.int64(1)]) == [0, 1]
-
-        # Fail
-        with pytest.raises(ValueError):
-            bounding_box._validate_ignored([mk.MagicMock()])
-        with pytest.raises(ValueError):
-            bounding_box._validate_ignored(['z'])
-        with pytest.raises(IndexError):
-            bounding_box._validate_ignored([3])
-        with pytest.raises(IndexError):
-            bounding_box._validate_ignored([np.int32(3)])
-        with pytest.raises(IndexError):
-            bounding_box._validate_ignored([np.int64(3)])
 
     def test___len__(self):
         intervals = {0: _Interval(-1, 1)}

--- a/astropy/modeling/tests/test_core.py
+++ b/astropy/modeling/tests/test_core.py
@@ -1326,3 +1326,11 @@ def test_bounding_box_pass_with_ignored():
     bind_bounding_box(model, (-1, 1), ignored=['y'])
     assert model.bounding_box.bounding_box() == (-1, 1)
     assert model.bounding_box == bbox
+
+
+def test_compound_bounding_box_pass_with_ignored():
+    model = models.Shift(1) & models.Shift(2) & models.Identity(1)
+    model.inputs = ('x', 'y', 'slit_id')
+    bbox = {(0,): ModelBoundingBox.validate(model, (-0.5, 1047.5), ignored=['y', 'slit_id']),
+            (1,): ModelBoundingBox.validate(model, (-0.5, 1047.5), ignored=['y', 'slit_id']), }
+    cbbox = CompoundBoundingBox.validate(model, bbox, selector_args=[('slit_id', True)], order='F')

--- a/astropy/modeling/tests/test_core.py
+++ b/astropy/modeling/tests/test_core.py
@@ -1331,6 +1331,14 @@ def test_bounding_box_pass_with_ignored():
 def test_compound_bounding_box_pass_with_ignored():
     model = models.Shift(1) & models.Shift(2) & models.Identity(1)
     model.inputs = ('x', 'y', 'slit_id')
-    bbox = {(0,): ModelBoundingBox.validate(model, (-0.5, 1047.5), ignored=['y', 'slit_id']),
-            (1,): ModelBoundingBox.validate(model, (-0.5, 1047.5), ignored=['y', 'slit_id']), }
-    cbbox = CompoundBoundingBox.validate(model, bbox, selector_args=[('slit_id', True)], order='F')
+    bbox = {(0,): (-0.5, 1047.5),
+            (1,): (-0.5, 2047.5), }
+    cbbox = CompoundBoundingBox.validate(model, bbox, selector_args=[('slit_id', True)],
+                                         ignored=['y'], order='F')
+    model.bounding_box = cbbox
+
+    model = models.Shift(1) & models.Shift(2) & models.Identity(1)
+    model.inputs = ('x', 'y', 'slit_id')
+    bind_compound_bounding_box(model, bbox, selector_args=[('slit_id', True)],
+                               ignored=['y'], order='F')
+    assert model.bounding_box == cbbox

--- a/astropy/modeling/tests/test_core.py
+++ b/astropy/modeling/tests/test_core.py
@@ -1311,3 +1311,18 @@ def test_compound_model_with_bounding_box_true_and_single_output():
     assert_equal(model(x, y), [4, 5])
     # Check with_bounding_box=True should be the same
     assert_equal(model(x, y, with_bounding_box=True), [4, 5])
+
+
+def test_bounding_box_pass_with_ignored():
+    """Test the possiblity of setting ignored variables in bounding box"""
+
+    model = models.Polynomial2D(2)
+    bbox = ModelBoundingBox.validate(model, (-1, 1), ignored=['y'])
+    model.bounding_box = bbox
+    assert model.bounding_box.bounding_box() == (-1, 1)
+    assert model.bounding_box == bbox
+
+    model = models.Polynomial2D(2)
+    bind_bounding_box(model, (-1, 1), ignored=['y'])
+    assert model.bounding_box.bounding_box() == (-1, 1)
+    assert model.bounding_box == bbox

--- a/docs/changes/modeling/12384.feature.rst
+++ b/docs/changes/modeling/12384.feature.rst
@@ -1,0 +1,2 @@
+Enable direct use of the ``ignored`` feature of ``ModelBoundingBox`` by users in
+addition to its use as part of enabling ``CompoundBoundingBox``.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request proposes an interface which enables the user to easily "ignore" some variables from the `bounding_box`'s use. The primary use for this is for models with multiple inputs where a single input is unbounded. This is achievable via setting the bounding interval for those inputs to be `(-np.inf, np.inf)`; however, this is cumbersome. This PR leverages the existing `ignored` feature of `ModelBoundingBox`.

Note that the `ignored` feature of `ModelBoundingBox` was originally introduced as so that selector inputs for compound bounding boxes could be ignored; however, there was no effort made to allow more general use of them. This PR is an attempt to make this feature available to users.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
