### PR TITLE
clean up formatting  in cosmology docs

### DIFF
--- a/docs/common_links.txt
+++ b/docs/common_links.txt
@@ -20,6 +20,21 @@
 
 .. Cosmology
 .. |Cosmology| replace:: :class:`~astropy.cosmology.Cosmology`
+.. |Cosmology.read| replace:: :meth:`~astropy.cosmology.Cosmology.read`
+.. |Cosmology.write| replace:: :meth:`~astropy.cosmology.Cosmology.write`
+.. |Cosmology.from_format| replace:: :meth:`~astropy.cosmology.Cosmology.from_format`
+.. |Cosmology.to_format| replace:: :meth:`~astropy.cosmology.Cosmology.to_format`
+
+.. |FLRW| replace:: :class:`~astropy.cosmology.FLRW`
+.. |LambdaCDM| replace:: :class:`~astropy.cosmology.LambdaCDM`
+.. |FlatLambdaCDM| replace:: :class:`~astropy.cosmology.FlatLambdaCDM`
+
+.. |Planck18| replace:: :ref:`Planck18 <astropy:Planck18>`
+
+.. |FlatCosmologyMixin| replace:: :class:`~astropy.cosmology.FlatCosmologyMixin`
+.. |FlatFLRWMixin| replace:: :class:`~astropy.cosmology.FlatFLRWMixin`
+
+.. |default_cosmology| replace:: :class:`~astropy.cosmology.default_cosmology`
 
 .. SAMP
 .. |SAMPClient| replace:: :class:`~astropy.samp.SAMPClient`

--- a/docs/cosmology/dev.rst
+++ b/docs/cosmology/dev.rst
@@ -6,24 +6,22 @@ Cosmology For Developers
 Cosmologies in Functions
 ========================
 
-It is often useful to assume a default cosmology so that the exact
-cosmology does not have to be specified every time a function or method
-is called. In this case, it is possible to specify a "default"
-cosmology.
+It is often useful to assume a default cosmology so that the exact cosmology
+does not have to be specified every time a function or method is called. In
+this case, it is possible to specify a "default" cosmology.
 
 You can set the default cosmology to a predefined value by using the
 "default_cosmology" option in the ``[cosmology.core]`` section of the
-configuration file (see :ref:`astropy_config`). Alternatively, you can
-use the :meth:`~astropy.cosmology.default_cosmology.set` function of
-:func:`~astropy.cosmology.default_cosmology` to set a cosmology for the current
-Python session. If you have not set a default cosmology using one of the
-methods described above, then the cosmology module will default to using the
+configuration file (see :ref:`astropy_config`). Alternatively, you can use the
+:meth:`~astropy.cosmology.default_cosmology.set` function of
+|default_cosmology| to set a cosmology for the current Python session. If you
+have not set a default cosmology using one of the methods described above, then
+the cosmology module will default to using the
 ``default_cosmology._value`` parameters.
 
-It is strongly recommended that you use the default cosmology through
-the :class:`~astropy.cosmology.default_cosmology` science state object. An
-override option can then be provided using something like the
-following:
+It is strongly recommended that you use the default cosmology through the
+|default_cosmology| science state object. An override option can then be
+provided using something like the following:
 
 .. code-block:: python
 
@@ -35,16 +33,15 @@ following:
 
         ... function code here ...
 
-This ensures that all code consistently uses the default cosmology
-unless explicitly overridden.
+This ensures that all code consistently uses the default cosmology unless
+explicitly overridden.
 
 .. note::
 
     In general it is better to use an explicit cosmology (for example
-    ``WMAP9.H(0)`` instead of
-    ``cosmology.default_cosmology.get().H(0)``). Use of the default
-    cosmology should generally be reserved for code that will be
-    included in the ``astropy`` core or an affiliated package.
+    ``WMAP9.H(0)`` instead of ``cosmology.default_cosmology.get().H(0)``).
+    Use of the default cosmology should generally be reserved for code that
+    will be included in the ``astropy`` core or an affiliated package.
 
 
 .. _astropy-cosmology-custom:
@@ -53,10 +50,9 @@ Custom Cosmologies
 ==================
 
 In :mod:`astropy.cosmology` cosmologies are classes, so custom cosmologies may
-be implemented by subclassing |Cosmology| (or more likely
-:class:`~astropy.cosmology.FLRW`) and adding details specific to that
-cosmology. Here we will review some of those details and tips and tricks to
-building a performant cosmology class.
+be implemented by subclassing |Cosmology| (or more likely |FLRW|) and adding
+details specific to that cosmology. Here we will review some of those details
+and tips and tricks to building a performant cosmology class.
 
 .. code-block:: python
 
@@ -85,7 +81,7 @@ signature or more deeply in the code. On a cosmology instance, the descriptor
 will return the parameter value.
 
 There are a number of best practices. For a reference, this is excerpted from
-the definition of :class:`~astropy.cosmology.FLRW`.
+the definition of |FLRW|.
 
 .. code-block:: python
 
@@ -160,12 +156,10 @@ Mixins
 inheritance lines. We use the term loosely as mixins are meant to be strictly
 orthogonal, but may not be, particularly in ``__init__``.
 
-Currently the only mixin is :class:`~astropy.cosmology.FlatCosmologyMixin`
-and its :class:`~astropy.cosmology.FLRW`-specific subclass
-:class:`~astropy.cosmology.FlatFLRWMixin`. "Flat" cosmologies should use this
-mixin. :class:`~astropy.cosmology.FlatFLRWMixin` must precede the base class in
-the multiple-inheritance so that this mixin's ``__init__`` proceeds the base
-class'.
+Currently the only mixin is |FlatCosmologyMixin| and its |FLRW|-specific
+subclass |FlatFLRWMixin|. "Flat" cosmologies should use this mixin.
+|FlatFLRWMixin| must precede the base class in the multiple-inheritance so that
+this mixin's ``__init__`` proceeds the base class'.
 
 
 .. _astropy-cosmology-fast-integrals:
@@ -174,9 +168,8 @@ Speeding up Integrals in Custom Cosmologies
 -------------------------------------------
 
 The supplied cosmology classes use a few tricks to speed up distance and time
-integrals.  It is not necessary for anyone subclassing
-:class:`~astropy.cosmology.FLRW` to use these tricks -- but if they do, such
-calculations may be a lot faster.
+integrals.  It is not necessary for anyone subclassing |FLRW| to use these
+tricks -- but if they do, such calculations may be a lot faster.
 
 The first, more basic, idea is that, in many cases, it's a big deal to provide
 explicit formulae for :meth:`~astropy.cosmology.FLRW.inv_efunc` rather than
@@ -184,19 +177,18 @@ simply setting up ``de_energy_scale`` -- assuming there is a nice expression.
 As noted above, almost all of the provided classes do this, and that template
 can pretty much be followed directly with the appropriate formula changes.
 
