### PR TITLE
Fix example versions in generate_releaserst.xsh command in release docs

### DIFF
--- a/docs/development/releasing.rst
+++ b/docs/development/releasing.rst
@@ -70,7 +70,7 @@ packages that use the full bugfix/maintenance branch approach.)
 
    You should then run the script in the root of the astropy repository as follows::
 
-      xonsh generate_releaserst.xsh 4.3 v4.3.dev \
+      xonsh generate_releaserst.xsh 4.3 v5.0.dev \
                                     --project-name=astropy \
                                     --pretty-project-name=astropy \
                                     --pat=<a GitHub personal access token>


### PR DESCRIPTION
### Description

I had made a mistake in my last update of the release docs adding the generate_releaserst.xsh command - the last tag was v5.0.dev not v4.3.dev!

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
