### PR TITLE
Enable doctests in 'What's new in 5.0'

### DIFF
--- a/docs/whatsnew/5.0.rst
+++ b/docs/whatsnew/5.0.rst
@@ -1,5 +1,3 @@
-.. doctest-skip-all
-
 .. _whatsnew-5.0:
 
 **************************
@@ -114,8 +112,10 @@ also added.
     >>> z.to(cu.littleh, equivalency)
     <Quantity 15656.37401543 littleh>
 
-    >>> z.to(u.Mpc, equivalency)
-    <Quantity 14004.03157418 Mpc>
+.. doctest-requires:: scipy
+
+      >>> z.to(u.Mpc, equivalency)
+      <Quantity 14004.03157418 Mpc>
 
 ``with_redshift`` is actually a composite of other equivalencies:
 ``redshift_distance``, ``redshift_hubble``, and ``redshift_temperature``,
@@ -132,9 +132,9 @@ New Unified I/O architecture
 I/O registry submodule has switched to a class-based architecture, allowing for
 the creation of custom registries. The three supported registry types are:
 
-* read-only : ``astropy.io.registry.UnifiedInputRegistry``
-* write-only : ``astropy.io.registry.UnifiedOutputRegistry``
-* read/write : ``astropy.io.registry.UnifiedIORegistry``
+* read-only : :class:`~astropy.io.registry.UnifiedInputRegistry`
+* write-only : :class:`~astropy.io.registry.UnifiedOutputRegistry`
+* read/write : :class:`~astropy.io.registry.UnifiedIORegistry`
 
 For backward compatibility all the methods on the read/write have corresponding
 module-level functions, which work with a default global read/write registry.


### PR DESCRIPTION
This enables the doctests and adds a missing doctest-requires. Also fixes some intersphinx links.