### PR TITLE
Refactor of testing for `modeling.utils`

### DIFF
--- a/astropy/modeling/tests/test_utils.py
+++ b/astropy/modeling/tests/test_utils.py
@@ -1,66 +1,151 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # pylint: disable=invalid-name
 import pytest
+import numpy as np
 
-from astropy.modeling.utils import _SpecialOperatorsDict
+from inspect import Parameter
 
-
-def test__SpecialOperatorsDict__set_value():
-    key = 'test'
-    val = 'value'
-
-    special_operators = _SpecialOperatorsDict()
-    assert key not in special_operators
-
-    special_operators._set_value(key, val)
-    assert key in special_operators
-    assert special_operators[key] == val
-
-    with pytest.raises(ValueError, match='Special operator "test" already exists'):
-        special_operators._set_value(key, val)
+from astropy.modeling.utils import (poly_map_domain, _validate_domain_window,
+                                    get_inputs_and_params, _SpecialOperatorsDict)
 
 
-def test__SpecialOperatorsDict___setitem__():
-    key = 'test'
-    val = 'value'
+def test_poly_map_domain():
+    oldx = np.array([1, 2, 3, 4])
 
-    special_operators = _SpecialOperatorsDict()
-    assert key not in special_operators
+    # test shift/scale
+    assert (poly_map_domain(oldx, (-4, 4), (-3, 3)) == [0.75, 1.5, 2.25, 3]).all()
 
-    with pytest.deprecated_call():
-        special_operators[key] = val
-    assert key in special_operators
-    assert special_operators[key] == val
-
-
-def test__SpecialOperatorsDict__get_unique_id():
-    special_operators = _SpecialOperatorsDict()
-    assert special_operators._unique_id == 0
-
-    assert special_operators._get_unique_id() == 1
-    assert special_operators._unique_id == 1
-
-    assert special_operators._get_unique_id() == 2
-    assert special_operators._unique_id == 2
-
-    assert special_operators._get_unique_id() == 3
-    assert special_operators._unique_id == 3
+    # errors
+    MESSAGE = 'Expected "domain" and "window" to be a tuple of size 2.'
+    with pytest.raises(ValueError) as err:
+        poly_map_domain(oldx, (-4,), (-3, 3))
+    assert str(err.value) == MESSAGE
+    with pytest.raises(ValueError) as err:
+        poly_map_domain(oldx, (-4, 4, -4), (-3, 3))
+    assert str(err.value) == MESSAGE
+    with pytest.raises(ValueError) as err:
+        poly_map_domain(oldx, (-4, 4), (-3,))
+    assert str(err.value) == MESSAGE
+    with pytest.raises(ValueError) as err:
+        poly_map_domain(oldx, (-4, 4), (-3, 3, -3))
+    assert str(err.value) == MESSAGE
 
 
-def test__SpecialOperatorsDict_add():
-    special_operators = _SpecialOperatorsDict()
+def test__validate_domain_window():
+    # Test if None
+    assert _validate_domain_window(None) is None
 
-    operator_name = 'test'
-    operator = 'operator'
+    # Test normal
+    assert _validate_domain_window((-2, 2)) == (-2, 2)
+    assert _validate_domain_window([-2, 2]) == (-2, 2)
+    assert _validate_domain_window(np.array([-2, 2])) == (-2, 2)
 
-    key0 = special_operators.add(operator_name, operator)
-    assert key0 == (operator_name, special_operators._unique_id)
-    assert key0 in special_operators
-    assert special_operators[key0] == operator
+    # Test error
+    MESSAGE = 'domain and window should be tuples of size 2.'
+    with pytest.raises(ValueError) as err:
+        _validate_domain_window((-2, 2, -2))
+    assert str(err.value) == MESSAGE
+    with pytest.raises(ValueError) as err:
+        _validate_domain_window((-2,))
+    assert str(err.value) == MESSAGE
+    with pytest.raises(ValueError) as err:
+        _validate_domain_window([-2])
+    assert str(err.value) == MESSAGE
+    with pytest.raises(ValueError) as err:
+        _validate_domain_window(np.array([-2]))
+    assert str(err.value) == MESSAGE
+    with pytest.raises(ValueError) as err:
+        _validate_domain_window(-2)
+    assert str(err.value) == MESSAGE
 
