### PR TITLE
Bugfix for fitting compound models with mixed output units

### DIFF
--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -1573,6 +1573,40 @@ class Model(metaclass=_ModelMeta):
 
         return model
 
+    def output_units(self, **kwargs):
+        """
+        Return a dictionary of output units for this model given a dictionary
+        of fitting inputs and outputs
+
+        The input and output Quantity objects should be given as keyword
+        arguments.
+
+        Notes
+        -----
+
+        This method is needed in order to be able to fit models with units in
+        the parameters, since we need to temporarily strip away the units from
+        the model during the fitting (which might be done by e.g. scipy
+        functions).
+
+        This method will force extra model evaluations, which maybe computationally
+        expensive. To avoid this, one can add a return_units property to the model,
+        see :ref:`astropy:models_return_units`.
+        """
+        units = self.return_units
+
+        if units is None or units == {}:
+            inputs = {inp: kwargs[inp] for inp in self.inputs}
+
+            values = self(**inputs)
+            if self.n_outputs == 1:
+                values = (values,)
+
+            units = {out: getattr(values[index], 'unit', dimensionless_unscaled)
+                     for index, out in enumerate(self.outputs)}
+
+        return units
+
     def strip_units_from_tree(self):
         for item in self._leaflist:
             for parname in item.param_names:
@@ -1602,7 +1636,6 @@ class Model(metaclass=_ModelMeta):
         units (as two dictionaries) and returns a dictionary giving the target
         units for each parameter.
         """
-
         model = self.copy()
         inputs_unit = {inp: getattr(kwargs[inp], 'unit', dimensionless_unscaled)
                        for inp in self.inputs if kwargs[inp] is not None}
@@ -3836,6 +3869,118 @@ class CompoundModel(Model):
 
         else:
             raise ValueError(f"No submodels found named {name}")
+
+    def _set_sub_models_and_parameter_units(self, left, right):
+        """
+        Provides a work-around to properly set the sub models and respective
+        parameters's units/values when using ``without_units_for_data``
+        or ``without_units_for_data`` methods.
+        """
+        model = CompoundModel(self.op, left, right)
+
+        self.left = left
+        self.right = right
+
+        for name in model.param_names:
+            model_parameter = getattr(model, name)
+            parameter = getattr(self, name)
+
+            parameter.value = model_parameter.value
+            parameter._set_unit(model_parameter.unit, force=True)
+
+    def without_units_for_data(self, **kwargs):
+        """
+        See `~astropy.modeling.Model.without_units_for_data` for overview
+        of this method.
+
+        Notes
+        -----
+        This modifies the behavior of the base method to account for the
+        case where the sub-models of a compound model have different output
+        units. This is only valid for compound * and / compound models as
+        in that case it is reasonable to mix the output units. It does this
+        by modifying the output units of each sub model by using the output
+        units of the other sub model so that we can apply the original function
+        and get the desired result.
+
+        Additional data has to be output in the mixed output unit case
+        so that the units can be properly rebuilt by
+        `~astropy.modeling.CompoundModel.with_units_from_data`.
+
+        Outside the mixed output units, this method is identical to the
+        base method.
+        """
+        if self.op in ['*', '/']:
+            model = self.copy()
+            inputs = {inp: kwargs[inp] for inp in self.inputs}
+
+            left_units = self.left.output_units(**kwargs)
+            right_units = self.right.output_units(**kwargs)
+
+            if self.op == '*':
+                left_kwargs = {out: kwargs[out] / right_units[out]
+                               for out in self.left.outputs if kwargs[out] is not None}
+                right_kwargs = {out: kwargs[out] / left_units[out]
+                                for out in self.right.outputs if kwargs[out] is not None}
+            else:
+                left_kwargs = {out: kwargs[out] * right_units[out]
+                               for out in self.left.outputs if kwargs[out] is not None}
+                right_kwargs = {out: 1 / kwargs[out] * left_units[out]
+                                for out in self.right.outputs if kwargs[out] is not None}
+
+            left_kwargs.update(inputs.copy())
+            right_kwargs.update(inputs.copy())
+
+            left = self.left.without_units_for_data(**left_kwargs)
+            if isinstance(left, tuple):
+                left_kwargs['_left_kwargs'] = left[1]
+                left_kwargs['_right_kwargs'] = left[2]
+                left = left[0]
+
+            right = self.right.without_units_for_data(**right_kwargs)
+            if isinstance(right, tuple):
+                right_kwargs['_left_kwargs'] = right[1]
+                right_kwargs['_right_kwargs'] = right[2]
+                right = right[0]
+
+            model._set_sub_models_and_parameter_units(left, right)
+
+            return model, left_kwargs, right_kwargs
+        else:
+            return super().without_units_for_data(**kwargs)
+
+    def with_units_from_data(self, **kwargs):
+        """
+        See `~astropy.modeling.Model.with_units_from_data` for overview
+        of this method.
+
+        Notes
+        -----
+        This modifies the behavior of the base method to account for the
+        case where the sub-models of a compound model have different output
+        units. This is only valid for compound * and / compound models as
+        in that case it is reasonable to mix the output units. In order to
+        do this it requires some additional information output by
+        `~astropy.modeling.CompoundModel.without_units_for_data` passed as
+        keyword arguments under the keywords ``_left_kwargs`` and ``_right_kwargs``.
+
+        Outside the mixed output units, this method is identical to the
+        base method.
+        """
+
+        if self.op in ['*', '/']:
+            left_kwargs = kwargs.pop('_left_kwargs')
+            right_kwargs = kwargs.pop('_right_kwargs')
+
+            left = self.left.with_units_from_data(**left_kwargs)
+            right = self.right.with_units_from_data(**right_kwargs)
+
+            model = self.copy()
+            model._set_sub_models_and_parameter_units(left, right)
+
+            return model
+        else:
+            return super().with_units_from_data(**kwargs)
 
 
 def _get_submodel_path(model, name):

--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -218,6 +218,11 @@ def fitter_unit_support(func):
                 # input units (to make sure that initial guesses on the parameters)
                 # are in the right unit system
                 model = model.without_units_for_data(**rename_data)
+                if isinstance(model, tuple):
+                    rename_data['_left_kwargs'] = model[1]
+                    rename_data['_right_kwargs'] = model[2]
+                    model = model[0]
+
                 # We strip away the units from the input itself
                 add_back_units = False
 

--- a/docs/changes/modeling/12475.bugfix.rst
+++ b/docs/changes/modeling/12475.bugfix.rst
@@ -1,0 +1,2 @@
+Fixes error when fitting multiplication or division based compound models
+where the sub-models have different output units.

--- a/docs/modeling/add-units.rst
+++ b/docs/modeling/add-units.rst
@@ -60,6 +60,8 @@ also be specified as an attribute rather than a property in simple cases::
 
     input_units = {'x': u.deg}
 
+.. _models_return_units:
+
 ``return_units``
 ^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This PR fixes errors arising from fitting multiplication and division compound models where the sub models have different output units.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #12320

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
