### PR TITLE
Unpin astropy-header and delay astropy import

### DIFF
--- a/astropy/cosmology/tests/mypackage/io/tests/conftest.py
+++ b/astropy/cosmology/tests/mypackage/io/tests/conftest.py
@@ -3,8 +3,13 @@
 # THIRD PARTY
 import pytest
 
-# LOCAL
-from mypackage.io import ASTROPY_GE_5
+try:
+    import astropy
+    from astropy.utils.introspection import minversion
+except ImportError:
+    ASTROPY_GE_5 = False
+else:
+    ASTROPY_GE_5 = minversion(astropy, "5.0")
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -38,9 +38,9 @@ __doctest_skip__ = ['OrderedDescriptor', 'OrderedDescriptorContainer']
 NOT_OVERWRITING_MSG = ('File {} already exists. If you mean to replace it '
                        'then use the argument "overwrite=True".')
 # A useful regex for tests.
-_NOT_OVERWRITING_MSG_MATCH = ('File .* already exists\. If you mean to '
-                              'replace it then use the argument '
-                              '"overwrite=True"\.')
+_NOT_OVERWRITING_MSG_MATCH = (r'File .* already exists\. If you mean to '
+                              r'replace it then use the argument '
+                              r'"overwrite=True"\.')
 
 
 def isiterable(obj):

--- a/astropy/wcs/tests/conftest.py
+++ b/astropy/wcs/tests/conftest.py
@@ -2,11 +2,8 @@
 
 import pytest
 
-import numpy as np
-
 from astropy import wcs
-
-from . helper import SimModelTAB
+from astropy.wcs.tests.helper import SimModelTAB
 
 
 @pytest.fixture(scope='module')

--- a/conftest.py
+++ b/conftest.py
@@ -8,8 +8,6 @@ import tempfile
 
 import hypothesis
 
-from astropy import __version__
-
 try:
     from pytest_astropy_header.display import PYTEST_HEADER_MODULES, TESTED_VERSIONS
 except ImportError:
@@ -24,6 +22,8 @@ def pytest_configure(config):
     PYTEST_HEADER_MODULES['Scikit-image'] = 'skimage'
     PYTEST_HEADER_MODULES['asdf'] = 'asdf'
     PYTEST_HEADER_MODULES['pyarrow'] = 'pyarrow'
+
+    from astropy import __version__
     TESTED_VERSIONS['Astropy'] = __version__
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,7 +52,6 @@ asdf_extensions =
 [options.extras_require]
 test =  # Required to run the astropy test suite.
     pytest-astropy>=0.9
-    pytest-astropy-header!=0.2.0
     pytest-xdist
 test_all =  # Required for testing, plus packages used by particular tests.
     pytest-astropy>=0.9

--- a/tox.ini
+++ b/tox.ini
@@ -71,9 +71,6 @@ deps =
     image: scipy
     image: pytest-mpl
 
-    # Temporary pin pytest-astropy-header
-    test: pytest-astropy-header==0.1.2
-
     # The oldestdeps factor is intended to be used to install the oldest versions of all
     # dependencies that have a minimum version.
     oldestdeps: numpy==1.18.*

--- a/tox.ini
+++ b/tox.ini
@@ -101,8 +101,8 @@ extras =
 
 commands =
     pip freeze
-    !cov-!double: pytest --pyargs astropy {toxinidir}/docs {env:MPLFLAGS} {posargs}
-    cov-!double: pytest --pyargs astropy {toxinidir}/docs {env:MPLFLAGS} --cov astropy --cov-config={toxinidir}/setup.cfg {posargs}
+    !cov-!double: pytest --import-mode=importlib --pyargs astropy {toxinidir}/docs {env:MPLFLAGS} {posargs}
+    cov-!double: pytest --import-mode=importlib --pyargs astropy {toxinidir}/docs {env:MPLFLAGS} --cov astropy --cov-config={toxinidir}/setup.cfg {posargs}
     double: python -c 'import sys; from astropy import test; test(); sys.exit(test())'
     cov: coverage xml -o {toxinidir}/coverage.xml
 


### PR DESCRIPTION
Alternative to  #12659

<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address ...

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #12646

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
