### PR TITLE
cosmo: Parameter clone

### DIFF
--- a/astropy/cosmology/flrw.py
+++ b/astropy/cosmology/flrw.py
@@ -1420,8 +1420,7 @@ class FlatFLRWMixin(FlatCosmologyMixin):
     but ``FlatLambdaCDM`` **will** be flat.
     """
 
-    Ode0 = Parameter(doc="Omega dark energy; dark energy density/critical density at z=0.",
-                     derived=True, fvalidate="float")  # no longer a Parameter
+    Ode0 = FLRW.Ode0.clone(derived=True)  # same as FLRW, but now a derived param.
 
     def __init_subclass__(cls):
         super().__init_subclass__()

--- a/astropy/cosmology/parameter.py
+++ b/astropy/cosmology/parameter.py
@@ -247,6 +247,17 @@ class Parameter:
         # all initialization failues, like incorrect input are handled by
         return type(self)(**kw)
 
+    def __eq__(self, other):
+        """Check Parameter equality. Only equal to other parameters."""
+        if not isinstance(other, Parameter):
+            return NotImplemented
+        # check equality on all @property
+        tocheck = (n for n in dir(self.__class__)  # sieve for @property
+                   if isinstance(getattr(self.__class__, n), property))
+        for n in tocheck:  # pass to ``other.__eq__`` if fails check
+            if not hasattr(other, n) or (getattr(self, n) != getattr(other, n)):
+                return NotImplemented
+        return True  # everything passed!
     def __repr__(self):
         return f"<Parameter {self._attr_name!r} at {hex(id(self))}>"
 

--- a/astropy/cosmology/parameter.py
+++ b/astropy/cosmology/parameter.py
@@ -13,9 +13,6 @@ class Parameter:
 
     Parameters
     ----------
-    name : str or None (optional, keyword-only)
-        The common name of the parameter. If `None` (default) the name will be
-        the |Cosmology| class parameter attribute.
     derived : bool (optional, keyword-only)
         Whether the Parameter is 'derived', default `False`.
         Derived parameters behave similarly to normal parameters, but are not
@@ -23,6 +20,11 @@ class Parameter:
         included in all methods. For reference, see ``Ode0`` in
         ``FlatFLRWMixin``, which removes :math:`\Omega_{de,0}`` as an
         independent parameter (:math:`\Omega_{de,0} \equiv 1 - \Omega_{tot}`).
+    unit : unit-like or None (optional, keyword-only)
+        The `~astropy.units.Unit` for the Parameter. If None (default) no
+        unit as assumed.
+    equivalencies : `~astropy.units.Equivalency` or sequence thereof
+        Unit equivalencies for this Parameter.
     fvalidate : callable[[object, object, Any], Any] or str (optional, keyword-only)
         Function to validate the Parameter value from instances of the
         cosmology class. If "default", uses default validator to assign units
@@ -30,11 +32,6 @@ class Parameter:
         For other valid string options, see ``Parameter._registry_validators``.
         'fvalidate' can also be set through a decorator with
         :meth:`~astropy.cosmology.Parameter.validator`.
-    unit : unit-like or None (optional, keyword-only)
-        The `~astropy.units.Unit` for the Parameter. If None (default) no
-        unit as assumed.
-    equivalencies : `~astropy.units.Equivalency` or sequence thereof
-        Unit equivalencies for this Parameter.
     fmt : str (optional, keyword-only)
         `format` specification, used when making string representation
         of the containing Cosmology.
@@ -49,23 +46,27 @@ class Parameter:
 
     _registry_validators = {}
 
-    def __init__(self, fvalidate="default", doc=None, *, name=None,
-                 derived=False, unit=None, equivalencies=[], fmt=".3g"):
+    def __init__(self, *, derived=False, unit=None, equivalencies=[],
+                 fvalidate="default", fmt=".3g", doc=None):
 
-        self._name = name
-        self._fmt = str(fmt)  # @property is `format_spec`
+        # attribute name on container cosmology class.
+        # really set in __set_name__, but if Parameter is not init'ed as a
+        # descriptor this ensures that the attributes exist.
+        self._attr_name = self._attr_name_private = None
+
         self._derived = derived
+        self._fmt = str(fmt)  # @property is `format_spec`
         self.__doc__ = doc
 
         # units stuff
         self._unit = u.Unit(unit) if unit is not None else None
         self._equivalencies = equivalencies
 
-        # parse registered fvalidate
+        # Parse registered `fvalidate`
+        self._fvalidate_in = fvalidate  # Always store input fvalidate.
         if callable(fvalidate):
-            self._validate_repr = repr(fvalidate)
+            pass
         elif fvalidate in self._registry_validators:
-            self._validate_repr = fvalidate  # don't need repr()
             fvalidate = self._registry_validators[fvalidate]
         elif isinstance(fvalidate, str):
             raise ValueError("`fvalidate`, if str, must be in "
@@ -76,16 +77,14 @@ class Parameter:
         self._fvalidate = fvalidate
 
     def __set_name__(self, cosmo_cls, name):
-        # name
+        # attribute name on container cosmology class
         self._attr_name = name
         self._attr_name_private = "_" + name
-        if self._name is None:  # set if not set in __init__
-            self._name = name
 
     @property
     def name(self):
         """Parameter name."""
-        return self._name
+        return self._attr_name
 
     @property
     def unit(self):
@@ -212,6 +211,31 @@ class Parameter:
 
     # -------------------------------------------
 
+    def _get_init_arguments(self, processed=False):
+        """Initialization arguments.
+
+        Parameters
+        ----------
+        interpreted : bool
+            Whether to more closely reproduce the input arguments (`False`,
+            default) or the processed arguments (`True`). The former is better
+            for string representations and round-tripping with ``eval(repr())``.
+
+        Returns
+        -------
+        dict[str, Any]
+        """
+        # The keys are added in this order because `repr` prints them in order.
+        kw = {"derived": self.derived,
+              "unit": self.unit,
+              "equivalencies": self.equivalencies,
+              # Validator is always turned into a function, but for ``repr`` it's nice
+              # to know if it was originally a string.
+              "fvalidate": self.fvalidate if processed else self._fvalidate_in,
+              "fmt": self.format_spec,
+              "doc": self.__doc__}
+        return kw
+
     def clone(self, **kw):
         """Clone this `Parameter`, changing any constructor argument.
 
