### PR TITLE
Cosmo restructure ``m_nu`` initialization

### DIFF
--- a/astropy/cosmology/flrw.py
+++ b/astropy/cosmology/flrw.py
@@ -251,8 +251,7 @@ class FLRW(Cosmology):
             elif self._nmasslessnu == 0:  # only massive
                 m = self._massivenu_mass
             else:  # a mix -- the most complicated case
-                m = np.append(np.zeros(self._nmasslessnu),
-                              self._massivenu_mass.value)
+                m = np.append(np.zeros(self._nmasslessnu), self._massivenu_mass)
             self._m_nu = m << self._m_nu.unit
 
         # -------------------

--- a/astropy/cosmology/flrw.py
+++ b/astropy/cosmology/flrw.py
@@ -194,7 +194,8 @@ class FLRW(Cosmology):
                     self._nmassivenu = self._nneutrinos
                     self._nmasslessnu = 0
             elif len(m_nu) != self._nneutrinos:  # not scalar, check number of masses
-                raise ValueError("unexpected number of neutrino masses.")
+                raise ValueError("unexpected number of neutrino masses — "
+                                 f"expected {self._nneutrinos}, got {len(m_nu)}.")
             # elif m_nu.value.max() == 0:
             #     pass  # if this is true, min = max = 0 = default case (above)
             elif np.any(m_nu.value > 0):  # Different masses.

--- a/astropy/cosmology/io/tests/base.py
+++ b/astropy/cosmology/io/tests/base.py
@@ -25,22 +25,22 @@ class IOTestMixinBase:
     See ``TestCosmology`` for an example.
     """
 
-    @pytest.fixture
+    @pytest.fixture(scope="class")
     def from_format(self):
         """Convert to Cosmology using ``Cosmology.from_format()``."""
         return Cosmology.from_format
 
-    @pytest.fixture
+    @pytest.fixture(scope="class")
     def to_format(self, cosmo):
         """Convert Cosmology instance using ``.to_format()``."""
         return cosmo.to_format
 
-    @pytest.fixture
+    @pytest.fixture(scope="class")
     def read(self):
         """Read Cosmology instance using ``Cosmology.read()``."""
         return Cosmology.read
 
-    @pytest.fixture
+    @pytest.fixture(scope="class")
     def write(self, cosmo):
         """Write Cosmology using ``.write()``."""
         return cosmo.write
@@ -74,21 +74,21 @@ class IOFormatTestBase(IOTestMixinBase):
         # but don't error b/c it can fail in parallel
         _COSMOLOGY_CLASSES.pop(CosmologyWithKwargs.__qualname__, None)
 
-    @pytest.fixture(params=cosmo_instances)
+    @pytest.fixture(scope="class", params=cosmo_instances)
     def cosmo(self, request):
         """Cosmology instance."""
         if isinstance(request.param, str):  # CosmologyWithKwargs
             return _COSMOLOGY_CLASSES[request.param](Tcmb0=3)
         return request.param
 
-    @pytest.fixture
+    @pytest.fixture(scope="class")
     def cosmo_cls(self, cosmo):
         """Cosmology classes."""
         return cosmo.__class__
 
     # -------------------------------------------
 
-    @pytest.fixture
+    @pytest.fixture(scope="class")
     def from_format(self):
         """Convert to Cosmology using function ``from``."""
         def use_from_format(*args, **kwargs):
@@ -97,14 +97,14 @@ class IOFormatTestBase(IOTestMixinBase):
 
         return use_from_format
 
-    @pytest.fixture
+    @pytest.fixture(scope="class")
     def to_format(self, cosmo):
         """Convert Cosmology to format using function ``to``."""
         return lambda *args, **kwargs: self.functions["to"](cosmo, *args, **kwargs)
 
     # -------------------------------------------
 
-    @pytest.fixture
+    @pytest.fixture(scope="class")
     def read(self):
         """Read Cosmology from file using function ``read``."""
         def use_read(*args, **kwargs):
@@ -113,7 +113,7 @@ class IOFormatTestBase(IOTestMixinBase):
 
         return use_read
 
-    @pytest.fixture
+    @pytest.fixture(scope="class")
     def write(self, cosmo):
         """Write Cosmology to file using function ``write``."""
         return lambda *args, **kwargs: self.functions["write"](cosmo, *args, **kwargs)

--- a/astropy/cosmology/io/tests/test_model.py
+++ b/astropy/cosmology/io/tests/test_model.py
@@ -40,7 +40,7 @@ class ToFromModelTestMixin(IOTestMixinBase):
     See ``TestCosmologyToFromFormat`` or ``TestCosmology`` for examples.
     """
 
