### PR TITLE
Test FLRW properties

### DIFF
--- a/astropy/cosmology/tests/test_core.py
+++ b/astropy/cosmology/tests/test_core.py
@@ -39,7 +39,9 @@ class MetaTestMixin:
         assert isinstance(cosmo_cls.meta, MetaData)
 
     def test_meta_on_instance(self, cosmo):
-        assert isinstance(cosmo.meta, dict)
+        assert isinstance(cosmo.meta, dict)  # test type
+        # value set at initialization
+        assert cosmo.meta == self.cls_kwargs.get("meta", {})
 
     def test_meta_mutable(self, cosmo):
         """The metadata is NOT immutable on a cosmology"""
@@ -241,8 +243,9 @@ class TestCosmology(ParameterTestMixin, MetaTestMixin,
         # correct
         assert cosmo == cosmo
         # different name <= not equal, but equivalent
-        assert cosmo != cosmo.clone(name="test_equality")
-        assert cosmo.__equiv__(cosmo.clone(name="test_equality"))
+        newcosmo = cosmo.clone(name="test_equality")
+        assert (cosmo != newcosmo) and (newcosmo != cosmo)
+        assert cosmo.__equiv__(newcosmo) and newcosmo.__equiv__(cosmo)
 
     # ---------------------------------------------------------------
 

--- a/astropy/cosmology/tests/test_cosmology.py
+++ b/astropy/cosmology/tests/test_cosmology.py
@@ -18,34 +18,21 @@ from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyUserWarni
 def test_basic():
     cosmo = flrw.FlatLambdaCDM(H0=70, Om0=0.27, Tcmb0=2.0, Neff=3.04,
                                Ob0=0.05, name="test", meta={"a": "b"})
-    assert allclose(cosmo.Odm0, 0.27 - 0.05)
     # This next test will fail if astropy.const starts returning non-mks
     #  units by default; see the comment at the top of core.py
-    assert allclose(cosmo.Ogamma0, 1.463285e-5, rtol=1e-4)
-    assert allclose(cosmo.Onu0, 1.01026e-5, rtol=1e-4)
-    assert allclose(cosmo.Ok0, 0.0)
     assert allclose(cosmo.Om0 + cosmo.Ode0 + cosmo.Ogamma0 + cosmo.Onu0,
                     1.0, rtol=1e-6)
     assert allclose(cosmo.Om(1) + cosmo.Ode(1) + cosmo.Ogamma(1) +
                     cosmo.Onu(1), 1.0, rtol=1e-6)
-    assert allclose(cosmo.Tnu0, 1.4275317 * u.K, rtol=1e-5)
-    assert allclose(cosmo.h, 0.7)
-    assert cosmo.meta == {"a": "b"}
 
     # Make sure setting them as quantities gives the same results
     H0 = u.Quantity(70, u.km / (u.s * u.Mpc))
     T = u.Quantity(2.0, u.K)
     cosmo = flrw.FlatLambdaCDM(H0=H0, Om0=0.27, Tcmb0=T, Neff=3.04, Ob0=0.05)
-    assert allclose(cosmo.Odm0, 0.27 - 0.05)
-    assert allclose(cosmo.Ogamma0, 1.463285e-5, rtol=1e-4)
-    assert allclose(cosmo.Onu0, 1.01026e-5, rtol=1e-4)
-    assert allclose(cosmo.Ok0, 0.0)
     assert allclose(cosmo.Om0 + cosmo.Ode0 + cosmo.Ogamma0 + cosmo.Onu0,
                     1.0, rtol=1e-6)
     assert allclose(cosmo.Om(1) + cosmo.Ode(1) + cosmo.Ogamma(1) +
                     cosmo.Onu(1), 1.0, rtol=1e-6)
-    assert allclose(cosmo.Tnu0, 1.4275317 * u.K, rtol=1e-5)
-    assert allclose(cosmo.h, 0.7)
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
@@ -65,7 +52,6 @@ def test_units():
     assert cosmo.H(1.0).unit == u.km / u.Mpc / u.s
     assert cosmo.Tcmb(1.0).unit == u.K
     assert cosmo.Tcmb([0.0, 1.0]).unit == u.K
-    assert cosmo.Tnu0.unit == u.K
     assert cosmo.Tnu(1.0).unit == u.K
     assert cosmo.Tnu([0.0, 1.0]).unit == u.K
     assert cosmo.arcsec_per_kpc_comoving(1.0).unit == u.arcsec / u.kpc
@@ -147,11 +133,6 @@ def test_equality():
     newcosmo = flrw.w0waCDM(**Planck18._init_arguments, Ode0=0.6)
     assert newcosmo != Planck18
     assert Planck18 != newcosmo
-
-    # different arguments
-    newcosmo = Planck18.clone(name="modified")
-    assert Planck18 != newcosmo  # the name was changed!
-    assert newcosmo != Planck18  # double check directions.
 
 
 def test_xtfuncs():


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

Add tests for all the derived properties on FLRW.
Checks for immutability and expected values.
There weren't really any tests for this in ``test_cosmology``

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
