### PR TITLE
ENH: fix compatibility with numpy 1.23

### DIFF
--- a/astropy/units/quantity_helper/function_helpers.py
+++ b/astropy/units/quantity_helper/function_helpers.py
@@ -43,7 +43,7 @@ from numpy.lib import recfunctions as rfn
 
 from astropy.units.core import (
     UnitsError, UnitTypeError, dimensionless_unscaled)
-from astropy.utils.compat import NUMPY_LT_1_20
+from astropy.utils.compat import NUMPY_LT_1_20, NUMPY_LT_1_23
 from astropy.utils import isiterable
 
 # In 1.17, overrides are enabled by default, but it is still possible to
@@ -122,8 +122,6 @@ UNSUPPORTED_FUNCTIONS |= TBD_FUNCTIONS
 # variable so that we can check consistency in the test routine -
 # test_quantity_non_ufuncs.py)
 IGNORED_FUNCTIONS = {
-    # Deprecated
-    np.asscalar, np.alen,
     # I/O - useless for Quantity, since no way to store the unit.
     np.save, np.savez, np.savetxt, np.savez_compressed,
     # Polynomials
@@ -136,7 +134,11 @@ if NUMPY_LT_1_20:
     # financial
     IGNORED_FUNCTIONS |= {np.fv, np.ipmt, np.irr, np.mirr, np.nper,
                           np.npv, np.pmt, np.ppmt, np.pv, np.rate}
-
+if NUMPY_LT_1_23:
+    IGNORED_FUNCTIONS |= {
+        # Deprecated, removed in numpy 1.23
+        np.asscalar, np.alen,
+    }
 UNSUPPORTED_FUNCTIONS |= IGNORED_FUNCTIONS
 
 

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -12,7 +12,7 @@ from astropy import units as u
 from astropy.units.quantity_helper.function_helpers import (
     ARRAY_FUNCTION_ENABLED, SUBCLASS_SAFE_FUNCTIONS, UNSUPPORTED_FUNCTIONS,
     FUNCTION_HELPERS, DISPATCHED_FUNCTIONS, IGNORED_FUNCTIONS, TBD_FUNCTIONS)
-from astropy.utils.compat import NUMPY_LT_1_20
+from astropy.utils.compat import NUMPY_LT_1_20, NUMPY_LT_1_23
 
 
 needs_array_function = pytest.mark.xfail(
@@ -2087,7 +2087,13 @@ if NUMPY_LT_1_20:
                            if f in np.lib.financial.__dict__.values()}
     untested_functions |= financial_functions
 
-deprecated_functions = {np.asscalar, np.alen}
+if NUMPY_LT_1_23:
+    deprecated_functions = {
+        # Deprecated, removed in numpy 1.23
+        np.asscalar, np.alen,
+    }
+else:
+    deprecated_functions = set()
 
 untested_functions |= deprecated_functions
 io_functions = {np.save, np.savez, np.savetxt, np.savez_compressed}

--- a/astropy/utils/compat/numpycompat.py
+++ b/astropy/utils/compat/numpycompat.py
@@ -5,7 +5,7 @@ earlier versions of Numpy.
 """
 from astropy.utils import minversion
 
-__all__ = ['NUMPY_LT_1_19', 'NUMPY_LT_1_20', 'NUMPY_LT_1_21_1', 'NUMPY_LT_1_22']
+__all__ = ['NUMPY_LT_1_19', 'NUMPY_LT_1_20', 'NUMPY_LT_1_21_1', 'NUMPY_LT_1_22', 'NUMPY_LT_1_23']
 
 # TODO: It might also be nice to have aliases to these named for specific
 # features/bugs we're checking for (ex:
@@ -14,3 +14,4 @@ NUMPY_LT_1_19 = not minversion('numpy', '1.19')
 NUMPY_LT_1_20 = not minversion('numpy', '1.20')
 NUMPY_LT_1_21_1 = not minversion('numpy', '1.21.1')
 NUMPY_LT_1_22 = not minversion('numpy', '1.22')
+NUMPY_LT_1_23 = not minversion('numpy', '1.23dev0')

--- a/astropy/utils/masked/function_helpers.py
+++ b/astropy/utils/masked/function_helpers.py
@@ -13,7 +13,7 @@ import numpy as np
 
 from astropy.units.quantity_helper.function_helpers import (
     FunctionAssigner)
-from astropy.utils.compat import NUMPY_LT_1_19, NUMPY_LT_1_20
+from astropy.utils.compat import NUMPY_LT_1_19, NUMPY_LT_1_20, NUMPY_LT_1_23
 
 # This module should not really be imported, but we define __all__
 # such that sphinx can typeset the functions with docstrings.
@@ -109,8 +109,6 @@ MASKED_SAFE_FUNCTIONS |= {
 }
 
 IGNORED_FUNCTIONS = {
-    # Deprecated
-    np.asscalar, np.alen,
     # I/O - useless for Masked, since no way to store the mask.
     np.save, np.savez, np.savetxt, np.savez_compressed,
     # Polynomials
@@ -141,6 +139,12 @@ IGNORED_FUNCTIONS |= {
 IGNORED_FUNCTIONS |= set(getattr(np, setopsname)
                          for setopsname in np.lib.arraysetops.__all__)
 
+
+if NUMPY_LT_1_23:
+    IGNORED_FUNCTIONS |= {
+        # Deprecated, removed in numpy 1.23
+        np.asscalar, np.alen,
+    }
 
 # Explicitly unsupported functions
 UNSUPPORTED_FUNCTIONS |= {

--- a/astropy/utils/masked/tests/test_function_helpers.py
+++ b/astropy/utils/masked/tests/test_function_helpers.py
@@ -18,7 +18,7 @@ import pytest
 import numpy as np
 from numpy.testing import assert_array_equal
 
-from astropy.utils.compat import NUMPY_LT_1_19, NUMPY_LT_1_20
+from astropy.utils.compat import NUMPY_LT_1_19, NUMPY_LT_1_20, NUMPY_LT_1_23
 from astropy.units.tests.test_quantity_non_ufuncs import (
     get_wrapped_functions)
 
@@ -1333,10 +1333,13 @@ if NUMPY_LT_1_20:
                            if f in np.lib.financial.__dict__.values()}
     untested_functions |= financial_functions
 
-deprecated_functions = {
-    np.asscalar,
-    np.alen,
+if NUMPY_LT_1_23:
+    deprecated_functions = {
+        # Deprecated, removed in numpy 1.23
+        np.asscalar, np.alen,
     }
+else:
+    deprecated_functions = set()
 
 untested_functions |= deprecated_functions
 io_functions = {np.save, np.savez, np.savetxt, np.savez_compressed}


### PR DESCRIPTION
### Description
Fixes #12534
This is not necessarily sufficient to fix compatibility with numpy 1.23 completely but it should at least address the problem I stumbled upon.

for reference the breaking change upstream is from https://github.com/numpy/numpy/pull/20414

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
