### PR TITLE
Cosmology property `is_flat`

### DIFF
--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -125,6 +125,15 @@ class Cosmology(metaclass=abc.ABCMeta):
         """The name of the Cosmology instance."""
         return self._name
 
+    @property
+    @abc.abstractmethod
+    def is_flat(self):
+        """
+        Return bool; `True` if the cosmology is flat.
+        This is abstract and must be defined in subclasses.
+        """
+        raise NotImplementedError("is_flat is not implemented")
+
     def clone(self, *, meta=None, **kwargs):
         """Returns a copy of this object with updated parameters, as specified.
 
@@ -313,7 +322,11 @@ class FlatCosmologyMixin(metaclass=abc.ABCMeta):
     ``LambdaCDM`` **may** be flat (for the a specific set of parameter values),
     but ``FlatLambdaCDM`` **will** be flat.
     """
-    pass
+
+    @property
+    def is_flat(self):
+        """Return `True`, the cosmology is flat."""
+        return True
 
 
 # -----------------------------------------------------------------------------

--- a/astropy/cosmology/flrw.py
+++ b/astropy/cosmology/flrw.py
@@ -286,6 +286,11 @@ class FLRW(Cosmology):
     # properties
 
     @property
+    def is_flat(self):
+        """Return bool; `True` if the cosmology is flat."""
+        return bool((self._Ok0 == 0.0) and (self.Otot0 == 1.0))
+
+    @property
     def Otot0(self):
         """Omega total; the total density/critical density at z=0."""
         return self._Om0 + self._Ogamma0 + self._Onu0 + self._Ode0 + self._Ok0
@@ -1502,11 +1507,10 @@ class FlatFLRWMixin(FlatCosmologyMixin):
         # check all parameters in other match those in 'self' and 'other' has
         # no extra parameters (case (2)) except for 'Ode0' and that other
         params_eq = (
-            set(self.__all_parameters__) == set(other.__all_parameters__) # no extra params
-            and all(np.all(getattr(self, k) == getattr(other, k))  # params equal
-                    for k in self.__all_parameters__)
-            # flatness conditions
-            and other.Ok0 == 0.0  # `Ode0` is checked in __all_parameters__
+            set(self.__all_parameters__) == set(other.__all_parameters__) # no extra
+            and all(np.all(getattr(self, k) == getattr(other, k))  # equal
+                    for k in self.__parameters__)
+            and other.is_flat
         )
 
         return params_eq

--- a/astropy/cosmology/io/tests/test_model.py
+++ b/astropy/cosmology/io/tests/test_model.py
@@ -42,8 +42,16 @@ class ToFromModelTestMixin(IOTestMixinBase):
     @pytest.fixture
     def method_name(self, cosmo):
         # get methods, ignoring private and dunder
-        methods = {n for n in dir(cosmo)
-                   if (callable(getattr(cosmo, n)) and not n.startswith("_"))}
+        methods = set()
+        for n in dir(cosmo):
+            try:  # get method, some will error on ABCs
+                m = getattr(cosmo, n)
+            except NotImplementedError:
+                continue
+
+            if callable(m) and not n.startswith("_"):
+                methods.add(n)
+
         # sieve out incompatible methods
         for n in tuple(methods):
             # remove non-introspectable methods

