### PR TITLE
register ``structured_to_unstructured``

### DIFF
--- a/astropy/units/quantity_helper/function_helpers.py
+++ b/astropy/units/quantity_helper/function_helpers.py
@@ -109,13 +109,13 @@ UNSUPPORTED_FUNCTIONS |= {
 UNSUPPORTED_FUNCTIONS |= {np.linalg.slogdet}
 
 # TODO! support whichever of these functions it makes sense to support
-TOSUPPORT_FUNCTIONS = {
+TBD_FUNCTIONS = {
     rfn.drop_fields, rfn.rename_fields, rfn.append_fields, rfn.join_by,
     rfn.apply_along_fields, rfn.assign_fields_by_name, rfn.merge_arrays,
     rfn.find_duplicates, rfn.recursive_fill_fields, rfn.require_fields,
     rfn.repack_fields, rfn.stack_arrays
 }
-UNSUPPORTED_FUNCTIONS |= TOSUPPORT_FUNCTIONS
+UNSUPPORTED_FUNCTIONS |= TBD_FUNCTIONS
 
 # The following are not just unsupported, but so unlikely to be thought
 # to be supported that we ignore them in testing.  (Kept in a separate
@@ -129,7 +129,7 @@ IGNORED_FUNCTIONS = {
     # Polynomials
     np.poly, np.polyadd, np.polyder, np.polydiv, np.polyfit, np.polyint,
     np.polymul, np.polysub, np.polyval, np.roots, np.vander,
-    # record array functions
+    # functions taking record arrays (which are deprecated)
     rfn.rec_append_fields, rfn.rec_drop_fields, rfn.rec_join,
 }
 if NUMPY_LT_1_20:
@@ -1062,6 +1062,7 @@ def structured_to_unstructured(arr, *args, **kwargs):
     """
     Convert a structured quantity to an unstructured one.
     This only works if all the units are compatible.
+
     """
     from astropy.units import StructuredUnit
 
@@ -1092,16 +1093,11 @@ def _build_structured_unit(dtype, unit):
     if dtype.fields is None:
         return unit
 
-    us = [_build_structured_unit(v[0], unit) for v in dtype.fields.values()]
-    return tuple(us)
+    return tuple(_build_structured_unit(v[0], unit) for v in dtype.fields.values())
 
 
 @function_helper(module=np.lib.recfunctions)
 def unstructured_to_structured(arr, dtype, *args, **kwargs):
-    """
-    Convert a structured quantity to an unstructured one.
-    This only works if all the units are compatible.
-    """
     from astropy.units import StructuredUnit
 
     target_unit = StructuredUnit(_build_structured_unit(dtype, arr.unit))

--- a/astropy/units/quantity_helper/function_helpers.py
+++ b/astropy/units/quantity_helper/function_helpers.py
@@ -39,7 +39,7 @@ import functools
 import operator
 
 import numpy as np
-from numpy.lib import recfunctions
+from numpy.lib import recfunctions as rfn
 
 from astropy.units.core import (
     UnitsError, UnitTypeError, dimensionless_unscaled)
@@ -108,6 +108,15 @@ UNSUPPORTED_FUNCTIONS |= {
 # Could be supported if we had a natural logarithm unit.
 UNSUPPORTED_FUNCTIONS |= {np.linalg.slogdet}
 
+# TODO! support whichever of these functions it makes sense to support
+TOSUPPORT_FUNCTIONS = {
+    rfn.drop_fields, rfn.rename_fields, rfn.append_fields, rfn.join_by,
+    rfn.apply_along_fields, rfn.assign_fields_by_name, rfn.merge_arrays,
+    rfn.find_duplicates, rfn.recursive_fill_fields, rfn.require_fields,
+    rfn.repack_fields, rfn.stack_arrays
+}
+UNSUPPORTED_FUNCTIONS |= TOSUPPORT_FUNCTIONS
+
 # The following are not just unsupported, but so unlikely to be thought
 # to be supported that we ignore them in testing.  (Kept in a separate
 # variable so that we can check consistency in the test routine -
@@ -119,7 +128,10 @@ IGNORED_FUNCTIONS = {
     np.save, np.savez, np.savetxt, np.savez_compressed,
     # Polynomials
     np.poly, np.polyadd, np.polyder, np.polydiv, np.polyfit, np.polyint,
-    np.polymul, np.polysub, np.polyval, np.roots, np.vander}
+    np.polymul, np.polysub, np.polyval, np.roots, np.vander,
+    # record array functions
+    rfn.rec_append_fields, rfn.rec_drop_fields, rfn.rec_join,
+}
 if NUMPY_LT_1_20:
     # financial
     IGNORED_FUNCTIONS |= {np.fv, np.ipmt, np.irr, np.mirr, np.nper,
@@ -1063,3 +1075,35 @@ def structured_to_unstructured(arr, *args, **kwargs):
 
     to_unit = arr.unit._recursively_apply(replace_unit)
     return (arr.to_value(to_unit), ) + args, kwargs, target_unit, None
+
+
+def _build_structured_unit(dtype, unit):
+    """Build structured unit from dtype
+
+    Parameters
+    ----------
+    dtype : `numpy.dtype`
+    unit : `astropy.units.Unit`
+
+    Returns
+    -------
+    `astropy.units.Unit` or tuple
+    """
+    if dtype.fields is None:
+        return unit
+
+    us = [_build_structured_unit(v[0], unit) for v in dtype.fields.values()]
+    return tuple(us)
+
+
+@function_helper(module=np.lib.recfunctions)
+def unstructured_to_structured(arr, dtype, *args, **kwargs):
+    """
+    Convert a structured quantity to an unstructured one.
+    This only works if all the units are compatible.
+    """
+    from astropy.units import StructuredUnit
+
+    target_unit = StructuredUnit(_build_structured_unit(dtype, arr.unit))
+
+    return (arr.to_value(arr.unit), dtype) + args, kwargs, target_unit, None

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -3,6 +3,7 @@ import itertools
 import inspect
 
 import numpy as np
+import numpy.lib.recfunctions as rfn
 from numpy.testing import assert_array_equal
 
 import pytest
@@ -10,7 +11,7 @@ import pytest
 from astropy import units as u
 from astropy.units.quantity_helper.function_helpers import (
     ARRAY_FUNCTION_ENABLED, SUBCLASS_SAFE_FUNCTIONS, UNSUPPORTED_FUNCTIONS,
-    FUNCTION_HELPERS, DISPATCHED_FUNCTIONS, IGNORED_FUNCTIONS)
+    FUNCTION_HELPERS, DISPATCHED_FUNCTIONS, IGNORED_FUNCTIONS, TOSUPPORT_FUNCTIONS)
 from astropy.utils.compat import NUMPY_LT_1_20
 
 
@@ -32,7 +33,7 @@ def get_wrapped_functions(*modules):
     return wrapped_functions
 
 
-all_wrapped_functions = get_wrapped_functions(np, np.fft, np.linalg)
+all_wrapped_functions = get_wrapped_functions(np, np.fft, np.linalg, np.lib.recfunctions)
 all_wrapped = set(all_wrapped_functions.values())
 
 
@@ -2051,6 +2052,15 @@ poly_functions = {
     }
 untested_functions |= poly_functions
 
+rec_functions = {
+    rfn.rec_append_fields, rfn.rec_drop_fields, rfn.rec_join,
+    rfn.drop_fields, rfn.rename_fields, rfn.append_fields, rfn.join_by,
+    rfn.repack_fields, rfn.apply_along_fields, rfn.assign_fields_by_name,
+    rfn.merge_arrays, rfn.stack_arrays, rfn.find_duplicates,
+    rfn.recursive_fill_fields, rfn.require_fields,
+}
+untested_functions |= rec_functions
+
 
 @needs_array_function
 def test_testing_completeness():
@@ -2078,4 +2088,4 @@ class TestFunctionHelpersCompleteness:
     # untested_function is created using all_wrapped_functions
     @needs_array_function
     def test_ignored_are_untested(self):
-        assert IGNORED_FUNCTIONS == untested_functions
+        assert IGNORED_FUNCTIONS == (untested_functions - TOSUPPORT_FUNCTIONS)

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -11,7 +11,7 @@ import pytest
 from astropy import units as u
 from astropy.units.quantity_helper.function_helpers import (
     ARRAY_FUNCTION_ENABLED, SUBCLASS_SAFE_FUNCTIONS, UNSUPPORTED_FUNCTIONS,
-    FUNCTION_HELPERS, DISPATCHED_FUNCTIONS, IGNORED_FUNCTIONS, TOSUPPORT_FUNCTIONS)
+    FUNCTION_HELPERS, DISPATCHED_FUNCTIONS, IGNORED_FUNCTIONS, TBD_FUNCTIONS)
 from astropy.utils.compat import NUMPY_LT_1_20
 
 
@@ -2034,6 +2034,53 @@ class TestLinAlg(metaclass=CoverageMeta):
         assert_array_equal(w, wx)
 
 
+class TestRecFunctions(metaclass=CoverageMeta):
+
+    def test_structured_to_unstructured(self):
+        # can't unstructure something with incompatible units
+        with pytest.raises(u.UnitConversionError, match="'m'"):
+            rfn.structured_to_unstructured(u.Quantity((0, 0.6), u.Unit("(eV, m)")))
+
+        # it works if all the units are equal
+        struct = u.Quantity((0, 0, 0.6), u.Unit("(eV, eV, eV)"))
+        unstruct = rfn.structured_to_unstructured(struct)
+        assert_array_equal(unstruct, [0, 0, 0.6] * u.eV)
+
+        # also if the units are convertible
+        struct = u.Quantity((0, 0, 0.6), u.Unit("(eV, eV, keV)"))
+        unstruct = rfn.structured_to_unstructured(struct)
+        assert_array_equal(unstruct, [0, 0, 600] * u.eV)
+
+        struct = u.Quantity((0, 0, 1.7827e-33), u.Unit("(eV, eV, g)"))
+        with u.add_enabled_equivalencies(u.mass_energy()):
+            unstruct = rfn.structured_to_unstructured(struct)
+        u.allclose(unstruct, [0, 0, 1.0000214] * u.eV)
+
+        # and if the dtype is nested
+        struct = [(5, (400.0, 3e6))] * u.Unit('m, (cm, um)')
+        unstruct = rfn.structured_to_unstructured(struct)
+        assert_array_equal(unstruct, [[5, 4, 3]] * u.m)
+
+        # For the other tests of ``structured_to_unstructured``, see
+        # ``test_structured.TestStructuredQuantityFunctions.test_structured_to_unstructured``
+
+    def test_unstructured_to_structured(self):
+        unstruct = [1, 2, 3] * u.m
+        dtype=np.dtype([("f1", float), ("f2", float), ("f3", float)])
+
+        # it works
+        struct = rfn.unstructured_to_structured(unstruct, dtype=dtype)
+        assert struct.unit == u.Unit("(m, m, m)")
+        assert_array_equal(rfn.structured_to_unstructured(struct), unstruct)
+
+        # can't structure something that's already structured
+        with pytest.raises(ValueError, match="arr must have at least one dimension"):
+            rfn.unstructured_to_structured(struct, dtype=dtype)
+
+        # For the other tests of ``structured_to_unstructured``, see
+        # ``test_structured.TestStructuredQuantityFunctions.test_unstructured_to_structured``
+
+
 untested_functions = set()
 if NUMPY_LT_1_20:
     financial_functions = {f for f in all_wrapped_functions.values()
@@ -2088,4 +2135,4 @@ class TestFunctionHelpersCompleteness:
     # untested_function is created using all_wrapped_functions
     @needs_array_function
     def test_ignored_are_untested(self):
-        assert IGNORED_FUNCTIONS == (untested_functions - TOSUPPORT_FUNCTIONS)
+        assert IGNORED_FUNCTIONS | TBD_FUNCTIONS == untested_functions

--- a/astropy/units/tests/test_structured.py
+++ b/astropy/units/tests/test_structured.py
@@ -12,8 +12,6 @@ from astropy import units as u
 from astropy.units import StructuredUnit, Unit, UnitBase, Quantity
 from astropy.utils.masked import Masked
 
-from .test_quantity_non_ufuncs import CoverageMeta
-
 
 class StructuredTestBase:
     @classmethod
@@ -561,7 +559,7 @@ class TestStructuredQuantity(StructuredTestBaseWithUnits):
         assert np.all(q_pv_t['pv'] == (1., 0.5) * self.pv_unit)
 
 
-class TestStructuredQuantityFunctions(StructuredTestBaseWithUnits, metaclass=CoverageMeta):
+class TestStructuredQuantityFunctions(StructuredTestBaseWithUnits):
     @classmethod
     def setup_class(self):
         super().setup_class()
@@ -587,33 +585,17 @@ class TestStructuredQuantityFunctions(StructuredTestBaseWithUnits, metaclass=Cov
         with pytest.raises(u.UnitConversionError, match="'km / s'"):
             rfn.structured_to_unstructured(self.q_pv)
 
-        # it works if all the units are equal
-        struct = u.Quantity((0, 0, 0.6), u.Unit("(eV, eV, eV)"))
-        unstruct = rfn.structured_to_unstructured(struct)
-        assert_array_equal(unstruct, [0, 0, 0.6] * u.eV)
-
-        # also if the units are convertible
-        struct = u.Quantity((0, 0, 0.6), u.Unit("(eV, eV, keV)"))
-        unstruct = rfn.structured_to_unstructured(struct)
-        assert_array_equal(unstruct, [0, 0, 600] * u.eV)
-
-        # and if the dtype is nested
-        struct = [(5, (400.0, 3e6))] * u.Unit('m, (cm, um)')
-        unstruct = rfn.structured_to_unstructured(struct)
-        assert_array_equal(unstruct, [[5, 4, 3]] * u.m)
+        # For the other tests of ``structured_to_unstructured``, see
+        # ``test_quantity_non_ufuncs.TestRecFunctions.test_structured_to_unstructured``
 
     def test_unstructured_to_structured(self):
         # can't structure something that's already structured
-        unstruct = [1, 2, 3] * u.m
-        dtype=np.dtype([("f1", int), ("f2", int), ("f3", int)])
+        dtype = np.dtype([("f1", float), ("f2", float)])
+        with pytest.raises(ValueError, match="The length of the last dimension"):
+            rfn.unstructured_to_structured(self.q_pv, dtype=self.q_pv.dtype)
 
-        # it works
-        struct = rfn.unstructured_to_structured(unstruct, dtype=dtype)
-        assert struct.unit == u.Unit("(m, m, m)")
-        assert_array_equal(rfn.structured_to_unstructured(struct), unstruct)
-
-        with pytest.raises(ValueError, match="arr must have at least one dimension"):
-            rfn.unstructured_to_structured(struct, dtype=dtype)
+        # For the other tests of ``structured_to_unstructured``, see
+        # ``test_quantity_non_ufuncs.TestRecFunctions.test_unstructured_to_structured``
 
 
 class TestStructuredSpecificTypeQuantity(StructuredTestBaseWithUnits):

--- a/docs/changes/units/12486.feature.rst
+++ b/docs/changes/units/12486.feature.rst
@@ -1,0 +1,1 @@
+Let ``numpy.lib.structured_to_unstructured`` work with structured quantities.

--- a/docs/changes/units/12486.feature.rst
+++ b/docs/changes/units/12486.feature.rst
@@ -1,1 +1,2 @@
-Let ``numpy.lib.structured_to_unstructured`` work with structured quantities.
+``structured_to_unstructured`` and ``unstructured_to_structured`` in
+``numpy.lib.recfunctions`` now work with Quantity.


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

It works with any structured quantity that has just one unit, or compatible units.


### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
