### PR TITLE
Support nanfunctions for utils.masked

### DIFF
--- a/astropy/utils/masked/core.py
+++ b/astropy/utils/masked/core.py
@@ -895,11 +895,11 @@ class MaskedNDArray(Masked, np.ndarray, base_cls=np.ndarray, data_cls=np.ndarray
 
     def min(self, axis=None, out=None, **kwargs):
         return super().min(axis=axis, out=out,
-                           **self._reduce_defaults(kwargs, np.max))
+                           **self._reduce_defaults(kwargs, np.nanmax))
 
     def max(self, axis=None, out=None, **kwargs):
         return super().max(axis=axis, out=out,
-                           **self._reduce_defaults(kwargs, np.min))
+                           **self._reduce_defaults(kwargs, np.nanmin))
 
     def nonzero(self):
         unmasked_nonzero = self.unmasked.nonzero()

--- a/astropy/utils/masked/function_helpers.py
+++ b/astropy/utils/masked/function_helpers.py
@@ -68,12 +68,8 @@ when it should not be or vice versa.
 UNSUPPORTED_FUNCTIONS = set()
 """Set of numpy functions that are not supported for masked arrays.
 
-For most, masked input simply makes no sense, but for others it may
-have been lack of time.  For instance, for the ``nanfunctions``, one
-could imagine replacing masked entries with ``np.nan``, but this works
-only for real and complex.
-
-Issues or PRs for support for functions are very welcome.
+For most, masked input simply makes no sense, but for others it may have
+been lack of time.  Issues or PRs for support for functions are welcome.
 """
 
 # Almost all from np.core.fromnumeric defer to methods so are OK.
@@ -140,10 +136,6 @@ IGNORED_FUNCTIONS |= {
     np.dot, np.vdot, np.inner, np.tensordot, np.cross,
     np.einsum, np.einsum_path,
 }
-
-# In principle, could just fill with np.nan, but then, so can the user.
-IGNORED_FUNCTIONS |= set(getattr(np, nanfuncname)
-                         for nanfuncname in np.lib.nanfunctions.__all__)
 
 # Really should do these...
 IGNORED_FUNCTIONS |= set(getattr(np, setopsname)
@@ -951,6 +943,53 @@ def array2string(a, max_line_width=None, precision=None,
 def array_str(a, max_line_width=None, precision=None, suppress_small=None):
     # Override to avoid special treatment of array scalars.
     return array2string(a, max_line_width, precision, suppress_small, ' ', "")
+
+
+# For the nanfunctions, we just treat any nan as an additional mask.
+_nanfunc_fill_values = {'nansum': 0, 'nancumsum': 0,
+                        'nanprod': 1, 'nancumprod': 1}
+
+
+def masked_nanfunc(nanfuncname):
+    np_func = getattr(np, nanfuncname[3:])
+    fill_value = _nanfunc_fill_values.get(nanfuncname, None)
+
+    def nanfunc(a, *args, **kwargs):
+        from astropy.utils.masked import Masked
+
+        a, mask = Masked._get_data_and_mask(a)
+        if issubclass(a.dtype.type, np.inexact):
+            nans = np.isnan(a)
+            mask = nans if mask is None else (nans | mask)
+
+        if mask is not None:
+            a = Masked(a, mask)
+            if fill_value is not None:
+                a = a.filled(fill_value)
+
+        return np_func(a, *args, **kwargs)
+
+    doc = f"Like `numpy.{nanfuncname}`, skipping masked values as well.\n\n"
+    if fill_value is not None:
+        # sum, cumsum, prod, cumprod
+        doc += (f"Masked/NaN values are replaced with {fill_value}. "
+                "The output is not masked.")
+    elif "arg" in nanfuncname:
+        doc += ("No exceptions are raised for fully masked/NaN slices.\n"
+                "Instead, these give index 0.")
+    else:
+        doc += ("No warnings are given for fully masked/NaN slices.\n"
+                "Instead, they are masked in the output.")
+
+    nanfunc.__doc__ = doc
+    nanfunc.__name__ = nanfuncname
+
+    return nanfunc
+
+
+for nanfuncname in np.lib.nanfunctions.__all__:
+    globals()[nanfuncname] = dispatched_function(masked_nanfunc(nanfuncname),
+                                                 helps=getattr(np, nanfuncname))
 
 
 # Add any dispatched or helper function that has a docstring to

--- a/astropy/utils/masked/tests/test_masked.py
+++ b/astropy/utils/masked/tests/test_masked.py
@@ -873,6 +873,12 @@ class TestMaskedArrayMethods(MaskedArraySetup):
         assert_array_equal(ma_min.unmasked, expected_data)
         assert not np.any(ma_min.mask)
 
+    def test_min_with_masked_nan(self):
+        ma = Masked([3., np.nan, 2.], mask=[False, True, False])
+        ma_min = ma.min()
+        assert_array_equal(ma_min.unmasked, np.array(2.))
+        assert not ma_min.mask
+
     @pytest.mark.parametrize('axis', (0, 1, None))
     def test_max(self, axis):
         ma_max = self.ma.max(axis)

--- a/docs/changes/utils/12454.bugfix.rst
+++ b/docs/changes/utils/12454.bugfix.rst
@@ -1,0 +1,2 @@
+Ensure that when taking the minimum or maximum of a ``Masked`` array,
+any masked NaN values are ignored.

--- a/docs/changes/utils/12454.feature.rst
+++ b/docs/changes/utils/12454.feature.rst
@@ -1,0 +1,3 @@
+The NaN-aware numpy functions such as ``np.nansum`` now work on Masked
+arrays, with masked values being treated as NaN, but without raising
+warnings or exceptions.


### PR DESCRIPTION
The idea is to treat all NaN as if they were Masked as well and then run the regular numpy routine, which takes masked into account. This gives the same results as the nanfunctions, except that there are no warnings or exceptions.

fixes part of #12430

Note that along the way also a small bug was fixed, where `ma.min()` and `ma.max()` would not ignore masked NaN values.