### PR TITLE
Add documentation on cosmology to model conversion

### DIFF
--- a/docs/modeling/physical_models.rst
+++ b/docs/modeling/physical_models.rst
@@ -288,3 +288,38 @@ The maximum circular velocity and radius of maximum circular velocity are availa
     # Display plot
     plt.tight_layout(rect=[0, 0.03, 1, 0.95])
     plt.show()
+
+
+.. _Cosmologies:
+
+Cosmologies
+===========
+
+The instances of the |Cosmology| class (and subclasses) include
+|Cosmology.to_format|, a method to convert a Cosmology to another python
+object. Relevant here is the conversion of any redshift method to a
+:class:`~astropy.modeling.FittableModel` instance, using the argument
+``format="astropy.model"``.
+Each |Cosmology| :class:`~astropy.cosmology.Parameter` is converted to a
+:class:`astropy.modeling.Model` :class:`~astropy.modeling.Parameter`
+and the redshift-method to the model's ``__call__`` / ``evaluate``.
+Now you can fit cosmologies with data!
+
+.. code-block::
+
+    >>> from astropy.cosmology import Planck18
+    >>> model = Planck18.to_format("astropy.model", method="lookback_time")
+    >>> model
+    <FlatLambdaCDMCosmologyLookbackTimeModel(H0=67.66 km / (Mpc s), Om0=0.30966,
+        Tcmb0=2.7255 K, Neff=3.046, m_nu=[0.  , 0.  , 0.06] eV, Ob0=0.04897,
+        name='Planck18')>
+
+When finished, e.g. fitting, a model can be turned back into a |Cosmology|
+using |Cosmology.from_format|.
+
+.. code-block::
+
+    >>> from astropy.cosmology import Cosmology
+    >>> cosmo = Cosmology.from_format(model, format="astropy.model")
+    >>> cosmo == Planck18
+    True

--- a/docs/modeling/physical_models.rst
+++ b/docs/modeling/physical_models.rst
@@ -297,18 +297,19 @@ Cosmologies
 
 The instances of the |Cosmology| class (and subclasses) include
 |Cosmology.to_format|, a method to convert a Cosmology to another python
-object. Relevant here is the conversion of any redshift method to a
-:class:`~astropy.modeling.FittableModel` instance, using the argument
+object. Specifically, any redshift method can be converted to a
+:class:`~astropy.modeling.FittableModel` instance using the argument
 ``format="astropy.model"``.
-Each |Cosmology| :class:`~astropy.cosmology.Parameter` is converted to a
-:class:`astropy.modeling.Model` :class:`~astropy.modeling.Parameter`
-and the redshift-method to the model's ``__call__`` / ``evaluate``.
-Now you can fit cosmologies with data!
+During the conversion, each |Cosmology| :class:`~astropy.cosmology.Parameter`
+is converted to a :class:`astropy.modeling.Model`
+:class:`~astropy.modeling.Parameter`, while the redshift-method becomes the
+model's ``__call__`` / ``evaluate`` method.
+This means cosmologies can now be fit with data!
 
 .. code-block::
 
     >>> from astropy.cosmology import Planck18
-    >>> model = Planck18.to_format("astropy.model", method="lookback_time")
+    >>> model = Planck18.to_format(format="astropy.model", method="lookback_time")
     >>> model
     <FlatLambdaCDMCosmologyLookbackTimeModel(H0=67.66 km / (Mpc s), Om0=0.30966,
         Tcmb0=2.7255 K, Neff=3.046, m_nu=[0.  , 0.  , 0.06] eV, Ob0=0.04897,


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

Add a note to modeling docs that a cosmology can be converted to a model.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
