### PR TITLE
Preserve non-float dtypes in Quantity columns from serialized mixins

### DIFF
--- a/astropy/io/fits/connect.py
+++ b/astropy/io/fits/connect.py
@@ -40,9 +40,6 @@ REMOVE_KEYWORDS = [
 # Column-specific keywords regex
 COLUMN_KEYWORD_REGEXP = "(" + "|".join(KEYWORD_NAMES) + ")[0-9]+"
 
-# Translation from 'datatype' in SERIALIZED-COLUMNS to `dtype`
-DATA_TYPES = {'string': 'str'}
-
 
 def is_column_keyword(keyword):
     return re.match(COLUMN_KEYWORD_REGEXP, keyword) is not None

--- a/astropy/io/fits/connect.py
+++ b/astropy/io/fits/connect.py
@@ -40,6 +40,9 @@ REMOVE_KEYWORDS = [
 # Column-specific keywords regex
 COLUMN_KEYWORD_REGEXP = "(" + "|".join(KEYWORD_NAMES) + ")[0-9]+"
 
+# Translation from 'datatype' in SERIALIZED-COLUMNS to `dtype`
+DATA_TYPES = {'string': 'str'}
+
 
 def is_column_keyword(keyword):
     return re.match(COLUMN_KEYWORD_REGEXP, keyword) is not None
@@ -111,8 +114,7 @@ def _decode_mixins(tbl):
             if attr in col:
                 setattr(tbl[col["name"]].info, attr, col[attr])
 
-    # Construct new table with mixins, using tbl.meta['__serialized_columns__']
-    # as guidance.
+    # Construct new table with mixins, using tbl.meta['__serialized_columns__'] as rules.
     tbl = serialize._construct_mixins_from_columns(tbl)
 
     return tbl

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -4223,7 +4223,7 @@ class QTable(Table):
             # Quantity subclasses identified in the unit (such as u.mag()).
             q_cls = Masked(Quantity) if isinstance(col, MaskedColumn) else Quantity
             try:
-                qcol = q_cls(col.data, col.unit, copy=False, subok=True)
+                qcol = q_cls(col.data, col.unit, copy=False, subok=True, dtype=col.dtype)
             except Exception as exc:
                 warnings.warn(
                     f"column {col.info.name} has a unit but is kept as "

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -4210,6 +4210,13 @@ class QTable(Table):
 
     """
 
+    def __init__(self, data=None, masked=False, names=None, dtype=None, **kwargs):
+        if dtype is None:
+            self._use_dtypes = False
+        else:
+            self._use_dtypes = True
+        super().__init__(data=data, masked=masked, names=names, dtype=dtype, **kwargs)
+
     def _is_mixin_for_table(self, col):
         """
         Determine if ``col`` should be added to the table directly as
@@ -4222,8 +4229,12 @@ class QTable(Table):
             # We need to turn the column into a quantity; use subok=True to allow
             # Quantity subclasses identified in the unit (such as u.mag()).
             q_cls = Masked(Quantity) if isinstance(col, MaskedColumn) else Quantity
+            if self._use_dtypes:
+                dtype = col.dtype
+            else:
+                dtype = None
             try:
-                qcol = q_cls(col.data, col.unit, copy=False, subok=True, dtype=col.dtype)
+                qcol = q_cls(col.data, col.unit, copy=False, subok=True, dtype=dtype)
             except Exception as exc:
                 warnings.warn(
                     f"column {col.info.name} has a unit but is kept as "

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -341,15 +341,18 @@ class TestNewFromColumns:
                 table_types.Column(name='b', data=u.Quantity([4, 5], unit=u.s, dtype=np.float32)),
                 table_types.Column(name='c', data=u.Quantity([7, 8], unit=u.kg, dtype=np.uint16))]
         t = table_types.Table(cols)
-        assert t.dtype == [('a', np.int64), ('b', np.float32), ('c', np.uint16)]
         assert t['a'].unit == u.m
         assert t['b'].unit == u.s
         assert t['c'].unit == u.kg
         if table_types.Table.__name__ == 'QTable':
+            assert t.dtype == [('a', np.float64), ('b', np.float32), ('c', np.float64)]
+            t = table_types.Table(cols, dtype=[np.int8, np.float64, np.uint8])
+            assert t.dtype == [('a', np.int8), ('b', np.float64), ('c', np.uint8)]
             assert np.all(t['a'].value == np.array([1, 2], dtype=np.int64))
             assert np.all(t['b'].value == np.array([4, 5], dtype=np.float32))
             assert np.all(t['c'].value == np.array([7, 8], dtype=np.uint16))
         else:
+            assert t.dtype == [('a', np.int64), ('b', np.float32), ('c', np.uint16)]
             assert np.all(t['a'] == np.array([1, 2], dtype=np.int64))
             assert np.all(t['b'] == np.array([4, 5], dtype=np.float32))
             assert np.all(t['c'] == np.array([7, 8], dtype=np.uint16))
@@ -357,14 +360,18 @@ class TestNewFromColumns:
     def test_from_table_quantities(self, table_types):
         cols = [table_types.Column(name='a', data=u.Quantity([1, 2], unit=u.pc, dtype=np.uint64)),
                 table_types.Column(name='b', data=u.Quantity([4, 5], unit=u.Hz, dtype=np.float32))]
+        tt = Table(cols)
         t = table_types.Table(Table(cols))
-        assert t.dtype == [('a', np.uint64), ('b', np.float32)]
         assert t['a'].unit == u.pc
         assert t['b'].unit == u.Hz
         if table_types.Table.__name__ == 'QTable':
+            assert t.dtype == [('a', np.float64), ('b', np.float32)]
+            t = table_types.Table(Table(cols), dtype=tt.dtype)
+            assert t.dtype == [('a', np.uint64), ('b', np.float32)]
             assert np.all(t['a'].value == np.array([1, 2], dtype=np.uint64))
             assert np.all(t['b'].value == np.array([4, 5], dtype=np.float32))
         else:
+            assert t.dtype == [('a', np.uint64), ('b', np.float32)]
             assert np.all(t['a'] == np.array([1, 2], dtype=np.uint64))
             assert np.all(t['b'] == np.array([4, 5], dtype=np.float32))
 

--- a/docs/changes/units/12505.bugfix.rst
+++ b/docs/changes/units/12505.bugfix.rst
@@ -1,0 +1,2 @@
+Store ``Quantity.dtype`` with ``_represent_as_dict`` so it is conserved in ``io.fits``
+and other serializations; also keep ``dtype`` on instantiation from ``Column``.


### PR DESCRIPTION
### Description
Columns of integer types that are serialised with Quantity information in FITS tables are presently automatically "upcast" when read back in, since `Quantity(data)` is called with its default settings, converting all numerical input to float[64]-type.

Fixes #12494, enabling both `Table.read()` and `QTable.read()` to recover the original (and stored) dtypes from a FITS table.

Fixes #15447 also.

The second commit addresses an additional issue that came up with the above: instantiating a `QTable` from integer columns also casts every non-float column to `float64`, overriding any types set with the `dtype` option as well.
Since the docstring states that `dtype=[...]` will set the column dtypes, I consider that latter part a bug.
The commit here implements the simple fix of adopting all original dtypes from the column, so creating a `QTable` from a `Table` or list of `Column`s will _always_ preserve their dtypes, whether explicitly set via the option or not (tested interactively to work with `Masked` as well, but proper tests are to follow when we have agreement on the desired functionality).
The above may be reasonable behaviour and is not breaking any existing tests, but of course changes results; in particular it is not consistent with the default behaviour of `Quantity()`, so I am leaving this to further discussion.
Honouring only an explicitly set list of `dtype=[...]` would be a bit lengthier, probably involving replicating a good bit of he `Table.__init__` setup in `QTable`.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