--- a/astropy/cosmology/tests/test_core.py
+++ b/astropy/cosmology/tests/test_core.py
@@ -77,6 +77,10 @@ class TestCosmology(ParameterTestMixin, MetaTestMixin,
                 self.Tcmb0 = Tcmb0
                 self.m_nu = m_nu
 
+            @property
+            def is_flat(self):
+                return super().is_flat()
+
         self.cls = SubCosmology
         self._cls_args = dict(H0=70 * (u.km / u.s / u.Mpc), Tcmb0=2.7 * u.K, m_nu=0.6 * u.eV)
         self.cls_kwargs = dict(name=self.__class__.__name__, meta={"a": "b"})
@@ -153,6 +157,11 @@ class TestCosmology(ParameterTestMixin, MetaTestMixin,
         # immutable
         with pytest.raises(AttributeError, match="can't set"):
             cosmo.name = None
+
+    def test_is_flat(self, cosmo_cls, cosmo):
+        """Test property ``is_flat``. It's an ABC."""
+        with pytest.raises(NotImplementedError, match="is_flat is not implemented"):
+            cosmo.is_flat
 
     # ------------------------------------------------
     # clone
@@ -309,12 +318,35 @@ class CosmologySubclassTest(TestCosmology):
         """Setup for testing."""
         pass
 
+    # ===============================================================
+    # Method & Attribute Tests
+
+    # ---------------------------------------------------------------
+    # instance-level
+
+    @abc.abstractmethod
+    def test_is_flat(self, cosmo_cls, cosmo):
+        """Test property ``is_flat``."""
+
 
 # -----------------------------------------------------------------------------
 
 
 class FlatCosmologyMixinTest:
-    """Test :class:`astropy.cosmology.core.FlatCosmologyMixin`."""
+    """Tests for :class:`astropy.cosmology.core.FlatCosmologyMixin` subclasses.
+
+    E.g to use this class::
+
+        class TestFlatSomeCosmology(FlatCosmologyMixinTest, TestSomeCosmology):
+            ...
+    """
+
+    def test_is_flat(self, cosmo_cls, cosmo):
+        """Test property ``is_flat``."""
+        super().test_is_flat(cosmo_cls, cosmo)
+
+        # it's always True
+        assert cosmo.is_flat is True
 
     def test_is_equivalent(self, cosmo):
         """Test :meth:`astropy.cosmology.core.FlatCosmologyMixin.is_equivalent`.

--- a/astropy/cosmology/tests/test_flrw.py
+++ b/astropy/cosmology/tests/test_flrw.py
@@ -489,6 +489,16 @@ class TestFLRW(CosmologyTest,
         assert cosmo.Ok0 is cosmo._Ok0
         assert np.allclose(cosmo.Ok0, 1.0 - (cosmo.Om0 + cosmo.Ode0 + cosmo.Ogamma0 + cosmo.Onu0))
 
+    def test_is_flat(self, cosmo_cls, cosmo):
+        """Test property ``is_flat``."""
+        # on the class
+        assert isinstance(cosmo_cls.is_flat, property)
+        assert cosmo_cls.is_flat.fset is None  # immutable
+
+        # on the instance
+        assert isinstance(cosmo.is_flat, bool)
+        assert cosmo.is_flat is bool((cosmo.Ok0 == 0.0) and (cosmo.Otot0 == 1.0))
+
     def test_Tnu0(self, cosmo_cls, cosmo):
         """Test property ``Tnu0``."""
         # on the class
@@ -758,7 +768,13 @@ class ParameterFlatOde0TestMixin(ParameterOde0TestMixin):
 
 
 class FlatFLRWMixinTest(FlatCosmologyMixinTest, ParameterFlatOde0TestMixin):
-    """Tests for :class:`astropy.cosmology.FlatFLRWMixin`."""
+    """Tests for :class:`astropy.cosmology.FlatFLRWMixin` subclasses.
+
+    E.g to use this class::
+
+        class TestFlatSomeFLRW(FlatFLRWMixinTest, TestSomeFLRW):
+            ...
+    """
 
     # ---------------------------------------------------------------
     # class-level
@@ -798,7 +814,6 @@ class FlatFLRWMixinTest(FlatCosmologyMixinTest, ParameterFlatOde0TestMixin):
 
         assert cosmo.Otot0 == 1.0
 
-    @pytest.mark.skipif(HAS_SCIPY, reason="scipy is not installed")
     def test_Otot(self, cosmo):
         """Test :meth:`astropy.cosmology.FLRW.Otot`. Should always be 1."""
         super().test_Otot(cosmo)

--- a/astropy/cosmology/tests/test_parameter.py
+++ b/astropy/cosmology/tests/test_parameter.py
@@ -226,6 +226,10 @@ class ParameterTestMixin:
             def __init__(self, param, *, name=None, meta=None):
                 self.param = param
 
+            @property
+            def is_flat(self):
+                return super().is_flat()
+
         assert Example(1).param == 1 * u.eV
         assert Example(1 * u.eV).param == 1 * u.eV
         assert Example(1 * u.J).param == (1 * u.J).to(u.eV)
@@ -248,6 +252,10 @@ class TestParameter(ParameterTestMixin):
 
             def __init__(self, param=15):
                 self.param = param
+
+            @property
+            def is_flat(self):
+                return super().is_flat()
 
         # with validator
         class Example2(Example1):

--- a/docs/changes/cosmology/12606.feature.rst
+++ b/docs/changes/cosmology/12606.feature.rst
@@ -1,0 +1,4 @@
+Add property ``is_flat`` to cosmologies to calculate the curvature of the Universe.
+
+``Cosmology`` is now an abstract class and subclasses must override the
+abstract property ``is_flat``.

--- a/docs/whatsnew/5.1.rst
+++ b/docs/whatsnew/5.1.rst
@@ -7,6 +7,17 @@ What's New in Astropy 5.1?
 Overview
 ========
 
+.. _whatsnew-5.0-cosmology:
+
+Updates to ``Cosmology``
+========================
+
+:class:`~astropy.cosmology.Cosmology` is now an abstract base class,
+and subclasses must override the abstract property ``is_flat``.
+For :class:`~astropy.cosmology.FLRW`, ``is_flat`` checks that ``Ok0=0`` and
+``Omtot0=1``.
+
+
 Full change log
 ===============
 


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

### Description

Add property ``is_flat`` to cosmologies to verify the curvature of the Universe.

It's abstract on `Cosmology`, making it abstract (finally).
On `FLRW` it checks ``Ok0`` and ``Otot0``.
On subclassess of `FlatCosmologyMixin` it's just `True`.

Flatness is a subtle thing. On FLRW cosmologies it's simple, but not in general. So it's abstract on `Cosmology`.


### Checklist for package maintainer(s)

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
