### PR TITLE
isort coordinates

### DIFF
--- a/astropy/coordinates/__init__.py
+++ b/astropy/coordinates/__init__.py
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+# isort: skip_file
 
 """
 This subpackage contains classes and functions for celestial coordinates

--- a/astropy/coordinates/angle_formats.py
+++ b/astropy/coordinates/angle_formats.py
@@ -23,11 +23,11 @@ from warnings import warn
 
 import numpy as np
 
-from .errors import (IllegalHourWarning, IllegalHourError,
-                     IllegalMinuteWarning, IllegalMinuteError,
-                     IllegalSecondWarning, IllegalSecondError)
-from astropy.utils import format_exception, parsing
 from astropy import units as u
+from astropy.utils import format_exception, parsing
+
+from .errors import (IllegalHourError, IllegalHourWarning, IllegalMinuteError,
+                     IllegalMinuteWarning, IllegalSecondError, IllegalSecondWarning)
 
 
 class _AngleParser:

--- a/astropy/coordinates/angle_utilities.py
+++ b/astropy/coordinates/angle_utilities.py
@@ -14,9 +14,7 @@ import numpy as np
 
 # Astropy
 import astropy.units as u
-from astropy.coordinates.representation import (
-    UnitSphericalRepresentation,
-    SphericalRepresentation)
+from astropy.coordinates.representation import SphericalRepresentation, UnitSphericalRepresentation
 
 
 def angular_separation(lon1, lat1, lon2, lat2):
@@ -233,8 +231,9 @@ def uniform_spherical_random_volume(size=1, max_radius=1):
 
 
 # # below here can be deleted in v5.0
-from astropy.utils.decorators import deprecated
 from astropy.coordinates import angle_formats
+from astropy.utils.decorators import deprecated
+
 __old_angle_utilities_funcs = ['check_hms_ranges', 'degrees_to_dms',
                                'degrees_to_string', 'dms_to_degrees',
                                'format_exception', 'hms_to_degrees',

--- a/astropy/coordinates/angles.py
+++ b/astropy/coordinates/angles.py
@@ -11,9 +11,10 @@ from collections import namedtuple
 
 import numpy as np
 
-from . import angle_formats as form
 from astropy import units as u
 from astropy.utils import isiterable
+
+from . import angle_formats as form
 
 __all__ = ['Angle', 'Latitude', 'Longitude']
 

--- a/astropy/coordinates/attributes.py
+++ b/astropy/coordinates/attributes.py
@@ -521,4 +521,4 @@ class DifferentialAttribute(Attribute):
 
 # do this here to prevent a series of complicated circular imports
 from .earth import EarthLocation
-from .representation import CartesianRepresentation, BaseDifferential
+from .representation import BaseDifferential, CartesianRepresentation

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -6,26 +6,23 @@ classes.
 """
 
 
-# Standard library
 import copy
 import inspect
-from collections import namedtuple, defaultdict
 import warnings
+from collections import defaultdict, namedtuple
 
-# Dependencies
 import numpy as np
 
-# Project
-from astropy.utils.compat.misc import override__dir__
-from astropy.utils.decorators import lazyproperty, format_doc
-from astropy.utils.exceptions import AstropyWarning, AstropyDeprecationWarning
 from astropy import units as u
 from astropy.utils import ShapedLikeNDArray, check_broadcast
-from .transformations import TransformGraph
+from astropy.utils.compat.misc import override__dir__
+from astropy.utils.decorators import format_doc, lazyproperty
+from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyWarning
+
 from . import representation as r
 from .angles import Angle
 from .attributes import Attribute
-
+from .transformations import TransformGraph
 
 __all__ = ['BaseCoordinateFrame', 'frame_transform_graph',
            'GenericFrame', 'RepresentationMapping']

--- a/astropy/coordinates/builtin_frames/__init__.py
+++ b/astropy/coordinates/builtin_frames/__init__.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+# isort: skip_file
+
 """
 This package contains the coordinate frames implemented by astropy.
 

--- a/astropy/coordinates/builtin_frames/altaz.py
+++ b/astropy/coordinates/builtin_frames/altaz.py
@@ -4,12 +4,10 @@
 import numpy as np
 
 from astropy import units as u
-from astropy.utils.decorators import format_doc
 from astropy.coordinates import representation as r
+from astropy.coordinates.attributes import EarthLocationAttribute, QuantityAttribute, TimeAttribute
 from astropy.coordinates.baseframe import BaseCoordinateFrame, RepresentationMapping, base_doc
-from astropy.coordinates.attributes import (TimeAttribute,
-                                            QuantityAttribute,
-                                            EarthLocationAttribute)
+from astropy.utils.decorators import format_doc
 
 __all__ = ['AltAz']
 

--- a/astropy/coordinates/builtin_frames/baseradec.py
+++ b/astropy/coordinates/builtin_frames/baseradec.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from astropy.utils.decorators import format_doc
 from astropy.coordinates import representation as r
 from astropy.coordinates.baseframe import BaseCoordinateFrame, RepresentationMapping, base_doc
+from astropy.utils.decorators import format_doc
 
 __all__ = ['BaseRADecFrame']
 

--- a/astropy/coordinates/builtin_frames/cirs.py
+++ b/astropy/coordinates/builtin_frames/cirs.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from astropy.utils.decorators import format_doc
-from astropy.coordinates.attributes import (TimeAttribute,
-                                            EarthLocationAttribute)
+from astropy.coordinates.attributes import EarthLocationAttribute, TimeAttribute
 from astropy.coordinates.baseframe import base_doc
-from .baseradec import doc_components, BaseRADecFrame
+from astropy.utils.decorators import format_doc
+
+from .baseradec import BaseRADecFrame, doc_components
 from .utils import DEFAULT_OBSTIME, EARTH_CENTER
 
 __all__ = ['CIRS']

--- a/astropy/coordinates/builtin_frames/cirs_observed_transforms.py
+++ b/astropy/coordinates/builtin_frames/cirs_observed_transforms.py
@@ -4,20 +4,20 @@
 Contains the transformation functions for getting to "observed" systems from CIRS.
 """
 
-import numpy as np
 import erfa
+
+import numpy as np
 
 from astropy import units as u
 from astropy.coordinates.baseframe import frame_transform_graph
+from astropy.coordinates.representation import SphericalRepresentation, UnitSphericalRepresentation
 from astropy.coordinates.transformations import FunctionTransformWithFiniteDifference
-from astropy.coordinates.representation import (SphericalRepresentation,
-                                                UnitSphericalRepresentation)
 
-from .cirs import CIRS
+from ..erfa_astrom import erfa_astrom
 from .altaz import AltAz
+from .cirs import CIRS
 from .hadec import HADec
 from .utils import PIOVER2
-from ..erfa_astrom import erfa_astrom
 
 
 @frame_transform_graph.transform(FunctionTransformWithFiniteDifference, CIRS, AltAz)

--- a/astropy/coordinates/builtin_frames/ecliptic.py
+++ b/astropy/coordinates/builtin_frames/ecliptic.py
@@ -2,11 +2,12 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 from astropy import units as u
-from astropy.utils.decorators import format_doc
 from astropy.coordinates import representation as r
+from astropy.coordinates.attributes import QuantityAttribute, TimeAttribute
 from astropy.coordinates.baseframe import BaseCoordinateFrame, base_doc