@@ -225,27 +249,23 @@ class Parameter:
         --------
         >>> p = Parameter()
         >>> p
-        Parameter(name=None, derived=False, unit=None, equivalencies=[],
+        Parameter(derived=False, unit=None, equivalencies=[],
                   fvalidate='default', fmt='.3g', doc=None)
 
-        >>> p.clone(name="cloned", unit="km")
-        Parameter(name='cloned', derived=False, unit=Unit("km"),
-                  equivalencies=[], fvalidate='default', fmt='.3g', doc=None)
+        >>> p.clone(unit="km")
+        Parameter(derived=False, unit=Unit("km"), equivalencies=[],
+                  fvalidate='default', fmt='.3g', doc=None)
         """
-        kw.setdefault("doc", self.__doc__)
-        kw.setdefault("fmt", self.format_spec)
-        kw.setdefault("unit", self.unit)
-        kw.setdefault("equivalencies", self.equivalencies)
-        kw.setdefault("derived", self.derived)
-        kw.setdefault("name", self.name)
-        # validator is always turned into a function, but for ``repr`` we want
-        # to know if it's originally a string.
-        fvalidate = (self._validate_repr if self._validate_repr in self._registry_validators
-                     else self.fvalidate)
-        kw.setdefault("fvalidate", fvalidate)
+        # Start with defaults, update from kw.
+        kwargs = {**self._get_init_arguments(), **kw}
+        # All initialization failures, like incorrect input are handled by init
+        cloned = type(self)(**kwargs)
+        # Transfer over the __set_name__ stuff. If `clone` is used to make a
+        # new descriptor, __set_name__ will be called again, overwriting this.
+        cloned._attr_name = self._attr_name
+        cloned._attr_name_private = self._attr_name_private
 
-        # all initialization failures, like incorrect input are handled by init
-        return type(self)(**kw)
+        return cloned
 
     def __eq__(self, other):
         """Check Parameter equality. Only equal to other Parameter objects.
@@ -258,11 +278,11 @@ class Parameter:
 
         Examples
         --------
-        >>> p1, p2 = Parameter(name="H0"), Parameter(name="H0")
+        >>> p1, p2 = Parameter(unit="km"), Parameter(unit="km")
         >>> p1 == p2
         True
 
-        >>> p3 = Parameter(name="not H0")
+        >>> p3 = Parameter(unit="km / s")
         >>> p3 == p1
         False
 
@@ -271,13 +291,11 @@ class Parameter:
         """
         if not isinstance(other, Parameter):
             return NotImplemented
-        # check equality on all @property
-        tocheck = (n for n in dir(self.__class__)  # sieve for @property
-                   if isinstance(getattr(self.__class__, n), property))
-        for n in tocheck:  # pass to ``other.__eq__`` if fails check
-            if not hasattr(other, n) or (getattr(self, n) != getattr(other, n)):
-                return NotImplemented
-        return True  # everything passed!
+        # Check equality on all `_init_arguments` & `name`.
+        # Need to compare the processed arguments because the inputs are many-
+        # to-one, e.g. `fvalidate` can be a string or the equivalent function.
+        return ((self._get_init_arguments(True) == other._get_init_arguments(True))
+                and (self.name == other.name))
 
     def __repr__(self):
         """String representation.
@@ -285,11 +303,8 @@ class Parameter:
         ``eval(repr())`` should work, depending if contents like ``fvalidate``
         can be similarly round-tripped.
         """
-        s = (f"Parameter(name={self.name!r}, derived={self.derived!r}, "
-             f"unit={self.unit!r}, equivalencies={self.equivalencies!r}, "
-             f"fvalidate={self._validate_repr!r}, fmt={self.format_spec!r}, "
-             f"doc={self.__doc__!r})")
-        return s
+        return "Parameter({})".format(", ".join(f"{k}={v!r}" for k, v in
+                                                self._get_init_arguments().items()))
 
 
 # ===================================================================

--- a/astropy/cosmology/parameter.py
+++ b/astropy/cosmology/parameter.py
@@ -213,7 +213,7 @@ class Parameter:
     # -------------------------------------------
 
     def clone(self, **kw):
-        """Clone `Parameter`.
+        """Clone this `Parameter`, changing any constructor argument.
 
         Parameters
         ----------
@@ -228,9 +228,9 @@ class Parameter:
         Parameter(name=None, derived=False, unit=None, equivalencies=[],
                   fvalidate='default', fmt='.3g', doc=None)
 
-        >>> p.clone(unit="km")
-        Parameter(name=None, derived=False, unit=Unit("km"), equivalencies=[],
-                  fvalidate='default', fmt='.3g', doc=None)
+        >>> p.clone(name="cloned", unit="km")
+        Parameter(name='cloned', derived=False, unit=Unit("km"),
+                  equivalencies=[], fvalidate='default', fmt='.3g', doc=None)
         """
         kw.setdefault("doc", self.__doc__)
         kw.setdefault("fmt", self.format_spec)
@@ -244,11 +244,31 @@ class Parameter:
                      else self.fvalidate)
         kw.setdefault("fvalidate", fvalidate)
 
