### PR TITLE
Fixed a subtle broadcasting bug when instantiating representations without copying the inputs

### DIFF
--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -238,14 +238,11 @@ class BaseRepresentationOrDifferential(ShapedLikeNDArray):
                 c_str = ', '.join(components[:2]) + ', and ' + components[2]
             raise ValueError(f"Input parameters {c_str} cannot be broadcast") from err
 
-        # If inputs have been copied, there is no reason to output a broadcasted array for a
-        # component, so we perform another copy of any component that has been broadcasted
-        # TODO: Look for some way to avoid the double copy in these situations
-        if copy:
-            attrs = [bc_attr.copy() if bc_attr.shape != attr.shape else attr
-                     for attr, bc_attr in zip(attrs, bc_attrs)]
-        else:
-            attrs = bc_attrs
+        # Use the broadcasted versions of components only if the shape is different.
+        # If copy==True, they will be copies of broadcasts of copies.
+        # TODO: Find a way to avoid the double copy
+        attrs = [(bc_attr.copy() if copy else bc_attr) if bc_attr.shape != attr.shape else attr
+                 for attr, bc_attr in zip(attrs, bc_attrs)]
 
         # Set private attributes for the attributes. (If not defined explicitly
         # on the class, the metaclass will define properties to access these.)

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -238,9 +238,18 @@ class BaseRepresentationOrDifferential(ShapedLikeNDArray):
                 c_str = ', '.join(components[:2]) + ', and ' + components[2]
             raise ValueError(f"Input parameters {c_str} cannot be broadcast") from err
 
-        # Use the broadcasted versions of components only if the shape is different.
-        # If copy==True, they will be copies of broadcasts of copies.
-        # TODO: Find a way to avoid the double copy
+        # The output of np.broadcast_arrays() has limitations on writeability, so we perform
+        # additional handling to enable writeability in most situations.  This is primarily
+        # relevant for allowing the changing of the wrap angle of longitude components.
+        #
+        # If the shape has changed for a given component, broadcasting is needed:
+        #     If copy=True, we make a copy of the broadcasted array to ensure writeability.
+        #         Note that array had already been copied prior to the broadcasting.
+        #         TODO: Find a way to avoid the double copy.
+        #     If copy=False, we use the broadcasted array, and writeability may still be
+        #         limited.
+        # If the shape has not changed for a given component, we can proceed with using the
+        #     non-broadcasted array, which avoids writeability issues from np.broadcast_arrays().
         attrs = [(bc_attr.copy() if copy else bc_attr) if bc_attr.shape != attr.shape else attr
                  for attr, bc_attr in zip(attrs, bc_attrs)]
 

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -257,6 +257,23 @@ class TestSphericalRepresentation:
                                          distance=[1, 2] * u.kpc)
         assert exc.value.args[0] == "Input parameters lon, lat, and distance cannot be broadcast"
 
+    def test_broadcasting_and_nocopy(self):
+
+        s1 = SphericalRepresentation(lon=[200] * u.deg,
+                                     lat=[0] * u.deg,
+                                     distance=[0] * u.kpc,
+                                     copy=False)
+        # With no copying, we should be able to modify the wrap angle of the longitude component
+        s1.lon.wrap_angle = 180 * u.deg
+
+        s2 = SphericalRepresentation(lon=[200] * u.deg,
+                                     lat=0 * u.deg,
+                                     distance=0 * u.kpc,
+                                     copy=False)
+        # We should be able to modify the wrap angle of the longitude component even if other
+        # components need to be broadcasted
+        s2.lon.wrap_angle = 180 * u.deg
+
     def test_readonly(self):
 
         s1 = SphericalRepresentation(lon=8 * u.hourangle,

--- a/docs/changes/coordinates/12556.bugfix.rst
+++ b/docs/changes/coordinates/12556.bugfix.rst
@@ -1,6 +1,2 @@
-Fixed a bug where instantiating a coordinate representation without copying the
-component inputs would return a representation whose components were always
-broadcasted versions, even for those components that did not need to change
-shape.  Broadcasted versions can have more restrictions on writeability than
-the original inputs, and is particularly problematic when changing the wrap
-angle on longitude components.
+Fixed a bug where changing the wrap angle of the longitude component of a
+representation could raise a warning or error in certain situations.

--- a/docs/changes/coordinates/12556.bugfix.rst
+++ b/docs/changes/coordinates/12556.bugfix.rst
@@ -1,0 +1,6 @@
+Fixed a bug where instantiating a coordinate representation without copying the
+component inputs would return a representation whose components were always
+broadcasted versions, even for those components that did not need to change
+shape.  Broadcasted versions can have more restrictions on writeability than
+the original inputs, and is particularly problematic when changing the wrap
+angle on longitude components.


### PR DESCRIPTION
Currently, when instantiating a coordinate representation without copying the component inputs, the representation's components will always be broadcasted versions rather than the originals (i.e., the output of `np.broadcast_arrays()`) even for those components that did not need to change shape.  The broadcasted version is flagged with `WARN_ON_WRITE`, which raises a deprecation warning if there is an attempt to modify the contents of such a component.  The primary way that this would occur for a user is when changing the wrap angle of a longitude component.  This PR modifies a no-copy instantiation so that the representation's components will be the original inputs for those inputs that did not need to change shape.

Examples of failures:
```python
>>> import warnings

>>> import astropy.units as u
>>> from astropy.coordinates import Longitude, SphericalRepresentation, UnitSphericalRepresentation

>>> # With copy=False, the longitude component is the same as the longitude input
>>> lon = Longitude([200]*u.deg)
>>> repr0 = UnitSphericalRepresentation(lon, [0]*u.deg, copy=False)
>>> repr0.lon is lon
True

>>> # If the latitude input needs to be broadcasted, the longitude component
>>> # becomes a broadcasted version even though there is no change in shape
>>> repr1 = UnitSphericalRepresentation(lon, 0*u.deg, copy=False)
>>> repr1.lon is lon
False

>>> # The longitude component is flagged with WARN_ON_WRITE=True
>>> repr1.lon.flags
  C_CONTIGUOUS : True
  F_CONTIGUOUS : True
  OWNDATA : False
  WRITEABLE : True  (with WARN_ON_WRITE=True)
  ALIGNED : True
  WRITEBACKIFCOPY : False
  UPDATEIFCOPY : False

>>> # Changing the wrap angle of the longitude component triggers a NumPy deprecation warning
>>> with warnings.catch_warnings():
...     warnings.filterwarnings("error")
...     repr1.lon.wrap_angle = 180*u.deg
---------------------------------------------------------------------------
DeprecationWarning                        Traceback (most recent call last)
...
DeprecationWarning: Numpy has detected that you (may be) writing to an array with
overlapping memory from np.broadcast_arrays. If this is intentional
set the WRITEABLE flag True or make a copy immediately before writing.

>>> # A similar problem occurs when representing a UnitSphericalRepresentation as a SphericalRepresentation
>>> # That's because there is a hidden broadcasting with the distance input of 1*u.one
>>> repr2 = repr0.represent_as(SphericalRepresentation)
>>> with warnings.catch_warnings():
...    warnings.filterwarnings("error")
...     repr2.lon.wrap_angle = 180*u.deg
---------------------------------------------------------------------------
DeprecationWarning                        Traceback (most recent call last)
...
DeprecationWarning: Numpy has detected that you (may be) writing to an array with
overlapping memory from np.broadcast_arrays. If this is intentional
set the WRITEABLE flag True or make a copy immediately before writing.
```

In the future, when `np.broadcast_arrays()` will always return read-only arrays, it will be presumably be even more important to return original inputs when possible.