### PR TITLE
Remove vestiges of Python 2

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -12,9 +12,6 @@ recursive-include astropy *.pyx *.c *.h *.map *.templ
 
 include astropy/astropy.cfg
 
-# We have to explicitly include the following modules, otherwise only the
-# Python 2 versions are included when making a source distribution in Python
-# 2, and similarly for Python 3:
 include astropy/extern/configobj/*.py
 recursive-include astropy/utils/compat *.py
 

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -460,9 +460,6 @@ class BaseRepresentationOrDifferential(ShapedLikeNDArray):
     def __truediv__(self, other):
         return self._scale_operation(operator.truediv, other)
 
-    def __div__(self, other):  # pragma: py2
-        return self._scale_operation(operator.truediv, other)
-
     def __neg__(self):
         return self._scale_operation(operator.neg)
 

--- a/astropy/coordinates/tests/test_representation_arithmetic.py
+++ b/astropy/coordinates/tests/test_representation_arithmetic.py
@@ -365,7 +365,7 @@ class TestArithmetic():
         r_cross_uv_cartesian = r_cross_uv.to_cartesian()
         assert_representation_allclose(r_cross_uv_cartesian,
                                        expected, atol=1.*u.upc)
-        # A final check, with the side benefit of ensuring __div__ and norm
+        # A final check, with the side benefit of ensuring __truediv__ and norm
         # work on multi-D representations.
         r_cross_uv_by_distance = r_cross_uv / self.distance
         uv_sph = unit_vectors.represent_as(UnitSphericalRepresentation)

--- a/astropy/io/ascii/latex.py
+++ b/astropy/io/ascii/latex.py
@@ -426,9 +426,8 @@ class AASTexData(LatexData):
         # To remove extra space(s) and // appended which creates an extra new line
         # in the end.
         if len(lines) > lines_length_initial:
-            # we compile separately because py2.6 doesn't have a flags keyword in re.sub
-            re_final_line = re.compile(r'\s* \\ \\ \s* $', flags=re.VERBOSE)
-            lines[-1] = re.sub(re_final_line, '', lines[-1])
+            lines[-1] = re.sub(r'\s* \\ \\ \s* $', '', lines[-1],
+                               flags=re.VERBOSE)
         lines.append(self.data_end)
         add_dictval_to_list(self.latex, 'tablefoot', lines)
         lines.append(r'\end{' + self.latex['tabletype'] + r'}')

--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -686,8 +686,6 @@ class Parameter:
     __rmul__ = _binary_arithmetic_operation(operator.mul, reflected=True)
     __pow__ = _binary_arithmetic_operation(operator.pow)
     __rpow__ = _binary_arithmetic_operation(operator.pow, reflected=True)
-    __div__ = _binary_arithmetic_operation(operator.truediv)
-    __rdiv__ = _binary_arithmetic_operation(operator.truediv, reflected=True)
     __truediv__ = _binary_arithmetic_operation(operator.truediv)
     __rtruediv__ = _binary_arithmetic_operation(operator.truediv,
                                                 reflected=True)

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -16,7 +16,6 @@ from astropy.utils.data_info import BaseColumnInfo, dtype_info_name
 from astropy.utils.misc import dtype_bytes_or_chars
 from . import groups
 from . import pprint
-from .np_utils import fix_column_name
 
 # These "shims" provide __getitem__ implementations for Column and MaskedColumn
 from ._column_mixins import _ColumnGetitemShim, _MaskedColumnGetitemShim
@@ -435,7 +434,7 @@ class BaseColumn(_ColumnGetitemShim, np.ndarray):
             self_data = np.array(data, dtype=dtype, copy=copy)
 
         self = self_data.view(cls)
-        self._name = fix_column_name(name)
+        self._name = None if name is None else str(name)
         self._parent_table = None
         self.unit = unit
         self._format = format
@@ -623,7 +622,8 @@ class BaseColumn(_ColumnGetitemShim, np.ndarray):
 
     @name.setter
     def name(self, val):
-        val = fix_column_name(val)
+        if val is not None:
+            val = str(val)
 
         if self.parent_table is not None:
             table = self.parent_table

--- a/astropy/table/np_utils.py
+++ b/astropy/table/np_utils.py
@@ -106,7 +106,9 @@ def get_descrs(arrays, col_name_map):
             raise TableMergeError('Key columns have different shape')
         shape = uniq_shapes.pop()
 
-        out_descrs.append((fix_column_name(out_name), dtype, shape))
+        if out_name is not None:
+            out_name = str(out_name)
+        out_descrs.append((out_name, dtype, shape))
 
     return out_descrs
 
@@ -150,19 +152,3 @@ def _check_for_sequence_of_structured_arrays(arrays):
             raise TypeError(err)
     if len(arrays) == 0:
         raise ValueError('`arrays` arg must include at least one array')
-
-
-def fix_column_name(val):
-    """
-    Fixes column names so that they are compatible with Numpy on
-    Python 2.  Raises a ValueError exception if the column name
-    contains Unicode characters, which can not reasonably be used as a
-    column name.
-    """
-    if val is not None:
-        try:
-            val = str(val)
-        except UnicodeEncodeError:
-            raise
-
-    return val

--- a/astropy/table/operations.py
+++ b/astropy/table/operations.py
@@ -23,7 +23,7 @@ from .table import Table, QTable, Row, Column, MaskedColumn
 from astropy.units import Quantity
 
 from . import _np_utils
-from .np_utils import fix_column_name, TableMergeError
+from .np_utils import TableMergeError
 
 __all__ = ['join', 'setdiff', 'hstack', 'vstack', 'unique',
            'join_skycoord', 'join_distance']
@@ -951,7 +951,9 @@ def get_descrs(arrays, col_name_map):
             raise TableMergeError(f'Key columns {names!r} have different shape')
         shape = uniq_shapes.pop()
 
-        out_descrs.append((fix_column_name(out_name), dtype, shape))
+        if out_name is not None:
+            out_name = str(out_name)
+        out_descrs.append((out_name, dtype, shape))
 
     return out_descrs
 

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -29,7 +29,6 @@ from .pprint import TableFormatter
 from .column import (BaseColumn, Column, MaskedColumn, _auto_names, FalseArray,
                      col_copy, _convert_sequence_data_to_array)
 from .row import Row
-from .np_utils import fix_column_name
 from .info import TableInfo
 from .index import Index, _IndexModeContext, get_index
 from .connect import TableRead, TableWrite
@@ -828,9 +827,7 @@ class Table:
         if names is None:
             names = default_names or [None] * n_cols
 
-        # Numpy does not support bytes column names on Python 3, so fix them
-        # up now.
-        names = [fix_column_name(name) for name in names]
+        names = [None if name is None else str(name) for name in names]
 
         self._check_names_dtype(names, dtype, n_cols)
 

--- a/astropy/table/tests/test_column.py
+++ b/astropy/table/tests/test_column.py
@@ -757,7 +757,6 @@ def test_col_unicode_sandwich_unicode():
     """
     Sanity check that Unicode Column behaves normally.
     """
-    # On Py2 the unicode must be ASCII-compatible, else the final test fails.
     uba = 'bä'
     uba8 = uba.encode('utf-8')
 

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -777,7 +777,7 @@ class UnitBase:
         p = validate_power(p)
         return CompositeUnit(1, [self], [p], _error_check=False)
 
-    def __div__(self, m):
+    def __truediv__(self, m):
         if isinstance(m, (bytes, str)):
             m = Unit(m)
 
@@ -793,7 +793,7 @@ class UnitBase:
         except TypeError:
             return NotImplemented
 
-    def __rdiv__(self, m):
+    def __rtruediv__(self, m):
         if isinstance(m, (bytes, str)):
             return Unit(m) / self
 
@@ -810,10 +810,6 @@ class UnitBase:
                 return Quantity(m, self**(-1))
         except TypeError:
             return NotImplemented
-
-    __truediv__ = __div__
-
-    __rtruediv__ = __rdiv__
 
     def __mul__(self, m):
         if isinstance(m, (bytes, str)):
@@ -1928,9 +1924,8 @@ class UnrecognizedUnit(IrreducibleUnit):
             "The unit {!r} is unrecognized, so all arithmetic operations "
             "with it are invalid.".format(self.name))
 
-    __pow__ = __div__ = __rdiv__ = __truediv__ = __rtruediv__ = __mul__ = \
-        __rmul__ = __lt__ = __gt__ = __le__ = __ge__ = __neg__ = \
-        _unrecognized_operator
+    __pow__ = __truediv__ = __rtruediv__ = __mul__ = __rmul__ = __lt__ = \
+        __gt__ = __le__ = __ge__ = __neg__ = _unrecognized_operator
 
     def __eq__(self, other):
         try:

--- a/astropy/units/function/core.py
+++ b/astropy/units/function/core.py
@@ -301,7 +301,7 @@ class FunctionUnitBase(metaclass=ABCMeta):
     def __rmul__(self, other):
         return self.__mul__(other)
 
-    def __div__(self, other):
+    def __truediv__(self, other):
         if isinstance(other, (str, UnitBase, FunctionUnitBase)):
             if self.physical_unit == dimensionless_unscaled:
                 # If dimensionless, drop back to normal unit and retry.
@@ -316,7 +316,7 @@ class FunctionUnitBase(metaclass=ABCMeta):
             except Exception:
                 return NotImplemented
 
-    def __rdiv__(self, other):
+    def __rtruediv__(self, other):
         if isinstance(other, (str, UnitBase, FunctionUnitBase)):
             if self.physical_unit == dimensionless_unscaled:
                 # If dimensionless, drop back to normal unit and retry.
@@ -327,10 +327,6 @@ class FunctionUnitBase(metaclass=ABCMeta):
         else:
             # Don't know what to do with anything not like a unit.
             return NotImplemented
-
-    __truediv__ = __div__
-
-    __rtruediv__ = __rdiv__
 
     def __pow__(self, power):
         if power == 0:
@@ -591,7 +587,7 @@ class FunctionQuantity(Quantity):
 
     def __rtruediv__(self, other):
         if self.unit.physical_unit == dimensionless_unscaled:
-            return self._function_view.__rdiv__(other)
+            return self._function_view.__rtruediv__(other)
 
         raise UnitTypeError("Cannot divide function quantities which "
                             "are not dimensionless into anything.")

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -1164,18 +1164,6 @@ class Quantity(np.ndarray):
 
         return super().__rtruediv__(other)
 
-    def __div__(self, other):
-        """ Division between `Quantity` objects. """
-        return self.__truediv__(other)
-
-    def __idiv__(self, other):
-        """ Division between `Quantity` objects. """
-        return self.__itruediv__(other)
-
-    def __rdiv__(self, other):
-        """ Division between `Quantity` objects. """
-        return self.__rtruediv__(other)
-
     def __pow__(self, other):
         if isinstance(other, Fraction):
             # Avoid getting object arrays by raising the value to a Fraction.

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -12,7 +12,6 @@ import os
 import io
 import re
 import shutil
-import socket
 import ssl
 import sys
 import urllib.request
@@ -1378,13 +1377,6 @@ def download_file(remote_url, cache=False, show_progress=True, timeout=None,
                                      '. requested URL: '
                                      + remote_url)
                 e.reason.args = (e.reason.errno, e.reason.strerror)
-            errors[source_url] = e
-        except socket.timeout as e:
-            # this isn't supposed to happen, but occasionally a socket.timeout
-            # gets through.  It's supposed to be caught in urllib and raised
-            # in this way, but for some reason in mysterious circumstances it
-            # doesn't (or didn't in python2?). So we'll just re-raise it here
-            # instead.
             errors[source_url] = e
     else:   # No success
         if not sources:


### PR DESCRIPTION
### Description

This pull request removes the few remaining traces of Python 2, except the handful from `astropy/extern`.

The `except`-block from `astropy/utils/data.py` has been removed under the assumption that it is not needed anymore, but because the problem it was meant to fix was intermittent it might be required after all. The removal of that `except`-block is therefore in a separate commit so that it could be easily reverted should the need arise.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
