### PR TITLE
Added spline plot to whatsnew.

### DIFF
--- a/docs/whatsnew/5.0.rst
+++ b/docs/whatsnew/5.0.rst
@@ -172,6 +172,37 @@ unique fitting requirements four fitters have been introduced:
 * :class:`~astropy.modeling.spline.SplineSplrepFitter`: provides an interface
   to fit a spline using the `scipy.interpolate.splrep` function.
 
+.. plot::
+
+    import numpy as np
+    import matplotlib.pyplot as plt
+    from astropy.modeling.models import Spline1D
+    from astropy.modeling.fitting import (SplineInterpolateFitter,
+                                          SplineSmoothingFitter,
+                                          SplineExactKnotsFitter)
+
+    x = np.linspace(-3, 3, 50)
+    y = np.exp(-x**2) + 0.1 * np.random.randn(50)
+    xs = np.linspace(-3, 3, 1000)
+    t = [-1, 0, 1]
+    spl = Spline1D()
+
+    fitter = SplineInterpolateFitter()
+    spl1 = fitter(spl, x, y)
+
+    fitter = SplineSmoothingFitter()
+    spl2 = fitter(spl, x, y, s=0.5)
+
+    fitter = SplineExactKnotsFitter()
+    spl3 = fitter(spl, x, y, t=t)
+
+    plt.plot(x, y, 'ro', label="Data")
+    plt.plot(xs, spl1(xs), 'b-', label="Interpolating")
+    plt.plot(xs, spl2(xs), 'g-', label="Smoothing")
+    plt.plot(xs, spl3(xs), 'k-', label="Exact Knots [-1, 0, 1]")
+    plt.legend()
+    plt.show()
+
 
 .. _whatsnew-5.0-dask-in-table:
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

@astrofrog [requested](https://github.com/astropy/astropy/pull/11634#issuecomment-964267423) that a plot of the new spline models be included in the whatsnew for v5.0. This PR adds this plot.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