-    @pytest.fixture
+    @pytest.fixture(scope="class")
     def method_name(self, cosmo):
         # get methods, ignoring private and dunder
         methods = get_redshift_methods(cosmo, allow_private=False, allow_z2=True)

--- a/astropy/cosmology/tests/test_connect.py
+++ b/astropy/cosmology/tests/test_connect.py
@@ -107,11 +107,11 @@ class ReadWriteTestMixin(test_ecsv.ReadWriteECSVTestMixin):
 class TestCosmologyReadWrite(ReadWriteTestMixin):
     """Test the classes CosmologyRead/Write."""
 
-    @pytest.fixture(params=cosmo_instances)
+    @pytest.fixture(scope="class", params=cosmo_instances)
     def cosmo(self, request):
         return getattr(cosmology.realizations, request.param)
 
-    @pytest.fixture
+    @pytest.fixture(scope="class")
     def cosmo_cls(self, cosmo):
         return cosmo.__class__
 
@@ -260,11 +260,11 @@ class ToFromFormatTestMixin(test_mapping.ToFromMappingTestMixin, test_model.ToFr
 class TestCosmologyToFromFormat(ToFromFormatTestMixin):
     """Test Cosmology[To/From]Format classes."""
 
-    @pytest.fixture(params=cosmo_instances)
+    @pytest.fixture(scope="class", params=cosmo_instances)
     def cosmo(self, request):
         return getattr(cosmology.realizations, request.param)
 
-    @pytest.fixture
+    @pytest.fixture(scope="class")
     def cosmo_cls(self, cosmo):
         return cosmo.__class__
 

--- a/astropy/cosmology/tests/test_core.py
+++ b/astropy/cosmology/tests/test_core.py
@@ -126,26 +126,23 @@ class TestCosmology(ParameterTestMixin, MetaTestMixin,
     def cls_args(self):
         return tuple(self._cls_args.values())
 
-    @property
-    def ba(self):
-        """Return filled `inspect.BoundArguments` for cosmology.
-
-        Note this is not a fixture because those are cached and too easily
-        mutated in-place, which is a difficult thing to diagnose.
-        """
-        ba = self.cls._init_signature.bind(*self.cls_args, **self.cls_kwargs)
-        ba.apply_defaults()
-        return ba
-
-    @pytest.fixture
+    @pytest.fixture(scope="class")
     def cosmo_cls(self):
         """The Cosmology class as a :func:`pytest.fixture`."""
         return self.cls
 
-    @pytest.fixture
+    @pytest.fixture(scope="function")  # ensure not cached.
+    def ba(self):
+        """Return filled `inspect.BoundArguments` for cosmology."""
+        ba = self.cls._init_signature.bind(*self.cls_args, **self.cls_kwargs)
+        ba.apply_defaults()
+        return ba
+
+    @pytest.fixture(scope="class")
     def cosmo(self, cosmo_cls):
         """The cosmology instance with which to test."""
-        ba = self.ba
+        ba = self.cls._init_signature.bind(*self.cls_args, **self.cls_kwargs)
+        ba.apply_defaults()
         return cosmo_cls(*ba.args, **ba.kwargs)
 
     # ===============================================================

--- a/astropy/cosmology/tests/test_cosmology.py
+++ b/astropy/cosmology/tests/test_cosmology.py
@@ -946,48 +946,6 @@ def test_absorption_distance():
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
-def test_massivenu_basic():
-    # Test no neutrinos case
-    tcos = flrw.FlatLambdaCDM(70.4, 0.272, Neff=4.05,
-                              Tcmb0=2.725 * u.K, m_nu=0)
-    assert allclose(tcos.Neff, 4.05)
-    assert not tcos.has_massive_nu
-    mnu = tcos.m_nu
-    assert len(mnu) == 4
-    assert mnu.unit == u.eV
-    assert allclose(mnu, [0.0, 0.0, 0.0, 0.0] * u.eV)
-    assert allclose(tcos.nu_relative_density(1.), 0.22710731766 * 4.05,
-                    rtol=1e-6)
-    assert allclose(tcos.nu_relative_density(1), 0.22710731766 * 4.05,
-                    rtol=1e-6)
-
-    # Alternative no neutrinos case
-    tcos = flrw.FlatLambdaCDM(70.4, 0.272, Tcmb0=0 * u.K,
-                              m_nu=str((0.4 * u.eV).to(u.g, u.mass_energy())))
-    assert not tcos.has_massive_nu
-    assert tcos.m_nu is None
-
-    # Test basic setting, retrieval of values
-    tcos = flrw.FlatLambdaCDM(70.4, 0.272, Tcmb0=2.725 * u.K,
-                              m_nu=u.Quantity([0.0, 0.01, 0.02], u.eV))
-    assert tcos.has_massive_nu
-    mnu = tcos.m_nu
-    assert len(mnu) == 3
-    assert mnu.unit == u.eV
-    assert allclose(mnu, [0.0, 0.01, 0.02] * u.eV)
-
-    # All massive neutrinos case
-    tcos = flrw.FlatLambdaCDM(70.4, 0.272, Tcmb0=2.725,
-                              m_nu=u.Quantity(0.1, u.eV), Neff=3.1)
-    assert allclose(tcos.Neff, 3.1)
-    assert tcos.has_massive_nu
-    mnu = tcos.m_nu
-    assert len(mnu) == 3
-    assert mnu.unit == u.eV
-    assert allclose(mnu, [0.1, 0.1, 0.1] * u.eV)
-
-
-@pytest.mark.skipif('not HAS_SCIPY')
 def test_distances():
     # Test distance calculations for various special case
     #  scenarios (no relativistic species, normal, massive neutrinos)

--- a/astropy/cosmology/tests/test_flrw.py
+++ b/astropy/cosmology/tests/test_flrw.py
@@ -88,10 +88,8 @@ class ParameterH0TestMixin(ParameterTestMixin):
         assert cosmo.H0 == self._cls_args["H0"]
         assert isinstance(cosmo.H0, u.Quantity) and cosmo.H0.unit == unit
 
-    def test_init_H0(self, cosmo_cls):
+    def test_init_H0(self, cosmo_cls, ba):
         """Test initialization for values of ``H0``."""
-        ba = self.ba
-
         # test that it works with units
         cosmo = cosmo_cls(*ba.args, **ba.kwargs)
         assert cosmo.H0 == ba.arguments["H0"]
@@ -132,10 +130,8 @@ class ParameterOm0TestMixin(ParameterTestMixin):
         assert cosmo.Om0 == self._cls_args["Om0"]
         assert isinstance(cosmo.Om0, float)
 
-    def test_init_Om0(self, cosmo_cls):
+    def test_init_Om0(self, cosmo_cls, ba):
         """Test initialization for values of ``Om0``."""
-        ba = self.ba
-
         # test that it works with units
         ba.arguments["Om0"] = ba.arguments["Om0"] << u.one  # ensure units
         cosmo = cosmo_cls(*ba.args, **ba.kwargs)
@@ -179,10 +175,8 @@ class ParameterOde0TestMixin(ParameterTestMixin):
         assert cosmo.Ode0 == self._cls_args["Ode0"]
         assert isinstance(cosmo.Ode0, float)
 
-    def test_init_Ode0(self, cosmo_cls):
+    def test_init_Ode0(self, cosmo_cls, ba):
         """Test initialization for values of ``Ode0``."""
-        ba = self.ba
-
         # test that it works with units
         ba.arguments["Ode0"] = ba.arguments["Ode0"] << u.one  # ensure units
         cosmo = cosmo_cls(*ba.args, **ba.kwargs)
@@ -231,10 +225,8 @@ class ParameterTcmb0TestMixin(ParameterTestMixin):
         assert cosmo.Tcmb0 == self.cls_kwargs["Tcmb0"]
         assert isinstance(cosmo.Tcmb0, u.Quantity) and cosmo.Tcmb0.unit == u.K
 
-    def test_init_Tcmb0(self, cosmo_cls):
+    def test_init_Tcmb0(self, cosmo_cls, ba):
         """Test initialization for values of ``Tcmb0``."""
-        ba = self.ba
-
         # test that it works with units
         cosmo = cosmo_cls(*ba.args, **ba.kwargs)
         assert cosmo.Tcmb0 == ba.arguments["Tcmb0"]
@@ -275,10 +267,8 @@ class ParameterNeffTestMixin(ParameterTestMixin):
         assert cosmo.Neff == self.cls_kwargs.get("Neff", 3.04)
         assert isinstance(cosmo.Neff, float)
 
-    def test_init_Neff(self, cosmo_cls):
+    def test_init_Neff(self, cosmo_cls, ba):
         """Test initialization for values of ``Neff``."""
-        ba = self.ba
-
         # test that it works with units
         ba.arguments["Neff"] = ba.arguments["Neff"] << u.one  # ensure units
         cosmo = cosmo_cls(*ba.args, **ba.kwargs)
@@ -326,41 +316,79 @@ class Parameterm_nuTestMixin(ParameterTestMixin):
             assert u.allclose(cosmo.m_nu[:self._nmasslessnu], 0 * u.eV)
             assert u.allclose(cosmo.m_nu[self._nmasslessnu], cosmo._massivenu_mass)
 
-    def test_init_m_nu(self, cosmo_cls):
-        """Test initialization for values of ``m_nu``."""
-        ba = self.ba
+    def test_init_m_nu(self, cosmo_cls, ba):
+        """Test initialization for values of ``m_nu``.
 
-        # test that it works with units
+        Note this requires the class to have a property ``has_massive_nu``.
+        """
+        # Test that it works when m_nu has units.
         cosmo = cosmo_cls(*ba.args, **ba.kwargs)
-        assert np.all(cosmo.m_nu == ba.arguments["m_nu"])
+        assert np.all(cosmo.m_nu == ba.arguments["m_nu"])  # (& checks len, unit)
+        assert not cosmo.has_massive_nu
+        assert cosmo.m_nu.unit == u.eV  # explicitly check unit once.
 
-        # also without units
+        # And it works when m_nu doesn't have units.
         ba.arguments["m_nu"] = ba.arguments["m_nu"].value  # strip units
         cosmo = cosmo_cls(*ba.args, **ba.kwargs)
         assert np.all(cosmo.m_nu.value == ba.arguments["m_nu"])
+        assert not cosmo.has_massive_nu
 
-        # negative m_nu fails
+        # A negative m_nu raises an exception.
         tba = copy.copy(ba)
         tba.arguments["m_nu"] = u.Quantity([-0.3, 0.2, 0.1], u.eV)
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="invalid"):
             cosmo_cls(*tba.args, **tba.kwargs)
 
-        # mismatch with Neff and Tcmb0
+    def test_init_m_nu_and_Neff(self, cosmo_cls, ba):
+        """Test initialization for values of ``m_nu`` and ``Neff``.
+
+        Note this test requires ``Neff`` as constructor input, and a property
+        ``has_massive_nu``.
+        """
+        # Mismatch with Neff = wrong number of neutrinos
         tba = copy.copy(ba)
-        tba.arguments["Tcmb0"] = 3
-        tba.arguments["Neff"] = 2
+        tba.arguments["Neff"] = 4.05
         tba.arguments["m_nu"] = u.Quantity([0.15, 0.2, 0.1], u.eV)
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="unexpected number of neutrino"):
             cosmo_cls(*tba.args, **tba.kwargs)
 
