### PR TITLE
Bugfix for using `SpectralCoord` bounds when validating `_Interval`

### DIFF
--- a/astropy/coordinates/spectral_quantity.py
+++ b/astropy/coordinates/spectral_quantity.py
@@ -297,5 +297,8 @@ class SpectralQuantity(SpecificTypeQuantity):
 
         return result
 
-    def to_value(self, *args, **kwargs):
-        return self.to(*args, **kwargs).value
+    def to_value(self, unit=None, *args, **kwargs):
+        if unit is None:
+            return self.view(np.ndarray)
+
+        return self.to(unit, *args, **kwargs).value

--- a/astropy/modeling/tests/test_bounding_box.py
+++ b/astropy/modeling/tests/test_bounding_box.py
@@ -10,6 +10,7 @@ from astropy.modeling.bounding_box import (_BaseInterval, _Interval, _ignored_in
                                            CompoundBoundingBox)
 from astropy.modeling.models import Gaussian1D, Gaussian2D, Shift, Scale, Identity
 from astropy.modeling.core import Model, fix_inputs
+from astropy.coordinates import SpectralCoord
 import astropy.units as u
 
 
@@ -187,6 +188,16 @@ class Test_Interval:
             assert num < _ignored_interval[1]
 
             assert not (_ignored_interval.outside(np.array([num]))).all()
+
+    def test_validate_with_SpectralCoord(self):
+        """Regression test for issue #12439"""
+
+        lower = SpectralCoord(1, u.um)
+        upper = SpectralCoord(10, u.um)
+
+        interval = _Interval.validate((lower, upper))
+        assert interval.lower == lower
+        assert interval.upper == upper
 
 
 class Test_BoundingDomain:

--- a/docs/changes/coordinates/12440.api.rst
+++ b/docs/changes/coordinates/12440.api.rst
@@ -1,0 +1,2 @@
+``SpectralQuantity`` and ``SpectralCoord`` ``.to_value`` method can now be called without
+``unit`` argument in order to maintain a consistent interface with ``Quantity.to_value``


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This PR fixes some of the issues noted in astropy/specutils#893 (listed as a blocker for 5.0 in #12430). The main issue is that for some child types of `Quantity`, the validate process for intervals fails, see issue #12439 for details.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #12439

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
