### PR TITLE
move `test_varyde_lumdist_mathematica`

### DIFF
--- a/astropy/cosmology/flrw.py
+++ b/astropy/cosmology/flrw.py
@@ -1452,8 +1452,8 @@ class FlatFLRWMixin(FlatCosmologyMixin):
     def __init__(self, *args, **kw):
         super().__init__(*args, **kw)  # guaranteed not to have `Ode0`
         # Do some twiddling after the fact to get flatness
-        self._Ode0 = 1.0 - self._Om0 - self._Ogamma0 - self._Onu0
         self._Ok0 = 0.0
+        self._Ode0 = 1.0 - (self._Om0 + self._Ogamma0 + self._Onu0 + self._Ok0)
 
     @property
     def Otot0(self):

--- a/astropy/cosmology/tests/test_cosmology.py
+++ b/astropy/cosmology/tests/test_cosmology.py
@@ -206,49 +206,6 @@ def test_de_subclass():
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
-def test_varyde_lumdist_mathematica():
-    """Tests a few varying dark energy EOS models against a mathematica
-    computation"""
-
-    # w0wa models
-    z = np.array([0.2, 0.4, 0.9, 1.2])
-    cosmo = flrw.w0waCDM(H0=70, Om0=0.2, Ode0=0.8, w0=-1.1, wa=0.2, Tcmb0=0.0)
-    assert allclose(cosmo.w0, -1.1)
-    assert allclose(cosmo.wa, 0.2)
-
-    assert allclose(cosmo.luminosity_distance(z),
-                    [1004.0, 2268.62, 6265.76, 9061.84] * u.Mpc, rtol=1e-4)
-    assert allclose(cosmo.de_density_scale(0.0), 1.0, rtol=1e-5)
-    assert allclose(cosmo.de_density_scale([0.0, 0.5, 1.5]),
-                    [1.0, 0.9246310669529021, 0.9184087000251957])
-
-    cosmo = flrw.w0waCDM(H0=70, Om0=0.3, Ode0=0.7, w0=-0.9, wa=0.0, Tcmb0=0.0)
-    assert allclose(cosmo.luminosity_distance(z),
-                    [971.667, 2141.67, 5685.96, 8107.41] * u.Mpc, rtol=1e-4)
-    cosmo = flrw.w0waCDM(H0=70, Om0=0.3, Ode0=0.7, w0=-0.9, wa=-0.5,
-                         Tcmb0=0.0)
-    assert allclose(cosmo.luminosity_distance(z),
-                    [974.087, 2157.08, 5783.92, 8274.08] * u.Mpc, rtol=1e-4)
-
-    # wpwa models
-    cosmo = flrw.wpwaCDM(H0=70, Om0=0.2, Ode0=0.8, wp=-1.1, wa=0.2, zp=0.5,
-                         Tcmb0=0.0)
-    assert allclose(cosmo.wp, -1.1)
-    assert allclose(cosmo.wa, 0.2)
-    assert allclose(cosmo.zp, 0.5)
-    assert allclose(cosmo.luminosity_distance(z),
-                    [1010.81, 2294.45, 6369.45, 9218.95] * u.Mpc, rtol=1e-4)
-
-    cosmo = flrw.wpwaCDM(H0=70, Om0=0.2, Ode0=0.8, wp=-1.1, wa=0.2, zp=0.9,
-                         Tcmb0=0.0)
-    assert allclose(cosmo.wp, -1.1)
-    assert allclose(cosmo.wa, 0.2)
-    assert allclose(cosmo.zp, 0.9)
-    assert allclose(cosmo.luminosity_distance(z),
-                    [1013.68, 2305.3, 6412.37, 9283.33] * u.Mpc, rtol=1e-4)
-
-
-@pytest.mark.skipif('not HAS_SCIPY')
 def test_matter():
     # Test non-relativistic matter evolution
     tcos = flrw.FlatLambdaCDM(70.0, 0.3, Ob0=0.045)

--- a/astropy/cosmology/tests/test_cosmology.py
+++ b/astropy/cosmology/tests/test_cosmology.py
@@ -158,23 +158,6 @@ def test_flat_z1():
                     [2404.0, 2404.24, 2404.4] * u.Mpc, rtol=1e-3)
 
 
