### PR TITLE
TST: Use NPY_DISABLE_CPU_FEATURES for numpy 1.22

### DIFF
--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -123,6 +123,6 @@ jobs:
           run: |
             python3 -m venv --system-site-packages tests
             source tests/bin/activate
-            export NPY_DISABLE_CPU_FEATURES="AVX512_SKX"
+            export NPY_DISABLE_CPU_FEATURES=AVX512_SKX
             ASTROPY_USE_SYSTEM_ALL=1 pip3 install -e .[test]
             python3 -m pytest

--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -123,5 +123,6 @@ jobs:
           run: |
             python3 -m venv --system-site-packages tests
             source tests/bin/activate
+            export NPY_DISABLE_CPU_FEATURES="AVX512F,AVX512CD,AVX512VL,AVX512BW,AVX512DQ,AVX512_SKX"
             ASTROPY_USE_SYSTEM_ALL=1 pip3 install -e .[test]
             python3 -m pytest

--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -123,6 +123,6 @@ jobs:
           run: |
             python3 -m venv --system-site-packages tests
             source tests/bin/activate
-            export NPY_DISABLE_CPU_FEATURES="AVX512F,AVX512CD,AVX512VL,AVX512BW,AVX512DQ,AVX512_SKX"
+            export NPY_DISABLE_CPU_FEATURES="AVX512_SKX"
             ASTROPY_USE_SYSTEM_ALL=1 pip3 install -e .[test]
             python3 -m pytest

--- a/astropy/coordinates/tests/test_matching.py
+++ b/astropy/coordinates/tests/test_matching.py
@@ -167,7 +167,7 @@ def test_search_around():
     idx1_0p05deg, idx2_0p05deg, d2d_0p05deg, d3d_0p05deg = search_around_sky(coo1, coo2, 0.05*u.deg)
 
     assert list(zip(idx1_1deg, idx2_1deg)) == [(0, 2), (0, 3), (1, 1), (1, 2)]
-    assert d2d_1deg[0] == 1.0*u.deg
+    assert_allclose(d2d_1deg[0], 1.0*u.deg, atol=1e-14*u.deg, rtol=0)
     assert_allclose(d2d_1deg, [1, 0, .1, .9]*u.deg)
 
     assert list(zip(idx1_0p05deg, idx2_0p05deg)) == [(0, 3)]

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -1886,10 +1886,10 @@ def test_match_to_catalog_3d_and_sky():
 
     idx, angle, quantity = cfk5_J1950.match_to_catalog_3d(cfk5_default)
     npt.assert_array_equal(idx, [0, 1, 2, 3])
-    assert_allclose(angle, 0*u.deg, atol=1e-15*u.deg, rtol=0)
+    assert_allclose(angle, 0*u.deg, atol=2e-15*u.deg, rtol=0)
     assert_allclose(quantity, 0*u.kpc, atol=1e-15*u.kpc, rtol=0)
 
     idx, angle, distance = cfk5_J1950.match_to_catalog_sky(cfk5_default)
     npt.assert_array_equal(idx, [0, 1, 2, 3])
-    assert_allclose(angle, 0 * u.deg, atol=1e-15*u.deg, rtol=0)
-    assert_allclose(distance, 0*u.kpc, atol=1e-15*u.kpc, rtol=0)
+    assert_allclose(angle, 0 * u.deg, atol=2e-15*u.deg, rtol=0)
+    assert_allclose(distance, 0*u.kpc, atol=2e-15*u.kpc, rtol=0)

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -5,6 +5,7 @@ import copy
 import gc
 import pickle
 import re
+import sys
 
 import pytest
 import numpy as np
@@ -19,6 +20,7 @@ except ImportError:
 from astropy.io import fits
 from astropy.table import Table
 from astropy.units import UnitsWarning, Unit, UnrecognizedUnit
+from astropy.utils.compat import NUMPY_LT_1_22
 from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyUserWarning
 
 from astropy.io.fits.column import ColumnAttribute, Delayed, NUMPY2FITS
@@ -2908,6 +2910,9 @@ class TestVLATables(FitsTestCase):
         for code in ('PJ()', 'QJ()'):
             test(code)
 
