### PR TITLE
Split IO test base classes

### DIFF
--- a/astropy/cosmology/io/tests/base.py
+++ b/astropy/cosmology/io/tests/base.py
@@ -5,6 +5,7 @@ import pytest
 
 # LOCAL
 import astropy.units as u
+from astropy.cosmology import units as cu
 from astropy.cosmology import Cosmology, Parameter, realizations
 from astropy.cosmology.core import _COSMOLOGY_CLASSES
 from astropy.cosmology.parameters import available
@@ -15,9 +16,20 @@ cosmo_instances = [getattr(realizations, name) for name in available]
 ##############################################################################
 
 
-class IOTestMixinBase:
+class IOTestBase:
+    """Base class for Cosmology I/O tests.
+
+    This class will not be directly called by :mod:`pytest` since its name does
+    not begin with ``Test``. To activate the contained tests this class must
+    be inherited in a subclass. Subclasses must define a :func:`pytest.fixture`
+    ``cosmo`` that returns/yields an instance of a |Cosmology|.
+    See ``TestCosmology`` for an example.
     """
-    Tests for a Cosmology[To/From]Format with some ``format``.
+
+
+class ToFromTestMixinBase(IOTestBase):
+    """Tests for a Cosmology[To/From]Format with some ``format``.
+
     This class will not be directly called by :mod:`pytest` since its name does
     not begin with ``Test``. To activate the contained tests this class must
     be inherited in a subclass. Subclasses must define a :func:`pytest.fixture`
@@ -35,6 +47,17 @@ class IOTestMixinBase:
         """Convert Cosmology instance using ``.to_format()``."""
         return cosmo.to_format
 
+
+class ReadWriteTestMixinBase(IOTestBase):
+    """Tests for a Cosmology[Read/Write].
+
+    This class will not be directly called by :mod:`pytest` since its name does
+    not begin with ``Test``. To activate the contained tests this class must
+    be inherited in a subclass. Subclasses must define a :func:`pytest.fixture`
+    ``cosmo`` that returns/yields an instance of a |Cosmology|.
+    See ``TestCosmology`` for an example.
+    """
+
     @pytest.fixture(scope="class")
     def read(self):
         """Read Cosmology instance using ``Cosmology.read()``."""
@@ -45,16 +68,28 @@ class IOTestMixinBase:
         """Write Cosmology using ``.write()``."""
         return cosmo.write
 
+    @pytest.fixture
+    def add_cu(self):
+        """Add :mod:`astropy.cosmology.units` to the enabled units."""
+        # TODO! autoenable 'cu' if cosmology is imported?
+        with u.add_enabled_units(cu):
+            yield
 
-class IOFormatTestBase(IOTestMixinBase):
-    """
-    Directly test ``to/from_<format>``.
-    These are not public API and are discouraged from public use, in favor of
-    ``Cosmology.to/from_format(..., format="<format>")``.
 
-    Subclasses should have an attribute ``functions`` which is a dictionary
-    containing two items: ``"to"=<function for to_format>`` and
-    ``"from"=<function for from_format>``.
+##############################################################################
+
+
+class IODirectTestBase(IOTestBase):
+    """Directly test Cosmology I/O functions.
+
+    These functions are not public API and are discouraged from public use, in
+    favor of the I/O methods on |Cosmology|. They are tested b/c they are used
+    internally and because some tests for the methods on |Cosmology| don't need
+    to be run in the |Cosmology| class's large test matrix.
+
+    This class will not be directly called by :mod:`pytest` since its name does
+    not begin with ``Test``. To activate the contained tests this class must
+    be inherited in a subclass.
     """
 
     @pytest.fixture(scope="class", autouse=True)
@@ -86,7 +121,24 @@ class IOFormatTestBase(IOTestMixinBase):
         """Cosmology classes."""
         return cosmo.__class__
 
-    # -------------------------------------------
+
+class ToFromDirectTestBase(IODirectTestBase, ToFromTestMixinBase):
+    """Directly test ``to/from_<format>``.
+
+    These functions are not public API and are discouraged from public use, in
+    favor of ``Cosmology.to/from_format(..., format="<format>")``. They are
+    tested because they are used internally and because some tests for the
+    methods on |Cosmology| don't need to be run in the |Cosmology| class's
+    large test matrix.
+
+    This class will not be directly called by :mod:`pytest` since its name does
+    not begin with ``Test``. To activate the contained tests this class must
+    be inherited in a subclass.
+
+    Subclasses should have an attribute ``functions`` which is a dictionary
+    containing two items: ``"to"=<function for to_format>`` and
+    ``"from"=<function for from_format>``.
+    """
 
     @pytest.fixture(scope="class")
     def from_format(self):