-The second, and more advanced, option is to also explicitly provide a
-scalar only version of :meth:`~astropy.cosmology.FLRW.inv_efunc`. This results
-in a fairly large speedup (>10x in most cases) in the distance and age
-integrals, even if only done in python, because testing whether the inputs are
-iterable or pure scalars turns out to be rather expensive. To take advantage of
-this, the key thing is to explicitly set the instance variables
+The second, and more advanced, option is to also explicitly provide a scalar
+only version of :meth:`~astropy.cosmology.FLRW.inv_efunc`. This results in a
+fairly large speedup (>10x in most cases) in the distance and age integrals,
+even if only done in python, because testing whether the inputs are iterable or
+pure scalars turns out to be rather expensive. To take advantage of this, the
+key thing is to explicitly set the instance variables
 ``self._inv_efunc_scalar`` and ``self._inv_efunc_scalar_args`` in the
 constructor for the subclass, where the latter are all the arguments except
 ``z`` to ``_inv_efunc_scalar``. The provided classes do use this optimization,
 and in fact go even further and provide optimizations for no radiation, and for
-radiation with massless neutrinos coded in cython. Consult the
-:class:`~astropy.cosmology.FLRW` subclasses for details, and
-``scalar_inv_efuncs`` for the details.
+radiation with massless neutrinos coded in cython. Consult the |FLRW|
+subclasses for details, and ``scalar_inv_efuncs`` for the details.
 
 However, the important point is that it is *not* necessary to do this.
 
@@ -205,18 +197,16 @@ Astropy Interoperability: I/O and your Cosmology Package
 ========================================================
 
 If you are developing a package and want to be able to interoperate with
-`astropy.cosmology.Cosmology`, you're in the right place! Here we will discuss
-and provide examples for enabling Astropy to read and write your file formats,
-but also convert your cosmology objects to and from Astropy's |Cosmology|.
+|Cosmology|, you're in the right place! Here we will discuss and provide
+examples for enabling Astropy to read and write your file formats, but also
+convert your cosmology objects to and from Astropy's |Cosmology|.
 
 The following presumes knowledge of how Astropy structures I/O functions. For
 a quick tutorial see :ref:`cosmology_io`.
 
-Now that we know how to build and register functions into
-:meth:`~astropy.cosmology.Cosmology.read`,
-:meth:`~astropy.cosmology.Cosmology.write`,
-:meth:`~astropy.cosmology.Cosmology.from_format`,
-:meth:`~astropy.cosmology.Cosmology.to_format`, we can do this in your package.
+Now that we know how to build and register functions into |Cosmology.read|,
+|Cosmology.write|, |Cosmology.from_format|, |Cosmology.to_format|, we can do
+this in your package.
 
 Consider a package -- since this is mine, it's cleverly named ``mypackage`` --
 with the following file structure: a module for cosmology codes and a module
@@ -254,10 +244,8 @@ Converting Objects Between Packages
 We want to enable conversion between cosmology objects from ``mypckage``
 to/from |Cosmology|. All the Astropy interface code is defined in
 ``mypackage/io/astropy_convert.py``. The following is a rough outline of the
-necessary functions and how to register them with astropy's unified
-I/O to be automatically available to
-:meth:`astropy.cosmology.Cosmology.from_format` and
-:meth:`astropy.cosmology.Cosmology.to_format`.
+necessary functions and how to register them with astropy's unified I/O to be
+automatically available to |Cosmology.from_format| and |Cosmology.to_format|.
 
 .. literalinclude:: ../../astropy/cosmology/tests/mypackage/io/astropy_convert.py
    :language: python
@@ -269,8 +257,7 @@ Reading and Writing
 Everything Astropy read/write related is defined in
 ``mypackage/io/astropy_io.py``. The following is a rough outline of the read,
 write, and identify functions and how to register them with astropy's unified
-io to be automatically available to :meth:`astropy.cosmology.Cosmology.read`
-and :meth:`astropy.cosmology.Cosmology.write`.
+IO to be automatically available to |Cosmology.read| and |Cosmology.write|.
 
 .. literalinclude:: ../../astropy/cosmology/tests/mypackage/io/astropy_io.py
    :language: python

--- a/docs/cosmology/dev.rst
+++ b/docs/cosmology/dev.rst
@@ -19,9 +19,8 @@ have not set a default cosmology using one of the methods described above, then
 the cosmology module will default to using the
 ``default_cosmology._value`` parameters.
 
-It is strongly recommended that you use the default cosmology through the
-|default_cosmology| science state object. An override option can then be
-provided using something like the following:
+You can override the default cosmology through the |default_cosmology| science
+state object, using something like the following:
 
 .. code-block:: python
 
@@ -38,10 +37,12 @@ explicitly overridden.
 
 .. note::
 
-    In general it is better to use an explicit cosmology (for example
-    ``WMAP9.H(0)`` instead of ``cosmology.default_cosmology.get().H(0)``).
+    If you are preparing a paper and thus need to ensure your code provides
+    reproducible results, it is better to use an explicit cosmology (for
+    example ``WMAP9.H(0)`` instead of ``default_cosmology.get().H(0)``).
     Use of the default cosmology should generally be reserved for code that
-    will be included in the ``astropy`` core or an affiliated package.
+    allows for the global cosmology state to be changed; e.g. code included in
+    ``astropy`` core or an affiliated package.
 
 
 .. _astropy-cosmology-custom:
@@ -188,7 +189,7 @@ constructor for the subclass, where the latter are all the arguments except
 ``z`` to ``_inv_efunc_scalar``. The provided classes do use this optimization,
 and in fact go even further and provide optimizations for no radiation, and for
 radiation with massless neutrinos coded in cython. Consult the |FLRW|
-subclasses for details, and ``scalar_inv_efuncs`` for the details.
+subclasses and ``scalar_inv_efuncs`` for the details.
 
 However, the important point is that it is *not* necessary to do this.
 
@@ -197,9 +198,9 @@ Astropy Interoperability: I/O and your Cosmology Package
 ========================================================
 
 If you are developing a package and want to be able to interoperate with
-|Cosmology|, you're in the right place! Here we will discuss and provide
-examples for enabling Astropy to read and write your file formats, but also
-convert your cosmology objects to and from Astropy's |Cosmology|.
+|Cosmology|, you're in the right place! Here we will discuss how to enable
+Astropy to read and write your file formats, and convert your cosmology objects
+to and from Astropy's |Cosmology|.
 
 The following presumes knowledge of how Astropy structures I/O functions. For
 a quick tutorial see :ref:`cosmology_io`.

--- a/docs/cosmology/index.rst
+++ b/docs/cosmology/index.rst
@@ -4,33 +4,42 @@
 Cosmological Calculations (`astropy.cosmology`)
 ***********************************************
 
+.. |wCDM| replace:: :class:`~astropy.cosmology.wCDM`
+.. |FlatwCDM| replace:: :class:`~astropy.cosmology.FlatwCDM`
+.. |w0wzCDM| replace:: :class:`~astropy.cosmology.w0wzCDM`
+.. |w0waCDM| replace:: :class:`~astropy.cosmology.w0waCDM`
+.. |wpwaCDM| replace:: :class:`~astropy.cosmology.wpwaCDM`
+.. |WMAP7| replace:: :ref:`WMAP7 <astropy:WMAP7>`
+.. |WMAP9| replace:: :ref:`WMAP9 <astropy:WMAP9>`
+.. |Planck13| replace:: :ref:`Planck13 <astropy:Planck13>`
+.. |Planck15| replace:: :ref:`Planck15 <astropy:Planck15>`
+.. |z_at_value| replace:: :func:`~astropy.cosmology.z_at_value`
+
 Introduction
 ============
 
 The :mod:`astropy.cosmology` sub-package contains classes for representing
