### PR TITLE
register structured units with yaml serialization

### DIFF
--- a/astropy/io/misc/tests/test_yaml.py
+++ b/astropy/io/misc/tests/test_yaml.py
@@ -33,10 +33,11 @@ def test_numpy_types(c):
     assert c == cy
 
 
-@pytest.mark.parametrize('c', [u.m, u.m / u.s, u.hPa, u.dimensionless_unscaled])
+@pytest.mark.parametrize('c', [u.m, u.m / u.s, u.hPa, u.dimensionless_unscaled,
+                               u.Unit('m, (cm, um)')])
 def test_unit(c):
     cy = load(dump(c))
-    if isinstance(c, u.CompositeUnit):
+    if isinstance(c, (u.CompositeUnit, u.StructuredUnit)):
         assert c == cy
     else:
         assert c is cy

--- a/astropy/io/misc/yaml.py
+++ b/astropy/io/misc/yaml.py
@@ -220,6 +220,7 @@ class AstropyDumper(yaml.SafeDumper):
 
 AstropyDumper.add_multi_representer(u.UnitBase, _unit_representer)
 AstropyDumper.add_multi_representer(u.FunctionUnitBase, _unit_representer)
+AstropyDumper.add_multi_representer(u.StructuredUnit, _unit_representer)
 AstropyDumper.add_representer(tuple, AstropyDumper._represent_tuple)
 AstropyDumper.add_representer(np.ndarray, _ndarray_representer)
 AstropyDumper.add_representer(Time, _time_representer)

--- a/docs/changes/units/12492.feature.rst
+++ b/docs/changes/units/12492.feature.rst
@@ -1,0 +1,1 @@
+Structured units can be serialized to/from yaml.


### PR DESCRIPTION
This fixes the structured unit serialization.
Doing the same for a ``numpy.void`` will take a separate commit.

The following work
```python
from astropy.io.misc.yaml import dump, load
import astropy.units as u
unit = u.Unit("(eV, eV, m)")
dump(unit)
```

```python
arr = u.Quantity([(0, 0, 0.6), ], u.Unit("(eV, eV, m)"))
dump(arr)
```

This does not

```python
arr = u.Quantity((0, 0, 0.6), u.Unit("(eV, eV, m)"))
dump(arr)
```

Fixes #12485 


### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
