### PR TITLE
Refactor `Distance` constructor, update docstring and error messages

### DIFF
--- a/astropy/coordinates/distances.py
+++ b/astropy/coordinates/distances.py
@@ -23,21 +23,20 @@ class Distance(u.SpecificTypeQuantity):
     """
     A one-dimensional distance.
 
-    This can be initialized in one of five ways:
+    This can be initialized by providing one of the following:
 
-    * A distance ``value`` (array or float) and a ``unit``
-    * A `~astropy.units.Quantity` object
-    * A redshift and (optionally) a cosmology.
-    * Providing a distance modulus
-    * Providing a parallax
+    * Distance ``value`` (array or float) and a ``unit``
+    * |Quantity| object with dimensionality of length
+    * Redshift and (optionally) a `~astropy.cosmology.Cosmology`
+    * Distance modulus
+    * Parallax
 
     Parameters
     ----------
     value : scalar or `~astropy.units.Quantity` ['length']
         The value of this distance.
     unit : `~astropy.units.UnitBase` ['length']
-        The units for this distance, *if* ``value`` is not a
-        `~astropy.units.Quantity`. Must have dimensions of distance.
+        The unit for this distance.
     z : float
         A redshift for this distance.  It will be converted to a distance
         by computing the luminosity distance for this redshift given the
@@ -63,34 +62,38 @@ class Distance(u.SpecificTypeQuantity):
     ndmin : int, optional
         See `~astropy.units.Quantity`.
     allow_negative : bool, optional
-        Whether to allow negative distances (which are possible is some
-        cosmologies).  Default: ``False``.
+        Whether to allow negative distances (which are possible in some
+        cosmologies).  Default: `False`.
 
     Raises
     ------
     `~astropy.units.UnitsError`
-        If the ``unit`` is not a distance.
+        If the ``unit`` is not a length unit.
     ValueError
         If value specified is less than 0 and ``allow_negative=False``.
 
-        If ``z`` is provided with a ``unit`` or ``cosmology`` is provided
-        when ``z`` is *not* given, or ``value`` is given as well as ``z``.
+        If ``cosmology`` is provided when ``z`` is *not* given.
 
-        If none of ``value``, ``z``, ``distmod``, or ``parallax`` were given.
+        If either none or more than one of ``value``, ``z``, ``distmod``,
+        or ``parallax`` were given.
 
 
     Examples
     --------
     >>> from astropy import units as u
-    >>> from astropy.cosmology import WMAP5, WMAP7
-    >>> d1 = Distance(10, u.Mpc)
-    >>> d2 = Distance(40, unit=u.au)
-    >>> d3 = Distance(value=5, unit=u.kpc)
-    >>> d4 = Distance(z=0.23)
-    >>> d5 = Distance(z=0.23, cosmology=WMAP5)
-    >>> d6 = Distance(distmod=24.47)
-    >>> d7 = Distance(Distance(10 * u.Mpc))
-    >>> d8 = Distance(parallax=21.34*u.mas)
+    >>> from astropy.cosmology import WMAP5
+    >>> Distance(10, u.Mpc)
+    <Distance 10. Mpc>
+    >>> Distance(40*u.pc, unit=u.kpc)
+    <Distance 0.04 kpc>
+    >>> Distance(z=0.23)                      # doctest: +FLOAT_CMP
+    <Distance 1184.01657566 Mpc>
+    >>> Distance(z=0.23, cosmology=WMAP5)     # doctest: +FLOAT_CMP
+    <Distance 1147.78831918 Mpc>
+    >>> Distance(distmod=24.47*u.mag)         # doctest: +FLOAT_CMP
+    <Distance 783.42964277 kpc>
+    >>> Distance(parallax=21.34*u.mas)        # doctest: +FLOAT_CMP
+    <Distance 46.86035614 pc>
     """
 
     _equivalent_unit = u.m

--- a/astropy/coordinates/distances.py
+++ b/astropy/coordinates/distances.py
@@ -121,7 +121,7 @@ class Distance(u.SpecificTypeQuantity):
             value = cosmology.luminosity_distance(z)
 
         elif cosmology is not None:
