### PR TITLE
EXP: Use entry points to register readers/writers/identifiers for Table

### DIFF
--- a/astropy/io/fits/connect.py
+++ b/astropy/io/fits/connect.py
@@ -410,6 +410,7 @@ def write_table_fits(input, output, overwrite=False, append=False):
         table_hdu.writeto(output)
 
 
-io_registry.register_reader('fits', Table, read_table_fits)
-io_registry.register_writer('fits', Table, write_table_fits)
-io_registry.register_identifier('fits', Table, is_fits)
+def register_fits():
+    io_registry.register_reader('fits', Table, read_table_fits)
+    io_registry.register_writer('fits', Table, write_table_fits)
+    io_registry.register_identifier('fits', Table, is_fits)

--- a/astropy/io/misc/asdf/connect.py
+++ b/astropy/io/misc/asdf/connect.py
@@ -110,6 +110,7 @@ def asdf_identify(origin, filepath, fileobj, *args, **kwargs):
     return filepath is not None and filepath.endswith('.asdf')
 
 
-io_registry.register_reader('asdf', Table, read_table)
-io_registry.register_writer('asdf', Table, write_table)
-io_registry.register_identifier('asdf', Table, asdf_identify)
+def register_asdf():
+    io_registry.register_reader('asdf', Table, read_table)
+    io_registry.register_writer('asdf', Table, write_table)
+    io_registry.register_identifier('asdf', Table, asdf_identify)

--- a/astropy/io/misc/connect.py
+++ b/astropy/io/misc/connect.py
@@ -4,6 +4,3 @@
 
 from . import hdf5
 from . import parquet
-
-hdf5.register_hdf5()
-parquet.register_parquet()

--- a/astropy/io/misc/pandas/connect.py
+++ b/astropy/io/misc/pandas/connect.py
@@ -111,13 +111,15 @@ def _pandas_write(fmt, tbl, filespec, overwrite=False, **kwargs):
     return write_method(filespec, **write_kwargs)
 
 
-for pandas_fmt, defaults in PANDAS_FMTS.items():
-    fmt = PANDAS_PREFIX + pandas_fmt  # Full format specifier
+def register_pandas():
 
-    if 'read' in defaults:
-        func = functools.partial(_pandas_read, fmt)
-        io_registry.register_reader(fmt, Table, func)
+    for pandas_fmt, defaults in PANDAS_FMTS.items():
+        fmt = PANDAS_PREFIX + pandas_fmt  # Full format specifier
 
-    if 'write' in defaults:
-        func = functools.partial(_pandas_write, fmt)
-        io_registry.register_writer(fmt, Table, func)
+        if 'read' in defaults:
+            func = functools.partial(_pandas_read, fmt)
+            io_registry.register_reader(fmt, Table, func)
+
+        if 'write' in defaults:
+            func = functools.partial(_pandas_write, fmt)
+            io_registry.register_writer(fmt, Table, func)

