### PR TITLE
Allow structured dtype for column serialization.

### DIFF
--- a/astropy/io/ascii/tests/test_ecsv.py
+++ b/astropy/io/ascii/tests/test_ecsv.py
@@ -299,6 +299,8 @@ tm2 = Time(tm, format='iso')
 tm3 = Time(tm, location=el)
 tm3.info.serialize_method['ecsv'] = 'jd1_jd2'
 obj = Column([{'a': 1}, {'b': [2]}], dtype='object')
+su = Column([(1, (1.5, 1.6)),
+             (2, (2.5, 2.6))], dtype=[('i', np.int64), ('f', np.float64, (2,))])
 tab = Table({'tm': tm, 'c': [1, 2], 'x': [3, 4] * u.m})
 qtab = QTable({'tm': tm, 'c': [1, 2], 'x': [3, 4] * u.m})
 
@@ -330,6 +332,7 @@ mixin_cols = {
     'srd': srd,
     'nd': NdarrayMixin([1, 2]),
     'obj': obj,
+    'su': su,
     'tab': tab,
     'qtab': qtab
 }
@@ -367,6 +370,7 @@ compare_attrs = {
     'srd': ['lon', 'lat', 'distance', 'differentials.s.d_lon_coslat',
             'differentials.s.d_lat', 'differentials.s.d_distance'],
     'obj': [],
+    'su': ['i', 'f'],
     'tab': ['tm', 'c', 'x'],
     'qtab': ['tm', 'c', 'x'],
 }
@@ -458,6 +462,7 @@ def test_ecsv_mixins_as_one(table_cls):
                         'srd.differentials.s.d_lon_coslat',
                         'srd.differentials.s.d_lat',
                         'srd.differentials.s.d_distance',
+                        'su.i', 'su.f',
                         'tab.tm',
                         'tab.c',
                         'tab.x',

--- a/astropy/table/info.py
+++ b/astropy/table/info.py
@@ -8,7 +8,7 @@ from contextlib import contextmanager
 from inspect import isclass
 
 import numpy as np
-from astropy.utils.data_info import DataInfo
+from astropy.utils.data_info import ParentDtypeInfo
 
 __all__ = ['table_info', 'TableInfo', 'serialize_method_as']
 
@@ -116,11 +116,22 @@ def table_info(tbl, option='attributes', out=''):
     out.writelines(outline + os.linesep for outline in outlines)
 
 
-class TableInfo(DataInfo):
+class TableInfo(ParentDtypeInfo):
     def __call__(self, option='attributes', out=''):
         return table_info(self._parent, option, out)
 
     __call__.__doc__ = table_info.__doc__
+
+    def _represent_as_dict(self):
+        return dict(self._parent.columns)
+
+    def _construct_from_dict(self, map):
+        return super()._construct_from_dict({'data': map})
+
+    @staticmethod
+    def default_format(val):
+        return val.table[val.index:val.index+1].pformat(
+            max_width=-1, show_name=False, show_unit=False, show_dtype=False)[0]
 
 
 @contextmanager

--- a/astropy/table/serialize.py
+++ b/astropy/table/serialize.py
@@ -39,6 +39,8 @@ __construct_mixin_classes = (
     'astropy.table.ndarray_mixin.NdarrayMixin',
     'astropy.table.table_helpers.ArrayWrapper',
     'astropy.table.column.MaskedColumn',
+    'astropy.table.table.Table',
+    'astropy.table.table.QTable',
     'astropy.coordinates.representation.CartesianRepresentation',
     'astropy.coordinates.representation.UnitSphericalRepresentation',
     'astropy.coordinates.representation.RadialRepresentation',

--- a/astropy/table/serialize.py
+++ b/astropy/table/serialize.py
@@ -328,15 +328,20 @@ def _construct_mixin_from_columns(new_name, obj_attrs, out):
     for name in data_attrs_map.values():
         del obj_attrs[name]
 
-    # Get the index where to add new column
-    idx = min(out.colnames.index(name) for name in data_attrs_map)
+    # YAML maps order alphabetically by key, while python code may expect
+    # the order in which the data were stored, so use the order in which the
+    # attributes appear in the serialized parts.
+    names = sorted(data_attrs_map, key=out.colnames.index)
+    # Similarly, we keep the index where to add new column, so that
+    # the output table keeps order as well.
+    idx = out.colnames.index(names[0])
 
     # Name is the column name in the table (e.g. "coord.ra") and
     # data_attr is the object attribute name  (e.g. "ra").  A different
     # example would be a formatted time object that would have (e.g.)
     # "time_col" and "value", respectively.
-    for name, data_attr in data_attrs_map.items():
-        obj_attrs[data_attr] = out[name]
+    for name in names:
+        obj_attrs[data_attrs_map[name]] = out[name]
         del out[name]
 
     info = obj_attrs.pop('__info__', {})

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -1072,7 +1072,7 @@ class Table:
         Coercion to a different dtype via np.array(table, dtype) is not
         supported and will raise a ValueError.
         """
-        if dtype is not None:
+        if dtype is not None and dtype != self.dtype:
             raise ValueError('Datatype coercion is not allowed')
 
         # This limitation is because of the following unexpected result that
@@ -2051,6 +2051,14 @@ class Table:
             # Get the first column name
             self._first_colname = next(iter(self.columns))
             return len(self.columns[self._first_colname])
+
+    @property
+    def shape(self):
+        """The shape of the table - a single-element tuple with the length.
+
+        This exists mostly for use of a table as a mixin column.
+        """
+        return (len(self),)
 
     def index_column(self, name):
         """

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -1242,13 +1242,6 @@ class Table:
                                 f'{fully_qualified_name} '
                                 'did not return a valid mixin column')
 