-from astropy.coordinates.attributes import TimeAttribute, QuantityAttribute
-from .utils import EQUINOX_J2000, DEFAULT_OBSTIME
+from astropy.utils.decorators import format_doc
+
+from .utils import DEFAULT_OBSTIME, EQUINOX_J2000
 
 __all__ = ['GeocentricMeanEcliptic', 'BarycentricMeanEcliptic',
            'HeliocentricMeanEcliptic', 'BaseEclipticFrame',

--- a/astropy/coordinates/builtin_frames/ecliptic_transforms.py
+++ b/astropy/coordinates/builtin_frames/ecliptic_transforms.py
@@ -7,21 +7,17 @@ import erfa
 
 from astropy import units as u
 from astropy.coordinates.baseframe import frame_transform_graph
-from astropy.coordinates.transformations import (
-    FunctionTransformWithFiniteDifference, DynamicMatrixTransform,
-    AffineTransform,
-)
-from astropy.coordinates.matrix_utilities import (rotation_matrix,
-                                                  matrix_product,
-                                                  matrix_transpose)
-
-from .icrs import ICRS
-from .gcrs import GCRS
-from .ecliptic import (GeocentricMeanEcliptic, BarycentricMeanEcliptic, HeliocentricMeanEcliptic,
-                       GeocentricTrueEcliptic, BarycentricTrueEcliptic, HeliocentricTrueEcliptic,
-                       HeliocentricEclipticIAU76, CustomBarycentricEcliptic)
-from .utils import get_jd12, get_offset_sun_from_barycenter, EQUINOX_J2000
 from astropy.coordinates.errors import UnitsError
+from astropy.coordinates.matrix_utilities import matrix_product, matrix_transpose, rotation_matrix
+from astropy.coordinates.transformations import (AffineTransform, DynamicMatrixTransform,
+                                                 FunctionTransformWithFiniteDifference)
+
+from .ecliptic import (BarycentricMeanEcliptic, BarycentricTrueEcliptic, CustomBarycentricEcliptic,
+                       GeocentricMeanEcliptic, GeocentricTrueEcliptic, HeliocentricEclipticIAU76,
+                       HeliocentricMeanEcliptic, HeliocentricTrueEcliptic)
+from .gcrs import GCRS
+from .icrs import ICRS
+from .utils import EQUINOX_J2000, get_jd12, get_offset_sun_from_barycenter
 
 
 def _mean_ecliptic_rotation_matrix(equinox):

--- a/astropy/coordinates/builtin_frames/equatorial.py
+++ b/astropy/coordinates/builtin_frames/equatorial.py
@@ -12,11 +12,12 @@ and can be combined with Local Apparent Sidereal Time to calculate the
 hour angle.
 """
 
-from astropy.utils.decorators import format_doc
-from astropy.coordinates.representation import (CartesianRepresentation, CartesianDifferential)
+from astropy.coordinates.attributes import EarthLocationAttribute, TimeAttribute
 from astropy.coordinates.baseframe import BaseCoordinateFrame, base_doc
 from astropy.coordinates.builtin_frames.baseradec import BaseRADecFrame, doc_components
-from astropy.coordinates.attributes import TimeAttribute, EarthLocationAttribute
+from astropy.coordinates.representation import CartesianDifferential, CartesianRepresentation
+from astropy.utils.decorators import format_doc
+
 from .utils import DEFAULT_OBSTIME, EARTH_CENTER
 
 __all__ = ['TEME', 'TETE']

--- a/astropy/coordinates/builtin_frames/fk4.py
+++ b/astropy/coordinates/builtin_frames/fk4.py
@@ -4,17 +4,16 @@
 import numpy as np
 
 from astropy import units as u
-from astropy.utils.decorators import format_doc
-from astropy.coordinates.baseframe import frame_transform_graph, base_doc
-from astropy.coordinates.attributes import TimeAttribute
-from astropy.coordinates.transformations import (
-    FunctionTransformWithFiniteDifference, DynamicMatrixTransform)
-from astropy.coordinates.representation import (CartesianRepresentation,
-                                                UnitSphericalRepresentation)
 from astropy.coordinates import earth_orientation as earth
+from astropy.coordinates.attributes import TimeAttribute
+from astropy.coordinates.baseframe import base_doc, frame_transform_graph
+from astropy.coordinates.representation import CartesianRepresentation, UnitSphericalRepresentation
+from astropy.coordinates.transformations import (DynamicMatrixTransform,
+                                                 FunctionTransformWithFiniteDifference)
+from astropy.utils.decorators import format_doc
 
+from .baseradec import BaseRADecFrame, doc_components
 from .utils import EQUINOX_B1950
-from .baseradec import doc_components, BaseRADecFrame
 
 __all__ = ['FK4', 'FK4NoETerms']
 

--- a/astropy/coordinates/builtin_frames/fk4_fk5_transforms.py
+++ b/astropy/coordinates/builtin_frames/fk4_fk5_transforms.py
@@ -5,14 +5,12 @@
 import numpy as np
 
 from astropy.coordinates.baseframe import frame_transform_graph
-from astropy.coordinates.transformations import DynamicMatrixTransform
 from astropy.coordinates.matrix_utilities import matrix_product, matrix_transpose
-
+from astropy.coordinates.transformations import DynamicMatrixTransform
 
 from .fk4 import FK4NoETerms
 from .fk5 import FK5
 from .utils import EQUINOX_B1950, EQUINOX_J2000
-
 
 # FK5 to/from FK4 ------------------->
 # B1950->J2000 matrix from Murray 1989 A&A 218,325 eqn 28

--- a/astropy/coordinates/builtin_frames/fk5.py
+++ b/astropy/coordinates/builtin_frames/fk5.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from astropy.utils.decorators import format_doc
-from astropy.coordinates.baseframe import frame_transform_graph, base_doc
-from astropy.coordinates.attributes import TimeAttribute
-from astropy.coordinates.transformations import DynamicMatrixTransform
 from astropy.coordinates import earth_orientation as earth
+from astropy.coordinates.attributes import TimeAttribute
+from astropy.coordinates.baseframe import base_doc, frame_transform_graph
+from astropy.coordinates.transformations import DynamicMatrixTransform
+from astropy.utils.decorators import format_doc
 
 from .baseradec import BaseRADecFrame, doc_components
 from .utils import EQUINOX_J2000

--- a/astropy/coordinates/builtin_frames/galactic.py
+++ b/astropy/coordinates/builtin_frames/galactic.py
@@ -2,14 +2,14 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 from astropy import units as u
-from astropy.utils.decorators import format_doc
-from astropy.coordinates.angles import Angle
 from astropy.coordinates import representation as r
+from astropy.coordinates.angles import Angle
 from astropy.coordinates.baseframe import BaseCoordinateFrame, RepresentationMapping, base_doc
+from astropy.utils.decorators import format_doc
 
+from .fk4 import FK4NoETerms
 # these are needed for defining the NGP
 from .fk5 import FK5
-from .fk4 import FK4NoETerms
 
 __all__ = ['Galactic']
 

--- a/astropy/coordinates/builtin_frames/galactic_transforms.py
+++ b/astropy/coordinates/builtin_frames/galactic_transforms.py
@@ -1,16 +1,14 @@
 # -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from astropy.coordinates.matrix_utilities import (rotation_matrix,
-                                                  matrix_product,
-                                                  matrix_transpose)
 from astropy.coordinates.baseframe import frame_transform_graph
+from astropy.coordinates.matrix_utilities import matrix_product, matrix_transpose, rotation_matrix
 from astropy.coordinates.transformations import DynamicMatrixTransform
 
-from .fk5 import FK5
 from .fk4 import FK4NoETerms
-from .utils import EQUINOX_B1950, EQUINOX_J2000
+from .fk5 import FK5
 from .galactic import Galactic
+from .utils import EQUINOX_B1950, EQUINOX_J2000
 
 
 # Galactic to/from FK4/FK5 ----------------------->

--- a/astropy/coordinates/builtin_frames/galactocentric.py
+++ b/astropy/coordinates/builtin_frames/galactocentric.py
@@ -8,19 +8,16 @@ from types import MappingProxyType
 import numpy as np
 
 from astropy import units as u
-from astropy.utils.state import ScienceState
-from astropy.utils.decorators import format_doc, classproperty, deprecated
-from astropy.coordinates.angles import Angle
-from astropy.coordinates.matrix_utilities import rotation_matrix, matrix_product, matrix_transpose
 from astropy.coordinates import representation as r
-from astropy.coordinates.baseframe import (BaseCoordinateFrame,
-                                           frame_transform_graph,
-                                           base_doc)
+from astropy.coordinates.angles import Angle
 from astropy.coordinates.attributes import (CoordinateAttribute,
-                                            QuantityAttribute,
-                                            DifferentialAttribute)
-from astropy.coordinates.transformations import AffineTransform
+                                            DifferentialAttribute, QuantityAttribute)
+from astropy.coordinates.baseframe import BaseCoordinateFrame, base_doc, frame_transform_graph
 from astropy.coordinates.errors import ConvertError
+from astropy.coordinates.matrix_utilities import matrix_product, matrix_transpose, rotation_matrix
+from astropy.coordinates.transformations import AffineTransform
+from astropy.utils.decorators import classproperty, deprecated, format_doc
+from astropy.utils.state import ScienceState
 
 from .icrs import ICRS
 

--- a/astropy/coordinates/builtin_frames/gcrs.py
+++ b/astropy/coordinates/builtin_frames/gcrs.py
@@ -2,12 +2,12 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 from astropy import units as u
-from astropy.utils.decorators import format_doc
-from astropy.coordinates.attributes import (TimeAttribute,
-                                            CartesianRepresentationAttribute)
-from .utils import DEFAULT_OBSTIME, EQUINOX_J2000
+from astropy.coordinates.attributes import CartesianRepresentationAttribute, TimeAttribute
 from astropy.coordinates.baseframe import base_doc
+from astropy.utils.decorators import format_doc
+
 from .baseradec import BaseRADecFrame, doc_components
+from .utils import DEFAULT_OBSTIME, EQUINOX_J2000
 
 __all__ = ['GCRS', 'PrecessedGeocentric']
 

--- a/astropy/coordinates/builtin_frames/hadec.py
+++ b/astropy/coordinates/builtin_frames/hadec.py
@@ -4,12 +4,10 @@
 import numpy as np
 
 from astropy import units as u
-from astropy.utils.decorators import format_doc
 from astropy.coordinates import representation as r
+from astropy.coordinates.attributes import EarthLocationAttribute, QuantityAttribute, TimeAttribute
 from astropy.coordinates.baseframe import BaseCoordinateFrame, RepresentationMapping, base_doc
-from astropy.coordinates.attributes import (TimeAttribute,
-                                            QuantityAttribute,
-                                            EarthLocationAttribute)
+from astropy.utils.decorators import format_doc
 
 __all__ = ['HADec']
 

--- a/astropy/coordinates/builtin_frames/hcrs.py
+++ b/astropy/coordinates/builtin_frames/hcrs.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from astropy.utils.decorators import format_doc
 from astropy.coordinates.attributes import TimeAttribute
-from .utils import DEFAULT_OBSTIME
 from astropy.coordinates.baseframe import base_doc
+from astropy.utils.decorators import format_doc
+
 from .baseradec import BaseRADecFrame, doc_components
+from .utils import DEFAULT_OBSTIME
 
 __all__ = ['HCRS']
 

--- a/astropy/coordinates/builtin_frames/icrs.py
+++ b/astropy/coordinates/builtin_frames/icrs.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from astropy.utils.decorators import format_doc
 from astropy.coordinates.baseframe import base_doc
+from astropy.utils.decorators import format_doc
+
 from .baseradec import BaseRADecFrame, doc_components
 
 __all__ = ['ICRS']

--- a/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
@@ -9,24 +9,18 @@ import numpy as np
 
 from astropy import units as u
 from astropy.coordinates.baseframe import frame_transform_graph
-from astropy.coordinates.transformations import (
-    FunctionTransformWithFiniteDifference,
-    AffineTransform,
-)
-from astropy.coordinates.representation import (
-    SphericalRepresentation,
-    CartesianRepresentation,
-    UnitSphericalRepresentation,
-    CartesianDifferential,
-)
-
-from .icrs import ICRS
-from .gcrs import GCRS
-from .cirs import CIRS
-from .hcrs import HCRS
-from .utils import aticq, atciqz, get_offset_sun_from_barycenter
+from astropy.coordinates.representation import (CartesianDifferential, CartesianRepresentation,
+                                                SphericalRepresentation,
+                                                UnitSphericalRepresentation)
+from astropy.coordinates.transformations import (AffineTransform,
+                                                 FunctionTransformWithFiniteDifference)
 
 from ..erfa_astrom import erfa_astrom
+from .cirs import CIRS
+from .gcrs import GCRS
+from .hcrs import HCRS
+from .icrs import ICRS
+from .utils import atciqz, aticq, get_offset_sun_from_barycenter
 
 
 # First the ICRS/CIRS related transforms

--- a/astropy/coordinates/builtin_frames/icrs_fk5_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_fk5_transforms.py
@@ -1,10 +1,8 @@
 # -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from astropy.coordinates.matrix_utilities import (rotation_matrix,
-                                                  matrix_product,
-                                                  matrix_transpose)
 from astropy.coordinates.baseframe import frame_transform_graph
+from astropy.coordinates.matrix_utilities import matrix_product, matrix_transpose, rotation_matrix
 from astropy.coordinates.transformations import DynamicMatrixTransform
 
 from .fk5 import FK5

--- a/astropy/coordinates/builtin_frames/icrs_observed_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_observed_transforms.py
@@ -6,18 +6,17 @@ Contains the transformation functions for getting to "observed" systems from ICR
 import erfa
 
 from astropy import units as u
-from astropy.coordinates.builtin_frames.utils import atciqz, aticq
 from astropy.coordinates.baseframe import frame_transform_graph
-from astropy.coordinates.transformations import FunctionTransformWithFiniteDifference
-from astropy.coordinates.representation import (SphericalRepresentation,
-                                                CartesianRepresentation,
+from astropy.coordinates.builtin_frames.utils import atciqz, aticq
+from astropy.coordinates.representation import (CartesianRepresentation, SphericalRepresentation,
                                                 UnitSphericalRepresentation)
+from astropy.coordinates.transformations import FunctionTransformWithFiniteDifference
 
-from .icrs import ICRS
+from ..erfa_astrom import erfa_astrom
 from .altaz import AltAz
 from .hadec import HADec
+from .icrs import ICRS
 from .utils import PIOVER2
-from ..erfa_astrom import erfa_astrom
 
 
 @frame_transform_graph.transform(FunctionTransformWithFiniteDifference, ICRS, AltAz)

--- a/astropy/coordinates/builtin_frames/intermediate_rotation_transforms.py
+++ b/astropy/coordinates/builtin_frames/intermediate_rotation_transforms.py
@@ -6,19 +6,20 @@ These are distinct from the ICRS and AltAz functions because they are just
 rotations without aberration corrections or offsets.
 """
 
-import numpy as np
 import erfa
 
-from astropy.coordinates.baseframe import frame_transform_graph
-from astropy.coordinates.transformations import FunctionTransformWithFiniteDifference
-from astropy.coordinates.matrix_utilities import matrix_transpose
+import numpy as np
 
-from .icrs import ICRS
-from .gcrs import GCRS, PrecessedGeocentric
+from astropy.coordinates.baseframe import frame_transform_graph
+from astropy.coordinates.matrix_utilities import matrix_transpose
+from astropy.coordinates.transformations import FunctionTransformWithFiniteDifference
+
 from .cirs import CIRS
-from .itrs import ITRS
 from .equatorial import TEME, TETE
-from .utils import get_polar_motion, get_jd12, EARTH_CENTER
+from .gcrs import GCRS, PrecessedGeocentric
+from .icrs import ICRS
+from .itrs import ITRS
+from .utils import EARTH_CENTER, get_jd12, get_polar_motion
 
 # # first define helper functions
 

--- a/astropy/coordinates/builtin_frames/itrs.py
+++ b/astropy/coordinates/builtin_frames/itrs.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from astropy.utils.decorators import format_doc
-from astropy.coordinates.representation import CartesianRepresentation, CartesianDifferential
-from astropy.coordinates.baseframe import BaseCoordinateFrame, base_doc
 from astropy.coordinates.attributes import TimeAttribute
+from astropy.coordinates.baseframe import BaseCoordinateFrame, base_doc
+from astropy.coordinates.representation import CartesianDifferential, CartesianRepresentation
+from astropy.utils.decorators import format_doc
+
 from .utils import DEFAULT_OBSTIME
 
 __all__ = ['ITRS']

--- a/astropy/coordinates/builtin_frames/lsr.py
+++ b/astropy/coordinates/builtin_frames/lsr.py
@@ -2,19 +2,19 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 from astropy import units as u
-from astropy.utils.decorators import format_doc
-from astropy.time import Time
 from astropy.coordinates import representation as r
-from astropy.coordinates.baseframe import (BaseCoordinateFrame,
-                                           RepresentationMapping,
-                                           frame_transform_graph, base_doc)
-from astropy.coordinates.transformations import AffineTransform
 from astropy.coordinates.attributes import DifferentialAttribute
+from astropy.coordinates.baseframe import (BaseCoordinateFrame, RepresentationMapping,
+                                           base_doc, frame_transform_graph)
+from astropy.coordinates.transformations import AffineTransform
+from astropy.time import Time
+from astropy.utils.decorators import format_doc
 
-from .baseradec import BaseRADecFrame, doc_components as doc_components_radec
-from .icrs import ICRS
-from .galactic import Galactic
+from .baseradec import BaseRADecFrame
+from .baseradec import doc_components as doc_components_radec
 from .fk4 import FK4
+from .galactic import Galactic
+from .icrs import ICRS
 
 # For speed
 J2000 = Time('J2000')

--- a/astropy/coordinates/builtin_frames/skyoffset.py
+++ b/astropy/coordinates/builtin_frames/skyoffset.py
@@ -1,13 +1,10 @@
 # -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from astropy import units as u
-from astropy.coordinates.transformations import DynamicMatrixTransform, FunctionTransform
-from astropy.coordinates.baseframe import (frame_transform_graph,
-                                           BaseCoordinateFrame)
 from astropy.coordinates.attributes import CoordinateAttribute, QuantityAttribute
-from astropy.coordinates.matrix_utilities import (rotation_matrix,
-                                                  matrix_product,
-                                                  matrix_transpose)
+from astropy.coordinates.baseframe import BaseCoordinateFrame, frame_transform_graph
+from astropy.coordinates.matrix_utilities import matrix_product, matrix_transpose, rotation_matrix
+from astropy.coordinates.transformations import DynamicMatrixTransform, FunctionTransform
 
 _skyoffset_cache = {}
 

--- a/astropy/coordinates/builtin_frames/supergalactic.py
+++ b/astropy/coordinates/builtin_frames/supergalactic.py
@@ -2,9 +2,10 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 from astropy import units as u
-from astropy.utils.decorators import format_doc
 from astropy.coordinates import representation as r
 from astropy.coordinates.baseframe import BaseCoordinateFrame, RepresentationMapping, base_doc
+from astropy.utils.decorators import format_doc
+
 from .galactic import Galactic
 
 __all__ = ['Supergalactic']

--- a/astropy/coordinates/builtin_frames/supergalactic_transforms.py
+++ b/astropy/coordinates/builtin_frames/supergalactic_transforms.py
@@ -1,10 +1,8 @@
 # -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from astropy.coordinates.matrix_utilities import (rotation_matrix,
-                                                  matrix_product,
-                                                  matrix_transpose)
 from astropy.coordinates.baseframe import frame_transform_graph
