### PR TITLE
Add Celprm and Prjprm WCSLIB wrappers

### DIFF
--- a/astropy/wcs/include/astropy_wcs/pyutil.h
+++ b/astropy/wcs/include/astropy_wcs/pyutil.h
@@ -133,6 +133,7 @@ extern PyObject* WcsExc_InvalidSubimageSpecification;
 extern PyObject* WcsExc_NonseparableSubimageCoordinateSystem;
 extern PyObject* WcsExc_NoWcsKeywordsFound;
 extern PyObject* WcsExc_InvalidTabularParameters;
+extern PyObject* WcsExc_InvalidPrjParameters;
 
 /* This is an array mapping the wcs status codes to Python exception
  * types.  The exception string is stored as part of wcslib itself in

--- a/astropy/wcs/include/astropy_wcs/wcslib_celprm_wrap.h
+++ b/astropy/wcs/include/astropy_wcs/wcslib_celprm_wrap.h
@@ -1,0 +1,20 @@
+#ifndef __WCSLIB_CELPRM_WRAP_H__
+#define __WCSLIB_CELPRM_WRAP_H__
+
+#include "pyutil.h"
+#include "wcs.h"
+
+extern PyTypeObject PyCelprmType;
+
+typedef struct {
+    PyObject_HEAD
+    struct celprm* x;
+    int* prefcount;
+    PyObject* owner;
+} PyCelprm;
+
+PyCelprm* PyCelprm_cnew(PyObject* wcsprm_obj, struct celprm* x, int* prefcount);
+
+int _setup_celprm_type(PyObject* m);
+
+#endif

--- a/astropy/wcs/include/astropy_wcs/wcslib_prjprm_wrap.h
+++ b/astropy/wcs/include/astropy_wcs/wcslib_prjprm_wrap.h
@@ -1,0 +1,20 @@
+#ifndef __WCSLIB_PRJPRM_WRAP_H__
+#define __WCSLIB_PRJPRM_WRAP_H__
+
+#include "pyutil.h"
+#include "wcs.h"
+
+extern PyTypeObject PyPrjprmType;
+
+typedef struct {
+    PyObject_HEAD
+    struct prjprm* x;
+    int* prefcount;
+    PyObject* owner;
+} PyPrjprm;
+
+PyPrjprm* PyPrjprm_cnew(PyObject* celprm, struct prjprm* x, int* prefcount);
+
+int _setup_prjprm_type(PyObject* m);
+
+#endif

--- a/astropy/wcs/setup_package.py
+++ b/astropy/wcs/setup_package.py
@@ -295,6 +295,8 @@ def get_extensions():
         'util.c',
         'wcslib_wrap.c',
         'wcslib_auxprm_wrap.c',
+        'wcslib_prjprm_wrap.c',
+        'wcslib_celprm_wrap.c',
         'wcslib_tabprm_wrap.c',
         'wcslib_wtbarr_wrap.c'
     ]

--- a/astropy/wcs/src/astropy_wcs.c
+++ b/astropy/wcs/src/astropy_wcs.c
@@ -7,6 +7,8 @@
 #include "astropy_wcs/wcslib_wrap.h"
 #include "astropy_wcs/wcslib_tabprm_wrap.h"
 #include "astropy_wcs/wcslib_auxprm_wrap.h"
+#include "astropy_wcs/wcslib_prjprm_wrap.h"
+#include "astropy_wcs/wcslib_celprm_wrap.h"
 #include "astropy_wcs/wcslib_units_wrap.h"
 #include "astropy_wcs/wcslib_wtbarr_wrap.h"
 #include "astropy_wcs/distortion_wrap.h"
@@ -858,6 +860,8 @@ PyInit__wcs(void)
       _setup_unit_list_proxy_type(m)||
       _setup_wcsprm_type(m)         ||
       _setup_auxprm_type(m)         ||
+      _setup_prjprm_type(m)         ||
+      _setup_celprm_type(m)         ||
       _setup_tabprm_type(m)         ||
       _setup_wtbarr_type(m)         ||
       _setup_distortion_type(m)     ||

--- a/astropy/wcs/src/pyutil.c
+++ b/astropy/wcs/src/pyutil.c
@@ -232,6 +232,7 @@ PyObject* WcsExc_InvalidSubimageSpecification;
 PyObject* WcsExc_NonseparableSubimageCoordinateSystem;
 PyObject* WcsExc_NoWcsKeywordsFound;
 PyObject* WcsExc_InvalidTabularParameters;
+PyObject* WcsExc_InvalidPrjParameters;
 
 /* This is an array mapping the wcs status codes to Python exception
  * types.  The exception string is stored as part of wcslib itself in
@@ -276,6 +277,7 @@ _define_exceptions(
   DEFINE_EXCEPTION(NonseparableSubimageCoordinateSystem);
   DEFINE_EXCEPTION(NoWcsKeywordsFound);
   DEFINE_EXCEPTION(InvalidTabularParameters);
+  DEFINE_EXCEPTION(InvalidPrjParameters);
   return 0;
 }
 
@@ -423,26 +425,24 @@ set_string(
       goto end;
     }
   } else {
-    PyErr_SetString(PyExc_TypeError, "value must be bytes or unicode");
+    PyErr_SetString(PyExc_TypeError, "'value' must be bytes or unicode.");
     goto end;
   }
 
-  if (len > maxlen) {
+  if (len >= maxlen) {
     PyErr_Format(
         PyExc_ValueError,
-        "'%s' must be less than %u characters",
+        "'%s' length must be less than %u characters.",
         propname,
-        (unsigned int)maxlen);
+        (unsigned int) maxlen);
     goto end;
   }
 
-  strncpy(dest, buffer, (size_t)maxlen);
-
+  strncpy(dest, buffer, (size_t)len + 1);
   result = 0;
 
  end:
   Py_XDECREF(ascii_obj);
-
   return result;
 }
 

--- a/astropy/wcs/src/wcslib_celprm_wrap.c
+++ b/astropy/wcs/src/wcslib_celprm_wrap.c
@@ -1,0 +1,483 @@
+#define NO_IMPORT_ARRAY
+
+#include "astropy_wcs/wcslib_celprm_wrap.h"
+#include "astropy_wcs/wcslib_prjprm_wrap.h"
+
+#include <wcs.h>
+#include <wcsprintf.h>
+#include <cel.h>
+#include <prj.h>
+#include <wcserr.h>
+#include <numpy/npy_math.h>
+
+#include <stdio.h>
+
+/*
+ It gets to be really tedious to type long docstrings in ANSI C syntax
+ (since multi-line strings literals are not valid).  Therefore, the
+ docstrings are written in doc/docstrings.py, which are then converted
+ by setup.py into docstrings.h, which we include here.
+*/
+#include "astropy_wcs/docstrings.h"
+#include "astropy_wcs/wcslib_wrap.h"
+
+
+PyObject** cel_errexc[7];
+
+
+static int wcslib_cel_to_python_exc(int status)
+{
+    if (status > 0 && status < 7) {
+        PyErr_SetString(*cel_errexc[status], cel_errmsg[status]);
+    } else if (status > 6) {
+        PyErr_SetString(
+            PyExc_RuntimeError,
+            "Unknown WCSLIB celprm-related error occurred.");
+    }
+    return status;
+}
+
+
+static int is_readonly(PyCelprm* self)
+{
+    if (self != NULL && self->owner != NULL) {
+        PyErr_SetString(
+                PyExc_AttributeError,
+                "Attribute 'cel' of 'astropy.wcs.Wcsprm' objects is read-only.");
+        return 1;
+    } else {
+        return 0;
+    }
+}
+
+
+static int is_cel_null(PyCelprm* self)
+{
+    if (self->x == NULL) {
+        PyErr_SetString(
+                PyExc_MemoryError,
+                "Underlying 'celprm' object is NULL.");
+        return 1;
+    } else {
+        return 0;
+    }
+}
+
+
+/***************************************************************************
+ * PyCelprm methods                                                        *
+ ***************************************************************************/
+
+static PyObject* PyCelprm_new(PyTypeObject* type, PyObject* args, PyObject* kwds)
+{
+    PyCelprm* self;
+    self = (PyCelprm*)type->tp_alloc(type, 0);
+    if (self == NULL) return NULL;
+    self->owner = NULL;
+    self->prefcount = NULL;
+
+    if ((self->x = calloc(1, sizeof(struct celprm))) == 0x0) {
+        PyErr_SetString(PyExc_MemoryError,
+        "Could not allocate memory for celprm structure.");
+        return NULL;
+    }
+    if ((self->prefcount = (int*) malloc(sizeof(int))) == 0x0) {
+        PyErr_SetString(PyExc_MemoryError, "Could not allocate memory.");
+        free(self->x);
+        return NULL;
+    }
+
+    if (wcslib_cel_to_python_exc(celini(self->x))) {
+        free(self->x);
+        free(self->prefcount);
+        return NULL;
+    }
+    *(self->prefcount) = 1;
+    return (PyObject*)self;
+}
+
+
+static int PyCelprm_traverse(PyCelprm* self, visitproc visit, void *arg)
+{
+    Py_VISIT(self->owner);
+    return 0;
+}
+
+
+static int PyCelprm_clear(PyCelprm* self)
+{
+    Py_CLEAR(self->owner);
+    return 0;
+}
+
+
+static void PyCelprm_dealloc(PyCelprm* self)
+{
+    PyCelprm_clear(self);
+    wcslib_cel_to_python_exc(celfree(self->x)); // free memory used for err msg
+    if (self->prefcount && (--(*self->prefcount)) == 0) {
+        free(self->x);
+        free(self->prefcount);
+    }
+    Py_TYPE(self)->tp_free((PyObject*)self);
+}
+
+
+static int PyCelprm_cset(PyCelprm* self)
+{
+    if (wcslib_cel_to_python_exc(celset(self->x))) {
+        return -1;
+    }
+    return 0;
+}
+
+
+static PyObject* PyCelprm_set(PyCelprm* self)
+{
+    if (is_readonly(self) || PyCelprm_cset(self)) return NULL;
+    Py_RETURN_NONE;
+}
+
+
+PyCelprm* PyCelprm_cnew(PyObject* wcsprm_obj, struct celprm* x, int* prefcount)
+{
+    PyCelprm* self;
+    self = (PyCelprm*)(&PyCelprmType)->tp_alloc(&PyCelprmType, 0);
+    if (self == NULL) return NULL;
+    self->x = x;
+    Py_XINCREF(wcsprm_obj);
+    self->owner = wcsprm_obj;
+    self->prefcount = prefcount;
+    if (prefcount) (*prefcount)++;
+    return self;
+}
+
+
+static PyObject* PyCelprm_copy(PyCelprm* self)
+{
+    PyCelprm* copy = NULL;
+    copy = PyCelprm_cnew(self->owner, self->x, self->prefcount);
+    if (copy == NULL) return NULL;
+    return (PyObject*)copy;
+}
+
+
+static PyObject* PyCelprm_deepcopy(PyCelprm* self)
+{
+    PyCelprm* copy = PyCelprm_new(&PyCelprmType, NULL, NULL);
+    if (copy == NULL) return NULL;
+
+    memcpy(copy->x, self->x, sizeof(struct celprm));
+    copy->x->err = NULL;
+    return (PyObject*)copy;
+}
+
+
+static PyObject* PyCelprm___str__(PyCelprm* self) {
+    /* if (PyCelprm_cset(self)) return NULL; */
+    /* This is not thread-safe, but since we're holding onto the GIL,
+       we can assume we won't have thread conflicts */
+    wcsprintf_set(NULL);
+    if (wcslib_cel_to_python_exc(celprt(self->x))) {
+        return NULL;
+    }
+    return PyUnicode_FromString(wcsprintf_buf());
+}
+
+
+/***************************************************************************
+ * Member getters/setters (properties)
+ */
+
+
+static PyObject* PyCelprm_get_flag(PyCelprm* self, void* closure)
+{
+    if (is_cel_null(self)) {
+        return NULL;
+    } else {
+        return get_int("flag", self->x->flag);
+    }
+}
+
+static PyObject* PyCelprm_get_offset(PyCelprm* self, void* closure)
+{
+    if (is_cel_null(self)) {
+        return NULL;
+    } else {
+        return get_bool("offset", self->x->offset);
+    }
+}
+
+
+static int PyCelprm_set_offset(PyCelprm* self, PyObject* value, void* closure)
+{
+    if (is_cel_null(self) || is_readonly(self)) {
+        return -1;
+    } else if (value == Py_None) {
+        self->x->offset = 0;
+        return 0;
+    } else {
+        return set_bool("offset", value, &self->x->offset);
+    }
+}
+
+
+static PyObject* PyCelprm_get_phi0(PyCelprm* self, void* closure)
+{
+    if (is_cel_null(self)) {
+        return NULL;
+    } else if (self->x->phi0 != UNDEFINED) {
+        return get_double("phi0", self->x->phi0);
+    }
+    Py_RETURN_NONE;
+}
+
+
+static int PyCelprm_set_phi0(PyCelprm* self, PyObject* value, void* closure)
+{
+    int result;
+    double phi0;
+
+    if (is_cel_null(self) || is_readonly(self)) {
+        return -1;
+    } else if (value == Py_None) {
+        if (self->x->phi0 != UNDEFINED) {
+            self->x->phi0 = UNDEFINED;
+            self->x->flag = 0;
+        }
+    } else {
+        result = set_double("phi0", value, &phi0);
+        if (result) return result;
+        if (phi0 != self->x->phi0) {
+            self->x->phi0 = phi0;
+            self->x->flag = 0;
+        }
+    }
+    return 0;
+}
+
+
+static PyObject* PyCelprm_get_theta0(PyCelprm* self, void* closure)
+{
+    if (is_cel_null(self)) {
+        return NULL;
+    } else if (self->x->theta0 != UNDEFINED) {
+        return get_double("theta0", self->x->theta0);
+    }
+    Py_RETURN_NONE;
+}
+
+
+static int PyCelprm_set_theta0(PyCelprm* self, PyObject* value, void* closure)
+{
+    int result;
+    double theta0;
+    if(is_cel_null(self) || is_readonly(self)) {
+        return -1;
+    } else if (value == Py_None) {
+        if (self->x->theta0 != UNDEFINED) {
+            self->x->theta0 = UNDEFINED;
+            self->x->flag = 0;
+        }
+    } else {
+        result = set_double("theta0", value, &theta0);
+        if (result) return result;
+        if (theta0 != self->x->theta0) {
+            self->x->theta0 = theta0;
+            self->x->flag = 0;
+        }
+    }
+    return 0;
+}
+
+
+static PyObject* PyCelprm_get_ref(PyCelprm* self, void* closure)
+{
+    Py_ssize_t size = 4;
+    if (is_cel_null(self)) {
+        return NULL;
+    } else {
+        return get_double_array("ref", self->x->ref, 1, &size, (PyObject*) self);
+    }
+}
+
+
+static int PyCelprm_set_ref(PyCelprm* self, PyObject* value, void* closure)
+{
+    int i;
+    int skip[4] = {0, 0, 0, 0};
+    double ref[4] = {0.0, 0.0, UNDEFINED, +90.0};
+    npy_intp size;
+    double *data;
+
+    if (is_cel_null(self) || is_readonly(self)) return -1;
+
+    if (value == Py_None) {
+        /* If ref is set to None - reset ref to celini values: */
+        for (i = 0; i < 4; i++) {
+            self->x->ref[i] = ref[i];
+        }
+        self->x->flag = 0;
+        return 0;
+    }
+
+    PyObject* value_array = PyArray_ContiguousFromAny(value, NPY_DOUBLE, 1, 1);
+    if (!value_array) return -1;
+
+    size = PyArray_SIZE(value_array);
+
+    if (size < 1) {
+        Py_DECREF(value_array);
+        PyErr_SetString(PyExc_ValueError,
+            "'ref' must be a non-empty 1-dimentional list of values or None.");
+        return -1;
+    }
+
+    if (size > 4) {
+        Py_DECREF(value_array);
+        PyErr_SetString(PyExc_RuntimeError, "Number of 'ref' values cannot exceed 4.");
+        return -1;
+    }
+
+    if (PyList_Check(value)) {
+        for (i = 0; i < size; i++) {
+            skip[i] = (PyList_GetItem(value, i) == Py_None);
+        }
+    }
+
+    data = (double*) PyArray_DATA(value_array);
+
+    for (i = 0; i < size; i++) {
+        if (skip[i]) continue;
+        if (npy_isnan(self->x->ref[i])) {
+            self->x->ref[i] = UNDEFINED;
+        } else {
+            self->x->ref[i] = data[i];
+        }
+    }
+    for (i = size; i < 4; i++) {
+        self->x->ref[i] = ref[i];
+    }
+
+    self->x->flag = 0;
+    Py_DECREF(value_array);
+    return 0;
+}
+
+
+static PyObject* PyCelprm_get_prj(PyCelprm* self, void* closure)
+{
+    if (is_cel_null(self)) return NULL;
+    return (PyObject*)PyPrjprm_cnew((PyObject *)self, &(self->x->prj), NULL);
+}
+
+
+static PyObject* PyCelprm_get_euler(PyCelprm* self, void* closure)
+{
+    Py_ssize_t size = 5;
+    if (is_cel_null(self)) return NULL;
+    return get_double_array("euler", self->x->euler, 1, &size, (PyObject*) self);
+}
+
+
+static PyObject* PyCelprm_get_latpreq(PyCelprm* self, void* closure)
+{
+    if (is_cel_null(self)) return NULL;
+    return get_int("lapreq", self->x->latpreq);
+}
+
+
+static PyObject* PyCelprm_get_isolat(PyCelprm* self, void* closure)
+{
+    if (is_cel_null(self)) {
+        return NULL;
+    } else {
+        return get_bool("isolat", self->x->isolat);
+    }
+}
+
+
+/***************************************************************************
+ * PyCelprm definition structures
+ */
+
+static PyGetSetDef PyCelprm_getset[] = {
+    {"offset", (getter)PyCelprm_get_offset, (setter)PyCelprm_set_offset, (char *)doc_cel_offset},
+    {"phi0", (getter)PyCelprm_get_phi0, (setter)PyCelprm_set_phi0, (char *)doc_celprm_phi0},
+    {"theta0", (getter)PyCelprm_get_theta0, (setter)PyCelprm_set_theta0, (char *)doc_celprm_theta0},
+    {"ref", (getter)PyCelprm_get_ref, (setter)PyCelprm_set_ref, (char *)doc_celprm_ref},
+    {"euler", (getter)PyCelprm_get_euler, NULL, (char *)doc_celprm_euler},
+    {"latpreq", (getter)PyCelprm_get_latpreq, NULL, (char *)doc_celprm_latpreq},
+    {"isolat", (getter)PyCelprm_get_isolat, NULL, (char *)doc_celprm_isolat},
+    {"_flag", (getter)PyCelprm_get_flag, NULL, ""},
+    {"prj", (getter)PyCelprm_get_prj, NULL, (char *)doc_celprm_prj},
+    {NULL}
+};
+
+
+static PyMethodDef PyCelprm_methods[] = {
+    {"set", (PyCFunction)PyCelprm_set, METH_NOARGS, doc_set_celprm},
+    {"__copy__", (PyCFunction)PyCelprm_copy, METH_NOARGS, ""},
+    {"__deepcopy__", (PyCFunction)PyCelprm_deepcopy, METH_O, ""},
+    {NULL}
+};
+
+
+PyTypeObject PyCelprmType = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    "astropy.wcs.Celprm",         /*tp_name*/
+    sizeof(PyCelprm),             /*tp_basicsize*/
+    0,                            /*tp_itemsize*/
+    (destructor)PyCelprm_dealloc, /*tp_dealloc*/
+    0,                            /*tp_print*/
+    0,                            /*tp_getattr*/
+    0,                            /*tp_setattr*/
+    0,                            /*tp_compare*/
+    0,                            /*tp_repr*/
+    0,                            /*tp_as_number*/
+    0,                            /*tp_as_sequence*/
+    0,                            /*tp_as_mapping*/
+    0,                            /*tp_hash */
+    0,                            /*tp_call*/
+    (reprfunc)PyCelprm___str__,   /*tp_str*/
+    0,                            /*tp_getattro*/
+    0,                            /*tp_setattro*/
+    0,                            /*tp_as_buffer*/
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /*tp_flags*/
+    doc_Celprm,                   /* tp_doc */
+    (traverseproc)PyCelprm_traverse, /* tp_traverse */
+    (inquiry)PyCelprm_clear,      /* tp_clear */
+    0,                            /* tp_richcompare */
+    0,                            /* tp_weaklistoffset */
+    0,                            /* tp_iter */
+    0,                            /* tp_iternext */
+    PyCelprm_methods,             /* tp_methods */
+    0,                            /* tp_members */
+    PyCelprm_getset,              /* tp_getset */
+    0,                            /* tp_base */
+    0,                            /* tp_dict */
+    0,                            /* tp_descr_get */
+    0,                            /* tp_descr_set */
+    0,                            /* tp_dictoffset */
+    0,                            /* tp_init */
+    0,                            /* tp_alloc */
+    PyCelprm_new,                 /* tp_new */
+};
+
+
+int _setup_celprm_type(PyObject* m)
+{
+    if (PyType_Ready(&PyCelprmType) < 0) return -1;
+    Py_INCREF(&PyCelprmType);
+    PyModule_AddObject(m, "Celprm", (PyObject *)&PyCelprmType);
+
+    cel_errexc[0] = NULL;                         /* Success */
+    cel_errexc[1] = &PyExc_MemoryError;           /* Null celprm pointer passed */
+    cel_errexc[2] = &WcsExc_InvalidPrjParameters; /* Invalid projection parameters */
+    cel_errexc[3] = &WcsExc_InvalidTransform;     /* Invalid coordinate transformation parameters */
+    cel_errexc[4] = &WcsExc_InvalidTransform;     /* Ill-conditioned coordinate transformation parameters */
+    cel_errexc[5] = &WcsExc_InvalidCoordinate;    /* One or more of the (x,y) coordinates were invalid */
+    cel_errexc[6] = &WcsExc_InvalidCoordinate;    /* One or more of the (lng,lat) coordinates were invalid */
+
+    return 0;
+}

