### PR TITLE
move Parameter conversion to own functions

### DIFF
--- a/astropy/cosmology/flrw.py
+++ b/astropy/cosmology/flrw.py
@@ -125,7 +125,7 @@ class FLRW(Cosmology):
                       unit="Kelvin", fvalidate="scalar")
     Neff = Parameter(doc="Number of effective neutrino species.", fvalidate="non-negative")
     m_nu = Parameter(doc="Mass of neutrino species.",
-                     unit="eV", equivalencies=u.mass_energy(), fmt="")
+                     unit="eV", equivalencies=u.mass_energy())
     Ob0 = Parameter(doc="Omega baryon; baryonic matter density/critical density at z=0.")
 
     def __init__(self, H0, Om0, Ode0, Tcmb0=0.0*u.K, Neff=3.04, m_nu=0.0*u.eV,

--- a/astropy/cosmology/flrw.py
+++ b/astropy/cosmology/flrw.py
@@ -122,7 +122,7 @@ class FLRW(Cosmology):
     Ode0 = Parameter(doc="Omega dark energy; dark energy density/critical density at z=0.",
                      fvalidate="float")
     Tcmb0 = Parameter(doc="Temperature of the CMB as `~astropy.units.Quantity` at z=0.",
-                      unit="Kelvin", fmt="0.4g", fvalidate="scalar")
+                      unit="Kelvin", fvalidate="scalar")
     Neff = Parameter(doc="Number of effective neutrino species.", fvalidate="non-negative")
     m_nu = Parameter(doc="Mass of neutrino species.",
                      unit="eV", equivalencies=u.mass_energy(), fmt="")

--- a/astropy/cosmology/io/_parameter.py
+++ b/astropy/cosmology/io/_parameter.py
@@ -1,0 +1,76 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+from numbers import Number
+
+import numpy as np
+
+from astropy.cosmology.parameter import Parameter
+from astropy.table import Column
+from astropy.modeling import Parameter as ModelParameter
+
+
+def _convert_Parameter_to_Column(parameter, value, param_meta=None):
+    """Convert a Cosmology Parameter to a Table Column.
+
+    Parameters
+    ----------
+    parameter : `astropy.cosmology.parameter.Parameter`
+    value : Any
+    meta : dict or None, optional
+        Information from the Cosmology's metadata.
+
+    Returns
+    -------
+    `astropy.table.Column`
+    """
+    if value is None:  # Create None column
+        data = [None]
+        dtype = np.object_
+        format = None
+    else:  # Create empty column. Assign later.
+        data = None  # assigned later
+        dtype = None
+        format = parameter.format_spec
+
+    col = Column(data=data,
+                 name=parameter.name,
+                 dtype=dtype,
+                 shape=np.shape(value),  # minimum of 1d
+                 length=1,  # Cosmology is scalar
+                 description=parameter.__doc__,
+                 unit=parameter.unit,
+                 format=format,
+                 meta=param_meta,
+                 copy=False,
+                 copy_indices=True)
+    if value is not None:
+        col[:] = value  # Assign value in-place
+
+    return col
+
+
+def _convert_Parameter_to_Model_Parameter(parameter, value, meta=None):
+    """Convert a Cosmology Parameter to a Model Parameter.
+
+    Parameters
+    ----------
+    parameter : `astropy.cosmology.parameter.Parameter`
+    value : Any
+    meta : dict or None, optional
+        Information from the Cosmology's metadata.
+        This function will use any of: 'getter', 'setter', 'fixed', 'tied',
+        'min', 'max', 'bounds', 'prior', 'posterior'.
+
+    Returns
+    -------
+    `astropy.modeling.Parameter`
+    """
+    # Get from meta information relavant to Model
+    extra = {k: v for k, v in (meta or {}).items()
+             if k in ('getter', 'setter', 'fixed', 'tied', 'min', 'max',
+                      'bounds', 'prior', 'posterior')}
+
+    return ModelParameter(description=parameter.__doc__,
+                          default=value,
+                          unit=getattr(value, "unit", None),
+                          **extra)

--- a/astropy/cosmology/io/_parameter.py
+++ b/astropy/cosmology/io/_parameter.py
@@ -1,7 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from numbers import Number
-
 import numpy as np
 
 from astropy.cosmology.parameter import Parameter

