### PR TITLE
Improve compound_bounding_box serialization

### DIFF
--- a/astropy/io/misc/asdf/tags/transform/basic.py
+++ b/astropy/io/misc/asdf/tags/transform/basic.py
@@ -92,16 +92,18 @@ class TransformType(AstropyAsdfType):
             node['bounding_box'] = bb
 
         elif isinstance(bb, CompoundBoundingBox):
+            cbbox = {}
             selector_args = [[sa.index, sa.ignore] for sa in bb.selector_args]
-            node['selector_args'] = selector_args
-            node['cbbox_keys'] = list(bb.bounding_boxes.keys())
+            cbbox['selector_args'] = selector_args
+            cbbox['cbbox_keys'] = list(bb.bounding_boxes.keys())
 
             bounding_boxes = list(bb.bounding_boxes.values())
             if len(model.inputs) - len(selector_args) == 1:
-                node['cbbox_values'] = [list(sbbox.bounding_box()) for sbbox in bounding_boxes]
+                cbbox['cbbox_values'] = [list(sbbox.bounding_box()) for sbbox in bounding_boxes]
             else:
-                node['cbbox_values'] = [[list(item) for item in sbbox.bounding_box()
+                cbbox['cbbox_values'] = [[list(item) for item in sbbox.bounding_box()
                                          if np.isfinite(item[0])] for sbbox in bounding_boxes]
+            node['compound_bounding_box'] = cbbox
 
         # model / parameter constraints
         if not isinstance(model, CompoundModel):

--- a/astropy/io/misc/asdf/tags/transform/basic.py
+++ b/astropy/io/misc/asdf/tags/transform/basic.py
@@ -69,12 +69,13 @@ class TransformType(AstropyAsdfType):
     @classmethod
     def _to_tree_base_transform_members(cls, model, node, ctx):
         def _transform_bbox(bbox):
-            bb = bbox.bounding_box(order='C')
-
-            if len(bbox) == 1:
-                return list(bb)
-            else:
-                return [list(interval) for interval in bb]
+            return {
+                'intervals': {
+                    _input: list(interval) for _input, interval in bbox.named_intervals.items()
+                },
+                'ignore': list(bbox.ignored_inputs),
+                'order': bbox.order
+            }
 
         if getattr(model, '_user_inverse', None) is not None:
             node['inverse'] = model._user_inverse
@@ -108,7 +109,7 @@ class TransformType(AstropyAsdfType):
                     'bbox': _transform_bbox(bbox)
                 } for key, bbox in bb.bounding_boxes.items()
             ]
-            node['compound_bounding_box'] = cbbox
+            node['bounding_box'] = cbbox
 
         # model / parameter constraints
         if not isinstance(model, CompoundModel):

--- a/astropy/io/misc/asdf/tags/transform/properties.py
+++ b/astropy/io/misc/asdf/tags/transform/properties.py
@@ -1,0 +1,58 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-
+import numpy as np
+
+from asdf.versioning import AsdfVersion
+
+from astropy.modeling.bounding_box import ModelBoundingBox, CompoundBoundingBox
+from astropy.modeling import mappings
+from astropy.modeling import functional_models
+from astropy.modeling.core import CompoundModel
+from astropy.io.misc.asdf.types import AstropyAsdfType
+from . import _parameter_to_value
+
+
+class BoundingBoxType(AstropyAsdfType):
+    name = 'transform/property/bounding_box'
+    version = '1.0.0'
+    types = ['astropy.modeling.bounding_box.ModelBoundingBox']
+
+    @classmethod
+    def from_tree_transform(cls, node, ctx):
+        pass
+
+    @classmethod
+    def to_tree_transform(cls, model, cts):
+        def _transform_bbox(bbox):
+            return {
+                'intervals': {
+                    _input: list(interval)
+                    for _input, interval in bbox.named_intervals.items()
+                },
+                'ignore': list(bbox.ignored_inputs),
+                'order': bbox.order
+            }
+
+        try:
+            bb = model.bounding_box
+        except NotImplementedError:
+            bb = None
+
+        if isinstance(bb, ModelBoundingBox):
+            return _transform_bbox(bb)
+
+        elif isinstance(bb, CompoundBoundingBox):
+            return {
+                'selector_args': [
+                    {
+                        'argument': sa.name(model),
+                        'ignore': sa.ignore
+                    } for sa in bb.selector_args
+                ],
+                'cbbox': [
+                    {
+                        'key': list(key),
+                        'bbox': _transform_bbox(bbox)
+                    } for key, bbox in bb.bounding_boxes.items()
+                ]
+            }

--- a/astropy/io/misc/asdf/tags/transform/tests/test_transform.py
+++ b/astropy/io/misc/asdf/tags/transform/tests/test_transform.py
@@ -394,18 +394,41 @@ def test_serialize_compound_bounding_box(tmpdir):
             (1,): ((-0.5, 3047.5), (-0.5, 4047.5)), }
     model.bounding_box = CompoundBoundingBox.validate(model, bbox, selector_args=[('slit_id', True)], order='F')
 
-    print(model.bounding_box)
-
     from astropy.io.misc.asdf.tags.transform.basic import TransformType
     node = TransformType._to_tree_base_transform_members(model, {}, None)
-    cbbox = node['compound_bounding_box']
-    assert cbbox['selector_args'] == [{'argument': 'slit_id', 'ignore': True}]
-    assert cbbox['cbbox'] == [
-        {'key': [0], bbox: None}
-    ]
-    print(node['compound_bounding_box']['cbbox'])
-
-    assert False
+    cbbox = node['bounding_box']
+    assert cbbox == {
+        'selector_args': [
+            {
+                'argument': 'slit_id',
+                'ignore': True
+            }
+        ],
+        'cbbox': [
+            {
+                'key': [0],
+                'bbox': {
+                    'intervals': {
+                        'x': [-0.5, 1047.5],
+                        'y': [-0.5, 2047.5]
+                    },
+                    'ignore': ['slit_id'],
+                    'order': 'F'
+                }
+            },
+            {
+                'key': [1],
+                'bbox': {
+                    'intervals': {
+                        'x': [-0.5, 3047.5],
+                        'y': [-0.5, 4047.5]
+                    },
+                    'ignore': ['slit_id'],
+                    'order': 'F'
+                }
+            },
+        ]
+    }
 
 
 # test some models and compound models with some input unit equivalencies


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

In working on asdf-format/asdf-transform-schemas#26, it has become clear that serialization of `CompoundBoundingBox` should be nested under one property rather than as a series of properties. This PR makes this change.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
