### PR TITLE
isort convolve

### DIFF
--- a/astropy/convolution/__init__.py
+++ b/astropy/convolution/__init__.py
@@ -1,11 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 
-from .core import *  # noqa
-from .kernels import *  # noqa
-from .utils import discretize_model, KernelSizeError  # noqa
-
-from .convolve import convolve, convolve_fft, interpolate_replace_nans, convolve_models, convolve_models_fft  # noqa
-
-# Deprecated kernels that are not defined in __all__
-from .kernels import MexicanHat1DKernel, MexicanHat2DKernel
+from .convolve import (convolve, convolve_fft, convolve_models,
+                       convolve_models_fft, interpolate_replace_nans)
+from .core import *
+from .kernels import *
+from .kernels import MexicanHat1DKernel, MexicanHat2DKernel  # Deprecated kernels
+from .utils import *

--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -1,23 +1,21 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-import warnings
-
-import os
 import ctypes
+import os
 import warnings
 from functools import partial
 
 import numpy as np
-from numpy.ctypeslib import ndpointer, load_library
+from numpy.ctypeslib import load_library, ndpointer
 
-from .core import Kernel, Kernel1D, Kernel2D, MAX_NORMALIZATION
-from astropy.utils.exceptions import AstropyUserWarning
-from astropy.utils.console import human_file_size
 from astropy import units as u
-from astropy.nddata import support_nddata
-from astropy.modeling.core import CompoundModel
-from astropy.modeling.core import SPECIAL_OPERATORS
 from astropy.modeling.convolution import Convolution
+from astropy.modeling.core import SPECIAL_OPERATORS, CompoundModel
+from astropy.nddata import support_nddata
+from astropy.utils.console import human_file_size
+from astropy.utils.exceptions import AstropyUserWarning
+
+from .core import MAX_NORMALIZATION, Kernel, Kernel1D, Kernel2D
 from .utils import KernelSizeError, has_even_axis, raise_even_kernel_exception
 
 LIBRARY_PATH = os.path.dirname(__file__)

