### PR TITLE
FEAT: New doppler_redshift equivalency

### DIFF
--- a/astropy/units/equivalencies.py
+++ b/astropy/units/equivalencies.py
@@ -21,7 +21,7 @@ from .core import UnitsError, Unit
 
 
 __all__ = ['parallax', 'spectral', 'spectral_density', 'doppler_radio',
-           'doppler_optical', 'doppler_relativistic', 'mass_energy',
+           'doppler_optical', 'doppler_relativistic', 'doppler_redshift', 'mass_energy',
            'brightness_temperature', 'thermodynamic_temperature',
            'beam_angular_area', 'dimensionless_angles', 'logarithmic',
            'temperature', 'temperature_energy', 'molar_mass_amu',
@@ -364,9 +364,9 @@ def doppler_radio(rest):
         return resten * (1-voverc)
 
     return Equivalency([(si.Hz, si.km/si.s, to_vel_freq, from_vel_freq),
-            (si.AA, si.km/si.s, to_vel_wav, from_vel_wav),
-            (si.eV, si.km/si.s, to_vel_en, from_vel_en),
-            ], "doppler_radio", {'rest': rest})
+                        (si.AA, si.km/si.s, to_vel_wav, from_vel_wav),
+                        (si.eV, si.km/si.s, to_vel_en, from_vel_en),
+                        ], "doppler_radio", {'rest': rest})
 
 
 def doppler_optical(rest):
@@ -430,9 +430,9 @@ def doppler_optical(rest):
         return resten / (1+voverc)
 
     return Equivalency([(si.Hz, si.km/si.s, to_vel_freq, from_vel_freq),
-            (si.AA, si.km/si.s, to_vel_wav, from_vel_wav),
-            (si.eV, si.km/si.s, to_vel_en, from_vel_en),
-            ], "doppler_optical", {'rest': rest})
+                        (si.AA, si.km/si.s, to_vel_wav, from_vel_wav),
+                        (si.eV, si.km/si.s, to_vel_en, from_vel_en),
+                        ], "doppler_optical", {'rest': rest})
 
 
 def doppler_relativistic(rest):
@@ -469,7 +469,7 @@ def doppler_relativistic(rest):
     >>> relativistic_wavelength = measured_velocity.to(u.mm, equivalencies=relativistic_CO_equiv)
     >>> relativistic_wavelength  # doctest: +FLOAT_CMP
     <Quantity 2.6116243681798923 mm>
-    """
+    """  # noqa: E501
 
     assert_is_spectral_unit(rest)
 
@@ -503,9 +503,34 @@ def doppler_relativistic(rest):
         return resten * ((1-voverc) / (1+(voverc)))**0.5
 
     return Equivalency([(si.Hz, si.km/si.s, to_vel_freq, from_vel_freq),
-            (si.AA, si.km/si.s, to_vel_wav, from_vel_wav),
-            (si.eV, si.km/si.s, to_vel_en, from_vel_en),
-            ], "doppler_relativistic", {'rest': rest})
+                        (si.AA, si.km/si.s, to_vel_wav, from_vel_wav),
+                        (si.eV, si.km/si.s, to_vel_en, from_vel_en),
+                        ], "doppler_relativistic", {'rest': rest})
+
+
+def doppler_redshift():
+    """
+    Returns the equivalence between Doppler redshift (unitless) and radial velocity.
+
+    .. note::
+
+        This equivalency is not compatible with cosmological
+        redshift, `astropy.cosmology.units.redshift`.
+
+    """
+    rv_unit = si.km / si.s
+    C_KMS = _si.c.to_value(rv_unit)
+
+    def convert_z_to_rv(z):
+        zponesq = (1 + z) ** 2
+        return C_KMS * (zponesq - 1) / (zponesq + 1)
+
+    def convert_rv_to_z(rv):
+        beta = rv / C_KMS
+        return np.sqrt((1 + beta) / (1 - beta)) - 1
+
+    return Equivalency([(dimensionless_unscaled, rv_unit, convert_z_to_rv, convert_rv_to_z)],
+                       "doppler_redshift")
 
 
 def molar_mass_amu():
