### PR TITLE
WIP: Enable dask use in convolution

### DIFF
--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -102,7 +102,7 @@ def _next_fast_lengths(shape):
 
 
 def _copy_input_if_needed(input, dtype=float, order='C', nan_treatment=None,
-                          mask=None, fill_value=None):
+                          mask=None, fill_value=None, nparray=np.array):
     # Alias input
     input = input.array if isinstance(input, Kernel) else input
     # strip quantity attributes
@@ -123,12 +123,12 @@ def _copy_input_if_needed(input, dtype=float, order='C', nan_treatment=None,
                 # ``float`` masked arrays. ``subok=True`` is needed to retain
                 # ``np.ma.maskedarray.filled()``. ``copy=False`` allows the fill
                 # to act as the copy if type and order are already correct.
-                output = np.array(input, dtype=dtype, copy=False, order=order, subok=True)
+                output = nparray(input, dtype=dtype, copy=False, order=order, subok=True)
                 output = output.filled(fill_value)
             else:
                 # Since we're making a copy, we might as well use `subok=False` to save,
                 # what is probably, a negligible amount of memory.
-                output = np.array(input, dtype=dtype, copy=True, order=order, subok=False)
+                output = nparray(input, dtype=dtype, copy=True, order=order, subok=False)
 
             if mask is not None:
                 # mask != 0 yields a bool mask for all ints/floats/bool
@@ -138,7 +138,7 @@ def _copy_input_if_needed(input, dtype=float, order='C', nan_treatment=None,
             # The advantage of `subok=True` is that it won't copy when array is an ndarray subclass. If it
             # is and `subok=False` (default), then it will copy even if `copy=False`. This uses less memory
             # when ndarray subclasses are passed in.
-            output = np.array(input, dtype=dtype, copy=False, order=order, subok=True)
+            output = nparray(input, dtype=dtype, copy=False, order=order, subok=True)
     except (TypeError, ValueError) as e:
         raise TypeError('input should be a Numpy array or something '
                         'convertible into a float array', e)
@@ -444,7 +444,7 @@ def convolve_fft(array, kernel, boundary='fill', fill_value=0.,
                  preserve_nan=False, mask=None, crop=True, return_fft=False,
                  fft_pad=None, psf_pad=None, min_wt=0.0, allow_huge=False,
                  fftn=np.fft.fftn, ifftn=np.fft.ifftn,
-                 complex_dtype=complex, dealias=False):
+                 complex_dtype=complex, dealias=False, nparray=np.array):
     """
     Convolve an ndarray with an nd-kernel.  Returns a convolved image with
     ``shape = array.shape``.  Assumes kernel is centered.
@@ -761,7 +761,7 @@ def convolve_fft(array, kernel, boundary='fill', fill_value=0.,
     # Add shapes elementwise for psf_pad.
     if psf_pad:  # default=False
         # add the sizes along each dimension (bigger)
-        newshape = np.array(arrayshape) + np.array(kernshape)
+        newshape = nparray(arrayshape) + nparray(kernshape)
     else:
         # take the larger shape in each dimension (smaller)
         newshape = np.maximum(arrayshape, kernshape)


### PR DESCRIPTION
Dask can't be used in convolution right now.  If you try `convolve_fft(..., fftn=dask.array.fft.fftn)`, it will produce an error like:
`AttributeError: 'numpy.ndarray' object has no attribute 'chunks'` (see also https://github.com/radio-astro-tools/spectral-cube/issues/784).

This is a WIP attempt to enable dask in convolution.

Example:
```python
import astropy.convolution
import dask.array
dy = dask.array.ones([100,100])
x = astropy.convolution.convolve_fft(dy, dy, fftn=dask.array.fft.fftn, ifftn=dask.array.fft.ifftn, npa=dask.array).compute()
```

seems to work!  But tests are needed.