### PR TITLE
Add redshift units to ``z_reion``

### DIFF
--- a/astropy/cosmology/io/tests/test_yaml.py
+++ b/astropy/cosmology/io/tests/test_yaml.py
@@ -9,6 +9,7 @@ from collections import OrderedDict
 import pytest
 
 # LOCAL
+import astropy.cosmology.units as cu
 import astropy.units as u
 from astropy.cosmology import Cosmology, FlatLambdaCDM, Planck18, realizations
 from astropy.cosmology.core import _COSMOLOGY_CLASSES, Parameter
@@ -48,7 +49,8 @@ def test_yaml_constructor():
     # it's too hard to manually construct a node, so we only test dump/load
     # this is also a good round-trip test
     yml = dump(Planck18)
-    cosmo = load(yml)
+    with u.add_enabled_units(cu):  # needed for redshift units
+        cosmo = load(yml)
     assert isinstance(cosmo, FlatLambdaCDM)
     assert cosmo == Planck18
     assert cosmo.meta == Planck18.meta

--- a/astropy/cosmology/io/yaml.py
+++ b/astropy/cosmology/io/yaml.py
@@ -8,6 +8,8 @@ the io registry cannot be displayed. These functions are registered into
 via these methods.
 """  # this is shown in the docs.
 
+import astropy.cosmology.units as cu
+import astropy.units as u
 from astropy.cosmology.core import _COSMOLOGY_CLASSES, Cosmology
 from astropy.cosmology.connect import convert_registry
 from astropy.io.misc.yaml import AstropyDumper, AstropyLoader, dump, load
@@ -129,7 +131,8 @@ def from_yaml(yml):
     -------
     `~astropy.cosmology.Cosmology` subclass instance
     """
-    return load(yml)
+    with u.add_enabled_units(cu):
+        return load(yml)
 
 
 def to_yaml(cosmology, *args):

--- a/astropy/cosmology/parameters.py
+++ b/astropy/cosmology/parameters.py
@@ -59,6 +59,7 @@ Pending WMAP team approval and subject to change.
 from types import MappingProxyType
 
 # LOCAL
+import astropy.cosmology.units as cu
 import astropy.units as u
 
 # Note: if you add a new cosmology, please also update the table
