### PR TITLE
Fix bug in WCSAxes that caused errors when drawing multiple times a f…

### DIFF
--- a/astropy/visualization/wcsaxes/coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/coordinate_helpers.py
@@ -926,14 +926,15 @@ class CoordinateHelper:
         else:
             return get_lon_lat_path(xy_world, pixel, xy_world_round)
 
+    def _clear_grid_contour(self):
+        if hasattr(self, '_grid') and self._grid:
+            for line in self._grid.collections:
+                line.remove()
+
     def _update_grid_contour(self):
 
         if self.coord_index is None:
             return
-
-        if hasattr(self, '_grid') and self._grid:
-            for line in self._grid.collections:
-                line.remove()
 
         xmin, xmax = self.parent_axes.get_xlim()
         ymin, ymax = self.parent_axes.get_ylim()

--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -432,6 +432,14 @@ class WCSAxes(Axes):
     def draw(self, renderer, **kwargs):
         """Draw the axes."""
 
+        # Before we do any drawing, we need to remove any existing grid lines
+        # drawn with contours, otherwise if we try and remove the contours
+        # part way through drawing, we end up with the issue mentioned in
+        # https://github.com/astropy/astropy/issues/12446
+        for coords in self._all_coords:
+            for coord in coords:
+                coord._clear_grid_contour()
+
         # In Axes.draw, the following code can result in the xlim and ylim
         # values changing, so we need to force call this here to make sure that
         # the limits are correct before we update the patch.

--- a/astropy/visualization/wcsaxes/tests/test_misc.py
+++ b/astropy/visualization/wcsaxes/tests/test_misc.py
@@ -531,3 +531,11 @@ def test_wcs_type_transform_regression():
 
     high_wcs = HighLevelWCSWrapper(sliced_wcs)
     ax.get_transform(sliced_wcs)
+
+
+def test_multiple_draws_grid_contours(tmpdir):
+    fig = plt.figure()
+    ax = fig.add_subplot(1, 1, 1, projection=WCS())
+    ax.grid(color='black', grid_type='contours')
+    fig.savefig(tmpdir / 'plot.png')
+    fig.savefig(tmpdir / 'plot.png')

--- a/docs/changes/visualization/12447.bugfix.rst
+++ b/docs/changes/visualization/12447.bugfix.rst
@@ -1,0 +1,2 @@
+Fix compatibility with Matplotlib 3.5 when using the ``grid_type='contours'``
+mode for drawing grid lines.


### PR DESCRIPTION
### Description

This fixes a bug in WCSAxes that occurs with the upcoming Matplotlib 3.5 release. The issue is described in detail in https://github.com/astropy/astropy/issues/12446, though we should keep that issue open once this PR is merged, as we need to think about longer-term refactoring of WCSAxes to avoid this kind of issue.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
