### PR TITLE
Fix structured units deserialization

### DIFF
--- a/astropy/units/structured.py
+++ b/astropy/units/structured.py
@@ -181,6 +181,7 @@ class StructuredUnit:
         return self
 
     def __getnewargs__(self):
+        """When de-serializing, e.g. pickle, start with a blank structure."""
         return (), None
 
     @property

--- a/astropy/units/tests/test_structured.py
+++ b/astropy/units/tests/test_structured.py
@@ -13,6 +13,7 @@ from numpy.testing import assert_array_equal
 from astropy import units as u
 from astropy.units import StructuredUnit, Unit, UnitBase, Quantity
 from astropy.tests.helper import pickle_protocol, check_pickling_recovery
+from astropy.utils.compat import NUMPY_LT_1_21_1
 from astropy.utils.masked import Masked
 
 
@@ -210,6 +211,7 @@ class TestStructuredUnitsCopyPickle(StructuredTestBaseWithUnits):
         assert su_copy == self.pv_t_unit
         assert su_copy._units is not self.pv_t_unit._units
 
+    @pytest.mark.skipif(NUMPY_LT_1_21_1, reason="https://stackoverflow.com/q/69571643")
     def test_pickle(self, pickle_protocol):
         check_pickling_recovery(self.pv_t_unit, pickle_protocol)
 

--- a/docs/changes/units/12583.bugfix.rst
+++ b/docs/changes/units/12583.bugfix.rst
@@ -1,2 +1,3 @@
 Structured units can now be copied with ``copy.copy`` and ``copy.deepcopy``
 and also pickled and unpicked also for ``protocol`` >= 2.
+This does not work for big-endian architecture with older ``numpy<1.21.1``.

--- a/docs/known_issues.rst
+++ b/docs/known_issues.rst
@@ -189,6 +189,14 @@ issues a ``numpy.ComplexWarning``.  This inconsistency persists between
 complex numbers.  To get the real part of a complex number, it is
 recommended to use ``numpy.real``.
 
+.. _structured_unit_deserialization_segfault:
+
+Structured units deserialization segfaults in big-endian
+--------------------------------------------------------
+
+Structured units deserialization with ``pickle`` may cause segmentation
+fault in big-endian machine with ``numpy<1.21.1``.
+
 Build/Installation/Test Issues
 ==============================
 


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

### Description

See #12586

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
