### PR TITLE
check if `data_class` has method for doc updates

### DIFF
--- a/astropy/io/registry/base.py
+++ b/astropy/io/registry/base.py
@@ -382,7 +382,12 @@ class _UnifiedIORegistryBase(metaclass=abc.ABCMeta):
         """
         Update the docstring to include all the available readers / writers for
         the ``data_class.read``/``data_class.write`` functions (respectively).
+        Don't update if the data_class does not have the relevant method.
         """
+        # abort if method "readwrite" isn't on data_class
+        if not hasattr(data_class, readwrite):
+            return
+
         from .interface import UnifiedReadWrite
 
         FORMATS_TEXT = 'The available built-in formats are:'


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

### Description

The registry checks for a method on `data_class` and tries to update the docs.
If the method doesn't exist the registration will fail.
It shouldn't as the method is not necessary for any part of the I/O.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