--- a/astropy/io/registry/__init__.py
+++ b/astropy/io/registry/__init__.py
@@ -3,11 +3,14 @@
 Unified I/O Registry.
 """
 
-from . import base, compat, core, interface
+from . import base, compat, core, entry_points, interface
 from .base import *
 from .compat import *
 from .compat import _identifiers, _readers, _writers  # for backwards compat
 from .core import *
+from .entry_points import *
 from .interface import *
 
-__all__ = core.__all__ + interface.__all__ + compat.__all__ + base.__all__
+__all__ = core.__all__ + interface.__all__ + compat.__all__ + base.__all__ + entry_points.__all__
+
+

--- a/astropy/io/registry/entry_points.py
+++ b/astropy/io/registry/entry_points.py
@@ -1,0 +1,21 @@
+from importlib.metadata import entry_points
+
+__all__ = ['load_all_entry_points']
+
+
+def load_all_entry_points(group):
+    """
+    Load all entry points in a given group for the I/O registry.
+
+    Paramters
+    ---------
+    name : str
+        Name of the entry points section, e.g. 'astropy_io_registry_table'.
+    """
+    eps = entry_points()
+    if group in eps:
+        for entry_point in eps[group]:
+            func = entry_point.load()
+            func()
+    else:
+        raise Exception(f'No group {group} found in entry points')

--- a/astropy/io/votable/connect.py
+++ b/astropy/io/votable/connect.py
@@ -174,6 +174,7 @@ def write_table_votable(input, output, table_id=None, overwrite=False,
     table_file.to_xml(output, tabledata_format=tabledata_format)
 
 
-io_registry.register_reader('votable', Table, read_table_votable)
-io_registry.register_writer('votable', Table, write_table_votable)
-io_registry.register_identifier('votable', Table, is_votable)
+def register_votable():
+    io_registry.register_reader('votable', Table, read_table_votable)
+    io_registry.register_writer('votable', Table, write_table_votable)
+    io_registry.register_identifier('votable', Table, is_votable)

--- a/astropy/table/__init__.py
+++ b/astropy/table/__init__.py
@@ -62,11 +62,10 @@ from .serialize import SerializedColumn, represent_mixins_as_columns  # noqa: E4
 from astropy.io import registry  # noqa: E402
 
 with registry.delay_doc_updates(Table):
-    # Import routines that connect readers/writers to astropy.table
-    from .jsviewer import JSViewer
+
+    # Load all entry points that define readers/writers for Table
+    registry.load_all_entry_points('astropy_io_registry_table')
+
+    # We need to manually import io.ascii here because it is harder to use
+    # entry points to define a single registration function there.
     import astropy.io.ascii.connect
-    import astropy.io.fits.connect
-    import astropy.io.misc.connect
-    import astropy.io.votable.connect
-    import astropy.io.misc.asdf.connect
-    import astropy.io.misc.pandas.connect  # noqa: F401

--- a/astropy/table/jsviewer.py
+++ b/astropy/table/jsviewer.py
@@ -197,4 +197,5 @@ def write_table_jsviewer(table, filename, table_id=None, max_lines=5000,
                 overwrite=overwrite)
 
 
-io_registry.register_writer('jsviewer', Table, write_table_jsviewer)
+def register_jsviewer():
+    io_registry.register_writer('jsviewer', Table, write_table_jsviewer)

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,6 +48,14 @@ console_scripts =
 asdf_extensions =
     astropy = astropy.io.misc.asdf.extension:AstropyExtension
     astropy-asdf = astropy.io.misc.asdf.extension:AstropyAsdfExtension
+astropy_io_registry_table =
+    fits = astropy.io.fits.connect:register_fits
+    hdf5 = astropy.io.misc.hdf5:register_hdf5
+    parquet = astropy.io.misc.parquet:register_parquet
+    votable = astropy.io.votable.connect:register_votable
+    asdf = astropy.io.misc.asdf.connect:register_asdf
+    pandas = astropy.io.misc.pandas.connect:register_pandas
+    jsviewer = astropy.table.jsviewer:register_jsviewer
 
 [options.extras_require]
 test =  # Required to run the astropy test suite.


### PR DESCRIPTION
### Description

This is a proof of concept of how we could use entry points to define Table readers/writers/identifiers and use it internally (following discussions in https://github.com/astropy/astropy/issues/6623).

Obviously this will need docs etc. if we decide to go ahead but for now I'm just interested in discussing.

### Pros

* With this, if a third-party package defines a reader/writer for astropy tables, it will no longer be required to do e.g.

```
import third_party_package
from astropy.table import Table
t = Table.read('blah', format='third-party')
```

instead,

```
from astropy.table import Table
t = Table.read('blah', format='third-party')
```

will work provided the third-party package defines the entry point in their ``setup.cfg``. This is the main benefit of allowing entry points.

* Having entry points also feels cleaner rather than having to hard-code all the imports in the code.
* We could imagine actually using this to lazy load/register reader/writers if we use the same name for the entry point as for the format - in principle doing ``Table.read(..., format='fits')`` could register just the FITS readers/writers. However this would require re-working how some things are done in the registry so is not trivial.

### Cons

* Importing astropy.table could take longer **if** many third-party packages define readers/writers
* Importing astropy.table could fail if a third-party package has a buggy entry point
* Tests involving the built-in readers writers will only work if astropy is installed - not if doing ``python setup.py build_ext --inplace`` followed by ``pytest`` (arguably not really an issue since direct use of setup.py is going to be deprecated at some point).

### Performance impact

Because this uses ``importlib.metadata`` as opposed to ``pkg_resources``, the performance impact is low with just the built-in readers/writers. I don't see a measurable difference - it takes me around 1.2 seconds to import astropy.table either way.

As noted above, having third-party packages define entry points could slow things down a bit depending how many use this.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
