### PR TITLE
Fix init of table from list of Mapping

### DIFF
--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -194,7 +194,7 @@ def _get_names_from_list_of_dict(rows):
 
     names = set()
     for row in rows:
-        if not isinstance(row, dict):
+        if not isinstance(row, Mapping):
             return None
         names.update(row)
     return list(names)
@@ -867,7 +867,7 @@ class Table:
             # For a Row object transform to an equivalent dict.
             values = {name: values[name] for name in values.colnames}
 
-        if not isinstance(values, dict):
+        if not isinstance(values, Mapping):
             # If not a dict map, assume iterable and map to dict if the right length
             if len(values) != len(self.columns):
                 raise ValueError(f'sequence of {attr} values must match number of columns')
@@ -2989,15 +2989,10 @@ class Table:
         if index < 0:
             index += N
 
-        def _is_mapping(obj):
-            """Minimal checker for mapping (dict-like) interface for obj"""
-            attrs = ('__getitem__', '__len__', '__iter__', 'keys', 'values', 'items')
-            return all(hasattr(obj, attr) for attr in attrs)
-
-        if _is_mapping(vals) or vals is None:
+        if isinstance(vals, Mapping) or vals is None:
             # From the vals and/or mask mappings create the corresponding lists
             # that have entries for each table column.
-            if mask is not None and not _is_mapping(mask):
+            if mask is not None and not isinstance(mask, Mapping):
                 raise TypeError("Mismatch between type of vals and mask")
 
             # Now check that the mask is specified for the same keys as the
@@ -3032,7 +3027,7 @@ class Table:
             mask = mask_list
 
         if isiterable(vals):
-            if mask is not None and (not isiterable(mask) or _is_mapping(mask)):
+            if mask is not None and (not isiterable(mask) or isinstance(mask, Mapping)):
                 raise TypeError("Mismatch between type of vals and mask")
 
             if len(self.columns) != len(vals):
@@ -3386,7 +3381,7 @@ class Table:
             If a certain column is not in the dict given, it will remain the
             same.
         '''
-        if isinstance(decimals, dict):
+        if isinstance(decimals, Mapping):
             decimal_values = decimals.values()
             column_names = decimals.keys()
         elif isinstance(decimals, int):

--- a/docs/changes/table/12417.bugfix.rst
+++ b/docs/changes/table/12417.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed an issue where initializing from a list of dict-like rows (Mappings) did
+not work unless the row values were instances of ``dict``. Now any object that
+is an instance of the more general ``collections.abc.Mapping`` will work.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request fixes a few places in the table code which explicitly referenced `dict` when it should be the more general `collections.abc.Mapping`.

The specific example that came up is using a list of FITS headers (from `fits.getheader(filename)`). This now should work.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #8118

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
