### PR TITLE
Remove an obsolete workaround from `Row.as_void()`

### DIFF
--- a/astropy/table/row.py
+++ b/astropy/table/row.py
@@ -132,22 +132,9 @@ class Row:
         cols = self._table.columns.values()
         vals = tuple(np.asarray(col)[index] for col in cols)
         if self._table.masked:
-            # The logic here is a little complicated to work around
-            # bug in numpy < 1.8 (numpy/numpy#483).  Need to build up
-            # a np.ma.mvoid object by hand.
-            from .table import descr
-
-            # Make np.void version of masks.  Use the table dtype but
-            # substitute bool for data type
-            masks = tuple(col.mask[index] if hasattr(col, 'mask') else False
-                          for col in cols)
-            descrs = (descr(col) for col in cols)
-            mask_dtypes = [(name, bool, shape) for name, type_, shape in descrs]
-            row_mask = np.array([masks], dtype=mask_dtypes)[0]
-
-            # Make np.void version of values, and then the final mvoid row
-            row_vals = np.array([vals], dtype=self.dtype)[0]
-            void_row = np.ma.mvoid(data=row_vals, mask=row_mask)
+            mask = tuple(col.mask[index] if hasattr(col, 'mask') else False
+                         for col in cols)
+            void_row = np.ma.array([vals], mask=[mask], dtype=self.dtype)[0]
         else:
             void_row = np.array([vals], dtype=self.dtype)[0]
         return void_row


### PR DESCRIPTION
### Description

6816150f3b6235b63c7f7387049859fa6ea9000c introduced a workaround to `astropy.table.row.Row.as_void()` that was necessitated by a bug in `numpy` < 1.8. Currently the minimum required `numpy` version is 1.18, so the previous code can be safely restored.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
