### PR TITLE
Cosmo strict copy

### DIFF
--- a/astropy/cosmology/connect.py
+++ b/astropy/cosmology/connect.py
@@ -218,6 +218,7 @@ class CosmologyFromFormat(io_registry.UnifiedReadWrite):
 
         with add_enabled_units(cu):
             cosmo = self.registry.read(self._cls, obj, *args, **kwargs)
+
         return cosmo
 
 

--- a/astropy/cosmology/io/tests/test_ecsv.py
+++ b/astropy/cosmology/io/tests/test_ecsv.py
@@ -166,10 +166,10 @@ class ReadWriteECSVTestMixin(IOTestMixinBase):
 
         assert (got == got2) and (got2 == got3)  # internal consistency
 
-        # not equal, because Tcmb0 is changed
+        # not equal, because Tcmb0 is changed, which also changes m_nu
         assert got != cosmo
         assert got.Tcmb0 == cosmo_cls._init_signature.parameters["Tcmb0"].default
-        assert got.clone(name=cosmo.name, Tcmb0=cosmo.Tcmb0) == cosmo
+        assert got.clone(name=cosmo.name, Tcmb0=cosmo.Tcmb0, m_nu=cosmo.m_nu) == cosmo
         # but the metadata is the same
         assert got.meta == cosmo.meta
 

--- a/astropy/cosmology/io/tests/test_mapping.py
+++ b/astropy/cosmology/io/tests/test_mapping.py
@@ -121,10 +121,10 @@ class ToFromMappingTestMixin(IOTestMixinBase):
 
         assert (got == got2) and (got2 == got3)  # internal consistency
 
-        # not equal, because Tcmb0 is changed
+        # not equal, because Tcmb0 is changed, which also changes m_nu
         assert got != cosmo
         assert got.Tcmb0 == cosmo.__class__._init_signature.parameters["Tcmb0"].default
-        assert got.clone(name=cosmo.name, Tcmb0=cosmo.Tcmb0) == cosmo
+        assert got.clone(name=cosmo.name, Tcmb0=cosmo.Tcmb0, m_nu=cosmo.m_nu) == cosmo
         # but the metadata is the same
         assert got.meta == cosmo.meta
 

--- a/astropy/cosmology/io/tests/test_table.py
+++ b/astropy/cosmology/io/tests/test_table.py
@@ -148,10 +148,10 @@ class ToFromTableTestMixin(IOTestMixinBase):
 
         assert (got == got2) and (got2 == got3)  # internal consistency
 
-        # not equal, because Tcmb0 is changed
+        # not equal, because Tcmb0 is changed, which also changes m_nu
         assert got != cosmo
         assert got.Tcmb0 == cosmo_cls._init_signature.parameters["Tcmb0"].default
-        assert got.clone(name=cosmo.name, Tcmb0=cosmo.Tcmb0) == cosmo
+        assert got.clone(name=cosmo.name, Tcmb0=cosmo.Tcmb0, m_nu=cosmo.m_nu) == cosmo
         # but the metadata is the same
         assert got.meta == cosmo.meta
 

--- a/astropy/cosmology/tests/test_connect.py
+++ b/astropy/cosmology/tests/test_connect.py
@@ -164,10 +164,10 @@ class TestCosmologyReadWrite(ReadWriteTestMixin):
 
         assert (got == got2) and (got2 == got3)  # internal consistency
 
-        # not equal, because Tcmb0 is changed
+        # not equal, because Tcmb0 is changed, which also changes m_nu
         assert got != cosmo
         assert got.Tcmb0 == cosmo.__class__._init_signature.parameters["Tcmb0"].default
-        assert got.clone(name=cosmo.name, Tcmb0=cosmo.Tcmb0) == cosmo
+        assert got.clone(name=cosmo.name, Tcmb0=cosmo.Tcmb0, m_nu=cosmo.m_nu) == cosmo
         # but the metadata is the same
         assert got.meta == cosmo.meta
 


### PR DESCRIPTION
### Description

The storing of initialization arguments was a good idea for making cloning easier but a few things have changed / are changing.
1. The Parameters object has been added, which regularizes how most inputs to a cosmology are handled.
2. I plan to allow a Cosmology to be array-valued.
    For large arrays, e.g. an MCMC chain, storing the initialization arguments doubles the memory footprint.

This new method changes `_init_arguments` from a dictionary to a `property`. Subclasses can override the property if needed. Parameters have a method ``inv_validate`` to reverse ``validate`` and get the original value.

I haven't yet decided how fully featured the ``inv_validate`` should be: a registry system like ``fvalidate`` or the current minimal implementation. The only think a registry system for ``inv_validate`` would change is that ``m_nu`` wouldn't need to be special-cased in ``FLRW._init_arguments``.


### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
