### PR TITLE
Update documentation about fits_ccddata_reader and extension HDUs in convenience.py

### DIFF
--- a/astropy/io/fits/convenience.py
+++ b/astropy/io/fits/convenience.py
@@ -19,23 +19,23 @@ one must open and re-parse the file.  In such cases it is better to use
 :class:`astropy.io.fits.HDUList` object and underlying HDU objects.
 
 Several of the convenience functions, such as `getheader` and `getdata` support
-special arguments for selecting which extension HDU to use when working with a
+special arguments for selecting which HDU to use when working with a
 multi-extension FITS file.  There are a few supported argument formats for
-selecting the extension.  See the documentation for `getdata` for an
+selecting the HDU.  See the documentation for `getdata` for an
 explanation of all the different formats.
 
 .. warning::
     All arguments to convenience functions other than the filename that are
-    *not* for selecting the extension HDU should be passed in as keyword
+    *not* for selecting the HDU should be passed in as keyword
     arguments.  This is to avoid ambiguity and conflicts with the
-    extension arguments.  For example, to set NAXIS=1 on the Primary HDU:
+    HDU arguments.  For example, to set NAXIS=1 on the Primary HDU:
 
     Wrong::
 
         astropy.io.fits.setval('myimage.fits', 'NAXIS', 1)
 
     The above example will try to set the NAXIS value on the first extension
-    HDU to blank.  That is, the argument '1' is assumed to specify an extension
+    HDU to blank.  That is, the argument '1' is assumed to specify an
     HDU.
 
     Right::
