### PR TITLE
Support reading and writing ASCII tables with embedded newlines in data fields

### DIFF
--- a/astropy/io/ascii/basic.py
+++ b/astropy/io/ascii/basic.py
@@ -176,7 +176,9 @@ class CommentedHeader(Basic):
 class TabHeaderSplitter(core.DefaultSplitter):
     """Split lines on tab and do not remove whitespace"""
     delimiter = '\t'
-    process_line = None
+
+    def process_line(self, line):
+        return line + '\n'
 
 
 class TabDataSplitter(TabHeaderSplitter):

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -451,7 +451,11 @@ class DefaultSplitter(BaseSplitter):
         If splitting on whitespace then replace unquoted tabs with space first"""
         if self.delimiter == r'\s':
             line = _replace_tab_with_space(line, self.escapechar, self.quotechar)
-        return line.strip()
+        return line.strip() + '\n'
+
+    def process_val(self, val):
+        """Remove whitespace at the beginning or end of value."""
+        return val.strip(' \t')
 
     def __call__(self, lines):
         """Return an iterator over the table ``lines``, where each iterator output
@@ -496,8 +500,8 @@ class DefaultSplitter(BaseSplitter):
                                         doublequote=self.doublequote,
                                         escapechar=self.escapechar,
                                         quotechar=self.quotechar,
-                                        quoting=self.quoting,
-                                        lineterminator='')
+                                        lineterminator='',
+                                        quoting=self.quoting)
         if self.process_val:
             vals = [self.process_val(x) for x in vals]
         out = self.csv_writer.writerow(vals)

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -500,11 +500,10 @@ class DefaultSplitter(BaseSplitter):
                                         doublequote=self.doublequote,
                                         escapechar=self.escapechar,
                                         quotechar=self.quotechar,
-                                        lineterminator='',
                                         quoting=self.quoting)
         if self.process_val:
             vals = [self.process_val(x) for x in vals]
-        out = self.csv_writer.writerow(vals)
+        out = self.csv_writer.writerow(vals).rstrip('\r\n')
 
         return out
 
@@ -1712,7 +1711,7 @@ def _get_writer(Writer, fast_writer, **kwargs):
             # Restore the default SplitterClass process_val method which strips
             # whitespace.  This may have been changed in the Writer
             # initialization (e.g. Rdb and Tab)
-            writer.data.splitter.process_val = operator.methodcaller('strip')
+            writer.data.splitter.process_val = operator.methodcaller('strip', ' \t')
         else:
             writer.data.splitter.process_val = None
     if 'names' in kwargs:

--- a/astropy/io/ascii/cparser.pyx
+++ b/astropy/io/ascii/cparser.pyx
@@ -1135,7 +1135,7 @@ cdef class FastWriter:
                             rows[i % N][j] = rows[i % N][j].strip()
 
                 if str_val and self.strip_whitespace:
-                    rows[i % N][j] = rows[i % N][j].strip()
+                    rows[i % N][j] = rows[i % N][j].strip(' \t')
 
             if i >= N - 1 and i % N == N - 1: # rows is now full
                 writer.writerows(rows)

--- a/astropy/io/ascii/src/tokenizer.c
+++ b/astropy/io/ascii/src/tokenizer.c
@@ -562,8 +562,11 @@ int tokenize(tokenizer_t *self, int end, int header, int num_cols)
                 // Parse rest of field normally, e.g. "ab"c
                 self->state = FIELD;
             }
-            else if (c == self->newline)
-                self->state = QUOTED_FIELD_NEWLINE;
+            // else if (c == self->newline)
+            // {
+            //     self->state = QUOTED_FIELD_NEWLINE;
+            //     PUSH(c);
+            // }
             else
             {
                 PUSH(c);

--- a/astropy/io/ascii/src/tokenizer.c
+++ b/astropy/io/ascii/src/tokenizer.c
@@ -526,25 +526,6 @@ int tokenize(tokenizer_t *self, int end, int header, int num_cols)
                 self->state = QUOTED_FIELD;
             }
 
