### PR TITLE
get_moon: Document observer-dependent location

### DIFF
--- a/astropy/coordinates/solar_system.py
+++ b/astropy/coordinates/solar_system.py
@@ -499,6 +499,10 @@ def get_moon(time, location=None, ephemeris=None):
 
     Notes
     -----
+    The coordinate returned is the apparent position, which is the position of
+    the moon at time *t* minus the light travel time from the moon to the
+    observing *location*.
+
     {_EPHEMERIS_NOTE}
     """
 


### PR DESCRIPTION
Add doc comment to get_moon(), like the one for get_body(), based on conversation at
https://community.openastronomy.org/t/distance-to-moon-inconsistent-results/217

<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

flake8 astropy --count --select=E101,W191,W291,W292,W293,W391,E111,E112,E113,E30,E502,E722,E901,E902,E999,F822,F823

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request essentially copies a comment in get_body() into
get_moon(), since it is relevant there also.
It addresses a confusion highlighted by the conversation at
https://community.openastronomy.org/t/distance-to-moon-inconsistent-results/217

Note: it may be the case that some other routines in solar_system.py could use
the same comment, but I didn't check very carefully.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->