### PR TITLE
pickle structured units

### DIFF
--- a/astropy/units/structured.py
+++ b/astropy/units/structured.py
@@ -487,6 +487,12 @@ class StructuredUnit:
 
         return self.values() != other.values()
 
+    def __reduce_ex__(self, protocol):
+        state = list(super().__reduce_ex__(protocol))
+        if protocol >= 2:
+            state[1] += (str(self), )  # add in ``units`` argument
+        return tuple(state)
+
 
 class Structure(np.void):
     """Single element structure for physical type IDs, etc.

--- a/astropy/units/structured.py
+++ b/astropy/units/structured.py
@@ -180,6 +180,9 @@ class StructuredUnit:
         self._units = np.array(tuple(converted), dtype)[()]
         return self
 
+    def __getnewargs__(self):
+        return (), None
+
     @property
     def field_names(self):
         """Possibly nested tuple of the field names of the parts."""
@@ -486,12 +489,6 @@ class StructuredUnit:
                 return NotImplemented
 
         return self.values() != other.values()
-
-    def __reduce_ex__(self, protocol):
-        state = list(super().__reduce_ex__(protocol))
-        if protocol >= 2:
-            state[1] += (str(self), )  # add in ``units`` argument
-        return tuple(state)
 
 
 class Structure(np.void):

--- a/astropy/units/tests/test_structured.py
+++ b/astropy/units/tests/test_structured.py
@@ -3,6 +3,8 @@
 """
 Test Structured units and quantities.
 """
+import copy
+
 import pytest
 import numpy as np
 import numpy.lib.recfunctions as rfn
@@ -194,9 +196,22 @@ class TestStructuredUnitBasics(StructuredTestBase):
         assert repr(su) == 'Unit("((km, km / s), yr)")'
         assert eval(repr(su)) == su
 
+
+class TestStructuredUnitsCopyPickle(StructuredTestBaseWithUnits):
+    def test_copy(self):
+        su_copy = copy.copy(self.pv_t_unit)
+        assert su_copy is not self.pv_t_unit
+        assert su_copy == self.pv_t_unit
+        assert su_copy._units is self.pv_t_unit._units
+
+    def test_deepcopy(self):
+        su_copy = copy.deepcopy(self.pv_t_unit)
+        assert su_copy is not self.pv_t_unit
+        assert su_copy == self.pv_t_unit
+        assert su_copy._units is not self.pv_t_unit._units
+
     def test_pickle(self, pickle_protocol):
-        su = StructuredUnit(((u.km, u.km/u.s), u.yr))
-        check_pickling_recovery(su, pickle_protocol)
+        check_pickling_recovery(self.pv_t_unit, pickle_protocol)
 
 
 class TestStructuredUnitAsMapping(StructuredTestBaseWithUnits):

--- a/astropy/units/tests/test_structured.py
+++ b/astropy/units/tests/test_structured.py
@@ -10,6 +10,7 @@ from numpy.testing import assert_array_equal
 
 from astropy import units as u
 from astropy.units import StructuredUnit, Unit, UnitBase, Quantity
+from astropy.tests.helper import pickle_protocol, check_pickling_recovery
 from astropy.utils.masked import Masked
 
 
@@ -192,6 +193,10 @@ class TestStructuredUnitBasics(StructuredTestBase):
         su = StructuredUnit(((u.km, u.km/u.s), u.yr))
         assert repr(su) == 'Unit("((km, km / s), yr)")'
         assert eval(repr(su)) == su
+
+    def test_pickle(self, pickle_protocol):
+        su = StructuredUnit(((u.km, u.km/u.s), u.yr))
+        check_pickling_recovery(su, pickle_protocol)
 
 
 class TestStructuredUnitAsMapping(StructuredTestBaseWithUnits):

--- a/docs/changes/units/12583.bugfix.rst
+++ b/docs/changes/units/12583.bugfix.rst
@@ -1,0 +1,1 @@
+Structured units can be pickled and unpicked when ``protocol`` >= 2.

--- a/docs/changes/units/12583.bugfix.rst
+++ b/docs/changes/units/12583.bugfix.rst
@@ -1,1 +1,2 @@
-Structured units can be pickled and unpicked when ``protocol`` >= 2.
+Structured units can now be copied with ``copy.copy`` and ``copy.deepcopy``
+and also pickled and unpicked also for ``protocol`` >= 2.


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

### Description

Allows structured units to be pickled and unpicked when ``protocol`` >= 2.

Fixes #12575

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