@@ -100,9 +152,29 @@ class IOFormatTestBase(IOTestMixinBase):
     @pytest.fixture(scope="class")
     def to_format(self, cosmo):
         """Convert Cosmology to format using function ``to``."""
-        return lambda *args, **kwargs: self.functions["to"](cosmo, *args, **kwargs)
+        def use_to_format(*args, **kwargs):
+            return self.functions["to"](cosmo, *args, **kwargs)
 
-    # -------------------------------------------
+        return use_to_format
+
+
+class ReadWriteDirectTestBase(IODirectTestBase, ToFromTestMixinBase):
+    """Directly test ``read/write_<format>``.
+
+    These functions are not public API and are discouraged from public use, in
+    favor of ``Cosmology.read/write(..., format="<format>")``. They are tested
+    because they are used internally and because some tests for the
+    methods on |Cosmology| don't need to be run in the |Cosmology| class's
+    large test matrix.
+
+    This class will not be directly called by :mod:`pytest` since its name does
+    not begin with ``Test``. To activate the contained tests this class must
+    be inherited in a subclass.
+
+    Subclasses should have an attribute ``functions`` which is a dictionary
+    containing two items: ``"read"=<function for read>`` and
+    ``"write"=<function for write>``.
+    """
 
     @pytest.fixture(scope="class")
     def read(self):
@@ -116,4 +188,7 @@ class IOFormatTestBase(IOTestMixinBase):
     @pytest.fixture(scope="class")
     def write(self, cosmo):
         """Write Cosmology to file using function ``write``."""
-        return lambda *args, **kwargs: self.functions["write"](cosmo, *args, **kwargs)
+        def use_write(*args, **kwargs):
+            return self.functions["write"](cosmo, *args, **kwargs)
+
+        return use_write

--- a/astropy/cosmology/io/tests/test_ecsv.py
+++ b/astropy/cosmology/io/tests/test_ecsv.py
@@ -13,7 +13,7 @@ from astropy.cosmology.io.ecsv import read_ecsv, write_ecsv
 from astropy.table import QTable, Table, vstack
 from astropy.cosmology.parameters import available
 
-from .base import IOTestMixinBase, IOFormatTestBase
+from .base import ReadWriteTestMixinBase, ReadWriteDirectTestBase
 
 cosmo_instances = [getattr(realizations, name) for name in available]
 cosmo_instances.append("TestReadWriteECSV.setup.<locals>.CosmologyWithKwargs")
@@ -21,7 +21,7 @@ cosmo_instances.append("TestReadWriteECSV.setup.<locals>.CosmologyWithKwargs")
 ###############################################################################
 
 
-class ReadWriteECSVTestMixin(IOTestMixinBase):
+class ReadWriteECSVTestMixin(ReadWriteTestMixinBase):
     """
     Tests for a Cosmology[Read/Write] with ``format="ascii.ecsv"``.
     This class will not be directly called by :mod:`pytest` since its name does
@@ -30,14 +30,6 @@ class ReadWriteECSVTestMixin(IOTestMixinBase):
     ``cosmo`` that returns/yields an instance of a |Cosmology|.
     See ``TestCosmology`` for an example.
     """
-
-    @pytest.fixture
-    def add_cu(self):
-        # TODO! autoenable 'cu' if cosmology is imported?
-        with u.add_enabled_units(cu):
-            yield
-
-    # ===============================================================
 
     def test_to_ecsv_bad_index(self, read, write, tmp_path):
         """Test if argument ``index`` is incorrect"""
@@ -206,7 +198,7 @@ class ReadWriteECSVTestMixin(IOTestMixinBase):
         assert got2 == cosmo
 
 