--- a/astropy/cosmology/io/mapping.py
+++ b/astropy/cosmology/io/mapping.py
@@ -79,7 +79,7 @@ def from_mapping(map, *, move_to_meta=False, cosmology=None):
         >>> del cm["Tcmb0"]  # show FlatLambdaCDM provides default
         >>> FlatLambdaCDM.from_format(cm)
         FlatLambdaCDM(name="Planck18", H0=67.66 km / (Mpc s), Om0=0.30966,
-                      Tcmb0=0 K, Neff=3.046, m_nu=None, Ob0=0.04897)
+                      Tcmb0=0.0 K, Neff=3.046, m_nu=None, Ob0=0.04897)
     """
     params = dict(map)  # so we are guaranteed to have a poppable map
 

--- a/astropy/cosmology/io/mapping.py
+++ b/astropy/cosmology/io/mapping.py
@@ -68,8 +68,8 @@ def from_mapping(map, *, move_to_meta=False, cosmology=None):
 
         >>> cosmo = Cosmology.from_format(cm, format="mapping")
         >>> cosmo
-        FlatLambdaCDM(name="Planck18", H0=67.7 km / (Mpc s), Om0=0.31,
-                      Tcmb0=2.725 K, Neff=3.05, m_nu=[0. 0. 0.06] eV, Ob0=0.049)
+        FlatLambdaCDM(name="Planck18", H0=67.66 km / (Mpc s), Om0=0.30966,
+                      Tcmb0=2.7255 K, Neff=3.046, m_nu=[0. 0. 0.06] eV, Ob0=0.04897)
 
     Specific cosmology classes can be used to parse the data. The class'
     default parameter values are used to fill in any information missing in the
@@ -78,8 +78,8 @@ def from_mapping(map, *, move_to_meta=False, cosmology=None):
         >>> from astropy.cosmology import FlatLambdaCDM
         >>> del cm["Tcmb0"]  # show FlatLambdaCDM provides default
         >>> FlatLambdaCDM.from_format(cm)
-        FlatLambdaCDM(name="Planck18", H0=67.7 km / (Mpc s), Om0=0.31,
-                      Tcmb0=0 K, Neff=3.05, m_nu=None, Ob0=0.049)
+        FlatLambdaCDM(name="Planck18", H0=67.66 km / (Mpc s), Om0=0.30966,
+                      Tcmb0=0 K, Neff=3.046, m_nu=None, Ob0=0.04897)
     """
     params = dict(map)  # so we are guaranteed to have a poppable map
 

--- a/astropy/cosmology/io/model.py
+++ b/astropy/cosmology/io/model.py
@@ -20,6 +20,8 @@ from astropy.modeling import FittableModel, Model
 from astropy.modeling import Parameter as ModelParameter
 from astropy.utils.decorators import classproperty
 
+from ._parameter import _convert_Parameter_to_Model_Parameter as _convert_Parameter
+
 __all__ = []  # nothing is publicly scoped
 
 
@@ -142,8 +144,8 @@ def from_model(model):
     >>> from astropy.cosmology import Cosmology, Planck18
     >>> model = Planck18.to_format("astropy.model", method="lookback_time")
     >>> Cosmology.from_format(model)
-    FlatLambdaCDM(name="Planck18", H0=67.7 km / (Mpc s), Om0=0.31,
-                  Tcmb0=2.725 K, Neff=3.05, m_nu=[0. 0. 0.06] eV, Ob0=0.049)
+    FlatLambdaCDM(name="Planck18", H0=67.66 km / (Mpc s), Om0=0.30966,
+                  Tcmb0=2.7255 K, Neff=3.046, m_nu=[0. 0. 0.06] eV, Ob0=0.04897)
     """
     cosmology = model.cosmology_class
     meta = copy.deepcopy(model.meta)
@@ -213,11 +215,10 @@ def to_model(cosmology, *_, method):
         if v is None:  # skip unspecified parameters
             continue
 
-        params[n] = ModelParameter(default=getattr(cosmology, n),
-                                   unit=getattr(cosmo_cls, n).unit,
-                                   **cosmology.meta.get(n, {}))
+        # add as Model Parameter
+        params[n] = _convert_Parameter(getattr(cosmo_cls, n), v, cosmology.meta.get(n))
 
-    # class name is cosmology name + method name + _CosmologyModel
+    # class name is cosmology name + Cosmology + method name + Model
     clsname = (cosmo_cls.__qualname__.replace(".", "_")
                + "Cosmology"
                + method.replace("_", " ").title().replace(" ", "")

--- a/astropy/cosmology/io/model.py
+++ b/astropy/cosmology/io/model.py
@@ -20,7 +20,7 @@ from astropy.modeling import FittableModel, Model
 from astropy.modeling import Parameter as ModelParameter
 from astropy.utils.decorators import classproperty
 
-from ._parameter import _convert_Parameter_to_Model_Parameter as _convert_Parameter
+from .utils import convert_parameter_to_model_parameter
 
 __all__ = []  # nothing is publicly scoped
 
@@ -216,7 +216,8 @@ def to_model(cosmology, *_, method):
             continue
 
         # add as Model Parameter
-        params[n] = _convert_Parameter(getattr(cosmo_cls, n), v, cosmology.meta.get(n))
+        params[n] = convert_parameter_to_model_parameter(getattr(cosmo_cls, n), v,
+                                                         cosmology.meta.get(n))
 
     # class name is cosmology name + Cosmology + method name + Model
     clsname = (cosmo_cls.__qualname__.replace(".", "_")

--- a/astropy/cosmology/io/row.py
+++ b/astropy/cosmology/io/row.py
@@ -69,10 +69,8 @@ def from_row(row, *, move_to_meta=False, cosmology=None):
     # parent table. If Row is ever separated from Table, this should be moved
     # to ``to_table``.
     for col in row._table.itercols():
-        # Only add metadata if exists and not empty,
-        # e.g. Table has Column with meta, QTable doesn't have Column.
-        if getattr(col, "meta", None):
-            meta[col.name].update(col.meta)
+        if col.info.meta:  # Only add metadata if not empty
+            meta[col.name].update(col.info.meta)
 
     # turn row into mapping, filling cosmo if not in a column
     mapping = dict(row)

--- a/astropy/cosmology/io/row.py
+++ b/astropy/cosmology/io/row.py
@@ -1,10 +1,11 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import copy
+from collections import defaultdict
 
 import numpy as np
 
-from astropy.table import Row
+from astropy.table import Row, QTable
 from astropy.cosmology.connect import convert_registry
 from astropy.cosmology.core import Cosmology
 
@@ -57,24 +58,33 @@ def from_row(row, *, move_to_meta=False, cosmology=None):
 
         >>> cosmo = Cosmology.from_format(cr, format="astropy.row")
         >>> cosmo
-        FlatLambdaCDM(name="Planck18", H0=67.7 km / (Mpc s), Om0=0.31,
-                      Tcmb0=2.725 K, Neff=3.05, m_nu=[0. 0. 0.06] eV, Ob0=0.049)
+        FlatLambdaCDM(name="Planck18", H0=67.66 km / (Mpc s), Om0=0.30966,
+                      Tcmb0=2.7255 K, Neff=3.046, m_nu=[0. 0. 0.06] eV, Ob0=0.04897)
     """
     # special values
     name = row['name'] if 'name' in row.columns else None  # get name from column
