### PR TITLE
Move test_zeroing

### DIFF
--- a/astropy/cosmology/flrw.py
+++ b/astropy/cosmology/flrw.py
@@ -1452,8 +1452,8 @@ class FlatFLRWMixin(FlatCosmologyMixin):
     def __init__(self, *args, **kw):
         super().__init__(*args, **kw)  # guaranteed not to have `Ode0`
         # Do some twiddling after the fact to get flatness
-        self._Ode0 = 1.0 - self._Om0 - self._Ogamma0 - self._Onu0
         self._Ok0 = 0.0
+        self._Ode0 = 1.0 - (self._Om0 + self._Ogamma0 + self._Onu0 + self._Ok0)
 
     @property
     def Otot0(self):

--- a/astropy/cosmology/tests/test_cosmology.py
+++ b/astropy/cosmology/tests/test_cosmology.py
@@ -158,23 +158,6 @@ def test_flat_z1():
                     [2404.0, 2404.24, 2404.4] * u.Mpc, rtol=1e-3)
 
 
-def test_zeroing():
-    """ Tests if setting params to 0s always respects that"""
-    # Make sure Ode = 0 behaves that way
-    cosmo = flrw.LambdaCDM(H0=70, Om0=0.27, Ode0=0.0)
-    assert allclose(cosmo.Ode([0, 1, 2, 3]), [0, 0, 0, 0])
-    assert allclose(cosmo.Ode(1), 0)
-    # Ogamma0 and Onu
-    cosmo = flrw.FlatLambdaCDM(H0=70, Om0=0.27, Tcmb0=0.0)
-    assert allclose(cosmo.Ogamma(1.5), [0, 0, 0, 0])
-    assert allclose(cosmo.Ogamma([0, 1, 2, 3]), [0, 0, 0, 0])
-    assert allclose(cosmo.Onu(1.5), [0, 0, 0, 0])
-    assert allclose(cosmo.Onu([0, 1, 2, 3]), [0, 0, 0, 0])
-    # Obaryon
-    cosmo = flrw.LambdaCDM(H0=70, Om0=0.27, Ode0=0.73, Ob0=0.0)
-    assert allclose(cosmo.Ob([0, 1, 2, 3]), [0, 0, 0, 0])
-
-
 # This class is to test whether the routines work correctly
 # if one only overloads w(z)
 class test_cos_sub(flrw.FLRW):


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

Moves another test to the new test suite.
Also simplifies constructing a BoundArgument for a cosmology.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
