### PR TITLE
Ensure that masked instances can be used to initialize np.ma.MaskedArray

### DIFF
--- a/astropy/utils/masked/core.py
+++ b/astropy/utils/masked/core.py
@@ -128,9 +128,11 @@ class Masked(NDArrayShapeMethods):
         """Get the masked wrapper for a given data class.
 
         If the data class does not exist yet but is a subclass of any of the
-        registered base data classes, it is automatically generated.
+        registered base data classes, it is automatically generated
+        (except we skip `~numpy.ma.MaskedArray` subclasses, since then the
+        masking mechanisms would interfere).
         """
-        if issubclass(data_cls, Masked):
+        if issubclass(data_cls, (Masked, np.ma.MaskedArray)):
             return data_cls
 
         masked_cls = cls._masked_classes.get(data_cls)
@@ -517,6 +519,16 @@ class MaskedNDArray(Masked, np.ndarray, base_cls=np.ndarray, data_cls=np.ndarray
         allows assignment.
         """
         return MaskedIterator(self)
+
+    @property
+    def _baseclass(self):
+        """Work-around for MaskedArray initialization.
+
+        Allows the base class to be inferred correctly when a masked instance
+        is used to initialize (or viewed as) a `~numpy.ma.MaskedArray`.
+
+        """
+        return self._data_cls
 
     def view(self, dtype=None, type=None):
         """New view of the masked array.

--- a/astropy/utils/masked/tests/test_masked.py
+++ b/astropy/utils/masked/tests/test_masked.py
@@ -1180,3 +1180,28 @@ class TestMaskedRecarray(MaskedArraySetup):
         mra.field(attr, self.msa['b'])
         assert_array_equal(mra.a.unmasked, self.msa['b'].unmasked)
         assert_array_equal(mra.a.mask, self.msa['b'].mask)
+
+
+class TestMaskedArrayInteractionWithNumpyMA(MaskedArraySetup):
+    def test_masked_array_from_masked(self):
+        """Check that we can initialize a MaskedArray properly."""
+        np_ma = np.ma.MaskedArray(self.ma)
+        assert type(np_ma) is np.ma.MaskedArray
+        assert type(np_ma.data) is self._data_cls
+        assert type(np_ma.mask) is np.ndarray
+        assert_array_equal(np_ma.data, self.a)
+        assert_array_equal(np_ma.mask, self.mask_a)
+
+    def test_view_as_masked_array(self):
+        """Test that we can be viewed as a MaskedArray."""
+        np_ma = self.ma.view(np.ma.MaskedArray)
+        assert type(np_ma) is np.ma.MaskedArray
+        assert type(np_ma.data) is self._data_cls
+        assert type(np_ma.mask) is np.ndarray
+        assert_array_equal(np_ma.data, self.a)
+        assert_array_equal(np_ma.mask, self.mask_a)
+
+
+class TestMaskedQuantityInteractionWithNumpyMA(
+        TestMaskedArrayInteractionWithNumpyMA, QuantitySetup):
+    pass

--- a/docs/changes/utils/12482.bugfix.rst
+++ b/docs/changes/utils/12482.bugfix.rst
@@ -1,0 +1,2 @@
+Ensure that a ``Masked`` instance can be used to initialize (or viewed
+as) a ``numpy.ma.Maskedarray``.


### PR DESCRIPTION
And also can be viewed as such.

This is a small bugfix to reduce incompatibility between `Masked` and `np.ma.MaskedArray`; a goal would be to ensure that `Masked` instances can be used well with `matplotlib`. Although this alone does not solve that, but this gives desired behaviour regardless:
```
In [1]: import numpy as np

In [2]: from astropy.utils.masked import Masked

In [3]: m = Masked([np.inf, 1., 2., np.nan, 3.], mask=[True, False, True, False, False])

In [4]: np.ma.MaskedArray(m)
Out[4]: 
masked_array(data=[--, 1.0, --, nan, 3.0],
             mask=[ True, False,  True, False, False],
       fill_value=1e+20)

In [5]: m.view(np.ma.MaskedArray)
Out[5]: 
masked_array(data=[--, 1.0, --, nan, 3.0],
             mask=[ True, False,  True, False, False],
       fill_value=1e+20)


# without this PR:
masked_MaskedNDArray(data=[——, 1.0, ——, nan, 3.0],
                     mask=[ True, False,  True, False, False],
               fill_value=1e+20)
```

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