-    meta = copy.deepcopy(row.meta)
+
+    meta = defaultdict(dict, copy.deepcopy(row.meta))
+    # Now need to add the Columnar metadata. This is only available on the
+    # parent table. If Row is ever separated from Table, this should be moved
+    # to ``to_table``.
+    for col in row._table.itercols():
+        # Only add metadata if exists and not empty,
+        # e.g. Table has Column with meta, QTable doesn't have Column.
+        if getattr(col, "meta", None):
+            meta[col.name].update(col.meta)
 
     # turn row into mapping, filling cosmo if not in a column
     mapping = dict(row)
     mapping["name"] = name
     mapping.setdefault("cosmology", meta.pop("cosmology", None))
-    mapping["meta"] = meta
+    mapping["meta"] = dict(meta)
 
     # build cosmology from map
     return from_mapping(mapping, move_to_meta=move_to_meta, cosmology=cosmology)
 
 
-def to_row(cosmology, *args, cosmology_in_meta=False):
+def to_row(cosmology, *args, cosmology_in_meta=False, table_cls=QTable):
     """Serialize the cosmology into a `~astropy.table.Row`.
 
     Parameters
@@ -83,6 +93,9 @@ def to_row(cosmology, *args, cosmology_in_meta=False):
     *args
         Not used. Needed for compatibility with
         `~astropy.io.registry.UnifiedReadWriteMethod`
+    table_cls: type (optional, keyword-only)
+        Astropy :class:`~astropy.table.Table` class or subclass type to use.
+        Default is :class:`~astropy.table.QTable`.
     cosmology_in_meta : bool
         Whether to put the cosmology class in the Table metadata (if `True`) or
         as the first column (if `False`, default).
@@ -114,7 +127,7 @@ def to_row(cosmology, *args, cosmology_in_meta=False):
     """
     from .table import to_table
 
-    table = to_table(cosmology, cosmology_in_meta=cosmology_in_meta)
+    table = to_table(cosmology, cls=table_cls, cosmology_in_meta=cosmology_in_meta)
     return table[0]  # extract row from table
 
 

--- a/astropy/cosmology/io/table.py
+++ b/astropy/cosmology/io/table.py
@@ -6,8 +6,9 @@ import numpy as np
 
 from astropy.cosmology.connect import convert_registry
 from astropy.cosmology.core import Cosmology
-from astropy.table import QTable, Table
+from astropy.table import QTable, Table, Column
 
+from ._parameter import _convert_Parameter_to_Column
 from .mapping import to_mapping
 from .row import from_row
 
@@ -64,8 +65,8 @@ def from_table(table, index=None, *, move_to_meta=False, cosmology=None):
 
         >>> cosmo = Cosmology.from_format(ct, format="astropy.table")
         >>> cosmo
-        FlatLambdaCDM(name="Planck18", H0=67.7 km / (Mpc s), Om0=0.31,
-                      Tcmb0=2.725 K, Neff=3.05, m_nu=[0. 0. 0.06] eV, Ob0=0.049)
+        FlatLambdaCDM(name="Planck18", H0=67.66 km / (Mpc s), Om0=0.30966,
+                      Tcmb0=2.7255 K, Neff=3.046, m_nu=[0. 0. 0.06] eV, Ob0=0.04897)
 
     Specific cosmology classes can be used to parse the data. The class'
     default parameter values are used to fill in any information missing in the
@@ -74,8 +75,8 @@ def from_table(table, index=None, *, move_to_meta=False, cosmology=None):
         >>> from astropy.cosmology import FlatLambdaCDM
         >>> del ct["Tcmb0"]  # show FlatLambdaCDM provides default
         >>> FlatLambdaCDM.from_format(ct)
