### PR TITLE
Improve creating registry keys from observatory names listed in JSON

### DIFF
--- a/astropy/coordinates/sites.py
+++ b/astropy/coordinates/sites.py
@@ -105,8 +105,11 @@ class SiteRegistry(Mapping):
             location = EarthLocation.from_geodetic(site_info.pop('longitude') * u.Unit(site_info.pop('longitude_unit')),
                                                    site_info.pop('latitude') * u.Unit(site_info.pop('latitude_unit')),
                                                    site_info.pop('elevation') * u.Unit(site_info.pop('elevation_unit')))
-            location.info.name = site_info.pop('name')
-            aliases = site_info.pop('aliases')
+            name = site_info.pop('name')
+            location.info.name = name
+            aliases = [alias for alias in site_info.pop('aliases') if alias]
+            if name not in aliases and name != site:
+                aliases.append(name)
             location.info.meta = site_info  # whatever is left
 
             reg.add_site([site] + aliases, location)

--- a/astropy/coordinates/tests/test_sites.py
+++ b/astropy/coordinates/tests/test_sites.py
@@ -44,6 +44,11 @@ def test_online_sites():
     assert 'keck' in names
     assert 'ctio' in names
 
+    # The JSON file contains `name` and `aliases` for each site, and astropy
+    # should use names from both, but not empty strings [#12721].
+    assert '' not in names
+    assert 'Royal Observatory Greenwich' in names
+
     with pytest.raises(KeyError) as exc:
         reg['nonexistent site']
     assert exc.value.args[0] == "Site 'nonexistent site' not in database. Use the 'names' attribute to see available sites."

--- a/docs/changes/coordinates/12721.bugfix.rst
+++ b/docs/changes/coordinates/12721.bugfix.rst
@@ -1,0 +1,4 @@
+The machinery that makes observatory locations available as ``EarthLocation``
+objects is now smarter about processing observatory names from its data files.
+More names are available for use and the empty string is no longer considered
+to be a valid name.

--- a/docs/coordinates/index.rst
+++ b/docs/coordinates/index.rst
@@ -340,7 +340,10 @@ a quick way to get an `~astropy.coordinates.EarthLocation` - the
     <EarthLocation (-1463969.30185172, -5166673.34223433, 3434985.71204565) m>
 
 To see the list of site names available, use
-:func:`astropy.coordinates.EarthLocation.get_site_names`.
+:func:`~astropy.coordinates.EarthLocation.get_site_names`::
+
+    >>> EarthLocation.get_site_names()  # doctest: +REMOTE_DATA
+    ['ALMA', 'ATST', 'Anglo-Australian Observatory', ...]
 
 For arbitrary Earth addresses (e.g., not observatory sites), use the
 `~astropy.coordinates.EarthLocation.of_address` classmethod. Any address passed

--- a/docs/coordinates/index.rst
+++ b/docs/coordinates/index.rst
@@ -1,13 +1,12 @@
-.. We call EarthLocation.of_site here first to force the downloading
-.. of sites.json so that future doctest output isn't cluttered with
-.. "Downloading ... [done]". This can be removed once we have a better
-.. way of ignoring output lines based on pattern-matching, e.g.:
+.. Force downloading of sites.json so that future doctest output isn't
+.. cluttered with "Downloading ... [done]". This can be removed once we have a
+.. better way of ignoring output lines based on pattern-matching, e.g.:
 .. https://github.com/astropy/pytest-doctestplus/issues/11
 
 .. testsetup::
 
     >>> from astropy.coordinates import EarthLocation
-    >>> EarthLocation.of_site('greenwich') # doctest: +IGNORE_OUTPUT +IGNORE_WARNINGS
+    >>> EarthLocation._get_site_registry(force_download=True)  #doctest: +REMOTE_DATA +IGNORE_OUTPUT
 
 .. _astropy-coordinates:
 


### PR DESCRIPTION
### Description

The file https://github.com/astropy/astropy-data/blob/84deb2cda3a62a852950fc766b9b16fd11296de3/coordinates/sites.json used by the machinery in `astropy/coordinates/sites.py` contains `name` and `aliases` entries for each site, but `astropy` currently does not use the `name` entry as a registry key but only as metadata. Many entries in the JSON file therefore duplicate the preferred name of the observatory both in `name` and `aliases`, and the ones that do not cannot be accessed by the preferred name through `astropy.coordinates.EarthLocation.of_site()`. However, `astropy` does treat the empty string as a valid alias for the observatory name.

This pull request improves creating registry keys from observatory names, and it also makes it possible to remove duplicated `aliases` entries in the future.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
