### PR TITLE
Numpy dev warning message change

### DIFF
--- a/astropy/modeling/tests/test_model_sets.py
+++ b/astropy/modeling/tests/test_model_sets.py
@@ -353,7 +353,7 @@ def test_linear_fit_model_set_common_weight():
     with pytest.raises(ValueError,
                        match='Found NaNs in the coefficient matrix'):
         with pytest.warns(RuntimeWarning,
-                          match=r'invalid value encountered in true_divide'):
+                          match=r'invalid value encountered in.*divide'):
             fitted_model = fitter(init_model, x, y, weights=np.zeros(10))
 
 
@@ -383,12 +383,12 @@ def test_linear_fit_model_set_weights():
     with pytest.raises(ValueError,
                        match='Found NaNs in the coefficient matrix'):
         with pytest.warns(RuntimeWarning,
-                          match=r'invalid value encountered in true_divide'):
+                          match=r'invalid value encountered in.*divide'):
             fitted_model = fitter(init_model, x, y, weights=weights)
 
     # Now we mask the values where weight is 0
     with pytest.warns(RuntimeWarning,
-                      match=r'invalid value encountered in true_divide'):
+                      match=r'invalid value encountered in.*divide'):
         fitted_model = fitter(init_model, x,
                               np.ma.array(y, mask=np.isclose(weights, 0)),
                               weights=weights)

--- a/astropy/nddata/mixins/tests/test_ndarithmetic.py
+++ b/astropy/nddata/mixins/tests/test_ndarithmetic.py
@@ -30,7 +30,7 @@ class StdDevUncertaintyUncorrelated(StdDevUncertainty):
 # Test with Data covers:
 # scalars, 1D, 2D and 3D
 # broadcasting between them
-@pytest.mark.filterwarnings("ignore:divide by zero encountered in true_divide")
+@pytest.mark.filterwarnings("ignore:divide by zero encountered.*")
 @pytest.mark.parametrize(('data1', 'data2'), [
                          (np.array(5), np.array(10)),
                          (np.array(5), np.arange(10)),
@@ -85,7 +85,7 @@ def test_arithmetics_data_invalid():
 # identical units (even dimensionless unscaled vs. no unit),
 # equivalent units (such as meter and kilometer)
 # equivalent composite units (such as m/s and km/h)
-@pytest.mark.filterwarnings("ignore:divide by zero encountered in true_divide")
+@pytest.mark.filterwarnings("ignore:divide by zero encountered.*")
 @pytest.mark.parametrize(('data1', 'data2'), [
     (np.array(5) * u.s, np.array(10) * u.s),
     (np.array(5) * u.s, np.arange(10) * u.h),
@@ -533,7 +533,7 @@ def test_arithmetics_varianceuncertainty_basic_with_correlation(
 # The point of this test is to compare the used formula to the theoretical one.
 # TODO: Maybe covering units too but I think that should work because of
 # the next tests. Also this may be reduced somehow.
-@pytest.mark.filterwarnings("ignore:divide by zero encountered in true_divide")
+@pytest.mark.filterwarnings("ignore:divide by zero encountered.*")
 @pytest.mark.parametrize(('cor', 'uncert1', 'data2'), [
     (-1, [1, 1, 3], [2, 2, 7]),
     (-0.5, [1, 1, 3], [2, 2, 7]),
@@ -710,7 +710,7 @@ def test_arithmetics_stddevuncertainty_one_missing():
 # Covering:
 # data with unit and uncertainty with unit (but equivalent units)
 # compared against correctly scaled NDDatas
-@pytest.mark.filterwarnings("ignore:.*encountered in true_divide.*")
+@pytest.mark.filterwarnings("ignore:.*encountered in.*divide.*")
 @pytest.mark.parametrize(('uncert1', 'uncert2'), [
     (np.array([1, 2, 3]) * u.m, None),
     (np.array([1, 2, 3]) * u.cm, None),
@@ -814,7 +814,7 @@ def test_arithmetics_stddevuncertainty_with_units(uncert1, uncert2):
 # Covering:
 # data with unit and uncertainty with unit (but equivalent units)
 # compared against correctly scaled NDDatas
-@pytest.mark.filterwarnings("ignore:.*encountered in true_divide.*")
+@pytest.mark.filterwarnings("ignore:.*encountered in.*divide.*")
 @pytest.mark.parametrize(('uncert1', 'uncert2'), [
     (np.array([1, 2, 3]) * u.m, None),
     (np.array([1, 2, 3]) * u.cm, None),
@@ -918,7 +918,7 @@ def test_arithmetics_varianceuncertainty_with_units(uncert1, uncert2):
 # Covering:
 # data with unit and uncertainty with unit (but equivalent units)
 # compared against correctly scaled NDDatas
-@pytest.mark.filterwarnings("ignore:.*encountered in true_divide.*")
+@pytest.mark.filterwarnings("ignore:.*encountered in.*divide.*")
 @pytest.mark.parametrize(('uncert1', 'uncert2'), [
     (np.array([1, 2, 3]) * u.m, None),
     (np.array([1, 2, 3]) * u.cm, None),

--- a/astropy/utils/masked/tests/test_masked.py
+++ b/astropy/utils/masked/tests/test_masked.py
@@ -824,7 +824,7 @@ class TestMaskedArrayMethods(MaskedArraySetup):
         assert result is out
         assert_masked_equal(out, expected)
 
-    @pytest.mark.filterwarnings("ignore:.*true_divide.*")
+    @pytest.mark.filterwarnings("ignore:.*encountered in.*divide")
     @pytest.mark.parametrize('axis', (0, 1, None))
     def test_var(self, axis):
         ma_var = self.ma.var(axis)


### PR DESCRIPTION
Fixes #12580

Hopefully, with this the -dev run is green again - definitely not an allowed failure!
### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
