### PR TITLE
Fix votable validate output handling

### DIFF
--- a/astropy/io/votable/table.py
+++ b/astropy/io/votable/table.py
@@ -209,7 +209,7 @@ def writeto(table, file, tabledata_format=None):
                  _debug_python_based_parser=True)
 
 
-def validate(source, output=None, xmllint=False, filename=None):
+def validate(source, output=sys.stdout, xmllint=False, filename=None):
     """
     Prints a validation report for the given file.
 
@@ -244,12 +244,10 @@ def validate(source, output=None, xmllint=False, filename=None):
 
     from astropy.utils.console import print_code_line, color_print
 
-    if output is None:
-        output = sys.stdout
-
     return_as_str = False
     if output is None:
         output = io.StringIO()
+        return_as_str = True
 
     lines = []
     votable = None

--- a/astropy/io/votable/tests/data/valid_votable.xml
+++ b/astropy/io/votable/tests/data/valid_votable.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<VOTABLE version="1.4" xmlns="http://www.ivoa.net/xml/VOTable/v1.3">
+  <RESOURCE name="myFavouriteGalaxies">
+    <COOSYS ID="sys" equinox="J2000" epoch="J2000" system="eq_FK5"/>
+    <TABLE name="results">
+      <DESCRIPTION>Velocities and Distance estimations</DESCRIPTION>
+      <PARAM name="Telescope" datatype="float" ucd="phys.size;instr.tel"
+             unit="m" value="3.6"/>
+      <FIELD name="RA"   ID="col1" ucd="pos.eq.ra;meta.main"
+             datatype="float" width="6" precision="2" unit="deg" ref="sys"/>
+      <FIELD name="Dec"  ID="col2" ucd="pos.eq.dec;meta.main"
+             datatype="float" width="6" precision="2" unit="deg" ref="sys"/>
+      <FIELD name="Name" ID="col3" ucd="meta.id;meta.main"
+             datatype="char" arraysize="8*"/>
+      <FIELD name="RVel" ID="col4" ucd="spect.dopplerVeloc" datatype="int"
+             width="5" unit="km/s"/>
+      <FIELD name="e_RVel" ID="col5" ucd="stat.error;spect.dopplerVeloc"
+             datatype="int" width="3" unit="km/s"/>
+      <FIELD name="R" ID="col6" ucd="pos.distance;pos.heliocentric"
+             datatype="float" width="4" precision="1" unit="Mpc">
+        <DESCRIPTION>Distance of Galaxy, assuming H=75km/s/Mpc</DESCRIPTION>
+      </FIELD>
+      <DATA>
+        <TABLEDATA>
+        <TR>
+          <TD>010.68</TD><TD>+41.27</TD><TD>N 224</TD><TD>-297</TD><TD>5</TD><TD>0.7</TD>
+        </TR>
+        <TR>
+          <TD>287.43</TD><TD>-63.85</TD><TD>N 6744</TD><TD>839</TD><TD>6</TD><TD>10.4</TD>
+        </TR>
+        <TR>
+          <TD>023.48</TD><TD>+30.66</TD><TD>N 598</TD><TD>-182</TD><TD>3</TD><TD>0.7</TD>
+        </TR>
+        </TABLEDATA>
+      </DATA>
+    </TABLE>
+  </RESOURCE>
+</VOTABLE>

--- a/astropy/io/votable/tests/table_test.py
+++ b/astropy/io/votable/tests/table_test.py
@@ -12,7 +12,7 @@ import numpy as np
 from astropy.config import set_temp_config, reload_config
 from astropy.utils.data import get_pkg_data_filename, get_pkg_data_fileobj
 from astropy.io.votable.table import parse, writeto
-from astropy.io.votable import tree, conf
+from astropy.io.votable import tree, conf, validate
 from astropy.io.votable.exceptions import VOWarning, W39, E25
 from astropy.table import Column, Table
 from astropy.table.table_helpers import simple_table
@@ -222,6 +222,20 @@ def test_binary2_masked_strings():
     assert not np.any(table.array.mask['epoch_photometry_url'])
     output = io.BytesIO()
     astropy_table.write(output, format='votable')
+
+
+def test_validate_output_type():
+    """
+    Issue #12603
+    """
+    votable_filepath = get_pkg_data_filename('data/regression.xml')
+    # When output is None, check that validate returns validation output as a string
+    validate_out = validate(votable_filepath, output=None)
+    assert type(validate_out) == str
+
+    # When output is not set, check that validate returns a bool
+    validate_out = validate(votable_filepath)
+    assert type(validate_out) == bool
 
 
 class TestVerifyOptions:

--- a/astropy/io/votable/tests/table_test.py
+++ b/astropy/io/votable/tests/table_test.py
@@ -224,18 +224,49 @@ def test_binary2_masked_strings():
     astropy_table.write(output, format='votable')
 
 
-def test_validate_output_type():
+def test_validate_output_invalid():
     """
-    Issue #12603
+    Issue #12603. Test that we get the correct output from votable.validate with an invalid
+    votable.
     """
-    votable_filepath = get_pkg_data_filename('data/regression.xml')
+
+    # A votable with errors
+    invalid_votable_filepath = get_pkg_data_filename('data/regression.xml')
+
     # When output is None, check that validate returns validation output as a string
-    validate_out = validate(votable_filepath, output=None)
-    assert type(validate_out) == str
+    validate_out = validate(invalid_votable_filepath, output=None)
+    assert isinstance(validate_out, str)
+    # Check for known error string
+    assert "E02: Incorrect number of elements in array." in validate_out
 
     # When output is not set, check that validate returns a bool
-    validate_out = validate(votable_filepath)
-    assert type(validate_out) == bool
+    validate_out = validate(invalid_votable_filepath)
+    assert isinstance(validate_out, bool)
+    # Check that validation output is correct (votable is not valid)
+    assert validate_out is False
+
+
+def test_validate_output_invalid():
+    """
+    Issue #12603. Test that we get the correct output from votable.validate with a valid
+    votable
+    """
+
+    # A valid votable. (Example from the votable standard:
+    # https://www.ivoa.net/documents/VOTable/20191021/REC-VOTable-1.4-20191021.html )
+    valid_votable_filepath = get_pkg_data_filename('data/valid_votable.xml')
+
+    # When output is None, check that validate returns validation output as a string
+    validate_out = validate(valid_votable_filepath, output=None)
+    assert isinstance(validate_out, str)
+    # Check for known good output string
+    assert "astropy.io.votable found no violations" in validate_out
+
+    # When output is not set, check that validate returns a bool
+    validate_out = validate(valid_votable_filepath)
+    assert isinstance(validate_out, bool)
+    # Check that validation output is correct (votable is valid)
+    assert validate_out is True
 
 
 class TestVerifyOptions:

--- a/astropy/io/votable/tests/table_test.py
+++ b/astropy/io/votable/tests/table_test.py
@@ -246,7 +246,7 @@ def test_validate_output_invalid():
     assert validate_out is False
 
 
-def test_validate_output_invalid():
+def test_validate_output_valid():
     """
     Issue #12603. Test that we get the correct output from votable.validate with a valid
     votable

--- a/docs/changes/io.votable/12604.bugfix.rst
+++ b/docs/changes/io.votable/12604.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug where ``astropy.io.votable.validate`` was printing output to ``sys.stdout`` when the ``output`` paramter was set to ``None``. ``validate`` now returns a string when ``output`` is set to ``None``, as documented.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address handling of output in the astropy.io.votable validate function.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #12603

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