-        case QUOTED_FIELD_NEWLINE:
-            if (self->state == QUOTED_FIELD)
-                ; // fall through
-            // Ignore initial whitespace if strip_whitespace_lines and
-            // newlines regardless
-            else if (((c == ' ' || c == '\t') && self->strip_whitespace_lines)
-                     || c == self->newline)
-                break;
-            else if (c == self->quotechar)
-            {
-                self->state = FIELD;
-                break;
-            }
-            else
-            {
-                // Once data begins, parse it as a normal quoted field
-                self->state = QUOTED_FIELD;
-            }
-
         case QUOTED_FIELD:
             if (c == self->quotechar)
             {
@@ -562,11 +543,6 @@ int tokenize(tokenizer_t *self, int end, int header, int num_cols)
                 // Parse rest of field normally, e.g. "ab"c
                 self->state = FIELD;
             }
-            // else if (c == self->newline)
-            // {
-            //     self->state = QUOTED_FIELD_NEWLINE;
-            //     PUSH(c);
-            // }
             else
             {
                 PUSH(c);

--- a/astropy/table/pprint.py
+++ b/astropy/table/pprint.py
@@ -270,6 +270,8 @@ class TableFormatter:
                                                show_length=show_length,
                                                outs=outs)
 
+        # Replace tab and newline with text representations so they display nicely.
+        # Newline in particular is a problem in a multicolumn table.
         col_strs = [val.replace('\t', '\\t').replace('\n', '\\n') for val in col_strs_iter]
         if len(col_strs) > 0:
             col_width = max(len(x) for x in col_strs)

--- a/astropy/table/pprint.py
+++ b/astropy/table/pprint.py
@@ -270,7 +270,7 @@ class TableFormatter:
                                                show_length=show_length,
                                                outs=outs)
 
-        col_strs = list(col_strs_iter)
+        col_strs = [val.replace('\t', '\\t').replace('\n', '\\n') for val in col_strs_iter]
         if len(col_strs) > 0:
             col_width = max(len(x) for x in col_strs)
 

--- a/astropy/table/tests/test_pprint.py
+++ b/astropy/table/tests/test_pprint.py
@@ -910,3 +910,14 @@ class TestColumnsShowHide:
         with t.pprint_exclude_names.set('a??'):
             out = t.pformat_all()
         assert out == exp
+
+
+def test_embedded_newline_tab():
+    """Newlines and tabs are escaped in table repr"""
+    t = Table(rows=[['a', 'b \n c \t \n d'], ['x', 'y\n']])
+    exp = [
+        r'col0      col1     ',
+        r'---- --------------',
+        r'   a b \n c \t \n d',
+        r'   x            y\n']
+    assert t.pformat_all() == exp

--- a/docs/changes/io.ascii/12631.bugfix.rst
+++ b/docs/changes/io.ascii/12631.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed ``io.ascii`` read and write functions for most formats to correctly handle
+data fields with embedded newlines for both the fast and pure-Python readers and
+writers.

--- a/docs/changes/table/12631.api.rst
+++ b/docs/changes/table/12631.api.rst
@@ -1,0 +1,2 @@
+Change the repr of the Table object to replace embedded newlines and tabs with
+``r'\n'`` and ``r'\t'`` respectively. This improves the display of such tables.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

Previously `io.ascii` had inconsistent behavior for data fields with embedded newlines. The behavior of the fast reader/writers was different from the Python versions, and none of them were entirely correct to allow round-trip of tables with embedded newlines in quoted fields in the data.

Basically this fix involves using the Python `csv` package in a more standard way and changing from `.strip()` to `.strip(' \t')` in various places to not strip newlines.

During development I realized a major problem that was almost impossible to look at tables with embedded newlines, so I fixed this in the table repr. If desired I can put this into a separate PR, but it does fall in the category of better support for tables with newlines.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