-        # wrong number of neutrinos
+        # No neutrinos, but Neff
+        tba.arguments["m_nu"] = 0
+        cosmo = cosmo_cls(*tba.args, **tba.kwargs)
+        assert not cosmo.has_massive_nu
+        assert len(cosmo.m_nu) == 4
+        assert cosmo.m_nu.unit == u.eV
+        assert u.allclose(cosmo.m_nu, 0 * u.eV)
+        # TODO! move this test when create ``test_nu_relative_density``
+        assert u.allclose(cosmo.nu_relative_density(1.0), 0.22710731766 * 4.05, rtol=1e-6)
+
+        # All massive neutrinos case, len from Neff
+        tba.arguments["m_nu"] = 0.1 * u.eV
+        cosmo = cosmo_cls(*tba.args, **tba.kwargs)
+        assert cosmo.has_massive_nu
+        assert len(cosmo.m_nu) == 4
+        assert cosmo.m_nu.unit == u.eV
+        assert u.allclose(cosmo.m_nu, [0.1, 0.1, 0.1, 0.1] * u.eV)
+
+    def test_init_m_nu_override_by_Tcmb0(self, cosmo_cls, ba):
+        """Test initialization for values of ``m_nu``.
+
+        Note this test requires ``Tcmb0`` as constructor input, and a property
+        ``has_massive_nu``.
+        """
+        # If Neff = 0, m_nu is None.
         tba = copy.copy(ba)