@@ -524,16 +549,16 @@ def mass_energy():
     """
 
     return Equivalency([(si.kg, si.J, lambda x: x * _si.c.value ** 2,
-             lambda x: x / _si.c.value ** 2),
-            (si.kg / si.m ** 2, si.J / si.m ** 2,
-             lambda x: x * _si.c.value ** 2,
-             lambda x: x / _si.c.value ** 2),
-            (si.kg / si.m ** 3, si.J / si.m ** 3,
-             lambda x: x * _si.c.value ** 2,
-             lambda x: x / _si.c.value ** 2),
-            (si.kg / si.s, si.J / si.s, lambda x: x * _si.c.value ** 2,
-             lambda x: x / _si.c.value ** 2),
-    ], "mass_energy")
+                         lambda x: x / _si.c.value ** 2),
+                        (si.kg / si.m ** 2, si.J / si.m ** 2,
+                         lambda x: x * _si.c.value ** 2,
+                         lambda x: x / _si.c.value ** 2),
+                        (si.kg / si.m ** 3, si.J / si.m ** 3,
+                         lambda x: x * _si.c.value ** 2,
+                         lambda x: x / _si.c.value ** 2),
+                        (si.kg / si.s, si.J / si.s, lambda x: x * _si.c.value ** 2,
+                         lambda x: x / _si.c.value ** 2),
+                        ], "mass_energy")
 
 
 def brightness_temperature(frequency, beam_area=None):
@@ -592,7 +617,7 @@ def brightness_temperature(frequency, beam_area=None):
         >>> surf_brightness = 1e6*u.MJy/u.sr
         >>> surf_brightness.to(u.K, equivalencies=u.brightness_temperature(500*u.GHz)) # doctest: +FLOAT_CMP
         <Quantity 130.1931904778803 K>
-    """
+    """  # noqa: E501
     if frequency.unit.is_equivalent(si.sr):
         if not beam_area.unit.is_equivalent(si.Hz):
             raise ValueError("The inputs to `brightness_temperature` are "
@@ -617,8 +642,8 @@ def brightness_temperature(frequency, beam_area=None):
             return (x_K * beam / factor)
 
         return Equivalency([(astrophys.Jy, si.K, convert_Jy_to_K, convert_K_to_Jy),
-                            (astrophys.Jy/astrophys.beam, si.K, convert_Jy_to_K, convert_K_to_Jy),],
-                           "brightness_temperature", {'frequency': frequency, 'beam_area': beam_area})
+                            (astrophys.Jy/astrophys.beam, si.K, convert_Jy_to_K, convert_K_to_Jy)],
+                           "brightness_temperature", {'frequency': frequency, 'beam_area': beam_area})  # noqa: E501
     else:
         def convert_JySr_to_K(x_jysr):
             factor = (2 * _si.k_B * si.K * nu**2 / _si.c**2).to(astrophys.Jy).value
@@ -626,10 +651,10 @@ def brightness_temperature(frequency, beam_area=None):
 
         def convert_K_to_JySr(x_K):
             factor = (astrophys.Jy / (2 * _si.k_B * nu**2 / _si.c**2)).to(si.K).value
-            return (x_K / factor) # multiplied by 1x for 1 steradian
+            return (x_K / factor)  # multiplied by 1x for 1 steradian
 
         return Equivalency([(astrophys.Jy/si.sr, si.K, convert_JySr_to_K, convert_K_to_JySr)],
-                           "brightness_temperature", {'frequency': frequency, 'beam_area': beam_area})
+                           "brightness_temperature", {'frequency': frequency, 'beam_area': beam_area})  # noqa: E501
 
 
 def beam_angular_area(beam_area):
@@ -647,7 +672,7 @@ def beam_angular_area(beam_area):
     """
     return Equivalency([(astrophys.beam, Unit(beam_area)),
                         (astrophys.beam**-1, Unit(beam_area)**-1),
-                        (astrophys.Jy/astrophys.beam, astrophys.Jy/Unit(beam_area)),],
+                        (astrophys.Jy/astrophys.beam, astrophys.Jy/Unit(beam_area))],
                        "beam_angular_area", {'beam_area': beam_area})
 
 
@@ -790,7 +815,8 @@ def plate_scale(platescale):
         raise UnitsError("The pixel scale must be in angle/distance or "
                          "distance/angle")
 
