### PR TITLE
Prevent `Distance` from being constructed with both `z` and `parallax`

### DIFF
--- a/astropy/coordinates/distances.py
+++ b/astropy/coordinates/distances.py
@@ -100,11 +100,16 @@ class Distance(u.SpecificTypeQuantity):
                 distmod=None, parallax=None, dtype=None, copy=True, order=None,
                 subok=False, ndmin=0, allow_negative=False):
 
-        if z is not None:
-            if value is not None or distmod is not None:
-                raise ValueError('Should given only one of `value`, `z` '
-                                 'or `distmod` in Distance constructor.')
+        n_not_none = sum(x is not None for x in [value, z, distmod, parallax])
+        if n_not_none == 0:
+            raise ValueError('None of `value`, `z`, `distmod`, or `parallax` '
+                             'were given to Distance constructor')
+        elif n_not_none > 1:
+            raise ValueError('Should given only one of `value`, `z`, '
+                             '`distmod`, or `parallax` in Distance '
+                             'constructor.')
 
+        if z is not None:
             if cosmology is None:
                 from astropy.cosmology import default_cosmology
                 cosmology = default_cosmology.get()
@@ -118,13 +123,6 @@ class Distance(u.SpecificTypeQuantity):
             if cosmology is not None:
                 raise ValueError('A `cosmology` was given but `z` was not '
                                  'provided in Distance constructor')
-
-            value_msg = ('Should given only one of `value`, `z`, `distmod`, or '
-                         '`parallax` in Distance constructor.')
-            n_not_none = np.sum([x is not None
-                                 for x in [value, z, distmod, parallax]])
-            if n_not_none > 1:
-                raise ValueError(value_msg)
 
             if distmod is not None:
                 value = cls._distmod_to_pc(distmod)
@@ -170,11 +168,6 @@ class Distance(u.SpecificTypeQuantity):
                                          "through, with negative parallaxes "
                                          "instead becoming NaN, use the "
                                          "`allow_negative=True` argument.")
-
-            elif value is None:
-                raise ValueError('None of `value`, `z`, `distmod`, or '
-                                 '`parallax` were given to Distance '
-                                 'constructor')
 
         # now we have arguments like for a Quantity, so let it do the work
         distance = super().__new__(

--- a/astropy/coordinates/distances.py
+++ b/astropy/coordinates/distances.py
@@ -102,12 +102,11 @@ class Distance(u.SpecificTypeQuantity):
 
         n_not_none = sum(x is not None for x in [value, z, distmod, parallax])
         if n_not_none == 0:
-            raise ValueError('None of `value`, `z`, `distmod`, or `parallax` '
+            raise ValueError('none of `value`, `z`, `distmod`, or `parallax` '
                              'were given to Distance constructor')
         elif n_not_none > 1:
-            raise ValueError('Should given only one of `value`, `z`, '
-                             '`distmod`, or `parallax` in Distance '
-                             'constructor.')
+            raise ValueError('more than one of `value`, `z`, `distmod`, or '
+                             '`parallax` were given to Distance constructor')
 
         if z is not None:
             if cosmology is None:

--- a/astropy/coordinates/tests/test_distance.py
+++ b/astropy/coordinates/tests/test_distance.py
@@ -127,7 +127,7 @@ def test_distances_scipy():
         Distance()
 
     # Regression test for #12531
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match='more than one'):
         Distance(z=0.23, parallax=1*u.mas)
 
     # vectors!  regression test for #11949

--- a/astropy/coordinates/tests/test_distance.py
+++ b/astropy/coordinates/tests/test_distance.py
@@ -126,6 +126,10 @@ def test_distances_scipy():
     with pytest.raises(ValueError):
         Distance()
 
+    # Regression test for #12531
+    with pytest.raises(ValueError):
+        Distance(z=0.23, parallax=1*u.mas)
+
     # vectors!  regression test for #11949
     d4 = Distance(z=[0.23, 0.45])  # as of writing, Planck18
     npt.assert_allclose(d4.z, [0.23, 0.45], rtol=1e-8)

--- a/docs/changes/coordinates/12531.bugfix.rst
+++ b/docs/changes/coordinates/12531.bugfix.rst
@@ -1,0 +1,2 @@
+Trying to create an instance of ``astropy.coordinates.Distance`` by providing
+both ``z`` and ``parallax`` now raises the expected ``ValueError``.


### PR DESCRIPTION
### Description

An instance of `coordinates.Distance` can be created by providing a distance value, distance modulus, parallax or redshift. Providing more than one of these should result in a `ValueError`, but if both redshift and parallax are provided then the `Distance` gets constructed from the redshift, and parallax will be silently ignored. This pull request fixes that bug.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