-cosmologies and utility functions for calculating commonly used
-quantities that depend on a cosmological model. This includes
-distances, ages, and lookback times corresponding to a measured
-redshift or the transverse separation corresponding to a measured
-angular separation.
+cosmologies and utility functions for calculating commonly used quantities that
+depend on a cosmological model. This includes distances, ages, and lookback
+times corresponding to a measured redshift or the transverse separation
+corresponding to a measured angular separation.
 
 :mod:`astropy.cosmology.units` extends the :mod:`astropy.units` sub-package,
 adding and collecting cosmological units and equivalencies, like :math:`h` for
 keeping track of (dimensionless) factors of the Hubble constant.
 
-For details on reading and writing cosmologies from files,
-see :ref:`cosmology_io`.
+For details on reading and writing cosmologies from files, see
+:ref:`cosmology_io`.
 
 For notes on building custom Cosmology classes and interfacing
-:mod:`astropy.cosmology` with 3rd-party packages,
-see :ref:`astropy-cosmology-for-developers`.
+:mod:`astropy.cosmology` with 3rd-party packages, see
+:ref:`astropy-cosmology-for-developers`.
 
 
 Getting Started
 ===============
 
-Cosmological quantities are calculated using methods of a
-:class:`~astropy.cosmology.Cosmology` object.
+Cosmological quantities are calculated using methods of a |Cosmology| object.
 
 Examples
 --------
@@ -51,18 +60,16 @@ transverse proper kiloparsecs (kpc) corresponding to an arcminute at z=3::
   >>> cosmo.kpc_proper_per_arcmin(3)  # doctest: +FLOAT_CMP
   <Quantity 472.97709620405266 kpc / arcmin>
 
-Here WMAP9 is a built-in object describing a cosmology with the
-parameters from the nine-year WMAP results. Several other built-in
-cosmologies are also available (see `Built-in Cosmologies`_). The
-available methods of the cosmology object are listed in the methods
-summary for the `~astropy.cosmology.FLRW` class. If you are using
-IPython you can also use tab completion to print a list of the
-available methods. To do this, after importing the cosmology as in the
-above example, type ``cosmo.`` at the IPython prompt and then press
-the tab key.
+Here |WMAP9| is a built-in object describing a cosmology with the parameters
+from the nine-year WMAP results. Several other built-in cosmologies are also
+available (see `Built-in Cosmologies`_). The available methods of the cosmology
+object are listed in the methods summary for the |FLRW| class. If you are using
+IPython you can also use tab completion to print a list of the available
+methods. To do this, after importing the cosmology as in the above example,
+type ``cosmo.`` at the IPython prompt and then press the tab key.
 
-All of these methods also accept an arbitrarily-shaped array of
-redshifts as input:
+All of these methods also accept an arbitrarily-shaped array of redshifts as
+input:
 
 .. doctest-requires:: scipy
 
@@ -80,17 +87,17 @@ classes::
   FlatLambdaCDM(H0=70 km / (Mpc s), Om0=0.3, Tcmb0=2.725 K,
                 Neff=3.04, m_nu=[0. 0. 0.] eV, Ob0=None)
 
-Note the presence of additional cosmological parameters (e.g., ``Neff``,
-the number of effective neutrino species) with default values; these
-can also be specified explicitly in the call to the constructor.
+Note the presence of additional cosmological parameters (e.g., ``Neff``, the
+number of effective neutrino species) with default values; these can also be
+specified explicitly in the call to the constructor.
 
 ..
   EXAMPLE END
 
-The cosmology sub-package makes use of `~astropy.units`, so in many
-cases returns values with units attached. Consult the documentation
-for that sub-package for more details, but briefly here we will show how to
-access the floating point or array values::
+The cosmology sub-package makes use of :mod:`~astropy.units`, so in many cases
+returns values with units attached. Consult the documentation for that
+sub-package for more details, but briefly here we will show how to access the
+floating point or array values::
 
   >>> from astropy.cosmology import WMAP9 as cosmo
   >>> H0 = cosmo.H(0)
@@ -111,13 +118,12 @@ listed below.
    Units and Equivalencies <units>
 
 