-        # Structured ndarray gets viewed as a mixin unless already a valid
-        # mixin class
-        if (not isinstance(data, Column) and not data_is_mixin
-                and isinstance(data, np.ndarray) and len(data.dtype) > 1):
-            data = data.view(NdarrayMixin)
-            data_is_mixin = True
-
         # Get the final column name using precedence.  Some objects may not
         # have an info attribute. Also avoid creating info as a side effect.
         if not name:

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -831,6 +831,16 @@ def test_primary_data_column_gets_description():
     assert tser['a'].description == 'parrot'
 
 
+@pytest.mark.parametrize('table_types', (Table, QTable))
+def test_table_as_mixin(table_types):
+    t = table_types({'a': [1, 2] * u.m, 'b': ['a', 'b']})
+    t['t'] = t
+    tser = serialize.represent_mixins_as_columns(t)
+    assert list(tser.columns.keys()) == ['a', 'b', 't.a', 't.b']
+    trec = serialize._construct_mixins_from_columns(tser)
+    assert np.all(trec == t)
+
+
 def test_skycoord_with_velocity():
     # Regression test for gh-6447
     sc = SkyCoord([1], [2], unit='deg', galcen_v_sun=None)

--- a/docs/changes/table/12610.feature.rst
+++ b/docs/changes/table/12610.feature.rst
@@ -1,0 +1,2 @@
+``Table`` and ``QTable`` can now be used as columns in other tables,
+and will be properly serialized to ECSV, etc.


### PR DESCRIPTION
Trial for addressing #12577, with some non-trivial test already in `test_ecsv.py`.

With this:
```
from astropy.table import QTable, Table, Column, MaskedColumn
tbl = QTable({"a": Column([(0.1, 0.3, 0.6)], dtype='f8,f8,f8', description='description', unit='m,cm,s'), "b": ['abcdef'], "c": MaskedColumn([1.], mask=[True]), "d": MaskedColumn([(0.5, 0.1, 0.6)], dtype='f8,f8,f8', mask=[(True, False, True)])})
tbl.write('temp.ecsv', overwrite=True, serialize_method='data_mask')
QTable.read('temp.ecsv') == tbl
masked_array(data=[True],
             mask=[False],
       fill_value=True)
```

The file looks as follows
```
# %ECSV 1.0
# ---
# datatype:
# - {name: a.f0, unit: m, datatype: float64}
# - {name: a.f1, unit: cm, datatype: float64}
# - {name: a.f2, unit: s, datatype: float64}
# - {name: b, datatype: string}
# - {name: c, datatype: float64}
# - {name: c.mask, datatype: bool}
# - {name: d.f0, datatype: float64}
# - {name: d.f0.mask, datatype: bool}
# - {name: d.f1, datatype: float64}
# - {name: d.f2, datatype: float64}
# - {name: d.f2.mask, datatype: bool}
# meta: !!omap
# - __serialized_columns__:
#     a:
#       __class__: astropy.units.quantity.Quantity
#       __info__: {description: description}
#       unit: &id001 !astropy.units.Unit {unit: '(m, cm, s)'}
#       value: !astropy.table.SerializedColumn
#         __class__: astropy.table.column.Column
#         __info__:
#           description: description
#           unit: *id001
#         __shape__: []
#         f0: !astropy.table.SerializedColumn {name: a.f0}
#         f1: !astropy.table.SerializedColumn {name: a.f1}
#         f2: !astropy.table.SerializedColumn {name: a.f2}
#     c:
#       __class__: astropy.table.column.MaskedColumn
#       data: !astropy.table.SerializedColumn {name: c}
#       mask: !astropy.table.SerializedColumn {name: c.mask}
#     d:
#       __class__: astropy.table.column.MaskedColumn
#       __shape__: []
#       f0: !astropy.table.SerializedColumn
#         __class__: astropy.table.column.MaskedColumn
#         data: !astropy.table.SerializedColumn {name: d.f0}
#         mask: !astropy.table.SerializedColumn {name: d.f0.mask}
#       f1: !astropy.table.SerializedColumn {name: d.f1}
#       f2: !astropy.table.SerializedColumn
#         __class__: astropy.table.column.MaskedColumn
#         data: !astropy.table.SerializedColumn {name: d.f2}
#         mask: !astropy.table.SerializedColumn {name: d.f2.mask}
# schema: astropy-2.0
a.f0 a.f1 a.f2 b c c.mask d.f0 d.f0.mask d.f1 d.f2 d.f2.mask
0.1 0.3 0.6 abcdef 1.0 True 0.5 True 0.1 0.6 True
```