-    return Equivalency([(si.m, si.radian, lambda d: d*platescale_val, lambda rad: rad/platescale_val)],
+    return Equivalency([(si.m, si.radian, lambda d: d*platescale_val,
+                         lambda rad: rad/platescale_val)],
                        "plate_scale", {'platescale': platescale})
 
 

--- a/astropy/units/equivalencies.py
+++ b/astropy/units/equivalencies.py
@@ -515,7 +515,7 @@ def doppler_redshift():
     .. note::
 
         This equivalency is not compatible with cosmological
-        redshift, `astropy.cosmology.units.redshift`.
+        redshift in `astropy.cosmology.units`.
 
     """
     rv_unit = si.km / si.s

--- a/astropy/units/tests/test_equivalencies.py
+++ b/astropy/units/tests/test_equivalencies.py
@@ -144,6 +144,24 @@ def test_bad_restfreqs(function, value):
         function(value)
 
 
+@pytest.mark.parametrize(('z', 'rv_ans'),
+                         [(0, 0 * (u.km / u.s)),
+                          (0.001, 299642.56184583 * (u.m / u.s)),
+                          (-1, -2.99792458e8 * (u.m / u.s))])
+def test_doppler_redshift(z, rv_ans):
+    z_in = z * u.dimensionless_unscaled
+    rv_out = z_in.to(u.km / u.s, u.doppler_redshift())
+    z_out = rv_out.to(u.dimensionless_unscaled, u.doppler_redshift())
+    assert_quantity_allclose(rv_out, rv_ans)
+    assert_quantity_allclose(z_out, z_in)  # Check roundtrip
+
+
+def test_doppler_redshift_no_cosmology():
+    from astropy.cosmology.units import redshift
+    with pytest.raises(u.UnitConversionError, match='not convertible'):
+        (0 * (u.km / u.s)).to(redshift, u.doppler_redshift())
+
+
 def test_massenergy():
     # The relative tolerance of these tests is set by the uncertainties
     # in the charge of the electron, which is known to about

--- a/docs/changes/units/12709.feature.rst
+++ b/docs/changes/units/12709.feature.rst
@@ -1,0 +1,2 @@
+New ``doppler_redshift`` equivalency to convert between
+Doppler redshift and radial velocity.

--- a/docs/units/equivalencies.rst
+++ b/docs/units/equivalencies.rst
@@ -519,7 +519,7 @@ To convert Doppler redshift (unitless) to ``km/s``::
     >>> z.to(u.km / u.s, u.doppler_redshift())  # doctest: +FLOAT_CMP
     <Quantity 28487.0661448 km / s>
 
-However, it cannot take the `~astropy.cosmology.units.redshift` unit
+However, it cannot take the cosmological redshift unit from `astropy.cosmology.units`
 because the latter should not be interpreted the same since the recessional
 velocity from the expansion of space can exceed the speed of light; see
 `Hubble's law: Redshift velocity and recessional velocity <https://en.wikipedia.org/wiki/Hubble%27s_law#Redshift_velocity_and_recessional_velocity>`_

--- a/docs/units/equivalencies.rst
+++ b/docs/units/equivalencies.rst
@@ -502,6 +502,31 @@ In a special relativity context it can be convenient to use the
 
 .. EXAMPLE END
 
+Doppler Redshift Equivalency
+----------------------------
+
+Conversion between Doppler redshift and radial velocity can be done with the
+:func:`~astropy.units.equivalencies.doppler_redshift` equivalency.
+
+Example
+^^^^^^^
+
+.. EXAMPLE START: Converting Doppler redshift to radial velocity
+
+To convert Doppler redshift (unitless) to ``km/s``::
+
+    >>> z = 0.1 * u.dimensionless_unscaled
+    >>> z.to(u.km / u.s, u.doppler_redshift())  # doctest: +FLOAT_CMP
+    <Quantity 28487.0661448 km / s>
+
+However, it cannot take the `~astropy.cosmology.units.redshift` unit
+because the latter should not be interpreted the same since the recessional
+velocity from the expansion of space can exceed the speed of light; see
+`Hubble's law: Redshift velocity and recessional velocity <https://en.wikipedia.org/wiki/Hubble%27s_law#Redshift_velocity_and_recessional_velocity>`_
+for more information.
+
+.. EXAMPLE END
+
 Writing New Equivalencies
 =========================
 

--- a/docs/whatsnew/5.1.rst
+++ b/docs/whatsnew/5.1.rst
@@ -7,6 +7,14 @@ What's New in Astropy 5.1?
 Overview
 ========
 
+Astropy 5.1 is a major release that adds significant new functionality since
+the 5.0 LTS release.
+
+In particular, this release includes:
+
+* :ref:`whatsnew-5.0-cosmology`
+* :ref:`whatsnew-doppler-redshift-eq`
+
 .. _whatsnew-5.0-cosmology:
 
 Updates to ``Cosmology``
@@ -17,6 +25,13 @@ and subclasses must override the abstract property ``is_flat``.
 For :class:`~astropy.cosmology.FLRW`, ``is_flat`` checks that ``Ok0=0`` and
 ``Omtot0=1``.
 
+.. _whatsnew-doppler-redshift-eq:
+
+``doppler_redshift`` equivalency
+================================
+
+New :func:`astropy.units.equivalencies.doppler_redshift` is added to
+provide conversion between Doppler redshift and radial velocity.
 
 Full change log
 ===============


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to formally expose the equivalency for conversion between Doppler redshift and radial velocity.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

* Follow up of https://github.com/astropy/astropy/pull/10185/files#r416867984
* Fixes #10240
* Could be used by spacetelescope/jdaviz#1031 (cc @kecnry)

- [x] Drop commit from #12711 once point is proven (whether RTD builds or not).

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
