### PR TITLE
Cosmo test ensure io tests run

### DIFF
--- a/astropy/cosmology/io/tests/base.py
+++ b/astropy/cosmology/io/tests/base.py
@@ -47,6 +47,11 @@ class ToFromTestMixinBase(IOTestBase):
         """Convert Cosmology instance using ``.to_format()``."""
         return cosmo.to_format
 
+    def can_autodentify(self, format):
+        """Check whether a format can auto-identify."""
+        identifiers = {k for k, _ in Cosmology.from_format.registry._identifiers.keys()}
+        return format in identifiers
+
 
 class ReadWriteTestMixinBase(IOTestBase):
     """Tests for a Cosmology[Read/Write].

--- a/astropy/cosmology/io/tests/test_ecsv.py
+++ b/astropy/cosmology/io/tests/test_ecsv.py
@@ -5,17 +5,11 @@ import pytest
 
 # LOCAL
 import astropy.units as u
-from astropy import cosmology
-from astropy.cosmology import Cosmology, realizations
 from astropy.cosmology.core import _COSMOLOGY_CLASSES
 from astropy.cosmology.io.ecsv import read_ecsv, write_ecsv
-from astropy.cosmology.parameters import available
 from astropy.table import QTable, Table, vstack
 
 from .base import ReadWriteDirectTestBase, ReadWriteTestMixinBase
-
-cosmo_instances = [getattr(realizations, name) for name in available]
-cosmo_instances.append("TestReadWriteECSV.setup.<locals>.CosmologyWithKwargs")
 
 ###############################################################################
 
@@ -199,7 +193,7 @@ class ReadWriteECSVTestMixin(ReadWriteTestMixinBase):
 
 class TestReadWriteECSV(ReadWriteDirectTestBase, ReadWriteECSVTestMixin):
     """
-    Directly test ``read/write``.
+    Directly test ``read/write_ecsv``.
     These are not public API and are discouraged from use, in favor of
     ``Cosmology.read/write(..., format="ascii.ecsv")``, but should be
     tested regardless b/c they are used internally.

--- a/astropy/cosmology/io/tests/test_mapping.py
+++ b/astropy/cosmology/io/tests/test_mapping.py
@@ -10,18 +10,12 @@ import numpy as np
 import pytest
 
 # LOCAL
-import astropy.units as u
-from astropy.cosmology import Cosmology, realizations
-from astropy.cosmology.core import _COSMOLOGY_CLASSES, Parameter
+from astropy.cosmology import Cosmology
+from astropy.cosmology.core import _COSMOLOGY_CLASSES
 from astropy.cosmology.io.mapping import from_mapping, to_mapping
-from astropy.cosmology.parameters import available
 from astropy.table import QTable, vstack
 
 from .base import ToFromDirectTestBase, ToFromTestMixinBase
-
-cosmo_instances = [getattr(realizations, name) for name in available]
-cosmo_instances.append("TestToFromMapping.setup.<locals>.CosmologyWithKwargs")
-
 
 ###############################################################################
 

--- a/astropy/cosmology/io/tests/test_model.py
+++ b/astropy/cosmology/io/tests/test_model.py
@@ -10,22 +10,14 @@ import pytest
 import numpy as np
 
 # LOCAL
-import astropy.units as u
-from astropy import cosmology
-from astropy.cosmology import Cosmology, Planck18, realizations
-from astropy.cosmology.core import _COSMOLOGY_CLASSES, Parameter
+from astropy.cosmology.core import _COSMOLOGY_CLASSES
 from astropy.cosmology.io.model import _CosmologyModel, from_model, to_model
-from astropy.cosmology.parameters import available
 from astropy.cosmology.tests.conftest import get_redshift_methods
 from astropy.modeling import FittableModel
 from astropy.modeling.models import Gaussian1D
 from astropy.utils.compat.optional_deps import HAS_SCIPY
 
 from .base import ToFromDirectTestBase, ToFromTestMixinBase
-
-cosmo_instances = [getattr(realizations, name) for name in available]
-cosmo_instances.append("TestToFromTable.setup.<locals>.CosmologyWithKwargs")
-
 
 ###############################################################################
 

--- a/astropy/cosmology/io/tests/test_row.py
+++ b/astropy/cosmology/io/tests/test_row.py
@@ -4,18 +4,11 @@
 import pytest
 
 # LOCAL
-import astropy.units as u
-from astropy import cosmology
-from astropy.cosmology import Cosmology, Planck18, realizations
-from astropy.cosmology.core import _COSMOLOGY_CLASSES, Parameter
+from astropy.cosmology.core import _COSMOLOGY_CLASSES
 from astropy.cosmology.io.row import from_row, to_row
-from astropy.cosmology.parameters import available
 from astropy.table import Row
 
 from .base import ToFromDirectTestBase, ToFromTestMixinBase
-
-cosmo_instances = [getattr(realizations, name) for name in available]
-cosmo_instances.append("TestToFromRow.setup.<locals>.CosmologyWithKwargs")
 
 ###############################################################################
 

--- a/astropy/cosmology/io/tests/test_table.py
+++ b/astropy/cosmology/io/tests/test_table.py
@@ -4,18 +4,13 @@
 import pytest
 
 # LOCAL
