### PR TITLE
Create Earth location object using OBSGEO and MJDAVG, not MJD-OBS

### DIFF
--- a/astropy/wcs/wcsapi/fitswcs.py
+++ b/astropy/wcs/wcsapi/fitswcs.py
@@ -428,10 +428,17 @@ class FITSWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
             if np.isnan(self.wcs.obsgeo[0]):
                 observer = None
             else:
-
                 earth_location = EarthLocation(*self.wcs.obsgeo[:3], unit=u.m)
-                obstime = Time(self.wcs.mjdobs, format='mjd', scale='utc',
-                               location=earth_location)
+
+                # Get the time scale from TIMESYS or fall back to 'utc'
+                tscale = self.wcs.timesys or 'utc'
+
+                if np.isnan(self.wcs.mjdavg):
+                    obstime = Time(self.wcs.mjdobs, format='mjd', scale=tscale,
+                                   location=earth_location)
+                else:
+                    obstime = Time(self.wcs.mjdavg, format='mjd', scale=tscale,
+                                   location=earth_location)
                 observer_location = SkyCoord(earth_location.get_itrs(obstime=obstime))
 
                 if self.wcs.specsys in VELOCITY_FRAMES:

--- a/astropy/wcs/wcsapi/tests/test_fitswcs.py
+++ b/astropy/wcs/wcsapi/tests/test_fitswcs.py
@@ -990,7 +990,7 @@ def test_spectralcoord_frame(header_spectral_frames):
 
     with iers.conf.set_temp('auto_download', False):
 
-        obstime = Time(f"2009-05-04T04:44:23", scale='utc')
+        obstime = Time("2009-05-04T04:44:23", scale='utc')
 
         header = header_spectral_frames.copy()
         header['MJD-OBS'] = obstime.mjd
@@ -1235,7 +1235,7 @@ def test_spectral_with_time_kw(header_spectral_with_time):
             assert_allclose(w.all_pix2world(*w.wcs.crpix, 1), w.wcs.crval)
             sky, spec = w.pixel_to_world(*w.wcs.crpix)
             assert_allclose((sky.spherical.lon.degree, sky.spherical.lat.degree, spec.value),
-                             w.wcs.crval, rtol=1e-3)
+                            w.wcs.crval, rtol=1e-3)
 
     # Chek with MJD-AVG and TIMESYS
     hdr = header_spectral_with_time.copy()

--- a/astropy/wcs/wcsapi/tests/test_fitswcs.py
+++ b/astropy/wcs/wcsapi/tests/test_fitswcs.py
@@ -1223,6 +1223,7 @@ TIMESYS = 'UTC'
 """
 
 
+@pytest.fixture
 def header_spectral_with_time():
     return Header.fromstring(HEADER_SPECTRAL_WITH_TIME, sep='\n')
 

--- a/docs/changes/wcs/12598.bugfix.rst
+++ b/docs/changes/wcs/12598.bugfix.rst
@@ -1,0 +1,2 @@
+``WCS.pixel_to_world`` now creates an ``EarthLocation`` object using ``MJD-AVG``
+if present before falling back to the old behaviour of using ``MJD-OBS``.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address an issue with the WCS API in the case of a spectral observation.
When `OBSGEO-X/Y/Z` keywords are present the code is looking for the time of the observation
in `MJD-OBS`. Paper III defines the OBSGEO keywords this way:

```
OBSGEO-X (floating-valued)
OBSGEO-Y (floating-valued)
OBSGEO-Z (floating-valued)
are reserved to define a representative location for the observation in a standard 
terrestrial reference frame. The location values should be right-handed, geocentric, 
Cartesian coordinates valid at the epoch of MJD-AVG or DATE-AVG. 
```
MJD-AVG, according to the `Time` paper is the effective time of the observation.
This PR changes the generation of the `EarthLocation` object to use `MJD-AVG`.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->



### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
