### PR TITLE
Fix Time.insert() with out_fmt set

### DIFF
--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -253,10 +253,11 @@ class TimeInfoBase(MixinInfo):
         jd1 = np.full(shape, jd2000, dtype='f8')
         jd2 = np.zeros(shape, dtype='f8')
         tm_attrs = {attr: getattr(col0, attr)
-                    for attr in ('scale', 'location',
-                                 'precision', 'in_subfmt', 'out_subfmt')}
+                    for attr in ('scale', 'location', 'precision')}
         out = self._parent_cls(jd1, jd2, format='jd', **tm_attrs)
         out.format = col0.format
+        out.out_subfmt = col0.out_subfmt
+        out.in_subfmt = col0.in_subfmt
 
         # Set remaining info attributes
         for attr, value in attrs.items():

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -2014,6 +2014,17 @@ def test_insert_time():
     assert np.all(tm2 == Time([10, 20, 1, 2], format='unix'))
 
 
+def test_insert_time_out_subfmt():
+    # Check insert() with out_subfmt set
+    T = Time(['1999-01-01', '1999-01-02'], out_subfmt='date')
+    T = T.insert(0, T[0])
+    assert T.out_subfmt == 'date'
+    assert T[0] == T[1]
+    T = T.insert(1, '1999-01-03')
+    assert T.out_subfmt == 'date'
+    assert str(T[1]) == '1999-01-03'
+
+
 def test_insert_exceptions():
     tm = Time(1, format='unix')
     with pytest.raises(TypeError) as err:

--- a/docs/changes/time/12732.bugfix.rst
+++ b/docs/changes/time/12732.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ``Time.insert()`` on times which have their ``out_subfmt`` set.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request allows `Time.insert()` to be used on string formatted times where `out_subfmt != '*'`.  The previous issue was trying to set out_subfmt on some internal logic that uses the `jd` format, which isn't possible. Instead we can just assign `out_subfmt` after the new instance has been created.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes https://github.com/astropy/astropy/issues/11952

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