+from astropy.coordinates.matrix_utilities import matrix_product, matrix_transpose, rotation_matrix
 from astropy.coordinates.transformations import StaticMatrixTransform
 
 from .galactic import Galactic

--- a/astropy/coordinates/builtin_frames/utils.py
+++ b/astropy/coordinates/builtin_frames/utils.py
@@ -8,15 +8,16 @@ the ``builtin_frames`` package.
 import warnings
 
 import erfa
+
 import numpy as np
 
 from astropy import units as u
-from astropy.time import Time
 from astropy.coordinates.earth import EarthLocation
+from astropy.time import Time
 from astropy.utils import iers
 from astropy.utils.exceptions import AstropyWarning
-from ..representation import CartesianDifferential
 
+from ..representation import CartesianDifferential
 
 # We use tt as the time scale for this equinoxes, primarily because it is the
 # convention for J2000 (it is unclear if there is any "right answer" for B1950)
@@ -346,11 +347,10 @@ def prepare_earth_position_vel(time):
         Heliocentric position of Earth in au
     """
     # this goes here to avoid circular import errors
-    from astropy.coordinates.solar_system import (
-        get_body_barycentric,
-        get_body_barycentric_posvel,
-        solar_system_ephemeris,
-    )
+    from astropy.coordinates.solar_system import (get_body_barycentric,
+                                                  get_body_barycentric_posvel,
+                                                  solar_system_ephemeris)
+
     # get barycentric position and velocity of earth
 
     ephemeris = solar_system_ephemeris.get()

--- a/astropy/coordinates/calculation.py
+++ b/astropy/coordinates/calculation.py
@@ -2,16 +2,15 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 
-# Standard library
 import re
 import textwrap
 import warnings
 from datetime import datetime
-from urllib.request import urlopen, Request
+from urllib.request import Request, urlopen
 
-# Third-party
 from astropy import time as atime
-from astropy.utils.console import color_print, _color_text
+from astropy.utils.console import _color_text, color_print
+
 from . import get_sun
 
 __all__ = []

--- a/astropy/coordinates/distances.py
+++ b/astropy/coordinates/distances.py
@@ -11,6 +11,7 @@ import numpy as np
 
 from astropy import units as u
 from astropy.utils.exceptions import AstropyWarning
+
 from .angles import Angle
 
 __all__ = ['Distance']

--- a/astropy/coordinates/earth.py
+++ b/astropy/coordinates/earth.py
@@ -1,29 +1,28 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from warnings import warn
 import collections
-import socket
 import json
-import urllib.request
+import socket
 import urllib.error
 import urllib.parse
+import urllib.request
+from warnings import warn
 
-import numpy as np
 import erfa
 
-from astropy import units as u
+import numpy as np
+
 from astropy import constants as consts
+from astropy import units as u
 from astropy.units.quantity import QuantityInfoBase
 from astropy.utils import data
 from astropy.utils.decorators import format_doc
 from astropy.utils.exceptions import AstropyUserWarning
 
-from .angles import Angle, Longitude, Latitude
-from .representation import (BaseRepresentation, CartesianRepresentation,
-                             CartesianDifferential)
-from .matrix_utilities import matrix_transpose
+from .angles import Angle, Latitude, Longitude
 from .errors import UnknownSiteException
-
+from .matrix_utilities import matrix_transpose
+from .representation import BaseRepresentation, CartesianDifferential, CartesianRepresentation
 
 __all__ = ['EarthLocation', 'BaseGeodeticRepresentation',
            'WGS84GeodeticRepresentation', 'WGS72GeodeticRepresentation',
@@ -731,8 +730,8 @@ class EarthLocation(u.Quantity):
             The GCRS velocity of the object
         """
         # Local import to prevent circular imports.
