### PR TITLE
Use Ubuntu packages from a PPA for tests on Ubuntu

### DIFF
--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -104,7 +104,9 @@ jobs:
           shell: /bin/bash
 
           install: |
-            echo "deb http://deb.debian.org/debian bullseye-backports main" >> /etc/apt/sources.list
+            apt-get update -q -y
+            apt-get install -q -y software-properties-common
+            add-apt-repository ppa:astropy/test-support
             apt-get update -q -y
             apt-get install -q -y git \
                                   g++ \
@@ -115,8 +117,7 @@ jobs:
                                   python3-ply \
                                   python3-venv \
                                   cython3 \
-                                  libwcs7/bullseye-backports \
-                                  wcslib-dev/bullseye-backports \
+                                  wcslib-dev \
                                   libcfitsio-dev \
                                   liberfa1
 


### PR DESCRIPTION
This is to merge after #12591.

### Description

To enable tests on non-x86 architectures, a weekly test was created to run on a Ubuntu installation, using pre-installed packages for cfitsio, wcslib, ... The problem here is that these packages may not have the version that is required to build and test Astropy. This is specifically the case for wcslib.

The first solution here, #12167 was to install a backport of the current version from the Debian repositoriy. This however has the disadvantage that there is no guarantee of ABI compatibility (different distribution, different time). The better solution is to have a backport specific to the used Ubuntu version (20.04 after #12591).

To have that, I created an ["astropy" team on Ubuntu's launchpad](https://launchpad.net/~astropy) and added a [test-support](https://launchpad.net/~astropy/+archive/ubuntu/test-support) package archive to it.

The relevant wcslib package for Ubuntu 20.04 is uploaded as well, with builds on amd64, arm64, armhf, ppc64el, s390x. As this is for 20.04 (and not 18.04), it should be merged after #12591.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