-    key1 = special_operators.add(operator_name, operator)
-    assert key1 == (operator_name, special_operators._unique_id)
-    assert key1 in special_operators
-    assert special_operators[key1] == operator
 
-    assert key0 != key1
+def test_get_inputs_and_params():
+    # test normal
+    def func1(input0, input1, param0=5, param1=7):
+        pass
+
+    inputs, params = get_inputs_and_params(func1)
+    for index, _input in enumerate(inputs):
+        assert isinstance(_input, Parameter)
+        assert _input.name == f"input{index}"
+        assert _input.kind == _input.POSITIONAL_OR_KEYWORD
+        assert _input.default == Parameter.empty
+    default = [5, 7]
+    for index, param in enumerate(params):
+        assert isinstance(param, Parameter)
+        assert param.name == f"param{index}"
+        assert param.kind == param.POSITIONAL_OR_KEYWORD
+        assert param.default == default[index]
+
+    # Error
+    MESSAGE = "Signature must not have *args or **kwargs"
+
+    def func2(input0, input1, *args, param0=5, param1=7):
+        pass
+
+    def func3(input0, input1, param0=5, param1=7, **kwargs):
+        pass
+
+    with pytest.raises(ValueError) as err:
+        get_inputs_and_params(func2)
+    assert str(err.value) == MESSAGE
+    with pytest.raises(ValueError) as err:
+        get_inputs_and_params(func3)
+    assert str(err.value) == MESSAGE
+
+
+class Test_SpecialOperatorsDict:
+    def setup(self):
+        self.key = 'test'
+        self.val = 'value'
+
+    def test__set_value(self):
+        special_operators = _SpecialOperatorsDict()
+        assert self.key not in special_operators
+
+        special_operators._set_value(self.key, self.val)
+        assert self.key in special_operators
+        assert special_operators[self.key] == self.val
+
+        with pytest.raises(ValueError, match='Special operator "test" already exists'):
+            special_operators._set_value(self.key, self.val)
+
+    def test___setitem__(self):
+        special_operators = _SpecialOperatorsDict()
+        assert self.key not in special_operators
+
+        with pytest.deprecated_call():
+            special_operators[self.key] = self.val
+        assert self.key in special_operators
+        assert special_operators[self.key] == self.val
+
+    def test__SpecialOperatorsDict__get_unique_id(self):
+        special_operators = _SpecialOperatorsDict()
+        assert special_operators._unique_id == 0
+
+        assert special_operators._get_unique_id() == 1
+        assert special_operators._unique_id == 1
+
+        assert special_operators._get_unique_id() == 2
+        assert special_operators._unique_id == 2
+
+        assert special_operators._get_unique_id() == 3
+        assert special_operators._unique_id == 3
+
+    def test__SpecialOperatorsDict_add(self):
+        special_operators = _SpecialOperatorsDict()
+
+        operator_name = 'test'
+        operator = 'operator'
+
+        key0 = special_operators.add(operator_name, operator)
+        assert key0 == (operator_name, special_operators._unique_id)
+        assert key0 in special_operators
+        assert special_operators[key0] == operator
+
+        key1 = special_operators.add(operator_name, operator)
+        assert key1 == (operator_name, special_operators._unique_id)
+        assert key1 in special_operators
+        assert special_operators[key1] == operator
+
+        assert key0 != key1

--- a/astropy/modeling/utils.py
+++ b/astropy/modeling/utils.py
@@ -200,7 +200,7 @@ def poly_map_domain(oldx, domain, window):
     domain = np.array(domain, dtype=np.float64)
     window = np.array(window, dtype=np.float64)
     if domain.shape != (2,) or window.shape != (2,):
-        raise ValueError('Expected "domain" and window to be a tuple of size 2.')
+        raise ValueError('Expected "domain" and "window" to be a tuple of size 2.')
     scl = (window[1] - window[0]) / (domain[1] - domain[0])
     off = (window[0] * domain[1] - window[1] * domain[0]) / (domain[1] - domain[0])
     return off + scl * oldx


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This PR refactors the testing in `~astropy.modeling.utils`. It groups the `_SpecialOperatorsDict` tests into a test class, and adds tests for functions in `modeling.utils` which were not completely covered by other tests.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