-Most of the functionality is enabled by the `~astropy.cosmology.FLRW`
-object. This represents a homogeneous and isotropic cosmology
-(characterized by the Friedmann-Lemaitre-Robertson-Walker metric,
-named after the people who solved Einstein's field equation for this
-special case). However, you cannot work with this class directly, as
-you must specify a dark energy model by using one of its subclasses
-instead, such as `~astropy.cosmology.FlatLambdaCDM`.
+Most of the functionality is enabled by the |FLRW| object. This represents a
+homogeneous and isotropic cosmology (characterized by the
+Friedmann-Lemaitre-Robertson-Walker metric, named after the people who solved
+Einstein's field equation for this special case). However, you cannot work with
+this class directly, as you must specify a dark energy model by using one of
+its subclasses instead, such as |FlatLambdaCDM|.
 
 Examples
 --------
@@ -126,8 +132,8 @@ Examples
   EXAMPLE START
   Working with the FlatLambdaCDM Class
 
-You can create a new `~astropy.cosmology.FlatLambdaCDM` object with
-arguments giving the Hubble parameter and Omega matter (both at z=0)::
+You can create a new |FlatLambdaCDM| object with arguments giving the Hubble
+parameter and Omega matter (both at z=0)::
 
   >>> from astropy.cosmology import FlatLambdaCDM
   >>> cosmo = FlatLambdaCDM(H0=70, Om0=0.3)
@@ -141,15 +147,13 @@ This can also be done more explicitly using units, which is recommended::
   >>> import astropy.units as u
   >>> cosmo = FlatLambdaCDM(H0=70 * u.km / u.s / u.Mpc, Tcmb0=2.725 * u.K, Om0=0.3)
 
-However, most of the parameters that accept units (``H0``, ``Tcmb0``)
-have default units, so unit quantities do not have to be used (with the
-exception of neutrino masses, where you must supply a unit if you want massive
-neutrinos).
+However, most of the parameters that accept units (``H0``, ``Tcmb0``) have
+default units, so unit quantities do not have to be used (with the exception of
+neutrino masses, where you must supply a unit if you want massive neutrinos).
 
-The predefined cosmologies described in the `Getting Started`_
-section are instances of `~astropy.cosmology.FlatLambdaCDM`, and have
-the same methods. So we can find the luminosity distance to
-redshift 4 by:
+The predefined cosmologies described in the `Getting Started`_ section are
+instances of |FlatLambdaCDM|, and have the same methods. So we can find the
+luminosity distance to redshift 4 by:
 
 .. doctest-requires:: scipy
 
@@ -171,9 +175,8 @@ They also accept arrays of redshifts:
   >>> cosmo.age([0.5, 1, 1.5] * cu.redshift)  # doctest: +FLOAT_CMP
   <Quantity [8.42128013, 5.74698021, 4.19645373] Gyr>
 
-See the `~astropy.cosmology.FLRW` and
-`~astropy.cosmology.FlatLambdaCDM` object docstring for all of the
-methods and attributes available.
+See the |FLRW| and |FlatLambdaCDM| object docstring for all of the methods and
+attributes available.
 
 ..
   EXAMPLE END
@@ -183,9 +186,9 @@ methods and attributes available.
   Working with Non-flat Universes with the LambdaCDM Class
 
 In addition to flat universes, non-flat varieties are supported, such as
-`~astropy.cosmology.LambdaCDM`. A variety of standard cosmologies with the
-parameters already defined are also available
-(see `Built-in Cosmologies`_)::
+|LambdaCDM|. A variety of standard cosmologies with the parameters already
+defined are also available (see `Built-in Cosmologies`_)
+::
 
   >>> from astropy.cosmology import WMAP7   # WMAP 7-year cosmology
   >>> WMAP7.critical_density(0)  # critical density at z = 0  # doctest: +FLOAT_CMP
@@ -200,13 +203,12 @@ You can see how the density parameters evolve with redshift as well::
   >>> WMAP7.Ode(np.array([0., 1.0, 2.0]))  # doctest: +FLOAT_CMP
   array([0.72791572, 0.2505506 , 0.0901026 ])
 
-Note that these do not quite add up to one, even though WMAP7 assumes a
-flat universe, because photons and neutrinos are included. Also note
-that the density parameters are unitless and so are not
-`~astropy.units.Quantity` objects.
+Note that these do not quite add up to one, even though |WMAP7| assumes a flat
+universe, because photons and neutrinos are included. Also note that the
+density parameters are unitless and so are not |Quantity| objects.
 
-It is possible to specify the baryonic matter density at redshift zero
-at class instantiation by passing the keyword argument ``Ob0``::
+It is possible to specify the baryonic matter density at redshift zero at class
+instantiation by passing the keyword argument ``Ob0``::
 
   >>> from astropy.cosmology import FlatLambdaCDM
   >>> cosmo = FlatLambdaCDM(H0=70, Om0=0.3, Ob0=0.05)
@@ -214,12 +216,11 @@ at class instantiation by passing the keyword argument ``Ob0``::
   FlatLambdaCDM(H0=70 km / (Mpc s), Om0=0.3, Tcmb0=0 K,
                 Neff=3.04, m_nu=None, Ob0=0.05)
 
-In this case the dark matter-only density at redshift 0 is
-available as class attribute ``Odm0`` and the redshift evolution of
-dark and baryonic matter densities can be computed using the methods
-``Odm`` and ``Ob``, respectively. If ``Ob0`` is not specified at class
-instantiation, it defaults to ``None`` and any method relying on it
-being specified will raise a ``ValueError``:
+In this case the dark matter-only density at redshift 0 is available as class
+attribute ``Odm0`` and the redshift evolution of dark and baryonic matter
+densities can be computed using the methods ``Odm`` and ``Ob``, respectively.
+If ``Ob0`` is not specified at class instantiation, it defaults to ``None`` and
+any method relying on it being specified will raise a ``ValueError``:
 
   >>> from astropy.cosmology import FlatLambdaCDM
   >>> cosmo = FlatLambdaCDM(H0=70, Om0=0.3)
@@ -229,8 +230,8 @@ being specified will raise a ``ValueError``:
   ValueError: Baryonic density not set for this cosmology, unclear
   meaning of dark matter density
 
-Cosmological instances have an optional ``name`` attribute which can be
-used to describe the cosmology::
+Cosmological instances have an optional ``name`` attribute which can be used to
+describe the cosmology::
 
   >>> from astropy.cosmology import FlatwCDM
   >>> cosmo = FlatwCDM(name='SNLS3+WMAP7', H0=71.58, Om0=0.262, w0=-1.016)
@@ -241,19 +242,17 @@ used to describe the cosmology::
 ..
   EXAMPLE END
 
-This is also an example with a different model for dark energy: a flat
-universe with a constant dark energy equation of state, but not
-necessarily a cosmological constant. A variety of additional dark
-energy models are also supported (see `Specifying a dark energy
-model`_).
+This is also an example with a different model for dark energy: a flat universe
+with a constant dark energy equation of state, but not necessarily a
+cosmological constant. A variety of additional dark energy models are also
+supported (see `Specifying a dark energy model`_).
 
-An important point is that the cosmological parameters of each
-instance are immutable — that is, if you want to change, say,
-``Om``, you need to make a new instance of the class. To make
-this more convenient, a ``clone`` operation is provided, which
-allows you to make a copy with specified values changed.
-Note that you cannot change the type of cosmology with this operation
-(e.g., flat to non-flat).
+An important point is that the cosmological parameters of each instance are
+immutable — that is, if you want to change, say, ``Om``, you need to make a new
+instance of the class. To make this more convenient, a
+:meth:`~astropy.cosmology.Cosmology.clone` operation is provided, which allows
+you to make a copy with specified values changed. Note that you cannot change
+the type of cosmology with this operation (e.g., flat to non-flat).
 
 ..
   EXAMPLE START
@@ -276,8 +275,8 @@ To make a copy of a cosmological instance using the ``clone`` operation:
 Finding the Redshift at a Given Value of a Cosmological Quantity
 ----------------------------------------------------------------
 
-If you know a cosmological quantity and you want to know the
-redshift which it corresponds to, you can use ``z_at_value``.
+If you know a cosmological quantity and you want to know the redshift which it
+corresponds to, you can use |z_at_value|.
 
 Example
 ^^^^^^^
@@ -298,11 +297,10 @@ To find the redshift using ``z_at_value``:
 ..
   EXAMPLE END
 
-For some quantities, there can be more than one redshift that satisfies
-a value. In this case you can use the ``zmin`` and ``zmax`` keywords
-to restrict the search range or set ``bracket`` to initialise it in the
-desired domain. See the ``z_at_value`` docstring for more detailed
-usage examples.
+For some quantities, there can be more than one redshift that satisfies a value.
+In this case you can use the ``zmin`` and ``zmax`` keywords to restrict the
+search range or set ``bracket`` to initialize it in the desired domain. See the
+|z_at_value| docstring for more detailed usage examples.
 
 
 Built-in Cosmologies
@@ -320,29 +318,30 @@ the WMAP and Planck satellite data. For example:
 A full list of the predefined cosmologies is given by
 ``cosmology.parameters.available`` and summarized below:
 
-========  ============================== ====  ===== =======
-Name      Source                         H0    Om    Flat
-========  ============================== ====  ===== =======
-WMAP1     Spergel et al. 2003            72.0  0.257 Yes
-WMAP3     Spergel et al. 2007            70.1  0.276 Yes
-WMAP5     Komatsu et al. 2009            70.2  0.277 Yes
-WMAP7     Komatsu et al. 2011            70.4  0.272 Yes
-WMAP9     Hinshaw et al. 2013            69.3  0.287 Yes
-Planck13  Planck Collab 2013, Paper XVI  67.8  0.307 Yes
-Planck15  Planck Collab 2015, Paper XIII 67.7  0.307 Yes
-Planck18  Planck Collab 2018, Paper VI   67.7  0.310 Yes
-========  ============================== ====  ===== =======
+===========  ============================== ====  ===== =======
+Name         Source                         H0    Om    Flat
+===========  ============================== ====  ===== =======
+_`WMAP1`     Spergel et al. 2003            72.0  0.257 Yes
+_`WMAP3`     Spergel et al. 2007            70.1  0.276 Yes
+_`WMAP5`     Komatsu et al. 2009            70.2  0.277 Yes
+_`WMAP7`     Komatsu et al. 2011            70.4  0.272 Yes
+_`WMAP9`     Hinshaw et al. 2013            69.3  0.287 Yes
+_`Planck13`  Planck Collab 2013, Paper XVI  67.8  0.307 Yes
+_`Planck15`  Planck Collab 2015, Paper XIII 67.7  0.307 Yes
+_`Planck18`  Planck Collab 2018, Paper VI   67.7  0.310 Yes
+===========  ============================== ====  ===== =======
 
 .. note::
 
   Unlike the Planck 2015 paper, the Planck 2018 paper includes massive
-  neutrinos in ``Om0`` but the Planck18 object includes them in ``m_nu`` instead
-  for consistency. Hence, the ``Om0`` value in Planck18 differs slightly
-  from the Planck 2018 paper but represents the same cosmological model.
+  neutrinos in ``Om0`` but the Planck18 object includes them in ``m_nu``
+  instead for consistency. Hence, the ``Om0`` value in Planck18 differs
+  slightly from the Planck 2018 paper but represents the same cosmological
+  model.
 
-Currently, all are instances of `~astropy.cosmology.FlatLambdaCDM`.
-More details about exactly where each set of parameters comes from
-are available in the docstring for each object::
+Currently, all are instances of |FlatLambdaCDM|. More details about exactly
+where each set of parameters comes from are available in the docstring for each
+object::
 
   >>> from astropy.cosmology import WMAP7
   >>> print(WMAP7.__doc__)
@@ -354,65 +353,58 @@ are available in the docstring for each object::
 Specifying a Dark Energy Model
 ------------------------------
 
-Along with the standard `~astropy.cosmology.FlatLambdaCDM` model
-described above, a number of additional dark energy models are
-provided. `~astropy.cosmology.FlatLambdaCDM`
-and `~astropy.cosmology.LambdaCDM` assume that dark
-energy is a cosmological constant, and should be the most commonly
-used cases; the former assumes a flat universe, the latter allows
-for spatial curvature. `~astropy.cosmology.FlatwCDM` and
-`~astropy.cosmology.wCDM` assume a constant dark
-energy equation of state parameterized by :math:`w_{0}`.
-Two forms of a variable dark energy equation of state are provided: the simple
-first order linear expansion :math:`w(z) = w_{0} + w_{z} z` by
-`~astropy.cosmology.w0wzCDM`, as well as the common CPL form by
-`~astropy.cosmology.w0waCDM`: :math:`w(z) = w_{0} + w_{a} (1 - a) =
-w_{0} + w_{a} z / (1 + z)` and its generalization to include a pivot
-redshift by `~astropy.cosmology.wpwaCDM`: :math:`w(z) = w_{p} + w_{a}
-(a_{p} - a)`.
+Along with the standard |FlatLambdaCDM| model described above, a number of
+additional dark energy models are provided. |FlatLambdaCDM| and |LambdaCDM|
+assume that dark energy is a cosmological constant, and should be the most
+commonly used cases; the former assumes a flat universe, the latter allows for
+spatial curvature. |FlatwCDM| and |wCDM| assume a constant dark energy equation
+of state parameterized by :math:`w_{0}`. Two forms of a variable dark energy
+equation of state are provided: the simple first order linear expansion
+:math:`w(z) = w_{0} + w_{z} z` by |w0wzCDM|, as well as the common CPL form by
+|w0waCDM|: :math:`w(z) = w_{0} + w_{a} (1 - a) = w_{0} + w_{a} z / (1 + z)`
+and its generalization to include a pivot redshift by |wpwaCDM|:
+:math:`w(z) = w_{p} + w_{a} (a_{p} - a)`.
 
-Users can specify their own equation of state by subclassing
-`~astropy.cosmology.FLRW`. See the provided subclasses for
-examples. It is advisable to stick to subclassing `~astropy.cosmology.FLRW`
-rather than one of its subclasses, since some of them use internal optimizations
-that also need to be propagated to any subclasses. Users wishing to use similar
-tricks (which can make distance calculations much faster) should consult the
-cosmology module source code for details.
+Users can specify their own equation of state by subclassing |FLRW|. See the
+provided subclasses for examples. It is advisable to stick to subclassing
+|FLRW| rather than one of its subclasses, since some of them use internal
+optimizations that also need to be propagated to any  subclasses. Users wishing
+to use similar tricks (which can make distance calculations much faster) should
+consult the cosmology module source code for details.
 
 Photons and Neutrinos
 ---------------------
 
-The cosmology classes (can) include the contribution to the energy density
-from both photons and neutrinos. By default, the latter are assumed
-massless. The three parameters controlling the properties of these
-species, which are arguments to the initializers of all of the
-cosmological classes, are ``Tcmb0`` (the temperature of the cosmic microwave
-background at z=0), ``Neff`` (the effective number of neutrino species), and
-``m_nu`` (the rest mass of the neutrino species). ``Tcmb0`` and ``m_nu`` should
-be expressed as unit Quantities. All three have standard default values — 0 K,
-3.04, and 0 eV, respectively. (The reason that ``Neff`` is not 3 has to do
-primarily with a small bump in the neutrino energy spectrum due to electron-
-positron annihilation, but is also affected by weak interaction physics.)
-Setting the CMB temperature to 0 removes the contribution of both neutrinos and
-photons. This is the default to ensure these components are excluded unless the
-user explicitly requests them.
+The cosmology classes (can) include the contribution to the energy density from
+both photons and neutrinos. By default, the latter are assumed massless. The
+three parameters controlling the properties of these species, which are
+arguments to the initializers of all of the cosmological classes, are ``Tcmb0``
+(the temperature of the cosmic microwave background at z=0), ``Neff`` (the
+effective number of neutrino species), and ``m_nu`` (the rest mass of the
+neutrino species). ``Tcmb0`` and ``m_nu`` should be expressed as unit
+Quantities. All three have standard default values — 0 K, 3.04, and 0 eV,
+respectively. (The reason that ``Neff`` is not 3 has to do primarily with a
+small bump in the neutrino energy spectrum due to electron-positron
+annihilation, but is also affected by weak interaction physics.) Setting the
+CMB temperature to 0 removes the contribution of both neutrinos and photons.
+This is the default to ensure these components are excluded unless the user
+explicitly requests them.
 
 Massive neutrinos are treated using the approach described in the
 WMAP seven-year cosmology paper (Komatsu et al. 2011, ApJS, 192, 18, section
 3.3). This is not the simple
 :math:`\Omega_{\nu 0} h^2 = \sum_i m_{\nu\, i} / 93.04\,\mathrm{eV}`
-approximation. Also note that the values of :math:`\Omega_{\nu}(z)`
-include both the kinetic energy and the rest mass energy components,
-and that the Planck13 and Planck15 cosmologies include a single
-species of neutrinos with non-zero mass (which is not included in
-:math:`\Omega_{m0}`).
+approximation. Also note that the values of :math:`\Omega_{\nu}(z)` include
+both the kinetic energy and the rest mass energy components, and that the
+|Planck13| and |Planck15| cosmologies include a single species of neutrinos
+with non-zero mass (which is not included in :math:`\Omega_{m0}`).
 
-Adding massive neutrinos can have significant performance implications.
-In particular, the computation of distance measures and lookback times
-are factors of three to four times slower than in the massless neutrino case.
-Therefore, if you need to compute many distances in such a cosmology and
-performance is critical, it is particularly useful to calculate them on
-a grid and use interpolation.
+Adding massive neutrinos can have significant performance implications. In
+particular, the computation of distance measures and lookback times are factors
+of three to four times slower than in the massless neutrino case. Therefore, if
+you need to compute many distances in such a cosmology and performance is
+critical, it is particularly useful to calculate them on a grid and use
+interpolation.
 
 Examples
 ^^^^^^^^
@@ -421,8 +413,8 @@ Examples
   EXAMPLE START
   Calculating the Contribution of Photons and Neutrinos to the Energy Density
 
-The contribution of photons and neutrinos to the total mass-energy density
-can be found as a function of redshift::
+The contribution of photons and neutrinos to the total mass-energy density can
+be found as a function of redshift::
 
   >>> from astropy.cosmology import WMAP7   # WMAP 7-year cosmology
   >>> WMAP7.Ogamma0, WMAP7.Onu0  # Current epoch values  # doctest: +FLOAT_CMP
@@ -441,9 +433,9 @@ set ``Tcmb0`` to 0 (which is also the default)::
   >>> cos.Ogamma0, cos.Onu0
   (0.0, 0.0)
 
-You can include photons but exclude any contributions from neutrinos by
-setting ``Tcmb0`` to be non-zero (2.725 K is the standard value for our
-Universe) but setting ``Neff`` to 0::
+You can include photons but exclude any contributions from neutrinos by setting
+``Tcmb0`` to be non-zero (2.725 K is the standard value for our Universe) but
+setting ``Neff`` to 0::
 
   >>> from astropy.cosmology import FlatLambdaCDM
   >>> cos = FlatLambdaCDM(70.4, 0.272, Tcmb0=2.725, Neff=0)
@@ -452,11 +444,11 @@ Universe) but setting ``Neff`` to 0::
   >>> cos.Onu(np.array([0, 1, 2]))  # But not neutrinos  # doctest: +FLOAT_CMP
   array([0., 0., 0.])
 