-        # all initialization failues, like incorrect input are handled by
+        # all initialization failures, like incorrect input are handled by init
         return type(self)(**kw)
 
     def __eq__(self, other):
-        """Check Parameter equality. Only equal to other parameters."""
+        """Check Parameter equality. Only equal to other Parameter objects.
+
+        Returns
+        -------
+        NotImplemented or True
+            `True` if equal, `NotImplemented` otherwise. This allows `other` to
+            be check for equality with ``other.__eq__``.
+
+        Examples
+        --------
+        >>> p1, p2 = Parameter(name="H0"), Parameter(name="H0")
+        >>> p1 == p2
+        True
+
+        >>> p3 = Parameter(name="not H0")
+        >>> p3 == p1
+        False
+
+        >>> p1 != 2
+        True
+        """
         if not isinstance(other, Parameter):
             return NotImplemented
         # check equality on all @property

--- a/astropy/cosmology/parameter.py
+++ b/astropy/cosmology/parameter.py
@@ -258,8 +258,18 @@ class Parameter:
             if not hasattr(other, n) or (getattr(self, n) != getattr(other, n)):
                 return NotImplemented
         return True  # everything passed!
+
     def __repr__(self):
-        return f"<Parameter {self._attr_name!r} at {hex(id(self))}>"
+        """String representation.
+
+        ``eval(repr())`` should work, depending if contents like ``fvalidate``
+        can be similarly round-tripped.
+        """
+        s = (f"Parameter(name={self.name!r}, derived={self.derived!r}, "
+             f"unit={self.unit!r}, equivalencies={self.equivalencies!r}, "
+             f"fvalidate={self._validate_repr!r}, fmt={self.format_spec!r}, "
+             f"doc={self.__doc__!r})")
+        return s
 
 
 # ===================================================================

