### PR TITLE
move test of w(z)

### DIFF
--- a/astropy/cosmology/tests/test_core.py
+++ b/astropy/cosmology/tests/test_core.py
@@ -17,11 +17,12 @@ import pytest
 import numpy as np
 
 # LOCAL
+import astropy.cosmology.units as cu
 import astropy.units as u
 from astropy.cosmology import Cosmology, core
 from astropy.cosmology.core import _COSMOLOGY_CLASSES
 from astropy.cosmology.parameter import Parameter
-from astropy.table import QTable, Table
+from astropy.table import QTable, Table, Column
 from astropy.utils.exceptions import AstropyDeprecationWarning
 from astropy.utils.metadata import MetaData
 
@@ -30,6 +31,27 @@ from .test_parameter import ParameterTestMixin
 
 ##############################################################################
 # SETUP / TEARDOWN
+
+
+scalar_zs = [
+    0, 1, 1100,  # interesting times
+    # FIXME! np.inf breaks some funcs. 0 * inf is an error
+    np.float64(3300),  # different type
+    2 * cu.redshift, 3 * u.one  # compatible units
+]
+_zarr = np.linspace(0, 1e5, num=20)
+array_zs = [
+    _zarr,  # numpy
+    _zarr.tolist(),  # pure python
+    Column(_zarr),  # table-like
+    _zarr * cu.redshift  # Quantity
+]
+valid_zs = scalar_zs + array_zs
+
+invalid_zs = [
+    (None, TypeError),  # wrong type
+    (4 * u.MeV, u.UnitConversionError),  # wrong unit
+]
 
 
 class SubCosmology(Cosmology):

--- a/astropy/cosmology/tests/test_cosmology.py
+++ b/astropy/cosmology/tests/test_cosmology.py
@@ -659,43 +659,6 @@ def test_integral():
                     cosmo.inv_efunc([1.0, 2.0, 6.0]), rtol=1e-7)
 
 
-def test_wz():
-    cosmo = flrw.LambdaCDM(H0=70, Om0=0.3, Ode0=0.70)
-    assert allclose(cosmo.w(1.0), -1.)
-    assert allclose(cosmo.w([0.1, 0.2, 0.5, 1.5, 2.5, 11.5]),
-                    [-1., -1, -1, -1, -1, -1])
-
-    cosmo = flrw.wCDM(H0=70, Om0=0.3, Ode0=0.70, w0=-0.5)
-    assert allclose(cosmo.w(1.0), -0.5)
-    assert allclose(cosmo.w([0.1, 0.2, 0.5, 1.5, 2.5, 11.5]),
-                    [-0.5, -0.5, -0.5, -0.5, -0.5, -0.5])
-    assert allclose(cosmo.w0, -0.5)
-
-    cosmo = flrw.w0wzCDM(H0=70, Om0=0.3, Ode0=0.70, w0=-1, wz=0.5)
-    assert allclose(cosmo.w(1.0), -0.5)
-    assert allclose(cosmo.w([0.0, 0.5, 1.0, 1.5, 2.3]),
-                    [-1.0, -0.75, -0.5, -0.25, 0.15])
-    assert allclose(cosmo.w0, -1.0)
-    assert allclose(cosmo.wz, 0.5)
-
-    cosmo = flrw.w0waCDM(H0=70, Om0=0.3, Ode0=0.70, w0=-1, wa=-0.5)
-    assert allclose(cosmo.w0, -1.0)
-    assert allclose(cosmo.wa, -0.5)
-    assert allclose(cosmo.w(1.0), -1.25)
-    assert allclose(cosmo.w([0.0, 0.5, 1.0, 1.5, 2.3]),
-                    [-1, -1.16666667, -1.25, -1.3, -1.34848485])
-
-    cosmo = flrw.wpwaCDM(H0=70, Om0=0.3, Ode0=0.70, wp=-0.9,
-                         wa=0.2, zp=0.5)
-    assert allclose(cosmo.wp, -0.9)
-    assert allclose(cosmo.wa, 0.2)
-    assert allclose(cosmo.zp, 0.5)
-    assert allclose(cosmo.w(0.5), -0.9)
-    assert allclose(cosmo.w([0.1, 0.2, 0.5, 1.5, 2.5, 11.5]),
-                    [-0.94848485, -0.93333333, -0.9, -0.84666667,
-                     -0.82380952, -0.78266667])
-
-
 @pytest.mark.skipif('not HAS_SCIPY')
 def test_de_densityscale():
     cosmo = flrw.LambdaCDM(H0=70, Om0=0.3, Ode0=0.70)


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

Move another test from `test_cosmology`. Small adjustments necessary.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