-The number of neutrino species is assumed to be the floor of ``Neff``,
-which in the default case is ``Neff=3``. Therefore, if non-zero neutrino masses
-are desired, then three masses should be provided. However, if only one
-value is provided, all of the species are assumed to have the same mass.
-``Neff`` is assumed to be shared equally between each species.
+The number of neutrino species is assumed to be the floor of ``Neff``, which in
+the default case is ``Neff=3``. Therefore, if non-zero neutrino masses are
+desired, then three masses should be provided. However, if only one value is
+provided, all of the species are assumed to have the same mass. ``Neff`` is
+assumed to be shared equally between each species.
 
 ::
 
@@ -480,8 +472,8 @@ value is provided, all of the species are assumed to have the same mass.
   >>> cosmo.Onu(1) * cosmo.critical_density(1)  # doctest: +FLOAT_CMP
   <Quantity 2.444380380370406e-31 g / cm3>
 
-While these examples used `~astropy.cosmology.FlatLambdaCDM`,
-the above examples also apply for all of the other cosmology classes.
+While these examples used |FlatLambdaCDM|, the above examples also apply for
+all of the other cosmology classes.
 
 ..
   EXAMPLE END
@@ -498,31 +490,28 @@ See Also
 Range of Validity and Reliability
 =================================
 