--- a/astropy/wcs/src/wcslib_prjprm_wrap.c
+++ b/astropy/wcs/src/wcslib_prjprm_wrap.c
@@ -1,0 +1,1010 @@
+#define NO_IMPORT_ARRAY
+#include <math.h>
+#include <float.h>
+
+#include "astropy_wcs/wcslib_celprm_wrap.h"
+#include "astropy_wcs/wcslib_prjprm_wrap.h"
+
+#include <wcs.h>
+#include <wcsprintf.h>
+#include <prj.h>
+#include <numpy/npy_math.h>
+#include "astropy_wcs/docstrings.h"
+
+
+PyObject** prj_errexc[5];
+
+
+static int is_dbl_equal(double x1, double x2)
+{
+    double ax1 = fabs(x1);
+    double ax2 = fabs(x2);
+    double minx = (ax1 < ax2) ? ax1 : ax2;
+    double diff = fabs(x1 - x2);
+    return (diff <= (2.0 * DBL_EPSILON * minx) || diff < DBL_MIN);
+}
+
+
+static int wcslib_prj_to_python_exc(int status)
+{
+    if (status > 0 && status < 5) {
+        PyErr_SetString(*prj_errexc[status], prj_errmsg[status]);
+    } else if (status > 5) {
+        PyErr_SetString(
+            PyExc_RuntimeError,
+            "Unknown WCSLIB prjprm-related error occurred.");
+    }
+    return status;
+}
+
+
+static int is_readonly(PyPrjprm* self)
+{
+    if (self != NULL && self->owner != NULL &&
+        ((PyCelprm*)self->owner)->owner != NULL) {
+        PyErr_SetString(
+            PyExc_AttributeError,
+            "Attribute 'prj' of 'astropy.wcs.Wcsprm.cel' objects is read-only.");
+        return 1;
+    } else {
+        return 0;
+    }
+}
+
+
+static int is_prj_null(PyPrjprm* self)
+{
+    if (self->x == NULL) {
+        PyErr_SetString(PyExc_MemoryError, "Underlying 'prjprm' object is NULL.");
+        return 1;
+    } else {
+        return 0;
+    }
+}
+
+
+/***************************************************************************
+ * PyPrjprm methods                                                        *
+ ***************************************************************************/
+
+static PyObject* PyPrjprm_new(PyTypeObject* type, PyObject* args, PyObject* kwds)
+{
+    PyPrjprm* self;
+    self = (PyPrjprm*)type->tp_alloc(type, 0);
+    if (self == NULL) return NULL;
+    self->owner = NULL;
+    self->x = NULL;
+    self->prefcount = NULL;
+    if ((self->x = calloc(1, sizeof(struct prjprm))) == 0x0) {
+        PyErr_SetString(PyExc_MemoryError, "Could not allocate memory.");
+        return NULL;
+    }
+    if ((self->prefcount = (int*) malloc(sizeof(int))) == 0x0) {
+        PyErr_SetString(PyExc_MemoryError, "Could not allocate memory.");
+        free(self->x);
+        return NULL;
+    }
+    if (wcslib_prj_to_python_exc(prjini(self->x)))
+    {
+        free(self->x);
+        free(self->prefcount);
+        return NULL;
+    }
+    *(self->prefcount) = 1;
+    return (PyObject*)self;
+}
+
+
+static int PyPrjprm_traverse(PyPrjprm* self, visitproc visit, void *arg)
+{
+    Py_VISIT(self->owner);
+    return 0;
+}
+
+
+static int PyPrjprm_clear(PyPrjprm* self)
+{
+    Py_CLEAR(self->owner);
+    return 0;
+}
+
+
+static void PyPrjprm_dealloc(PyPrjprm* self)
+{
+    PyPrjprm_clear(self);
+    if (self->prefcount && (--(*self->prefcount)) == 0) {
+        wcslib_prj_to_python_exc(prjfree(self->x));
+        free(self->x);
+        free(self->prefcount);
+    }
+    Py_TYPE(self)->tp_free((PyObject*)self);
+}
+
+
+PyPrjprm* PyPrjprm_cnew(PyObject* celprm_obj, struct prjprm* x, int* prefcount)
+{
+    PyPrjprm* self;
+    self = (PyPrjprm*)(&PyPrjprmType)->tp_alloc(&PyPrjprmType, 0);
+    if (self == NULL) return NULL;
+    self->x = x;
+    Py_XINCREF(celprm_obj);
+    self->owner = celprm_obj;
+    self->prefcount = prefcount;
+    if (prefcount) (*prefcount)++;
+    return self;
+}
+
+
+static PyObject* PyPrjprm_copy(PyPrjprm* self)
+{
+    PyPrjprm* copy = NULL;
+    copy = PyPrjprm_cnew(self->owner, self->x, self->prefcount);
+    if (copy == NULL) return NULL;
+    return (PyObject*)copy;
+}
+
+
+static PyObject* PyPrjprm_deepcopy(PyPrjprm* self)
+{
+    PyPrjprm* copy = PyPrjprm_new(&PyPrjprmType, NULL, NULL);
+    if (copy == NULL) return NULL;
+
+    memcpy(copy->x, self->x, sizeof(struct prjprm));
+    copy->x->err = NULL;
+    return (PyObject*)copy;
+}
+
+
+static PyObject* PyPrjprm___str__(PyPrjprm* self)
+{
+    wcsprintf_set(NULL);
+    if (wcslib_prj_to_python_exc(prjprt(self->x))) {
+        return NULL;
+    }
+    return PyUnicode_FromString(wcsprintf_buf());
+}
+
+
+static int PyPrjprm_cset(PyPrjprm* self)
+{
+    if (wcslib_prj_to_python_exc(prjset(self->x))) {
+        return -1;
+    }
+    return 0;
+}
+
+
+static PyObject* PyPrjprm_set(PyPrjprm* self)
+{
+    if (is_readonly(self) || PyPrjprm_cset(self)) return NULL;
+    Py_RETURN_NONE;
+}
+
+
+static PyObject* _prj_eval(PyPrjprm* self, int (*prjfn)(PRJX2S_ARGS),
+                           PyObject* x1_in, PyObject* x2_in)
+{
+    Py_ssize_t i, ndim;
+    npy_intp *x1_dims, *x2_dims;
+    Py_ssize_t     nelem      = 1;
+    PyArrayObject* x1         = NULL;
+    PyArrayObject* x2         = NULL;
+    PyArrayObject* prj_x1     = NULL;
+    PyArrayObject* prj_x2     = NULL;
+    PyArrayObject* stat       = NULL;
+    PyObject*      result     = NULL;
+    int            status     = -1;
+
+    // TODO: This assumes the same shape for the input arrays.
+    //       Instead, we should broadcast.
+
+    x1 = (PyArrayObject *) PyArray_ContiguousFromObject(x1_in, NPY_DOUBLE, 1, NPY_MAXDIMS);
+    if (x1 == NULL) {
+      goto exit;
+    }
+    x2 = (PyArrayObject *) PyArray_ContiguousFromObject(x2_in, NPY_DOUBLE, 1, NPY_MAXDIMS);
+    if (x2 == NULL) {
+      goto exit;
+    }
+
+    ndim = PyArray_NDIM(x1);
+
+    if (ndim != PyArray_NDIM(x2)) {
+        PyErr_SetString(PyExc_ValueError, "Input array dimensions do not match.");
+        goto exit;
+    }
+
+    x1_dims = PyArray_DIMS(x1);
+    x2_dims = PyArray_DIMS(x2);
+    for (i = 0; i < ndim; i++) {
+        if (x1_dims[i] != x2_dims[i]) {
+            PyErr_SetString(PyExc_ValueError, "Input array dimensions do not match.");
+            goto exit;
+        }
+        nelem *= x1_dims[i];
+    }
+
+    prj_x1 = (PyArrayObject*)PyArray_SimpleNew(ndim, x1_dims, NPY_DOUBLE);
+    if (prj_x1 == NULL) {
+      goto exit;
+    }
+
+    prj_x2 = (PyArrayObject*)PyArray_SimpleNew(ndim, x1_dims, NPY_DOUBLE);
+    if (prj_x2 == NULL) {
+      goto exit;
+    }
+
+    stat = (PyArrayObject*)PyArray_SimpleNew(ndim, x1_dims, NPY_INT);
+    if (stat == NULL) {
+      goto exit;
+    }
+
+    Py_BEGIN_ALLOW_THREADS
+    status = prjfn(
+        self->x,
+        nelem, 0, 1, 1,
+        (double*)PyArray_DATA(x1),
+        (double*)PyArray_DATA(x2),
+        (double*)PyArray_DATA(prj_x1),
+        (double*)PyArray_DATA(prj_x2),
+        (int*)PyArray_DATA(stat));
+    Py_END_ALLOW_THREADS
+
+    switch (status) {
+    case 3:
+    case 4:
+        for (i = 0; i < nelem; ++i) {
+            if (((int *)PyArray_DATA(stat))[i]) {
+                ((double *)PyArray_DATA(prj_x1))[i] = NPY_NAN;
+                ((double *)PyArray_DATA(prj_x2))[i] = NPY_NAN;
+            }
+        }
+    case 0:
+        result = Py_BuildValue("(OO)", prj_x1, prj_x2);
+        break;
+    default:
+        wcslib_prj_to_python_exc(status);
+        break;
+    }
+
+    exit:
+        Py_XDECREF(x1);
+        Py_XDECREF(x2);
+        Py_XDECREF(prj_x1);
+        Py_XDECREF(prj_x2);
+        Py_XDECREF(stat);
+
+    return result;
+}
+
+
+static PyObject* PyPrjprm_prjx2s(PyPrjprm* self, PyObject* args, PyObject* kwds)
+{
+    PyObject* x = NULL;
+    PyObject* y = NULL;
+    const char* keywords[] = { "x", "y", NULL };
+
+    if (is_prj_null(self)) return NULL;
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "OO:prjx2s",
+        (char **)keywords, &x, &y)) {
+        return NULL;
+    }
+
+    if (self->x->prjx2s == NULL || self->x->flag == 0) {
+        if (is_readonly(self)) {
+            PyErr_SetString(
+                PyExc_AttributeError,
+                "Attribute 'prj' of 'astropy.wcs.Wcsprm.cel' objects is "
+                "read-only and cannot be automatically set.");
+            return NULL;
+        } else if (PyPrjprm_cset(self)) {
+            return NULL;
+        }
+    }
+
+    return _prj_eval(self, self->x->prjx2s, x, y);
+}
+
+
+static PyObject* PyPrjprm_prjs2x(PyPrjprm* self, PyObject* args, PyObject* kwds)
+{
+    PyObject* phi = NULL;
+    PyObject* theta = NULL;
+    const char* keywords[] = { "phi", "theta", NULL };
+
+    if (is_prj_null(self)) return NULL;
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "OO:prjs2x",
+        (char **)keywords, &phi, &theta)) {
+        return NULL;
+    }
+
+    if (self->x->prjs2x == NULL || self->x->flag == 0) {
+        if (is_readonly(self)) {
+            PyErr_SetString(
+                PyExc_AttributeError,
+                "Attribute 'prj' of 'astropy.wcs.Wcsprm.cel' objects is "
+                "read-only and cannot be automatically set.");
+            return NULL;
+        } else if (PyPrjprm_cset(self)) {
+            return NULL;
+        }
+    }
+
+    return _prj_eval(self, self->x->prjs2x, phi, theta);
+}
+
+
+/***************************************************************************
+ * Member getters/setters (properties)
+ */
+
+static PyObject* PyPrjprm_get_flag(PyPrjprm* self, void* closure)
+{
+    if (is_prj_null(self)) {
+        return NULL;
+    } else {
+        return get_int("flag", self->x->flag);
+    }
+}
+
+
+static PyObject* PyPrjprm_get_code(PyPrjprm* self, void* closure)
+{
+    if (is_prj_null(self)) {
+        return NULL;
+    } else {
+        return get_string("code", self->x->code);
+    }
+}
+
+
+static int PyPrjprm_set_code(PyPrjprm* self, PyObject* value, void* closure)
+{
+    char code[4];
+    int code_len;
+
+    if (is_prj_null(self) || is_readonly(self)) {
+        return -1;
+    } else if (value == Py_None) {
+        if (strcmp("   ", self->x->code)) {
+            strcpy(self->x->code, "   ");
+            self->x->flag = 0;
+            if (self->owner) ((PyCelprm*)self->owner)->x->flag = 0;
+        }
+    } else {
+        if (set_string("code", value, code, 4)) return -1;
+        code_len = strlen(code);
+        if (code_len != 3) {
+            PyErr_Format(PyExc_ValueError,
+                "'code' must be exactly a three character string. "
+                "Provided 'code' ('%s') is %d characters long.",
+                code, code_len);
+            return -1;
+        }
+        if (strcmp(code, self->x->code)) {
+            strncpy(self->x->code, code, 4);
+            self->x->code[3] = '\0';  /* just to be safe */
+            self->x->flag = 0;
+            if (self->owner) ((PyCelprm*)self->owner)->x->flag = 0;
+        }
+    }
+    return 0;
+}
+
+
+static PyObject* PyPrjprm_get_r0(PyPrjprm* self, void* closure)
+{
+    if (is_prj_null(self)) {
+        return NULL;
+    } else if (self->x->r0 == UNDEFINED) {
+        Py_RETURN_NONE;
+    } else {
+        return get_double("r0", self->x->r0);
+    }
+}
+
+
+static int PyPrjprm_set_r0(PyPrjprm* self, PyObject* value, void* closure)
+{
+    int result;
+    double r0;
+    if (is_prj_null(self) || is_readonly(self)) {
+        return -1;
+    } else if (value == Py_None) {
+        if (self->x->r0 != UNDEFINED) {
+            self->x->r0 = UNDEFINED;
+            self->x->flag = 0;
+            if (self->owner) ((PyCelprm*)self->owner)->x->flag = 0;
+        }
+    } else {
+        result = set_double("r0", value, &r0);
+        if (result) return result;
+        if (r0 != self->x->r0) {
+            self->x->r0 = r0;
+            self->x->flag = 0;
+            if (self->owner) ((PyCelprm*)self->owner)->x->flag = 0;
+        }
+    }
+    return 0;
+}
+
+
+static PyObject* PyPrjprm_get_phi0(PyPrjprm* self, void* closure)
+{
+    if (is_prj_null(self)) {
+        return NULL;
+    } else if (self->x->phi0 == UNDEFINED) {
+        Py_RETURN_NONE;
+    } else {
+        return get_double("phi0", self->x->phi0);
+    }
+}
+
+
+static int PyPrjprm_set_phi0(PyPrjprm* self, PyObject* value, void* closure)
+{
+    int result;
+    double phi0;
+    if (is_prj_null(self) || is_readonly(self)) {
+        return -1;
+    } else if (value == Py_None) {
+        if (self->x->phi0 != UNDEFINED) {
+            self->x->phi0 = UNDEFINED;
+            self->x->flag = 0;
+            if (self->owner) ((PyCelprm*)self->owner)->x->flag = 0;
+        }
+    } else {
+        result = set_double("phi0", value, &phi0);
+        if (result) return result;
+        if (phi0 != self->x->phi0) {
+            self->x->phi0 = phi0;
+            self->x->flag = 0;
+            if (self->owner) ((PyCelprm*)self->owner)->x->flag = 0;
+        }
+    }
+    return 0;
+}
+
+
+static PyObject* PyPrjprm_get_theta0(PyPrjprm* self, void* closure)
+{
+    if (is_prj_null(self)) {
+        return NULL;
+    } else if (self->x->theta0 == UNDEFINED) {
+        Py_RETURN_NONE;
+    } else {
+        return get_double("theta0", self->x->theta0);
+    }
+}
+
+
+static int PyPrjprm_set_theta0(PyPrjprm* self, PyObject* value, void* closure)
+{
+    int result;
+    double theta0;
+    if (is_prj_null(self) || is_readonly(self)) {
+        return -1;
+    } else if (value == Py_None) {
+        if (self->x->theta0 != UNDEFINED) {
+            self->x->theta0 = UNDEFINED;
+            self->x->flag = 0;
+            if (self->owner) ((PyCelprm*)self->owner)->x->flag = 0;
+        }
+    } else {
+        result = set_double("theta0", value, &theta0);
+        if (result) return result;
+        if (theta0 != self->x->theta0) {
+            self->x->theta0 = theta0;
+            self->x->flag = 0;
+            if (self->owner) ((PyCelprm*)self->owner)->x->flag = 0;
+        }
+    }
+    return 0;
+}
+
+
+static PyObject* PyPrjprm_get_pv(PyPrjprm* self, void* closure)
+{
+    int k;
+    Py_ssize_t size = PVN;
+    double *pv;
+    PyObject* pv_array;
+
+    if (is_prj_null(self)) return NULL;
+
+    pv_array = (PyArrayObject*) PyArray_SimpleNew(1, &size, NPY_DOUBLE);
+    if (pv_array == NULL) return NULL;
+    pv = (double*) PyArray_DATA(pv_array);
+
+    for (k = 0; k < PVN; k++) {
+        if (self->x->pv[k] == UNDEFINED) {
+            pv[k] = (double) NPY_NAN;
+        } else {
+            pv[k] = self->x->pv[k];
+        }
+    }
+
+    return pv_array;
+}
+
+
+static int PyPrjprm_set_pv(PyPrjprm* self, PyObject* value, void* closure)
+{
+    int k, modified;
+    npy_intp size;
+    double *data;
+    PyObject* value_array = NULL;
+    int skip[PVN];
+
+    if (is_prj_null(self) || is_readonly(self)) return -1;
+
+    if (value == Py_None) {
+        /* If pv is set to None - reset pv to prjini values: */
+        self->x->pv[0] = 0.0;
+        for (k = 1; k < 4; self->x->pv[k++] = UNDEFINED);
+        for (k = 4; k < PVN; self->x->pv[k++] = 0.0);
+        self->x->flag = 0;
+        if (self->owner) ((PyCelprm*)self->owner)->x->flag = 0;
+        return 0;
+    }
+
+    value_array = PyArray_ContiguousFromAny(value, NPY_DOUBLE, 1, 1);
+    if (!value_array) return -1;
+
+    size = PyArray_SIZE(value_array);
+
+    if (size < 1) {
+        Py_DECREF(value_array);
+        PyErr_SetString(PyExc_ValueError,
+            "PV must be a non-empty 1-dimentional list of values or None.");
+        return -1;
+    }
+
+    if (size > PVN) {
+        Py_DECREF(value_array);
+        PyErr_Format(PyExc_RuntimeError, "Number of PV values cannot exceed %d.", PVN);
+        return -1;
+    }
+
+    if (PyList_Check(value)) {
+        for (k = 0; k < size; k++) {
+            skip[k] = (PyList_GetItem(value, k) == Py_None);
+        }
+    } else if (PyTuple_Check(value)) {
+        for (k = 0; k < size; k++) {
+            skip[k] = (PyTuple_GetItem(value, k) == Py_None);
+        }
+    } else {
+        for (k = 0; k < size; k++) skip[k] = 0;
+    }
+
+    data = (double*) PyArray_DATA(value_array);
+
+    modified = 0;
+    for (k = 0; k < size; k++) {
+        if (skip[k]) continue;
+        if (is_dbl_equal(self->x->pv[k], data[k])) {
+            /* update PV but do not flag it as modified since values are
+               essentially the same.
+            */
+            self->x->pv[k] = data[k];
+        } else if (npy_isnan(data[k])) {
+            self->x->pv[k] = UNDEFINED;
+            modified = 1;
+        } else {
+            self->x->pv[k] = data[k];
+            modified = 1;
+        }
+    }
+    Py_DECREF(value_array);
+
+    if (modified) {
+        self->x->flag = 0;
+        if (self->owner) ((PyCelprm*)self->owner)->x->flag = 0;
+    }
+    return 0;
+}
+
+
+static PyObject* PyPrjprm_get_pvi(PyPrjprm* self, PyObject* args, PyObject* kwds)
+{
+    int idx;
+    PyObject* index = NULL;
+    PyObject* value = NULL;
+    const char* keywords[] = { "index", NULL };
+
+    if (is_prj_null(self)) return NULL;
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O:get_pvi",
+        (char **)keywords, &index)) {
+        return NULL;
+    }
+
+    if (!PyLong_Check(index)) {
+        PyErr_SetString(PyExc_TypeError,
+        "PV index must be an integer number.");
+    }
+
+    idx = PyLong_AsLong(index);
+    if (idx == -1 && PyErr_Occurred()) {
+        return NULL;
+    }
+
+    if (idx < 0 || idx >= PVN) {
+        PyErr_Format(PyExc_ValueError,
+            "PV index must be an integer number between 0 and %d.", PVN - 1);
+        return NULL;
+    }
+
+    if (self->x->pv[idx] == UNDEFINED) {
+        return PyFloat_FromDouble((double) NPY_NAN);
+    } else {
+        return PyFloat_FromDouble(self->x->pv[idx]);
+    }
+}
+
+
+static PyObject* PyPrjprm_set_pvi(PyPrjprm* self, PyObject* args, PyObject* kwds)
+{
+    int idx, size;
+    double data;
+    PyObject* scalar= NULL;
+    PyObject* index = NULL;
+    PyObject* value = NULL;
+    PyObject* flt_value = NULL;
+    PyObject* value_array = NULL;
+    const char* keywords[] = { "index", "value", NULL };
+    PyArray_Descr* dbl_descr = PyArray_DescrNewFromType(NPY_DOUBLE);
+
+    if (is_prj_null(self) || is_readonly(self)) return NULL;
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "OO:set_pvi",
+        (char **)keywords, &index, &value)) {
+        return NULL;
+    }
+
+    if (!PyLong_Check(index)) {
+        PyErr_SetString(PyExc_TypeError,
+        "PV index must be an integer number.");
+    }
+
+    idx = PyLong_AsLong(index);
+    if (idx == -1 && PyErr_Occurred()) {
+        return NULL;
+    }
+
+    if (idx < 0 || idx >= PVN) {
+        PyErr_Format(PyExc_ValueError,
+            "PV index must be an integer number between 0 and %d.", PVN - 1);
+        return NULL;
+    }
+
+    if (value == Py_None) {
+        /* If pv is set to None - reset pv to prjini values: */
+        self->x->pv[idx] = (idx > 0 && idx < 4) ? UNDEFINED : 0.0;
+        self->x->flag = 0;
+        if (self->owner) ((PyCelprm*)self->owner)->x->flag = 0;
+        Py_RETURN_NONE;
+    }
+
+    if (PyFloat_Check(value) || PyLong_Check(value)) {
+        data = PyFloat_AsDouble(value);
+        if (data == -1.0 && PyErr_Occurred()) {
+            return NULL;
+        }
+
+    } else if (PyUnicode_Check(value)) {
+        flt_value = PyFloat_FromString(value);
+        if (!flt_value) return NULL;
+        data = PyFloat_AsDouble(flt_value);
+        Py_DECREF(flt_value);
+        if (data == -1.0 && PyErr_Occurred()) {
+            return NULL;
+        }
+
+    } else {
+        if (PyArray_Converter(value, &value_array) == NPY_FAIL) {
+            return NULL;
+        }
+
+        size = PyArray_SIZE(value_array);
+        if (size != 1) {
+            Py_DECREF(value_array);
+            PyErr_SetString(PyExc_ValueError,
+                "PV value must be a scalar-like object or None.");
+            return NULL;
+        }
+
+        scalar = PyArray_ToScalar(PyArray_DATA(value_array), value_array);
+        Py_DECREF(value_array);
+        if (!scalar) {
+            Py_DECREF(scalar);
+            PyErr_SetString(PyExc_TypeError, "Unable to convert value to scalar.");
+        }
+
+        PyArray_CastScalarToCtype(scalar, &data, dbl_descr);
+        Py_DECREF(scalar);
+        if (PyErr_Occurred()) {
+            return NULL;
+        }
+    }
+
+    data = (isnan(data)) ? UNDEFINED : data;
+
+    if (!is_dbl_equal(self->x->pv[idx], data)) {
+        self->x->flag = 0;
+        if (self->owner) ((PyCelprm*)self->owner)->x->flag = 0;
+    }
+    self->x->pv[idx] = data;
+
+    Py_RETURN_NONE;
+}
+
+
+static PyObject* PyPrjprm_get_bounds(PyPrjprm* self, void* closure)
+{
+    if (is_prj_null(self)) {
+        return NULL;
+    } else {
+        return get_int("bounds", self->x->bounds);
+    }
+}
+
+
+static int PyPrjprm_set_bounds(PyPrjprm* self, PyObject* value, void* closure)
+{
+    if (is_prj_null(self) || is_readonly(self)) {
+        return -1;
+    } else if (value == Py_None) {
+        self->x->bounds = 0;
+        return 0;
+    } else {
+        return set_int("bounds", value, &self->x->bounds);
+    }
+}
+
+
+static PyObject* PyPrjprm_get_w(PyPrjprm* self, void* closure)
+{
+    Py_ssize_t size = 10;
+    int k;
+    double *w;
+    PyObject* w_array;
+
+    if (is_prj_null(self)) return NULL;
+
+    w_array = (PyObject*) PyArray_SimpleNew(1, &size, NPY_DOUBLE);
+    if (w_array == NULL) return NULL;
+    w = (double*) PyArray_DATA(w_array);
+
+    for (k = 0; k < size; k++) {
+        if (self->x->w[k] == UNDEFINED) {
+            w[k] = (double) NPY_NAN;
+        } else {
+            w[k] = self->x->w[k];
+        }
+    }
+
+    return w_array;
+}
+
+
+static PyObject* PyPrjprm_get_name(PyPrjprm* self, void* closure)
+{
+    if (is_prj_null(self)) {
+        return NULL;
+    } else {
+        return get_string("name", self->x->name);
+    }
+}
+
+
+static PyObject* PyPrjprm_get_category(PyPrjprm* self, void* closure)
+{
+    if (is_prj_null(self)) {
+        return NULL;
+    } else {
+        return get_int("category", self->x->category);
+    }
+}
+
+
+static PyObject* PyPrjprm_get_pvrange(PyPrjprm* self, void* closure)
+{
+    if (is_prj_null(self)) {
+        return NULL;
+    } else {
+        return get_int("pvrange", self->x->pvrange);
+    }
+}
+
+
+static PyObject* PyPrjprm_get_simplezen(PyPrjprm* self, void* closure)
+{
+    if (is_prj_null(self)) {
+        return NULL;
+    } else {
+        return PyBool_FromLong(self->x->simplezen);
+    }
+}
+
+
+static PyObject* PyPrjprm_get_equiareal(PyPrjprm* self, void* closure)
+{
+    if (is_prj_null(self)) {
+        return NULL;
+    } else {
+        return PyBool_FromLong(self->x->equiareal);
+    }
+}
+
+
+static PyObject* PyPrjprm_get_conformal(PyPrjprm* self, void* closure)
+{
+    if (is_prj_null(self)) {
+        return NULL;
+    } else {
+        return PyBool_FromLong(self->x->conformal);
+    }
+}
+
+
+static PyObject* PyPrjprm_get_global_projection(PyPrjprm* self, void* closure)
+{
+    if (is_prj_null(self)) {
+        return NULL;
+    } else {
+        return PyBool_FromLong(self->x->global);
+    }
+}
+
+
+static PyObject* PyPrjprm_get_divergent(PyPrjprm* self, void* closure)
+{
+    if (is_prj_null(self)) {
+        return NULL;
+    } else {
+        return PyBool_FromLong(self->x->divergent);
+    }
+}
+
+
+static PyObject* PyPrjprm_get_x0(PyPrjprm* self, void* closure)
+{
+    if (is_prj_null(self)) {
+        return NULL;
+    } else {
+        return get_double("x0", self->x->x0);
+    }
+}
+
+
+static PyObject* PyPrjprm_get_y0(PyPrjprm* self, void* closure)
+{
+    if (is_prj_null(self)) {
+        return NULL;
+    } else {
+        return get_double("y0", self->x->y0);
+    }
+}
+
+
+static PyObject* PyPrjprm_get_m(PyPrjprm* self, void* closure)
+{
+    if (is_prj_null(self)) {
+        return NULL;
+    } else {
+        return get_int("m", self->x->m);
+    }
+}
+
+
+static PyObject* PyPrjprm_get_n(PyPrjprm* self, void* closure)
+{
+    if (is_prj_null(self)) {
+        return NULL;
+    } else {
+        return get_int("n", self->x->n);
+    }
+}
+
+
+/***************************************************************************
+ * PyPrjprm definition structures
+ */
+
+static PyGetSetDef PyPrjprm_getset[] = {
+    {"r0", (getter)PyPrjprm_get_r0, (setter)PyPrjprm_set_r0, (char *)doc_prjprm_r0},
+    {"phi0", (getter)PyPrjprm_get_phi0, (setter)PyPrjprm_set_phi0, (char *)doc_prjprm_phi0},
+    {"theta0", (getter)PyPrjprm_get_theta0, (setter)PyPrjprm_set_theta0, (char *)doc_prjprm_theta0},
+    {"pv", (getter)PyPrjprm_get_pv, (setter)PyPrjprm_set_pv, (char *)doc_prjprm_pv},
+    {"w", (getter)PyPrjprm_get_w, NULL, (char *)doc_prjprm_w},
+    {"name", (getter)PyPrjprm_get_name, NULL, (char *)doc_prjprm_name},
+    {"code", (getter)PyPrjprm_get_code, (setter)PyPrjprm_set_code, (char *)doc_prjprm_code},
+    {"bounds", (getter)PyPrjprm_get_bounds, (setter)PyPrjprm_set_bounds, (char *)doc_prjprm_bounds},
+    {"category", (getter)PyPrjprm_get_category, NULL, (char *)doc_prjprm_category},
+    {"pvrange", (getter)PyPrjprm_get_pvrange, NULL, (char *)doc_prjprm_pvrange},
+    {"simplezen", (getter)PyPrjprm_get_simplezen, NULL, (char *)doc_prjprm_simplezen},
+    {"equiareal", (getter)PyPrjprm_get_equiareal, NULL, (char *)doc_prjprm_equiareal},
+    {"conformal", (getter)PyPrjprm_get_conformal, NULL, (char *)doc_prjprm_conformal},
+    {"global_projection", (getter)PyPrjprm_get_global_projection, NULL, (char *)doc_prjprm_global_projection},
+    {"divergent", (getter)PyPrjprm_get_divergent, NULL, (char *)doc_prjprm_divergent},
+    {"x0", (getter)PyPrjprm_get_x0, NULL, (char *)doc_prjprm_x0},
+    {"y0", (getter)PyPrjprm_get_y0, NULL, (char *)doc_prjprm_y0},
+    {"m", (getter)PyPrjprm_get_m, NULL, (char *)doc_prjprm_m},
+    {"n", (getter)PyPrjprm_get_n, NULL, (char *)doc_prjprm_n},
+    {"_flag", (getter)PyPrjprm_get_flag, NULL, ""},
+    {NULL}
+};
+
+
+static PyMethodDef PyPrjprm_methods[] = {
+    {"set", (PyCFunction)PyPrjprm_set, METH_NOARGS, (char*)doc_prjprm_set},
+    {"prjx2s", (PyCFunction)PyPrjprm_prjx2s, METH_VARARGS|METH_KEYWORDS, (char*)doc_prjprm_prjx2s},
+    {"prjs2x", (PyCFunction)PyPrjprm_prjs2x, METH_VARARGS|METH_KEYWORDS, (char*)doc_prjprm_prjs2x},
+    {"set_pvi", (PyCFunction)PyPrjprm_set_pvi, METH_VARARGS|METH_KEYWORDS, (char*)doc_prjprm_pvi},
+    {"get_pvi", (PyCFunction)PyPrjprm_get_pvi, METH_VARARGS|METH_KEYWORDS, (char*)doc_prjprm_pvi},
+    {"__copy__", (PyCFunction)PyPrjprm_copy, METH_NOARGS, ""},
+    {"__deepcopy__", (PyCFunction)PyPrjprm_deepcopy, METH_O, ""},
+    {NULL}
+};
+
+
+PyTypeObject PyPrjprmType = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    "astropy.wcs.Prjprm",         /*tp_name*/
+    sizeof(PyPrjprm),             /*tp_basicsize*/
+    0,                            /*tp_itemsize*/
+    (destructor)PyPrjprm_dealloc, /*tp_dealloc*/
+    0,                            /*tp_print*/
+    0,                            /*tp_getattr*/
+    0,                            /*tp_setattr*/
+    0,                            /*tp_compare*/
+    0,                            /*tp_repr*/
+    0,                            /*tp_as_number*/
+    0,                            /*tp_as_sequence*/
+    0,                            /*tp_as_mapping*/
+    0,                            /*tp_hash */
+    0,                            /*tp_call*/
+    (reprfunc)PyPrjprm___str__,   /*tp_str*/
+    0,                            /*tp_getattro*/
+    0,                            /*tp_setattro*/
+    0,                            /*tp_as_buffer*/
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /*tp_flags*/
+    doc_Prjprm,                   /* tp_doc */
+    (traverseproc)PyPrjprm_traverse, /* tp_traverse */
+    (inquiry)PyPrjprm_clear,      /* tp_clear */
+    0,                            /* tp_richcompare */
+    0,                            /* tp_weaklistoffset */
+    0,                            /* tp_iter */
+    0,                            /* tp_iternext */
+    PyPrjprm_methods,             /* tp_methods */
+    0,                            /* tp_members */
+    PyPrjprm_getset,              /* tp_getset */
+    0,                            /* tp_base */
+    0,                            /* tp_dict */
+    0,                            /* tp_descr_get */
+    0,                            /* tp_descr_set */
+    0,                            /* tp_dictoffset */
+    0,                            /* tp_init */
+    0,                            /* tp_alloc */
+    PyPrjprm_new,                 /* tp_new */
+};
+
+
+int _setup_prjprm_type(PyObject* m)
+{
+    if (PyType_Ready(&PyPrjprmType) < 0) return -1;
+    Py_INCREF(&PyPrjprmType);
+    PyModule_AddObject(m, "Prjprm", (PyObject *)&PyPrjprmType);
+
+    prj_errexc[0] = NULL;                         /* Success */
+    prj_errexc[1] = &PyExc_MemoryError;           /* Null prjprm pointer passed */
+    prj_errexc[2] = &WcsExc_InvalidPrjParameters; /* Invalid projection parameters */
+    prj_errexc[3] = &WcsExc_InvalidCoordinate;    /* One or more of the (x,y) coordinates were invalid */
+    prj_errexc[4] = &WcsExc_InvalidCoordinate;    /* One or more of the (lng,lat) coordinates were invalid */
+
+    return 0;
+}

