### PR TITLE
Ensure scalar QuantityDistribution work properly with ufuncs.

### DIFF
--- a/astropy/uncertainty/tests/test_distribution.py
+++ b/astropy/uncertainty/tests/test_distribution.py
@@ -449,3 +449,12 @@ def test_distr_cannot_view_new_dtype():
 
     with pytest.raises(ValueError, match='with a new dtype'):
         ad.view(np.dtype('f8'), Distribution)
+
+
+def test_scalar_quantity_distribution():
+    # Regression test for gh-12336
+    angles = Distribution([90., 30., 0.] * u.deg)
+    sin_angles = np.sin(angles)  # This failed in 4.3.
+    assert isinstance(sin_angles, Distribution)
+    assert isinstance(sin_angles, u.Quantity)
+    assert_array_equal(sin_angles, Distribution(np.sin([90., 30., 0.]*u.deg)))

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -2552,7 +2552,7 @@ def _condition_arg(value):
     ValueError
         If value is not as expected
     """
-    if isinstance(value, (np.ndarray, float, int, complex)):
+    if isinstance(value, (np.ndarray, float, int, complex, np.void)):
         return value
 
     avalue = np.array(value)

--- a/docs/changes/uncertainty/12471.bugfix.rst
+++ b/docs/changes/uncertainty/12471.bugfix.rst
@@ -1,0 +1,2 @@
+Ensure that scalar ``QuantityDistribution`` unit conversion in ufuncs
+works properly again.


### PR DESCRIPTION
Fixes #12236

Note that the actual fix is in `units`, though the bug showed itself in `uncertainties`.

Maybe good to get in 5.0 still? It is an annoying bug. But can be 5.0.1 too.