--- a/astropy/cosmology/tests/test_parameter.py
+++ b/astropy/cosmology/tests/test_parameter.py
@@ -428,6 +428,21 @@ class TestParameter(ParameterTestMixin):
         with pytest.raises(TypeError):
             param.clone(not_a_valid_parameter=True)
 
+    # -------------------------------------------
+
+    def test_Parameter_equality(self):
+        """Test Parameter equality. Determined from the @property."""
+        p1 = Parameter(name="H0")
+        p2 = Parameter(name="H0")
+        assert p1 == p2
+
+        # not equal parameters
+        p3 = Parameter(name="not H0")
+        assert p3 != p1
+
+        # misc
+        assert p1 != 2  # show doesn't error 
+
     # ==============================================================
 
     def test_Parameter_doesnt_change_with_generic_class(self):

--- a/astropy/cosmology/tests/test_parameter.py
+++ b/astropy/cosmology/tests/test_parameter.py
@@ -443,7 +443,7 @@ class TestParameter(ParameterTestMixin):
         assert p3 != p1
 
         # misc
-        assert p1 != 2  # show doesn't error 
+        assert p1 != 2  # show doesn't error
 
     # -------------------------------------------
 

--- a/docs/changes/cosmology/12479.feature.rst
+++ b/docs/changes/cosmology/12479.feature.rst
@@ -1,0 +1,5 @@
+A method ``clone`` has been added to ``Parameter`` to quickly deep copy the
+object and change any constructor argument.
+A supporting equality method is added, and ``repr`` is enhanced to be able to
+roundtrip -- ``eval(repr(Parameter()))`` -- if the Parameter's arguments can
+similarly roundtrip.

--- a/docs/changes/cosmology/12479.feature.rst
+++ b/docs/changes/cosmology/12479.feature.rst
@@ -3,3 +3,4 @@ object and change any constructor argument.
 A supporting equality method is added, and ``repr`` is enhanced to be able to
 roundtrip -- ``eval(repr(Parameter()))`` -- if the Parameter's arguments can
 similarly roundtrip.
+Parameter's arguments are made keyword-only.

--- a/docs/cosmology/dev.rst
+++ b/docs/cosmology/dev.rst
@@ -140,6 +140,17 @@ The last thing to note is pretty formatting for the |Cosmology|. Each
 <https://docs.python.org/3/library/string.html#formatspec>`_ ".3g", but this
 may be overridden, like :attr:`~astropy.cosmology.FLRW.Tcmb0` does.
 
+If a new cosmology modifies an existing Parameter, then the
+`Parameter.clone() <astropy.cosmology.Parameter.clone>`_ method is useful
+to deep-copy the parameter and change any constructor argument. For example,
+see ``FlatFLRWMixin`` in ``astropy.cosmology.flrw`` (also shown below).
+
+.. code-block:: python
+
+    class FlatFLRWMixin(FlatCosmologyMixin):
+        ...
+
+        Ode0 = FLRW.Ode0.clone(derived=True)  # now a derived param.
 
 Mixins
 ------


### PR DESCRIPTION
Add a method ``clone`` to Parameter to make copying a Parameter much easier.

Also modify ``repr`` to make it mostly round-trippable. It really depends on the contents of the Parameter, like ``fvalidate`` and ``equivalencies``. If they can round-trip, then so can this.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
