### PR TITLE
TST: Attempt to fix CI

### DIFF
--- a/astropy/conftest.py
+++ b/astropy/conftest.py
@@ -69,7 +69,10 @@ def fast_thread_switching():
 
 
 def pytest_configure(config):
-    from astropy import __version__
+    try:
+        from astropy import __version__
+    except ImportError:
+        __version__ = 'unknown'
     from astropy.utils.iers import conf as iers_conf
 
     # Disable IERS auto download for testing

--- a/astropy/conftest.py
+++ b/astropy/conftest.py
@@ -18,7 +18,6 @@ except ImportError:
 
 import pytest
 
-from astropy import __version__
 from astropy.tests.helper import enable_deprecations_as_exceptions
 
 # This is needed to silence a warning from matplotlib caused by
@@ -70,6 +69,7 @@ def fast_thread_switching():
 
 
 def pytest_configure(config):
+    from astropy import __version__
     from astropy.utils.iers import conf as iers_conf
 
     # Disable IERS auto download for testing

--- a/astropy/conftest.py
+++ b/astropy/conftest.py
@@ -68,11 +68,19 @@ def fast_thread_switching():
     sys.setswitchinterval(old)
 
 
-def pytest_configure(config):
+def pytest_report_header(config):
     try:
-        from astropy import __version__
+        from astropy import __version__  # noqa: F401
     except ImportError:
-        __version__ = 'unknown'
+        return
+
+    # This gets added after the pytest-astropy-header output.
+    return (f'ARCH_ON_CI: {os.environ.get("ARCH_ON_CI", "undefined")}\n'
+            f'IS_CRON: {os.environ.get("IS_CRON", "undefined")}\n')
+
+
+def pytest_configure(config):
+    from astropy import __version__
     from astropy.utils.iers import conf as iers_conf
 
     # Disable IERS auto download for testing

--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -38,9 +38,9 @@ __doctest_skip__ = ['OrderedDescriptor', 'OrderedDescriptorContainer']
 NOT_OVERWRITING_MSG = ('File {} already exists. If you mean to replace it '
                        'then use the argument "overwrite=True".')
 # A useful regex for tests.
-_NOT_OVERWRITING_MSG_MATCH = ('File .* already exists\. If you mean to '
-                              'replace it then use the argument '
-                              '"overwrite=True"\.')
+_NOT_OVERWRITING_MSG_MATCH = (r'File .* already exists\. If you mean to '
+                              r'replace it then use the argument '
+                              r'"overwrite=True"\.')
 
 
 def isiterable(obj):

--- a/conftest.py
+++ b/conftest.py
@@ -17,7 +17,10 @@ except ImportError:
 
 # This has to be in the root dir or it will not display in CI.
 def pytest_configure(config):
-    from astropy import __version__
+    try:
+        from astropy import __version__
+    except ImportError:
+        __version__ = 'unknown'
 
     PYTEST_HEADER_MODULES['PyERFA'] = 'erfa'
     PYTEST_HEADER_MODULES['Cython'] = 'cython'

--- a/conftest.py
+++ b/conftest.py
@@ -8,8 +8,6 @@ import tempfile
 
 import hypothesis
 
-from astropy import __version__
-
 try:
     from pytest_astropy_header.display import PYTEST_HEADER_MODULES, TESTED_VERSIONS
 except ImportError:
@@ -19,6 +17,8 @@ except ImportError:
 
 # This has to be in the root dir or it will not display in CI.
 def pytest_configure(config):
+    from astropy import __version__
+
     PYTEST_HEADER_MODULES['PyERFA'] = 'erfa'
     PYTEST_HEADER_MODULES['Cython'] = 'cython'
     PYTEST_HEADER_MODULES['Scikit-image'] = 'skimage'

--- a/conftest.py
+++ b/conftest.py
@@ -17,11 +17,7 @@ except ImportError:
 
 # This has to be in the root dir or it will not display in CI.
 def pytest_configure(config):
-    try:
-        from astropy import __version__
-    except ImportError:
-        __version__ = 'unknown'
-
+    from astropy import __version__
     PYTEST_HEADER_MODULES['PyERFA'] = 'erfa'
     PYTEST_HEADER_MODULES['Cython'] = 'cython'
     PYTEST_HEADER_MODULES['Scikit-image'] = 'skimage'
@@ -32,6 +28,11 @@ def pytest_configure(config):
 
 # This has to be in the root dir or it will not display in CI.
 def pytest_report_header(config):
+    try:
+        from astropy import __version__  # noqa: F401
+    except ImportError:
+        return
+
     # This gets added after the pytest-astropy-header output.
     return (f'ARCH_ON_CI: {os.environ.get("ARCH_ON_CI", "undefined")}\n'
             f'IS_CRON: {os.environ.get("IS_CRON", "undefined")}\n')


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is an attempt to fix CI that started failing. The timing coincided with new `pytest-astropy-header` 0.2.0 release.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