-        FlatLambdaCDM(name="Planck18", H0=67.7 km / (Mpc s), Om0=0.31,
-                      Tcmb0=0 K, Neff=3.05, m_nu=None, Ob0=0.049)
+        FlatLambdaCDM(name="Planck18", H0=67.66 km / (Mpc s), Om0=0.30966,
+                      Tcmb0=0 K, Neff=3.046, m_nu=None, Ob0=0.04897)
 
     For tables with multiple rows of cosmological parameters, the ``index``
     argument is needed to select the correct row. The index can be an integer
@@ -208,17 +209,28 @@ def to_table(cosmology, *args, cls=QTable, cosmology_in_meta=True):
     if not issubclass(cls, Table):
         raise TypeError(f"'cls' must be a (sub)class of Table, not {type(cls)}")
 
-    # start by getting a map representation. This requires minimal repackaging.
-    p = to_mapping(cosmology)
-    p["cosmology"] = p["cosmology"].__qualname__
-    # create metadata from mapping
-    meta = p.pop("meta")
-    if cosmology_in_meta:  # move class to Table meta
-        meta["cosmology"] = p.pop("cosmology")
-    # package parameters into lists for Table parsing
-    params = {k: [v] for k, v in p.items()}
+    # Start by getting a map representation.
+    data = to_mapping(cosmology)
+    data["cosmology"] = data["cosmology"].__qualname__  # change to str
 
-    tbl = cls(params, meta=meta)
+    # Metadata
+    meta = data.pop("meta")  # remove the meta
+    if cosmology_in_meta:
+        meta["cosmology"] = data.pop("cosmology")
+
+    # Need to turn everything into something Table can process:
+    # - Column for Parameter
+    # - list for anything else
+    cosmo_cls = cosmology.__class__
+    for k, v in data.items():
+        if k in cosmology.__parameters__:
+            col = _convert_Parameter_to_Column(getattr(cosmo_cls, k), v,
+                                               cosmology.meta.get(k))
+        else:
+            col = Column([v])
+        data[k] = col
+
+    tbl = cls(data, meta=meta)
     tbl.add_index("name", unique=True)
     return tbl
 

--- a/astropy/cosmology/io/table.py
+++ b/astropy/cosmology/io/table.py
@@ -8,9 +8,9 @@ from astropy.cosmology.connect import convert_registry
 from astropy.cosmology.core import Cosmology
 from astropy.table import QTable, Table, Column
 
-from ._parameter import _convert_Parameter_to_Column
 from .mapping import to_mapping
 from .row import from_row
+from .utils import convert_parameter_to_column
 
 
 def from_table(table, index=None, *, move_to_meta=False, cosmology=None):
@@ -76,7 +76,7 @@ def from_table(table, index=None, *, move_to_meta=False, cosmology=None):
         >>> del ct["Tcmb0"]  # show FlatLambdaCDM provides default
         >>> FlatLambdaCDM.from_format(ct)
         FlatLambdaCDM(name="Planck18", H0=67.66 km / (Mpc s), Om0=0.30966,
-                      Tcmb0=0 K, Neff=3.046, m_nu=None, Ob0=0.04897)
+                      Tcmb0=0.0 K, Neff=3.046, m_nu=None, Ob0=0.04897)
 
     For tables with multiple rows of cosmological parameters, the ``index``
     argument is needed to select the correct row. The index can be an integer
@@ -224,8 +224,8 @@ def to_table(cosmology, *args, cls=QTable, cosmology_in_meta=True):
     cosmo_cls = cosmology.__class__
     for k, v in data.items():
         if k in cosmology.__parameters__:
-            col = _convert_Parameter_to_Column(getattr(cosmo_cls, k), v,
-                                               cosmology.meta.get(k))
+            col = convert_parameter_to_column(getattr(cosmo_cls, k), v,
+                                              cosmology.meta.get(k))
         else:
             col = Column([v])
         data[k] = col

--- a/astropy/cosmology/io/utils.py
+++ b/astropy/cosmology/io/utils.py
@@ -7,8 +7,8 @@ from astropy.table import Column
 from astropy.modeling import Parameter as ModelParameter
 
 
-def _convert_Parameter_to_Column(parameter, value, param_meta=None):
-    """Convert a Cosmology Parameter to a Table Column.
+def convert_parameter_to_column(parameter, value, meta=None):
+    """Convert a |Cosmology| Parameter to a Table |Column|.
 
     Parameters
     ----------
@@ -21,33 +21,20 @@ def _convert_Parameter_to_Column(parameter, value, param_meta=None):
     -------
     `astropy.table.Column`
     """
-    if value is None:  # Create None column
-        data = [None]
-        dtype = np.object_
-        format = None
-    else:  # Create empty column. Assign later.
-        data = None  # assigned later
-        dtype = None
-        format = parameter.format_spec
+    format = None if value is None else parameter.format_spec
+    shape = (1,) + np.shape(value)  # minimum of 1d
 
-    col = Column(data=data,
+    col = Column(data=np.reshape(value, shape),
                  name=parameter.name,
-                 dtype=dtype,
-                 shape=np.shape(value),  # minimum of 1d
-                 length=1,  # Cosmology is scalar
+                 dtype=None,  # inferred from the data
                  description=parameter.__doc__,
-                 unit=parameter.unit,
                  format=format,
-                 meta=param_meta,
-                 copy=False,
-                 copy_indices=True)
-    if value is not None:
-        col[:] = value  # Assign value in-place
+                 meta=meta)
 
     return col
 
 
-def _convert_Parameter_to_Model_Parameter(parameter, value, meta=None):
+def convert_parameter_to_model_parameter(parameter, value, meta=None):
     """Convert a Cosmology Parameter to a Model Parameter.
 
     Parameters