-        from .builtin_frames.intermediate_rotation_transforms import (
-            cirs_to_itrs_mat, gcrs_to_cirs_mat)
+        from .builtin_frames.intermediate_rotation_transforms import (cirs_to_itrs_mat,
+                                                                      gcrs_to_cirs_mat)
 
         # Get gcrs_posvel by transforming via CIRS (slightly faster than TETE).
         return self._get_gcrs_posvel(obstime,

--- a/astropy/coordinates/earth_orientation.py
+++ b/astropy/coordinates/earth_orientation.py
@@ -11,10 +11,10 @@ is instead primarily for internal use in `coordinates`
 
 import numpy as np
 
-from astropy.time import Time
 from astropy import units as u
-from .matrix_utilities import rotation_matrix, matrix_product, matrix_transpose
+from astropy.time import Time
 
+from .matrix_utilities import matrix_product, matrix_transpose, rotation_matrix
 
 jd1950 = Time('B1950').jd
 jd2000 = Time('J2000').jd

--- a/astropy/coordinates/erfa_astrom.py
+++ b/astropy/coordinates/erfa_astrom.py
@@ -6,20 +6,18 @@ expense of accuracy.
 """
 import warnings
 
-import numpy as np
 import erfa
 
-from astropy.time import Time
-from astropy.utils.state import ScienceState
+import numpy as np
+
 import astropy.units as u
+from astropy.time import Time
 from astropy.utils.exceptions import AstropyWarning
+from astropy.utils.state import ScienceState
 
-from .builtin_frames.utils import (
-    get_jd12, get_cip, prepare_earth_position_vel, get_polar_motion,
-    pav2pv
-)
+from .builtin_frames.utils import (get_cip, get_jd12, get_polar_motion,
+                                   pav2pv, prepare_earth_position_vel)
 from .matrix_utilities import rotation_matrix
-
 
 __all__ = []
 

--- a/astropy/coordinates/funcs.py
+++ b/astropy/coordinates/funcs.py
@@ -11,17 +11,19 @@ interfaces.
 import warnings
 from collections.abc import Sequence
 
-import numpy as np
 import erfa
+
+import numpy as np
 
 from astropy import units as u
 from astropy.constants import c
 from astropy.io import ascii
-from astropy.utils import isiterable, data
-from .sky_coordinate import SkyCoord
+from astropy.utils import data, isiterable
+
 from .builtin_frames import GCRS, PrecessedGeocentric
-from .representation import SphericalRepresentation, CartesianRepresentation
 from .builtin_frames.utils import get_jd12
+from .representation import CartesianRepresentation, SphericalRepresentation
+from .sky_coordinate import SkyCoord
 
 __all__ = ['cartesian_to_spherical', 'spherical_to_cartesian', 'get_sun',
            'get_constellation', 'concatenate_representations', 'concatenate']

--- a/astropy/coordinates/matching.py
+++ b/astropy/coordinates/matching.py
@@ -6,9 +6,10 @@ This module contains functions for matching coordinate catalogs.
 
 import numpy as np
 
-from .representation import UnitSphericalRepresentation
 from astropy import units as u
+
 from . import Angle
+from .representation import UnitSphericalRepresentation
 from .sky_coordinate import SkyCoord
 
 __all__ = ['match_coordinates_3d', 'match_coordinates_sky', 'search_around_3d',

--- a/astropy/coordinates/matrix_utilities.py
+++ b/astropy/coordinates/matrix_utilities.py
@@ -5,9 +5,11 @@
 Utililies used for constructing and inspecting rotation matrices.
 """
 from functools import reduce
+
 import numpy as np
 
 from astropy import units as u
+
 from .angles import Angle
 
 

--- a/astropy/coordinates/name_resolve.py
+++ b/astropy/coordinates/name_resolve.py
@@ -12,16 +12,17 @@ reference for that measurement and input the coordinates manually.
 import os
 import re
 import socket
-import urllib.request
-import urllib.parse
 import urllib.error
+import urllib.parse
+import urllib.request
 
 # Astropy
 from astropy import units as u
-from .sky_coordinate import SkyCoord
 from astropy.utils import data
 from astropy.utils.data import download_file, get_file_contents
 from astropy.utils.state import ScienceState
+
+from .sky_coordinate import SkyCoord
 
 __all__ = ["get_icrs_coordinates"]
 

--- a/astropy/coordinates/orbital_elements.py
+++ b/astropy/coordinates/orbital_elements.py
@@ -5,14 +5,15 @@ algorithms contained within Jean Meeus, 'Astronomical Algorithms',
 second edition, 1998, Willmann-Bell.
 """
 
-import numpy as np
-from numpy.polynomial.polynomial import polyval
 import erfa
 
-from astropy.utils import deprecated
+import numpy as np
+from numpy.polynomial.polynomial import polyval
 
 from astropy import units as u
-from . import ICRS, SkyCoord, GeocentricTrueEcliptic
+from astropy.utils import deprecated
+
+from . import ICRS, GeocentricTrueEcliptic, SkyCoord
 from .builtin_frames.utils import get_jd12
 
 __all__ = ["calc_moon"]

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -6,21 +6,22 @@ coordinates.
 
 import abc
 import functools
-import operator
 import inspect
+import operator
 import warnings
 
-import numpy as np
-import astropy.units as u
 from erfa import ufunc as erfa_ufunc
 
-from .angles import Angle, Longitude, Latitude
-from .distances import Distance
-from .matrix_utilities import is_O3
+import numpy as np
+
+import astropy.units as u
 from astropy.utils import ShapedLikeNDArray, classproperty
 from astropy.utils.data_info import MixinInfo
 from astropy.utils.exceptions import DuplicateRepresentationWarning
 
+from .angles import Angle, Latitude, Longitude
+from .distances import Distance
+from .matrix_utilities import is_O3
 
 __all__ = ["BaseRepresentationOrDifferential", "BaseRepresentation",
            "CartesianRepresentation", "SphericalRepresentation",

--- a/astropy/coordinates/sites.py
+++ b/astropy/coordinates/sites.py
@@ -12,13 +12,14 @@ updating the ``location.json`` file.
 
 
 import json
-from difflib import get_close_matches
 from collections.abc import Mapping
+from difflib import get_close_matches
 
-from astropy.utils.data import get_pkg_data_contents, get_file_contents
+from astropy import units as u
+from astropy.utils.data import get_file_contents, get_pkg_data_contents
+
 from .earth import EarthLocation
 from .errors import UnknownSiteException
-from astropy import units as u
 
 
 class SiteRegistry(Mapping):

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -1,30 +1,28 @@
-import re
 import copy
-import warnings
 import operator
+import re
+import warnings
 
-import numpy as np
 import erfa
 
-from astropy.utils.compat.misc import override__dir__
+import numpy as np
+
 from astropy import units as u
 from astropy.constants import c as speed_of_light
-from astropy.utils.data_info import MixinInfo
-from astropy.utils import ShapedLikeNDArray
 from astropy.table import QTable
 from astropy.time import Time
+from astropy.utils import ShapedLikeNDArray
+from astropy.utils.compat.misc import override__dir__
+from astropy.utils.data_info import MixinInfo
 from astropy.utils.exceptions import AstropyUserWarning
 
-from .distances import Distance
 from .angles import Angle
-from .baseframe import (BaseCoordinateFrame, frame_transform_graph,
-                        GenericFrame)
+from .baseframe import BaseCoordinateFrame, GenericFrame, frame_transform_graph
 from .builtin_frames import ICRS, SkyOffsetFrame
+from .distances import Distance
 from .representation import (RadialDifferential, SphericalDifferential,
-                             SphericalRepresentation,
-                             UnitSphericalCosLatDifferential,
-                             UnitSphericalDifferential,
-                             UnitSphericalRepresentation)
+                             SphericalRepresentation, UnitSphericalCosLatDifferential,
+                             UnitSphericalDifferential, UnitSphericalRepresentation)
 from .sky_coordinate_parsers import (_get_frame_class, _get_frame_without_data,
                                      _parse_coordinate_data)
 

--- a/astropy/coordinates/sky_coordinate_parsers.py
+++ b/astropy/coordinates/sky_coordinate_parsers.py
@@ -1,16 +1,15 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+import inspect
 import re
 from collections.abc import Sequence
-import inspect
 
 import numpy as np
 
-from astropy.units import Unit, IrreducibleUnit
 from astropy import units as u
+from astropy.units import IrreducibleUnit, Unit
 
-from .baseframe import (BaseCoordinateFrame, frame_transform_graph,
-                        _get_repr_cls, _get_diff_cls)
+from .baseframe import BaseCoordinateFrame, _get_diff_cls, _get_repr_cls, frame_transform_graph
 from .builtin_frames import ICRS
 from .representation import (BaseRepresentation, SphericalRepresentation,
                              UnitSphericalRepresentation)

--- a/astropy/coordinates/solar_system.py
+++ b/astropy/coordinates/solar_system.py
@@ -4,22 +4,24 @@ This module contains convenience functions for retrieving solar system
 ephemerides from jplephem.
 """
 
-from urllib.parse import urlparse
 import os.path
+from urllib.parse import urlparse
 
-import numpy as np
 import erfa
 
-from .sky_coordinate import SkyCoord
+import numpy as np
+
+from astropy import units as u
+from astropy.constants import c as speed_of_light
+from astropy.utils import indent
 from astropy.utils.data import download_file
 from astropy.utils.decorators import classproperty, deprecated
 from astropy.utils.state import ScienceState
-from astropy.utils import indent
-from astropy import units as u
-from astropy.constants import c as speed_of_light
-from .representation import CartesianRepresentation, CartesianDifferential
+
 from .builtin_frames import GCRS, ICRS, ITRS, TETE
 from .builtin_frames.utils import get_jd12
+from .representation import CartesianDifferential, CartesianRepresentation
+from .sky_coordinate import SkyCoord
 
 __all__ = ["get_body", "get_moon", "get_body_barycentric",
            "get_body_barycentric_posvel", "solar_system_ephemeris"]

--- a/astropy/coordinates/spectral_coordinate.py
+++ b/astropy/coordinates/spectral_coordinate.py
@@ -1,15 +1,13 @@
 import warnings
 from textwrap import indent
 
-import astropy.units as u
 import numpy as np
+
+import astropy.units as u
 from astropy.constants import c
-from astropy.coordinates import (ICRS,
-                                 CartesianDifferential,
-                                 CartesianRepresentation, SkyCoord)
+from astropy.coordinates import ICRS, CartesianDifferential, CartesianRepresentation, SkyCoord
+from astropy.coordinates.baseframe import BaseCoordinateFrame, frame_transform_graph
 from astropy.coordinates.spectral_quantity import SpectralQuantity
-from astropy.coordinates.baseframe import (BaseCoordinateFrame,
-                                           frame_transform_graph)
 from astropy.utils.exceptions import AstropyUserWarning
 
 __all__ = ['SpectralCoord']

--- a/astropy/coordinates/spectral_quantity.py
+++ b/astropy/coordinates/spectral_quantity.py
@@ -1,9 +1,10 @@
 import numpy as np
-from astropy.units import si
-from astropy.units import equivalencies as eq
+
 from astropy.units import Unit
-from astropy.units.quantity import SpecificTypeQuantity, Quantity
+from astropy.units import equivalencies as eq
+from astropy.units import si
 from astropy.units.decorators import quantity_input
+from astropy.units.quantity import Quantity, SpecificTypeQuantity
 
 __all__ = ['SpectralQuantity']
 

--- a/astropy/coordinates/tests/accuracy/generate_ref_ast.py
+++ b/astropy/coordinates/tests/accuracy/generate_ref_ast.py
@@ -8,7 +8,7 @@ import os
 
 import numpy as np
 
-from astropy.table import Table, Column
+from astropy.table import Column, Table
 
 
 def ref_fk4_no_e_fk4(fnout='fk4_no_e_fk4.csv'):

--- a/astropy/coordinates/tests/accuracy/generate_spectralcoord_ref.py
+++ b/astropy/coordinates/tests/accuracy/generate_spectralcoord_ref.py
@@ -11,10 +11,10 @@ if __name__ == "__main__":
 
     import numpy as np
 
-    from astropy.table import QTable
-    from astropy.coordinates import SkyCoord, Angle
-    from astropy.time import Time
     from astropy import units as u
+    from astropy.coordinates import Angle, SkyCoord
+    from astropy.table import QTable
+    from astropy.time import Time
 
     np.random.seed(12345)
 

--- a/astropy/coordinates/tests/accuracy/test_altaz_icrs.py
+++ b/astropy/coordinates/tests/accuracy/test_altaz_icrs.py
@@ -5,13 +5,13 @@ We use "known good" examples computed with other coordinate libraries.
 """
 
 import pytest
+
 import numpy as np
 
 from astropy import units as u
-from astropy.time import Time
+from astropy.coordinates import Angle, EarthLocation, SkyCoord
 from astropy.coordinates.builtin_frames import AltAz
-from astropy.coordinates import EarthLocation
-from astropy.coordinates import Angle, SkyCoord
+from astropy.time import Time
 
 
 def test_against_hor2eq():

--- a/astropy/coordinates/tests/accuracy/test_ecliptic.py
+++ b/astropy/coordinates/tests/accuracy/test_ecliptic.py
@@ -3,22 +3,21 @@
 Accuracy tests for Ecliptic coordinate systems.
 """
 
-import numpy as np
-
 import pytest
 
-from astropy.units import allclose as quantity_allclose
+import numpy as np
+
 from astropy import units as u
+from astropy.constants import R_earth, R_sun
 from astropy.coordinates import SkyCoord
-from astropy.coordinates.builtin_frames import (FK5, ICRS, GCRS,
+from astropy.coordinates.builtin_frames import (FK5, GCRS, ICRS, BarycentricMeanEcliptic,
+                                                BarycentricTrueEcliptic, CustomBarycentricEcliptic,
                                                 GeocentricMeanEcliptic, GeocentricTrueEcliptic,
-                                                BarycentricMeanEcliptic, BarycentricTrueEcliptic,
-                                                CustomBarycentricEcliptic,
-                                                HeliocentricMeanEcliptic, HeliocentricTrueEcliptic,
-                                                HeliocentricEclipticIAU76)
+                                                HeliocentricEclipticIAU76,
+                                                HeliocentricMeanEcliptic, HeliocentricTrueEcliptic)
 from astropy.coordinates.solar_system import get_body_barycentric_posvel
-from astropy.constants import R_sun, R_earth
 from astropy.time import Time
+from astropy.units import allclose as quantity_allclose
 
 
 def test_against_pytpm_doc_example():

--- a/astropy/coordinates/tests/accuracy/test_fk4_no_e_fk4.py
+++ b/astropy/coordinates/tests/accuracy/test_fk4_no_e_fk4.py
@@ -4,10 +4,10 @@
 import numpy as np
 
 from astropy import units as u
-from astropy.coordinates.builtin_frames import FK4NoETerms, FK4
-from astropy.time import Time
-from astropy.table import Table
 from astropy.coordinates.angle_utilities import angular_separation
+from astropy.coordinates.builtin_frames import FK4, FK4NoETerms
+from astropy.table import Table
+from astropy.time import Time
 from astropy.utils.data import get_pkg_data_contents
 
 # the number of tests to run

--- a/astropy/coordinates/tests/accuracy/test_fk4_no_e_fk5.py
+++ b/astropy/coordinates/tests/accuracy/test_fk4_no_e_fk5.py
@@ -4,10 +4,10 @@
 import numpy as np
 
 from astropy import units as u
-from astropy.coordinates.builtin_frames import FK4NoETerms, FK5
-from astropy.time import Time
-from astropy.table import Table
 from astropy.coordinates.angle_utilities import angular_separation
+from astropy.coordinates.builtin_frames import FK5, FK4NoETerms
+from astropy.table import Table
+from astropy.time import Time
 from astropy.utils.data import get_pkg_data_contents
 
 # the number of tests to run

--- a/astropy/coordinates/tests/accuracy/test_galactic_fk4.py
+++ b/astropy/coordinates/tests/accuracy/test_galactic_fk4.py
@@ -4,10 +4,10 @@
 import numpy as np
 
 from astropy import units as u
-from astropy.coordinates.builtin_frames import Galactic, FK4
-from astropy.time import Time
-from astropy.table import Table
 from astropy.coordinates.angle_utilities import angular_separation
+from astropy.coordinates.builtin_frames import FK4, Galactic
+from astropy.table import Table
+from astropy.time import Time
 from astropy.utils.data import get_pkg_data_contents
 
 # the number of tests to run

--- a/astropy/coordinates/tests/accuracy/test_icrs_fk5.py
+++ b/astropy/coordinates/tests/accuracy/test_icrs_fk5.py
@@ -4,10 +4,10 @@
 import numpy as np
 
 from astropy import units as u
-from astropy.coordinates.builtin_frames import ICRS, FK5
-from astropy.time import Time
-from astropy.table import Table
 from astropy.coordinates.angle_utilities import angular_separation
+from astropy.coordinates.builtin_frames import FK5, ICRS
+from astropy.table import Table
+from astropy.time import Time
 from astropy.utils.data import get_pkg_data_contents
 
 # the number of tests to run

--- a/astropy/coordinates/tests/test_angle_generators.py
+++ b/astropy/coordinates/tests/test_angle_generators.py
@@ -1,15 +1,14 @@
 """Unit tests for the astropy.coordinates.angle_utilities module"""
 
-import numpy as np
 import pytest
 
+import numpy as np
+
 import astropy.units as u
+from astropy.coordinates.angle_utilities import (golden_spiral_grid,
+                                                 uniform_spherical_random_surface,
+                                                 uniform_spherical_random_volume)
 from astropy.utils import NumpyRNGContext
-from astropy.coordinates.angle_utilities import (
-    golden_spiral_grid,
-    uniform_spherical_random_surface,
-    uniform_spherical_random_volume
-)
 
 
 def test_golden_spiral_grid_input():

--- a/astropy/coordinates/tests/test_angles.py
+++ b/astropy/coordinates/tests/test_angles.py
@@ -5,15 +5,15 @@
 import threading
 import warnings
 
-import numpy as np
 import pytest
+
+import numpy as np
 from numpy.testing import assert_allclose, assert_array_equal
 
 import astropy.units as u
-from astropy.coordinates.angles import Longitude, Latitude, Angle
-from astropy.coordinates.errors import (
-    IllegalSecondError, IllegalMinuteError, IllegalHourError,
-    IllegalSecondWarning, IllegalMinuteWarning)
+from astropy.coordinates.angles import Angle, Latitude, Longitude
+from astropy.coordinates.errors import (IllegalHourError, IllegalMinuteError, IllegalMinuteWarning,
+                                        IllegalSecondError, IllegalSecondWarning)
 from astropy.utils.exceptions import AstropyDeprecationWarning
 
 
@@ -1011,9 +1011,9 @@ def test_angle_with_cds_units_enabled():
     Especially the example in
     https://github.com/astropy/astropy/issues/5350#issuecomment-248770151
     """
-    from astropy.units import cds
     # the problem is with the parser, so remove it temporarily
     from astropy.coordinates.angle_formats import _AngleParser
+    from astropy.units import cds
     del _AngleParser._thread_local._parser
     with cds.enable():
         Angle('5d')

--- a/astropy/coordinates/tests/test_angular_separation.py
+++ b/astropy/coordinates/tests/test_angular_separation.py
@@ -7,12 +7,13 @@ Tests for the projected separation stuff
 """
 
 import pytest
+
 import numpy as np
 
-from astropy.tests.helper import assert_quantity_allclose as assert_allclose
 from astropy import units as u
-from astropy.coordinates.builtin_frames import ICRS, FK5, Galactic
 from astropy.coordinates import Angle, Distance
+from astropy.coordinates.builtin_frames import FK5, ICRS, Galactic
+from astropy.tests.helper import assert_quantity_allclose as assert_allclose
 
 # lon1, lat1, lon2, lat2 in degrees
 coords = [(1, 0, 0, 0),

--- a/astropy/coordinates/tests/test_api_ape5.py
+++ b/astropy/coordinates/tests/test_api_ape5.py
@@ -13,28 +13,29 @@ deviations from the original APE5 plan.
 """
 
 import pytest
+
 import numpy as np
 from numpy import testing as npt
 
-from astropy.tests.helper import assert_quantity_allclose as assert_allclose
-from astropy import units as u
-from astropy import time
 from astropy import coordinates as coords
+from astropy import time
+from astropy import units as u
+from astropy.tests.helper import assert_quantity_allclose as assert_allclose
 from astropy.units import allclose
 from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa
 
 
 def test_representations_api():
-    from astropy.coordinates.representation import SphericalRepresentation, \
-        UnitSphericalRepresentation, PhysicsSphericalRepresentation, \
-        CartesianRepresentation
-    from astropy.coordinates import Angle, Longitude, Latitude, Distance
+    from astropy.coordinates import Angle, Distance, Latitude, Longitude
+    from astropy.coordinates.representation import (CartesianRepresentation,
+                                                    PhysicsSphericalRepresentation,
+                                                    SphericalRepresentation,
+                                                    UnitSphericalRepresentation)
 
     # <-----------------Classes for representation of coordinate data-------------->
     # These classes inherit from a common base class and internally contain Quantity
     # objects, which are arrays (although they may act as scalars, like numpy's
     # length-0  "arrays")
-
     # They can be initialized with a variety of ways that make intuitive sense.
     # Distance is optional.
     UnitSphericalRepresentation(lon=8*u.hour, lat=5*u.deg)
@@ -139,14 +140,14 @@ def test_representations_api():
 
 
 def test_frame_api():
-    from astropy.coordinates.representation import SphericalRepresentation, \
-                                 UnitSphericalRepresentation
-    from astropy.coordinates.builtin_frames import ICRS, FK5
+    from astropy.coordinates.builtin_frames import FK5, ICRS
+    from astropy.coordinates.representation import (SphericalRepresentation,
+                                                    UnitSphericalRepresentation)
+
     # <--------------------Reference Frame/"Low-level" classes--------------------->
     # The low-level classes have a dual role: they act as specifiers of coordinate
     # frames and they *may* also contain data as one of the representation objects,
     # in which case they are the actual coordinate objects themselves.
-
     # They can always accept a representation as a first argument
     icrs = ICRS(UnitSphericalRepresentation(lon=8*u.hour, lat=5*u.deg))
 
@@ -226,14 +227,14 @@ def test_frame_api():
 
 
 def test_transform_api():
+    from astropy.coordinates.baseframe import BaseCoordinateFrame, frame_transform_graph
+    from astropy.coordinates.builtin_frames import FK5, ICRS
     from astropy.coordinates.representation import UnitSphericalRepresentation
-    from astropy.coordinates.builtin_frames import ICRS, FK5
-    from astropy.coordinates.baseframe import frame_transform_graph, BaseCoordinateFrame
     from astropy.coordinates.transformations import DynamicMatrixTransform
+
     # <------------------------Transformations------------------------------------->
     # Transformation functionality is the key to the whole scheme: they transform
     # low-level classes from one frame to another.
-
     # (used below but defined above in the API)
     fk5 = FK5(ra=8*u.hour, dec=5*u.deg)
 

--- a/astropy/coordinates/tests/test_arrays.py
+++ b/astropy/coordinates/tests/test_arrays.py
@@ -3,17 +3,16 @@
 from contextlib import ExitStack
 
 import pytest
+
 import numpy as np
 from numpy import testing as npt
 
 from astropy import units as u
-from astropy.time import Time
-from astropy.tests.helper import assert_quantity_allclose as assert_allclose
-from astropy.utils.compat import NUMPY_LT_1_19
-
-from astropy.coordinates import (Angle, ICRS, FK4, FK5, Galactic, SkyCoord,
-                                 CartesianRepresentation)
+from astropy.coordinates import FK4, FK5, ICRS, Angle, CartesianRepresentation, Galactic, SkyCoord
 from astropy.coordinates.angle_formats import dms_to_degrees, hms_to_hours
+from astropy.tests.helper import assert_quantity_allclose as assert_allclose
+from astropy.time import Time
+from astropy.utils.compat import NUMPY_LT_1_19
 
 
 def test_angle_arrays():

--- a/astropy/coordinates/tests/test_atc_replacements.py
+++ b/astropy/coordinates/tests/test_atc_replacements.py
@@ -3,14 +3,14 @@
 
 """Test replacements for ERFA functions atciqz and aticq."""
 
-import pytest
 import erfa
+import pytest
 
+import astropy.units as u
+from astropy.coordinates import SphericalRepresentation
+from astropy.coordinates.builtin_frames.utils import atciqz, aticq, get_jd12
 from astropy.tests.helper import assert_quantity_allclose as assert_allclose
 from astropy.time import Time
-import astropy.units as u
-from astropy.coordinates.builtin_frames.utils import get_jd12, atciqz, aticq
-from astropy.coordinates import SphericalRepresentation
 
 # Hard-coded random values
 sph = SphericalRepresentation(lon=[15., 214.] * u.deg,

--- a/astropy/coordinates/tests/test_celestial_transformations.py
+++ b/astropy/coordinates/tests/test_celestial_transformations.py
@@ -2,17 +2,17 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import pytest
+
 import numpy as np
 
 from astropy import units as u
-from astropy.coordinates import galactocentric_frame_defaults
+from astropy.coordinates import (CartesianDifferential, CartesianRepresentation,
+                                 EarthLocation, SkyCoord, galactocentric_frame_defaults)
+from astropy.coordinates.builtin_frames import (CIRS, FK4, FK5, GCRS, HCRS, ICRS, LSR,
+                                                FK4NoETerms, Galactic, GalacticLSR,
+                                                Galactocentric, Supergalactic)
 from astropy.coordinates.distances import Distance
-from astropy.coordinates.builtin_frames import (
-    ICRS, FK5, FK4, FK4NoETerms, Galactic, CIRS,
-    Supergalactic, Galactocentric, HCRS, GCRS, LSR, GalacticLSR)
-from astropy.coordinates import SkyCoord
 from astropy.tests.helper import assert_quantity_allclose as assert_allclose
-from astropy.coordinates import EarthLocation, CartesianRepresentation, CartesianDifferential
 from astropy.time import Time
 from astropy.units import allclose
 

--- a/astropy/coordinates/tests/test_distance.py
+++ b/astropy/coordinates/tests/test_distance.py
@@ -5,15 +5,16 @@ This includes tests for the Distance class and related calculations
 """
 
 import pytest
+
 import numpy as np
 from numpy import testing as npt
 
 from astropy import units as u
-from astropy.units import allclose as quantity_allclose
-from astropy.coordinates import Longitude, Latitude, Distance, CartesianRepresentation
+from astropy.coordinates import CartesianRepresentation, Distance, Latitude, Longitude
 from astropy.coordinates.builtin_frames import ICRS, Galactic
-from astropy.utils.exceptions import AstropyWarning
+from astropy.units import allclose as quantity_allclose
 from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa
+from astropy.utils.exceptions import AstropyWarning
 
 
 def test_distances():

--- a/astropy/coordinates/tests/test_earth.py
+++ b/astropy/coordinates/tests/test_earth.py
@@ -6,15 +6,16 @@
 import pickle
 
 import pytest
+
 import numpy as np
 
-from astropy.coordinates.earth import EarthLocation, ELLIPSOIDS
-from astropy.coordinates.angles import Longitude, Latitude
-from astropy.units import allclose as quantity_allclose
-from astropy import units as u
-from astropy.time import Time
 from astropy import constants
+from astropy import units as u
+from astropy.coordinates.angles import Latitude, Longitude
+from astropy.coordinates.earth import ELLIPSOIDS, EarthLocation
 from astropy.coordinates.name_resolve import NameResolveError
+from astropy.time import Time
+from astropy.units import allclose as quantity_allclose
 
 
 def allclose_m14(a, b, rtol=1.e-14, atol=None):

--- a/astropy/coordinates/tests/test_erfa_astrom.py
+++ b/astropy/coordinates/tests/test_erfa_astrom.py
@@ -1,14 +1,12 @@
-import numpy as np
 import pytest
 
+import numpy as np
+
 import astropy.units as u
+from astropy.coordinates import CIRS, GCRS, AltAz, EarthLocation, SkyCoord
+from astropy.coordinates.erfa_astrom import ErfaAstrom, ErfaAstromInterpolator, erfa_astrom
 from astropy.time import Time
 from astropy.utils.exceptions import AstropyWarning
-from astropy.coordinates import EarthLocation, AltAz, GCRS, SkyCoord, CIRS
-
-from astropy.coordinates.erfa_astrom import (
-    erfa_astrom, ErfaAstrom, ErfaAstromInterpolator
-)
 
 
 def test_science_state():
@@ -96,13 +94,11 @@ def test_interpolation_nd():
 
 
 def test_interpolation_broadcasting():
-    from astropy.coordinates.angle_utilities import golden_spiral_grid
-    from astropy.coordinates import SkyCoord, EarthLocation, AltAz
-    from astropy.time import Time
     import astropy.units as u
-
-    from astropy.coordinates.erfa_astrom import (erfa_astrom,
-                                                 ErfaAstromInterpolator)
+    from astropy.coordinates import AltAz, EarthLocation, SkyCoord
+    from astropy.coordinates.angle_utilities import golden_spiral_grid
+    from astropy.coordinates.erfa_astrom import ErfaAstromInterpolator, erfa_astrom
+    from astropy.time import Time
 
     # 1000 gridded locations on the sky
     rep = golden_spiral_grid(100)

--- a/astropy/coordinates/tests/test_finite_difference_velocities.py
+++ b/astropy/coordinates/tests/test_finite_difference_velocities.py
@@ -3,20 +3,20 @@
 
 
 import pytest
-import numpy as np
-from astropy.units import allclose as quantity_allclose
 
-from astropy import units as u
+import numpy as np
+
 from astropy import constants
-from astropy.time import Time
-from astropy.coordinates.builtin_frames import ICRS, AltAz, LSR, GCRS, Galactic, FK5
+from astropy import units as u
+from astropy.coordinates import (CartesianDifferential, CartesianRepresentation,
+                                 DynamicMatrixTransform, FunctionTransformWithFiniteDifference,
+                                 SphericalDifferential, SphericalRepresentation, TimeAttribute,
+                                 get_sun)
 from astropy.coordinates.baseframe import frame_transform_graph
+from astropy.coordinates.builtin_frames import FK5, GCRS, ICRS, LSR, AltAz, Galactic
 from astropy.coordinates.sites import get_builtin_sites
-from astropy.coordinates import (TimeAttribute,
-                FunctionTransformWithFiniteDifference, get_sun,
-                CartesianRepresentation, SphericalRepresentation,
-                CartesianDifferential, SphericalDifferential,
-                DynamicMatrixTransform)
+from astropy.time import Time
+from astropy.units import allclose as quantity_allclose
 
 J2000 = Time('J2000')
 
@@ -73,7 +73,7 @@ def test_faux_lsr(dt, symmetric):
 
 def test_faux_fk5_galactic():
 
-    from astropy.coordinates.builtin_frames.galactic_transforms import fk5_to_gal, _gal_to_fk5
+    from astropy.coordinates.builtin_frames.galactic_transforms import _gal_to_fk5, fk5_to_gal
 
     class Galactic2(Galactic):
         pass

--- a/astropy/coordinates/tests/test_formatting.py
+++ b/astropy/coordinates/tests/test_formatting.py
@@ -6,8 +6,8 @@ test_sky_coord
 """
 
 
-from astropy.coordinates.angles import Angle
 from astropy import units as u
+from astropy.coordinates.angles import Angle
 
 
 def test_to_string_precision():

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -1,51 +1,27 @@
 # -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from copy import deepcopy
-import numpy as np
-import pytest
 import re
+from copy import deepcopy
+
+import pytest
+
+import numpy as np
 
 from astropy import units as u
-from astropy.units import allclose
+from astropy.coordinates import EarthLocation, SkyCoord, galactocentric_frame_defaults
+from astropy.coordinates import representation as r
+from astropy.coordinates.attributes import (Attribute, CoordinateAttribute,
+                                            DifferentialAttribute, EarthLocationAttribute,
+                                            QuantityAttribute, TimeAttribute)
+from astropy.coordinates.baseframe import BaseCoordinateFrame, RepresentationMapping
+from astropy.coordinates.builtin_frames import (FK4, FK5, GCRS, HCRS, ICRS, ITRS,
+                                                AltAz, Galactic, Galactocentric, HADec)
+from astropy.coordinates.representation import REPRESENTATION_CLASSES, CartesianDifferential
 from astropy.tests.helper import assert_quantity_allclose as assert_allclose
-from astropy.utils.exceptions import AstropyWarning
 from astropy.time import Time
-
-from astropy.coordinates import (
-    EarthLocation,
-    galactocentric_frame_defaults,
-    representation as r,
-    SkyCoord,
-)
-from astropy.coordinates.attributes import (
-    Attribute,
-    CoordinateAttribute,
-    DifferentialAttribute,
-    EarthLocationAttribute,
-    QuantityAttribute,
-    TimeAttribute,
-)
-from astropy.coordinates.baseframe import (
-    BaseCoordinateFrame,
-    RepresentationMapping
-)
-from astropy.coordinates.builtin_frames import (
-    AltAz,
-    HADec,
-    FK4,
-    FK5,
-    Galactic,
-    Galactocentric,
-    GCRS,
-    HCRS,
-    ICRS,
-    ITRS
-)
-from astropy.coordinates.representation import (
-    CartesianDifferential,
-    REPRESENTATION_CLASSES,
-)
+from astropy.units import allclose
+from astropy.utils.exceptions import AstropyWarning
 
 from .test_representation import unitphysics  # this fixture is used below # noqa
 

--- a/astropy/coordinates/tests/test_frames_with_velocity.py
+++ b/astropy/coordinates/tests/test_frames_with_velocity.py
@@ -2,15 +2,16 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import pytest
+
 import numpy as np
 
 from astropy import units as u
-from astropy.coordinates.builtin_frames import CIRS, ICRS, Galactic, Galactocentric
 from astropy.coordinates import builtin_frames as bf
 from astropy.coordinates import galactocentric_frame_defaults
-from astropy.units import allclose as quantity_allclose
-from astropy.coordinates.errors import ConvertError
 from astropy.coordinates import representation as r
+from astropy.coordinates.builtin_frames import CIRS, ICRS, Galactic, Galactocentric
+from astropy.coordinates.errors import ConvertError
+from astropy.units import allclose as quantity_allclose
 
 
 def test_api():

--- a/astropy/coordinates/tests/test_funcs.py
+++ b/astropy/coordinates/tests/test_funcs.py
@@ -7,6 +7,7 @@ Tests for miscellaneous functionality in the `funcs` module
 
 
 import pytest
+
 import numpy as np
 from numpy import testing as npt
 
@@ -33,7 +34,7 @@ def test_sun():
 
 
 def test_constellations(recwarn):
-    from astropy.coordinates import ICRS, FK5, SkyCoord
+    from astropy.coordinates import FK5, ICRS, SkyCoord
     from astropy.coordinates.funcs import get_constellation
 
     inuma = ICRS(9*u.hour, 65*u.deg)
@@ -64,7 +65,7 @@ def test_constellations(recwarn):
 
 
 def test_concatenate():
-    from astropy.coordinates import FK5, SkyCoord, ICRS
+    from astropy.coordinates import FK5, ICRS, SkyCoord
     from astropy.coordinates.funcs import concatenate
 
     # Just positions
@@ -100,8 +101,8 @@ def test_concatenate():
 
 
 def test_concatenate_representations():
-    from astropy.coordinates.funcs import concatenate_representations
     from astropy.coordinates import representation as r
+    from astropy.coordinates.funcs import concatenate_representations
 
     reps = [r.CartesianRepresentation([1, 2, 3.]*u.kpc),
             r.SphericalRepresentation(lon=1*u.deg, lat=2.*u.deg,
@@ -164,8 +165,8 @@ def test_concatenate_representations():
 
 
 def test_concatenate_representations_different_units():
-    from astropy.coordinates.funcs import concatenate_representations
     from astropy.coordinates import representation as r
+    from astropy.coordinates.funcs import concatenate_representations
 
     reps = [r.CartesianRepresentation([1, 2, 3.]*u.pc),
             r.CartesianRepresentation([1, 2, 3.]*u.kpc)]

--- a/astropy/coordinates/tests/test_geodetic_representations.py
+++ b/astropy/coordinates/tests/test_geodetic_representations.py
@@ -2,17 +2,14 @@
 
 """Test geodetic representations"""
 import pytest
+
 from numpy.testing import assert_array_equal
 
-from astropy.coordinates.representation import CartesianRepresentation
-
-from astropy.coordinates.earth import (
-    WGS84GeodeticRepresentation,
-    GRS80GeodeticRepresentation,
-    WGS72GeodeticRepresentation)
-
-from astropy.units import allclose as quantity_allclose
 from astropy import units as u
+from astropy.coordinates.earth import (GRS80GeodeticRepresentation, WGS72GeodeticRepresentation,
+                                       WGS84GeodeticRepresentation)
+from astropy.coordinates.representation import CartesianRepresentation
+from astropy.units import allclose as quantity_allclose
 
 
 def test_cartesian_wgs84geodetic_roundtrip():

--- a/astropy/coordinates/tests/test_iau_fullstack.py
+++ b/astropy/coordinates/tests/test_iau_fullstack.py
@@ -3,19 +3,19 @@
 
 import warnings
 
+import erfa
 import pytest
+
 import numpy as np
 from numpy import testing as npt
-import erfa
 
 from astropy import units as u
-from astropy.time import Time
+from astropy.coordinates import EarthLocation, SkyCoord
+from astropy.coordinates.angle_utilities import golden_spiral_grid
 from astropy.coordinates.builtin_frames import ICRS, AltAz
 from astropy.coordinates.builtin_frames.utils import get_jd12
-from astropy.coordinates import EarthLocation
-from astropy.coordinates import SkyCoord
+from astropy.time import Time
 from astropy.utils import iers
-from astropy.coordinates.angle_utilities import golden_spiral_grid
 
 
 # These fixtures are used in test_iau_fullstack
@@ -155,11 +155,10 @@ def test_future_altaz():
     warning is raised when attempting to get to AltAz in the future (beyond
     IERS tables)
     """
-    from astropy.utils.exceptions import AstropyWarning
-
     # this is an ugly hack to get the warning to show up even if it has already
     # appeared
     from astropy.coordinates.builtin_frames import utils
+    from astropy.utils.exceptions import AstropyWarning
     if hasattr(utils, '__warningregistry__'):
         utils.__warningregistry__.clear()
 

--- a/astropy/coordinates/tests/test_icrs_observed_transformations.py
+++ b/astropy/coordinates/tests/test_icrs_observed_transformations.py
@@ -5,13 +5,11 @@
 import numpy as np
 
 from astropy import units as u
+from astropy.coordinates import (CIRS, ICRS, AltAz, EarthLocation,
+                                 HADec, SkyCoord, frame_transform_graph)
+from astropy.coordinates.angle_utilities import golden_spiral_grid
 from astropy.tests.helper import assert_quantity_allclose as assert_allclose
 from astropy.time import Time
-from astropy.coordinates import (
-    EarthLocation, ICRS,  CIRS, AltAz, HADec, SkyCoord)
-
-from astropy.coordinates.angle_utilities import golden_spiral_grid
-from astropy.coordinates import frame_transform_graph
 
 
 def test_icrs_altaz_consistency():

--- a/astropy/coordinates/tests/test_intermediate_transformations.py
+++ b/astropy/coordinates/tests/test_intermediate_transformations.py
@@ -5,30 +5,30 @@
 import os
 from importlib import metadata
 
-
-import pytest
-import numpy as np
 import erfa
+import pytest
+
+import numpy as np
 
 from astropy import units as u
+from astropy.coordinates import (CIRS, GCRS, HCRS, ICRS, ITRS, TEME, TETE, AltAz, Angle,
+                                 CartesianDifferential, CartesianRepresentation, EarthLocation,
+                                 HADec, HeliocentricMeanEcliptic, PrecessedGeocentric, SkyCoord,
+                                 SphericalRepresentation, UnitSphericalRepresentation, get_sun,
+                                 solar_system_ephemeris)
+from astropy.coordinates.angle_utilities import golden_spiral_grid
+from astropy.coordinates.builtin_frames.intermediate_rotation_transforms import (cirs_to_itrs_mat,
+                                                                                 gcrs_to_cirs_mat,
+                                                                                 get_location_gcrs,
+                                                                                 tete_to_itrs_mat)
+from astropy.coordinates.builtin_frames.utils import get_jd12
+from astropy.coordinates.solar_system import _apparent_position_in_true_coordinates, get_body
 from astropy.tests.helper import assert_quantity_allclose as assert_allclose
 from astropy.time import Time
-from astropy.coordinates import (
-    EarthLocation, get_sun, ICRS, GCRS, CIRS, ITRS, AltAz, HADec,
-    PrecessedGeocentric, CartesianRepresentation, SkyCoord,
-    CartesianDifferential, SphericalRepresentation, UnitSphericalRepresentation,
-    HCRS, HeliocentricMeanEcliptic, TEME, TETE, Angle)
-from astropy.coordinates.solar_system import _apparent_position_in_true_coordinates, get_body
-from astropy.utils import iers
-from astropy.utils.exceptions import AstropyWarning, AstropyDeprecationWarning
-from astropy.utils.compat.optional_deps import HAS_JPLEPHEM
-
-from astropy.coordinates.angle_utilities import golden_spiral_grid
-from astropy.coordinates.builtin_frames.intermediate_rotation_transforms import (
-    get_location_gcrs, tete_to_itrs_mat, gcrs_to_cirs_mat, cirs_to_itrs_mat)
-from astropy.coordinates.builtin_frames.utils import get_jd12
-from astropy.coordinates import solar_system_ephemeris
 from astropy.units import allclose
+from astropy.utils import iers
+from astropy.utils.compat.optional_deps import HAS_JPLEPHEM
+from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyWarning
 
 CI = os.environ.get('CI', False) == "true"
 

--- a/astropy/coordinates/tests/test_matching.py
+++ b/astropy/coordinates/tests/test_matching.py
@@ -2,15 +2,13 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import pytest
+
 import numpy as np
 from numpy import testing as npt
 
-from astropy.tests.helper import assert_quantity_allclose as assert_allclose
-
 from astropy import units as u
-
 from astropy.coordinates import matching
-
+from astropy.tests.helper import assert_quantity_allclose as assert_allclose
 from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa
 
 """
@@ -24,6 +22,7 @@ Note that this requires scipy.
 def test_matching_function():
     from astropy.coordinates import ICRS
     from astropy.coordinates.matching import match_coordinates_3d
+
     # this only uses match_coordinates_3d because that's the actual implementation
 
     cmatch = ICRS([4, 2.1]*u.degree, [0, 0]*u.degree)
@@ -128,8 +127,8 @@ def test_python_kdtree(monkeypatch):
 @pytest.mark.skipif(not HAS_SCIPY, reason="Requires scipy.")
 def test_matching_method():
     from astropy.coordinates import ICRS, SkyCoord
-    from astropy.utils import NumpyRNGContext
     from astropy.coordinates.matching import match_coordinates_3d, match_coordinates_sky
+    from astropy.utils import NumpyRNGContext
 
     with NumpyRNGContext(987654321):
         cmatch = ICRS(np.random.rand(20) * 360.*u.degree,
@@ -158,7 +157,7 @@ def test_matching_method():
 @pytest.mark.skipif(not HAS_SCIPY, reason="Requires scipy")
 def test_search_around():
     from astropy.coordinates import ICRS, SkyCoord
-    from astropy.coordinates.matching import search_around_sky, search_around_3d
+    from astropy.coordinates.matching import search_around_3d, search_around_sky
 
     coo1 = ICRS([4, 2.1]*u.degree, [0, 0]*u.degree, distance=[1, 5] * u.kpc)
     coo2 = ICRS([1, 2, 3, 4]*u.degree, [0, 0, 0, 0]*u.degree, distance=[1, 1, 1, 5] * u.kpc)
@@ -239,7 +238,7 @@ def test_search_around():
 
 @pytest.mark.skipif(not HAS_SCIPY, reason="Requires scipy")
 def test_search_around_scalar():
-    from astropy.coordinates import SkyCoord, Angle
+    from astropy.coordinates import Angle, SkyCoord
 
     cat = SkyCoord([1, 2, 3], [-30, 45, 8], unit="deg")
     target = SkyCoord('1.1 -30.1', unit="deg")
@@ -290,7 +289,7 @@ def test_match_catalog_empty():
 @pytest.mark.filterwarnings(
     r'ignore:invalid value encountered in.*:RuntimeWarning')
 def test_match_catalog_nan():
-    from astropy.coordinates import SkyCoord, Galactic
+    from astropy.coordinates import Galactic, SkyCoord
 
     sc1 = SkyCoord(1, 2, unit="deg")
     sc_with_nans = SkyCoord(1, np.nan, unit="deg")

--- a/astropy/coordinates/tests/test_matrix_utilities.py
+++ b/astropy/coordinates/tests/test_matrix_utilities.py
@@ -4,8 +4,7 @@ import numpy as np
 from numpy.testing import assert_allclose, assert_array_equal
 
 from astropy import units as u
-from astropy.coordinates.matrix_utilities import (rotation_matrix, angle_axis,
-                                                  is_O3, is_rotation)
+from astropy.coordinates.matrix_utilities import angle_axis, is_O3, is_rotation, rotation_matrix
 
 
 def test_rotation_matrix():

--- a/astropy/coordinates/tests/test_name_resolve.py
+++ b/astropy/coordinates/tests/test_name_resolve.py
@@ -8,17 +8,15 @@ import time
 import urllib.request
 
 import pytest
+from pytest_remotedata.disable_internet import no_internet
+
 import numpy as np
 
-from astropy.coordinates.name_resolve import (get_icrs_coordinates,
-                                              NameResolveError,
-                                              sesame_database, _parse_response,
-                                              sesame_url)
-from astropy.coordinates.sky_coordinate import SkyCoord
-from astropy.config import paths
 from astropy import units as u
-
-from pytest_remotedata.disable_internet import no_internet
+from astropy.config import paths
+from astropy.coordinates.name_resolve import (NameResolveError, _parse_response,
+                                              get_icrs_coordinates, sesame_database, sesame_url)
+from astropy.coordinates.sky_coordinate import SkyCoord
 
 _cached_ngc3642 = dict()
 _cached_ngc3642["simbad"] = """# NGC 3642    #Q22523669

--- a/astropy/coordinates/tests/test_pickle.py
+++ b/astropy/coordinates/tests/test_pickle.py
@@ -1,11 +1,12 @@
 import pickle
+
 import pytest
+
 import numpy as np
 
-from astropy.coordinates import Longitude
 from astropy import coordinates as coord
-from astropy.tests.helper import pickle_protocol, check_pickling_recovery  # noqa
-
+from astropy.coordinates import Longitude
+from astropy.tests.helper import check_pickling_recovery, pickle_protocol  # noqa
 # Can't test distances without scipy due to cosmology deps
 from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa
 

--- a/astropy/coordinates/tests/test_regression.py
+++ b/astropy/coordinates/tests/test_regression.py
@@ -6,31 +6,29 @@ Regression tests for coordinates-related bugs that don't have an obvious other
 place to live
 """
 
-import io
 import copy
-import pytest
-import numpy as np
+import io
 from contextlib import nullcontext
+
+import pytest
 from erfa import ErfaWarning
 
-from astropy import units as u
-from astropy.coordinates import (
-    AltAz, EarthLocation, SkyCoord, get_sun, ICRS,
-    GeocentricMeanEcliptic, Longitude, Latitude, GCRS, HCRS, CIRS,
-    get_moon, FK4, FK4NoETerms, BaseCoordinateFrame, ITRS,
-    QuantityAttribute, UnitSphericalRepresentation,
-    SphericalRepresentation, CartesianRepresentation,
-    FunctionTransform, get_body,
-    CylindricalRepresentation, CylindricalDifferential,
-    CartesianDifferential)
-from astropy.coordinates.sites import get_builtin_sites
-from astropy.time import Time
-from astropy.utils import iers
-from astropy.table import Table
+import numpy as np
 
+from astropy import units as u
+from astropy.coordinates import (CIRS, FK4, GCRS, HCRS, ICRS, ITRS, AltAz, BaseCoordinateFrame,
+                                 CartesianDifferential, CartesianRepresentation,
+                                 CylindricalDifferential, CylindricalRepresentation, EarthLocation,
+                                 FK4NoETerms, FunctionTransform, GeocentricMeanEcliptic, Latitude,
+                                 Longitude, QuantityAttribute, SkyCoord, SphericalRepresentation,
+                                 UnitSphericalRepresentation, get_body, get_moon, get_sun)
+from astropy.coordinates.sites import get_builtin_sites
+from astropy.table import Table
 from astropy.tests.helper import assert_quantity_allclose
-from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa
+from astropy.time import Time
 from astropy.units import allclose as quantity_allclose
+from astropy.utils import iers
+from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa
 
 
 def test_regression_5085():
@@ -161,7 +159,7 @@ def test_regression_4082():
     """
     Issue: https://github.com/astropy/astropy/issues/4082
     """
-    from astropy.coordinates import search_around_sky, search_around_3d
+    from astropy.coordinates import search_around_3d, search_around_sky
     cat = SkyCoord([10.076, 10.00455], [18.54746, 18.54896], unit='deg')
     search_around_sky(cat[0:1], cat, seplimit=u.arcsec * 60, storekdtree=False)
     # in the issue, this raises a TypeError
@@ -203,11 +201,10 @@ def test_regression_futuretimes_4302():
 
     Relevant comment: https://github.com/astropy/astropy/pull/4302#discussion_r44836531
     """
-    from astropy.utils.exceptions import AstropyWarning
-
     # this is an ugly hack to get the warning to show up even if it has already
     # appeared
     from astropy.coordinates.builtin_frames import utils
+    from astropy.utils.exceptions import AstropyWarning
     if hasattr(utils, '__warningregistry__'):
         utils.__warningregistry__.clear()
 

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -4,27 +4,28 @@
 from copy import deepcopy
 
 import pytest
+
 import numpy as np
 from numpy.testing import assert_allclose, assert_array_equal
 
 from astropy import units as u
-from astropy.tests.helper import (assert_quantity_allclose as
-                                  assert_allclose_quantity)
-from astropy.utils import isiterable
-from astropy.utils.exceptions import DuplicateRepresentationWarning
-from astropy.coordinates.angles import Longitude, Latitude, Angle
+from astropy.coordinates.angles import Angle, Latitude, Longitude
 from astropy.coordinates.distances import Distance
 from astropy.coordinates.matrix_utilities import rotation_matrix
-from astropy.coordinates.representation import (
-    REPRESENTATION_CLASSES, DIFFERENTIAL_CLASSES, DUPLICATE_REPRESENTATIONS,
-    BaseRepresentation, SphericalRepresentation, UnitSphericalRepresentation,
-    SphericalCosLatDifferential, CartesianRepresentation, RadialRepresentation,
-    RadialDifferential, CylindricalRepresentation,
-    PhysicsSphericalRepresentation, CartesianDifferential,
-    SphericalDifferential, CylindricalDifferential,
-    PhysicsSphericalDifferential, UnitSphericalDifferential,
-    UnitSphericalCosLatDifferential)
-
+from astropy.coordinates.representation import (DIFFERENTIAL_CLASSES, DUPLICATE_REPRESENTATIONS,
+                                                REPRESENTATION_CLASSES, BaseRepresentation,
+                                                CartesianDifferential, CartesianRepresentation,
+                                                CylindricalDifferential, CylindricalRepresentation,
+                                                PhysicsSphericalDifferential,
+                                                PhysicsSphericalRepresentation, RadialDifferential,
+                                                RadialRepresentation, SphericalCosLatDifferential,
+                                                SphericalDifferential, SphericalRepresentation,
+                                                UnitSphericalCosLatDifferential,
+                                                UnitSphericalDifferential,
+                                                UnitSphericalRepresentation)
+from astropy.tests.helper import assert_quantity_allclose as assert_allclose_quantity
+from astropy.utils import isiterable
+from astropy.utils.exceptions import DuplicateRepresentationWarning
 
 # create matrices for use in testing ``.transform()`` methods
 matrices = {
@@ -1657,8 +1658,8 @@ def test_minimal_subclass():
 
 
 def test_duplicate_warning():
-    from astropy.coordinates.representation import DUPLICATE_REPRESENTATIONS
-    from astropy.coordinates.representation import REPRESENTATION_CLASSES
+    from astropy.coordinates.representation import (DUPLICATE_REPRESENTATIONS,
+                                                    REPRESENTATION_CLASSES)
 
     with pytest.warns(DuplicateRepresentationWarning):
         class UnitSphericalRepresentation(BaseRepresentation):

--- a/astropy/coordinates/tests/test_representation_arithmetic.py
+++ b/astropy/coordinates/tests/test_representation_arithmetic.py
@@ -4,19 +4,20 @@ import functools
 import operator
 
 import pytest
+
 import numpy as np
 
 from astropy import units as u
-from astropy.coordinates import (
-    PhysicsSphericalRepresentation, CartesianRepresentation,
-    CylindricalRepresentation, SphericalRepresentation,
-    UnitSphericalRepresentation, SphericalDifferential,
-    CartesianDifferential, UnitSphericalDifferential,
-    SphericalCosLatDifferential, UnitSphericalCosLatDifferential,
-    PhysicsSphericalDifferential, CylindricalDifferential,
-    RadialRepresentation, RadialDifferential, Longitude, Latitude)
-from astropy.coordinates.representation import DIFFERENTIAL_CLASSES
+from astropy.coordinates import (CartesianDifferential, CartesianRepresentation,
+                                 CylindricalDifferential, CylindricalRepresentation,
+                                 Latitude, Longitude, PhysicsSphericalDifferential,
+                                 PhysicsSphericalRepresentation, RadialDifferential,
+                                 RadialRepresentation, SphericalCosLatDifferential,
+                                 SphericalDifferential, SphericalRepresentation,
+                                 UnitSphericalCosLatDifferential, UnitSphericalDifferential,
+                                 UnitSphericalRepresentation)
 from astropy.coordinates.angle_utilities import angular_separation
+from astropy.coordinates.representation import DIFFERENTIAL_CLASSES
 from astropy.tests.helper import assert_quantity_allclose, quantity_allclose
 
 

--- a/astropy/coordinates/tests/test_representation_methods.py
+++ b/astropy/coordinates/tests/test_representation_methods.py
@@ -2,12 +2,13 @@
 
 
 import pytest
+
 import numpy as np
 
 from astropy import units as u
-from astropy.coordinates import (SphericalRepresentation, Longitude, Latitude,
-                                 SphericalDifferential)
+from astropy.coordinates import Latitude, Longitude, SphericalDifferential, SphericalRepresentation
 from astropy.units.quantity_helper.function_helpers import ARRAY_FUNCTION_ENABLED
+
 from .test_representation import representation_equal
 
 

--- a/astropy/coordinates/tests/test_shape_manipulation.py
+++ b/astropy/coordinates/tests/test_shape_manipulation.py
@@ -1,16 +1,16 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-import numpy as np
-from numpy.testing import assert_array_equal
 import pytest
 
-from astropy import units as u
-from astropy.units.quantity_helper.function_helpers import ARRAY_FUNCTION_ENABLED
-from astropy.coordinates import Longitude, Latitude, EarthLocation, SkyCoord
+import numpy as np
+from numpy.testing import assert_array_equal
 
+from astropy import units as u
+from astropy.coordinates import EarthLocation, Latitude, Longitude, SkyCoord
 # test on frame with most complicated frame attributes.
-from astropy.coordinates.builtin_frames import ICRS, AltAz, GCRS
+from astropy.coordinates.builtin_frames import GCRS, ICRS, AltAz
 from astropy.time import Time
+from astropy.units.quantity_helper.function_helpers import ARRAY_FUNCTION_ENABLED
 
 
 @pytest.fixture(params=[True, False] if ARRAY_FUNCTION_ENABLED

--- a/astropy/coordinates/tests/test_sites.py
+++ b/astropy/coordinates/tests/test_sites.py
@@ -1,11 +1,11 @@
 
 import pytest
 
+from astropy import units as u
+from astropy.coordinates import EarthLocation, Latitude, Longitude
+from astropy.coordinates.sites import SiteRegistry, get_builtin_sites, get_downloaded_sites
 from astropy.tests.helper import assert_quantity_allclose
 from astropy.units import allclose as quantity_allclose
-from astropy import units as u
-from astropy.coordinates import Longitude, Latitude, EarthLocation
-from astropy.coordinates.sites import get_builtin_sites, get_downloaded_sites, SiteRegistry
 
 
 def test_builtin_sites():

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -10,27 +10,27 @@ import copy
 from copy import deepcopy
 
 import pytest
-import numpy as np
-import numpy.testing as npt
 from erfa import ErfaWarning
 
+import numpy as np
+import numpy.testing as npt
+
 from astropy import units as u
-from astropy.tests.helper import assert_quantity_allclose as assert_allclose
-from astropy.coordinates.representation import REPRESENTATION_CLASSES, DUPLICATE_REPRESENTATIONS
-from astropy.coordinates import (ICRS, FK4, FK5, Galactic, GCRS, SkyCoord, Angle,
-                                 SphericalRepresentation, CartesianRepresentation,
-                                 UnitSphericalRepresentation, AltAz,
-                                 BaseCoordinateFrame, Attribute,
-                                 frame_transform_graph, RepresentationMapping)
-from astropy.coordinates import Latitude, EarthLocation
+from astropy.coordinates import (FK4, FK5, GCRS, ICRS, AltAz, Angle, Attribute,
+                                 BaseCoordinateFrame, CartesianRepresentation, EarthLocation,
+                                 Galactic, Latitude, RepresentationMapping, SkyCoord,
+                                 SphericalRepresentation, UnitSphericalRepresentation,
+                                 frame_transform_graph)
+from astropy.coordinates.representation import DUPLICATE_REPRESENTATIONS, REPRESENTATION_CLASSES
 from astropy.coordinates.transformations import FunctionTransform
-from astropy.time import Time
-from astropy.utils import minversion, isiterable
-from astropy.units import allclose as quantity_allclose
 from astropy.io import fits
-from astropy.wcs import WCS
 from astropy.io.misc.asdf.tags.helpers import skycoord_equal
+from astropy.tests.helper import assert_quantity_allclose as assert_allclose
+from astropy.time import Time
+from astropy.units import allclose as quantity_allclose
+from astropy.utils import isiterable, minversion
 from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa
+from astropy.wcs import WCS
 
 RA = 1.0 * u.deg
 DEC = 2.0 * u.deg
@@ -904,7 +904,7 @@ def test_table_to_coord():
 
     (Regression test for #1762 )
     """
-    from astropy.table import Table, Column
+    from astropy.table import Column, Table
 
     t = Table()
     t.add_column(Column(data=[1, 2, 3], name='ra', unit=u.deg))
@@ -1127,8 +1127,8 @@ def test_nodata_failure():
                                           ('all', 0),
                                           ('all', 1)])
 def test_wcs_methods(mode, origin):
-    from astropy.wcs import WCS
     from astropy.utils.data import get_pkg_data_contents
+    from astropy.wcs import WCS
     from astropy.wcs.utils import pixel_to_skycoord
 
     header = get_pkg_data_contents('../../wcs/tests/data/maps/1904-66_TAN.hdr', encoding='binary')
@@ -1284,7 +1284,7 @@ def test_init_with_frame_instance_keyword():
 
 
 def test_guess_from_table():
-    from astropy.table import Table, Column
+    from astropy.table import Column, Table
     from astropy.utils import NumpyRNGContext
 
     tab = Table()

--- a/astropy/coordinates/tests/test_sky_coord_velocities.py
+++ b/astropy/coordinates/tests/test_sky_coord_velocities.py
@@ -13,14 +13,12 @@ import pytest
 import numpy as np
 
 from astropy import units as u
+from astropy.coordinates import (ICRS, CartesianDifferential, CartesianRepresentation, Galactic,
+                                 PrecessedGeocentric, RadialDifferential, SkyCoord,
+                                 SphericalCosLatDifferential, SphericalDifferential,
+                                 SphericalRepresentation, UnitSphericalCosLatDifferential,
+                                 UnitSphericalDifferential, UnitSphericalRepresentation)
 from astropy.tests.helper import assert_quantity_allclose
-from astropy.coordinates import (
-    SkyCoord, ICRS, SphericalRepresentation, SphericalDifferential,
-    SphericalCosLatDifferential, UnitSphericalRepresentation,
-    UnitSphericalDifferential, UnitSphericalCosLatDifferential,
-    RadialDifferential, CartesianRepresentation,
-    CartesianDifferential, Galactic, PrecessedGeocentric)
-
 from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa
 
 

--- a/astropy/coordinates/tests/test_skyoffset_transformations.py
+++ b/astropy/coordinates/tests/test_skyoffset_transformations.py
@@ -2,14 +2,15 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import pytest
+
 import numpy as np
 
 from astropy import units as u
+from astropy.coordinates import EarthLocation, SkyCoord
+from astropy.coordinates.builtin_frames import FK5, ICRS, AltAz, Galactic, SkyOffsetFrame
 from astropy.coordinates.distances import Distance
-from astropy.coordinates.builtin_frames import ICRS, FK5, Galactic, AltAz, SkyOffsetFrame
-from astropy.coordinates import SkyCoord, EarthLocation
-from astropy.time import Time
 from astropy.tests.helper import assert_quantity_allclose as assert_allclose
+from astropy.time import Time
 
 
 def test_altaz_attribute_transforms():

--- a/astropy/coordinates/tests/test_solar_system.py
+++ b/astropy/coordinates/tests/test_solar_system.py
@@ -1,25 +1,27 @@
 import os
-
-import pytest
-import numpy as np
 from urllib.error import HTTPError
 
-from astropy.time import Time
+import pytest
+
+import numpy as np
+
 from astropy import units as u
 from astropy.constants import c
 from astropy.coordinates.builtin_frames import GCRS, TETE
 from astropy.coordinates.earth import EarthLocation
-from astropy.coordinates.sky_coordinate import SkyCoord
-from astropy.coordinates.representation import CartesianRepresentation, UnitSphericalRepresentation
-from astropy.coordinates.solar_system import (get_body, get_moon, BODY_NAME_TO_KERNEL_SPEC,
-                                              _get_apparent_body_position, solar_system_ephemeris,
-                                              get_body_barycentric, get_body_barycentric_posvel)
 from astropy.coordinates.funcs import get_sun
+from astropy.coordinates.representation import CartesianRepresentation, UnitSphericalRepresentation
+from astropy.coordinates.sky_coordinate import SkyCoord
+from astropy.coordinates.solar_system import (BODY_NAME_TO_KERNEL_SPEC,
+                                              _get_apparent_body_position, get_body,
+                                              get_body_barycentric, get_body_barycentric_posvel,
+                                              get_moon, solar_system_ephemeris)
 from astropy.tests.helper import assert_quantity_allclose
+from astropy.time import Time
 from astropy.units import allclose as quantity_allclose
+from astropy.utils.compat.optional_deps import HAS_JPLEPHEM  # noqa
+from astropy.utils.compat.optional_deps import HAS_SKYFIELD
 from astropy.utils.data import download_file
-from astropy.utils.compat.optional_deps import (HAS_JPLEPHEM,  # noqa
-                                                HAS_SKYFIELD)
 
 if HAS_SKYFIELD:
     from skyfield.api import Loader, Topos

--- a/astropy/coordinates/tests/test_spectral_coordinate.py
+++ b/astropy/coordinates/tests/test_spectral_coordinate.py
@@ -1,25 +1,24 @@
 from contextlib import nullcontext
 
-import astropy.units as u
+import pytest
+
 import numpy as np
 from numpy.testing import assert_allclose
 
-import pytest
+import astropy.units as u
 from astropy import time
 from astropy.constants import c
+from astropy.coordinates import (FK5, GCRS, ICRS, CartesianDifferential,
+                                 CartesianRepresentation, EarthLocation, Galactic, SkyCoord,
+                                 SpectralQuantity, get_body_barycentric_posvel)
+from astropy.coordinates.spectral_coordinate import (SpectralCoord,
+                                                     _apply_relativistic_doppler_shift)
 from astropy.table import Table
+from astropy.tests.helper import assert_quantity_allclose, quantity_allclose
 from astropy.time import Time
 from astropy.utils import iers
-from astropy.coordinates import (SkyCoord, EarthLocation, ICRS, GCRS, Galactic,
-                                 CartesianDifferential,
-                                 get_body_barycentric_posvel,
-                                 FK5, CartesianRepresentation,
-                                 SpectralQuantity)
-from astropy.tests.helper import assert_quantity_allclose, quantity_allclose
-from astropy.utils.exceptions import AstropyUserWarning, AstropyWarning
 from astropy.utils.data import get_pkg_data_filename
-
-from astropy.coordinates.spectral_coordinate import SpectralCoord, _apply_relativistic_doppler_shift
+from astropy.utils.exceptions import AstropyUserWarning, AstropyWarning
 from astropy.wcs.wcsapi.fitswcs import VELOCITY_FRAMES as FITSWCS_VELOCITY_FRAMES
 
 

--- a/astropy/coordinates/tests/test_spectral_quantity.py
+++ b/astropy/coordinates/tests/test_spectral_quantity.py
@@ -1,12 +1,11 @@
 import pytest
-import numpy as np
 
+import numpy as np
 from numpy.testing import assert_allclose
 
 from astropy import units as u
-from astropy.tests.helper import assert_quantity_allclose
-
 from astropy.coordinates.spectral_quantity import SpectralQuantity
+from astropy.tests.helper import assert_quantity_allclose
 
 SPECTRAL_UNITS = (u.GHz, u.micron, u.keV, (1 / u.nm).unit, u.km / u.s)
 

--- a/astropy/coordinates/tests/test_transformations.py
+++ b/astropy/coordinates/tests/test_transformations.py
@@ -2,14 +2,15 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 
-import numpy as np
 import pytest
 
+import numpy as np
+
 from astropy import units as u
-from astropy.coordinates import transformations as t
-from astropy.coordinates.builtin_frames import ICRS, FK5, FK4, FK4NoETerms, Galactic, AltAz, HCRS
 from astropy.coordinates import representation as r
+from astropy.coordinates import transformations as t
 from astropy.coordinates.baseframe import frame_transform_graph
+from astropy.coordinates.builtin_frames import FK4, FK5, HCRS, ICRS, AltAz, FK4NoETerms, Galactic
 from astropy.coordinates.matrix_utilities import rotation_matrix
 from astropy.tests.helper import assert_quantity_allclose as assert_allclose
 from astropy.time import Time
@@ -140,8 +141,8 @@ def test_sphere_cart():
     """
     Tests the spherical <-> cartesian transform functions
     """
+    from astropy.coordinates import cartesian_to_spherical, spherical_to_cartesian
     from astropy.utils import NumpyRNGContext
-    from astropy.coordinates import spherical_to_cartesian, cartesian_to_spherical
 
     x, y, z = spherical_to_cartesian(1, 0, 0)
     assert_allclose(x, 1)
@@ -441,8 +442,8 @@ def test_frame_override_component_with_attribute():
     It was previously possible to define a frame with an attribute with the
     same name as a component. We don't want to allow this!
     """
-    from astropy.coordinates.baseframe import BaseCoordinateFrame
     from astropy.coordinates.attributes import Attribute
+    from astropy.coordinates.baseframe import BaseCoordinateFrame
 
     class BorkedFrame(BaseCoordinateFrame):
         ra = Attribute(default=150)

--- a/astropy/coordinates/tests/test_unit_representation.py
+++ b/astropy/coordinates/tests/test_unit_representation.py
@@ -5,19 +5,14 @@ from copy import deepcopy
 
 import pytest
 
-from astropy.coordinates import Longitude, Latitude
-from astropy.coordinates.representation import (REPRESENTATION_CLASSES,
-                                                SphericalRepresentation,
+import astropy.coordinates
+import astropy.units as u
+from astropy.coordinates import ICRS, Latitude, Longitude
+from astropy.coordinates.baseframe import RepresentationMapping, frame_transform_graph
+from astropy.coordinates.representation import (REPRESENTATION_CLASSES, SphericalRepresentation,
                                                 UnitSphericalRepresentation,
                                                 _invalidate_reprdiff_cls_hash)
-from astropy.coordinates.baseframe import frame_transform_graph
 from astropy.coordinates.transformations import FunctionTransform
-from astropy.coordinates import ICRS
-from astropy.coordinates.baseframe import RepresentationMapping
-
-import astropy.units as u
-
-import astropy.coordinates
 
 # Classes setup, borrowed from SunPy.
 

--- a/astropy/coordinates/tests/test_utils.py
+++ b/astropy/coordinates/tests/test_utils.py
@@ -1,9 +1,11 @@
+import pytest
+
+from astropy.coordinates.builtin_frames.utils import (get_offset_sun_from_barycenter,
+                                                      get_polar_motion)
+from astropy.coordinates.solar_system import get_body_barycentric_posvel
 from astropy.tests.helper import assert_quantity_allclose
 from astropy.time import Time
-from astropy.coordinates.builtin_frames.utils import get_polar_motion, get_offset_sun_from_barycenter
-from astropy.coordinates.solar_system import get_body_barycentric_posvel
 from astropy.utils.exceptions import AstropyWarning
-import pytest
 
 
 def test_polar_motion_unsupported_dates():

--- a/astropy/coordinates/tests/test_velocity_corrs.py
+++ b/astropy/coordinates/tests/test_velocity_corrs.py
@@ -3,14 +3,14 @@ import pytest
 
 import numpy as np
 
-from astropy.tests.helper import assert_quantity_allclose
 from astropy import units as u
-from astropy.time import Time
-from astropy.coordinates import EarthLocation, SkyCoord, Angle, Distance
-from astropy.coordinates.sites import get_builtin_sites
-from astropy.utils.data import download_file
 from astropy.constants import c as speed_of_light
+from astropy.coordinates import Angle, Distance, EarthLocation, SkyCoord
+from astropy.coordinates.sites import get_builtin_sites
 from astropy.table import Table
+from astropy.tests.helper import assert_quantity_allclose
+from astropy.time import Time
+from astropy.utils.data import download_file
 
 
 @pytest.mark.parametrize('kind', ['heliocentric', 'barycentric'])
@@ -251,6 +251,7 @@ def _get_barycorr_bvcs(coos, loc, injupyter=False):
     the tests.
     """
     import barycorr
+
     from astropy.utils.console import ProgressBar
 
     bvcs = []
@@ -376,6 +377,7 @@ def _get_barycorr_bvcs_withvels(coos, loc, injupyter=False):
     the tests.
     """
     import barycorr
+
     from astropy.utils.console import ProgressBar
 
     bvcs = []

--- a/astropy/coordinates/transformations.py
+++ b/astropy/coordinates/transformations.py
@@ -18,12 +18,11 @@ transformations that are typically how the algorithms are defined.
 import heapq
 import inspect
 import subprocess
-from warnings import warn
-
 from abc import ABCMeta, abstractmethod
 from collections import defaultdict
-from contextlib import suppress, contextmanager
+from contextlib import contextmanager, suppress
 from inspect import signature
+from warnings import warn
 
 import numpy as np
 
@@ -997,8 +996,7 @@ class FunctionTransformWithFiniteDifference(FunctionTransform):
         self._finite_difference_frameattr_name = value
 
     def __call__(self, fromcoord, toframe):
-        from .representation import (CartesianRepresentation,
-                                     CartesianDifferential)
+        from .representation import CartesianDifferential, CartesianRepresentation
 
         supcall = self.func
         if fromcoord.data.differentials:
@@ -1095,11 +1093,9 @@ class BaseAffineTransform(CoordinateTransform):
     """
 
     def _apply_transform(self, fromcoord, matrix, offset):
-        from .representation import (UnitSphericalRepresentation,
-                                     CartesianDifferential,
-                                     SphericalDifferential,
-                                     SphericalCosLatDifferential,
-                                     RadialDifferential)
+        from .representation import (CartesianDifferential, RadialDifferential,
+                                     SphericalCosLatDifferential, SphericalDifferential,
+                                     UnitSphericalRepresentation)
 
         data = fromcoord.data
         has_velocity = 's' in data.differentials


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

ran ``isort astropy/coordinates/ -l 99``.
Put in a few ``isort: skip file`` for places of circular import confusion. Those can be returned to at a later date to properly sort out.

THIS IS NOT TURNING ON ISORT, MERELY A STYLISTIC PR.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