-The code in this sub-package is tested against several widely used
-online cosmology calculators and has been used to perform many
-calculations in refereed papers. You can check the range of redshifts
-over which the code is regularly tested in the module
-``astropy.cosmology.tests.test_cosmology``. If you find any bugs,
-please let us know by `opening an issue at the GitHub repository
-<https://github.com/astropy/astropy/issues>`_!
+The code in this sub-package is tested against several widely used online
+cosmology calculators and has been used to perform many calculations in
+refereed papers. You can check the range of redshifts over which the code is
+regularly tested in the module ``astropy.cosmology.tests.test_cosmology``. If
+you find any bugs, please let us know by `opening an issue at the GitHub
+repository <https://github.com/astropy/astropy/issues>`_!
 
-A more difficult question is the range of redshifts over which
-the code is expected to return valid results. This is necessarily
-model-dependent, but in general you should not expect the numeric
-results to be well behaved for redshifts more than a few times
-larger than the epoch of matter-radiation equality (so, for typical
-models, not above z = 5-6,000, but for some models much lower redshifts
-may be ill-behaved). In particular, you should pay attention to warnings
-from the ``scipy`` integration package about integrals failing to converge
-(which may only be issued once per session).
+A more difficult question is the range of redshifts over which the code is
+expected to return valid results. This is necessarily model-dependent, but in
+general you should not expect the numeric results to be well behaved for
+redshifts more than a few times larger than the epoch of matter-radiation
+equality (so, for typical models, not above z = 5-6,000, but for some models
+much lower redshifts may be ill-behaved). In particular, you should pay
+attention to warnings from the :mod:`scipy.integrate` package about integrals
+failing to converge (which may only be issued once per session).
 
-The built-in cosmologies use the parameters as listed in the
-respective papers. These provide only a limited range of precision,
-and so you should not expect derived quantities to match beyond
-that precision. For example, the Planck 2013 and 2015 results only provide the
-Hubble constant to four digits. Therefore, they should not be expected
-to match the age quoted by the Planck team to better than that, despite
-the fact that five digits are quoted in the papers.
+The built-in cosmologies use the parameters as listed in the respective papers.
+These provide only a limited range of precision, and so you should not expect
+derived quantities to match beyond that precision. For example, the Planck 2013
+and 2015 results only provide the Hubble constant to four digits. Therefore,
+they should not be expected to match the age quoted by the Planck team to
+better than that, despite the fact that five digits are quoted in the papers.
 
 Reference/API
 =============

--- a/docs/cosmology/index.rst
+++ b/docs/cosmology/index.rst
@@ -63,10 +63,7 @@ transverse proper kiloparsecs (kpc) corresponding to an arcminute at z=3::
 Here |WMAP9| is a built-in object describing a cosmology with the parameters
 from the nine-year WMAP results. Several other built-in cosmologies are also
 available (see `Built-in Cosmologies`_). The available methods of the cosmology
