### PR TITLE
Bugfix for key error in `fix_inputs` models `input_units_equivalencies` property

### DIFF
--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -3599,9 +3599,12 @@ class CompoundModel(Model):
     @property
     def input_units_equivalencies(self):
         inputs_map = self.inputs_map()
-        return {key: inputs_map[key][0].input_units_equivalencies[orig_key]
+        input_units_equivalencies_dict = {key: inputs_map[key][0].input_units_equivalencies[orig_key]
                 for key, (mod, orig_key) in inputs_map.items()
-                if inputs_map[key][0].input_units_equivalencies is not None}
+                if inputs_map[key][0].input_units_equivalencies is not None }
+        if not input_units_equivalencies_dict:
+            return None
+        return input_units_equivalencies_dict
 
     @property
     def input_units_allow_dimensionless(self):

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -3599,11 +3599,14 @@ class CompoundModel(Model):
     @property
     def input_units_equivalencies(self):
         inputs_map = self.inputs_map()
-        input_units_equivalencies_dict = {key: inputs_map[key][0].input_units_equivalencies[orig_key]
-                for key, (mod, orig_key) in inputs_map.items()
-                if inputs_map[key][0].input_units_equivalencies is not None }
+        input_units_equivalencies_dict = {
+            key: inputs_map[key][0].input_units_equivalencies[orig_key]
+            for key, (mod, orig_key) in inputs_map.items()
+            if inputs_map[key][0].input_units_equivalencies is not None
+        }
         if not input_units_equivalencies_dict:
             return None
+
         return input_units_equivalencies_dict
 
     @property

--- a/astropy/modeling/tests/test_models_quantities.py
+++ b/astropy/modeling/tests/test_models_quantities.py
@@ -7,6 +7,7 @@ import numpy as np
 from astropy import units as u
 from astropy.tests.helper import assert_quantity_allclose
 from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa
+from astropy.modeling.core import fix_inputs
 
 from astropy.modeling.functional_models import (
     Gaussian1D, Sersic1D,
@@ -376,33 +377,33 @@ def test_models_bounding_box(model):
 def test_compound_model_input_units_equivalencies_defaults(model):
     m = model['class'](**model['parameters'])
 
-    assert m.input_units_equivalencies == None
+    assert m.input_units_equivalencies is None
 
     compound_model = m + m
-    assert compound_model.inputs_map()['x'][0].input_units_equivalencies == None
+    assert compound_model.inputs_map()['x'][0].input_units_equivalencies is None
     fixed_input_model = fix_inputs(compound_model, {'x':1})
 
-    assert fixed_input_model.input_units_equivalencies == None
+    assert fixed_input_model.input_units_equivalencies is None
 
     compound_model = m - m
-    assert compound_model.inputs_map()['x'][0].input_units_equivalencies == None
+    assert compound_model.inputs_map()['x'][0].input_units_equivalencies is None
     fixed_input_model = fix_inputs(compound_model, {'x':1})
 
-    assert fixed_input_model.input_units_equivalencies == None
+    assert fixed_input_model.input_units_equivalencies is None
 
     compound_model = m & m
-    assert compound_model.inputs_map()['x1'][0].input_units_equivalencies == None
+    assert compound_model.inputs_map()['x1'][0].input_units_equivalencies is None
     fixed_input_model = fix_inputs(compound_model, {'x0':1})
-    assert fixed_input_model.inputs_map()['x1'][0].input_units_equivalencies == None
+    assert fixed_input_model.inputs_map()['x1'][0].input_units_equivalencies is None
 
-    assert fixed_input_model.input_units_equivalencies == None
+    assert fixed_input_model.input_units_equivalencies is None
 
     if m.n_outputs == m.n_inputs:
         compound_model = m | m
-        assert compound_model.inputs_map()['x'][0].input_units_equivalencies == None
+        assert compound_model.inputs_map()['x'][0].input_units_equivalencies is None
         fixed_input_model = fix_inputs(compound_model, {'x':1})
 
-        assert fixed_input_model.input_units_equivalencies == None
+        assert fixed_input_model.input_units_equivalencies is None
 
 
 @pytest.mark.skipif('not HAS_SCIPY')

--- a/astropy/modeling/tests/test_models_quantities.py
+++ b/astropy/modeling/tests/test_models_quantities.py
@@ -372,6 +372,39 @@ def test_models_bounding_box(model):
             assert_quantity_allclose(bbox[i], model['bounding_box'][i])
 
 
+@pytest.mark.parametrize('model', MODELS)
+def test_compound_model_input_units_equivalencies_defaults(model):
+    m = model['class'](**model['parameters'])
+
+    assert m.input_units_equivalencies == None
+
+    compound_model = m + m
+    assert compound_model.inputs_map()['x'][0].input_units_equivalencies == None
+    fixed_input_model = fix_inputs(compound_model, {'x':1})
+
+    assert fixed_input_model.input_units_equivalencies == None
+
+    compound_model = m - m
+    assert compound_model.inputs_map()['x'][0].input_units_equivalencies == None
+    fixed_input_model = fix_inputs(compound_model, {'x':1})
+
+    assert fixed_input_model.input_units_equivalencies == None
+
+    compound_model = m & m
+    assert compound_model.inputs_map()['x1'][0].input_units_equivalencies == None
+    fixed_input_model = fix_inputs(compound_model, {'x0':1})
+    assert fixed_input_model.inputs_map()['x1'][0].input_units_equivalencies == None
+
+    assert fixed_input_model.input_units_equivalencies == None
+
+    if m.n_outputs == m.n_inputs:
+        compound_model = m | m
+        assert compound_model.inputs_map()['x'][0].input_units_equivalencies == None
+        fixed_input_model = fix_inputs(compound_model, {'x':1})
+
+        assert fixed_input_model.input_units_equivalencies == None
+
+
 @pytest.mark.skipif('not HAS_SCIPY')
 @pytest.mark.filterwarnings(r'ignore:.*:RuntimeWarning')
 @pytest.mark.filterwarnings(r'ignore:Model is linear in parameters.*')

--- a/astropy/modeling/tests/test_quantities_evaluation.py
+++ b/astropy/modeling/tests/test_quantities_evaluation.py
@@ -297,16 +297,20 @@ def test_compound_input_units_equivalencies():
     sp = Shift(10 * u.pix)
 
     cs = s1 | s2
+    assert cs.input_units_equivalencies == {'x': u.pixel_scale(0.5 * u.deg / u.pix)}
 
     out = cs(10 * u.pix)
     assert_quantity_allclose(out, 25 * u.deg)
 
     cs = sp | s1
+    assert cs.input_units_equivalencies is None
 
     out = cs(10 * u.pix)
     assert_quantity_allclose(out, 20 * u.deg)
 
     cs = s1 & s2
+    assert cs.input_units_equivalencies == {'x0': u.pixel_scale(0.5 * u.deg / u.pix)}
+
     cs = cs.rename('TestModel')
     out = cs(20 * u.pix, 10 * u.deg)
     assert_quantity_allclose(out, 20 * u.deg)

--- a/astropy/modeling/tests/test_quantities_evaluation.py
+++ b/astropy/modeling/tests/test_quantities_evaluation.py
@@ -9,7 +9,6 @@ import numpy as np
 import pytest
 from numpy.testing import assert_allclose
 
-
 from astropy.modeling.core import Model
 from astropy.modeling.models import Gaussian1D, Shift, Scale, Pix2Sky_TAN
 from astropy import units as u

--- a/docs/changes/modeling/12597.bugfix.rst
+++ b/docs/changes/modeling/12597.bugfix.rst
@@ -1,0 +1,2 @@
+Bugfix for ``keyerror`` thrown by ``Model.input_units_equivalencies`` when
+used on ``fix_inputs`` models which have no set unit equivalencies.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This PR is an update of PR #10359 by @Iamsoto which was auto-closed. It fixes a key error which arises in `fix_inputs` models when using the `input_unitist_equivalencies` property. See #10359 for details.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #10319. Closes #10359.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
