### PR TITLE
Misc docstring fixes for cosmology

### DIFF
--- a/astropy/cosmology/funcs.py
+++ b/astropy/cosmology/funcs.py
@@ -120,37 +120,37 @@ def z_at_value(func, fval, zmin=1e-8, zmax=1000, ztol=1e-8, maxfun=500,
     Parameters
     ----------
     func : function or method
-       A function that takes a redshift as input.
+        A function that takes a redshift as input.
 
     fval : `~astropy.units.Quantity`
-       The (scalar or array) value of ``func(z)`` to recover.
+        The (scalar or array) value of ``func(z)`` to recover.
 
     zmin : float or array-like['dimensionless'] or quantity-like, optional
-       The lower search limit for ``z``.  Beware of divergences
-       in some cosmological functions, such as distance moduli,
-       at z=0 (default 1e-8).
+        The lower search limit for ``z``.  Beware of divergences
+        in some cosmological functions, such as distance moduli,
+        at z=0 (default 1e-8).
 
     zmax : float or array-like['dimensionless'] or quantity-like, optional
-       The upper search limit for ``z`` (default 1000).
+        The upper search limit for ``z`` (default 1000).
 
     ztol : float or array-like['dimensionless'], optional
-       The relative error in ``z`` acceptable for convergence.
+        The relative error in ``z`` acceptable for convergence.
 
     maxfun : int or array-like, optional
-       The maximum number of function evaluations allowed in the
-       optimization routine (default 500).
+        The maximum number of function evaluations allowed in the
+        optimization routine (default 500).
 
     method : str or callable, optional
-       Type of solver to pass to the minimizer. The built-in options provided
-       by :func:`~scipy.optimize.minimize_scalar` are 'Brent' (default),
-       'Golden' and 'Bounded' with names case insensitive - see documentation
-       there for details. It also accepts a custom solver by passing any
-       user-provided callable object that meets the requirements listed
-       therein under the Notes on "Custom minimizers" - or in more detail in
-       :doc:`scipy:tutorial/optimize` - although their use is currently
-       untested.
+        Type of solver to pass to the minimizer. The built-in options provided
+        by :func:`~scipy.optimize.minimize_scalar` are 'Brent' (default),
+        'Golden' and 'Bounded' with names case insensitive - see documentation
+        there for details. It also accepts a custom solver by passing any
+        user-provided callable object that meets the requirements listed
+        therein under the Notes on "Custom minimizers" - or in more detail in
+        :doc:`scipy:tutorial/optimize` - although their use is currently
+        untested.
 
-       .. versionadded:: 4.3
+        .. versionadded:: 4.3
 
     bracket : sequence or object array[sequence], optional
         For methods 'Brent' and 'Golden', ``bracket`` defines the bracketing
@@ -161,18 +161,18 @@ def z_at_value(func, fval, zmin=1e-8, zmax=1000, ztol=1e-8, maxfun=500,
         distance this may be used to start the search on the desired side of
         the maximum, but see Examples below for usage notes.
 
-       .. versionadded:: 4.3
+        .. versionadded:: 4.3
 
     verbose : bool, optional
-       Print diagnostic output from solver (default `False`).
+        Print diagnostic output from solver (default `False`).
 
-       .. versionadded:: 4.3
+        .. versionadded:: 4.3
 
     Returns
     -------
     z : `~astropy.units.Quantity` ['redshift']
-      The redshift ``z`` satisfying ``zmin < z < zmax`` and ``func(z) =
-      fval`` within ``ztol``. Has units of cosmological redshift.
+        The redshift ``z`` satisfying ``zmin < z < zmax`` and ``func(z) =
+        fval`` within ``ztol``. Has units of cosmological redshift.
 
     Warns
     -----

--- a/astropy/cosmology/io/ecsv.py
+++ b/astropy/cosmology/io/ecsv.py
@@ -59,7 +59,7 @@ def write_ecsv(cosmology, file, *, overwrite=False, cls=QTable, cosmology_in_met
 
     overwrite : bool
         Whether to overwrite the file, if it exists.
-    cls: type (optional, keyword-only)
+    cls : type (optional, keyword-only)
         Astropy :class:`~astropy.table.Table` (sub)class to use when writing.
         Default is :class:`~astropy.table.QTable`.
     cosmology_in_meta : bool

--- a/astropy/cosmology/io/mapping.py
+++ b/astropy/cosmology/io/mapping.py
@@ -125,7 +125,7 @@ def to_mapping(cosmology, *args, cls=dict):
     *args
         Not used. Needed for compatibility with
         `~astropy.io.registry.UnifiedReadWriteMethod`
-    cls: type (optional, keyword-only)
+    cls : type (optional, keyword-only)
         `dict` or `collections.Mapping` subclass.
         The mapping type to return. Default is `dict`.
 

--- a/astropy/cosmology/io/row.py
+++ b/astropy/cosmology/io/row.py
@@ -91,7 +91,7 @@ def to_row(cosmology, *args, cosmology_in_meta=False, table_cls=QTable):
     *args
         Not used. Needed for compatibility with
         `~astropy.io.registry.UnifiedReadWriteMethod`
-    table_cls: type (optional, keyword-only)
+    table_cls : type (optional, keyword-only)
         Astropy :class:`~astropy.table.Table` class or subclass type to use.
         Default is :class:`~astropy.table.QTable`.
     cosmology_in_meta : bool

--- a/astropy/cosmology/io/table.py
+++ b/astropy/cosmology/io/table.py
@@ -147,7 +147,7 @@ def to_table(cosmology, *args, cls=QTable, cosmology_in_meta=True):
     *args
         Not used. Needed for compatibility with
         `~astropy.io.registry.UnifiedReadWriteMethod`
-    cls: type (optional, keyword-only)
+    cls : type (optional, keyword-only)
         Astropy :class:`~astropy.table.Table` class or subclass type to return.
         Default is :class:`~astropy.table.QTable`.
     cosmology_in_meta : bool

--- a/astropy/cosmology/parameter.py
+++ b/astropy/cosmology/parameter.py
@@ -216,7 +216,7 @@ class Parameter:
 
         Parameters
         ----------
-        interpreted : bool
+        processed : bool
             Whether to more closely reproduce the input arguments (`False`,
             default) or the processed arguments (`True`). The former is better
             for string representations and round-tripping with ``eval(repr())``.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

I discovered https://pypi.org/project/velin/, which is a small command line utility to automatically fix small/common numpydoc issues in docstrings. I've run it on `astropy`, and it seemed to catch a few things. This PR is fixes to `cosmology`.

- I've checked all these by eye to make sure they look sensible
- I figured it would be best to open one PR/sub-module


<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