-            raise ValueError('A `cosmology` was given but `z` was not '
+            raise ValueError('a `cosmology` was given but `z` was not '
                              'provided in Distance constructor')
 
         elif distmod is not None:
@@ -147,20 +147,18 @@ class Distance(u.SpecificTypeQuantity):
             if np.any(parallax < 0):
                 if allow_negative:
                     warnings.warn(
-                        "Negative parallaxes are converted to NaN "
+                        "negative parallaxes are converted to NaN "
                         "distances even when `allow_negative=True`, "
                         "because negative parallaxes cannot be transformed "
-                        "into distances. See discussion in this paper: "
+                        "into distances. See the discussion in this paper: "
                         "https://arxiv.org/abs/1507.02105", AstropyWarning)
                 else:
-                    raise ValueError("Some parallaxes are negative, which "
-                                     "are notinterpretable as distances. "
-                                     "See the discussion in this paper: "
-                                     "https://arxiv.org/abs/1507.02105 . "
-                                     "If you want parallaxes to pass "
-                                     "through, with negative parallaxes "
-                                     "instead becoming NaN, use the "
-                                     "`allow_negative=True` argument.")
+                    raise ValueError(
+                        "some parallaxes are negative, which are not "
+                        "interpretable as distances. See the discussion in "
+                        "this paper: https://arxiv.org/abs/1507.02105 . You "
+                        "can convert negative parallaxes to NaN distances by "
+                        "providing the `allow_negative=True` argument.")
 
         # now we have arguments like for a Quantity, so let it do the work
         distance = super().__new__(
@@ -173,8 +171,8 @@ class Distance(u.SpecificTypeQuantity):
             any_negative = np.any(distance.value < 0)
 
         if not allow_negative and any_negative:
-            raise ValueError("Distance must be >= 0.  Use the argument "
-                             "'allow_negative=True' to allow negative values.")
+            raise ValueError("distance must be >= 0. Use the argument "
+                             "`allow_negative=True` to allow negative values.")
 
         return distance
 

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -1936,7 +1936,7 @@ class SphericalRepresentation(BaseRepresentation):
             try:
                 self._distance = Distance(self._distance, copy=False)
             except ValueError as e:
-                if e.args[0].startswith('Distance must be >= 0'):
+                if e.args[0].startswith('distance must be >= 0'):
                     raise ValueError("Distance must be >= 0. To allow negative "
                                      "distance values, you must explicitly pass"
                                      " in a `Distance` object with the the "

--- a/astropy/coordinates/tests/test_distance.py
+++ b/astropy/coordinates/tests/test_distance.py
@@ -36,6 +36,9 @@ def test_distances():
     with pytest.raises(u.UnitsError):
         Distance(12)
 
+    with pytest.raises(ValueError, match='none of `value`, `z`, `distmod`,'):
+        Distance(unit=u.km)
+
     # standard units are pre-defined
     npt.assert_allclose(distance.lyr, 39.138765325702551)
     npt.assert_allclose(distance.km, 370281309776063.0)
@@ -120,11 +123,8 @@ def test_distances_scipy():
     d6 = Distance(z=0.23, cosmology=WMAP5, unit=u.km)
     npt.assert_allclose(d6.value, 3.5417046898762366e+22)
 
-    with pytest.raises(ValueError):
-        Distance(cosmology=WMAP5, unit=u.km)
-
-    with pytest.raises(ValueError):
-        Distance()
+    with pytest.raises(ValueError, match='a `cosmology` was given but `z`'):
+        Distance(parallax=1*u.mas, cosmology=WMAP5)
 
     # Regression test for #12531
     with pytest.raises(ValueError, match='more than one'):


### PR DESCRIPTION
### Description

This pull request contains two commits. The first refactors the `Distance` constructor by removing a level of indentation and reducing code duplication. The second commit implements (mostly) small changes to the error messages.

EDIT: I have added a third commit that updates the `Distance` docstring.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