-class TestReadWriteECSV(IOFormatTestBase, ReadWriteECSVTestMixin):
+class TestReadWriteECSV(ReadWriteDirectTestBase, ReadWriteECSVTestMixin):
     """
     Directly test ``read/write``.
     These are not public API and are discouraged from use, in favor of

--- a/astropy/cosmology/io/tests/test_mapping.py
+++ b/astropy/cosmology/io/tests/test_mapping.py
@@ -17,7 +17,7 @@ from astropy.cosmology.io.mapping import from_mapping, to_mapping
 from astropy.cosmology.parameters import available
 from astropy.table import QTable, vstack
 
-from .base import IOTestMixinBase, IOFormatTestBase
+from .base import ToFromTestMixinBase, ToFromDirectTestBase
 
 cosmo_instances = [getattr(realizations, name) for name in available]
 cosmo_instances.append("TestToFromMapping.setup.<locals>.CosmologyWithKwargs")
@@ -26,9 +26,9 @@ cosmo_instances.append("TestToFromMapping.setup.<locals>.CosmologyWithKwargs")
 ###############################################################################
 
 
-class ToFromMappingTestMixin(IOTestMixinBase):
-    """
-    Tests for a Cosmology[To/From]Format with ``format="mapping"``.
+class ToFromMappingTestMixin(ToFromTestMixinBase):
+    """Tests for a Cosmology[To/From]Format with ``format="mapping"``.
+
     This class will not be directly called by :mod:`pytest` since its name does
     not begin with ``Test``. To activate the contained tests this class must
     be inherited in a subclass. Subclasses must define a :func:`pytest.fixture`
@@ -186,7 +186,7 @@ class ToFromMappingTestMixin(IOTestMixinBase):
         assert got.meta == cosmo.meta
 
 
-class TestToFromMapping(IOFormatTestBase, ToFromMappingTestMixin):
+class TestToFromMapping(ToFromDirectTestBase, ToFromMappingTestMixin):
     """Directly test ``to/from_mapping``."""
 
     def setup_class(self):

--- a/astropy/cosmology/io/tests/test_model.py
+++ b/astropy/cosmology/io/tests/test_model.py
@@ -21,7 +21,7 @@ from astropy.modeling import FittableModel
 from astropy.modeling.models import Gaussian1D
 from astropy.utils.compat.optional_deps import HAS_SCIPY
 
-from .base import IOTestMixinBase, IOFormatTestBase
+from .base import ToFromTestMixinBase, ToFromDirectTestBase
 
 cosmo_instances = [getattr(realizations, name) for name in available]
 cosmo_instances.append("TestToFromTable.setup.<locals>.CosmologyWithKwargs")
@@ -30,9 +30,9 @@ cosmo_instances.append("TestToFromTable.setup.<locals>.CosmologyWithKwargs")
 ###############################################################################
 
 
-class ToFromModelTestMixin(IOTestMixinBase):
-    """
-    Tests for a Cosmology[To/From]Format with ``format="astropy.model"``.
+class ToFromModelTestMixin(ToFromTestMixinBase):
+    """Tests for a Cosmology[To/From]Format with ``format="astropy.model"``.
+
     This class will not be directly called by :mod:`pytest` since its name does
     not begin with ``Test``. To activate the contained tests this class must
     be inherited in a subclass. Subclasses must define a :func:`pytest.fixture`
@@ -160,7 +160,7 @@ class ToFromModelTestMixin(IOTestMixinBase):
         pass  # there's no partial information with a Model
 
 
-class TestToFromModel(IOFormatTestBase, ToFromModelTestMixin):
+class TestToFromModel(ToFromDirectTestBase, ToFromModelTestMixin):
     """Directly test ``to/from_model``."""
 
     def setup_class(self):

--- a/astropy/cosmology/io/tests/test_row.py
+++ b/astropy/cosmology/io/tests/test_row.py
@@ -12,7 +12,7 @@ from astropy.cosmology.io.row import from_row, to_row
 from astropy.table import Row
 from astropy.cosmology.parameters import available
 
-from .base import IOTestMixinBase, IOFormatTestBase
+from .base import ToFromTestMixinBase, ToFromDirectTestBase
 
 cosmo_instances = [getattr(realizations, name) for name in available]
 cosmo_instances.append("TestToFromRow.setup.<locals>.CosmologyWithKwargs")
@@ -20,7 +20,7 @@ cosmo_instances.append("TestToFromRow.setup.<locals>.CosmologyWithKwargs")
 ###############################################################################
 
 
-class ToFromRowTestMixin(IOTestMixinBase):
+class ToFromRowTestMixin(ToFromTestMixinBase):
     """
     Tests for a Cosmology[To/From]Format with ``format="astropy.row"``.
     This class will not be directly called by :mod:`pytest` since its name does
