### PR TITLE
Allow any remotely available JPL ephemeris version

### DIFF
--- a/astropy/coordinates/solar_system.py
+++ b/astropy/coordinates/solar_system.py
@@ -6,6 +6,7 @@ ephemerides from jplephem.
 
 from urllib.parse import urlparse
 import os.path
+import re
 
 import numpy as np
 import erfa
@@ -80,7 +81,10 @@ class solar_system_ephemeris(ScienceState):
     This can be one of the following::
 
     - 'builtin': polynomial approximations to the orbital elements.
-    - 'de430', 'de432s', 'de440', 'de440s': short-cuts for recent JPL dynamical models.
+    - 'dexxx[s]', for a JPL dynamical model, where xxx is the three digit version number
+      (e.g. de430), and the s is optional to specify the 'small' version of a kernel.
+      The version number must correspond to an ephemeris file available at
+      https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/
     - 'jpl': Alias for the default JPL ephemeris (currently, 'de430').
     - URL: (str) The url to a SPK ephemeris in SPICE binary (.bsp) format.
     - PATH: (str) File path to a SPK ephemeris in SPICE binary (.bsp) format.
@@ -160,9 +164,10 @@ def _get_kernel(value):
                           "(https://pypi.org/project/jplephem/)")
 
     if value.lower() == 'jpl':
+        # Get the default JPL ephemeris URL
         value = DEFAULT_JPL_EPHEMERIS
 
-    if value.lower() in ('de430', 'de432s', 'de440', 'de440s'):
+    if re.compile(r'de[0-9][0-9][0-9]s?').match(value.lower()):
         value = ('https://naif.jpl.nasa.gov/pub/naif/generic_kernels'
                  '/spk/planets/{:s}.bsp'.format(value.lower()))
 

--- a/astropy/coordinates/solar_system.py
+++ b/astropy/coordinates/solar_system.py
@@ -78,12 +78,13 @@ One can check which bodies are covered by a given ephemeris using::
 class solar_system_ephemeris(ScienceState):
     """Default ephemerides for calculating positions of Solar-System bodies.
 
-    This can be one of the following::
+    This can be one of the following:
 
     - 'builtin': polynomial approximations to the orbital elements.
-    - 'dexxx[s]', for a JPL dynamical model, where xxx is the three digit version number
-      (e.g. de430), and the s is optional to specify the 'small' version of a kernel.
-      The version number must correspond to an ephemeris file available at
+    - 'dexxx[s]', for a JPL dynamical model, where xxx is the three digit
+      version number (e.g. de430), and the 's' is optional to specify the
+      'small' version of a kernel. The version number must correspond to an
+      ephemeris file available at:
       https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/
     - 'jpl': Alias for the default JPL ephemeris (currently, 'de430').
     - URL: (str) The url to a SPK ephemeris in SPICE binary (.bsp) format.

--- a/astropy/coordinates/tests/test_solar_system.py
+++ b/astropy/coordinates/tests/test_solar_system.py
@@ -427,10 +427,18 @@ def test_url_or_file_ephemeris(time):
 @pytest.mark.remote_data
 @pytest.mark.skipif('not HAS_JPLEPHEM')
 def test_url_ephemeris_wrong_input():
-    # Try loading a non-existing URL:
     time = Time('1960-01-12 00:00')
     with pytest.raises((HTTPError, URLError)):
+        # A non-existent URL
         get_body('earth', time, ephemeris=get_pkg_data_filename('path/to/nonexisting/file.bsp'))
+
+    with pytest.raises(HTTPError):
+        # A non-existent version of the JPL ephemeris
+        get_body('earth', time, ephemeris='de001')
+
+    with pytest.raises(ValueError):
+        # An invalid string
+        get_body('earth', time, ephemeris='not_an_ephemeris')
 
 
 @pytest.mark.skipif('not HAS_JPLEPHEM')

--- a/docs/changes/coordinates/12541.feature.rst
+++ b/docs/changes/coordinates/12541.feature.rst
@@ -1,0 +1,2 @@
+The ephemeris used in `astropy.coordinates` can now be set to any version of
+the JPL ephemeris available from https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This allows any ephemeris available at https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/ to be used, instead of the previous limited set.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
