### PR TITLE
Performance improvement for bytes-type Column searchsorted

### DIFF
--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -840,6 +840,18 @@ class BaseColumn(_ColumnGetitemShim, np.ndarray):
     def unit(self):
         self._unit = None
 
+    def searchsorted(self, v, side='left', sorter=None):
+        # For bytes type data, encode the `v` value as UTF-8 (if necessary) before
+        # calling searchsorted. This prevents a factor of 1000 slowdown in
+        # searchsorted in this case.
+        a = self.data
+        if a.dtype.kind == 'S' and not isinstance(v, bytes):
+            v = np.asarray(v)
+            if v.dtype.kind == 'U':
+                v = np.char.encode(v, 'utf-8')
+        return np.searchsorted(a, v, side=side, sorter=sorter)
+    searchsorted.__doc__ = np.ndarray.searchsorted.__doc__
+
     def convert_unit_to(self, new_unit, equivalencies=[]):
         """
         Converts the values of the column in-place from the current

--- a/astropy/table/tests/test_column.py
+++ b/astropy/table/tests/test_column.py
@@ -933,3 +933,23 @@ def test_masked_column_serialize_method_propagation():
     assert mc4.info.serialize_method['ecsv'] == 'data_mask'
     mc5 = mc[1:]
     assert mc5.info.serialize_method['ecsv'] == 'data_mask'
+
+
+@pytest.mark.parametrize('dtype', ['S', 'U', 'i'])
+def test_searchsorted(Column, dtype):
+    c = Column([1, 2, 2, 3], dtype=dtype)
+    if isinstance(Column, table.MaskedColumn):
+        # Searchsorted seems to ignore the mask
+        c[2] = np.ma.masked
+
+    if dtype == 'i':
+        vs = (2, [2, 1])
+    else:
+        vs = ('2', ['2', '1'], b'2', [b'2', b'1'])
+    for v in vs:
+        v = np.array(v, dtype=dtype)
+        exp = np.searchsorted(c.data, v, side='right')
+        res = c.searchsorted(v, side='right')
+        assert np.all(res == exp)
+        res = np.searchsorted(c, v, side='right')
+        assert np.all(res == exp)

--- a/docs/changes/table/12680.feature.rst
+++ b/docs/changes/table/12680.feature.rst
@@ -1,0 +1,3 @@
+Improve the performance of ``np.searchsorted`` by a factor of 1000 for a
+bytes-type ``Column`` when the search value is ``str`` or an array of ``str``.
+This happens commonly for string data stored in FITS or HDF5 format files.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address a severe performance issue using `np.searchsorted` with a `bytes` `Column` (dtype='S') where the search value is `str`. This ends up doing a UTF-8 decode for every comparison and is 1000 times slower than the equivalent call when the search value is `bytes`.

The solution here is to detect this situation and encode the search value in advance.  This PR overrides the `searchsorted` method, which will be called by the `np.searchsorted(...)`  function as well.

#### Performance 

Since this adds a call to a Python function there is an additional overhead of 1 to 2 µs for searchsorted calls.
The `np.searchsorted` function can finish in 500 ns in some cases, so the overhead is noticeable. For searchsorted on str or bytes columns, typical performance in `main` for a 100000 element array is 1.5 to 2 µs, which ends up going to about 3 µs in this branch. For the case of a bytes Column with a unicode val, the time went from 8 ms to 8 µs (factor of 1000).

The good news is that searchsorted should not generally be used in a tight loop given that the search value can be an array.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
