### PR TITLE
Deprecate setting and getting pixels in a WCSAxes Spine

### DIFF
--- a/astropy/visualization/wcsaxes/coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/coordinate_helpers.py
@@ -785,8 +785,6 @@ class CoordinateHelper:
                     frac = (t - w1[imin]) / (w2[imin] - w1[imin])
                     x_data_i = spine.data[imin, 0] + frac * (spine.data[imax, 0] - spine.data[imin, 0])
                     y_data_i = spine.data[imin, 1] + frac * (spine.data[imax, 1] - spine.data[imin, 1])
-                    x_pix_i = spine.pixel[imin, 0] + frac * (spine.pixel[imax, 0] - spine.pixel[imin, 0])
-                    y_pix_i = spine.pixel[imin, 1] + frac * (spine.pixel[imax, 1] - spine.pixel[imin, 1])
                     delta_angle = tick_angle[imax] - tick_angle[imin]
                     if delta_angle > 180.:
                         delta_angle -= 360.
@@ -819,7 +817,7 @@ class CoordinateHelper:
                     # it's faster to format many ticklabels at once outside
                     # of the loop
                     self.lblinfo.append(dict(axis=axis,
-                                             pixel=(x_pix_i, y_pix_i),
+                                             data=(x_data_i, y_data_i),
                                              world=world,
                                              angle=spine.normal_angle[imin],
                                              axis_displacement=imin + frac))

--- a/docs/changes/visualization/12621.api.rst
+++ b/docs/changes/visualization/12621.api.rst
@@ -1,0 +1,5 @@
+The pixel attribute of ``astropy.visualization.wcsaxes.frame.Spine`` is deprecated
+and will be removed in a future astropy version.
+Because it is (in general) not possible to correctly calculate pixel
+coordinates before Matplotlib is drawing a figure, instead set the world or data
+coordinates of the ``Spine`` using the appropriate setters.

--- a/docs/changes/visualization/12621.bugfix.rst
+++ b/docs/changes/visualization/12621.bugfix.rst
@@ -1,0 +1,3 @@
+The location of a ``astropy.visualization.wcsaxes.frame.Spine`` in a plot is now
+correctly calculated when the DPI of a figure changes between a WCSAxes being
+created and the figure being drawn.

--- a/docs/changes/wcs/12630.api.rst
+++ b/docs/changes/wcs/12630.api.rst
@@ -1,0 +1,7 @@
+The ``pixel`` argument to ``astropy.visualization.wcsaxes.ticklabels.TickLabels.add``
+no longer does anything, is deprecated, and will be removed in a future
+astropy version. It has been replaced by a new required ``data`` argument, which
+should be used to specify the data coordinates of the tick label being added.
+
+This changes has been made because it is (in general) not possible to correctly
+calculate pixel coordinates before Matplotlib is drawing a figure.

--- a/docs/changes/wcs/12630.bugfix.rst
+++ b/docs/changes/wcs/12630.bugfix.rst
@@ -1,0 +1,3 @@
+The locations of ``WCSAxes`` ticks and tick-labels are now correctly calculated
+when the DPI of a figure changes between a WCSAxes being created and the figure
+being drawn, or when a rasterized artist is added to the WCSAxes.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
When using Matplotlib, it is generally only safe to calculate pixel coordinates of artists at draw time, as that is when the figure DPI is set in stone. Calculating the pixel coordinates before drawing can lead to issues like https://github.com/astropy/astropy/issues/12568.

This PR fixes this issue for `WCSAxes` `Spine`s by ensuring that pixel calculations are done at draw time. It also deprecates getting and setting pixel coordinates.

<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to partly address https://github.com/astropy/astropy/issues/12568. Before that issue can be fully resolved I think there is also a fix required on the Matplotlib side.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