-object are listed in the methods summary for the |FLRW| class. If you are using
-IPython you can also use tab completion to print a list of the available
-methods. To do this, after importing the cosmology as in the above example,
-type ``cosmo.`` at the IPython prompt and then press the tab key.
+object are listed in the methods summary for the |FLRW| class.
 
 All of these methods also accept an arbitrarily-shaped array of redshifts as
 input:
@@ -147,9 +144,6 @@ This can also be done more explicitly using units, which is recommended::
   >>> import astropy.units as u
   >>> cosmo = FlatLambdaCDM(H0=70 * u.km / u.s / u.Mpc, Tcmb0=2.725 * u.K, Om0=0.3)
 
-However, most of the parameters that accept units (``H0``, ``Tcmb0``) have
-default units, so unit quantities do not have to be used (with the exception of
-neutrino masses, where you must supply a unit if you want massive neutrinos).
 
 The predefined cosmologies described in the `Getting Started`_ section are
 instances of |FlatLambdaCDM|, and have the same methods. So we can find the

--- a/docs/cosmology/io.rst
+++ b/docs/cosmology/io.rst
@@ -5,7 +5,7 @@ Read, Write, and Convert Cosmology Objects
 
 For *temporary* storage an easy means to serialize and deserialize a Cosmology
 object is using the :mod:`pickle` module. This is good for e.g. passing a
-Cosmology between threads.
+|Cosmology| between threads.
 
 .. doctest-skip::
 
@@ -30,10 +30,8 @@ and writing data in different formats.
 Getting Started
 ===============
 
-The |Cosmology| class includes two methods,
-:meth:`~astropy.cosmology.Cosmology.read` and
-:meth:`~astropy.cosmology.Cosmology.write`, that make it possible to read from
-and write to files.
+The |Cosmology| class includes two methods, |Cosmology.read| and
+|Cosmology.write|, that make it possible to read from and write to files.
 
 Currently the only registered ``read`` / ``write`` format is "ascii.ecsv",
 like for Table. Also, custom ``read`` / ``write`` formats may be registered
@@ -48,7 +46,7 @@ positional arguments and keyword arguments are passed to the reader methods.
     >>> from astropy.cosmology import Planck18
     >>> Planck18.write("example_cosmology.ecsv", format="ascii.ecsv")
 
-Reading back the cosmology is most safely done from ``Cosmology``, the base
+Reading back the cosmology is most safely done from |Cosmology|, the base
 class, as it provides no default information and therefore requires the file
 to have all necessary information to describe a cosmology.
 
@@ -74,11 +72,10 @@ This list will include both built-in and registered 3rd-party formats.
 "myformat" is from an `example 3rd-party package
 <https://github.com/astropy/astropy/tree/main/astropy/cosmology/tests/mypackage>`_.
 
-When a subclass of ``Cosmology`` is used to read a file, the subclass will
-provide a keyword argument ``cosmology=<class>`` to the registered read
-method. The method uses this cosmology class, regardless of the class
-indicated in the file, and sets parameters' default values from the class'
-signature.
+When a subclass of |Cosmology| is used to read a file, the subclass will provide
+a keyword argument ``cosmology=<class>`` to the registered read method. The
+method uses this cosmology class, regardless of the class indicated in the
+file, and sets parameters' default values from the class' signature.
 
 .. doctest-skip::
 
@@ -89,9 +86,8 @@ signature.
 
 Reading and writing |Cosmology| objects go through intermediate
 representations, often a dict or |QTable| instance. These intermediate
-representations are accessible through the methods
-:meth:`~astropy.cosmology.Cosmology.to_format` /
-:meth:`~astropy.cosmology.Cosmology.from_format`.
+representations are accessible through the methods |Cosmology.to_format| /
+|Cosmology.from_format|.
 
 To see the a list of the available conversion formats:
 
@@ -113,8 +109,7 @@ For instance, in the above, "mapping" is built-in while "mypackage" and
 is from an `example 3rd-party package
 <https://github.com/astropy/astropy/tree/main/astropy/cosmology/tests/mypackage>`_.
 
-:meth:`~astropy.cosmology.Cosmology.to_format` /
-:meth:`~astropy.cosmology.Cosmology.from_format` parse a Cosmology to/from
+|Cosmology.to_format| / |Cosmology.from_format| parse a Cosmology to/from
 another python object. This can be useful for e.g., iterating through an MCMC
 of cosmological parameters or printing out a cosmological model to a journal
 format, like latex or HTML. When 3rd party cosmology packages register with
@@ -135,7 +130,7 @@ instances between packages!
      ...
 
 Now this dict can be used to load a new cosmological instance identical
-to the ``Planck18`` cosmology from which it was created.
+to the |Planck18| cosmology from which it was created.
 
 .. code-block::
 
@@ -148,8 +143,8 @@ to the ``Planck18`` cosmology from which it was created.
 
 .. EXAMPLE START: Planck18 to QTable and back
 
-Another pre-registered format is "table", for converting a |Cosmology| to
-and from a |QTable|.
+Another pre-registered format is "table", for converting a |Cosmology| to and
+from a |QTable|.
 
 .. code-block::
 
@@ -162,8 +157,8 @@ and from a |QTable|.
     -------- ------------ ------- ------- ------- ----------- -------
     Planck18        67.66 0.30966  2.7255   3.046 0.0 .. 0.06 0.04897
 
-Cosmology supports the astropy Table-like protocol (see :ref:`Table-like Objects`)
-to the same effect:
+Cosmology supports the astropy Table-like protocol (see
+:ref:`Table-like Objects`) to the same effect:
 
 .. code-block::
 
@@ -177,8 +172,8 @@ to the same effect:
     -------- ------------ ------- ------- ------- ----------- -------
     Planck18        67.66 0.30966  2.7255   3.046 0.0 .. 0.06 0.04897
 
-Now this |QTable| can be used to load a new cosmological
-instance identical to the ``Planck18`` cosmology from which it was created.
+Now this |QTable| can be used to load a new cosmological instance identical to
+the |Planck18| cosmology from which it was created.
 
 .. code-block::
 
@@ -187,15 +182,14 @@ instance identical to the ``Planck18`` cosmology from which it was created.
     FlatLambdaCDM(name="Planck18", H0=67.7 km / (Mpc s), Om0=0.31,
                   Tcmb0=2.725 K, Neff=3.05, m_nu=[0. 0. 0.06] eV, Ob0=0.049)
 
-Perhaps more usefully, |QTable| can be saved to ``latex``
-and ``html`` formats, which can be copied into journal articles and websites,
-respectively.
+Perhaps more usefully, |QTable| can be saved to ``latex`` and ``html`` formats,
+which can be copied into journal articles and websites, respectively.
 
 .. EXAMPLE END
 
 .. EXAMPLE START: Planck18 to Model and back
 