@@ -78,7 +79,7 @@ Planck18 = MappingProxyType(dict(
     n=0.9665,
     sigma8=0.8102,
     tau=0.0561,
-    z_reion=7.82,
+    z_reion=7.82 * cu.redshift,
     t0=13.787 * u.Gyr,
     Tcmb0=2.7255 * u.K,
     Neff=3.046,
@@ -98,7 +99,7 @@ Planck15 = MappingProxyType(dict(
     n=0.9667,
     sigma8=0.8159,
     tau=0.066,
-    z_reion=8.8,
+    z_reion=8.8 * cu.redshift,
     t0=13.799 * u.Gyr,
     Tcmb0=2.7255 * u.K,
     Neff=3.046,
@@ -118,7 +119,7 @@ Planck13 = MappingProxyType(dict(
     n=0.9611,
     sigma8=0.8288,
     tau=0.0952,
-    z_reion=11.52,
+    z_reion=11.52 * cu.redshift,
     t0=13.7965 * u.Gyr,
     Tcmb0=2.7255 * u.K,
     Neff=3.046,
@@ -138,7 +139,7 @@ WMAP9 = MappingProxyType(dict(
     n=0.9608,
     sigma8=0.820,
     tau=0.081,
-    z_reion=10.1,
+    z_reion=10.1 * cu.redshift,
     t0=13.772 * u.Gyr,
     Tcmb0=2.725 * u.K,
     Neff=3.04,
@@ -158,7 +159,7 @@ WMAP7 = MappingProxyType(dict(
     n=0.967,
     sigma8=0.810,
     tau=0.085,
-    z_reion=10.3,
+    z_reion=10.3 * cu.redshift,
     t0=13.76 * u.Gyr,
     Tcmb0=2.725 * u.K,
     Neff=3.04,
@@ -178,7 +179,7 @@ WMAP5 = MappingProxyType(dict(
     n=0.962,
     sigma8=0.817,
     tau=0.088,
-    z_reion=11.3,
+    z_reion=11.3 * cu.redshift,
     t0=13.72 * u.Gyr,
     Tcmb0=2.725 * u.K,
     Neff=3.04,
@@ -198,7 +199,7 @@ WMAP3 = MappingProxyType(dict(
     n=0.946,
     sigma8=0.784,
     tau=0.079,
-    z_reion=10.3,
+    z_reion=10.3 * cu.redshift,
     t0=13.78 * u.Gyr,
     Tcmb0=2.725 * u.K,
     Neff=3.04,
@@ -216,11 +217,11 @@ WMAP1 = MappingProxyType(dict(
     Oc0=0.213,
     Ob0=0.0436,
     Om0=0.257,
-    H0=72. * (u.km / u.s / u.Mpc),
+    H0=72.0 * (u.km / u.s / u.Mpc),
     n=0.96,
     sigma8=0.75,
     tau=0.117,
-    z_reion=17.0,  # Only from WMAP1. Does not exist in the combined analysis.
+    z_reion=17.0 * cu.redshift,  # Only from WMAP1. Does not exist in the combined analysis.
     t0=13.4 * u.Gyr,
     Tcmb0=2.725 * u.K,
     Neff=3.04,

--- a/astropy/cosmology/tests/test_core.py
+++ b/astropy/cosmology/tests/test_core.py
@@ -17,6 +17,7 @@ import pytest
 import numpy as np
 
 # LOCAL
+import astropy.cosmology.units as cu
 import astropy.units as u
 from astropy.cosmology import Cosmology, core
 from astropy.cosmology.core import _COSMOLOGY_CLASSES
@@ -328,10 +329,10 @@ class TestCosmology(ParameterTestMixin, MetaTestMixin,
         """Test instances can pickle and unpickle."""
         # pickle and unpickle
         f = pickle.dumps(cosmo, protocol=pickle_protocol)
-        unpickled = pickle.loads(f)
+        with u.add_enabled_units(cu):
+            unpickled = pickle.loads(f)
 
-        # test equality
-        # assert unpickled == cosmo  # FIXME! #12214 for comparing redshifts.
+        assert unpickled == cosmo
         assert unpickled.meta == cosmo.meta
 
 

--- a/astropy/cosmology/tests/test_realizations.py
+++ b/astropy/cosmology/tests/test_realizations.py
@@ -7,6 +7,8 @@ import pickle
 import pytest
 
 # LOCAL
+import astropy.cosmology.units as cu
+import astropy.units as u
 from astropy import cosmology
 from astropy.cosmology import parameters, realizations
 from astropy.cosmology.realizations import default_cosmology, Planck13
@@ -96,8 +98,14 @@ def test_pickle_builtin_realizations(name, pickle_protocol):
 
     # pickle and unpickle
     f = pickle.dumps(original, protocol=pickle_protocol)
-    unpickled = pickle.loads(f)
+    with u.add_enabled_units(cu):
+        unpickled = pickle.loads(f)
 
-    # test equality
     assert unpickled == original
     assert unpickled.meta == original.meta
+
+    # if the units are not enabled, it isn't equal because redshift units
+    # are not equal. This is a weird, known issue.
+    unpickled = pickle.loads(f)
+    assert unpickled == original
+    assert unpickled.meta != original.meta

--- a/docs/changes/cosmology/12624.api.rst
+++ b/docs/changes/cosmology/12624.api.rst
@@ -1,0 +1,1 @@
+Units of redshift are added to ``z_reion`` in built-in realizations' metadata.


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

Add redshift units to ``z_reion``.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
