### PR TITLE
Misc docstring fixes for timeseries

### DIFF
--- a/astropy/timeseries/periodograms/bls/core.py
+++ b/astropy/timeseries/periodograms/bls/core.py
@@ -128,7 +128,7 @@ class BoxLeastSquares(BasePeriodogram):
         minimum_period, maximum_period : float or `~astropy.units.Quantity` ['time'], optional
             The minimum/maximum periods to search. If not provided, these will
             be computed as described in the notes below.
-        minimum_n_transits : int, optional
+        minimum_n_transit : int, optional
             If ``maximum_period`` is not provided, this is used to compute the
             maximum period to search by asserting that any systems with at
             least ``minimum_n_transits`` will be within the range of searched
@@ -574,7 +574,7 @@ class BoxLeastSquares(BasePeriodogram):
 
         Parameters
         ----------
-        t_model : array-like or `~astropy.units.Quantity` ['time']
+        t : array-like or `~astropy.units.Quantity` ['time']
             Times where the mask should be evaluated.
         period : float or `~astropy.units.Quantity` ['time']
             The period of the transits.

--- a/astropy/timeseries/periodograms/lombscargle/core.py
+++ b/astropy/timeseries/periodograms/lombscargle/core.py
@@ -338,13 +338,7 @@ class LombScargle(BasePeriodogram):
             or 'fast'.
         normalization : {'standard', 'model', 'log', 'psd'}, optional
             If specified, override the normalization specified at instantiation.
-        fit_mean : bool, optional
-            If True, include a constant offset as part of the model at each
-            frequency. This can lead to more accurate results, especially in
-            the case of incomplete phase coverage.
-        center_data : bool, optional
-            If True, pre-center the data by subtracting the weighted mean of
-            the input data. This is especially important if fit_mean = False.
+
         method_kwds : dict, optional
             additional keywords to pass to the lomb-scargle method
 

--- a/astropy/timeseries/periodograms/lombscargle/implementations/scipy_impl.py
+++ b/astropy/timeseries/periodograms/lombscargle/implementations/scipy_impl.py
@@ -12,7 +12,7 @@ def lombscargle_scipy(t, y, frequency, normalization='standard',
 
     Parameters
     ----------
-    t, y: array-like
+    t, y : array-like
         times, values, and errors of the data points. These should be
         broadcastable to the same shape. None should be `~astropy.units.Quantity`.
     frequency : array-like

--- a/astropy/timeseries/periodograms/lombscargle/implementations/utils.py
+++ b/astropy/timeseries/periodograms/lombscargle/implementations/utils.py
@@ -31,10 +31,10 @@ def extirpolate(x, y, N=None, M=4):
     Returns
     -------
     yN : ndarray
-         N extirpolated values associated with range(N)
+        N extirpolated values associated with range(N)
 
-    Example
-    -------
+    Examples
+    --------
     >>> rng = np.random.default_rng(0)
     >>> x = 100 * rng.random(20)
     >>> y = np.sin(x)


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

I discovered https://pypi.org/project/velin/, which is a small command line utility to automatically fix small/common numpydoc issues in docstrings. I've run it on `astropy`, and it seemed to catch a few things. This PR is fixes to `timeseries`.

- I've checked all these by eye to make sure they look sensible
- I figured it would be best to open one PR/sub-module

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
