### PR TITLE
Misc WCSAxes code cleanups

### DIFF
--- a/astropy/visualization/wcsaxes/frame.py
+++ b/astropy/visualization/wcsaxes/frame.py
@@ -27,9 +27,9 @@ class Spine:
         self.parent_axes = parent_axes
         self.transform = transform
 
-        self.data = None
-        self.pixel = None
-        self.world = None
+        self._data = None
+        self._pixel = None
+        self._world = None
 
     @property
     def data(self):
@@ -37,12 +37,11 @@ class Spine:
 
     @data.setter
     def data(self, value):
+        self._data = value
         if value is None:
-            self._data = None
             self._pixel = None
             self._world = None
         else:
-            self._data = value
             self._pixel = self.parent_axes.transData.transform(self._data)
             with np.errstate(invalid='ignore'):
                 self._world = self.transform.transform(self._data)
@@ -54,13 +53,12 @@ class Spine:
 
     @pixel.setter
     def pixel(self, value):
+        self._pixel = value
         if value is None:
             self._data = None
-            self._pixel = None
             self._world = None
         else:
             self._data = self.parent_axes.transData.inverted().transform(self._data)
-            self._pixel = value
             self._world = self.transform.transform(self._data)
             self._update_normal()
 
@@ -70,14 +68,13 @@ class Spine:
 
     @world.setter
     def world(self, value):
+        self._world = value
         if value is None:
             self._data = None
             self._pixel = None
-            self._world = None
         else:
             self._data = self.transform.transform(value)
             self._pixel = self.parent_axes.transData.transform(self._data)
-            self._world = value
             self._update_normal()
 
     def _update_normal(self):
@@ -118,12 +115,11 @@ class SpineXAligned(Spine):
 
     @data.setter
     def data(self, value):
+        self._data = value
         if value is None:
-            self._data = None
             self._pixel = None
             self._world = None
         else:
-            self._data = value
             self._pixel = self.parent_axes.transData.transform(self._data)
             with np.errstate(invalid='ignore'):
                 self._world = self.transform.transform(self._data[:,0:1])
@@ -135,13 +131,12 @@ class SpineXAligned(Spine):
 
     @pixel.setter
     def pixel(self, value):
+        self._pixel = value
         if value is None:
             self._data = None
-            self._pixel = None
             self._world = None
         else:
             self._data = self.parent_axes.transData.inverted().transform(self._data)
-            self._pixel = value
             self._world = self.transform.transform(self._data[:,0:1])
             self._update_normal()
 

--- a/astropy/visualization/wcsaxes/ticklabels.py
+++ b/astropy/visualization/wcsaxes/ticklabels.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+from collections import defaultdict
 
 import numpy as np
 
@@ -37,25 +38,18 @@ class TickLabels(Text):
             self.set_size(rcParams['xtick.labelsize'])
 
     def clear(self):
-        self.world = {}
-        self.pixel = {}
-        self.angle = {}
-        self.text = {}
-        self.disp = {}
+        self.world = defaultdict(list)
+        self.pixel = defaultdict(list)
+        self.angle = defaultdict(list)
+        self.text = defaultdict(list)
+        self.disp = defaultdict(list)
 
     def add(self, axis, world, pixel, angle, text, axis_displacement):
-        if axis not in self.world:
-            self.world[axis] = [world]
-            self.pixel[axis] = [pixel]
-            self.angle[axis] = [angle]
-            self.text[axis] = [text]
-            self.disp[axis] = [axis_displacement]
-        else:
-            self.world[axis].append(world)
-            self.pixel[axis].append(pixel)
-            self.angle[axis].append(angle)
-            self.text[axis].append(text)
-            self.disp[axis].append(axis_displacement)
+        self.world[axis].append(world)
+        self.pixel[axis].append(pixel)
+        self.angle[axis].append(angle)
+        self.text[axis].append(text)
+        self.disp[axis].append(axis_displacement)
         self._stale = True
 
     def sort(self):

--- a/astropy/visualization/wcsaxes/ticks.py
+++ b/astropy/visualization/wcsaxes/ticks.py
@@ -112,42 +112,30 @@ class Ticks(Line2D):
             return [x for x in self._visible_axes if x in self.world]
 
     def clear(self):
-        self.world = {}
-        self.pixel = {}
-        self.angle = {}
-        self.disp = {}
-        self.minor_world = {}
-        self.minor_pixel = {}
-        self.minor_angle = {}
-        self.minor_disp = {}
+        self.world = defaultdict(list)
+        self.pixel = defaultdict(list)
+        self.angle = defaultdict(list)
+        self.disp = defaultdict(list)
+        self.minor_world = defaultdict(list)
+        self.minor_pixel = defaultdict(list)
+        self.minor_angle = defaultdict(list)
+        self.minor_disp = defaultdict(list)
 
     def add(self, axis, world, pixel, angle, axis_displacement):
-        if axis not in self.world:
-            self.world[axis] = [world]
-            self.pixel[axis] = [pixel]
-            self.angle[axis] = [angle]
-            self.disp[axis] = [axis_displacement]
-        else:
-            self.world[axis].append(world)
-            self.pixel[axis].append(pixel)
-            self.angle[axis].append(angle)
-            self.disp[axis].append(axis_displacement)
+        self.world[axis].append(world)
+        self.pixel[axis].append(pixel)
+        self.angle[axis].append(angle)
+        self.disp[axis].append(axis_displacement)
 
     def get_minor_world(self):
         return self.minor_world
 
     def add_minor(self, minor_axis, minor_world, minor_pixel, minor_angle,
                   minor_axis_displacement):
-        if minor_axis not in self.minor_world:
-            self.minor_world[minor_axis] = [minor_world]
-            self.minor_pixel[minor_axis] = [minor_pixel]
-            self.minor_angle[minor_axis] = [minor_angle]
-            self.minor_disp[minor_axis] = [minor_axis_displacement]
-        else:
-            self.minor_world[minor_axis].append(minor_world)
-            self.minor_pixel[minor_axis].append(minor_pixel)
-            self.minor_angle[minor_axis].append(minor_angle)
-            self.minor_disp[minor_axis].append(minor_axis_displacement)
+        self.minor_world[minor_axis].append(minor_world)
+        self.minor_pixel[minor_axis].append(minor_pixel)
+        self.minor_angle[minor_axis].append(minor_angle)
+        self.minor_disp[minor_axis].append(minor_axis_displacement)
 
     def __len__(self):
         return len(self.world)


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

I'm going to take a look at various WCSAxes issues in the near future. This PR doesn't change any behaviour or API, but cleans up the code a bit to:
- Avoid calling the setters when initialising `Spine`. Setting private attributes is fine.
- Reduce line duplication within setters in `Spine`
- Use `defaultdict` in ticklabels to reduce a lot of duplication

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
