### PR TITLE
Remove dependency on deprecated distutils.version.StrictVersion

### DIFF
--- a/astropy/io/fits/util.py
+++ b/astropy/io/fits/util.py
@@ -17,12 +17,10 @@ import weakref
 from contextlib import contextmanager, suppress
 from functools import wraps
 
-from astropy.utils import data
-
-from distutils.version import LooseVersion
-
 import numpy as np
+from packaging.version import Version
 
+from astropy.utils import data
 from astropy.utils.exceptions import AstropyUserWarning
 
 path_like = (str, os.PathLike)
@@ -561,7 +559,7 @@ def _array_from_file(infile, dtype, count):
         global CHUNKED_FROMFILE
         if CHUNKED_FROMFILE is None:
             if (sys.platform == 'darwin' and
-                    LooseVersion(platform.mac_ver()[0]) < LooseVersion('10.9')):
+                    Version(platform.mac_ver()[0]) < Version('10.9')):
                 CHUNKED_FROMFILE = True
             else:
                 CHUNKED_FROMFILE = False

--- a/astropy/io/votable/util.py
+++ b/astropy/io/votable/util.py
@@ -11,7 +11,7 @@ import io
 import re
 import gzip
 
-from distutils import version
+from packaging.version import Version
 
 
 __all__ = [
@@ -207,7 +207,7 @@ def version_compare(a, b):
     def version_to_tuple(v):
         if v[0].lower() == 'v':
             v = v[1:]
-        return version.StrictVersion(v)
+        return Version(v)
     av = version_to_tuple(a)
     bv = version_to_tuple(b)
     # Can't use cmp because it was removed from Python 3.x


### PR DESCRIPTION
All builds are failing because of a new deprecation message from distutils. In this particular case, just substituting `packaging.version.Version` for `distutils.version.StrictVersion` seemed an easy win, especially since one should not generally be strict on input.

Even if people disagree, however, I would suggest to merge this first (if tests pass) and argue later...

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
