### PR TITLE
Make `_fitter_to_model_params` and `_model_to_fit_params` public.

### DIFF
--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -532,7 +532,7 @@ class LinearLSQFitter(metaclass=_FitterMeta):
 
         model_copy = model.copy()
         model_copy.sync_constraints = False
-        _, fitparam_indices = _model_to_fit_params(model_copy)
+        _, fitparam_indices = model_to_fit_params(model_copy)
 
         if model_copy.n_inputs == 2 and z is None:
             raise ValueError("Expected x, y and z for a 2 dimensional model.")
@@ -1150,7 +1150,7 @@ class LevMarLSQFitter(metaclass=_FitterMeta):
             dfunc = None
         else:
             dfunc = self._wrap_deriv
-        init_values, _ = _model_to_fit_params(model_copy)
+        init_values, _ = model_to_fit_params(model_copy)
         fitparams, cov_x, dinfo, mess, ierr = optimize.leastsq(
             self.objective_function, init_values, args=farg, Dfun=dfunc,
             col_deriv=model_copy.col_fit_deriv, maxfev=maxiter, epsfcn=epsilon,
@@ -1310,7 +1310,7 @@ class SLSQPLSQFitter(Fitter):
         model_copy.sync_constraints = False
         farg = _convert_input(x, y, z)
         farg = (model_copy, weights, ) + farg
-        init_values, _ = _model_to_fit_params(model_copy)
+        init_values, _ = model_to_fit_params(model_copy)
         fitparams, self.fit_info = self._opt_method(
             self.objective_function, init_values, farg, **kwargs)
         fitter_to_model_params(model_copy, fitparams)
@@ -1378,7 +1378,7 @@ class SimplexLSQFitter(Fitter):
         farg = _convert_input(x, y, z)
         farg = (model_copy, weights, ) + farg
 
-        init_values, _ = _model_to_fit_params(model_copy)
+        init_values, _ = model_to_fit_params(model_copy)
 
         fitparams, self.fit_info = self._opt_method(
             self.objective_function, init_values, farg, **kwargs)
@@ -1409,14 +1409,14 @@ class JointFitter(metaclass=_FitterMeta):
         self.initvals = list(initvals)
         self.jointparams = jointparameters
         self._verify_input()
-        self.fitparams = self._model_to_fit_params()
+        self.fitparams = self.model_to_fit_params()
 
         # a list of model.n_inputs
         self.modeldims = [m.n_inputs for m in self.models]
         # sum all model dimensions
         self.ndim = np.sum(self.modeldims)
 
-    def _model_to_fit_params(self):
+    def model_to_fit_params(self):
         fparams = []
         fparams.extend(self.initvals)
         for model in self.models:
@@ -1599,7 +1599,7 @@ def fitter_to_model_params(model, fps):
     constrained parameters.
     """
 
-    _, fit_param_indices = _model_to_fit_params(model)
+    _, fit_param_indices = model_to_fit_params(model)
 
     has_tied = any(model.tied.values())
     has_fixed = any(model.fixed.values())
@@ -1656,7 +1656,7 @@ def fitter_to_model_params(model, fps):
                 model._array_to_parameters()
 
 
-def _model_to_fit_params(model):
+def model_to_fit_params(model):
     """
     Convert a model instance's parameter array to an array that can be used
     with a fitter that doesn't natively support fixed or tied parameters.

--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -315,7 +315,7 @@ class Fitter(metaclass=_FitterMeta):
         """
         model = args[0]
         meas = args[-1]
-        _fitter_to_model_params(model, fps)
+        fitter_to_model_params(model, fps)
         res = self._stat_method(meas, model, *args[1:-1])
         return res
 
@@ -768,7 +768,7 @@ class LinearLSQFitter(metaclass=_FitterMeta):
         lacoef /= scl[:, np.newaxis] if scl.ndim < rhs.ndim else scl
         self.fit_info['params'] = lacoef
 
-        _fitter_to_model_params(model_copy, lacoef.flatten())
+        fitter_to_model_params(model_copy, lacoef.flatten())
 
         # TODO: Only Polynomial models currently have an _order attribute;
         # maybe change this to read isinstance(model, PolynomialBase)
@@ -1075,7 +1075,7 @@ class LevMarLSQFitter(metaclass=_FitterMeta):
 
         model = args[0]
         weights = args[1]
-        _fitter_to_model_params(model, fps)
+        fitter_to_model_params(model, fps)
         meas = args[-1]
         if weights is None:
             return np.ravel(model(*args[2: -1]) - meas)
@@ -1155,7 +1155,7 @@ class LevMarLSQFitter(metaclass=_FitterMeta):
             self.objective_function, init_values, args=farg, Dfun=dfunc,
             col_deriv=model_copy.col_fit_deriv, maxfev=maxiter, epsfcn=epsilon,
             xtol=acc, full_output=True)
-        _fitter_to_model_params(model_copy, fitparams)
+        fitter_to_model_params(model_copy, fitparams)
         self.fit_info.update(dinfo)
         self.fit_info['cov_x'] = cov_x
         self.fit_info['message'] = mess
@@ -1197,7 +1197,7 @@ class LevMarLSQFitter(metaclass=_FitterMeta):
 
         if any(model.fixed.values()) or any(model.tied.values()):
             # update the parameters with the current values from the fitter
-            _fitter_to_model_params(model, params)
+            fitter_to_model_params(model, params)
             if z is None:
                 full = np.array(model.fit_deriv(x, *model.parameters))
                 if not model.col_fit_deriv:
@@ -1313,7 +1313,7 @@ class SLSQPLSQFitter(Fitter):
         init_values, _ = _model_to_fit_params(model_copy)
         fitparams, self.fit_info = self._opt_method(
             self.objective_function, init_values, farg, **kwargs)
-        _fitter_to_model_params(model_copy, fitparams)
+        fitter_to_model_params(model_copy, fitparams)
 
         model_copy.sync_constraints = True
         return model_copy
@@ -1382,7 +1382,7 @@ class SimplexLSQFitter(Fitter):
 
         fitparams, self.fit_info = self._opt_method(
             self.objective_function, init_values, farg, **kwargs)
-        _fitter_to_model_params(model_copy, fitparams)
+        fitter_to_model_params(model_copy, fitparams)
         model_copy.sync_constraints = True
         return model_copy
 
@@ -1593,7 +1593,7 @@ def _convert_input(x, y, z=None, n_models=1, model_set_axis=0):
 # its own versions of these)
 # TODO: Most of this code should be entirely rewritten; it should not be as
 # inefficient as it is.
-def _fitter_to_model_params(model, fps):
+def fitter_to_model_params(model, fps):
     """
     Constructs the full list of model parameters from the fitted and
     constrained parameters.

--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -34,6 +34,7 @@ import numpy as np
 
 from astropy.units import Quantity
 from astropy.utils.exceptions import AstropyUserWarning
+from astropy.utils.decorators import deprecated
 from .utils import poly_map_domain, _combine_equivalency_dict
 from .optimizers import (SLSQP, Simplex)
 from .statistic import (leastsquare)
@@ -1656,6 +1657,11 @@ def fitter_to_model_params(model, fps):
                 model._array_to_parameters()
 
 
+@deprecated('5.1', 'private method: _fitter_to_model_params has been made public now')
+def _fitter_to_model_params(model, fps):
+    return fitter_to_model_params(model, fps)
+
+
 def model_to_fit_params(model):
     """
     Convert a model instance's parameter array to an array that can be used
@@ -1677,6 +1683,11 @@ def model_to_fit_params(model):
                 del fitparam_indices[idx]
         return (np.array(params), fitparam_indices)
     return (model.parameters, fitparam_indices)
+
+
+@deprecated('5.1', 'private method: _model_to_fit_params has been made public now')
+def _model_to_fit_params(model):
+    return model_to_fit_params(model)
 
 
 def _validate_constraints(supported_constraints, model):

--- a/docs/changes/modeling/12585.api.rst
+++ b/docs/changes/modeling/12585.api.rst
@@ -1,0 +1,2 @@
+Made ``astropy.modeling.fitting._fitter_to_model_params`` and ``astropy.modeling.fitting._model_to_fit_params``
+public methods.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

Use of the methods `_fitter_to_model_params` and `_model_to_fit_params` from `astropy.modeling.fitting` when creating custom fitters or subclassing fitters has come up a few times for me recently (and others see #11735). It is unfortunate that these functions are private because using them externally then posses some dangers. Since using these methods is sometimes necessary when creating one's own fitters, this PR makes these methods public to avoid the issues associated with using astropy private methods outside astropy.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #11735

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