--- a/astropy/wcs/tests/conftest.py
+++ b/astropy/wcs/tests/conftest.py
@@ -2,8 +2,6 @@
 
 import pytest
 
-import numpy as np
-
 from astropy import wcs
 
 from . helper import SimModelTAB
@@ -46,3 +44,11 @@ def tab_wcs_2di_f():
     w = wcs.WCS(hdulist[0].header, hdulist)
 
     return w
+
+
+@pytest.fixture(scope='function')
+def prj_TAB():
+    prj = wcs.Prjprm()
+    prj.code = 'TAN'
+    prj.set()
+    return prj

--- a/astropy/wcs/tests/test_celprm.py
+++ b/astropy/wcs/tests/test_celprm.py
@@ -1,0 +1,144 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from copy import copy, deepcopy
+import pytest
+
+import numpy as np
+from astropy import wcs
+
+from . helper import SimModelTAB
+
+
+_WCS_UNDEFINED = 987654321.0e99
+
+
+def test_celprm_init():
+    # test PyCelprm_cnew
+    assert wcs.WCS().wcs.cel
+
+    # test PyCelprm_new
+    assert wcs.Celprm()
+
+    with pytest.raises(wcs.InvalidPrjParametersError):
+        cel = wcs.Celprm()
+        cel.set()
+
+    # test deletion does not crash
+    cel = wcs.Celprm()
+    del cel
+
+
+def test_celprm_copy():
+    # shallow copy
+    cel = wcs.Celprm()
+    cel2 = copy(cel)
+    cel3 = copy(cel2)
+    cel.ref = [6, 8, 18, 3]
+    assert (np.allclose(cel.ref, cel2.ref, atol=1e-12, rtol=0) and
+            np.allclose(cel.ref, cel3.ref, atol=1e-12, rtol=0))
+    del cel, cel2, cel3
+
+    # deep copy
+    cel = wcs.Celprm()
+    cel2 = deepcopy(cel)
+    cel.ref = [6, 8, 18, 3]
+    assert not np.allclose(cel.ref, cel2.ref, atol=1e-12, rtol=0)
+    del cel, cel2
+
+
+def test_celprm_offset():
+    cel = wcs.Celprm()
+    assert not cel.offset
+    cel.offset = True
+    assert cel.offset
+
+
+def test_celprm_prj():
+    cel = wcs.Celprm()
+    assert cel.prj is not None
+    cel.prj.code = 'TAN'
+    cel.set()
+    assert cel._flag
+
+
+def test_celprm_phi0():
+    cel = wcs.Celprm()
+    cel.prj.code = 'TAN'
+
+    assert cel.phi0 == None
+    assert cel._flag == 0
+    cel.set()
+    assert cel.phi0 == 0.0
+
+    cel.phi0 = 0.0
+    assert cel._flag
+
+    cel.phi0 = 2.0
+    assert cel._flag == 0
+
+    cel.phi0 = None
+    assert cel.phi0 == None
+    assert cel._flag == 0
+
+
+def test_celprm_theta0():
+    cel = wcs.Celprm()
+    cel.prj.code = 'TAN'
+
+    assert cel.theta0 == None
+    assert cel._flag == 0
+
+    cel.theta0 = 4.0
+    cel.set()
+    assert cel.theta0 == 4.0
+
+    cel.theta0 = 4.0
+    assert cel._flag
+
+    cel.theta0 = 8.0
+    assert cel._flag == 0
+
+    cel.theta0 = None
+    assert cel.theta0 == None
+    assert cel._flag == 0
+
+
+def test_celprm_ref():
+    cel = wcs.Celprm()
+    cel.prj.code = 'TAN'
+    cel.set()
+
+    assert np.allclose(cel.ref, [0.0, 0.0, 180.0, 0.0], atol=1e-12, rtol=0)
+
+    cel.phi0 = 2.0
+    cel.theta0 = 4.0
+    cel.ref = [123, 12]
+    cel.set()
+
+    assert np.allclose(cel.ref, [123.0, 12.0, 2, 82], atol=1e-12, rtol=0)
+
+    cel.ref = [None, 13, None, None]
+    assert np.allclose(cel.ref, [123.0, 13.0, 2, 82], atol=1e-12, rtol=0)
+
+
+def test_celprm_isolat():
+    cel = wcs.Celprm()
+    cel.prj.code = 'TAN'
+    cel.set()
+
+    assert cel.isolat == 0
+
+
+def test_celprm_latpreq():
+    cel = wcs.Celprm()
+    cel.prj.code = 'TAN'
+    cel.set()
+
+    assert cel.latpreq == 0
+
+
+def test_celprm_euler():
+    cel = wcs.Celprm()
+    cel.prj.code = 'TAN'
+    cel.set()
+
+    assert np.allclose(cel.euler, [0.0, 90.0, 180.0, 0.0, 1.0], atol=1e-12, rtol=0)

