### PR TITLE
Depreciate `AliasDict`

### DIFF
--- a/astropy/modeling/utils.py
+++ b/astropy/modeling/utils.py
@@ -10,14 +10,21 @@ from inspect import signature
 
 import numpy as np
 import warnings
-from astropy.utils import isiterable
 
 from astropy import units as u
+from astropy.utils.decorators import deprecated
 
-
+__doctest_skip__ = ['AliasDict']
 __all__ = ['AliasDict', 'poly_map_domain', 'comb', 'ellipse_extent']
 
 
+deprecation_msg = """
+AliasDict is deprecated because it no longer serves a function anywhere
+inside astropy.
+"""
+
+
+@deprecated('5.0', deprecation_msg)
 class AliasDict(MutableMapping):
     """
     Creates a `dict` like object that wraps an existing `dict` or other
@@ -342,18 +349,6 @@ def get_inputs_and_params(func):
             params.append(param)
 
     return inputs, params
-
-
-def _parameter_with_unit(parameter, unit):
-    if parameter.unit is None:
-        return parameter.value * unit
-    return parameter.quantity.to(unit)
-
-
-def _parameter_without_unit(value, old_unit, new_unit):
-    if old_unit is None:
-        return value
-    return value * old_unit.to(new_unit)
 
 
 def _combine_equivalency_dict(keys, eq1=None, eq2=None):

--- a/docs/changes/modeling/12411.api.rst
+++ b/docs/changes/modeling/12411.api.rst
@@ -1,0 +1,1 @@
+Deprecated the ``AliasDict`` class in ``modeling.utils``.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

The class `~astropy.modeling.utils.AliasDict` seems to no longer serve any function within astropy. This PR depreciates this class as it appears to be dead code.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
