### PR TITLE
Misc docstring fixes for io

### DIFF
--- a/astropy/io/ascii/basic.py
+++ b/astropy/io/ascii/basic.py
@@ -325,7 +325,6 @@ class RdbHeader(TabHeader):
         Line 1: RDB col definitions
         Line 2+: RDB data rows
 
-
         Parameters
         ----------
         lines : list

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -316,7 +316,8 @@ class BaseInputter:
             Can be either a file name, string (newline separated) with all header and data
             lines (must have at least 2 lines), a file-like object with a
             ``read()`` method, or a list of strings.
-        newline: line separator, if `None` use OS default from ``splitlines()``.
+        newline :
+            Line separator. If `None` use OS default from ``splitlines()``.
 
         Returns
         -------
@@ -1671,7 +1672,7 @@ extra_writer_pars = ('delimiter', 'comment', 'quotechar', 'formats',
 def _get_writer(Writer, fast_writer, **kwargs):
     """Initialize a table writer allowing for common customizations. This
     routine is for internal (package) use only and is useful because it depends
-    only on the "core" module. """
+    only on the "core" module."""
 
     from .fastbasic import FastBasic
 

--- a/astropy/io/ascii/daophot.py
+++ b/astropy/io/ascii/daophot.py
@@ -148,15 +148,13 @@ class DaophotHeader(core.BaseHeader):
         header.  The DAOphot header is specialized so that we just copy the entire BaseHeader
         get_cols routine and modify as needed.
 
-
-
         Parameters
         ----------
         lines : list
             List of table lines
 
         Returns
-        ----------
+        -------
         col : list
             List of table Columns
         """

--- a/astropy/io/ascii/qdp.py
+++ b/astropy/io/ascii/qdp.py
@@ -156,7 +156,7 @@ def _interpret_err_lines(err_specs, ncols, names=None):
     ncols : int
         Number of data columns
 
-    Other parameters
+    Other Parameters
     ----------------
     names : list of str
         Name of data columns (defaults to ['col1', 'col2', ...]), _not_
@@ -242,7 +242,7 @@ def _get_tables_from_qdp_file(qdp_file, input_colnames=None, delimiter=None):
     qdp_file : str
         Input QDP file name
 
-    Other parameters
+    Other Parameters
     ----------------
     input_colnames : list of str
         Name of data columns (defaults to ['col1', 'col2', ...]), _not_
@@ -392,7 +392,7 @@ def _read_table_qdp(qdp_file, names=None, table_id=None, delimiter=None):
     qdp_file : str
         Input QDP file name
 
-    Other parameters
+    Other Parameters
     ----------------
     names : list of str
         Name of data columns (defaults to ['col1', 'col2', ...]), _not_
@@ -430,7 +430,7 @@ def _write_table_qdp(table, filename=None, err_specs=None):
     filename : str
         Output QDP file name
 
-    Other parameters
+    Other Parameters
     ----------------
     err_specs : dict
         Dictionary of the format {'serr': [1], 'terr': [2, 3]}, specifying

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -572,7 +572,7 @@ def _get_guess_kwargs_list(read_kwargs):
     Parameters
     ----------
     read_kwargs : dict
-       User-supplied read keyword args
+        User-supplied read keyword args
 
     Returns
     -------
@@ -870,7 +870,7 @@ def get_read_trace():
     Returns
     -------
     trace : list of dict
-       Ordered list of format guesses and status
+        Ordered list of format guesses and status
     """
 
     return copy.deepcopy(_read_trace)

--- a/astropy/io/fits/card.py
+++ b/astropy/io/fits/card.py
@@ -597,7 +597,6 @@ class Card(_Verify):
 
         Examples
         --------
-
         ::
 
             self._check_if_rvkc('DP1', 'AXIS.1: 2')

--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -2503,7 +2503,7 @@ def _parse_tdisp_format(tdisp):
 
     Parameters
     ----------
-    tdisp: str
+    tdisp : str
         TDISPn FITS Header keyword.  Used to specify display formatting.
 
     Returns
@@ -2560,7 +2560,7 @@ def _fortran_to_python_format(tdisp):
 
     Parameters
     ----------
-    tdisp: str
+    tdisp : str
         TDISPn FITS Header keyword.  Used to specify display formatting.
 
     Returns
@@ -2585,9 +2585,9 @@ def python_to_tdisp(format_string, logical_dtype=False):
 
     Parameters
     ----------
-    format_string: str
+    format_string : str
         TDISPn FITS Header keyword.  Used to specify display formatting.
-    logical_dtype: bool
+    logical_dtype : bool
         True is this format type should be a logical type, 'L'. Needs special
         handling.
 

--- a/astropy/io/fits/connect.py
+++ b/astropy/io/fits/connect.py
@@ -152,7 +152,7 @@ def read_table_fits(input, hdu=None, astropy_native=False, memmap=False,
         ``U``) internally, you should set this to `False`, but note that this
         will use more memory. If set to `False`, string columns will not be
         memory-mapped even if ``memmap`` is `True`.
-    unit_parse_strict: str, optional
+    unit_parse_strict : str, optional
         Behaviour when encountering invalid column units in the FITS header.
         Default is "silent", which will create a
         :class:`~astropy.units.core.UnrecognizedUnit`.

--- a/astropy/io/fits/convenience.py
+++ b/astropy/io/fits/convenience.py
@@ -94,8 +94,7 @@ def getheader(filename, *args, **kwargs):
     ext, extname, extver
         The rest of the arguments are for extension specification.  See the
         `getdata` documentation for explanations/examples.
-
-    kwargs
+    **kwargs
         Any additional keyword arguments to be passed to
         `astropy.io.fits.open`.
 
@@ -179,7 +178,7 @@ def getdata(filename, *args, header=None, lower=None, upper=None, view=None,
 
            data.view(view)
 
-    kwargs
+    **kwargs
         Any additional keyword arguments to be passed to
         `astropy.io.fits.open`.
 
@@ -272,8 +271,7 @@ def getval(filename, keyword, *args, **kwargs):
     ext, extname, extver
         The rest of the arguments are for extension specification.
         See `getdata` for explanations/examples.
-
-    kwargs
+    **kwargs
         Any additional keyword arguments to be passed to
         `astropy.io.fits.open`.
         *Note:* This function automatically specifies ``do_not_scale_image_data
@@ -340,8 +338,7 @@ def setval(filename, keyword, *args, value=None, comment=None, before=None,
     ext, extname, extver
         The rest of the arguments are for extension specification.
         See `getdata` for explanations/examples.
-
-    kwargs
+    **kwargs
         Any additional keyword arguments to be passed to
         `astropy.io.fits.open`.
         *Note:* This function automatically specifies ``do_not_scale_image_data
@@ -380,8 +377,7 @@ def delval(filename, keyword, *args, **kwargs):
     ext, extname, extver
         The rest of the arguments are for extension specification.
         See `getdata` for explanations/examples.
-
-    kwargs
+    **kwargs
         Any additional keyword arguments to be passed to
         `astropy.io.fits.open`.
         *Note:* This function automatically specifies ``do_not_scale_image_data
@@ -655,7 +651,7 @@ def append(filename, data, header=None, checksum=False, verify=True, **kwargs):
         to the end of the file.  Setting ``verify`` to `False` can be much
         faster.
 
-    kwargs
+    **kwargs
         Additional arguments are passed to:
 
         - `~astropy.io.fits.writeto` if the file does not exist or is empty.
@@ -775,8 +771,7 @@ def info(filename, output=None, **kwargs):
         A file-like object to write the output to.  If ``False``, does not
         output to a file and instead returns a list of tuples representing the
         HDU info.  Writes to ``sys.stdout`` by default.
-
-    kwargs
+    **kwargs
         Any additional keyword arguments to be passed to
         `astropy.io.fits.open`.
         *Note:* This function sets ``ignore_missing_end=True`` by default.
@@ -846,7 +841,7 @@ def printdiff(inputa, inputb, *args, **kwargs):
             printdiff('inA.fits', 'inB.fits',
                       ext=('sci', 1), extname='err', extver=2)
 
-    kwargs
+    **kwargs
         Any additional keyword arguments to be passed to
         `~astropy.io.fits.FITSDiff`.
 

--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -35,18 +35,15 @@ class FITS_record:
         Parameters
         ----------
         input : array
-           The array to wrap.
-
+            The array to wrap.
         row : int, optional
-           The starting logical row of the array.
-
+            The starting logical row of the array.
         start : int, optional
-           The starting column in the row associated with this object.
-           Used for subsetting the columns of the `FITS_rec` object.
-
+            The starting column in the row associated with this object.
+            Used for subsetting the columns of the `FITS_rec` object.
         end : int, optional
-           The ending column in the row associated with this object.
-           Used for subsetting the columns of the `FITS_rec` object.
+            The ending column in the row associated with this object.
+            Used for subsetting the columns of the `FITS_rec` object.
         """
 
         self.array = input

--- a/astropy/io/fits/hdu/base.py
+++ b/astropy/io/fits/hdu/base.py
@@ -275,24 +275,24 @@ class _BaseHDU:
         Parameters
         ----------
         data : str, bytearray, memoryview, ndarray
-           A byte string containing the HDU's header and data.
+            A byte string containing the HDU's header and data.
 
         checksum : bool, optional
-           Check the HDU's checksum and/or datasum.
+            Check the HDU's checksum and/or datasum.
 
         ignore_missing_end : bool, optional
-           Ignore a missing end card in the header data.  Note that without the
-           end card the end of the header may be ambiguous and resulted in a
-           corrupt HDU.  In this case the assumption is that the first 2880
-           block that does not begin with valid FITS header data is the
-           beginning of the data.
+            Ignore a missing end card in the header data.  Note that without the
+            end card the end of the header may be ambiguous and resulted in a
+            corrupt HDU.  In this case the assumption is that the first 2880
+            block that does not begin with valid FITS header data is the
+            beginning of the data.
 
-        kwargs : optional
-           May consist of additional keyword arguments specific to an HDU
-           type--these correspond to keywords recognized by the constructors of
-           different HDU classes such as `PrimaryHDU`, `ImageHDU`, or
-           `BinTableHDU`.  Any unrecognized keyword arguments are simply
-           ignored.
+        **kwargs : optional
+            May consist of additional keyword arguments specific to an HDU
+            type--these correspond to keywords recognized by the constructors of
+            different HDU classes such as `PrimaryHDU`, `ImageHDU`, or
+            `BinTableHDU`.  Any unrecognized keyword arguments are simply
+            ignored.
         """
 
         return cls._readfrom_internal(data, checksum=checksum,
@@ -975,23 +975,22 @@ class _ValidHDU(_BaseHDU, _Verify):
         Returns
         -------
         dict or None
+            The dictionary details information about the locations of
+            this HDU within an associated file.  Returns `None` when
+            the HDU is not associated with a file.
 
-           The dictionary details information about the locations of
-           this HDU within an associated file.  Returns `None` when
-           the HDU is not associated with a file.
+            Dictionary contents:
 
-           Dictionary contents:
-
-           ========== ================================================
-           Key        Value
-           ========== ================================================
-           file       File object associated with the HDU
-           filemode   Mode in which the file was opened (readonly, copyonwrite,
-                      update, append, ostream)
-           hdrLoc     Starting byte location of header in file
-           datLoc     Starting byte location of data block in file
-           datSpan    Data size including padding
-           ========== ================================================
+            ========== ================================================
+            Key        Value
+            ========== ================================================
+            file       File object associated with the HDU
+            filemode   Mode in which the file was opened (readonly, copyonwrite,
+                       update, append, ostream)
+            hdrLoc     Starting byte location of header in file
+            datLoc     Starting byte location of data block in file
+            datSpan    Data size including padding
+            ========== ================================================
         """
 
         if hasattr(self, '_file') and self._file:
@@ -1242,12 +1241,10 @@ class _ValidHDU(_BaseHDU, _Verify):
         Parameters
         ----------
         when : str, optional
-           comment string for the cards; by default the comments
-           will represent the time when the checksum was calculated
-
+            comment string for the cards; by default the comments
+            will represent the time when the checksum was calculated
         override_datasum : bool, optional
-           add the ``CHECKSUM`` card only
-
+            add the ``CHECKSUM`` card only
         checksum_keyword : str, optional
             The name of the header keyword to store the checksum value in; this
             is typically 'CHECKSUM' per convention, but there exist use cases
@@ -1294,9 +1291,9 @@ class _ValidHDU(_BaseHDU, _Verify):
         Returns
         -------
         valid : int
-           - 0 - failure
-           - 1 - success
-           - 2 - no ``DATASUM`` keyword present
+            - 0 - failure
+            - 1 - success
+            - 2 - no ``DATASUM`` keyword present
         """
 
         if 'DATASUM' in self._header:
@@ -1317,9 +1314,9 @@ class _ValidHDU(_BaseHDU, _Verify):
         Returns
         -------
         valid : int
-           - 0 - failure
-           - 1 - success
-           - 2 - no ``CHECKSUM`` keyword present
+            - 0 - failure
+            - 1 - success
+            - 2 - no ``CHECKSUM`` keyword present
         """
 
         if 'CHECKSUM' in self._header:

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -432,8 +432,7 @@ class HDUList(list, _Verify):
             It should be noted that if that memory is read-only (such as a
             Python string) the returned :class:`HDUList`'s data portions will
             also be read-only.
-
-        kwargs : dict
+        **kwargs : dict
             Optional keyword arguments.  See
             :func:`astropy.io.fits.open` for details.
 
@@ -695,35 +694,34 @@ class HDUList(list, _Verify):
         Parameters
         ----------
         key : int, str, tuple of (string, int) or BaseHDU
-           The key identifying the HDU.  If ``key`` is a tuple, it is of the
-           form ``(name, ver)`` where ``ver`` is an ``EXTVER`` value that must
-           match the HDU being searched for.
+            The key identifying the HDU.  If ``key`` is a tuple, it is of the
+            form ``(name, ver)`` where ``ver`` is an ``EXTVER`` value that must
+            match the HDU being searched for.
 
-           If the key is ambiguous (e.g. there are multiple 'SCI' extensions)
-           the first match is returned.  For a more precise match use the
-           ``(name, ver)`` pair.
+            If the key is ambiguous (e.g. there are multiple 'SCI' extensions)
+            the first match is returned.  For a more precise match use the
+            ``(name, ver)`` pair.
 
-           If even the ``(name, ver)`` pair is ambiguous (it shouldn't be
-           but it's not impossible) the numeric index must be used to index
-           the duplicate HDU.
+            If even the ``(name, ver)`` pair is ambiguous (it shouldn't be
+            but it's not impossible) the numeric index must be used to index
+            the duplicate HDU.
 
-           When ``key`` is an HDU object, this function returns the
-           index of that HDU object in the ``HDUList``.
+            When ``key`` is an HDU object, this function returns the
+            index of that HDU object in the ``HDUList``.
 
         Returns
         -------
         index : int
-           The index of the HDU in the `HDUList`.
+            The index of the HDU in the `HDUList`.
 
         Raises
         ------
         ValueError
-           If ``key`` is an HDU object and it is not found in the ``HDUList``.
-
+            If ``key`` is an HDU object and it is not found in the ``HDUList``.
         KeyError
-           If an HDU specified by the ``key`` that is an extension number,
-           extension name, or a tuple of extension name and version is not
-           found in the ``HDUList``.
+            If an HDU specified by the ``key`` that is an extension number,
+            extension name, or a tuple of extension name and version is not
+            found in the ``HDUList``.
 
         """
 

--- a/astropy/io/fits/hdu/table.py
+++ b/astropy/io/fits/hdu/table.py
@@ -116,7 +116,6 @@ class _TableLikeHDU(_ValidHDU):
 
         Notes
         -----
-
         Any additional keyword arguments accepted by the HDU class's
         ``__init__`` may also be passed in as keyword arguments.
         """

--- a/astropy/io/fits/header.py
+++ b/astropy/io/fits/header.py
@@ -810,9 +810,9 @@ class Header:
         Parameters
         ----------
         strip : bool, optional
-           If `True`, strip any headers that are specific to one of the
-           standard HDU types, so that this header can be used in a different
-           HDU.
+            If `True`, strip any headers that are specific to one of the
+            standard HDU types, so that this header can be used in a different
+            HDU.
 
         Returns
         -------

--- a/astropy/io/misc/hdf5.py
+++ b/astropy/io/misc/hdf5.py
@@ -76,7 +76,7 @@ def read_table_hdf5(input, path=None, character_as_bytes=True):
     path : str
         The path from which to read the table inside the HDF5 file.
         This should be relative to the input file or group.
-    character_as_bytes: bool
+    character_as_bytes : bool
         If `True` then Table columns are left as bytes.
         If `False` then Table columns are converted to unicode.
     """

--- a/astropy/io/misc/yaml.py
+++ b/astropy/io/misc/yaml.py
@@ -338,7 +338,7 @@ def dump(data, stream=None, **kwargs):
 
     Parameters
     ----------
-    data: object
+    data : object
         Object to serialize to YAML
     stream : file-like, optional
         YAML output (if not supplied a string is returned)

--- a/astropy/io/votable/converters.py
+++ b/astropy/io/votable/converters.py
@@ -1373,8 +1373,8 @@ def numpy_to_votable_dtype(dtype, shape):
     Returns
     -------
     attributes : dict
-       A dict containing 'datatype' and 'arraysize' keys that can be
-       set on a VOTable FIELD element.
+        A dict containing 'datatype' and 'arraysize' keys that can be
+        set on a VOTable FIELD element.
     """
     if dtype.num not in numpy_dtype_to_field_mapping:
         raise TypeError(
@@ -1427,8 +1427,8 @@ def table_column_to_votable_datatype(column):
     Returns
     -------
     attributes : dict
-       A dict containing 'datatype' and 'arraysize' keys that can be
-       set on a VOTable FIELD element.
+        A dict containing 'datatype' and 'arraysize' keys that can be
+        set on a VOTable FIELD element.
     """
     votable_string_dtype = None
     if column.info.meta is not None:

--- a/astropy/io/votable/table.py
+++ b/astropy/io/votable/table.py
@@ -108,7 +108,7 @@ def parse(source, columns=None, invalid='exception', verify=None,
     -------
     votable : `~astropy.io.votable.tree.VOTableFile` object
 
-    See also
+    See Also
     --------
     astropy.io.votable.exceptions : The exceptions this function may raise.
     """

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -456,8 +456,7 @@ class Element:
         ----------
         w : astropy.utils.xml.writer.XMLWriter object
             An XML writer to write to.
-
-        kwargs : dict
+        **kwargs : dict
             Any configuration parameters to control the output.
         """
         raise NotImplementedError()


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

I discovered https://pypi.org/project/velin/, which is a small command line utility to automatically fix small/common numpydoc issues in docstrings. I've run it on `astropy`, and it seemed to catch a few things. This PR is fixes to `io`.

- I've checked all these by eye to make sure they look sensible
- I figured it would be best to open one PR/sub-module


<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.