### PR TITLE
Parameters vector bugfix for Spline models.

### DIFF
--- a/astropy/modeling/spline.py
+++ b/astropy/modeling/spline.py
@@ -136,6 +136,7 @@ class _Spline(FittableModel):
         def _setter(value, model: "_Spline", index: int, attr: str):
             getattr(model, attr)[index] = value
             return value
+
         getter = functools.partial(_getter, index=index, attr=attr)
         setter = functools.partial(_setter, index=index, attr=attr)
 
@@ -184,6 +185,14 @@ class _Spline(FittableModel):
     def _init_spline(self, knots, coeffs, bounds=None):
         self._init_data(knots, coeffs, bounds)
         self._init_parameters()
+
+        # fill _parameters and related attributes
+        self._initialize_parameters((), {})
+        self._initialize_slices()
+
+        # Calling this will properly fill the _parameter vector, which is
+        #   used directly sometimes without being properly filled.
+        _ = self.parameters
 
     def _init_tck(self, degree):
         self._c = None
@@ -354,6 +363,10 @@ class Spline1D(_Spline):
             self.c = value[1]
         else:
             self._init_spline(value[0], value[1])
+
+        # Calling this will properly fill the _parameter vector, which is
+        #   used directly sometimes without being properly filled.
+        _ = self.parameters
 
     @property
     def bspline(self):

--- a/astropy/modeling/tests/test_spline.py
+++ b/astropy/modeling/tests/test_spline.py
@@ -1144,6 +1144,16 @@ class TestSpline1D:
         assert_allclose(fitter.fit_info['spline']._eval_args[0], spline._eval_args[0])
         assert_allclose(fitter.fit_info['spline']._eval_args[1],  spline._eval_args[1])
 
+        # check that _parameters are correct
+        assert len(fit_spl._parameters) == len(fit_spl.t) + len(fit_spl.c)
+        assert_allclose(fit_spl._parameters[:len(fit_spl.t)], fit_spl.t)
+        assert_allclose(fit_spl._parameters[len(fit_spl.t):], fit_spl.c)
+
+        # check that parameters are correct
+        assert len(fit_spl.parameters) == len(fit_spl.t) + len(fit_spl.c)
+        assert_allclose(fit_spl.parameters[:len(fit_spl.t)], fit_spl.t)
+        assert_allclose(fit_spl.parameters[len(fit_spl.t):], fit_spl.c)
+
         assert_allclose(spline.get_residual(), fitter.fit_info['resid'])
 
         assert_allclose(fit_spl(self.x), spline(self.x))

--- a/docs/changes/modeling/12523.bugfix.rst
+++ b/docs/changes/modeling/12523.bugfix.rst
@@ -1,0 +1,1 @@
+Bugfix for incorrectly initialized and filled ``parameters`` data for ``Spline1D`` model.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This PR fixes a bug in `Spline1D` models where the model does not properly fill the `_parameters` and `parameters` data correctly. This has been fixed by adding the appropriate calls to initialize and fill the data structures which support these properties/values.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