--- a/astropy/wcs/tests/test_prjprm.py
+++ b/astropy/wcs/tests/test_prjprm.py
@@ -1,0 +1,247 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from copy import copy, deepcopy
+import pytest
+
+import numpy as np
+from astropy import wcs
+
+from . helper import SimModelTAB
+
+
+def test_prjprm_init():
+    # test PyPrjprm_cnew
+    assert wcs.WCS().wcs.cel.prj
+
+    # test PyPrjprm_new
+    assert wcs.Prjprm()
+
+    with pytest.raises(wcs.InvalidPrjParametersError):
+        prj = wcs.Prjprm()
+        prj.set()
+
+    # test deletion does not crash
+    prj = wcs.Prjprm()
+    del prj
+
+
+def test_prjprm_copy():
+    # shallow copy
+    prj = wcs.Prjprm()
+    prj2 = copy(prj)
+    prj3 = copy(prj2)
+    prj.pv = [0, 6, 8, 18, 3]
+    assert (np.allclose(prj.pv, prj2.pv, atol=1e-12, rtol=0) and
+            np.allclose(prj.pv, prj3.pv, atol=1e-12, rtol=0))
+    del prj, prj2, prj3
+
+    # deep copy
+    prj = wcs.Prjprm()
+    prj2 = deepcopy(prj)
+    prj.pv = [0, 6, 8, 18, 3]
+    assert not np.allclose(prj.pv, prj2.pv, atol=1e-12, rtol=0)
+    del prj, prj2
+
+
+def test_prjprm_flag():
+    prj = wcs.Prjprm()
+    assert prj._flag == 0
+
+
+def test_prjprm_code():
+    prj = wcs.Prjprm()
+
+    assert prj.code == '   '
+    assert prj._flag == 0
+
+    prj.code = 'TAN'
+    prj.set()
+    assert prj.code == 'TAN'
+    assert prj._flag
+
+    prj.code = 'TAN'
+    assert prj._flag
+
+    prj.code = None
+    assert prj.code == '   '
+    assert prj._flag == 0
+
+
+def test_prjprm_phi0():
+    prj = wcs.Prjprm()
+
+    assert prj.phi0 == None
+    assert prj._flag == 0
+
+    prj.code = 'TAN'
+    prj.phi0 = 2.0
+    prj.set()
+    assert prj.phi0 == 0
+
+    prj.phi0 = 0.0
+    assert prj._flag
+
+    prj.phi0 = 2.0
+    assert prj._flag == 0
+
+    prj.phi0 = None
+    assert prj.phi0 == None
+    assert prj._flag == 0
+
+
+def test_prjprm_theta0():
+    prj = wcs.Prjprm()
+
+    assert prj.theta0 == None
+    assert prj._flag == 0
+
+    prj.code = 'TAN'
+    prj.phi0 = 2.0
+    prj.theta0 = 4.0
+    prj.set()
+    assert prj.theta0 == 4.0
+
+    prj.theta0 = 4.0
+    assert prj._flag
+
+    prj.theta0 = 8.0
+    assert prj._flag == 0
+
+    prj.theta0 = None
+    assert prj.theta0 == None
+    assert prj._flag == 0
+
+
+def test_prjprm_pv():
+    prj = wcs.Prjprm()
+
+    assert prj.pv.size == wcs.PRJ_PVN
+
+    assert prj.theta0 == None
+    assert prj._flag == 0
+
+    prj.code = 'ZPN'
+    prj.phi0 = 2.0
+    prj.theta0 = 4.0
+    pv = [float(i) if (i % 2) else i for i in range(wcs.PRJ_PVN)]
+    prj.pv = pv
+    prj.set()
+    assert prj.phi0 == 2.0
+    assert prj.theta0 == 4.0
+    assert np.allclose(prj.pv, pv, atol=1e-6, rtol=0)
+
+    # test the same with numpy.ndarray (flag not cleared for same values):
+    prj.pv = prj.pv
+    assert prj._flag != 0
+    prj.set()
+    assert np.allclose(prj.pv, pv, atol=1e-6, rtol=0)
+
+    # test the same but modify PV values to check that flag is cleared:
+    prj.pv = np.array(pv) + 2e-7
+    assert prj._flag == 0
+    prj.set()
+    assert np.allclose(prj.pv, pv, atol=1e-6, rtol=0)
+
+    # check that None in pv list leave value unchanged and values not set
+    # by the list are left unchanged:
+    prj.code = 'SZP'
+    prj.pv = [0.0, 99.0, None]
+    assert np.allclose(prj.pv[:4], [0.0, 99.0, 2.0, 3.0], atol=1e-6, rtol=0)
+
+    # check that None resets PV to uninitialized (before prjset()) values:
+    prj.pv = None
+    assert prj.pv[0] == 0.0
+    assert np.all(np.isnan(prj.pv[1:4]))
+    assert np.allclose(prj.pv[5:], 0, atol=0, rtol=0)
+
+    # check we can set all PVs to nan:
+    nan_pvs = wcs.PRJ_PVN * [np.nan]
+    prj.code = 'TAN'
+    prj.pv = nan_pvs  # set using a list
+    prj.set()
+    assert np.all(np.isnan(prj.pv))
+    prj.pv = np.array(nan_pvs)  # set using a numpy.ndarray
+    prj.set()
+    assert np.all(np.isnan(prj.pv))
+
+
+def test_prjprm_pvrange():
+    prj = wcs.Prjprm()
+    prj.code = 'ZPN'
+    prj.phi0 = 2.0
+    prj.theta0 = 4.0
+    prj.pv = [0.0, 1.0, 2.0, 3.0]
+    prj.set()
+    assert prj.pvrange == wcs.PRJ_PVN
+
+    prj.code = 'SZP'
+    prj.set()
+    assert prj.pvrange == 103
+
+
+def test_prjprm_bounds(prj_TAB):
+    assert prj_TAB.bounds == 7
+    prj_TAB.bounds = 0
+    assert prj_TAB.bounds == 0
+
+
+def test_prjprm_category(prj_TAB):
+    assert prj_TAB.category == wcs.PRJ_ZENITHAL
+
+
+def test_prjprm_name(prj_TAB):
+    assert prj_TAB.name
+
+
+def test_prjprm_w(prj_TAB):
+    assert np.all(np.isfinite(prj_TAB.w))
+
+
+def test_prjprm_simplezen(prj_TAB):
+    assert prj_TAB.simplezen == 1
+
+
+def test_prjprm_equiareal(prj_TAB):
+    assert prj_TAB.equiareal == 0
+
+
+def test_prjprm_conformal(prj_TAB):
+    assert prj_TAB.conformal == 0
+
+
+def test_prjprm_global_projection(prj_TAB):
+    assert prj_TAB.global_projection == 0
+
+
+def test_prjprm_divergent(prj_TAB):
+    assert prj_TAB.divergent == 1
+
+
+def test_prjprm_r0(prj_TAB):
+    assert prj_TAB.r0 > 0.0
+
+
+def test_prjprm_x0_y0(prj_TAB):
+    assert prj_TAB.x0 == 0.0
+    assert prj_TAB.y0 == 0.0
+
+
+def test_prjprm_n_m(prj_TAB):
+    assert prj_TAB.n == 0
+    assert prj_TAB.m == 0
+
+
+def test_prjprm_prj_roundtrips(prj_TAB):
+    # some random values:
+    x = [-0.002, 0.014, -0.003, 0.015, -0.047, -0.029, -0.042, 0.027, 0.021]
+    y = [0.022, -0.017, -0.048, -0.049, -0.043, 0.015, 0.046, 0.031, 0.011]
+
+    xr, yr = prj_TAB.prjs2x(*prj_TAB.prjx2s(x, y))
+    assert np.allclose(x, xr, atol=1e-12, rtol=0)
+    assert np.allclose(y, yr, atol=1e-12, rtol=0)
+
+    # same test for a Prjprm that was not previously explicitly "set":
+    prj = wcs.Prjprm()
+    prj.code = 'TAN'
+    xr, yr = prj.prjs2x(*prj.prjx2s(x, y))
+    assert np.allclose(x, xr, atol=1e-12, rtol=0)
+    assert np.allclose(y, yr, atol=1e-12, rtol=0)