-        tba.arguments["Tcmb0"] = 3
-        tba.arguments["m_nu"] = u.Quantity([-0.3, 0.2], u.eV)  # 2, expecting 3
-        with pytest.raises(ValueError):
-            cosmo_cls(*tba.args, **tba.kwargs)
+        tba.arguments["Neff"] = 0
+        cosmo = cosmo_cls(*ba.args, **ba.kwargs)
+        assert cosmo.m_nu is None
+        assert not cosmo.has_massive_nu
 
-        # TODO! transfer tests for initializing neutrinos
+        # If Tcmb0 = 0, m_nu is None
+        tba = copy.copy(ba)
+        tba.arguments["Tcmb0"] = 0
+        cosmo = cosmo_cls(*ba.args, **ba.kwargs)
+        assert cosmo.m_nu is None
+        assert not cosmo.has_massive_nu
 
 
 class ParameterOb0TestMixin(ParameterTestMixin):
@@ -390,10 +418,8 @@ class ParameterOb0TestMixin(ParameterTestMixin):
         assert cosmo.Ob0 is cosmo._Ob0
         assert cosmo.Ob0 == 0.03
 
-    def test_init_Ob0(self, cosmo_cls):
+    def test_init_Ob0(self, cosmo_cls, ba):
         """Test initialization for values of ``Ob0``."""
