### PR TITLE
Add cosmology units to ECSV reading

### DIFF
--- a/astropy/cosmology/io/ecsv.py
+++ b/astropy/cosmology/io/ecsv.py
@@ -1,5 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+import astropy.cosmology.units as cu
+import astropy.units as u
 from astropy.table import QTable
 from astropy.cosmology.connect import readwrite_registry
 from astropy.cosmology.core import Cosmology
@@ -42,7 +44,8 @@ def read_ecsv(filename, index=None, *, move_to_meta=False, cosmology=None, **kwa
     `~astropy.cosmology.Cosmology` subclass instance
     """
     kwargs["format"] = "ascii.ecsv"
-    table = QTable.read(filename, **kwargs)
+    with u.add_enabled_units(cu):
+        table = QTable.read(filename, **kwargs)
 
     # build cosmology from table
     return from_table(table, index=index, move_to_meta=move_to_meta, cosmology=cosmology)

--- a/docs/changes/cosmology/12636.bugfix.rst
+++ b/docs/changes/cosmology/12636.bugfix.rst
@@ -1,0 +1,2 @@
+Reading a cosmology from an ECSV will load redshift and Hubble parameter units
+from the cosmology units module.


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

### Description

Related to #12214. Units defined outside of astropy.units don't always unserialize correctly. This is a quick fix to ensure that units defined in ``cosmology.units`` are always available.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
