### PR TITLE
Ensure quantity.to_string(format='latex') always typesets big exponents. 

### DIFF
--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -1381,13 +1381,12 @@ class Quantity(np.ndarray):
             formatter = {'float_kind': float_formatter,
                          'complex_kind': complex_formatter}
             if conf.latex_array_threshold > -1:
-                np.set_printoptions(threshold=conf.latex_array_threshold,
-                                    formatter=formatter)
+                np.set_printoptions(threshold=conf.latex_array_threshold)
 
             # the view is needed for the scalar case - value might be float
             latex_value = np.array2string(
                 self.view(np.ndarray),
-                max_line_width=np.inf, separator=',~')
+                formatter=formatter, max_line_width=np.inf, separator=',~')
 
             latex_value = latex_value.replace('...', r'\dots')
         finally:

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -989,6 +989,7 @@ class TestQuantityDisplay:
             assert r'\dots' in lsbig
             lsvbig = qvbig._repr_latex_()
             assert r'\dots' in lsvbig
+            assert lsvbig.endswith(',~1 \\times 10^{13}] \\; \\mathrm{m}$')
         finally:
             # prevent side-effects from influencing other tests
             np.set_printoptions(**pops)

--- a/docs/changes/units/12573.bugfix.rst
+++ b/docs/changes/units/12573.bugfix.rst
@@ -1,0 +1,3 @@
+Ensure that ``Quantity.to_string(format='latex')`` properly typesets exponents
+also when ``u.quantity.conf.latex_array_threshold = -1`` (i.e., when the threshold
+is taken from numpy).


### PR DESCRIPTION
In current master, due to a bug, the formatter is not overridden when `u.quantity.conf.latex_array_threshold = -1` (i.e., when the threshold is taken from numpy).

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
