### PR TITLE
Clarify file signature detection details in `astropy.utils.data.get_readable_fileobj()`

### DIFF
--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -331,15 +331,14 @@ def get_readable_fileobj(name_or_obj, encoding=None, cache=False,
     # Check if the file object supports random access, and if not,
     # then wrap it in a BytesIO buffer.  It would be nicer to use a
     # BufferedReader to avoid reading loading the whole file first,
-    # but that is not compatible with streams or urllib2.urlopen
-    # objects on Python 2.x.
+    # but that might not be compatible with all possible I/O classes.
     if not hasattr(fileobj, 'seek'):
         try:
             # py.path.LocalPath objects have .read() method but it uses
             # text mode, which won't work. .read_binary() does, and
             # surely other ducks would return binary contents when
             # called like this.
-            # py.path.LocalPath is what comes from the tmpdir fixture
+            # py.path.LocalPath is what comes from the legacy tmpdir fixture
             # in pytest.
             fileobj = io.BytesIO(fileobj.read_binary())
         except AttributeError:


### PR DESCRIPTION
### Description

Currently `astropy.utils.data.get_readable_fileobj()`  checks the file signature of a non-random access file-like object (i.e. one that does not have a `seek()` method) by reading in *all* its contents to access the first few bytes. It would be better to wrap such a file-like object in a `io.BufferedReader`. A comment in the code lists a few Python 2 reasons why that can't be done, but Python 2 is no longer supported so those reasons are not valid anymore.

EDIT: The discussion below came to the conclusion that compatibility issues are still relevant despite Python 2 not being supported anymore, so this pull request only updates the code comment so that it wouldn't be misleading.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
