### PR TITLE
Temporary fix problems with Quantity.__class_getitem__

### DIFF
--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -402,8 +402,7 @@ class Quantity(np.ndarray):
         # Quantity does not (yet) properly extend the NumPy generics types,
         # introduced in numpy v1.22+, instead just including the unit info as
         # metadata using Annotated.
-        if not NUMPY_LT_1_22:
-            cls = super().__class_getitem__((cls, *shape_dtype))
+        # TODO: ensure we do interact with NDArray.__class_getitem__.
         return Annotated.__class_getitem__((cls, unit))
 
     def __new__(cls, value, unit=None, dtype=None, copy=True, order=None,

--- a/astropy/utils/masked/function_helpers.py
+++ b/astropy/utils/masked/function_helpers.py
@@ -611,8 +611,7 @@ def _masked_quantile(a, q, axis=None, out=None, **kwargs):
 
 
 @dispatched_function
-def quantile(a, q, axis=None, out=None, overwrite_input=False,
-             interpolation='linear', keepdims=False):
+def quantile(a, q, axis=None, out=None, **kwargs):
     from astropy.utils.masked import Masked
     if isinstance(q, Masked) or out is not None and not isinstance(out, Masked):
         raise NotImplementedError
@@ -622,9 +621,9 @@ def quantile(a, q, axis=None, out=None, overwrite_input=False,
     if not np.lib.function_base._quantile_is_valid(q):
         raise ValueError("Quantiles must be in the range [0, 1]")
 
+    keepdims = kwargs.pop('keepdims', False)
     r, k = np.lib.function_base._ureduce(
-        a, func=_masked_quantile, q=q, axis=axis, out=out,
-        interpolation=interpolation, overwrite_input=overwrite_input)
+        a, func=_masked_quantile, q=q, axis=axis, out=out, **kwargs)
     return (r.reshape(k) if keepdims else r) if out is None else out
 
 

--- a/docs/changes/units/12511.bugfix.rst
+++ b/docs/changes/units/12511.bugfix.rst
@@ -1,0 +1,1 @@
+Fix bad typing problems by removing interaction with ``NDArray.__class_getitem__``.

--- a/docs/changes/utils/12511.bugfix.rst
+++ b/docs/changes/utils/12511.bugfix.rst
@@ -1,0 +1,2 @@
+Ensure ``Masked`` also works with numpy >=1.22, which has a keyword argument
+name change for ``np.quantile``.


### PR DESCRIPTION
Not a permanent fix, but we need to get the tests running again!

EDIT: also include a fix for `Masked` no longer working with `np.quantile`.