@@ -83,7 +83,7 @@ __all__ = ['getheader', 'getdata', 'getval', 'setval', 'delval', 'writeto',
 
 def getheader(filename, *args, **kwargs):
     """
-    Get the header from an extension of a FITS file.
+    Get the header from an HDU of a FITS file.
 
     Parameters
     ----------
@@ -92,7 +92,7 @@ def getheader(filename, *args, **kwargs):
         must be one of the following rb, rb+, or ab+).
 
     ext, extname, extver
-        The rest of the arguments are for extension specification.  See the
+        The rest of the arguments are for extension HDU specification.  See the
         `getdata` documentation for explanations/examples.
 
     kwargs
@@ -118,7 +118,7 @@ def getheader(filename, *args, **kwargs):
 def getdata(filename, *args, header=None, lower=None, upper=None, view=None,
             **kwargs):
     """
-    Get the data from an extension of a FITS file (and optionally the
+    Get the data from an HDU of a FITS file (and optionally the
     header).
 
     Parameters
@@ -128,23 +128,23 @@ def getdata(filename, *args, header=None, lower=None, upper=None, view=None,
         following rb, rb+, or ab+.
 
     ext
-        The rest of the arguments are for extension specification.
+        The rest of the arguments are for extension HDU specification.
         They are flexible and are best illustrated by examples.
 
-        No extra arguments implies the primary header::
+        No extra arguments implies the primary HDU::
 
             getdata('in.fits')
 
         .. note::
-            Exclusive to ``getdata``: if extension is not specified
+            Exclusive to ``getdata``: if ``ext`` is not specified
             and primary header contains no data, ``getdata`` attempts
             to retrieve data from first extension.
 
-        By extension number::
+        By HDU number::
 
-            getdata('in.fits', 0)      # the primary header
-            getdata('in.fits', 2)      # the second extension
-            getdata('in.fits', ext=2)  # the second extension
+            getdata('in.fits', 0)      # the primary HDU
+            getdata('in.fits', 2)      # the second extension HDU
+            getdata('in.fits', ext=2)  # the second extension HDU
 
         By name, i.e., ``EXTNAME`` value (if unique)::
 
@@ -194,7 +194,7 @@ def getdata(filename, *args, header=None, lower=None, upper=None, view=None,
     Raises
     ------
     IndexError
-        If no data is found in searched extensions.
+        If no data is found in searched HDUs.
     """
 
     mode, closed = _get_file_mode(filename)
@@ -213,7 +213,7 @@ def getdata(filename, *args, header=None, lower=None, upper=None, view=None,
             if ext_given:
                 raise IndexError(f"No data in HDU #{extidx}.")
 
-            # fallback to the first non-primary extension
+            # fallback to the first non-primary HDU
             if len(hdulist) == 1:
                 raise IndexError(
                     "No data in Primary HDU and no extension HDU found."
@@ -270,7 +270,7 @@ def getval(filename, keyword, *args, **kwargs):
         Keyword name
 
     ext, extname, extver
-        The rest of the arguments are for extension specification.
+        The rest of the arguments are for extension HDU specification.
         See `getdata` for explanations/examples.
 
     kwargs
@@ -338,7 +338,7 @@ def setval(filename, keyword, *args, value=None, comment=None, before=None,
         will automatically be preserved  (default: `False`).
 
     ext, extname, extver
-        The rest of the arguments are for extension specification.
+        The rest of the arguments are for extension HDU specification.
         See `getdata` for explanations/examples.
 
     kwargs
@@ -378,7 +378,7 @@ def delval(filename, keyword, *args, **kwargs):
         Keyword name or index
 
     ext, extname, extver
-        The rest of the arguments are for extension specification.
+        The rest of the arguments are for extension HDU specification.
         See `getdata` for explanations/examples.
 
     kwargs
@@ -720,15 +720,15 @@ def update(filename, data, *args, **kwargs):
         The rest of the arguments are flexible: the 3rd argument can be the
         header associated with the data.  If the 3rd argument is not a
         `Header`, it (and other positional arguments) are assumed to be the
-        extension specification(s).  Header and extension specs can also be
+        HDU specification(s).  Header and HDU specs can also be
         keyword arguments.  For example::
 
             update(file, dat, hdr, 'sci')  # update the 'sci' extension
-            update(file, dat, 3)  # update the 3rd extension
-            update(file, dat, hdr, 3)  # update the 3rd extension
-            update(file, dat, 'sci', 2)  # update the 2nd SCI extension
-            update(file, dat, 3, header=hdr)  # update the 3rd extension
-            update(file, dat, header=hdr, ext=5)  # update the 5th extension
+            update(file, dat, 3)  # update the 3rd HDU
+            update(file, dat, hdr, 3)  # update the 3rd HDU
+            update(file, dat, 'sci', 2)  # update the 2nd SCI HDU
+            update(file, dat, 3, header=hdr)  # update the 3rd HDU
+            update(file, dat, header=hdr, ext=5)  # update the 5th HDU
 
     **kwargs
         Any additional keyword arguments to be passed to
@@ -763,7 +763,7 @@ def info(filename, output=None, **kwargs):
     Print the summary information on a FITS file.
 
     This includes the name, type, length of header, data shape and type
-    for each extension.
+    for each HDU.
 
     Parameters
     ----------
@@ -813,7 +813,7 @@ def printdiff(inputa, inputb, *args, **kwargs):
         object to compare to ``inputa``.
 
     ext, extname, extver
-        Additional positional arguments are for extension specification if your
+        Additional positional arguments are for extension HDU specification if your
         inputs are string filenames (will not work if
         ``inputa`` and ``inputb`` are ``HDU`` objects or `HDUList` objects).
         They are flexible and are best illustrated by examples.  In addition
@@ -823,8 +823,8 @@ def printdiff(inputa, inputb, *args, **kwargs):
         By extension number::
 
             printdiff('inA.fits', 'inB.fits', 0)      # the primary HDU
-            printdiff('inA.fits', 'inB.fits', 2)      # the second extension
-            printdiff('inA.fits', 'inB.fits', ext=2)  # the second extension
+            printdiff('inA.fits', 'inB.fits', 2)      # the second extension HDU
+            printdiff('inA.fits', 'inB.fits', ext=2)  # the second extension HDU
 
         By name, i.e., ``EXTNAME`` value (if unique). ``EXTNAME`` values are
         not case sensitive:

--- a/astropy/io/fits/convenience.py
+++ b/astropy/io/fits/convenience.py
@@ -34,7 +34,7 @@ explanation of all the different formats.
 
         astropy.io.fits.setval('myimage.fits', 'NAXIS', 1)
 
-    The above example will try to set the NAXIS value on the first non-primary
+    The above example will try to set the NAXIS value on the first extension
     HDU to blank.  That is, the argument '1' is assumed to specify an
     HDU.
 
@@ -43,7 +43,7 @@ explanation of all the different formats.
         astropy.io.fits.setval('myimage.fits', 'NAXIS', value=1)
 
     This will set the NAXIS keyword to 1 on the primary HDU (the default).  To
-    specify the first non-primary HDU use::
+    specify the first extension HDU use::
 
         astropy.io.fits.setval('myimage.fits', 'NAXIS', value=1, ext=1)
 
@@ -138,13 +138,13 @@ def getdata(filename, *args, header=None, lower=None, upper=None, view=None,
         .. note::
             Exclusive to ``getdata``: if ``ext`` is not specified
             and primary header contains no data, ``getdata`` attempts
-            to retrieve data from first non-primary HDU.
+            to retrieve data from first extension HDU.
 
         By HDU number::
 
             getdata('in.fits', 0)      # the primary HDU
-            getdata('in.fits', 2)      # the second non-primary HDU
-            getdata('in.fits', ext=2)  # the second non-primary HDU
+            getdata('in.fits', 2)      # the second extension HDU
+            getdata('in.fits', ext=2)  # the second extension HDU
 
         By name, i.e., ``EXTNAME`` value (if unique)::
 
@@ -213,16 +213,16 @@ def getdata(filename, *args, header=None, lower=None, upper=None, view=None,
             if ext_given:
                 raise IndexError(f"No data in HDU #{extidx}.")
 
-            # fallback to the first non-primary HDU
+            # fallback to the first extension HDU
             if len(hdulist) == 1:
                 raise IndexError(
-                    "No data in Primary HDU and no non-primary HDU found."
+                    "No data in Primary HDU and no extension HDU found."
                     )
             hdu = hdulist[1]
             data = hdu.data
             if data is None:
                 raise IndexError(
-                    "No data in either Primary or first non-primary HDUs."
+                    "No data in either Primary or first extension HDUs."
                     )
 
         if header:
@@ -724,11 +724,11 @@ def update(filename, data, *args, **kwargs):
         keyword arguments.  For example::
 
             update(file, dat, hdr, 'sci')  # update the 'sci' extension
-            update(file, dat, 3)  # update the 3rd HDU
-            update(file, dat, hdr, 3)  # update the 3rd HDU
-            update(file, dat, 'sci', 2)  # update the 2nd SCI HDU
-            update(file, dat, 3, header=hdr)  # update the 3rd HDU
-            update(file, dat, header=hdr, ext=5)  # update the 5th HDU
+            update(file, dat, 3)  # update the 3rd extension HDU
+            update(file, dat, hdr, 3)  # update the 3rd extension HDU
+            update(file, dat, 'sci', 2)  # update the 2nd extension HDU named 'sci'
+            update(file, dat, 3, header=hdr)  # update the 3rd extension HDU
+            update(file, dat, header=hdr, ext=5)  # update the 5th extension HDU
 
     **kwargs
         Any additional keyword arguments to be passed to
@@ -823,8 +823,8 @@ def printdiff(inputa, inputb, *args, **kwargs):
         By HDU number::
 
             printdiff('inA.fits', 'inB.fits', 0)      # the primary HDU
-            printdiff('inA.fits', 'inB.fits', 2)      # the second non-primary HDU
-            printdiff('inA.fits', 'inB.fits', ext=2)  # the second non-primary HDU
+            printdiff('inA.fits', 'inB.fits', 2)      # the second extension HDU
+            printdiff('inA.fits', 'inB.fits', ext=2)  # the second extension HDU
 
         By name, i.e., ``EXTNAME`` value (if unique). ``EXTNAME`` values are
         not case sensitive:

--- a/astropy/io/fits/convenience.py
+++ b/astropy/io/fits/convenience.py
@@ -34,7 +34,7 @@ explanation of all the different formats.
 
         astropy.io.fits.setval('myimage.fits', 'NAXIS', 1)
 
-    The above example will try to set the NAXIS value on the first extension
+    The above example will try to set the NAXIS value on the first non-primary
     HDU to blank.  That is, the argument '1' is assumed to specify an
     HDU.
 
@@ -43,7 +43,7 @@ explanation of all the different formats.
         astropy.io.fits.setval('myimage.fits', 'NAXIS', value=1)
 
     This will set the NAXIS keyword to 1 on the primary HDU (the default).  To
-    specify the first extension HDU use::
+    specify the first non-primary HDU use::
 
         astropy.io.fits.setval('myimage.fits', 'NAXIS', value=1, ext=1)
 
@@ -92,7 +92,7 @@ def getheader(filename, *args, **kwargs):
         must be one of the following rb, rb+, or ab+).
 
     ext, extname, extver
-        The rest of the arguments are for extension HDU specification.  See the
+        The rest of the arguments are for HDU specification.  See the
         `getdata` documentation for explanations/examples.
 
     kwargs
@@ -128,7 +128,7 @@ def getdata(filename, *args, header=None, lower=None, upper=None, view=None,
         following rb, rb+, or ab+.
 
     ext
-        The rest of the arguments are for extension HDU specification.
+        The rest of the arguments are for HDU specification.
         They are flexible and are best illustrated by examples.
 
         No extra arguments implies the primary HDU::
@@ -138,13 +138,13 @@ def getdata(filename, *args, header=None, lower=None, upper=None, view=None,
         .. note::
             Exclusive to ``getdata``: if ``ext`` is not specified
             and primary header contains no data, ``getdata`` attempts
-            to retrieve data from first extension.
+            to retrieve data from first non-primary HDU.
 
         By HDU number::
 
             getdata('in.fits', 0)      # the primary HDU
-            getdata('in.fits', 2)      # the second extension HDU
-            getdata('in.fits', ext=2)  # the second extension HDU
+            getdata('in.fits', 2)      # the second non-primary HDU
+            getdata('in.fits', ext=2)  # the second non-primary HDU
 
         By name, i.e., ``EXTNAME`` value (if unique)::
 
@@ -216,13 +216,13 @@ def getdata(filename, *args, header=None, lower=None, upper=None, view=None,
             # fallback to the first non-primary HDU
             if len(hdulist) == 1:
                 raise IndexError(
-                    "No data in Primary HDU and no extension HDU found."
+                    "No data in Primary HDU and no non-primary HDU found."
                     )
             hdu = hdulist[1]
             data = hdu.data
             if data is None:
                 raise IndexError(
-                    "No data in either Primary or first extension HDUs."
+                    "No data in either Primary or first non-primary HDUs."
                     )
 
         if header:
@@ -270,7 +270,7 @@ def getval(filename, keyword, *args, **kwargs):
         Keyword name
 
     ext, extname, extver
-        The rest of the arguments are for extension HDU specification.
+        The rest of the arguments are for HDU specification.
         See `getdata` for explanations/examples.
 
     kwargs
@@ -338,7 +338,7 @@ def setval(filename, keyword, *args, value=None, comment=None, before=None,
         will automatically be preserved  (default: `False`).
 
     ext, extname, extver
-        The rest of the arguments are for extension HDU specification.
+        The rest of the arguments are for HDU specification.
         See `getdata` for explanations/examples.
 
     kwargs
@@ -378,7 +378,7 @@ def delval(filename, keyword, *args, **kwargs):
         Keyword name or index
 
     ext, extname, extver
-        The rest of the arguments are for extension HDU specification.
+        The rest of the arguments are for HDU specification.
         See `getdata` for explanations/examples.
 
     kwargs
@@ -701,7 +701,7 @@ def append(filename, data, header=None, checksum=False, verify=True, **kwargs):
 
 def update(filename, data, *args, **kwargs):
     """
-    Update the specified extension with the input data/header.
+    Update the specified HDU with the input data/header.
 
     Parameters
     ----------
@@ -813,18 +813,18 @@ def printdiff(inputa, inputb, *args, **kwargs):
         object to compare to ``inputa``.
 
     ext, extname, extver
-        Additional positional arguments are for extension HDU specification if your
+        Additional positional arguments are for HDU specification if your
         inputs are string filenames (will not work if
         ``inputa`` and ``inputb`` are ``HDU`` objects or `HDUList` objects).
         They are flexible and are best illustrated by examples.  In addition
         to using these arguments positionally you can directly call the
         keyword parameters ``ext``, ``extname``.
 
-        By extension number::
+        By HDU number::
 
             printdiff('inA.fits', 'inB.fits', 0)      # the primary HDU
-            printdiff('inA.fits', 'inB.fits', 2)      # the second extension HDU
-            printdiff('inA.fits', 'inB.fits', ext=2)  # the second extension HDU
+            printdiff('inA.fits', 'inB.fits', 2)      # the second non-primary HDU
+            printdiff('inA.fits', 'inB.fits', ext=2)  # the second non-primary HDU
 
         By name, i.e., ``EXTNAME`` value (if unique). ``EXTNAME`` values are
         not case sensitive:

--- a/astropy/io/fits/tests/test_convenience.py
+++ b/astropy/io/fits/tests/test_convenience.py
@@ -419,7 +419,7 @@ class TestConvenience(FitsTestCase):
 
         with pytest.raises(
             IndexError,
-            match="No data in either Primary or first extension HDUs."
+            match="No data in either Primary or first non-primary HDUs."
         ):
             fits.getdata(buf)
 
@@ -434,6 +434,6 @@ class TestConvenience(FitsTestCase):
 
         with pytest.raises(
             IndexError,
-            match="No data in Primary HDU and no extension HDU found."
+            match="No data in Primary HDU and no non-primary HDU found."
         ):
             fits.getdata(buf)

--- a/astropy/io/fits/tests/test_convenience.py
+++ b/astropy/io/fits/tests/test_convenience.py
@@ -419,7 +419,7 @@ class TestConvenience(FitsTestCase):
 
         with pytest.raises(
             IndexError,
-            match="No data in either Primary or first non-primary HDUs."
+            match="No data in either Primary or first extension HDUs."
         ):
             fits.getdata(buf)
 
@@ -434,6 +434,6 @@ class TestConvenience(FitsTestCase):
 
         with pytest.raises(
             IndexError,
-            match="No data in Primary HDU and no non-primary HDU found."
+            match="No data in Primary HDU and no extension HDU found."
         ):
             fits.getdata(buf)

--- a/astropy/nddata/ccddata.py
+++ b/astropy/nddata/ccddata.py
@@ -535,7 +535,7 @@ def fits_ccddata_reader(filename, hdu=0, unit=None, hdu_uncertainty='UNCERT',
     filename : str
         Name of fits file.
 
-    hdu : int, str, tuple of (string, int), or BaseHDU, optional
+    hdu : int, str, tuple of (str, int), optional
         Index or other identifier of the Header Data Unit of the FITS
         file from which CCDData should be initialized. If zero and
         no data in the primary HDU, it will search for the first

--- a/astropy/nddata/ccddata.py
+++ b/astropy/nddata/ccddata.py
@@ -535,10 +535,10 @@ def fits_ccddata_reader(filename, hdu=0, unit=None, hdu_uncertainty='UNCERT',
     filename : str
         Name of fits file.
 
-    hdu : int, optional
-        FITS extension from which CCDData should be initialized. If zero and
-        and no data in the primary extension, it will search for the first
-        extension with data. The header will be added to the primary header.
+    hdu : int, str, tuple of (string, int), or an HDU object, optional
+        FITS file from which CCDData should be initialized. If zero and
+        and no data in the primary HDU, it will search for the first
+        extension HDU with data. The header will be added to the primary HDU.
         Default is ``0``.
 
     unit : `~astropy.units.Unit`, optional

--- a/astropy/nddata/ccddata.py
+++ b/astropy/nddata/ccddata.py
@@ -535,7 +535,7 @@ def fits_ccddata_reader(filename, hdu=0, unit=None, hdu_uncertainty='UNCERT',
     filename : str
         Name of fits file.
 
-    hdu : int, str, tuple of (string, int), or an HDU object, optional
+    hdu : int, str, tuple of (string, int), or BaseHDU, optional
         Index or other identifier of the Header Data Unit of the FITS
         file from which CCDData should be initialized. If zero and
         no data in the primary HDU, it will search for the first

--- a/astropy/nddata/ccddata.py
+++ b/astropy/nddata/ccddata.py
@@ -536,7 +536,7 @@ def fits_ccddata_reader(filename, hdu=0, unit=None, hdu_uncertainty='UNCERT',
         Name of fits file.
 
     hdu : int, str, tuple of (string, int), or an HDU object, optional
-        Index or other identifier of the Header Data Unit of the FITS 
+        Index or other identifier of the Header Data Unit of the FITS
         file from which CCDData should be initialized. If zero and
         no data in the primary HDU, it will search for the first
         extension HDU with data. The header will be added to the primary HDU.

--- a/astropy/nddata/ccddata.py
+++ b/astropy/nddata/ccddata.py
@@ -536,8 +536,9 @@ def fits_ccddata_reader(filename, hdu=0, unit=None, hdu_uncertainty='UNCERT',
         Name of fits file.
 
     hdu : int, str, tuple of (string, int), or an HDU object, optional
-        FITS file from which CCDData should be initialized. If zero and
-        and no data in the primary HDU, it will search for the first
+        Index or other identifier of the Header Data Unit of the FITS 
+        file from which CCDData should be initialized. If zero and
+        no data in the primary HDU, it will search for the first
         extension HDU with data. The header will be added to the primary HDU.
         Default is ``0``.
 

--- a/astropy/nddata/tests/test_ccddata.py
+++ b/astropy/nddata/tests/test_ccddata.py
@@ -149,13 +149,19 @@ def test_initialize_from_fits_with_extension(tmpdir):
     fake_img1 = np.zeros([2, 2])
     fake_img2 = np.arange(4).reshape(2, 2)
     hdu0 = fits.PrimaryHDU()
-    hdu1 = fits.ImageHDU(fake_img1)
-    hdu2 = fits.ImageHDU(fake_img2)
+    hdu1 = fits.ImageHDU(fake_img1, name='first', ver=1)
+    hdu2 = fits.ImageHDU(fake_img2, name='second', ver=1)
     hdus = fits.HDUList([hdu0, hdu1, hdu2])
     filename = tmpdir.join('afile.fits').strpath
     hdus.writeto(filename)
     ccd = CCDData.read(filename, hdu=2, unit='adu')
     # ccd should pick up the unit adu from the fits header...did it?
+    np.testing.assert_array_equal(ccd.data, fake_img2)
+    # check hdu string parameter
+    ccd = CCDData.read(filename, hdu='second', unit='adu')
+    np.testing.assert_array_equal(ccd.data, fake_img2)
+    # check hdu tuple parameter
+    ccd = CCDData.read(filename, hdu=('second', 1), unit='adu')
     np.testing.assert_array_equal(ccd.data, fake_img2)
 
 


### PR DESCRIPTION
### Description
This pull request is meant to contribute to #10978.
It closes  #11953 addressing the reviewer comment.
The PR also update some docstrings in `convenience.py`, as requested in this [comment](https://github.com/astropy/astropy/issues/10978#issuecomment-737540110) ... hoping my understanding of extensions and HDUs is enough to make myself clear... :)

Answering to [this comment](https://github.com/astropy/astropy/issues/10978#issuecomment-738514658), I can confirm that no tests are performed on `CCDData.read` where `hdu` is not an integer.
Should I add the tests in this pull request? Or focus on documentation and open a new one?

Closes #10978.

Thanks for listening.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
