### PR TITLE
Implement multiplication and division of LogQuantities

### DIFF
--- a/docs/changes/units/12566.feature.rst
+++ b/docs/changes/units/12566.feature.rst
@@ -1,0 +1,1 @@
+Implement multiplication and division of LogQuantities and numbers

--- a/docs/units/logarithmic_units.rst
+++ b/docs/units/logarithmic_units.rst
@@ -209,7 +209,7 @@ calculate the reddening::
     >>> A_V = R_V * EB_V
     >>> A_B = (R_V+1) * EB_V
     >>> EB_V, A_V, A_B  # doctest: +FLOAT_CMP
-    (<Magnitude 0.4 mag>, <Quantity 1.24 mag>, <Quantity 1.64 mag>)
+    (<Magnitude 0.4 mag>, <Magnitude 1.24 mag>, <Magnitude 1.64 mag>)
 
 Here, you see that the extinctions have been converted to quantities. This
 happens generally for division and multiplication, since these processes


### PR DESCRIPTION
### Description

There are a few use cases where one needs to multiply or divide logarithmic quantities; especially for dimensionless quantities. But also for magnitudes may benefit from it, like when one wants to have the (geometric) mean between two magnitudes:

```Python
m1 = 14 * u.ABmag
m2 = 15 * u.ABmag
print(m1+m2/2)
```
An intended effect is that now the multiplication of a LogQuantity is now returning a proper LogQuantity, so that
```Python
m1 = 2 * u.mag()
print((2 * m1).physical)
```
works as expected.

This evolved from a discussion in #12548, and while not fixing it, it may bring the solution a bit closer.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
