### PR TITLE
Support structured quantity, including scalars.

### DIFF
--- a/astropy/io/misc/tests/test_yaml.py
+++ b/astropy/io/misc/tests/test_yaml.py
@@ -8,7 +8,6 @@ from io import StringIO
 
 import pytest
 import numpy as np
-import yaml
 
 from astropy.coordinates import (SkyCoord, EarthLocation, Angle, Longitude, Latitude,
                                  SphericalRepresentation, UnitSphericalRepresentation,
@@ -58,18 +57,30 @@ def test_custom_unit(c):
         assert cy2 is c
 
 
-@pytest.mark.parametrize('c', [Angle('1 2 3', unit='deg'),
-                               Longitude('1 2 3', unit='deg'),
-                               Latitude('1 2 3', unit='deg'),
-                               [[1], [3]] * u.m,
-                               np.array([[1, 2], [3, 4]], order='F'),
-                               np.array([[1, 2], [3, 4]], order='C'),
-                               np.array([1, 2, 3, 4])[::2]])
+@pytest.mark.parametrize('c', [
+    Angle('1 2 3', unit='deg'),
+    Longitude('1 2 3', unit='deg'),
+    Latitude('1 2 3', unit='deg'),
+    [[1], [3]] * u.m,
+    np.array([[1, 2], [3, 4]], order='F'),
+    np.array([[1, 2], [3, 4]], order='C'),
+    np.array([1, 2, 3, 4])[::2],
+    np.array([(1., 2), (3., 4)], dtype='f8,i4'),  # array with structured dtype.
+    np.array((1., 2), dtype='f8,i4'),  # array scalar with structured dtype.
+    np.array((1., 2), dtype='f8,i4')[()],  # numpy void.
+    np.array((1., 2.), dtype='f8,f8') * u.s,  # Quantity structured scalar.
+    [((1., 2., 3.), (4., 5., 6.)),  # Quantity with structured unit.
+     ((11., 12., 13.), (14., 15., 16.))] * u.Unit('m, m/s'),
+    np.array([((1., 2., 3.), (4., 5., 6.)),
+              ((11., 12., 13.), (14., 15., 16.))],
+             dtype=[('p', '3f8'), ('v', '3f8')]) * u.Unit('m, m/s')
+    ])
 def test_ndarray_subclasses(c):
     cy = load(dump(c))
 
     assert np.all(c == cy)
     assert c.shape == cy.shape
+    assert c.dtype == cy.dtype
     assert type(c) is type(cy)
 
     cc = 'C_CONTIGUOUS'

--- a/docs/changes/io.misc/12509.bugfix.rst
+++ b/docs/changes/io.misc/12509.bugfix.rst
@@ -1,0 +1,2 @@
+YAML can now also represent quantities and arrays with structured dtype,
+as well as structured scalars based on ``np.void``.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

As the title indicates, this allows structured quantities, including scalars, to be saved to yaml. This is independent of whether the unit is structured. I ended up deciding not to try to represent the void as a tuple, but rather as an opaque binary blob, since in principle the structure can be quite large and include arrays.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #12497

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
