### PR TITLE
Prevent `Table.remove_columns()` and `Table.keep_columns()` from failing with generators

### DIFF
--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -2994,3 +2994,21 @@ def test_remove_columns_with_generator():
     t = table.table_helpers.simple_table(1)
     t.remove_columns(col for col in t.colnames if col == 'a')
     assert t.colnames == ['b', 'c']
+
+
+def test_keep_columns_invalid_names_messages():
+    t = table.table_helpers.simple_table(1)
+    with pytest.raises(KeyError, match='column "d" does not exist'):
+        t.keep_columns(['c', 'd'])
+    with pytest.raises(KeyError,
+                       match='columns {\'[de]\', \'[de]\'} do not exist'):
+        t.keep_columns(['c', 'd', 'e'])
+
+
+def test_remove_columns_invalid_names_messages():
+    t = table.table_helpers.simple_table(1)
+    with pytest.raises(KeyError, match='column "d" does not exist'):
+        t.remove_columns(['c', 'd'])
+    with pytest.raises(KeyError,
+                       match='columns {\'[de]\', \'[de]\'} do not exist'):
+        t.remove_columns(['c', 'd', 'e'])

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -2980,3 +2980,17 @@ def test_read_write_not_replaceable():
 
     with pytest.raises(AttributeError):
         t.write = 'fake_write'
+
+
+def test_keep_columns_with_generator():
+    # Regression test for #12529
+    t = table.table_helpers.simple_table(1)
+    t.keep_columns(col for col in t.colnames if col == 'a')
+    assert t.colnames == ['a']
+
+
+def test_remove_columns_with_generator():
+    # Regression test for #12529
+    t = table.table_helpers.simple_table(1)
+    t.remove_columns(col for col in t.colnames if col == 'a')
+    assert t.colnames == ['b', 'c']

--- a/docs/changes/table/12529.bugfix.rst
+++ b/docs/changes/table/12529.bugfix.rst
@@ -1,0 +1,3 @@
+``astropy.table.Table.keep_columns()`` and
+``astropy.table.Table.remove_columns()`` now work with generators of column
+names.


### PR DESCRIPTION
### Description

If a generator of column names is passed to `Table.remove_columns()` then it currently fails *silently* because the generator is used up while checking if all the columns to be removed are valid. This pull request converts the generator into a list so that the specified columns actually get removed.

EDIT:

`Table.keep_columns()` suffers from a very similar bug, but with a far worse outcome. Passing a generator to that method results in all the columns getting deleted. I have expanded the scope of this pull request to include `keep_columns()` because the solution is very similar.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