--- a/astropy/cosmology/parameter.py
+++ b/astropy/cosmology/parameter.py
@@ -47,7 +47,7 @@ class Parameter:
     _registry_validators = {}
 
     def __init__(self, *, derived=False, unit=None, equivalencies=[],
-                 fvalidate="default", fmt="g", doc=None):
+                 fvalidate="default", fmt="", doc=None):
 
         # attribute name on container cosmology class.
         # really set in __set_name__, but if Parameter is not init'ed as a
@@ -250,11 +250,11 @@ class Parameter:
         >>> p = Parameter()
         >>> p
         Parameter(derived=False, unit=None, equivalencies=[],
-                  fvalidate='default', fmt='g', doc=None)
+                  fvalidate='default', fmt='', doc=None)
 
         >>> p.clone(unit="km")
         Parameter(derived=False, unit=Unit("km"), equivalencies=[],
-                  fvalidate='default', fmt='g', doc=None)
+                  fvalidate='default', fmt='', doc=None)
         """
         # Start with defaults, update from kw.
         kwargs = {**self._get_init_arguments(), **kw}

--- a/astropy/cosmology/parameter.py
+++ b/astropy/cosmology/parameter.py
@@ -47,7 +47,7 @@ class Parameter:
     _registry_validators = {}
 
     def __init__(self, *, derived=False, unit=None, equivalencies=[],
-                 fvalidate="default", fmt=".3g", doc=None):
+                 fvalidate="default", fmt="g", doc=None):
 
         # attribute name on container cosmology class.
         # really set in __set_name__, but if Parameter is not init'ed as a
@@ -250,11 +250,11 @@ class Parameter:
         >>> p = Parameter()
         >>> p
         Parameter(derived=False, unit=None, equivalencies=[],
-                  fvalidate='default', fmt='.3g', doc=None)
+                  fvalidate='default', fmt='g', doc=None)
 
         >>> p.clone(unit="km")
         Parameter(derived=False, unit=Unit("km"), equivalencies=[],
-                  fvalidate='default', fmt='.3g', doc=None)
+                  fvalidate='default', fmt='g', doc=None)
         """
         # Start with defaults, update from kw.
         kwargs = {**self._get_init_arguments(), **kw}

--- a/astropy/cosmology/realizations.py
+++ b/astropy/cosmology/realizations.py
@@ -54,12 +54,12 @@ class default_cosmology(ScienceState):
     To get the default cosmology:
 
         >>> default_cosmology.get()
