### PR TITLE
isort top-level astropy

### DIFF
--- a/astropy/__init__.py
+++ b/astropy/__init__.py
@@ -6,8 +6,8 @@ Python. It also provides an index for other astronomy packages and tools for
 managing them.
 """
 
-import sys
 import os
+import sys
 from warnings import warn
 
 from .version import version as __version__
@@ -133,6 +133,7 @@ class astronomical_constants(base_constants_version):
 
 # Create the test() function
 from .tests.runner import TestRunner  # noqa: E402
+
 test = TestRunner.make_test_runner_in(__path__[0])
 
 
@@ -189,8 +190,8 @@ def online_help(query):
     query : str
         The search query.
     """
-    from urllib.parse import urlencode
     import webbrowser
+    from urllib.parse import urlencode
 
     version = __version__
     if 'dev' in version:
@@ -209,6 +210,7 @@ __dir_inc__ = ['__version__', '__githash__',
 
 
 from types import ModuleType as __module_type__  # noqa: E402
+
 # Clean up top-level namespace--delete everything that isn't in __dir_inc__
 # or is a magic attribute, and that isn't a submodule of this package
 for varname in dir():

--- a/astropy/_dev/scm_version.py
+++ b/astropy/_dev/scm_version.py
@@ -1,6 +1,7 @@
 # Try to use setuptools_scm to get the current version; this is only used
 # in development installations from the git repository.
 import os.path as pth
+
 try:
     from setuptools_scm import get_version
     version = get_version(root=pth.join('..', '..'), relative_to=__file__)

--- a/astropy/_erfa/__init__.py
+++ b/astropy/_erfa/__init__.py
@@ -1,14 +1,13 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import warnings
 
-from erfa import core, ufunc, helpers  # noqa
+from erfa import core, helpers, ufunc  # noqa
 from erfa.core import *  # noqa
-from erfa.ufunc import (dt_eraASTROM, dt_eraLDBODY, dt_eraLEAPSECOND, dt_pv,  # noqa
-                        dt_sign, dt_type, dt_ymdf, dt_hmsf, dt_dmsf)
 from erfa.helpers import leap_seconds  # noqa
+from erfa.ufunc import (dt_dmsf, dt_eraASTROM, dt_eraLDBODY,  # noqa
+                        dt_eraLEAPSECOND, dt_hmsf, dt_pv, dt_sign, dt_type, dt_ymdf)
 
 from astropy.utils.exceptions import AstropyDeprecationWarning
-
 
 warnings.warn('The private astropy._erfa module has been made into its '
               'own package, pyerfa, which is a dependency of '

--- a/astropy/conftest.py
+++ b/astropy/conftest.py
@@ -4,8 +4,8 @@ This file contains pytest configuration settings that are astropy-specific
 (i.e.  those that would not necessarily be shared by affiliated packages
 making use of astropy's test runner).
 """
-import os
 import builtins
+import os
 import sys
 import tempfile
 import warnings


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

isort top-level astropy 

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
