### PR TITLE
MNT: Remove all mention of distutils

### DIFF
--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -21,10 +21,7 @@ from .utils import KernelSizeError, has_even_axis, raise_even_kernel_exception
 LIBRARY_PATH = os.path.dirname(__file__)
 
 try:
-    with warnings.catch_warnings():
-        # distutils.sysconfig module is deprecated in Python 3.10
-        warnings.simplefilter('ignore', DeprecationWarning)
-        _convolve = load_library("_convolve", LIBRARY_PATH)
+    _convolve = load_library("_convolve", LIBRARY_PATH)
 except Exception:
     raise ImportError("Convolution C extension is missing. Try re-building astropy.")
 

--- a/astropy/tests/command.py
+++ b/astropy/tests/command.py
@@ -39,7 +39,7 @@ class FixRemoteDataOption(type):
     with --remote-data. We've now changed the --remote-data option so that it
     takes arguments, but we still want --remote-data to work as before and to
     enable all remote tests. With this metaclass, we can modify sys.argv
-    before distutils/setuptools try to parse the command-line options.
+    before setuptools try to parse the command-line options.
     """
     def __init__(cls, name, bases, dct):
 

--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -31,16 +31,6 @@ __all__ = ['raises', 'enable_deprecations_as_exceptions', 'remote_data',
 remote_data = pytest.mark.remote_data
 
 
-# distutils expects options to be Unicode strings
-def _fix_user_options(options):
-    def to_str_or_none(x):
-        if x is None:
-            return None
-        return str(x)
-
-    return [tuple(to_str_or_none(x) for x in y) for y in options]
-
-
 def _save_coverage(cov, result, rootdir, testing_path):
     """
     This method is called after the tests have been run in coverage mode

--- a/astropy/version.py
+++ b/astropy/version.py
@@ -16,15 +16,15 @@ except Exception:
     version = '0.0.0'
 
 
-# We use LooseVersion to define major, minor, micro, but ignore any suffixes.
+# We use Version to define major, minor, micro, but ignore any suffixes.
 def split_version(version):
     pieces = [0, 0, 0]
 
     try:
-        from distutils.version import LooseVersion
+        from packaging.version import Version
 
-        for j, piece in enumerate(LooseVersion(version).version[:3]):
-            pieces[j] = int(piece)
+        v = Version(version)
+        pieces = [v.major, v.minor, v.micro]
 
     except Exception:
         pass

--- a/docs/nitpick-exceptions
+++ b/docs/nitpick-exceptions
@@ -83,7 +83,6 @@ py:class xmlrpclib.Fault
 py:class xmlrpclib.Error
 py:class xmlrpc.client.Fault
 py:class xmlrpc.client.Error
-py:obj distutils.version.LooseVersion
 py:obj pkg_resources.parse_version
 py:class pandas.DataFrame
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -121,7 +121,6 @@ xfail_strict = true
 qt_no_exception_capture = 1
 filterwarnings =
     error
-    ignore:Distutils was imported before Setuptools
     ignore:unclosed <socket:ResourceWarning
     ignore:unclosed <ssl.SSLSocket:ResourceWarning
     ignore:numpy.ufunc size changed:RuntimeWarning
@@ -143,8 +142,6 @@ filterwarnings =
     # Ignore a warning we emit about not supporting the parallel
     # reading option for now, can be removed once the issue is fixed
     ignore:parallel reading does not currently work, so falling back to serial
-    # numpy.distutils uses distutils.sysconfgi, which is deprecated
-    ignore:The distutils.sysconfig module is deprecated, use sysconfig instead
     # numpy configurable allocator now wants memory policy set
     ignore:Trying to dealloc data, but a memory policy is not set.
 doctest_norecursedirs =

--- a/tox.ini
+++ b/tox.ini
@@ -149,8 +149,6 @@ deps =
     matplotlib
 extras = test
 commands =
-    # The --collect-submodules numpy.distutils line below is necessary
-    # due to https://github.com/pyinstaller/pyinstaller-hooks-contrib/issues/129
     pyinstaller --onefile run_astropy_tests.py \
                 --distpath . \
                 --additional-hooks-dir hooks \
@@ -159,6 +157,5 @@ commands =
                 --hidden-import pytest_openfiles.plugin \
                 --hidden-import pytest_remotedata.plugin \
                 --hidden-import pytest_doctestplus.plugin \
-                --hidden-import pytest_mpl.plugin \
-                --collect-submodules numpy.distutils
+                --hidden-import pytest_mpl.plugin
     ./run_astropy_tests --astropy-root {toxinidir}


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to remove all mention of `distutils` because it is deprecated.

I don't think this needs a change log?

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

* Fixes #12650
* Fixes #12322 
* Fixes #10578

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
