### PR TITLE
Table as serializable mixin column

### DIFF
--- a/astropy/table/info.py
+++ b/astropy/table/info.py
@@ -8,7 +8,7 @@ from contextlib import contextmanager
 from inspect import isclass
 
 import numpy as np
-from astropy.utils.data_info import DataInfo
+from astropy.utils.data_info import ParentDtypeInfo
 
 __all__ = ['table_info', 'TableInfo', 'serialize_method_as']
 
@@ -116,11 +116,22 @@ def table_info(tbl, option='attributes', out=''):
     out.writelines(outline + os.linesep for outline in outlines)
 
 
-class TableInfo(DataInfo):
+class TableInfo(ParentDtypeInfo):
     def __call__(self, option='attributes', out=''):
         return table_info(self._parent, option, out)
 
     __call__.__doc__ = table_info.__doc__
+
+    def _represent_as_dict(self):
+        return dict(self._parent.columns)
+
+    def _construct_from_dict(self, map):
+        return super()._construct_from_dict({'data': map})
+
+    @staticmethod
+    def default_format(val):
+        return val.table[val.index:val.index+1].pformat(
+            max_width=-1, show_name=False, show_unit=False, show_dtype=False)[0]
 
 
 @contextmanager

--- a/astropy/table/serialize.py
+++ b/astropy/table/serialize.py
@@ -39,6 +39,8 @@ __construct_mixin_classes = (
     'astropy.table.ndarray_mixin.NdarrayMixin',
     'astropy.table.table_helpers.ArrayWrapper',
     'astropy.table.column.MaskedColumn',
+    'astropy.table.table.Table',
+    'astropy.table.table.QTable',
     'astropy.coordinates.representation.CartesianRepresentation',
     'astropy.coordinates.representation.UnitSphericalRepresentation',
     'astropy.coordinates.representation.RadialRepresentation',

--- a/astropy/table/serialize.py
+++ b/astropy/table/serialize.py
@@ -328,15 +328,20 @@ def _construct_mixin_from_columns(new_name, obj_attrs, out):
     for name in data_attrs_map.values():
         del obj_attrs[name]
 
-    # Get the index where to add new column
-    idx = min(out.colnames.index(name) for name in data_attrs_map)
+    # YAML maps order alphabetically by key, while python code may expect
+    # the order in which the data were stored, so use the order in which the
+    # attributes appear in the serialized parts.
+    names = sorted(data_attrs_map, key=out.colnames.index)
+    # Similarly, we keep the index where to add new column, so that
+    # the output table keeps order as well.
+    idx = out.colnames.index(names[0])
 
     # Name is the column name in the table (e.g. "coord.ra") and
     # data_attr is the object attribute name  (e.g. "ra").  A different
     # example would be a formatted time object that would have (e.g.)
     # "time_col" and "value", respectively.
-    for name, data_attr in data_attrs_map.items():
-        obj_attrs[data_attr] = out[name]
+    for name in names:
+        obj_attrs[data_attrs_map[name]] = out[name]
         del out[name]
 
     info = obj_attrs.pop('__info__', {})

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -1072,7 +1072,7 @@ class Table:
         Coercion to a different dtype via np.array(table, dtype) is not
         supported and will raise a ValueError.
         """
-        if dtype is not None:
+        if dtype is not None and dtype != self.dtype:
             raise ValueError('Datatype coercion is not allowed')
 
         # This limitation is because of the following unexpected result that
@@ -2051,6 +2051,14 @@ class Table:
             # Get the first column name
             self._first_colname = next(iter(self.columns))
             return len(self.columns[self._first_colname])
+
+    @property
+    def shape(self):
+        """The shape of the table - a single-element tuple with the length.
+
+        This exists mostly for use of a table as a mixin column.
+        """
+        return (len(self),)
 
     def index_column(self, name):
         """

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -831,6 +831,16 @@ def test_primary_data_column_gets_description():
     assert tser['a'].description == 'parrot'
 
 
+@pytest.mark.parametrize('table_types', (Table, QTable))
+def test_table_as_mixin(table_types):
+    t = table_types({'a': [1, 2] * u.m, 'b': ['a', 'b']})
+    t['t'] = t
+    tser = serialize.represent_mixins_as_columns(t)
+    assert list(tser.columns.keys()) == ['a', 'b', 't.a', 't.b']
+    trec = serialize._construct_mixins_from_columns(tser)
+    assert np.all(trec == t)
+
+
 def test_skycoord_with_velocity():
     # Regression test for gh-6447
     sc = SkyCoord([1], [2], unit='deg', galcen_v_sun=None)

--- a/docs/changes/table/12610.feature.rst
+++ b/docs/changes/table/12610.feature.rst
@@ -1,0 +1,2 @@
+``Table`` and ``QTable`` can now be used as columns in other tables,
+and will be properly serialized to ECSV, etc.


### PR DESCRIPTION
Basically a revival of #3963, but now also trying to ensure that the table can be serialized. Note that at the moment I let this work by also serializing `TableColumns` -- the idea would be that this can very easily be used for structured columns as well (i.e., replacing the `ColumnMapping` of #12589). But perhaps unnecessary indirection; the column could also be serialized via a `Table` even if that would then mean a line more in `_construct_from_dict`.

The one thing that is not good yet is the formatting: really should replace the `void*` data type with something more useful! But really, it is remarkable how *little* is needed to get this to work!

Example:
```
from astropy.table import QTable, Column
from astropy.coordinates import SkyCoord
qt = QTable({"a": Column([1., 2.], description='description', unit='m'), 'sc': SkyCoord([1., 2.], [3., 4.], unit='deg')})
qt['t'] = qt
qt
 
<QTable length=2>
   a       sc         t     
   m    deg,deg   m deg,deg 
float64 SkyCoord   void128  
------- -------- -----------
    1.0  1.0,3.0 1.0 1.0,3.0
    2.0  2.0,4.0 2.0 2.0,4.0
```