-Using ``format="astropy.model`` any redshift(s) method of a cosmology may be
+Using ``format="astropy.model"`` any redshift(s) method of a cosmology may be
 turned into a :class:`astropy.modeling.Model`. Each |Cosmology|
 :class:`~astropy.cosmology.Parameter` is converted to a
 :class:`astropy.modeling.Model` :class:`~astropy.modeling.Parameter`
@@ -210,8 +204,8 @@ Now you can fit cosmologies with data!
         Tcmb0=2.7255 K, Neff=3.046, m_nu=[0.  , 0.  , 0.06] eV, Ob0=0.04897,
         name='Planck18')>
 
-Like for the other formats, the ``Planck18`` cosmology can be recovered with
-`~astropy.cosmology.Cosmology.from_format`.
+Like for the other formats, the |Planck18| cosmology can be recovered with
+|Cosmology.from_format|.
 
 
 .. _custom_cosmology_converters:
@@ -221,21 +215,19 @@ Custom Cosmology To/From Formats
 
 Custom representation formats may also be registered into the Astropy Cosmology
 I/O framework for use by these methods. For details of the framework see
-:ref:`io_registry`.
-Note |Cosmology| ``to/from_format`` uses a custom registry, available at
-``Cosmology.<to/from>_format.registry``.
+:ref:`io_registry`. Note |Cosmology| ``to/from_format`` uses a custom registry,
+available at ``Cosmology.<to/from>_format.registry``.
 
 .. EXAMPLE START : custom to/from format
 
-As an example, the following is an implementation of an
-:class:`astropy.table.Row` converter. We can and should use inbuilt parsers,
-like |QTable|, but to show a more complete example we limit ourselves to only
-the "mapping" parser.
+As an example, the following is an implementation of an |Row| converter. We can
+and should use inbuilt parsers, like |QTable|, but to show a more complete
+example we limit ourselves to only the "mapping" parser.
 
-We start by defining the function to parse a `astropy.table.Row` into a
-|Cosmology|. This function should take 1 positional argument, the row object,
-and 2 keyword arguments, for how to handle extra metadata and which Cosmology
-class to use. Details about metadata treatment are in
+We start by defining the function to parse a |Row| into a |Cosmology|. This
+function should take 1 positional argument, the row object, and 2 keyword
+arguments, for how to handle extra metadata and which Cosmology class to use.
+Details about metadata treatment are in
 ``Cosmology.from_format.help("mapping")``.
 
 .. code-block:: python
@@ -257,10 +249,10 @@ class to use. Details about metadata treatment are in
     ...                                  cosmology=cosmology)
 
 The next step is a function to perform the reverse operation: parse a
-|Cosmology| into a `~astropy.table.Row`. This function requires only the
-cosmology object and a ``*args`` to absorb unneeded information passed by
+|Cosmology| into a |Row|. This function requires only the cosmology object and
+a ``*args`` to absorb unneeded information passed by
 :class:`astropy.io.registry.UnifiedReadWrite` (which implements
-:meth:`astropy.cosmology.Cosmology.to_format`).
+|Cosmology.to_format|).
 
 .. code-block:: python
 
@@ -294,9 +286,8 @@ register everything into `astropy.io.registry`.
     >>> # convert_registry.register_writer("astropy.row", Cosmology, to_table_row)
     >>> # convert_registry.register_identifier("astropy.row", Cosmology, row_identify)
 
-Now the registered functions can be used in
-:meth:`astropy.cosmology.Cosmology.from_format` and
-:meth:`astropy.cosmology.Cosmology.to_format`.
+Now the registered functions can be used in |Cosmology.from_format| and
+|Cosmology.to_format|.
 
 .. code-block:: python
 
@@ -322,8 +313,8 @@ Now the registered functions can be used in
 Custom Cosmology Readers/Writers
 ================================
 
-Custom ``read`` / ``write`` formats may be registered into the Astropy Cosmology
-I/O framework. For details of the framework see :ref:`io_registry`.
+Custom ``read`` / ``write`` formats may be registered into the Astropy
+Cosmology I/O framework. For details of the framework see :ref:`io_registry`.
 Note |Cosmology| ``read/write`` uses a custom registry, available at
 ``Cosmology.<read/write>.registry``.
 
@@ -335,9 +326,8 @@ As an example, in the following we will fully work out a |Cosmology| <-> JSON
 
 We start by defining the function to parse JSON into a |Cosmology|. This
 function should take 1 positional argument, the file object or file path. We
-will also pass kwargs through to
-:meth:`~astropy.cosmology.Cosmology.from_format`, which handles metadata and
-which Cosmology class to use. Details of are in
+will also pass kwargs through to |Cosmology.from_format|, which handles
+metadata and which Cosmology class to use. Details of are in
 ``Cosmology.from_format.help("mapping")``.
 
 .. code-block:: python
@@ -407,9 +397,8 @@ register everything into :mod:`astropy.io.registry`.
     >>> readwrite_registry.register_writer("json", Cosmology, write_json)
     >>> readwrite_registry.register_identifier("json", Cosmology, json_identify)
 
-Now the registered functions can be used in
-:meth:`astropy.cosmology.Cosmology.read` and
-:meth:`astropy.cosmology.Cosmology.write`.
+Now the registered functions can be used in |Cosmology.read| and
+|Cosmology.write|.
 
 .. doctest-skip:: win32
 

--- a/docs/cosmology/units.rst
+++ b/docs/cosmology/units.rst
@@ -34,13 +34,12 @@ About the Units
 Cosmological Redshift and Dimensionless Equivalency
 ---------------------------------------------------
 
-There are numerous measures of distance in cosmology -- luminosities,
-CMB temperature, the universe's age, etc. -- but redshift is the principal
-measure from which others are defined. In cosmology, distance measures are
-commonly exasperating to follow in a derivation, because they are used
-so interchangeably. ``astropy`` provides the ``redshift`` unit and associated
-equivalencies to assist in these derivations by providing a way to convert
-to/from redshift "units".
+There are numerous measures of distance in cosmology -- luminosities, CMB
+temperature, the universe's age, etc. -- but redshift is the principal measure
+from which others are defined. In cosmology, distance measures are commonly
+exasperating to follow in a derivation, because they are used interchangeably.
+``astropy`` provides the ``redshift`` unit and associated equivalencies to
+assist in these derivations and unify the distance measures.
 
 Examples
 ^^^^^^^^
@@ -116,7 +115,7 @@ so too will the conversions.
     <Quantity 3303. K>
 
 If no argument is given (or the argument is `None`), this equivalency assumes
-the current default :class:`~astropy.cosmology.Cosmology`:
+the current default |Cosmology|:
 
     >>> z.to(u.K, cu.with_redshift())
     <Quantity 3000.7755 K>
@@ -169,7 +168,7 @@ literature as just ``h``, here it is ``littleh`` to avoid confusion with
 "hours."
 
 If no argument is given (or the argument is `None`), this equivalency assumes
-the ``H0`` from the current default :class:`~astropy.cosmology.Cosmology`:
+the ``H0`` from the current default |Cosmology|:
 
 .. code-block:: python
 


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

Just some cleaning. Minimal wording change. Mostly getting stuff to same wrap length.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
