### PR TITLE
avoid sunpy logger in asdf roundtrip

### DIFF
--- a/astropy/cosmology/tests/test_units.py
+++ b/astropy/cosmology/tests/test_units.py
@@ -393,17 +393,11 @@ class Test_with_redshift:
 # they are not in ``astropy.units.equivalencies``, so the following fails
 @pytest.mark.skipif(not HAS_ASDF, reason="requires ASDF")
 @pytest.mark.parametrize("equiv", [cu.with_H0])
-def test_equivalencies_asdf(tmpdir, equiv):
+def test_equivalencies_asdf(tmpdir, equiv, recwarn):
     from asdf.tests import helpers
 
     tree = {"equiv": equiv()}
-    with (
-        pytest.warns(AstropyDeprecationWarning, match="`with_H0`")
-        if equiv.__name__ == "with_H0"
-        else contextlib.nullcontext()
-    ):
-
-        helpers.assert_roundtrip_tree(tree, tmpdir)
+    helpers.assert_roundtrip_tree(tree, tmpdir)
 
 
 def test_equivalency_context_manager():


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

@dhomeier, @ayshih does this fix the issue?

Fixes #12425

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
