### PR TITLE
Make indexing in models more robust

### DIFF
--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -18,6 +18,7 @@ import copy
 import inspect
 import itertools
 import functools
+import numbers
 import operator
 import types
 
@@ -3348,9 +3349,9 @@ class CompoundModel(Model):
                     if leftind == start and rightind == stop:
                         return node
                 raise IndexError("No appropriate subtree matches slice")
-        if isinstance(index, type(0)):
+        if isinstance(index, numbers.Integral):
             return leaflist[index]
-        elif isinstance(index, type('')):
+        elif isinstance(index, str):
             return leaflist[self._str_index_to_int(index)]
         else:
             raise TypeError('index must be integer, slice, or model name string')

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -3349,7 +3349,7 @@ class CompoundModel(Model):
                     if leftind == start and rightind == stop:
                         return node
                 raise IndexError("No appropriate subtree matches slice")
-        if isinstance(index, numbers.Integral):
+        if np.issubdtype(type(index), np.integer):
             return leaflist[index]
         elif isinstance(index, str):
             return leaflist[self._str_index_to_int(index)]

--- a/astropy/modeling/tests/test_core.py
+++ b/astropy/modeling/tests/test_core.py
@@ -1342,3 +1342,28 @@ def test_compound_bounding_box_pass_with_ignored():
     bind_compound_bounding_box(model, bbox, selector_args=[('slit_id', True)],
                                ignored=['y'], order='F')
     assert model.bounding_box == cbbox
+
+
+@pytest.mark.parametrize('int_type', [int, np.int32, np.int64, np.uint32, np.uint64])
+def test_model_integer_indexing(int_type):
+    """Regression for PR 12561; verify that compound model components
+     can be accessed by integer index"""
+    gauss = models.Gaussian2D()
+    airy = models.AiryDisk2D()
+    compound = gauss + airy
+
+    assert compound[int_type(0)] == gauss
+    assert compound[int_type(1)] == airy
+
+
+def test_model_string_indexing():
+    """Regression for PR 12561; verify that compound model components
+     can be accessed by indexing with model name"""
+    gauss = models.Gaussian2D()
+    gauss.name = 'Model1'
+    airy = models.AiryDisk2D()
+    airy.name = 'Model2'
+    compound = gauss + airy
+
+    assert compound['Model1'] == gauss
+    assert compound['Model2'] == airy

--- a/docs/changes/modeling/12561.bugfix.rst
+++ b/docs/changes/modeling/12561.bugfix.rst
@@ -1,0 +1,2 @@
+Indexing on models can now be used with all types of integers
+(like ``numpy.int64``) instead of just ``int``.


### PR DESCRIPTION
### Description
Currently integer-indexing a model is only possible with built-in python integers, `numpy` ints don't work e.g.:
```python
my_model[np.int64(0)] 
-> TypeError('index must be integer, slice, or model name string')
```
This makes the type check more general to allow anything that fits into the duck-type category "whole number".

Also, comparing against `str` directly is a bit more clear and should save a few CPU-cycles.

edit: I didn't really touch the changelog or anything because this seems a bit too small to mention there...