### PR TITLE
BUG: Skip good_enough when auto_max_age is None

### DIFF
--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -984,7 +984,7 @@ class LeapSeconds(QTable):
         after the present.
         """
         offset = 180 - (30 if conf.auto_max_age is None else conf.auto_max_age)
-        good_enough = cls._today() + TimeDelta(180 - offset, format='jd')
+        good_enough = cls._today() + TimeDelta(offset, format='jd')
 
         if files is None:
             # Basic files to go over (entries in _auto_open_files can be

--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -983,8 +983,8 @@ class LeapSeconds(QTable):
         that expires more than 180 - `~astropy.utils.iers.Conf.auto_max_age`
         after the present.
         """
-        good_enough = cls._today() + TimeDelta(180-_none_to_float(conf.auto_max_age),
-                                               format='jd')
+        offset = 180 - (30 if conf.auto_max_age is None else conf.auto_max_age)
+        good_enough = cls._today() + TimeDelta(180 - offset, format='jd')
 
         if files is None:
             # Basic files to go over (entries in _auto_open_files can be
@@ -1028,7 +1028,7 @@ class LeapSeconds(QTable):
             raise ValueError('none of the files could be read. The '
                              'following errors were raised:\n' + str(err_list))
 
-        if self.expires < self._today():
+        if self.expires < self._today() and conf.auto_max_age is not None:
             warn('leap-second file is expired.', IERSStaleWarning)
 
         return self

--- a/astropy/utils/iers/tests/test_leap_second.py
+++ b/astropy/utils/iers/tests/test_leap_second.py
@@ -139,18 +139,20 @@ def test_fake_file(tmpdir):
     assert fake.expires == Time('2345-06-28', scale='tai')
 
 
-# For this set of tests, leap-seconds are allowed to be expired
-# except as explicitly tested.
-@pytest.mark.filterwarnings(iers.IERSStaleWarning)
 class TestAutoOpenExplicitLists:
+    # For this set of tests, leap-seconds are allowed to be expired
+    # except as explicitly tested.
+    @pytest.mark.filterwarnings(iers.IERSStaleWarning)
     def test_auto_open_simple(self):
         ls = iers.LeapSeconds.auto_open([iers.IERS_LEAP_SECOND_FILE])
         assert ls.meta['data_url'] == iers.IERS_LEAP_SECOND_FILE
 
+    @pytest.mark.filterwarnings(iers.IERSStaleWarning)
     def test_auto_open_erfa(self):
         ls = iers.LeapSeconds.auto_open(['erfa', iers.IERS_LEAP_SECOND_FILE])
         assert ls.meta['data_url'] in ['erfa', iers.IERS_LEAP_SECOND_FILE]
 
+    @pytest.mark.filterwarnings(iers.IERSStaleWarning)
     def test_fake_future_file(self, tmpdir):
         fake_file = make_fake_file('28 June 2345', tmpdir)
         # Try as system file for auto_open, setting auto_max_age such
@@ -184,6 +186,7 @@ class TestAutoOpenExplicitLists:
         assert ls2.expires == Time('2012-06-27', scale='tai')
 
         # Use the fake files to make sure auto_max_age is safe.
+        # Should have no warning here.
         with iers.conf.set_temp('auto_max_age', None):
             ls3 = iers.LeapSeconds.auto_open([fake_file1,
                                               iers.IERS_LEAP_SECOND_FILE])

--- a/astropy/utils/iers/tests/test_leap_second.py
+++ b/astropy/utils/iers/tests/test_leap_second.py
@@ -186,11 +186,14 @@ class TestAutoOpenExplicitLists:
         assert ls2.expires == Time('2012-06-27', scale='tai')
 
         # Use the fake files to make sure auto_max_age is safe.
-        # Should have no warning here.
+        # Should have no warning in either example.
         with iers.conf.set_temp('auto_max_age', None):
             ls3 = iers.LeapSeconds.auto_open([fake_file1,
                                               iers.IERS_LEAP_SECOND_FILE])
-        assert ls3.meta['data_url'] == fake_file1
+        assert ls3.meta['data_url'] == iers.IERS_LEAP_SECOND_FILE
+        with iers.conf.set_temp('auto_max_age', None):
+            ls4 = iers.LeapSeconds.auto_open([fake_file1, fake_file2])
+        assert ls4.meta['data_url'] == fake_file2
 
 
 @pytest.mark.remote_data

--- a/docs/changes/utils/12713.bugfix.rst
+++ b/docs/changes/utils/12713.bugfix.rst
@@ -1,0 +1,2 @@
+``astropy.utils.iers.LeapSeconds.auto_open()`` no longer emits unnecessary
+warnings when ``astropy.utils.iers.conf.auto_max_age`` is set to ``None``.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to lessen unnecessary warnings when `iers.conf.auto_max_age` is `None`.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #12708

### TODO

- [x] See if others think this is the correct solution.
- [x] Add test(s).
- [x] Add change log.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