-        ba = self.ba
-
         # test that it works with units
         assert isinstance(ba.arguments["Ob0"], u.Quantity)
         cosmo = cosmo_cls(*ba.args, **ba.kwargs)
@@ -478,12 +504,11 @@ class TestFLRW(CosmologyTest,
         # TODO! tests for initializing calculated values, e.g. `h`
         # TODO! transfer tests for initializing neutrinos
 
-    def test_init_Tcmb0_zeroing(self, cosmo_cls):
+    def test_init_Tcmb0_zeroing(self, cosmo_cls, ba):
         """Test if setting Tcmb0 parameter to 0 influences other parameters.
 
         TODO: consider moving this test to ``FLRWSubclassTest``
         """
-        ba = self.ba
         ba.arguments["Tcmb0"] = 0.0
         cosmo = cosmo_cls(*ba.args, **ba.kwargs)
 
@@ -817,10 +842,8 @@ class ParameterFlatOde0TestMixin(ParameterOde0TestMixin):
         assert cosmo.Ode0 is cosmo._Ode0
         assert cosmo.Ode0 == 1.0 - (cosmo.Om0 + cosmo.Ogamma0 + cosmo.Onu0)
 
-    def test_init_Ode0(self, cosmo_cls):
+    def test_init_Ode0(self, cosmo_cls, ba):
         """Test initialization for values of ``Ode0``."""
-        ba = self.ba
-
         cosmo = cosmo_cls(*ba.args, **ba.kwargs)
         assert cosmo.Ode0 == 1.0 - (cosmo.Om0 + cosmo.Ogamma0 + cosmo.Onu0 + cosmo.Ok0)
 
@@ -1040,10 +1063,8 @@ class Parameterw0TestMixin(ParameterTestMixin):
         assert cosmo.w0 is cosmo._w0
         assert cosmo.w0 == self.cls_kwargs["w0"]
 
-    def test_init_w0(self, cosmo_cls):
+    def test_init_w0(self, cosmo_cls, ba):
         """Test initialization for values of ``w0``."""
-        ba = self.ba
-
         # test that it works with units
         ba.arguments["w0"] = ba.arguments["w0"] << u.one  # ensure units
         cosmo = cosmo_cls(*ba.args, **ba.kwargs)
@@ -1149,10 +1170,8 @@ class ParameterwaTestMixin(ParameterTestMixin):
         assert cosmo.wa is cosmo._wa
         assert cosmo.wa == self.cls_kwargs["wa"]
 
-    def test_init_wa(self, cosmo_cls):
+    def test_init_wa(self, cosmo_cls, ba):
         """Test initialization for values of ``wa``."""
-        ba = self.ba
-
         # test that it works with units
         ba.arguments["wa"] = ba.arguments["wa"] << u.one  # ensure units
         cosmo = cosmo_cls(*ba.args, **ba.kwargs)
@@ -1259,10 +1278,8 @@ class ParameterwpTestMixin(ParameterTestMixin):
         assert cosmo.wp is cosmo._wp
         assert cosmo.wp == self.cls_kwargs["wp"]
 
-    def test_init_wp(self, cosmo_cls):
+    def test_init_wp(self, cosmo_cls, ba):
         """Test initialization for values of ``wp``."""
-        ba = self.ba
-
         # test that it works with units
         ba.arguments["wp"] = ba.arguments["wp"] << u.one  # ensure units
         cosmo = cosmo_cls(*ba.args, **ba.kwargs)
@@ -1298,10 +1315,8 @@ class ParameterzpTestMixin(ParameterTestMixin):
         assert cosmo.zp is cosmo._zp
         assert cosmo.zp == self.cls_kwargs["zp"] << cu.redshift
 
-    def test_init_zp(self, cosmo_cls):
+    def test_init_zp(self, cosmo_cls, ba):
         """Test initialization for values of ``zp``."""
-        ba = self.ba
-
         # test that it works with units
         ba.arguments["zp"] = ba.arguments["zp"] << u.one  # ensure units
         cosmo = cosmo_cls(*ba.args, **ba.kwargs)
@@ -1389,10 +1404,8 @@ class ParameterwzTestMixin(ParameterTestMixin):
         assert cosmo.wz is cosmo._wz
         assert cosmo.wz == self.cls_kwargs["wz"]
 
-    def test_init_wz(self, cosmo_cls):
+    def test_init_wz(self, cosmo_cls, ba):
         """Test initialization for values of ``wz``."""
-        ba = self.ba
-
         # test that it works with units
         ba.arguments["wz"] = ba.arguments["wz"] << u.one  # ensure units
         cosmo = cosmo_cls(*ba.args, **ba.kwargs)

--- a/astropy/cosmology/tests/test_flrw.py
+++ b/astropy/cosmology/tests/test_flrw.py
@@ -489,7 +489,7 @@ class TestFLRW(CosmologyTest,
         super().teardown_class(self)
         _COSMOLOGY_CLASSES.pop("SubFLRW", None)
 
-    @pytest.fixture
+    @pytest.fixture(scope="class")
     def nonflatcosmo(self):
         """A non-flat cosmology used in equivalence tests."""
         return LambdaCDM(70, 0.4, 0.8)

--- a/astropy/cosmology/tests/test_parameter.py
+++ b/astropy/cosmology/tests/test_parameter.py
@@ -273,17 +273,17 @@ class TestParameter(ParameterTestMixin):
         for cls in self.classes.values():
             _COSMOLOGY_CLASSES.pop(cls.__qualname__)
 
-    @pytest.fixture(params=["Example1", "Example2"])
+    @pytest.fixture(scope="class", params=["Example1", "Example2"])
     def cosmo_cls(self, request):
         """Cosmology class."""
         return self.classes[request.param]
 
-    @pytest.fixture
+    @pytest.fixture(scope="class")
     def cosmo(self, cosmo_cls):
         """Cosmology instance"""
         return cosmo_cls()
 
-    @pytest.fixture
+    @pytest.fixture(scope="class")
     def param(self, cosmo_cls):
         """Get Parameter 'param' from cosmology class."""
         return cosmo_cls.param

--- a/astropy/cosmology/tests/test_units.py
+++ b/astropy/cosmology/tests/test_units.py
@@ -201,7 +201,7 @@ def test_redshift_distance_wrong_kind():
 class Test_with_redshift:
     """Test `astropy.cosmology.units.with_redshift`."""
 
-    @pytest.fixture
+    @pytest.fixture(scope="class")
     def cosmo(self):
         """Test cosmology."""
         return Planck13.clone(Tcmb0=3 * u.K)


### PR DESCRIPTION
### Description

Simplify ``m_nu`` initialization, properly cache some test fixtures, and enhance some error messages.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