-        FlatLambdaCDM(name="Planck18", H0=67.7 km / (Mpc s), Om0=0.31, ...
+        FlatLambdaCDM(name="Planck18", H0=67.66 km / (Mpc s), Om0=0.30966, ...
 
     To get a specific cosmology:
 
         >>> default_cosmology.get("Planck13")
-        FlatLambdaCDM(name="Planck13", H0=67.8 km / (Mpc s), Om0=0.307, ...
+        FlatLambdaCDM(name="Planck13", H0=67.77 km / (Mpc s), Om0=0.30712, ...
     """
 
     _default_value = "Planck18"
@@ -92,12 +92,12 @@ class default_cosmology(ScienceState):
         To get the default cosmology:
 
         >>> default_cosmology.get()
-        FlatLambdaCDM(name="Planck18", H0=67.7 km / (Mpc s), Om0=0.31, ...
+        FlatLambdaCDM(name="Planck18", H0=67.66 km / (Mpc s), Om0=0.30966, ...
 
         To get a specific cosmology:
 
         >>> default_cosmology.get("Planck13")
-        FlatLambdaCDM(name="Planck13", H0=67.8 km / (Mpc s), Om0=0.307, ...
+        FlatLambdaCDM(name="Planck13", H0=67.77 km / (Mpc s), Om0=0.30712, ...
         """
         if key is None:
             key = cls._value

--- a/astropy/cosmology/tests/test_flrw.py
+++ b/astropy/cosmology/tests/test_flrw.py
@@ -887,8 +887,8 @@ class TestLambdaCDM(FLRWSubclassTest):
         """Test method ``.__repr__()``."""
         super().test_repr(cosmo_cls, cosmo)
 
-        expected = ("LambdaCDM(name=\"ABCMeta\", H0=70 km / (Mpc s), Om0=0.27,"
-                    " Ode0=0.73, Tcmb0=3 K, Neff=3.04, m_nu=[0. 0. 0.] eV,"
+        expected = ("LambdaCDM(name=\"ABCMeta\", H0=70.0 km / (Mpc s), Om0=0.27,"
+                    " Ode0=0.73, Tcmb0=3.0 K, Neff=3.04, m_nu=[0. 0. 0.] eV,"
                     " Ob0=None)")
         assert repr(cosmo) == expected
 
@@ -909,8 +909,8 @@ class TestFlatLambdaCDM(FlatFLRWMixinTest, TestLambdaCDM):
         """Test method ``.__repr__()``."""
         super().test_repr(cosmo_cls, cosmo)
 
-        expected = ("FlatLambdaCDM(name=\"ABCMeta\", H0=70 km / (Mpc s),"
-                    " Om0=0.27, Tcmb0=3 K, Neff=3.04, m_nu=[0. 0. 0.] eV,"
+        expected = ("FlatLambdaCDM(name=\"ABCMeta\", H0=70.0 km / (Mpc s),"
+                    " Om0=0.27, Tcmb0=3.0 K, Neff=3.04, m_nu=[0. 0. 0.] eV,"
                     " Ob0=None)")
         assert repr(cosmo) == expected
 
@@ -985,8 +985,8 @@ class TestwCDM(FLRWSubclassTest, Parameterw0TestMixin):
         """Test method ``.__repr__()``."""
         super().test_repr(cosmo_cls, cosmo)
 
-        expected = ("wCDM(name=\"ABCMeta\", H0=70 km / (Mpc s), Om0=0.27,"
-                    " Ode0=0.73, w0=-1, Tcmb0=3 K, Neff=3.04,"
+        expected = ("wCDM(name=\"ABCMeta\", H0=70.0 km / (Mpc s), Om0=0.27,"
+                    " Ode0=0.73, w0=-1.0, Tcmb0=3.0 K, Neff=3.04,"
                     " m_nu=[0. 0. 0.] eV, Ob0=None)")
         assert repr(cosmo) == expected
 
@@ -1007,8 +1007,8 @@ class TestFlatwCDM(FlatFLRWMixinTest, TestwCDM):
         """Test method ``.__repr__()``."""
         super().test_repr(cosmo_cls, cosmo)
 
-        expected = ("FlatwCDM(name=\"ABCMeta\", H0=70 km / (Mpc s), Om0=0.27,"
-                    " w0=-1, Tcmb0=3 K, Neff=3.04, m_nu=[0. 0. 0.] eV,"
+        expected = ("FlatwCDM(name=\"ABCMeta\", H0=70.0 km / (Mpc s), Om0=0.27,"
+                    " w0=-1.0, Tcmb0=3.0 K, Neff=3.04, m_nu=[0. 0. 0.] eV,"
                     " Ob0=None)")
         assert repr(cosmo) == expected
 
@@ -1084,8 +1084,8 @@ class Testw0waCDM(FLRWSubclassTest, Parameterw0TestMixin, ParameterwaTestMixin):
         """Test method ``.__repr__()``."""
         super().test_repr(cosmo_cls, cosmo)
 
-        expected = ("w0waCDM(name=\"ABCMeta\", H0=70 km / (Mpc s), Om0=0.27,"
-                    " Ode0=0.73, w0=-1, wa=0, Tcmb0=3 K, Neff=3.04,"
+        expected = ("w0waCDM(name=\"ABCMeta\", H0=70.0 km / (Mpc s), Om0=0.27,"
+                    " Ode0=0.73, w0=-1.0, wa=0.0, Tcmb0=3.0 K, Neff=3.04,"
                     " m_nu=[0. 0. 0.] eV, Ob0=None)")
         assert repr(cosmo) == expected
 
@@ -1106,8 +1106,8 @@ class TestFlatw0waCDM(FlatFLRWMixinTest, Testw0waCDM):
         """Test method ``.__repr__()``."""
         super().test_repr(cosmo_cls, cosmo)
 
-        expected = ("Flatw0waCDM(name=\"ABCMeta\", H0=70 km / (Mpc s),"
-                    " Om0=0.27, w0=-1, wa=0, Tcmb0=3 K, Neff=3.04,"
+        expected = ("Flatw0waCDM(name=\"ABCMeta\", H0=70.0 km / (Mpc s),"
+                    " Om0=0.27, w0=-1.0, wa=0.0, Tcmb0=3.0 K, Neff=3.04,"
                     " m_nu=[0. 0. 0.] eV, Ob0=None)")
         assert repr(cosmo) == expected
 
@@ -1225,8 +1225,8 @@ class TestwpwaCDM(FLRWSubclassTest,
         """Test method ``.__repr__()``."""
         super().test_repr(cosmo_cls, cosmo)
 
-        expected = ("wpwaCDM(name=\"ABCMeta\", H0=70 km / (Mpc s), Om0=0.27,"
-                    " Ode0=0.73, wp=-1, wa=0, zp=0 redshift, Tcmb0=3 K,"
+        expected = ("wpwaCDM(name=\"ABCMeta\", H0=70.0 km / (Mpc s), Om0=0.27,"
+                    " Ode0=0.73, wp=-1.0, wa=0.0, zp=0.0 redshift, Tcmb0=3.0 K,"
                     " Neff=3.04, m_nu=[0. 0. 0.] eV, Ob0=None)")
         assert repr(cosmo) == expected
 
@@ -1302,7 +1302,7 @@ class Testw0wzCDM(FLRWSubclassTest, Parameterw0TestMixin, ParameterwzTestMixin):
         """Test method ``.__repr__()``."""
         super().test_repr(cosmo_cls, cosmo)
 
-        expected = ("w0wzCDM(name=\"ABCMeta\", H0=70 km / (Mpc s), Om0=0.27,"
-                    " Ode0=0.73, w0=-1, wz=0, Tcmb0=3 K, Neff=3.04,"
+        expected = ("w0wzCDM(name=\"ABCMeta\", H0=70.0 km / (Mpc s), Om0=0.27,"
+                    " Ode0=0.73, w0=-1.0, wz=0.0, Tcmb0=3.0 K, Neff=3.04,"
                     " m_nu=[0. 0. 0.] eV, Ob0=None)")
         assert repr(cosmo) == expected

--- a/astropy/cosmology/tests/test_flrw.py
+++ b/astropy/cosmology/tests/test_flrw.py
@@ -120,7 +120,6 @@ class ParameterOm0TestMixin(ParameterTestMixin):
         # on the class
         assert isinstance(cosmo_cls.Om0, Parameter)
         assert "Omega matter" in cosmo_cls.Om0.__doc__
-        assert cosmo_cls.Tcmb0.format_spec == "0.4g"
 
         # validation
         assert cosmo_cls.Om0.validate(cosmo, 1) == 1

--- a/astropy/cosmology/tests/test_parameter.py
+++ b/astropy/cosmology/tests/test_parameter.py
@@ -70,7 +70,7 @@ class ParameterTestMixin:
         assert parameter.fvalidate is _validate_with_unit
         assert parameter.unit is None
         assert parameter.equivalencies == []
-        assert parameter.format_spec == ".3g"
+        assert parameter.format_spec == "g"
         assert parameter.derived is False
         assert parameter.name is None
 
@@ -300,7 +300,7 @@ class TestParameter(ParameterTestMixin):
         # custom from init
         assert param._unit == u.m
         assert param._equivalencies == u.mass_energy()
-        assert param._fmt == ".3g"
+        assert param._fmt == "g"
         assert param._derived == False
 
         # custom from set_name
@@ -336,7 +336,7 @@ class TestParameter(ParameterTestMixin):
         """Test :attr:`astropy.cosmology.Parameter.format_spec`."""
         super().test_Parameter_format_spec(param)
 
-        assert param.format_spec == ".3g"
+        assert param.format_spec == "g"
 
     def test_Parameter_derived(self, cosmo_cls, param):
         """Test :attr:`astropy.cosmology.Parameter.derived`."""
@@ -453,7 +453,7 @@ class TestParameter(ParameterTestMixin):
 
         assert "Parameter(" in r
         for subs in ("derived=False", 'unit=Unit("m")', 'equivalencies=[(Unit("kg"), Unit("J")',
-                     "fmt='.3g'", "doc='Description of example parameter.'"):
+                     "fmt='g'", "doc='Description of example parameter.'"):
             assert subs in r, subs
 
         # `fvalidate` is a little tricker b/c one of them is custom!

--- a/astropy/cosmology/tests/test_parameter.py
+++ b/astropy/cosmology/tests/test_parameter.py
@@ -70,7 +70,7 @@ class ParameterTestMixin:
         assert parameter.fvalidate is _validate_with_unit
         assert parameter.unit is None
         assert parameter.equivalencies == []
-        assert parameter.format_spec == "g"
+        assert parameter.format_spec == ""
         assert parameter.derived is False
         assert parameter.name is None
 
@@ -300,7 +300,7 @@ class TestParameter(ParameterTestMixin):
         # custom from init
         assert param._unit == u.m
         assert param._equivalencies == u.mass_energy()
-        assert param._fmt == "g"
+        assert param._fmt == ""
         assert param._derived == False
 
         # custom from set_name
@@ -336,7 +336,7 @@ class TestParameter(ParameterTestMixin):
         """Test :attr:`astropy.cosmology.Parameter.format_spec`."""
         super().test_Parameter_format_spec(param)
 
-        assert param.format_spec == "g"
+        assert param.format_spec == ""
 
     def test_Parameter_derived(self, cosmo_cls, param):
         """Test :attr:`astropy.cosmology.Parameter.derived`."""
@@ -453,7 +453,7 @@ class TestParameter(ParameterTestMixin):
 
         assert "Parameter(" in r
         for subs in ("derived=False", 'unit=Unit("m")', 'equivalencies=[(Unit("kg"), Unit("J")',
-                     "fmt='g'", "doc='Description of example parameter.'"):
+                     "fmt=''", "doc='Description of example parameter.'"):
             assert subs in r, subs
 
         # `fvalidate` is a little tricker b/c one of them is custom!

--- a/docs/changes/cosmology/12612.api.rst
+++ b/docs/changes/cosmology/12612.api.rst
@@ -1,4 +1,4 @@
 In I/O, conversions of Parameters move more relevant information from the
 Parameter to the Column.
 
-The Parameter ``format_spec`` is changed from ``".3g"`` to ``"g"``.
+The default Parameter ``format_spec`` is changed from ``".3g"`` to ``""``.

--- a/docs/changes/cosmology/12612.api.rst
+++ b/docs/changes/cosmology/12612.api.rst
@@ -1,0 +1,4 @@
+In I/O, conversions of Parameters move more relevant information from the
+Parameter to the Column.
+
+The Parameter ``format_spec`` is changed from ``".3g"`` to ``"g"``.

--- a/docs/cosmology/index.rst
+++ b/docs/cosmology/index.rst
@@ -230,8 +230,8 @@ describe the cosmology::
   >>> from astropy.cosmology import FlatwCDM
   >>> cosmo = FlatwCDM(name='SNLS3+WMAP7', H0=71.58, Om0=0.262, w0=-1.016)
   >>> cosmo
-  FlatwCDM(name="SNLS3+WMAP7", H0=71.6 km / (Mpc s), Om0=0.262,
-           w0=-1.02, Tcmb0=0 K, Neff=3.04, m_nu=None, Ob0=None)
+  FlatwCDM(name="SNLS3+WMAP7", H0=71.58 km / (Mpc s), Om0=0.262,
+           w0=-1.016, Tcmb0=0 K, Neff=3.04, m_nu=None, Ob0=None)
 
 ..
   EXAMPLE END

--- a/docs/cosmology/index.rst
+++ b/docs/cosmology/index.rst
@@ -81,7 +81,7 @@ classes::
   >>> from astropy.cosmology import FlatLambdaCDM
   >>> cosmo = FlatLambdaCDM(H0=70, Om0=0.3, Tcmb0=2.725)
   >>> cosmo  # doctest: +FLOAT_CMP
-  FlatLambdaCDM(H0=70 km / (Mpc s), Om0=0.3, Tcmb0=2.725 K,
+  FlatLambdaCDM(H0=70.0 km / (Mpc s), Om0=0.3, Tcmb0=2.725 K,
                 Neff=3.04, m_nu=[0. 0. 0.] eV, Ob0=None)
 
 Note the presence of additional cosmological parameters (e.g., ``Neff``, the
@@ -135,7 +135,7 @@ parameter and Omega matter (both at z=0)::
   >>> from astropy.cosmology import FlatLambdaCDM
   >>> cosmo = FlatLambdaCDM(H0=70, Om0=0.3)
   >>> cosmo
-  FlatLambdaCDM(H0=70 km / (Mpc s), Om0=0.3, Tcmb0=0 K,
+  FlatLambdaCDM(H0=70.0 km / (Mpc s), Om0=0.3, Tcmb0=0.0 K,
                 Neff=3.04, m_nu=None, Ob0=None)
 
 This can also be done more explicitly using units, which is recommended::
@@ -207,7 +207,7 @@ instantiation by passing the keyword argument ``Ob0``::
   >>> from astropy.cosmology import FlatLambdaCDM
   >>> cosmo = FlatLambdaCDM(H0=70, Om0=0.3, Ob0=0.05)
   >>> cosmo
-  FlatLambdaCDM(H0=70 km / (Mpc s), Om0=0.3, Tcmb0=0 K,
+  FlatLambdaCDM(H0=70.0 km / (Mpc s), Om0=0.3, Tcmb0=0.0 K,
                 Neff=3.04, m_nu=None, Ob0=0.05)
 
 In this case the dark matter-only density at redshift 0 is available as class
@@ -231,7 +231,7 @@ describe the cosmology::
   >>> cosmo = FlatwCDM(name='SNLS3+WMAP7', H0=71.58, Om0=0.262, w0=-1.016)
   >>> cosmo
   FlatwCDM(name="SNLS3+WMAP7", H0=71.58 km / (Mpc s), Om0=0.262,
-           w0=-1.016, Tcmb0=0 K, Neff=3.04, m_nu=None, Ob0=None)
+           w0=-1.016, Tcmb0=0.0 K, Neff=3.04, m_nu=None, Ob0=None)
 
 ..
   EXAMPLE END

--- a/docs/cosmology/io.rst
+++ b/docs/cosmology/io.rst
@@ -179,8 +179,8 @@ the |Planck18| cosmology from which it was created.
 
     >>> cosmo = Cosmology.from_format(ct, format="astropy.table")
     >>> cosmo
-    FlatLambdaCDM(name="Planck18", H0=67.7 km / (Mpc s), Om0=0.31,
-                  Tcmb0=2.725 K, Neff=3.05, m_nu=[0. 0. 0.06] eV, Ob0=0.049)
+    FlatLambdaCDM(name="Planck18", H0=67.66 km / (Mpc s), Om0=0.30966,
+                  Tcmb0=2.7255 K, Neff=3.046, m_nu=[0. 0. 0.06] eV, Ob0=0.04897)
 
 Perhaps more usefully, |QTable| can be saved to ``latex`` and ``html`` formats,
 which can be copied into journal articles and websites, respectively.


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

In I/O, conversions of Parameters are now handled by separate functions.

In Table (and Row) ``Column`` are now explicitly created, now moving (almost) all relevant information from the Parameter to the Column, e.g. the Parameter ``__doc__`` is set as the Column description.
As part of this, the ``fmt`` needed to be changed from ``.3g`` to ``g``, which is both an improvement and rectifies an earlier formatting mistake.

Model Parameters are also better constructed.


### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
