### PR TITLE
Remove use of global set_enabled_equivalencies, to fix doc build

### DIFF
--- a/docs/units/equivalencies.rst
+++ b/docs/units/equivalencies.rst
@@ -641,21 +641,7 @@ Examples
 
 .. EXAMPLE START: Using Equivalencies in Larger Pieces of Code
 
-To enable radians to be treated as a dimensionless unit with the
-:func:`~astropy.units.set_enabled_equivalencies` function:
-
-  >>> u.set_enabled_equivalencies(u.dimensionless_angles())
-  <astropy.units.core._UnitContext object at ...>
-  >>> u.deg.to('')  # doctest: +FLOAT_CMP
-  0.017453292519943295
-
-Here, any list of equivalencies could be used, or you could add, for example,
-:func:`~astropy.units.equivalencies.spectral` and
-:func:`~astropy.units.equivalencies.spectral_density` (since these return
-lists, they should indeed be combined by adding them together).
-
-The disadvantage of the above approach is that you may forget to turn the
-default off (done by giving an empty argument). To automate this, use
+To enable radians to be treated as a dimensionless unit use
 :func:`~astropy.units.set_enabled_equivalencies` as a `context manager
 <https://docs.python.org/3/reference/datamodel.html#context-managers>`_::
 
@@ -664,5 +650,25 @@ default off (done by giving an empty argument). To automate this, use
   ...    c = np.exp(1j*phase)
   >>> c  # doctest: +FLOAT_CMP
   <Quantity -1.+1.2246468e-16j>
+
+To permanently and globally enable radians to be treated as a dimensionless
+unit use :func:`~astropy.units.set_enabled_equivalencies` not as a context
+manager:
+
+.. doctest-skip::
+
+  >>> u.set_enabled_equivalencies(u.dimensionless_angles())
+  <astropy.units.core._UnitContext object at ...>
+  >>> u.deg.to('')  # doctest: +FLOAT_CMP
+  0.017453292519943295
+
+The disadvantage of the above approach is that you may forget to turn the
+default off (done by giving an empty argument).
+
+:func:`~astropy.units.set_enabled_equivalencies` accepts any list of
+equivalencies, so you could add, for example,
+:func:`~astropy.units.equivalencies.spectral` and
+:func:`~astropy.units.equivalencies.spectral_density` (since these return
+lists, they should indeed be combined by adding them together).
 
 .. EXAMPLE END


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

Just moves the paragraphs around to emphasize the context manager

Fixes #12368

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
