### PR TITLE
Fix tight_layout for WCSAxes

### DIFF
--- a/astropy/tests/figures/py39-test-image-mpl311.json
+++ b/astropy/tests/figures/py39-test-image-mpl311.json
@@ -3,6 +3,7 @@
   "astropy.visualization.wcsaxes.tests.test_frame.TestFrame.test_update_clip_path_rectangular": "d40c2b8cf866d5c67b94fd2dbed93933966340892f0bd08a181cfdcce83b9d7b",
   "astropy.visualization.wcsaxes.tests.test_frame.TestFrame.test_update_clip_path_nonrectangular": "fff881a1a786ff5d91a0e4d04c2cdc3f22065c14b69d8cf4a1f7f52564b689a1",
   "astropy.visualization.wcsaxes.tests.test_frame.TestFrame.test_update_clip_path_change_wcs": "4e7b2987ea47d21c4c1c0fe155acf3d2c634dff64120f039bbd677c4022ab980",
+  "astropy.visualization.wcsaxes.tests.test_images.TestBasic.test_tight_layout": "31e38883b6334728a745dccf31ab25e554038160f871fa04b069450dd28fc9f4",
   "astropy.visualization.wcsaxes.tests.test_images.TestBasic.test_image_plot": "171e531cfb5df305db9c240ec0e73e97ab13922ae6117d34aeab7f976ac605ff",
   "astropy.visualization.wcsaxes.tests.test_images.TestBasic.test_axes_off": "a6236830a0c4fdbfad9d65b3dd66ee07a40028a3e59eb9ff646be6f6ab935971",
   "astropy.visualization.wcsaxes.tests.test_images.TestBasic.test_axisbelow[True]": "6ed81e1156e2a1ddb5a74cbaf835b76e9f6919d4b619d7732c6ee3267994e2b6",

--- a/astropy/tests/figures/py39-test-image-mpldev.json
+++ b/astropy/tests/figures/py39-test-image-mpldev.json
@@ -3,6 +3,7 @@
   "astropy.visualization.wcsaxes.tests.test_frame.TestFrame.test_update_clip_path_rectangular": "66ffe63ff629746487f2e61948b793e149b83c5ffe918f36c511c514173eb9cd",
   "astropy.visualization.wcsaxes.tests.test_frame.TestFrame.test_update_clip_path_nonrectangular": "4b1d06507697d8a4bc4c044e98ba2d0a7590334368723e008076e7f78515b689",
   "astropy.visualization.wcsaxes.tests.test_frame.TestFrame.test_update_clip_path_change_wcs": "7689bd5b70feb9e58d8ec8d383d99c39c383efaf5f3fb680908c5f8183b626c2",
+  "astropy.visualization.wcsaxes.tests.test_images.TestBasic.test_tight_layout": "4ffca112bf08be3ea8aad05ab47eb16317fe6f7d058e5976fe62f188dd5b3ee4",
   "astropy.visualization.wcsaxes.tests.test_images.TestBasic.test_image_plot": "d00971851289338a82d0dfbbb1030e9cea46eee6a0a755b306720d830fa0711c",
   "astropy.visualization.wcsaxes.tests.test_images.TestBasic.test_axes_off": "32c022d6eb8b1c79c7ce065081bcf65d482b34a32efdfdef03f82898a828d41d",
   "astropy.visualization.wcsaxes.tests.test_images.TestBasic.test_axisbelow[True]": "978a807d0d7701fe13d0035e8db4f22661d519df9ebeefb7d1f5f8e54fdbda32",

--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -445,20 +445,20 @@ class WCSAxes(Axes):
         visible_ticks = []
 
         for coords in self._all_coords:
-
+            # Draw grids
             coords.frame.update()
             for coord in coords:
                 coord._draw_grid(renderer)
 
         for coords in self._all_coords:
-
+            # Draw tick labels
             for coord in coords:
                 coord._draw_ticks(renderer, bboxes=self._bboxes,
                                   ticklabels_bbox=ticklabels_bbox[coord])
                 visible_ticks.extend(coord.ticklabels.get_visible_axes())
 
         for coords in self._all_coords:
-
+            # Draw axis labels
             for coord in coords:
                 coord._draw_axislabels(renderer, bboxes=self._bboxes,
                                        ticklabels_bbox=ticklabels_bbox,
@@ -662,6 +662,8 @@ class WCSAxes(Axes):
         if not self.get_visible():
             return
 
+        # Do a draw to populate the self._bboxes list
+        self.draw_wcsaxes(renderer)
         bb = [b for b in self._bboxes if b and (b.width != 0 or b.height != 0)]
         bb.append(super().get_tightbbox(renderer, *args, **kwargs))
 

--- a/astropy/visualization/wcsaxes/tests/test_images.py
+++ b/astropy/visualization/wcsaxes/tests/test_images.py
@@ -43,6 +43,15 @@ class BaseImageTests:
 
 
 class TestBasic(BaseImageTests):
+    @pytest.mark.remote_data(source='astropy')
+    @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
+                                   tolerance=0, style={})
+    def tight_layout(self):
+        # Check that tight_layout works on a WCSAxes.
+        fig = plt.figure(figsize=(8, 6))
+        axs = [fig.add_subplot(2, 1, i, projection=WCS(self.msx_header))
+               for i in [1, 2]]
+        fig.tight_layout()
 
     @pytest.mark.remote_data
     @pytest.mark.mpl_image_compare(tolerance=0, style={})

--- a/astropy/visualization/wcsaxes/tests/test_images.py
+++ b/astropy/visualization/wcsaxes/tests/test_images.py
@@ -44,8 +44,7 @@ class BaseImageTests:
 
 class TestBasic(BaseImageTests):
     @pytest.mark.remote_data(source='astropy')
-    @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
-                                   tolerance=0, style={})
+    @pytest.mark.mpl_image_compare(tolerance=0, style={})
     def tight_layout(self):
         # Check that tight_layout works on a WCSAxes.
         fig = plt.figure(figsize=(8, 6))

--- a/astropy/visualization/wcsaxes/tests/test_images.py
+++ b/astropy/visualization/wcsaxes/tests/test_images.py
@@ -52,6 +52,7 @@ class TestBasic(BaseImageTests):
         axs = [fig.add_subplot(2, 1, i, projection=WCS(self.msx_header))
                for i in [1, 2]]
         fig.tight_layout()
+        return fig
 
     @pytest.mark.remote_data
     @pytest.mark.mpl_image_compare(tolerance=0, style={})

--- a/astropy/visualization/wcsaxes/tests/test_images.py
+++ b/astropy/visualization/wcsaxes/tests/test_images.py
@@ -43,9 +43,10 @@ class BaseImageTests:
 
 
 class TestBasic(BaseImageTests):
-    @pytest.mark.remote_data(source='astropy')
+
+    @pytest.mark.remote_data
     @pytest.mark.mpl_image_compare(tolerance=0, style={})
-    def tight_layout(self):
+    def test_tight_layout(self):
         # Check that tight_layout works on a WCSAxes.
         fig = plt.figure(figsize=(8, 6))
         axs = [fig.add_subplot(2, 1, i, projection=WCS(self.msx_header))

--- a/docs/changes/visualization/12418.bugfix.rst
+++ b/docs/changes/visualization/12418.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed calling ``.tight_layout()`` on a WCSAxes.


### PR DESCRIPTION
Without doing a major refactoring of WCSAxes to make things work more like they do in Matplotlib, this fixes https://github.com/astropy/astropy/issues/8703