### PR TITLE
Refactor mixin tests, to avoid duplication between ECSV, FITS, HDF5

### DIFF
--- a/astropy/io/fits/fitstime.py
+++ b/astropy/io/fits/fitstime.py
@@ -595,7 +595,7 @@ def time_to_fits(table):
                     hdr.extend([Card(keyword=f'OBSGEO-{dim.upper()}',
                                      value=getattr(location, dim).to_value(u.m))
                                 for dim in ('x', 'y', 'z')])
-            elif location != col.location:
+            elif np.any(location != col.location):
                 raise ValueError('Multiple Time Columns with different geocentric '
                                  'observatory locations ({}, {}) encountered.'
                                  'This is not supported by the FITS standard.'

--- a/astropy/io/misc/tests/test_hdf5.py
+++ b/astropy/io/misc/tests/test_hdf5.py
@@ -3,15 +3,9 @@
 import pytest
 import numpy as np
 
-from astropy.table import Table, QTable, NdarrayMixin, Column
+from astropy.table import Table, QTable, Column
 from astropy.table.table_helpers import simple_table
 
-from astropy import units as u
-
-from astropy.coordinates import (SkyCoord, Latitude, Longitude, Angle, EarthLocation,
-                                 SphericalRepresentation, CartesianRepresentation,
-                                 SphericalCosLatDifferential)
-from astropy.time import Time, TimeDelta
 from astropy.units import allclose as quantity_allclose
 from astropy.units.quantity import QuantityInfo
 from astropy.utils.exceptions import AstropyUserWarning
@@ -21,6 +15,15 @@ from astropy.io.misc.hdf5 import meta_path
 from astropy.utils.compat.optional_deps import HAS_H5PY  # noqa
 if HAS_H5PY:
     import h5py
+
+from astropy.io.tests.mixin_columns import mixin_cols, compare_attrs, serialized_names
+
+
+# HDF5 does not support object dtype (since it stores binary representations).
+unsupported_cols = {name: col for name, col in mixin_cols.items()
+                    if (isinstance(col, np.ndarray) and col.dtype.kind == 'O')}
+mixin_cols = {name: col for name, col in mixin_cols.items()
+              if name not in unsupported_cols}
 
 ALL_DTYPES = [np.uint8, np.uint16, np.uint32, np.uint64, np.int8,
               np.int16, np.int32, np.int64, np.float32, np.float64,
@@ -658,92 +661,6 @@ def assert_objects_equal(obj1, obj2, attrs, compare_class=True):
         else:
             assert np.all(a1 == a2)
 
-# Testing HDF5 table read/write with mixins.  This is mostly
-# copied from FITS mixin testing, and it might be good to unify it.
-# Analogous tests also exist for ECSV.
-
-
-el = EarthLocation(x=1 * u.km, y=3 * u.km, z=5 * u.km)
-el2 = EarthLocation(x=[1, 2] * u.km, y=[3, 4] * u.km, z=[5, 6] * u.km)
-sr = SphericalRepresentation(
-    [0, 1]*u.deg, [2, 3]*u.deg, 1*u.kpc)
-cr = CartesianRepresentation(
-    [0, 1]*u.pc, [4, 5]*u.pc, [8, 6]*u.pc)
-sd = SphericalCosLatDifferential(
-    [0, 1]*u.mas/u.yr, [0, 1]*u.mas/u.yr, 10*u.km/u.s)
-srd = SphericalRepresentation(sr, differentials=sd)
-sc = SkyCoord([1, 2], [3, 4], unit='deg,deg', frame='fk4',
-              obstime='J1990.5')
-scd = SkyCoord([1, 2], [3, 4], [5, 6], unit='deg,deg,m', frame='fk4',
-               obstime=['J1990.5', 'J1991.5'])
-scdc = scd.copy()
-scdc.representation_type = 'cartesian'
-scpm = SkyCoord([1, 2], [3, 4], [5, 6], unit='deg,deg,pc',
-                pm_ra_cosdec=[7, 8]*u.mas/u.yr, pm_dec=[9, 10]*u.mas/u.yr)
-scpmrv = SkyCoord([1, 2], [3, 4], [5, 6], unit='deg,deg,pc',
-                  pm_ra_cosdec=[7, 8]*u.mas/u.yr, pm_dec=[9, 10]*u.mas/u.yr,
-                  radial_velocity=[11, 12]*u.km/u.s)
-scrv = SkyCoord([1, 2], [3, 4], [5, 6], unit='deg,deg,pc',
-                radial_velocity=[11, 12]*u.km/u.s)
-tm = Time([2450814.5, 2450815.5], format='jd', scale='tai', location=el)
-
-# NOTE: in the test below the name of the column "x" for the Quantity is
-# important since it tests the fix for #10215 (namespace clash, where "x"
-# clashes with "el2.x").
-mixin_cols = {
-    'tm': tm,
-    'dt': TimeDelta([1, 2] * u.day),
-    'sc': sc,
-    'scd': scd,
-    'scdc': scdc,
-    'scpm': scpm,
-    'scpmrv': scpmrv,
-    'scrv': scrv,
-    'x': [1, 2] * u.m,
-    'qdb': [10, 20] * u.dB(u.mW),
-    'qdex': [4.5, 5.5] * u.dex(u.cm/u.s**2),
-    'qmag': [21, 22] * u.ABmag,
-    'lat': Latitude([1, 2] * u.deg),
-    'lon': Longitude([1, 2] * u.deg, wrap_angle=180. * u.deg),
-    'ang': Angle([1, 2] * u.deg),
-    'el2': el2,
-    'sr': sr,
-    'cr': cr,
-    'sd': sd,
-    'srd': srd,
-}
-
-time_attrs = ['value', 'shape', 'format', 'scale', 'location']
-compare_attrs = {
-    'c1': ['data'],
-    'c2': ['data'],
-    'tm': time_attrs,
-    'dt': ['shape', 'value', 'format', 'scale'],
-    'sc': ['ra', 'dec', 'representation_type', 'frame.name'],
-    'scd': ['ra', 'dec', 'distance', 'representation_type', 'frame.name'],
-    'scdc': ['x', 'y', 'z', 'representation_type', 'frame.name'],
-    'scpm': ['ra', 'dec', 'distance', 'pm_ra_cosdec', 'pm_dec',
-             'representation_type', 'frame.name'],
-    'scpmrv': ['ra', 'dec', 'distance', 'pm_ra_cosdec', 'pm_dec',
-               'radial_velocity', 'representation_type', 'frame.name'],
-    'scrv': ['ra', 'dec', 'distance', 'radial_velocity', 'representation_type',
-             'frame.name'],
-    'x': ['value', 'unit'],
-    'qdb': ['value', 'unit'],
-    'qdex': ['value', 'unit'],
-    'qmag': ['value', 'unit'],
-    'lon': ['value', 'unit', 'wrap_angle'],
-    'lat': ['value', 'unit'],
-    'ang': ['value', 'unit'],
-    'el2': ['x', 'y', 'z', 'ellipsoid'],
-    'nd': ['x', 'y', 'z'],
-    'sr': ['lon', 'lat', 'distance'],
-    'cr': ['x', 'y', 'z'],
-    'sd': ['d_lon_coslat', 'd_lat', 'd_distance'],
-    'srd': ['lon', 'lat', 'distance', 'differentials.s.d_lon_coslat',
-            'differentials.s.d_lat', 'differentials.s.d_distance'],
-}
-
 
 @pytest.mark.skipif('not HAS_H5PY')
 def test_hdf5_mixins_qtable_to_table(tmpdir):
@@ -762,11 +679,6 @@ def test_hdf5_mixins_qtable_to_table(tmpdir):
 
     for name, col in t.columns.items():
         col2 = t2[name]
-
-        # Special-case Time, which does not yet support round-tripping
-        # the format.
-        if isinstance(col2, Time):
-            col2.format = col.format
 
         attrs = compare_attrs[name]
         compare_class = True
@@ -789,37 +701,9 @@ def test_hdf5_mixins_as_one(table_cls, tmpdir):
     """Test write/read all cols at once and validate intermediate column names"""
     filename = str(tmpdir.join('test_simple.hdf5'))
     names = sorted(mixin_cols)
-
-    serialized_names = ['ang',
-                        'cr.x', 'cr.y', 'cr.z',
-                        'dt.jd1', 'dt.jd2',
-                        'el2.x', 'el2.y', 'el2.z',
-                        'lat',
-                        'lon',
-                        'qdb',
-                        'qdex',
-                        'qmag',
-                        'sc.ra', 'sc.dec',
-                        'scd.ra', 'scd.dec', 'scd.distance',
-                        'scd.obstime.jd1', 'scd.obstime.jd2',
-                        'scdc.x', 'scdc.y', 'scdc.z',
-                        'scdc.obstime.jd1', 'scdc.obstime.jd2',
-                        'scpm.ra', 'scpm.dec', 'scpm.distance',
-                        'scpm.pm_ra_cosdec', 'scpm.pm_dec',
-                        'scpmrv.ra', 'scpmrv.dec', 'scpmrv.distance',
-                        'scpmrv.pm_ra_cosdec', 'scpmrv.pm_dec',
-                        'scpmrv.radial_velocity',
-                        'scrv.ra', 'scrv.dec', 'scrv.distance',
-                        'scrv.radial_velocity',
-                        'sd.d_lon_coslat', 'sd.d_lat', 'sd.d_distance',
-                        'sr.lon', 'sr.lat', 'sr.distance',
-                        'srd.lon', 'srd.lat', 'srd.distance',
-                        'srd.differentials.s.d_lon_coslat',
-                        'srd.differentials.s.d_lat',
-                        'srd.differentials.s.d_distance',
-                        'tm.jd1', 'tm.jd2',
-                        'x',
-                        ]
+    all_serialized_names = []
+    for name in names:
+        all_serialized_names.extend(serialized_names[name])
 
     t = table_cls([mixin_cols[name] for name in names], names=names)
     t.meta['C'] = 'spam'
@@ -837,7 +721,8 @@ def test_hdf5_mixins_as_one(table_cls, tmpdir):
 
     # Read directly via hdf5 and confirm column names
     h5 = h5py.File(filename, 'r')
-    assert list(h5['root'].dtype.names) == serialized_names
+    h5_names = list(h5['root'].dtype.names)
+    assert h5_names == all_serialized_names
     h5.close()
 
 
@@ -857,21 +742,30 @@ def test_hdf5_mixins_per_column(table_cls, name_col, tmpdir):
     if not t.has_mixin_columns:
         pytest.skip('column is not a mixin (e.g. Quantity subclass in Table)')
 
-    if isinstance(t[name], NdarrayMixin):
-        pytest.xfail('NdarrayMixin not supported')
-
     t.write(filename, format="hdf5", path='root', serialize_meta=True)
     t2 = table_cls.read(filename, format='hdf5', path='root')
 
     assert t.colnames == t2.colnames
 
     for colname in t.colnames:
-        assert_objects_equal(t[colname], t2[colname], compare_attrs[colname])
+        compare = ['data'] if colname in ('c1', 'c2') else compare_attrs[colname]
+        assert_objects_equal(t[colname], t2[colname], compare)
 
     # Special case to make sure Column type doesn't leak into Time class data
     if name.startswith('tm'):
         assert t2[name]._time.jd1.__class__ is np.ndarray
         assert t2[name]._time.jd2.__class__ is np.ndarray
+
+
+@pytest.mark.parametrize('name_col', unsupported_cols.items())
+@pytest.mark.xfail(reason='column type unsupported')
+def test_fits_unsupported_mixin(self, name_col, tmpdir):
+    # Check that we actually fail in writing unsupported columns defined
+    # on top.
+    filename = str(tmpdir.join('test_simple.fits'))
+    name, col = name_col
+    Table([col], names=[name]).write(filename, format='hdf5', path='root',
+                                     serialize_meta=True)
 
 
 @pytest.mark.skipif('not HAS_H5PY')

--- a/astropy/io/tests/mixin_columns.py
+++ b/astropy/io/tests/mixin_columns.py
@@ -1,0 +1,137 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Mixin columns for use in ascii/tests/test_ecsv.py, fits/tests/test_connect.py,
+and misc/tests/test_hdf5.py
+"""
+
+from astropy import coordinates, table, time, units as u
+
+
+el = coordinates.EarthLocation(x=[1, 2] * u.km, y=[3, 4] * u.km, z=[5, 6] * u.km)
+sr = coordinates.SphericalRepresentation(
+    [0, 1]*u.deg, [2, 3]*u.deg, 1*u.kpc)
+cr = coordinates.CartesianRepresentation(
+    [0, 1]*u.pc, [4, 5]*u.pc, [8, 6]*u.pc)
+sd = coordinates.SphericalCosLatDifferential(
+    [0, 1]*u.mas/u.yr, [0, 1]*u.mas/u.yr, 10*u.km/u.s)
+srd = coordinates.SphericalRepresentation(
+    sr, differentials=sd)
+sc = coordinates.SkyCoord([1, 2], [3, 4], unit='deg,deg',
+                          frame='fk4', obstime='J1990.5')
+scd = coordinates.SkyCoord(
+    [1, 2], [3, 4], [5, 6], unit='deg,deg,m', frame='fk4',
+    obstime=['J1990.5'] * 2)
+scdc = scd.copy()
+scdc.representation_type = 'cartesian'
+scpm = coordinates.SkyCoord(
+    [1, 2], [3, 4], [5, 6], unit='deg,deg,pc',
+    pm_ra_cosdec=[7, 8]*u.mas/u.yr, pm_dec=[9, 10]*u.mas/u.yr)
+scpmrv = coordinates.SkyCoord(
+    [1, 2], [3, 4], [5, 6], unit='deg,deg,pc',
+    pm_ra_cosdec=[7, 8]*u.mas/u.yr, pm_dec=[9, 10]*u.mas/u.yr,
+    radial_velocity=[11, 12]*u.km/u.s)
+scrv = coordinates.SkyCoord(
+    [1, 2], [3, 4], [5, 6], unit='deg,deg,pc',
+    radial_velocity=[11, 12]*u.km/u.s)
+tm = time.Time([51000.5, 51001.5], format='mjd', scale='tai',
+               precision=5, location=el[0])
+tm2 = time.Time(tm, precision=3, format='iso')
+tm3 = time.Time(tm, location=el)
+tm3.info.serialize_method['ecsv'] = 'jd1_jd2'
+obj = table.Column([{'a': 1}, {'b': [2]}], dtype='object')
+
+# NOTE: for testing, the name of the column "x" for the
+# Quantity is important since it tests the fix for #10215
+# (namespace clash, where "x" clashes with "el.x").
+mixin_cols = {
+    'tm': tm,
+    'tm2': tm2,
+    'tm3': tm3,
+    'dt': time.TimeDelta([1, 2] * u.day),
+    'sc': sc,
+    'scd': scd,
+    'scdc': scdc,
+    'scpm': scpm,
+    'scpmrv': scpmrv,
+    'scrv': scrv,
+    'x': [1, 2] * u.m,
+    'qdb': [10, 20] * u.dB(u.mW),
+    'qdex': [4.5, 5.5] * u.dex(u.cm / u.s**2),
+    'qmag': [21, 22] * u.ABmag,
+    'lat': coordinates.Latitude([1, 2] * u.deg),
+    'lon': coordinates.Longitude([1, 2] * u.deg, wrap_angle=180. * u.deg),
+    'ang': coordinates.Angle([1, 2] * u.deg),
+    'el': el,
+    'sr': sr,
+    'cr': cr,
+    'sd': sd,
+    'srd': srd,
+    'nd': table.NdarrayMixin([1, 2]),
+    'obj': obj,
+}
+time_attrs = ['value', 'shape', 'format', 'scale', 'precision',
+              'in_subfmt', 'out_subfmt', 'location']
+compare_attrs = {
+    'tm': time_attrs,
+    'tm2': time_attrs,
+    'tm3': time_attrs,
+    'dt': ['shape', 'value', 'format', 'scale'],
+    'sc': ['ra', 'dec', 'representation_type', 'frame.name'],
+    'scd': ['ra', 'dec', 'distance', 'representation_type', 'frame.name'],
+    'scdc': ['x', 'y', 'z', 'representation_type', 'frame.name'],
+    'scpm': ['ra', 'dec', 'distance', 'pm_ra_cosdec', 'pm_dec',
+             'representation_type', 'frame.name'],
+    'scpmrv': ['ra', 'dec', 'distance', 'pm_ra_cosdec', 'pm_dec',
+               'radial_velocity', 'representation_type', 'frame.name'],
+    'scrv': ['ra', 'dec', 'distance', 'radial_velocity',
+             'representation_type', 'frame.name'],
+    'x': ['value', 'unit'],
+    'qdb': ['value', 'unit'],
+    'qdex': ['value', 'unit'],
+    'qmag': ['value', 'unit'],
+    'lon': ['value', 'unit', 'wrap_angle'],
+    'lat': ['value', 'unit'],
+    'ang': ['value', 'unit'],
+    'el': ['x', 'y', 'z', 'ellipsoid'],
+    'nd': ['data'],
+    'sr': ['lon', 'lat', 'distance'],
+    'cr': ['x', 'y', 'z'],
+    'sd': ['d_lon_coslat', 'd_lat', 'd_distance'],
+    'srd': ['lon', 'lat', 'distance', 'differentials.s.d_lon_coslat',
+            'differentials.s.d_lat', 'differentials.s.d_distance'],
+    'obj': [],
+    'su': ['i', 'f'],
+    'tab': ['tm', 'c', 'x'],
+    'qtab': ['tm', 'c', 'x'],
+}
+non_trivial_names = {
+    'cr': ['cr.x', 'cr.y', 'cr.z'],
+    'dt': ['dt.jd1', 'dt.jd2'],
+    'el': ['el.x', 'el.y', 'el.z'],
+    'sc': ['sc.ra', 'sc.dec'],
+    'scd': ['scd.ra', 'scd.dec', 'scd.distance',
+            'scd.obstime.jd1', 'scd.obstime.jd2'],
+    'scdc': ['scdc.x', 'scdc.y', 'scdc.z',
+             'scdc.obstime.jd1', 'scdc.obstime.jd2'],
+    'scfc': ['scdc.x', 'scdc.y', 'scdc.z',
+             'scdc.obstime.jd1', 'scdc.obstime.jd2'],
+    'scpm': ['scpm.ra', 'scpm.dec', 'scpm.distance',
+             'scpm.pm_ra_cosdec', 'scpm.pm_dec'],
+    'scpmrv': ['scpmrv.ra', 'scpmrv.dec', 'scpmrv.distance',
+               'scpmrv.pm_ra_cosdec', 'scpmrv.pm_dec',
+               'scpmrv.radial_velocity'],
+    'scrv': ['scrv.ra', 'scrv.dec', 'scrv.distance',
+             'scrv.radial_velocity'],
+    'sd': ['sd.d_lon_coslat', 'sd.d_lat', 'sd.d_distance'],
+    'sr': ['sr.lon', 'sr.lat', 'sr.distance'],
+    'srd': ['srd.lon', 'srd.lat', 'srd.distance',
+            'srd.differentials.s.d_lon_coslat',
+            'srd.differentials.s.d_lat',
+            'srd.differentials.s.d_distance'],
+    'tm': ['tm.jd1', 'tm.jd2'],
+    'tm2': ['tm2.jd1', 'tm2.jd2'],
+    'tm3': ['tm3.jd1', 'tm3.jd2',
+            'tm3.location.x', 'tm3.location.y', 'tm3.location.z'],
+}
+serialized_names = {name: non_trivial_names.get(name, [name])
+                    for name in sorted(mixin_cols)}


### PR DESCRIPTION
As I'm trying to add new types of objects that can be serialized, it becomes a bit painful to have to update separately the tests for ECSV, FITS, and HDF5, so I factored them out.

In principle, this could also be used/combined with what is done in `table/tests/test_mixin.py`, but that setup is a bit different. So, I thought to start with the simple stuff.

<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address ...

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