-def test_zeroing():
-    """ Tests if setting params to 0s always respects that"""
-    # Make sure Ode = 0 behaves that way
-    cosmo = flrw.LambdaCDM(H0=70, Om0=0.27, Ode0=0.0)
-    assert allclose(cosmo.Ode([0, 1, 2, 3]), [0, 0, 0, 0])
-    assert allclose(cosmo.Ode(1), 0)
-    # Ogamma0 and Onu
-    cosmo = flrw.FlatLambdaCDM(H0=70, Om0=0.27, Tcmb0=0.0)
-    assert allclose(cosmo.Ogamma(1.5), [0, 0, 0, 0])
-    assert allclose(cosmo.Ogamma([0, 1, 2, 3]), [0, 0, 0, 0])
-    assert allclose(cosmo.Onu(1.5), [0, 0, 0, 0])
-    assert allclose(cosmo.Onu([0, 1, 2, 3]), [0, 0, 0, 0])
-    # Obaryon
-    cosmo = flrw.LambdaCDM(H0=70, Om0=0.27, Ode0=0.73, Ob0=0.0)
-    assert allclose(cosmo.Ob([0, 1, 2, 3]), [0, 0, 0, 0])
-
-
 # This class is to test whether the routines work correctly
 # if one only overloads w(z)
 class test_cos_sub(flrw.FLRW):

--- a/astropy/cosmology/tests/test_flrw.py
+++ b/astropy/cosmology/tests/test_flrw.py
@@ -1172,6 +1172,32 @@ class Testw0waCDM(FLRWSubclassTest, Parameterw0TestMixin, ParameterwaTestMixin):
                     " m_nu=[0. 0. 0.] eV, Ob0=None)")
         assert repr(cosmo) == expected
 
+    # ===============================================================
+    # Usage Tests
+
+    @pytest.mark.skipif(not HAS_SCIPY, reason="requires scipy")
+    def test_varyde_lumdist_mathematica(self, cosmo_cls):
+        """Test dark energy EOS models against a Mathematica computation."""
+        z = np.array([0.2, 0.4, 0.9, 1.2])
+        ba = self.ba
+        ba.arguments.update(dict(H0=70, Om0=0.2, Ode0=0.8, w0=-1.1, wa=0.2, Tcmb0=0.0))
+
+        cosmo = cosmo_cls(*ba.args, **ba.kwargs)
+        assert u.allclose(cosmo.luminosity_distance(z),
+                          [1004.0, 2268.62, 6265.76, 9061.84] * u.Mpc, rtol=1e-4)
+        assert u.allclose(cosmo.de_density_scale(0.0), 1.0, rtol=1e-5)
+        assert u.allclose(cosmo.de_density_scale([0.0, 0.5, 1.5]),
+                          [1.0, 0.9246310669529021, 0.9184087000251957])
+
+        ba.arguments.update(dict(Om0=0.3, Ode0=0.7, w0=-0.9, wa=0.0))
+        cosmo = cosmo_cls(*ba.args, **ba.kwargs)
+        assert u.allclose(cosmo.luminosity_distance(z),
+                          [971.667, 2141.67, 5685.96, 8107.41] * u.Mpc, rtol=1e-4)
+
+        ba.arguments["wa"] = -0.5
+        cosmo = cosmo_cls(*ba.args, **ba.kwargs)
+        assert u.allclose(cosmo.luminosity_distance(z),
+                          [974.087, 2157.08, 5783.92, 8274.08] * u.Mpc, rtol=1e-4)
 
 # -----------------------------------------------------------------------------
 
@@ -1326,6 +1352,21 @@ class TestwpwaCDM(FLRWSubclassTest,
                     " Neff=3.04, m_nu=[0. 0. 0.] eV, Ob0=None)")
         assert repr(cosmo) == expected
 
+    # ===============================================================
+    # Usage Tests
+
+    @pytest.mark.skipif(not HAS_SCIPY, reason="requires scipy")
+    def test_varyde_lumdist_mathematica(self, cosmo_cls):
+        """Test dark energy EOS models against a Mathematica computation."""
+        z = np.array([0.2, 0.4, 0.9, 1.2])
+
+        cosmo = cosmo_cls(H0=70, Om0=0.2, Ode0=0.8, wp=-1.1, wa=0.2, zp=0.5, Tcmb0=0.0)
+        assert u.allclose(cosmo.luminosity_distance(z),
+                          [1010.81, 2294.45, 6369.45, 9218.95] * u.Mpc, rtol=1e-4)
+
+        cosmo = cosmo_cls(H0=70, Om0=0.2, Ode0=0.8, wp=-1.1, wa=0.2, zp=0.9, Tcmb0=0.0)
+        assert u.allclose(cosmo.luminosity_distance(z),
+                          [1013.68, 2305.3, 6412.37, 9283.33] * u.Mpc, rtol=1e-4)
 
 # -----------------------------------------------------------------------------
 


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>


### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
