### PR TITLE
Fix use of memmap with Table.read and add option to deactivate the masking of invalid values

### DIFF
--- a/astropy/io/fits/connect.py
+++ b/astropy/io/fits/connect.py
@@ -164,9 +164,8 @@ def read_table_fits(input, hdu=None, astropy_native=False, memmap=False,
     mask_invalid : bool, optional
         By default the code masks NaNs in float columns and empty strings in
         string columns. Set this parameter to `False` to avoid the performance
-        penalty of doing this masking step. It's also needing when using
-        ``memmap=True`` because otherwise reading the float/string columns to
-        mask them will cause the loading of the data.
+        penalty of doing this masking step. The masking is always deactivated
+        when using ``memmap=True`` (see above).
 
     """
 
@@ -223,7 +222,7 @@ def read_table_fits(input, hdu=None, astropy_native=False, memmap=False,
 
     else:
 
-        if memmap and mask_invalid:
+        if memmap:
             # using memmap is not compatible with masking invalid value by
             # default so we deactivate the masking
             mask_invalid = False

--- a/astropy/io/fits/connect.py
+++ b/astropy/io/fits/connect.py
@@ -146,6 +146,8 @@ def read_table_fits(input, hdu=None, astropy_native=False, memmap=False,
         fit the table in memory, you may be better off leaving memory mapping
         off. However, if your table would not fit in memory, you should set this
         to `True`.
+        When set to `True` then ``mask_invalid`` is set to `False` since the
+        masking would cause loading the full data array.
     character_as_bytes : bool, optional
         If `True`, string columns are stored as Numpy byte arrays (dtype ``S``)
         and are converted on-the-fly to unicode strings when accessing
@@ -220,6 +222,11 @@ def read_table_fits(input, hdu=None, astropy_native=False, memmap=False,
         table = input
 
     else:
+
+        if memmap and mask_invalid:
+            # using memmap is not compatible with masking invalid value by
+            # default so we deactivate the masking
+            mask_invalid = False
 
         hdulist = fits_open(input, character_as_bytes=character_as_bytes,
                             memmap=memmap)

--- a/astropy/io/fits/connect.py
+++ b/astropy/io/fits/connect.py
@@ -112,7 +112,8 @@ def _decode_mixins(tbl):
 
 
 def read_table_fits(input, hdu=None, astropy_native=False, memmap=False,
-                    character_as_bytes=True, unit_parse_strict='warn'):
+                    character_as_bytes=True, unit_parse_strict='warn',
+                    mask_invalid=True):
     """
     Read a Table object from an FITS file
 
@@ -246,9 +247,9 @@ def read_table_fits(input, hdu=None, astropy_native=False, memmap=False,
             # Return a MaskedColumn even if no elements are masked so
             # we roundtrip better.
             masked = True
-        elif issubclass(coltype, np.inexact):
+        elif mask_invalid and issubclass(coltype, np.inexact):
             mask = np.isnan(data[col.name])
-        elif issubclass(coltype, np.character):
+        elif mask_invalid and issubclass(coltype, np.character):
             mask = col.array == b''
 
         if masked or np.any(mask):

--- a/astropy/io/fits/connect.py
+++ b/astropy/io/fits/connect.py
@@ -159,6 +159,12 @@ def read_table_fits(input, hdu=None, astropy_native=False, memmap=False,
         :class:`~astropy.units.core.UnrecognizedUnit`.
         Values are the ones allowed by the ``parse_strict`` argument of
         :class:`~astropy.units.core.Unit`: ``raise``, ``warn`` and ``silent``.
+    mask_invalid : bool, optional
+        By default the code masks NaNs in float columns and empty strings in
+        string columns. Set this parameter to `False` to avoid the performance
+        penalty of doing this masking step. It's also needing when using
+        ``memmap=True`` because otherwise reading the float/string columns to
+        mask them will cause the loading of the data.
 
     """
 
@@ -223,6 +229,7 @@ def read_table_fits(input, hdu=None, astropy_native=False, memmap=False,
                 hdulist, hdu=hdu,
                 astropy_native=astropy_native,
                 unit_parse_strict=unit_parse_strict,
+                mask_invalid=mask_invalid,
             )
         finally:
             hdulist.close()

--- a/astropy/io/fits/tests/test_connect.py
+++ b/astropy/io/fits/tests/test_connect.py
@@ -362,6 +362,10 @@ class TestSingleTable:
         tab = Table.read(filename, mask_invalid=False)
         assert tab.mask is None
 
+        # using memmap also deactivate the masking
+        tab = Table.read(filename, memmap=True)
+        assert tab.mask is None
+
     def test_mask_null_on_read(self, tmpdir):
         filename = str(tmpdir.join('test_null_format_parse_on_read.fits'))
         col = fits.Column(name='a', array=np.array([1, 2, 99, 60000], dtype='u2'),

--- a/astropy/io/fits/tests/test_connect.py
+++ b/astropy/io/fits/tests/test_connect.py
@@ -373,6 +373,20 @@ class TestSingleTable:
         assert any(tab.mask)
         assert tab.mask[2]
 
+    def test_mask_str_on_read(self, tmpdir):
+        filename = str(tmpdir.join('test_null_format_parse_on_read.fits'))
+        col = fits.Column(name='a', array=np.array([b'foo', b'bar', b''], dtype='|S3'),
+                          format='A3')
+        bin_table_hdu = fits.BinTableHDU.from_columns([col])
+        bin_table_hdu.writeto(filename, overwrite=True)
+
+        tab = Table.read(filename)
+        assert any(tab.mask)
+        assert tab.mask[2]
+
+        tab = Table.read(filename, mask_invalid=False)
+        assert tab.mask is None
+
 
 class TestMultipleHDU:
 

--- a/astropy/io/fits/tests/test_connect.py
+++ b/astropy/io/fits/tests/test_connect.py
@@ -14,7 +14,7 @@ from astropy.io.fits import HDUList, PrimaryHDU, BinTableHDU, ImageHDU, table_to
 from astropy.io import fits
 
 from astropy import units as u
-from astropy.table import Table, QTable, NdarrayMixin, Column
+from astropy.table import Table, QTable, Column
 from astropy.table.table_helpers import simple_table
 from astropy.units import allclose as quantity_allclose
 from astropy.units.format.fits import UnitScaleError
@@ -359,9 +359,13 @@ class TestSingleTable:
         assert any(tab.mask)
         assert tab.mask[2]
 
+        tab = Table.read(filename, mask_invalid=False)
+        assert tab.mask is None
+
     def test_mask_null_on_read(self, tmpdir):
         filename = str(tmpdir.join('test_null_format_parse_on_read.fits'))
-        col = fits.Column(name='a', array=np.array([1, 2, 99, 60000], dtype='u2'), format='I', null=99, bzero=32768)
+        col = fits.Column(name='a', array=np.array([1, 2, 99, 60000], dtype='u2'),
+                          format='I', null=99, bzero=32768)
         bin_table_hdu = fits.BinTableHDU.from_columns([col])
         bin_table_hdu.writeto(filename, overwrite=True)
 

--- a/docs/changes/io.fits/12544.bugfix.rst
+++ b/docs/changes/io.fits/12544.bugfix.rst
@@ -1,0 +1,3 @@
+Add a ``mask_invalid`` option to ``Table.read`` to deactivate the masking of
+NaNs in float columns and empty strings in string columns. This option is
+necessary to allow effective use of memory-mapped reading with ``memmap=True``.

--- a/docs/changes/io.fits/12544.bugfix.rst
+++ b/docs/changes/io.fits/12544.bugfix.rst
@@ -1,3 +1,4 @@
-Add a ``mask_invalid`` option to ``Table.read`` to deactivate the masking of
-NaNs in float columns and empty strings in string columns. This option is
-necessary to allow effective use of memory-mapped reading with ``memmap=True``.
+Add a ``mask_invalid`` option to ``Table.read`` to allow deactivating the
+masking of NaNs in float columns and empty strings in string columns. This
+option is necessary to allow effective use of memory-mapped reading with
+``memmap=True``.

--- a/docs/io/unified.rst
+++ b/docs/io/unified.rst
@@ -481,7 +481,8 @@ sentinel values according to the FITS standard:
 
 When the file is read back those elements are marked as masked in the returned
 table, but see `issue #4708 <https://github.com/astropy/astropy/issues/4708>`_
-for problems in all three cases.
+for problems in all three cases. It is possible to deactivate the masking with
+``mask_invalid=False``.
 
 The FITS standard has a few limitations:
 


### PR DESCRIPTION
Since #11222 (v4.3) using `memmap` with `Table.read` is no more possible since the data is loaded to look for NaNs in float columns and empty strings in string columns. I think adding an option to avoid those checks would be useful, though I'm not sure what should be the default value. `True` is best for compatibility with v4.3+ and people may expect Astropy to mask by default. `False` is best for memory usage and performance on big tables. 

Update: the PR adds a `mask_invalid` option and deactivates the masking when using memmap, also fix #12981 which is asking for a similar option.

<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address ...

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
