### PR TITLE
Simplify `Or` in cosmology internals

### DIFF
--- a/astropy/cosmology/flrw.py
+++ b/astropy/cosmology/flrw.py
@@ -730,10 +730,8 @@ class FLRW(Cosmology):
         It is not necessary to override this method, but if de_density_scale
         takes a particularly simple form, it may be advantageous to.
         """
-        if self._massivenu:
-            Or = self._Ogamma0 * (1 + self.nu_relative_density(z))
-        else:
-            Or = self._Ogamma0 + self._Onu0
+        Or = self._Ogamma0 + (self._Onu0 if not self._massivenu
+                              else self._Ogamma0 * self.nu_relative_density(z))
         zp1 = aszarr(z) + 1.0  # (converts z [unit] -> z [dimensionless])
 
         return np.sqrt(zp1 ** 2 * ((Or * zp1 + self._Om0) * zp1 + self._Ok0) +
@@ -754,10 +752,8 @@ class FLRW(Cosmology):
             Returns `float` if the input is scalar.
         """
         # Avoid the function overhead by repeating code
-        if self._massivenu:
-            Or = self._Ogamma0 * (1 + self.nu_relative_density(z))
-        else:
-            Or = self._Ogamma0 + self._Onu0
+        Or = self._Ogamma0 + (self._Onu0 if not self._massivenu
+                              else self._Ogamma0 * self.nu_relative_density(z))
         zp1 = aszarr(z) + 1.0  # (converts z [unit] -> z [dimensionless])
 
         return (zp1 ** 2 * ((Or * zp1 + self._Om0) * zp1 + self._Ok0) +
@@ -2011,10 +2007,8 @@ class LambdaCDM(FLRW):
         """
         # We override this because it takes a particularly simple
         # form for a cosmological constant
-        if self._massivenu:
-            Or = self._Ogamma0 * (1. + self.nu_relative_density(z))
-        else:
-            Or = self._Ogamma0 + self._Onu0
+        Or = self._Ogamma0 + (self._Onu0 if not self._massivenu
+                              else self._Ogamma0 * self.nu_relative_density(z))
         zp1 = aszarr(z) + 1.0  # (converts z [unit] -> z [dimensionless])
 
         return np.sqrt(zp1 ** 2 * ((Or * zp1 + self._Om0) * zp1 + self._Ok0) + self._Ode0)
@@ -2034,10 +2028,8 @@ class LambdaCDM(FLRW):
             Returns `float` if the input is scalar.
             Defined such that :math:`H_z = H_0 / E`.
         """
-        if self._massivenu:
-            Or = self._Ogamma0 * (1 + self.nu_relative_density(z))
-        else:
-            Or = self._Ogamma0 + self._Onu0
+        Or = self._Ogamma0 + (self._Onu0 if not self._massivenu
+                              else self._Ogamma0 * self.nu_relative_density(z))
         zp1 = aszarr(z) + 1.0  # (converts z [unit] -> z [dimensionless])
 
         return (zp1 ** 2 * ((Or * zp1 + self._Om0) * zp1 + self._Ok0) + self._Ode0)**(-0.5)
@@ -2138,10 +2130,8 @@ class FlatLambdaCDM(FlatFLRWMixin, LambdaCDM):
         """
         # We override this because it takes a particularly simple
         # form for a cosmological constant
-        if self._massivenu:
-            Or = self._Ogamma0 * (1 + self.nu_relative_density(z))
-        else:
-            Or = self._Ogamma0 + self._Onu0
+        Or = self._Ogamma0 + (self._Onu0 if not self._massivenu
+                              else self._Ogamma0 * self.nu_relative_density(z))
         zp1 = aszarr(z) + 1.0  # (converts z [unit] -> z [dimensionless])
 
         return np.sqrt(zp1 ** 3 * (Or * zp1 + self._Om0) + self._Ode0)
@@ -2161,10 +2151,8 @@ class FlatLambdaCDM(FlatFLRWMixin, LambdaCDM):
             Returns `float` if the input is scalar.
             Defined such that :math:`H_z = H_0 / E`.
         """
-        if self._massivenu:
-            Or = self._Ogamma0 * (1. + self.nu_relative_density(z))
-        else:
-            Or = self._Ogamma0 + self._Onu0
+        Or = self._Ogamma0 + (self._Onu0 if not self._massivenu
+                              else self._Ogamma0 * self.nu_relative_density(z))
         zp1 = aszarr(z) + 1.0  # (converts z [unit] -> z [dimensionless])
         return (zp1 ** 3 * (Or * zp1 + self._Om0) + self._Ode0)**(-0.5)
 
@@ -2319,10 +2307,8 @@ class wCDM(FLRW):
             Returns `float` if the input is scalar.
             Defined such that :math:`H(z) = H_0 E(z)`.
         """
-        if self._massivenu:
-            Or = self._Ogamma0 * (1. + self.nu_relative_density(z))
-        else:
-            Or = self._Ogamma0 + self._Onu0
+        Or = self._Ogamma0 + (self._Onu0 if not self._massivenu
+                              else self._Ogamma0 * self.nu_relative_density(z))
         zp1 = aszarr(z) + 1.0  # (converts z [unit] -> z [dimensionless])
 
         return np.sqrt(zp1 ** 2 * ((Or * zp1 + self._Om0) * zp1 + self._Ok0) +
@@ -2343,10 +2329,8 @@ class wCDM(FLRW):
             Returns `float` if the input is scalar.
             Defined such that :math:`H_z = H_0 / E`.
         """
-        if self._massivenu:
-            Or = self._Ogamma0 * (1. + self.nu_relative_density(z))
-        else:
-            Or = self._Ogamma0 + self._Onu0
+        Or = self._Ogamma0 + (self._Onu0 if not self._massivenu
+                              else self._Ogamma0 * self.nu_relative_density(z))
         zp1 = aszarr(z) + 1.0  # (converts z [unit] -> z [dimensionless])
 
         return (zp1 ** 2 * ((Or * zp1 + self._Om0) * zp1 + self._Ok0) +
@@ -2451,10 +2435,8 @@ class FlatwCDM(FlatFLRWMixin, wCDM):
             Returns `float` if the input is scalar.
             Defined such that :math:`H(z) = H_0 E(z)`.
         """
-        if self._massivenu:
-            Or = self._Ogamma0 * (1. + self.nu_relative_density(z))
-        else:
-            Or = self._Ogamma0 + self._Onu0
+        Or = self._Ogamma0 + (self._Onu0 if not self._massivenu
+                              else self._Ogamma0 * self.nu_relative_density(z))
         zp1 = aszarr(z) + 1.0  # (converts z [unit] -> z [dimensionless])
 
         return np.sqrt(zp1 ** 3 * (Or * zp1 + self._Om0) +
@@ -2475,10 +2457,8 @@ class FlatwCDM(FlatFLRWMixin, wCDM):
             Returns `float` if the input is scalar.
             Defined such that :math:`H(z) = H_0 E(z)`.
         """
-        if self._massivenu:
-            Or = self._Ogamma0 * (1. + self.nu_relative_density(z))
-        else:
-            Or = self._Ogamma0 + self._Onu0
+        Or = self._Ogamma0 + (self._Onu0 if not self._massivenu
+                              else self._Ogamma0 * self.nu_relative_density(z))
         zp1 = aszarr(z) + 1.0  # (converts z [unit] -> z [dimensionless])
 
         return (zp1 ** 3 * (Or * zp1 + self._Om0) +


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

Switching an if statement to a ternary statement. More compact and I think it reads better for the massive neutrino case, explicitly showing the neutrino contribution is `Ogamma0 * nu_factor`, rather than factoring `Ogamma0` out.

At some point I want an `Orad` and `Orad0`, but not in this PR.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
