### PR TITLE
Enable using `unit` together with `parallax` in `Distance` constructor

### DIFF
--- a/astropy/coordinates/distances.py
+++ b/astropy/coordinates/distances.py
@@ -143,8 +143,9 @@ class Distance(u.SpecificTypeQuantity):
                 copy = False
 
             elif parallax is not None:
-                value = parallax.to_value(u.pc, equivalencies=u.parallax())
-                unit = u.pc
+                if unit is None:
+                    unit = u.pc
+                value = parallax.to_value(unit, equivalencies=u.parallax())
 
                 # Continue on to take account of unit and other arguments
                 # but a copy is already made, so no longer necessary

--- a/astropy/coordinates/tests/test_distance.py
+++ b/astropy/coordinates/tests/test_distance.py
@@ -241,6 +241,11 @@ def test_parallax():
     with pytest.warns(AstropyWarning):
         Distance(parallax=[10, 1, -1] * u.mas, allow_negative=True)
 
+    # Regression test for #12569; `unit` was ignored if `parallax` was given.
+    d = Distance(parallax=1*u.mas, unit=u.kpc)
+    assert d.value == 1.
+    assert d.unit is u.kpc
+
 
 def test_distance_in_coordinates():
     """

--- a/docs/changes/coordinates/12569.bugfix.rst
+++ b/docs/changes/coordinates/12569.bugfix.rst
@@ -1,0 +1,2 @@
+``astropy.coordinates.Distance`` constructor no longer ignores the ``unit``
+keyword when ``parallax`` is provided.


### PR DESCRIPTION
### Description

Currently if a `Distance` instance is created from a `parallax` then specifying `unit` has no effect and the resulting distance is always in parsecs.  This pull request enables specifying a different unit.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
