### PR TITLE
Avoid duplicate storage of info in serialized columns.

### DIFF
--- a/astropy/table/serialize.py
+++ b/astropy/table/serialize.py
@@ -134,7 +134,8 @@ def _represent_mixin_as_column(col, name, new_cols, mixin_cols,
         # MaskedColumn).  For primary data, we attempt to store any info on
         # the format, etc., on the column, but not for ancillary data (e.g.,
         # no sense to use a float format for a mask).
-        if data_attr == col.info._represent_as_dict_primary_data:
+        is_primary = data_attr == col.info._represent_as_dict_primary_data
+        if is_primary:
             new_name = name
             new_info = info
         else:
@@ -146,6 +147,10 @@ def _represent_mixin_as_column(col, name, new_cols, mixin_cols,
                                        and np.any(data.mask)) else Column
             new_cols.append(col_cls(data, name=new_name, **new_info))
             obj_attrs[data_attr] = SerializedColumn({'name': new_name})
+            if is_primary:
+                # Don't store info in the __serialized_columns__ dict for this column
+                # since this is redundant with info stored on the new column.
+                info = {}
         else:
             # recurse. This will define obj_attrs[new_name].
             _represent_mixin_as_column(data, new_name, new_cols, obj_attrs)

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -817,6 +817,20 @@ def test_represent_mixins_as_columns_unit_fix():
     serialize.represent_mixins_as_columns(t)
 
 
+def test_primary_data_column_gets_description():
+    """
+    If the mixin defines a primary data column, that should get the
+    description, format, etc., so no __info__ should be needed.
+    """
+    t = QTable({'a': [1, 2] * u.m})
+    t['a'].info.description = 'parrot'
+    t['a'].info.format = '7.2f'
+    tser = serialize.represent_mixins_as_columns(t)
+    assert '__info__' not in tser.meta['__serialized_columns__']['a']
+    assert tser['a'].format == '7.2f'
+    assert tser['a'].description == 'parrot'
+
+
 def test_skycoord_with_velocity():
     # Regression test for gh-6447
     sc = SkyCoord([1], [2], unit='deg', galcen_v_sun=None)

--- a/astropy/utils/masked/core.py
+++ b/astropy/utils/masked/core.py
@@ -352,9 +352,12 @@ class MaskedNDArrayInfo(MaskedInfoBase, ParentDtypeInfo):
         return out
 
     def _construct_from_dict(self, map):
-        # 'data' may be a Column or a MaskedColumn.  In the former case,
-        # there will also be a 'mask'.
-        return Masked(map.pop('data').data, mask=map.pop('mask', None))
+        # Override usual handling, since MaskedNDArray takes shape and buffer
+        # as input, which is less useful here.
+        # The map can contain either a MaskedColumn or a Column and a mask.
+        # Extract the mask for the former case.
+        map.setdefault('mask', getattr(map['data'], 'mask', False))
+        return self._parent_cls.from_unmasked(**map)
 
 
 class MaskedArraySubclassInfo(MaskedInfoBase):

--- a/docs/changes/table/12607.bugfix.rst
+++ b/docs/changes/table/12607.bugfix.rst
@@ -1,0 +1,2 @@
+Avoid duplicate storage of info in serialized columns if the column
+used to serialize already can hold that information.


### PR DESCRIPTION
As is, info is store on any primary data column, but also in the serialized column, which makes the header unnecessarily long. (Saw this while working on #12589, and includes a bit of the other small refactoring there.)

I think this is a bug, but could also call it refactoring.

Comparing this PR with current master:
```
from astropy.table import QTable, Column
QTable({"a": Column([1.], description='description', unit='')}).write('temp.ecsv', overwrite=True)

--> current master
# %ECSV 1.0
# ---
# datatype:
# - {name: a, datatype: float64, description: description}
# meta: !!omap
# - __serialized_columns__:
#     a:
#       __class__: astropy.units.quantity.Quantity
#       __info__: {description: description}
#       unit: !astropy.units.Unit {unit: ''}
#       value: !astropy.table.SerializedColumn {name: a}
# schema: astropy-2.0
a
1.0


--> this PR (__info__ removed)

# %ECSV 1.0
# ---
# datatype:
# - {name: a, datatype: float64, description: description}
# meta: !!omap
# - __serialized_columns__:
#     a:
#       __class__: astropy.units.quantity.Quantity
#       unit: !astropy.units.Unit {unit: ''}
#       value: !astropy.table.SerializedColumn {name: a}
# schema: astropy-2.0
a
1.0
```

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
