### PR TITLE
move `test_flrw_moved_deprecation` test

### DIFF
--- a/astropy/cosmology/tests/test_core.py
+++ b/astropy/cosmology/tests/test_core.py
@@ -21,6 +21,7 @@ from astropy.cosmology import Cosmology, core
 from astropy.cosmology.core import _COSMOLOGY_CLASSES
 from astropy.cosmology.parameter import Parameter
 from astropy.table import QTable, Table
+from astropy.utils.exceptions import AstropyDeprecationWarning
 from astropy.utils.metadata import MetaData
 
 from .test_connect import ReadWriteTestMixin, ToFromFormatTestMixin
@@ -313,3 +314,18 @@ class FlatCosmologyMixinTest:
         vs   FlatFLRWMixinTest -> FlatCosmologyMixinTest -> TestFLRW -> TestCosmology
         """
         CosmologySubclassTest.test_is_equivalent(self, cosmo)
+
+
+# -----------------------------------------------------------------------------
+
+
+def test_flrw_moved_deprecation():
+    """Test the deprecation warning about the move of FLRW classes."""
+    from astropy.cosmology import flrw
+
+    # it's deprecated to import `flrw/*` from `core.py`
+    with pytest.warns(AstropyDeprecationWarning):
+        from astropy.cosmology.core import FLRW
+
+    # but they are the same object
+    assert FLRW is flrw.FLRW

--- a/astropy/cosmology/tests/test_cosmology.py
+++ b/astropy/cosmology/tests/test_cosmology.py
@@ -15,14 +15,6 @@ from astropy.utils.compat.optional_deps import HAS_SCIPY
 from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyUserWarning
 
 
-def test_flrw_moved_deprecation():
-    """Test the  deprecation warning about the move of FLRW classes."""
-    with pytest.warns(AstropyDeprecationWarning):
-        from astropy.cosmology.core import FLRW
-
-    assert FLRW is flrw.FLRW
-
-
 def test_init():
     """ Tests to make sure the code refuses inputs it is supposed to"""
     with pytest.raises(ValueError):


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

Moving another test.
Gonna move them all by v5.1 and stabilize the test suite API. Hopefully make it super easy to add new IO formats and cosmology classes to Astropy. And if the format/class is in 3rd party code to use this test suite to test the format/class.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