-import astropy.units as u
-from astropy import cosmology
-from astropy.cosmology import Cosmology, Planck18, realizations
-from astropy.cosmology.core import _COSMOLOGY_CLASSES, Parameter
+from astropy.cosmology import Cosmology, Planck18
+from astropy.cosmology.core import _COSMOLOGY_CLASSES
 from astropy.cosmology.io.table import from_table, to_table
-from astropy.cosmology.parameters import available
 from astropy.table import QTable, Table, vstack
 
 from .base import ToFromDirectTestBase, ToFromTestMixinBase
 
-cosmo_instances = [getattr(realizations, name) for name in available]
-cosmo_instances.append("TestToFromTable.setup.<locals>.CosmologyWithKwargs")
 
 ###############################################################################
 

--- a/astropy/cosmology/io/tests/test_yaml.py
+++ b/astropy/cosmology/io/tests/test_yaml.py
@@ -11,18 +11,13 @@ import pytest
 # LOCAL
 import astropy.cosmology.units as cu
 import astropy.units as u
-from astropy.cosmology import Cosmology, FlatLambdaCDM, Planck18, realizations
-from astropy.cosmology.core import _COSMOLOGY_CLASSES, Parameter
+from astropy.cosmology import Cosmology, FlatLambdaCDM, Planck18
+from astropy.cosmology.core import _COSMOLOGY_CLASSES
 from astropy.cosmology.io.yaml import from_yaml, to_yaml, yaml_constructor, yaml_representer
-from astropy.cosmology.parameters import available
 from astropy.io.misc.yaml import AstropyDumper, AstropyLoader, dump, load
 from astropy.table import QTable, vstack
 
 from .base import ToFromDirectTestBase, ToFromTestMixinBase
-
-cosmo_instances = [getattr(realizations, name) for name in available]
-# cosmo_instances.append("TestToFromYAML.setup.<locals>.CosmologyWithKwargs")
-
 
 ##############################################################################
 # Test Serializer

--- a/astropy/cosmology/io/yaml.py
+++ b/astropy/cosmology/io/yaml.py
@@ -119,20 +119,39 @@ def register_cosmology_yaml(cosmo_cls):
 # Unified-I/O Functions
 
 
-def from_yaml(yml):
+def from_yaml(yml, *, cosmology=None):
     """Load `~astropy.cosmology.Cosmology` from :mod:`yaml` object.
 
     Parameters
     ----------
     yml : str
         :mod:`yaml` representation of |Cosmology| object
+    cosmology : str, `~astropy.cosmology.Cosmology` class, or None (optional, keyword-only)
+        The expected cosmology class (or string name thereof). This argument is
+        required for compatibility with the standard set of keyword arguments
+        in format `~astropy.cosmology.Cosmology.from_format`. This argument
+        is only checked for correctness if not `None`.
 
     Returns
     -------
     `~astropy.cosmology.Cosmology` subclass instance
+
+    Raises
+    ------
+    TypeError
+        If the |Cosmology| object loaded from ``yml`` is not an instance of
+        the ``cosmology`` (and ``cosmology`` is not `None`).
     """
     with u.add_enabled_units(cu):
-        return load(yml)
+        cosmo = load(yml)
+
+    # Check argument `cosmology`
+    if isinstance(cosmology, str):
+        cosmology = _COSMOLOGY_CLASSES[cosmology]
+    if cosmology is not None and not isinstance(cosmo, cosmology):
+        raise TypeError(f"cosmology {cosmo} is not an {cosmology} instance.")
+
+    return cosmo
 
 
 def to_yaml(cosmology, *args):

--- a/astropy/cosmology/tests/mypackage/io/astropy_convert.py
+++ b/astropy/cosmology/tests/mypackage/io/astropy_convert.py
@@ -33,12 +33,17 @@ from mypackage.cosmology import MyCosmology
 __doctest_skip__ = ['*']
 
 
-def from_mypackage(mycosmo):
+def from_mypackage(mycosmo, *, cosmology=None):
     """Load `~astropy.cosmology.Cosmology` from ``mypackage`` object.
 
     Parameters
     ----------
     mycosmo : `~mypackage.cosmology.MyCosmology`
+
+    cosmology : str, `~astropy.cosmology.Cosmology` class, or None (optional, keyword-only)
+        The cosmology class (or string name thereof) to use when constructing
+        the cosmology instance. The class also provides default parameter values,
+        filling in any non-mandatory arguments missing in 'mycosmo'.
 
     Returns
     -------
@@ -71,10 +76,11 @@ def from_mypackage(mycosmo):
     # TODO! CUSTOMIZE FOR DETECTION
     # Here we just force FlatLambdaCDM, but if your package allows for
     # non-flat cosmologies...
-    m["cosmology"] = FlatLambdaCDM
+    cosmology = FlatLambdaCDM if cosmology is None else cosmology
 
-    # build cosmology
-    return Cosmology.from_format(m, format="mapping", move_to_meta=True)
+    # Build the cosmology from the dict, moving extra info to the metadata.
+    return Cosmology.from_format(m, format="mapping",
+                                 move_to_meta=True, cosmology=cosmology)
 
 
 def to_mypackage(cosmology, *args):


### PR DESCRIPTION
Some of the ``pytest.mark.parameterize`` hadn't been updated to include the new Cosmology I/O formats like YAML.
I've automated the collection, where possible, manually updated where not.
For YAML I had to fix a missing argument.
I also took the opportunity to streamline and simplify some of the tests.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