--- a/astropy/wcs/tests/test_wcsprm.py
+++ b/astropy/wcs/tests/test_wcsprm.py
@@ -541,7 +541,6 @@ def test_latpole():
 
 def test_lattyp():
     w = _wcs.Wcsprm()
-    print(repr(w.lattyp))
     assert w.lattyp == "    "
 
 

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -57,9 +57,10 @@ from .wcsapi.fitswcs import FITSWCSAPIMixin, SlicedFITSWCS
 
 __all__ = ['FITSFixedWarning', 'WCS', 'find_all_wcs',
            'DistortionLookupTable', 'Sip', 'Tabprm', 'Wcsprm', 'Auxprm',
-           'Wtbarr', 'WCSBase', 'validate', 'WcsError', 'SingularMatrixError',
-           'InconsistentAxisTypesError', 'InvalidTransformError',
-           'InvalidCoordinateError', 'NoSolutionError',
+           'Celprm', 'Prjprm', 'Wtbarr', 'WCSBase', 'validate', 'WcsError',
+           'SingularMatrixError', 'InconsistentAxisTypesError',
+           'InvalidTransformError', 'InvalidCoordinateError',
+           'InvalidPrjParametersError', 'NoSolutionError',
            'InvalidSubimageSpecificationError', 'NoConvergence',
            'NonseparableSubimageCoordinateSystemError',
            'NoWcsKeywordsFoundError', 'InvalidTabularParametersError']
