### PR TITLE
isort pyinstaller

### DIFF
--- a/.pyinstaller/hooks/hook-skyfield.py
+++ b/.pyinstaller/hooks/hook-skyfield.py
@@ -2,4 +2,5 @@
 # https://github.com/pyinstaller/pyinstaller-hooks-contrib
 # once that repository is ready for pull requests
 from PyInstaller.utils.hooks import collect_data_files
+
 datas = collect_data_files('skyfield')

--- a/.pyinstaller/run_astropy_tests.py
+++ b/.pyinstaller/run_astropy_tests.py
@@ -1,13 +1,16 @@
 # We need to import this here and run metadata.version to make sure
 # metadata.version('numpy') works correctly in the astropy code itself.
 from importlib import metadata
+
 metadata.version('numpy')
 
 import os
-import sys
-import pytest
 import shutil
+import sys
+
 import erfa  # noqa
+import pytest
+
 import astropy  # noqa
 
 if len(sys.argv) == 3 and sys.argv[1] == '--astropy-root':


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
