### PR TITLE
Make OrderedDict into a dict in astropy.io.misc

### DIFF
--- a/astropy/io/misc/asdf/tags/time/tests/test_time.py
+++ b/astropy/io/misc/asdf/tags/time/tests/test_time.py
@@ -6,7 +6,6 @@ import pytest
 asdf = pytest.importorskip('asdf')
 
 import datetime
-from collections import OrderedDict
 
 import numpy as np
 
@@ -18,7 +17,7 @@ import asdf.schema as asdf_schema
 
 
 def _flatten_combiners(schema):
-    newschema = OrderedDict()
+    newschema = dict()
 
     def add_entry(path, schema, combiner):
         # TODO: Simplify?
@@ -31,13 +30,13 @@ def _flatten_combiners(schema):
                     cursor.append({})
                 cursor = cursor[part]
             elif part == 'items':
-                cursor = cursor.setdefault('items', OrderedDict())
+                cursor = cursor.setdefault('items', dict())
             else:
-                cursor = cursor.setdefault('properties', OrderedDict())
+                cursor = cursor.setdefault('properties', dict())
                 if i < len(path) - 1 and isinstance(path[i+1], int):
                     cursor = cursor.setdefault(part, [])
                 else:
-                    cursor = cursor.setdefault(part, OrderedDict())
+                    cursor = cursor.setdefault(part, dict())
 
         cursor.update(schema)
 


### PR DESCRIPTION
This is a very minor change, as per #10888. I hope it will work out of the box. Since Python 3.7, dictionaries are supposed to be ordered, so there shouldn't be a need for OrderedDict anymore.

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