--- a/astropy/convolution/core.py
+++ b/astropy/convolution/core.py
@@ -15,13 +15,14 @@ integrates to one per default.
 Currently only symmetric 2D kernels are supported.
 """
 
-import warnings
 import copy
+import warnings
 
 import numpy as np
+
 from astropy.utils.exceptions import AstropyUserWarning
-from .utils import (discretize_model, add_kernel_arrays_1D,
-                    add_kernel_arrays_2D)
+
+from .utils import add_kernel_arrays_1D, add_kernel_arrays_2D, discretize_model
 
 MAX_NORMALIZATION = 100
 

--- a/astropy/convolution/kernels.py
+++ b/astropy/convolution/kernels.py
@@ -4,11 +4,12 @@ import math
 
 import numpy as np
 
-from .core import Kernel1D, Kernel2D, Kernel
-from .utils import has_even_axis, raise_even_kernel_exception, KernelSizeError
 from astropy.modeling import models
 from astropy.modeling.core import Fittable1DModel, Fittable2DModel
 from astropy.utils.decorators import deprecated
+
+from .core import Kernel, Kernel1D, Kernel2D
+from .utils import KernelSizeError, has_even_axis, raise_even_kernel_exception
 
 __all__ = ['Gaussian1DKernel', 'Gaussian2DKernel', 'CustomKernel',
            'Box1DKernel', 'Box2DKernel', 'Tophat2DKernel',

--- a/astropy/convolution/setup_package.py
+++ b/astropy/convolution/setup_package.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+
 from setuptools import Extension
 
 import numpy

--- a/astropy/convolution/tests/test_convolve.py
+++ b/astropy/convolution/tests/test_convolve.py
@@ -1,21 +1,19 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-import pytest
-import numpy as np
-import numpy.ma as ma
+import itertools
 from contextlib import nullcontext
 
+import pytest
+
+import numpy as np
+import numpy.ma as ma
+from numpy.testing import assert_allclose, assert_array_almost_equal, assert_array_almost_equal_nulp
+
+from astropy import units as u
 from astropy.convolution.convolve import convolve, convolve_fft
 from astropy.convolution.kernels import Gaussian2DKernel
+from astropy.utils.compat.optional_deps import HAS_PANDAS, HAS_SCIPY  # noqa
 from astropy.utils.exceptions import AstropyUserWarning
-from astropy import units as u
-from astropy.utils.compat.optional_deps import HAS_SCIPY, HAS_PANDAS  # noqa
-
-from numpy.testing import (assert_array_almost_equal_nulp,
-                           assert_array_almost_equal,
-                           assert_allclose)
-
-import itertools
 
 VALID_DTYPES = ('>f4', '<f4', '>f8', '<f8')
 VALID_DTYPE_MATRIX = list(itertools.product(VALID_DTYPES, VALID_DTYPES))

--- a/astropy/convolution/tests/test_convolve_fft.py
+++ b/astropy/convolution/tests/test_convolve_fft.py
@@ -4,12 +4,13 @@ import itertools
 from contextlib import nullcontext
 
 import pytest
-import numpy as np
-from numpy.testing import assert_allclose, assert_array_equal, assert_array_almost_equal_nulp
 
-from astropy.convolution.convolve import convolve_fft, convolve
-from astropy.utils.exceptions import AstropyUserWarning
+import numpy as np
+from numpy.testing import assert_allclose, assert_array_almost_equal_nulp, assert_array_equal
+
 from astropy import units as u
+from astropy.convolution.convolve import convolve, convolve_fft
+from astropy.utils.exceptions import AstropyUserWarning
 
 VALID_DTYPES = ('>f4', '<f4', '>f8', '<f8')
 VALID_DTYPE_MATRIX = list(itertools.product(VALID_DTYPES, VALID_DTYPES))

--- a/astropy/convolution/tests/test_convolve_kernels.py
+++ b/astropy/convolution/tests/test_convolve_kernels.py
@@ -3,13 +3,14 @@
 import itertools
 
 import pytest
+
 import numpy as np
-from numpy.testing import assert_almost_equal, assert_allclose
+from numpy.testing import assert_allclose, assert_almost_equal
 
 from astropy import units as u
 from astropy.convolution.convolve import convolve, convolve_fft
-from astropy.convolution.kernels import Gaussian2DKernel, Box2DKernel, Tophat2DKernel
-from astropy.convolution.kernels import Moffat2DKernel
+from astropy.convolution.kernels import (Box2DKernel, Gaussian2DKernel,
+                                         Moffat2DKernel, Tophat2DKernel)
 from astropy.utils.exceptions import AstropyDeprecationWarning
 
 SHAPES_ODD = [[15, 15], [31, 31]]

--- a/astropy/convolution/tests/test_convolve_models.py
+++ b/astropy/convolution/tests/test_convolve_models.py
@@ -1,14 +1,16 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import math
-import numpy as np
+
 import pytest
 
-from astropy.convolution.convolve import convolve, convolve_fft, convolve_models
-from astropy.modeling import models, fitting
-from astropy.utils.misc import NumpyRNGContext
-from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa
+import numpy as np
 from numpy.testing import assert_allclose, assert_almost_equal
+
+from astropy.convolution.convolve import convolve, convolve_fft, convolve_models
+from astropy.modeling import fitting, models
+from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa
+from astropy.utils.misc import NumpyRNGContext
 
 
 class TestConvolve1DModels:

--- a/astropy/convolution/tests/test_convolve_nddata.py
+++ b/astropy/convolution/tests/test_convolve_nddata.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import pytest
+
 import numpy as np
 
 from astropy.convolution.convolve import convolve, convolve_fft

--- a/astropy/convolution/tests/test_convolve_speeds.py
+++ b/astropy/convolution/tests/test_convolve_speeds.py
@@ -4,7 +4,6 @@ import timeit
 
 import numpy as np  # pylint: disable=W0611
 
-
 # largest image size to use for "linear" and fft convolutions
 max_exponents_linear = {1: 15, 2: 7, 3: 5}
 max_exponents_fft = {1: 15, 2: 10, 3: 7}

--- a/astropy/convolution/tests/test_discretize.py
+++ b/astropy/convolution/tests/test_discretize.py
@@ -3,16 +3,16 @@
 import itertools
 
 import pytest
+
 import numpy as np
 from numpy.testing import assert_allclose
 
 from astropy.convolution.utils import discretize_model
-from astropy.modeling.functional_models import (
-    Gaussian1D, Box1D, RickerWavelet1D, Gaussian2D, Box2D, RickerWavelet2D)
+from astropy.modeling.functional_models import (Box1D, Box2D, Gaussian1D, Gaussian2D,
+                                                RickerWavelet1D, RickerWavelet2D)
 from astropy.modeling.tests.example_models import models_1D, models_2D
 from astropy.modeling.tests.test_models import create_model
 from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa
-
 
 modes = ['center', 'linear_interp', 'oversample']
 test_models_1D = [Gaussian1D, Box1D, RickerWavelet1D]

--- a/astropy/convolution/tests/test_kernel_class.py
+++ b/astropy/convolution/tests/test_kernel_class.py
@@ -3,20 +3,20 @@
 import itertools
 
 import pytest
+
 import numpy as np
-from numpy.testing import assert_almost_equal, assert_allclose
+from numpy.testing import assert_allclose, assert_almost_equal
 
 from astropy.convolution.convolve import convolve, convolve_fft
-from astropy.convolution.kernels import (
-    Gaussian1DKernel, Gaussian2DKernel, Box1DKernel, Box2DKernel,
-    Trapezoid1DKernel, TrapezoidDisk2DKernel, RickerWavelet1DKernel,
-    Tophat2DKernel, RickerWavelet2DKernel, AiryDisk2DKernel, Ring2DKernel,
-    CustomKernel, Model1DKernel, Model2DKernel, Kernel1D, Kernel2D)
-
+from astropy.convolution.kernels import (AiryDisk2DKernel, Box1DKernel, Box2DKernel, CustomKernel,
+                                         Gaussian1DKernel, Gaussian2DKernel, Kernel1D, Kernel2D,
+                                         Model1DKernel, Model2DKernel, RickerWavelet1DKernel,
+                                         RickerWavelet2DKernel, Ring2DKernel, Tophat2DKernel,
+                                         Trapezoid1DKernel, TrapezoidDisk2DKernel)
 from astropy.convolution.utils import KernelSizeError
 from astropy.modeling.models import Box2D, Gaussian1D, Gaussian2D
-from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyUserWarning
 from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa
+from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyUserWarning
 
 WIDTHS_ODD = [3, 5, 7, 9]
 WIDTHS_EVEN = [2, 4, 8, 16]

--- a/astropy/convolution/tests/test_pickle.py
+++ b/astropy/convolution/tests/test_pickle.py
@@ -1,10 +1,11 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import pytest
+
 import numpy as np
 
 from astropy import convolution as conv
-from astropy.tests.helper import pickle_protocol, check_pickling_recovery  # noqa
+from astropy.tests.helper import check_pickling_recovery, pickle_protocol  # noqa
 
 
 @pytest.mark.parametrize(("name", "args", "kwargs", "xfail"),

--- a/astropy/convolution/utils.py
+++ b/astropy/convolution/utils.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import ctypes
+
 import numpy as np
 
 from astropy.modeling.core import FittableModel, custom_model
@@ -284,6 +285,7 @@ def discretize_integrate_1D(model, x_range):
     Discretize model by integrating numerically the model over the bin.
     """
     from scipy.integrate import quad
+
     # Set up grid
     x = np.arange(x_range[0] - 0.5, x_range[1] + 0.5)
     values = np.array([])
@@ -299,6 +301,7 @@ def discretize_integrate_2D(model, x_range, y_range):
     Discretize model by integrating the model over the pixel.
     """
     from scipy.integrate import dblquad
+
     # Set up grid
     x = np.arange(x_range[0] - 0.5, x_range[1] + 0.5)
     y = np.arange(y_range[0] - 0.5, y_range[1] + 0.5)


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

Running ``isort`` on ``astropy/convolution``  and adding ``__all__`` to ``__init__.py``.
The exact command was ``>>> isort astropy/convolution/ -l 100``

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
