### PR TITLE
Omega total

### DIFF
--- a/astropy/cosmology/flrw.py
+++ b/astropy/cosmology/flrw.py
@@ -286,6 +286,11 @@ class FLRW(Cosmology):
     # properties
 
     @property
+    def Otot0(self):
+        """Omega total; the total density/critical density at z=0."""
+        return self._Om0 + self._Ogamma0 + self._Onu0 + self._Ode0 + self._Ok0
+
+    @property
     def Odm0(self):
         """Omega dark matter; dark matter density/critical density at z=0."""
         return self._Odm0
@@ -364,6 +369,22 @@ class FLRW(Cosmology):
         This must be overridden by subclasses.
         """
         raise NotImplementedError("w(z) is not implemented")
+
+    def Otot(self, z):
+        """The total density parameter at redshift ``z``.
+
+        Parameters
+        ----------
+        z : Quantity-like ['redshift'], array-like, or `~numbers.Number`
+            Input redshifts.
+
+        Returns
+        -------
+        Otot : ndarray or float
+            The total density relative to the critical density at each redshift.
+            Returns float if input scalar.
+        """
+        return self.Om(z) + self.Ogamma(z) + self.Onu(z) + self.Ode(z) + self.Ok(z)
 
     def Om(self, z):
         """
@@ -1432,6 +1453,26 @@ class FlatFLRWMixin(FlatCosmologyMixin):
         # Do some twiddling after the fact to get flatness
         self._Ode0 = 1.0 - self._Om0 - self._Ogamma0 - self._Onu0
         self._Ok0 = 0.0
+
+    @property
+    def Otot0(self):
+        """Omega total; the total density/critical density at z=0."""
+        return 1.0
+
+    def Otot(self, z):
+        """The total density parameter at redshift ``z``.
+
+        Parameters
+        ----------
+        z : Quantity-like ['redshift'], array-like, or `~numbers.Number`
+            Input redshifts.
+
+        Returns
+        -------
+        Otot : ndarray or float
+            Returns float if input scalar. Value of 1.
+        """
+        return 1.0 if isinstance(z, (Number, np.generic)) else np.ones_like(z, subok=False)
 
     def __equiv__(self, other):
         """flat-FLRW equivalence. Use ``.is_equivalent()`` for actual check!

--- a/astropy/cosmology/tests/test_cosmology.py
+++ b/astropy/cosmology/tests/test_cosmology.py
@@ -15,26 +15,6 @@ from astropy.utils.compat.optional_deps import HAS_SCIPY
 from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyUserWarning
 
 
-def test_basic():
-    cosmo = flrw.FlatLambdaCDM(H0=70, Om0=0.27, Tcmb0=2.0, Neff=3.04,
-                               Ob0=0.05, name="test", meta={"a": "b"})
-    # This next test will fail if astropy.const starts returning non-mks
-    #  units by default; see the comment at the top of core.py
-    assert allclose(cosmo.Om0 + cosmo.Ode0 + cosmo.Ogamma0 + cosmo.Onu0,
-                    1.0, rtol=1e-6)
-    assert allclose(cosmo.Om(1) + cosmo.Ode(1) + cosmo.Ogamma(1) +
-                    cosmo.Onu(1), 1.0, rtol=1e-6)
-
-    # Make sure setting them as quantities gives the same results
-    H0 = u.Quantity(70, u.km / (u.s * u.Mpc))
-    T = u.Quantity(2.0, u.K)
-    cosmo = flrw.FlatLambdaCDM(H0=H0, Om0=0.27, Tcmb0=T, Neff=3.04, Ob0=0.05)
-    assert allclose(cosmo.Om0 + cosmo.Ode0 + cosmo.Ogamma0 + cosmo.Onu0,
-                    1.0, rtol=1e-6)
-    assert allclose(cosmo.Om(1) + cosmo.Ode(1) + cosmo.Ogamma(1) +
-                    cosmo.Onu(1), 1.0, rtol=1e-6)
-
-
 @pytest.mark.skipif('not HAS_SCIPY')
 def test_units():
     """ Test if the right units are being returned"""

--- a/astropy/cosmology/tests/test_funcs.py
+++ b/astropy/cosmology/tests/test_funcs.py
@@ -228,7 +228,7 @@ def test_z_at_value_roundtrip(cosmo):
     # special handling
     # clone is not a redshift-dependent method
     # nu_relative_density is not redshift-dependent in the WMAP cosmologies
-    skip = ('Ok',
+    skip = ('Ok', 'Otot',
             'angular_diameter_distance_z1z2',
             'clone', 'is_equivalent',
             'de_density_scale', 'w')

--- a/docs/changes/cosmology/12590.feature.rst
+++ b/docs/changes/cosmology/12590.feature.rst
@@ -1,0 +1,2 @@
+Add methods ``Otot`` and ``Otot0`` to FLRW cosmologies to calculate the total
+energy density of the Universe.


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

### Description

Add methods ``Otot`` and ``Otot0`` to FLRW cosmologies to calculate the total energy density of the Universe.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
