### PR TITLE
Use +FLOAT_CMP to fix test failure on i386 and others in convolve.py

### DIFF
--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -619,7 +619,7 @@ def convolve_fft(array, kernel, boundary='fill', fill_value=0.,
     >>> convolve_fft([1, np.nan, 3], [1, 1, 1])
     array([0.5, 2. , 1.5])
 
-    >>> convolve_fft([1, 0, 3], [0, 1, 0])
+    >>> convolve_fft([1, 0, 3], [0, 1, 0])  # doctest: +FLOAT_CMP
     array([ 1.00000000e+00, -3.70074342e-17,  3.00000000e+00])
 
     >>> convolve_fft([1, 2, 3], [1])


### PR DESCRIPTION
### Description

This fixes an left-over missing +FLOAT_CMP in `astropy/convolution/convolve.py`, which causes a test failure on some platforms (most prominently, i386).

Fixes #12512 

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