@@ -109,7 +109,7 @@ class ToFromRowTestMixin(IOTestMixinBase):
         pass  # there are no partial info options
 
 
-class TestToFromTable(IOFormatTestBase, ToFromRowTestMixin):
+class TestToFromTable(ToFromDirectTestBase, ToFromRowTestMixin):
     """
     Directly test ``to/from_row``.
     These are not public API and are discouraged from use, in favor of

--- a/astropy/cosmology/io/tests/test_table.py
+++ b/astropy/cosmology/io/tests/test_table.py
@@ -12,7 +12,7 @@ from astropy.cosmology.io.table import from_table, to_table
 from astropy.cosmology.parameters import available
 from astropy.table import QTable, Table, vstack
 
-from .base import IOTestMixinBase, IOFormatTestBase
+from .base import ToFromTestMixinBase, ToFromDirectTestBase
 
 cosmo_instances = [getattr(realizations, name) for name in available]
 cosmo_instances.append("TestToFromTable.setup.<locals>.CosmologyWithKwargs")
@@ -20,7 +20,7 @@ cosmo_instances.append("TestToFromTable.setup.<locals>.CosmologyWithKwargs")
 ###############################################################################
 
 
-class ToFromTableTestMixin(IOTestMixinBase):
+class ToFromTableTestMixin(ToFromTestMixinBase):
     """
     Tests for a Cosmology[To/From]Format with ``format="astropy.table"``.
     This class will not be directly called by :mod:`pytest` since its name does
@@ -209,7 +209,7 @@ class ToFromTableTestMixin(IOTestMixinBase):
             from_format(tbls, index=cosmo.name, format="astropy.table")
 
 
-class TestToFromTable(IOFormatTestBase, ToFromTableTestMixin):
+class TestToFromTable(ToFromDirectTestBase, ToFromTableTestMixin):
     """Directly test ``to/from_table``."""
 
     def setup_class(self):

--- a/astropy/cosmology/io/tests/test_yaml.py
+++ b/astropy/cosmology/io/tests/test_yaml.py
@@ -18,7 +18,7 @@ from astropy.cosmology.parameters import available
 from astropy.io.misc.yaml import AstropyDumper, AstropyLoader, dump, load
 from astropy.table import QTable, vstack
 
-from .base import IOTestMixinBase, IOFormatTestBase
+from .base import ToFromTestMixinBase, ToFromDirectTestBase
 
 cosmo_instances = [getattr(realizations, name) for name in available]
 # cosmo_instances.append("TestToFromYAML.setup.<locals>.CosmologyWithKwargs")
@@ -60,7 +60,7 @@ def test_yaml_constructor():
 # Test Unified I/O
 
 
-class ToFromYAMLTestMixin(IOTestMixinBase):
+class ToFromYAMLTestMixin(ToFromTestMixinBase):
     """
     Tests for a Cosmology[To/From]Format with ``format="yaml"``.
     This class will not be directly called by :mod:`pytest` since its name does
@@ -129,7 +129,7 @@ class ToFromYAMLTestMixin(IOTestMixinBase):
     #     """
 
 
-class TestToFromYAML(IOFormatTestBase, ToFromYAMLTestMixin):
+class TestToFromYAML(ToFromDirectTestBase, ToFromYAMLTestMixin):
     """
     Directly test ``to/from_yaml``.
     These are not public API and are discouraged from use, in favor of
@@ -146,7 +146,7 @@ class TestToFromYAML(IOFormatTestBase, ToFromYAMLTestMixin):
     def setup(self):
         """
         Setup and teardown for tests.
-        This overrides from super because `IOFormatTestBase` adds a custom
+        This overrides from super because `ToFromDirectTestBase` adds a custom
         Cosmology ``CosmologyWithKwargs`` that is not registered with YAML.
         """
         yield  # run tests


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

The base classes for the I/O tests were a mixture of the read/write and to/from_format. This was a little confusing. I split the classes and add more explanation how that portion of the test suite works.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