+    # TODO: Unpin when Numpy bug is resolved.
+    @pytest.mark.skipif(not NUMPY_LT_1_22 and sys.platform == 'win32',
+                        reason='https://github.com/numpy/numpy/issues/20699')
     def test_copy_vla(self):
         """
         Regression test for https://github.com/spacetelescope/PyFITS/issues/47

--- a/astropy/modeling/tests/test_models.py
+++ b/astropy/modeling/tests/test_models.py
@@ -292,10 +292,15 @@ class Fittable2DModelTester:
             if test_parameters['log_fit']:
                 x = np.logspace(x_lim[0], x_lim[1], self.N)
                 y = np.logspace(y_lim[0], y_lim[1], self.M)
+                x_test = np.logspace(x_lim[0], x_lim[1], self.N*10)
+                y_test = np.logspace(y_lim[0], y_lim[1], self.M*10)
         else:
             x = np.linspace(x_lim[0], x_lim[1], self.N)
             y = np.linspace(y_lim[0], y_lim[1], self.M)
+            x_test = np.linspace(x_lim[0], x_lim[1], self.N*10)
+            y_test = np.linspace(y_lim[0], y_lim[1], self.M*10)
         xv, yv = np.meshgrid(x, y)
+        xv_test, yv_test = np.meshgrid(x_test, y_test)
 
         try:
             model_with_deriv = create_model(model_class, test_parameters,
@@ -327,9 +332,13 @@ class Fittable2DModelTester:
         fitter_no_deriv = fitting.LevMarLSQFitter()
         new_model_no_deriv = fitter_no_deriv(model_no_deriv, xv, yv, data,
                                              estimate_jacobian=True)
-        assert_allclose(new_model_with_deriv.parameters,
-                        new_model_no_deriv.parameters,
+        assert_allclose(new_model_with_deriv(xv_test, yv_test),
+                        new_model_no_deriv(xv_test, yv_test),
                         rtol=0.1)
+        if model_class != Gaussian2D:
+            assert_allclose(new_model_with_deriv.parameters,
+                            new_model_no_deriv.parameters,
+                            rtol=0.1)
 
 
 class Fittable1DModelTester:

--- a/astropy/modeling/tests/test_models.py
+++ b/astropy/modeling/tests/test_models.py
@@ -334,7 +334,7 @@ class Fittable2DModelTester:
                                              estimate_jacobian=True)
         assert_allclose(new_model_with_deriv(xv_test, yv_test),
                         new_model_no_deriv(xv_test, yv_test),
-                        rtol=0.1)
+                        rtol=1e-3)
         if model_class != Gaussian2D:
             assert_allclose(new_model_with_deriv.parameters,
                             new_model_no_deriv.parameters,

--- a/astropy/modeling/tests/test_models.py
+++ b/astropy/modeling/tests/test_models.py
@@ -334,7 +334,7 @@ class Fittable2DModelTester:
                                              estimate_jacobian=True)
         assert_allclose(new_model_with_deriv(xv_test, yv_test),
                         new_model_no_deriv(xv_test, yv_test),
-                        rtol=1e-3)
+                        rtol=1e-2)
         if model_class != Gaussian2D:
             assert_allclose(new_model_with_deriv.parameters,
                             new_model_no_deriv.parameters,

--- a/examples/coordinates/plot_galactocentric-frame.py
+++ b/examples/coordinates/plot_galactocentric-frame.py
@@ -48,7 +48,7 @@ import astropy.units as u
 ##############################################################################
 # Let's first define a barycentric coordinate and velocity in the ICRS frame.
 # We'll use the data for the star HD 39881 from the `Simbad
-# <http://simbad.harvard.edu/simbad/>`_ database:
+# <https://simbad.u-strasbg.fr/simbad/>`_ database:
 
 c1 = coord.SkyCoord(ra=89.014303*u.degree, dec=13.924912*u.degree,
                     distance=(37.59*u.mas).to(u.pc, u.parallax()),

--- a/examples/coordinates/rv-to-gsr.py
+++ b/examples/coordinates/rv-to-gsr.py
@@ -35,7 +35,7 @@ coord.galactocentric_frame_defaults.set('latest')
 ################################################################################
 # For this example, let's work with the coordinates and barycentric radial
 # velocity of the star HD 155967, as obtained from
-# `Simbad <http://simbad.harvard.edu/simbad/>`_:
+# `Simbad <https://simbad.u-strasbg.fr/simbad/>`_:
 icrs = coord.SkyCoord(ra=258.58356362*u.deg, dec=14.55255619*u.deg,
                       radial_velocity=-16.1*u.km/u.s, frame='icrs')
 

--- a/tox.ini
+++ b/tox.ini
@@ -160,5 +160,6 @@ commands =
                 --hidden-import pytest_openfiles.plugin \
                 --hidden-import pytest_remotedata.plugin \
                 --hidden-import pytest_doctestplus.plugin \
-                --hidden-import pytest_mpl.plugin
+                --hidden-import pytest_mpl.plugin \
+                --collect-submodules numpy.distutils
     ./run_astropy_tests --astropy-root {toxinidir}

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,7 @@ passenv = HOME WINDIR LC_ALL LC_CTYPE CC CI IS_CRON ARCH_ON_CI TEST_READ_HUGE_FI
 
 # For coverage, we need to pass extra options to the C compiler
 setenv =
+    NPY_DISABLE_CPU_FEATURES = "AVX512F,AVX512CD,AVX512VL,AVX512BW,AVX512DQ,AVX512_SKX"
     cov: CFLAGS = --coverage -fno-inline-functions -O0
     image: MPLFLAGS = --mpl
     !image: MPLFLAGS =
@@ -143,6 +144,8 @@ commands =
 # to run them.
 description = check that astropy can be included in a pyinstaller bundle
 changedir = .pyinstaller
+setenv =
+    NPY_DISABLE_CPU_FEATURES = "AVX512F,AVX512CD,AVX512VL,AVX512BW,AVX512DQ,AVX512_SKX"
 deps =
     pyinstaller
     pytest-mpl

--- a/tox.ini
+++ b/tox.ini
@@ -144,12 +144,11 @@ commands =
 # to run them.
 description = check that astropy can be included in a pyinstaller bundle
 changedir = .pyinstaller
-setenv =
-    NPY_DISABLE_CPU_FEATURES = "AVX512F,AVX512CD,AVX512VL,AVX512BW,AVX512DQ,AVX512_SKX"
 deps =
     pyinstaller
     pytest-mpl
     matplotlib
+    numpy==1.21.*
 extras = test
 commands =
     pyinstaller --onefile run_astropy_tests.py \
@@ -160,6 +159,5 @@ commands =
                 --hidden-import pytest_openfiles.plugin \
                 --hidden-import pytest_remotedata.plugin \
                 --hidden-import pytest_doctestplus.plugin \
-                --hidden-import pytest_mpl.plugin \
-                --collect-submodules numpy.distutils
+                --hidden-import pytest_mpl.plugin
     ./run_astropy_tests --astropy-root {toxinidir}

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ passenv = HOME WINDIR LC_ALL LC_CTYPE CC CI IS_CRON ARCH_ON_CI TEST_READ_HUGE_FI
 
 # For coverage, we need to pass extra options to the C compiler
 setenv =
-    NPY_DISABLE_CPU_FEATURES = "AVX512_SKX"
+    NPY_DISABLE_CPU_FEATURES = AVX512_SKX
     cov: CFLAGS = --coverage -fno-inline-functions -O0
     image: MPLFLAGS = --mpl
     !image: MPLFLAGS =

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ passenv = HOME WINDIR LC_ALL LC_CTYPE CC CI IS_CRON ARCH_ON_CI TEST_READ_HUGE_FI
 
 # For coverage, we need to pass extra options to the C compiler
 setenv =
-    NPY_DISABLE_CPU_FEATURES = "AVX512F,AVX512CD,AVX512VL,AVX512BW,AVX512DQ,AVX512_SKX"
+    NPY_DISABLE_CPU_FEATURES = "AVX512_SKX"
     cov: CFLAGS = --coverage -fno-inline-functions -O0
     image: MPLFLAGS = --mpl
     !image: MPLFLAGS =


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to disable numpy avx512 instructions in CI.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

* Close #12682 
* Caused by numpy/numpy#19478 (numpy 1.22.0)
* Similar to matplotlib/matplotlib#22099 
* Avoids numpy/numpy#20699 

- [ ] Open follow-up issues.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.