### PR TITLE
Backport PR #12714 on branch v5.0.x (TST: Add regression test for Issue 12706)

### DIFF
--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -20,7 +20,7 @@ except ImportError:
 from astropy.io import fits
 from astropy.table import Table
 from astropy.units import UnitsWarning
-from astropy.utils.compat import NUMPY_LT_1_22
+from astropy.utils.compat import NUMPY_LT_1_22, NUMPY_LT_1_22_1
 from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyUserWarning
 
 from astropy.io.fits.column import ColumnAttribute, Delayed, NUMPY2FITS
@@ -2914,8 +2914,7 @@ class TestVLATables(FitsTestCase):
         for code in ('PJ()', 'QJ()'):
             test(code)
 
-    # TODO: Unpin when Numpy bug is resolved.
-    @pytest.mark.skipif(not NUMPY_LT_1_22 and sys.platform == 'win32',
+    @pytest.mark.skipif(not NUMPY_LT_1_22 and NUMPY_LT_1_22_1 and sys.platform == 'win32',
                         reason='https://github.com/numpy/numpy/issues/20699')
     def test_copy_vla(self):
         """

--- a/astropy/table/tests/test_groups.py
+++ b/astropy/table/tests/test_groups.py
@@ -4,6 +4,7 @@ import pytest
 import numpy as np
 
 from astropy.table import Table, Column, QTable, table_helpers, NdarrayMixin, unique
+from astropy.utils.compat import NUMPY_LT_1_22, NUMPY_LT_1_22_1
 from astropy.utils.exceptions import AstropyUserWarning
 from astropy import time
 from astropy import units as u
@@ -510,6 +511,20 @@ def test_column_aggregate(T1):
                                  ' 0.0',
                                  ' 6.0',
                                  '22.0']
+
+
+@pytest.mark.skipif(not NUMPY_LT_1_22 and NUMPY_LT_1_22_1,
+                    reason='https://github.com/numpy/numpy/issues/20699')
+def test_column_aggregate_f8():
+    """https://github.com/astropy/astropy/issues/12706"""
+    # Just want to make sure it does not crash again.
+    for masked in (False, True):
+        tg = Table({'a': np.arange(2, dtype='>f8')}, masked=masked).group_by('a')
+        tga = tg['a'].groups.aggregate(np.sum)
+        assert tga.pformat() == [' a ',
+                                 '---',
+                                 '0.0',
+                                 '1.0']
 
 
 def test_table_filter():

--- a/astropy/utils/compat/numpycompat.py
+++ b/astropy/utils/compat/numpycompat.py
@@ -5,7 +5,8 @@ earlier versions of Numpy.
 """
 from astropy.utils import minversion
 
-__all__ = ['NUMPY_LT_1_19', 'NUMPY_LT_1_20', 'NUMPY_LT_1_21_1', 'NUMPY_LT_1_22', 'NUMPY_LT_1_23']
+__all__ = ['NUMPY_LT_1_19', 'NUMPY_LT_1_20', 'NUMPY_LT_1_21_1',
+           'NUMPY_LT_1_22', 'NUMPY_LT_1_22_1', 'NUMPY_LT_1_23']
 
 # TODO: It might also be nice to have aliases to these named for specific
 # features/bugs we're checking for (ex:
@@ -14,4 +15,5 @@ NUMPY_LT_1_19 = not minversion('numpy', '1.19')
 NUMPY_LT_1_20 = not minversion('numpy', '1.20')
 NUMPY_LT_1_21_1 = not minversion('numpy', '1.21.1')
 NUMPY_LT_1_22 = not minversion('numpy', '1.22')
+NUMPY_LT_1_22_1 = not minversion('numpy', '1.22.1')
 NUMPY_LT_1_23 = not minversion('numpy', '1.23dev0')


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is a manual backport of #12714 . We should backport this because this will guard LTS against regression from future numpy releases during its lifetime.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Also see #12706 .

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