@@ -86,6 +87,8 @@ if _wcs is not None:
     Sip = _wcs.Sip
     Wcsprm = _wcs.Wcsprm
     Auxprm = _wcs.Auxprm
+    Celprm = _wcs.Celprm
+    Prjprm = _wcs.Prjprm
     Tabprm = _wcs.Tabprm
     Wtbarr = _wcs.Wtbarr
     WcsError = _wcs.WcsError
@@ -98,10 +101,11 @@ if _wcs is not None:
     NonseparableSubimageCoordinateSystemError = _wcs.NonseparableSubimageCoordinateSystemError
     NoWcsKeywordsFoundError = _wcs.NoWcsKeywordsFoundError
     InvalidTabularParametersError = _wcs.InvalidTabularParametersError
+    InvalidPrjParametersError = _wcs.InvalidPrjParametersError
 
     # Copy all the constants from the C extension into this module's namespace
     for key, val in _wcs.__dict__.items():
-        if key.startswith(('WCSSUB_', 'WCSHDR_', 'WCSHDO_', 'WCSCOMPARE_')):
+        if key.startswith(('WCSSUB_', 'WCSHDR_', 'WCSHDO_', 'WCSCOMPARE_', 'PRJ_')):
             locals()[key] = val
             __all__.append(key)
 

--- a/docs/changes/wcs/12514.feature.rst
+++ b/docs/changes/wcs/12514.feature.rst
@@ -1,0 +1,3 @@
+``astropy.wcs.Celprm`` and ``astropy.wcs.Prjprm`` have been added
+to allow access to lower level WCSLIB functionality and to allow direct
+access to the ``cel`` and ``prj`` members of ``Wcsprm``.


### PR DESCRIPTION
### Description

This PR adds `Celprm` and `Prjprm` Python wrappers to WCSLIB's `celprm` and `prjprm` structures to directly access members `cel` and `prj` of the `Wcsprm` wrapper. It also supports creation of these structures as stand-alone objects.

### Checklist for package maintainer(s)

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
