### PR TITLE
Add __array_func__ for astropy.time.Time

### DIFF
--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -31,8 +31,7 @@ from .formats import (TIME_FORMATS, TIME_DELTA_FORMATS,
 # Import TimeFromEpoch to avoid breaking code that followed the old example of
 # making a custom timescale in the documentation.
 from .formats import TimeFromEpoch  # noqa
-from .time_helper.function_helpers import (
-    CUSTOM_FUNCTIONS, UNSUPPORTED_FUNCTIONS)
+from .time_helper.function_helpers import CUSTOM_FUNCTIONS, UNSUPPORTED_FUNCTIONS
 
 from astropy.extern import _strptime
 

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -2317,3 +2317,18 @@ def test_location_init_fail():
     with pytest.raises(ValueError,
                        match='cannot concatenate times unless all locations'):
         Time([tm, tm2])
+
+
+def test_linspace():
+    t1 = Time('2020-01-01 00:00:00')
+    t2 = Time('2020-01-01 01:00:00')
+
+    ts = np.linspace(t1, t2, 3)
+    atol = 1 * u.ms
+    assert ts[0].isclose(Time('2020-01-01 00:00:00'), atol=atol)
+    assert ts[1].isclose(Time('2020-01-01 00:30:00'), atol=atol)
+    assert ts[2].isclose(Time('2020-01-01 01:00:00'), atol=atol)
+
+    ts = np.linspace(t1, t2, 2, endpoint=False)
+    assert ts[0].isclose(Time('2020-01-01 00:00:00'), atol=atol)
+    assert ts[1].isclose(Time('2020-01-01 00:30:00'), atol=atol)

--- a/astropy/time/time_helper/__init__.py
+++ b/astropy/time/time_helper/__init__.py
@@ -1,0 +1,4 @@
+"""
+Helper functions for Time.
+"""
+from . import function_helpers

--- a/astropy/time/time_helper/function_helpers.py
+++ b/astropy/time/time_helper/function_helpers.py
@@ -1,0 +1,26 @@
+"""
+Helpers for overriding numpy functions in
+`~astropy.time.Time.__array_function__`.
+"""
+import numpy as np
+
+from astropy.units.quantity_helper.function_helpers import FunctionAssigner
+
+# TODO: Fill this in with functions that don't make sense for times
+UNSUPPORTED_FUNCTIONS = {}
+# Functions that return the final result of the numpy function
+CUSTOM_FUNCTIONS = {}
+
+custom_functions = FunctionAssigner(CUSTOM_FUNCTIONS)
+
+
+@custom_functions(helps={np.linspace})
+def linspace(tstart, tstop, *args, **kwargs):
+    from astropy.time import Time
+    if isinstance(tstart, Time):
+        if not isinstance(tstop, Time):
+            return NotImplemented
+
+    offsets = np.linspace(np.zeros(tstart.shape), np.ones(tstop.shape),
+                          *args, **kwargs)
+    return tstart + (tstop - tstart) * offsets

--- a/docs/changes/time/12703.feature.rst
+++ b/docs/changes/time/12703.feature.rst
@@ -1,0 +1,2 @@
+Add support for calling ``numpy.linspace()`` with two ``Time`` instances to
+generate a linearly spaced set of times.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

xref https://github.com/astropy/astropy/issues/8610. This provides some numpy array functions for `Time` objects. Most notably, one can now do the following without an errror(!):
```python
from astropy.time import Time, TimeDelta
import numpy as np

t0 = Time('2021-01-01')
t1 = Time('2022-01-01')

times = np.linspace(t0, t1, num=50)
```

This still needs:
- [ ] Tests
- [ ] What's new
- [ ] API docs???

but opening now for feedback and a full CI run.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
