### PR TITLE
fix handling of Column objects for astropy.cosmology.utils.aszarr (issue #12518)

### DIFF
--- a/astropy/cosmology/utils.py
+++ b/astropy/cosmology/utils.py
@@ -135,7 +135,7 @@ def aszarr(z):
         return z
     elif hasattr(z, "shape"):  # ducktypes NumPy array
         if hasattr(z, "unit"):  # Quantity Column
-            return z.to(cu.redshift).value  # for speed only use enabled equivs
+            return (z << cu.redshift).value  # for speed only use enabled equivs
         return z
     # not one of the preferred types: Number / array ducktype
     return Quantity(z, cu.redshift).value

--- a/astropy/cosmology/utils.py
+++ b/astropy/cosmology/utils.py
@@ -134,8 +134,8 @@ def aszarr(z):
     if isinstance(z, (Number, np.generic)):  # scalars
         return z
     elif hasattr(z, "shape"):  # ducktypes NumPy array
-        if hasattr(z, "unit"):  # Quantity
-            return z.to_value(cu.redshift)  # for speed only use enabled equivs
+        if hasattr(z, "unit"):  # Quantity Column
+            return z.to(cu.redshift).value  # for speed only use enabled equivs
         return z
     # not one of the preferred types: Number / array ducktype
     return Quantity(z, cu.redshift).value

--- a/astropy/cosmology/utils.py
+++ b/astropy/cosmology/utils.py
@@ -128,7 +128,7 @@ def inf_like(x):
 
 def aszarr(z):
     """
-    Redshift as a `~numbers.Number` or `~numpy.ndarray` / |Quantity|.
+    Redshift as a `~numbers.Number` or `~numpy.ndarray` / |Quantity| / |Column|.
     Allows for any ndarray ducktype by checking for attribute "shape".
     """
     if isinstance(z, (Number, np.generic)):  # scalars

--- a/docs/changes/cosmology/12525.bugfix.rst
+++ b/docs/changes/cosmology/12525.bugfix.rst
@@ -1,0 +1,1 @@
+``astropy.cosmology.utils.aszarr`` can now convert ``Column`` objects.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->
astropy.cosmology.util.aszarr does not handle Column objects correctly as Column objects have the attribute 'unit', but do not have the method `to_value`. Using `to(cu.redshift).value` method can fix the handling of Column objects since it is a method for both Column and Quantity objects.
<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address ...

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #12518

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
