### PR TITLE
refactor json tests to use mixin classes

### DIFF
--- a/astropy/cosmology/io/tests/base.py
+++ b/astropy/cosmology/io/tests/base.py
@@ -5,8 +5,8 @@ import pytest
 
 # LOCAL
 import astropy.units as u
-from astropy.cosmology import units as cu
 from astropy.cosmology import Cosmology, Parameter, realizations
+from astropy.cosmology import units as cu
 from astropy.cosmology.core import _COSMOLOGY_CLASSES
 from astropy.cosmology.parameters import available
 

--- a/astropy/cosmology/io/tests/test_ecsv.py
+++ b/astropy/cosmology/io/tests/test_ecsv.py
@@ -4,16 +4,15 @@
 import pytest
 
 # LOCAL
-import astropy.cosmology.units as cu
 import astropy.units as u
 from astropy import cosmology
 from astropy.cosmology import Cosmology, realizations
 from astropy.cosmology.core import _COSMOLOGY_CLASSES
 from astropy.cosmology.io.ecsv import read_ecsv, write_ecsv
-from astropy.table import QTable, Table, vstack
 from astropy.cosmology.parameters import available
+from astropy.table import QTable, Table, vstack
 
-from .base import ReadWriteTestMixinBase, ReadWriteDirectTestBase
+from .base import ReadWriteDirectTestBase, ReadWriteTestMixinBase
 
 cosmo_instances = [getattr(realizations, name) for name in available]
 cosmo_instances.append("TestReadWriteECSV.setup.<locals>.CosmologyWithKwargs")
@@ -78,9 +77,9 @@ class ReadWriteECSVTestMixin(ReadWriteTestMixinBase):
 
     # -----------------------
 
-    def test_tofrom_ecsv_instance(self, cosmo_cls, cosmo, read, write, tmp_path, add_cu):
+    def test_readwrite_ecsv_instance(self, cosmo_cls, cosmo, read, write, tmp_path, add_cu):
         """Test cosmology -> ascii.ecsv -> cosmology."""
-        fp = tmp_path / "test_tofrom_ecsv_instance.ecsv"
+        fp = tmp_path / "test_readwrite_ecsv_instance.ecsv"
 
         # ------------
         # To Table
@@ -133,13 +132,13 @@ class ReadWriteECSVTestMixin(ReadWriteTestMixinBase):
         got = read(fp)
         assert got == cosmo
 
-    def test_fromformat_ecsv_subclass_partial_info(self, cosmo_cls, cosmo, read, write,
-                                                   tmp_path, add_cu):
+    def test_readwrite_ecsv_subclass_partial_info(self, cosmo_cls, cosmo, read,
+                                                  write, tmp_path, add_cu):
         """
         Test writing from an instance and reading from that class.
         This works with missing information.
         """
-        fp = tmp_path / "test_fromformat_ecsv_subclass_partial_info.ecsv"
+        fp = tmp_path / "test_read_ecsv_subclass_partial_info.ecsv"
 
         # test write
         write(fp, format="ascii.ecsv")
@@ -165,9 +164,9 @@ class ReadWriteECSVTestMixin(ReadWriteTestMixinBase):
         # but the metadata is the same
         assert got.meta == cosmo.meta
 
-    def test_tofrom_ecsv_mutlirow(self, cosmo, read, write, tmp_path, add_cu):
+    def test_readwrite_ecsv_mutlirow(self, cosmo, read, write, tmp_path, add_cu):
         """Test if table has multiple rows."""
-        fp = tmp_path / "test_tofrom_ecsv_mutlirow.ecsv"
+        fp = tmp_path / "test_readwrite_ecsv_mutlirow.ecsv"
 
         # Make
         cosmo1 = cosmo.clone(name="row 0")

--- a/astropy/cosmology/io/tests/test_json.py
+++ b/astropy/cosmology/io/tests/test_json.py
@@ -1,0 +1,163 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+# STDLIB
+import json
+import os
+
+# THIRD PARTY
+import pytest
+
+# LOCAL
+import astropy.units as u
+from astropy.cosmology import units as cu
+from astropy.cosmology.connect import readwrite_registry
+from astropy.cosmology.core import _COSMOLOGY_CLASSES, Cosmology
+
+from .base import ReadWriteDirectTestBase, ReadWriteTestMixinBase
+
+###############################################################################
+
+
+def read_json(filename, **kwargs):
+    """Read JSON.
+
+    Parameters
+    ----------
+    filename : str
+    **kwargs
+        Keyword arguments into :meth:`~astropy.cosmology.Cosmology.from_format`
+
+    Returns
+    -------
+    `~astropy.cosmology.Cosmology` instance
+    """
+    # read
+    if isinstance(filename, (str, bytes, os.PathLike)):
+        with open(filename, "r") as file:
+            data = file.read()
+    else:  # file-like : this also handles errors in dumping
+        data = filename.read()
+
+    mapping = json.loads(data)  # parse json mappable to dict
+
+    # deserialize Quantity
+    with u.add_enabled_units(cu.redshift):
+        for k, v in mapping.items():
+            if isinstance(v, dict) and "value" in v and "unit" in v:
+                mapping[k] = u.Quantity(v["value"], v["unit"])
+        for k, v in mapping.get("meta", {}).items():  # also the metadata
+            if isinstance(v, dict) and "value" in v and "unit" in v:
+                mapping["meta"][k] = u.Quantity(v["value"], v["unit"])
+
+    return Cosmology.from_format(mapping, format="mapping", **kwargs)
+
+
+def write_json(cosmology, file, *, overwrite=False):
+    """Write Cosmology to JSON.
+
+    Parameters
+    ----------
+    cosmology : `astropy.cosmology.Cosmology` subclass instance
+    file : path-like or file-like
+    overwrite : bool (optional, keyword-only)
+    """
+    data = cosmology.to_format("mapping")  # start by turning into dict
+    data["cosmology"] = data["cosmology"].__qualname__
+
+    # serialize Quantity
+    for k, v in data.items():
+        if isinstance(v, u.Quantity):
+            data[k] = {"value": v.value.tolist(), "unit": str(v.unit)}
+    for k, v in data.get("meta", {}).items():  # also serialize the metadata
+        if isinstance(v, u.Quantity):
+            data["meta"][k] = {"value": v.value.tolist(), "unit": str(v.unit)}
+
+    # check that file exists and whether to overwrite.
+    if os.path.exists(file) and not overwrite:
+        raise IOError(f"{file} exists. Set 'overwrite' to write over.")
+    with open(file, "w") as write_file:
+        json.dump(data, write_file)
+
+
+def json_identify(origin, filepath, fileobj, *args, **kwargs):
+    return filepath is not None and filepath.endswith(".json")
+
+
+###############################################################################
+
+
+class ReadWriteJSONTestMixin(ReadWriteTestMixinBase):
+    """
+    Tests for a Cosmology[Read/Write] with ``format="json"``.
+    This class will not be directly called by :mod:`pytest` since its name does
+    not begin with ``Test``. To activate the contained tests this class must
+    be inherited in a subclass. Subclasses must dfine a :func:`pytest.fixture`
+    ``cosmo`` that returns/yields an instance of a |Cosmology|.
+    See ``TestCosmology`` for an example.
+    """
+
+    @pytest.fixture(scope="class", autouse=True)
+    def register_and_unregister_json(self):
+        """Setup & teardown for JSON read/write tests."""
+        # Register
+        readwrite_registry.register_reader("json", Cosmology, read_json, force=True)
+        readwrite_registry.register_writer("json", Cosmology, write_json, force=True)
+        readwrite_registry.register_identifier("json", Cosmology, json_identify, force=True)
+
+        yield  # Run all tests in class
+
+        # Unregister
+        readwrite_registry.unregister_reader("json", Cosmology)
+        readwrite_registry.unregister_writer("json", Cosmology)
+        readwrite_registry.unregister_identifier("json", Cosmology)
+
+    # ========================================================================
+
+    def test_readwrite_json_subclass_partial_info(self, cosmo_cls, cosmo, read,
+                                                  write, tmp_path, add_cu):
+        """
+        Test writing from an instance and reading from that class.
+        This works with missing information.
+        """
+        fp = tmp_path / "test_readwrite_json_subclass_partial_info.json"
+
+        # test write
+        cosmo.write(fp, format="json")
+
+        # partial information
+        with open(fp, "r") as file:
+            L = file.readlines()[0]
+        L = L[: L.index('"cosmology":')] + L[L.index(", ") + 2 :]  # remove cosmology
+        i = L.index('"Tcmb0":')  # delete Tcmb0
+        L = L[:i] + L[L.index(", ", L.index(", ", i) + 1) + 2 :]  # second occurence
+
+        tempfname = tmp_path / f"{cosmo.name}_temp.json"
+        with open(tempfname, "w") as file:
+            file.writelines([L])
+
+        # read with the same class that wrote fills in the missing info with
+        # the default value
+        got = cosmo_cls.read(tempfname, format="json")
+        got2 = read(tempfname, format="json", cosmology=cosmo_cls)
+        got3 = read(tempfname, format="json", cosmology=cosmo_cls.__qualname__)
+
+        assert (got == got2) and (got2 == got3)  # internal consistency
+
+        # not equal, because Tcmb0 is changed, which also changes m_nu
+        assert got != cosmo
+        assert got.Tcmb0 == cosmo_cls._init_signature.parameters["Tcmb0"].default
+        assert got.clone(name=cosmo.name, Tcmb0=cosmo.Tcmb0, m_nu=cosmo.m_nu) == cosmo
+        # but the metadata is the same
+        assert got.meta == cosmo.meta
+
+
+class TestReadWriteJSON(ReadWriteDirectTestBase, ReadWriteJSONTestMixin):
+    """
+    Directly test ``read/write_json``.
+    These are not public API and are discouraged from use, in favor of
+    ``Cosmology.read/write(..., format="json")``, but should be
+    tested regardless b/c they are used internally.
+    """
+
+    def setup_class(self):
+        self.functions = {"read": read_json, "write": write_json}

--- a/astropy/cosmology/io/tests/test_mapping.py
+++ b/astropy/cosmology/io/tests/test_mapping.py
@@ -17,7 +17,7 @@ from astropy.cosmology.io.mapping import from_mapping, to_mapping
 from astropy.cosmology.parameters import available
 from astropy.table import QTable, vstack
 
-from .base import ToFromTestMixinBase, ToFromDirectTestBase
+from .base import ToFromDirectTestBase, ToFromTestMixinBase
 
 cosmo_instances = [getattr(realizations, name) for name in available]
 cosmo_instances.append("TestToFromMapping.setup.<locals>.CosmologyWithKwargs")

--- a/astropy/cosmology/io/tests/test_model.py
+++ b/astropy/cosmology/io/tests/test_model.py
@@ -21,7 +21,7 @@ from astropy.modeling import FittableModel
 from astropy.modeling.models import Gaussian1D
 from astropy.utils.compat.optional_deps import HAS_SCIPY
 
-from .base import ToFromTestMixinBase, ToFromDirectTestBase
+from .base import ToFromDirectTestBase, ToFromTestMixinBase
 
 cosmo_instances = [getattr(realizations, name) for name in available]
 cosmo_instances.append("TestToFromTable.setup.<locals>.CosmologyWithKwargs")

--- a/astropy/cosmology/io/tests/test_row.py
+++ b/astropy/cosmology/io/tests/test_row.py
@@ -6,13 +6,13 @@ import pytest
 # LOCAL
 import astropy.units as u
 from astropy import cosmology
-from astropy.cosmology import Cosmology, realizations, Planck18
+from astropy.cosmology import Cosmology, Planck18, realizations
 from astropy.cosmology.core import _COSMOLOGY_CLASSES, Parameter
 from astropy.cosmology.io.row import from_row, to_row
-from astropy.table import Row
 from astropy.cosmology.parameters import available
+from astropy.table import Row
 
-from .base import ToFromTestMixinBase, ToFromDirectTestBase
+from .base import ToFromDirectTestBase, ToFromTestMixinBase
 
 cosmo_instances = [getattr(realizations, name) for name in available]
 cosmo_instances.append("TestToFromRow.setup.<locals>.CosmologyWithKwargs")

--- a/astropy/cosmology/io/tests/test_table.py
+++ b/astropy/cosmology/io/tests/test_table.py
@@ -12,7 +12,7 @@ from astropy.cosmology.io.table import from_table, to_table
 from astropy.cosmology.parameters import available
 from astropy.table import QTable, Table, vstack
 
-from .base import ToFromTestMixinBase, ToFromDirectTestBase
+from .base import ToFromDirectTestBase, ToFromTestMixinBase
 
 cosmo_instances = [getattr(realizations, name) for name in available]
 cosmo_instances.append("TestToFromTable.setup.<locals>.CosmologyWithKwargs")

--- a/astropy/cosmology/io/tests/test_yaml.py
+++ b/astropy/cosmology/io/tests/test_yaml.py
@@ -18,7 +18,7 @@ from astropy.cosmology.parameters import available
 from astropy.io.misc.yaml import AstropyDumper, AstropyLoader, dump, load
 from astropy.table import QTable, vstack
 
-from .base import ToFromTestMixinBase, ToFromDirectTestBase
+from .base import ToFromDirectTestBase, ToFromTestMixinBase
 
 cosmo_instances = [getattr(realizations, name) for name in available]
 # cosmo_instances.append("TestToFromYAML.setup.<locals>.CosmologyWithKwargs")

--- a/astropy/cosmology/tests/conftest.py
+++ b/astropy/cosmology/tests/conftest.py
@@ -7,18 +7,13 @@
 
 # STDLIB
 import inspect
-import json
-import os
 
 # THIRD-PARTY
 import pytest
 
 # LOCAL
-import astropy.cosmology.units as cu
-import astropy.units as u
 from astropy.cosmology import core
-from astropy.cosmology.core import Cosmology
-from astropy.tests.helper import pickle_protocol
+from astropy.tests.helper import pickle_protocol  # noqa: F403
 
 
 ###############################################################################
@@ -69,72 +64,6 @@ def get_redshift_methods(cosmology, allow_private=True, allow_z2=True):
             methods.discard(n)
 
     return methods
-
-
-def read_json(filename, **kwargs):
-    """Read JSON.
-
-    Parameters
-    ----------
-    filename : str
-    **kwargs
-        Keyword arguments into :meth:`~astropy.cosmology.Cosmology.from_format`
-
-    Returns
-    -------
-    `~astropy.cosmology.Cosmology` instance
-
-    """
-    # read
-    if isinstance(filename, (str, bytes, os.PathLike)):
-        with open(filename, "r") as file:
-            data = file.read()
-    else:  # file-like : this also handles errors in dumping
-        data = filename.read()
-
-    mapping = json.loads(data)  # parse json mappable to dict
-
-    # deserialize Quantity
-    with u.add_enabled_units(cu.redshift):
-        for k, v in mapping.items():
-            if isinstance(v, dict) and "value" in v and "unit" in v:
-                mapping[k] = u.Quantity(v["value"], v["unit"])
-        for k, v in mapping.get("meta", {}).items():  # also the metadata
-            if isinstance(v, dict) and "value" in v and "unit" in v:
-                mapping["meta"][k] = u.Quantity(v["value"], v["unit"])
-
-    return Cosmology.from_format(mapping, **kwargs)
-
-
-def write_json(cosmology, file, *, overwrite=False):
-    """Write Cosmology to JSON.
-
-    Parameters
-    ----------
-    cosmology : `astropy.cosmology.Cosmology` subclass instance
-    file : path-like or file-like
-    overwrite : bool (optional, keyword-only)
-    """
-    data = cosmology.to_format("mapping")  # start by turning into dict
-    data["cosmology"] = data["cosmology"].__qualname__
-
-    # serialize Quantity
-    for k, v in data.items():
-        if isinstance(v, u.Quantity):
-            data[k] = {"value": v.value.tolist(), "unit": str(v.unit)}
-    for k, v in data.get("meta", {}).items():  # also serialize the metadata
-        if isinstance(v, u.Quantity):
-            data["meta"][k] = {"value": v.value.tolist(), "unit": str(v.unit)}
-
-    # check that file exists and whether to overwrite.
-    if os.path.exists(file) and not overwrite:
-        raise IOError(f"{file} exists. Set 'overwrite' to write over.")
-    with open(file, "w") as write_file:
-        json.dump(data, write_file)
-
-
-def json_identify(origin, filepath, fileobj, *args, **kwargs):
-    return filepath is not None and filepath.endswith(".json")
 
 
 ###############################################################################

--- a/astropy/cosmology/tests/test_core.py
+++ b/astropy/cosmology/tests/test_core.py
@@ -22,7 +22,7 @@ import astropy.units as u
 from astropy.cosmology import Cosmology, core
 from astropy.cosmology.core import _COSMOLOGY_CLASSES
 from astropy.cosmology.parameter import Parameter
-from astropy.table import QTable, Table, Column
+from astropy.table import Column, QTable, Table
 from astropy.utils.exceptions import AstropyDeprecationWarning
 from astropy.utils.metadata import MetaData
 

--- a/astropy/cosmology/tests/test_flrw.py
+++ b/astropy/cosmology/tests/test_flrw.py
@@ -14,21 +14,20 @@ import pytest
 
 import numpy as np
 
+import astropy.constants as const
 # LOCAL
 import astropy.cosmology.units as cu
 import astropy.units as u
-import astropy.constants as const
 from astropy.cosmology import (FLRW, FlatLambdaCDM, Flatw0waCDM, FlatwCDM,
                                LambdaCDM, Planck18, w0waCDM, w0wzCDM, wCDM, wpwaCDM)
 from astropy.cosmology.core import _COSMOLOGY_CLASSES
-from astropy.cosmology.flrw import (a_B_c2, critdens_const, ellipkinc,
-                                    H0units_to_invs, hyp2f1, quad)
+from astropy.cosmology.flrw import H0units_to_invs, a_B_c2, critdens_const, ellipkinc, hyp2f1, quad
 from astropy.cosmology.parameter import Parameter
 from astropy.utils.compat.optional_deps import HAS_SCIPY
 
 from .conftest import get_redshift_methods
-from .test_core import CosmologySubclassTest as CosmologyTest, valid_zs, invalid_zs
-from .test_core import FlatCosmologyMixinTest, ParameterTestMixin
+from .test_core import CosmologySubclassTest as CosmologyTest
+from .test_core import FlatCosmologyMixinTest, ParameterTestMixin, invalid_zs, valid_zs
 
 
 ##############################################################################

--- a/astropy/cosmology/tests/test_funcs.py
+++ b/astropy/cosmology/tests/test_funcs.py
@@ -11,7 +11,8 @@ import numpy as np
 from astropy import units as u
 from astropy.cosmology import core, flrw
 from astropy.cosmology.funcs import _z_at_scalar_value, z_at_value
-from astropy.cosmology.realizations import WMAP1, WMAP3, WMAP5, WMAP7, WMAP9, Planck13, Planck15, Planck18
+from astropy.cosmology.realizations import (WMAP1, WMAP3, WMAP5, WMAP7, WMAP9,
+                                            Planck13, Planck15, Planck18)
 from astropy.units import allclose
 from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa
 from astropy.utils.exceptions import AstropyUserWarning

--- a/astropy/cosmology/tests/test_realizations.py
+++ b/astropy/cosmology/tests/test_realizations.py
@@ -11,7 +11,7 @@ import astropy.cosmology.units as cu
 import astropy.units as u
 from astropy import cosmology
 from astropy.cosmology import parameters, realizations
-from astropy.cosmology.realizations import default_cosmology, Planck13
+from astropy.cosmology.realizations import Planck13, default_cosmology
 from astropy.tests.helper import pickle_protocol
 from astropy.utils.exceptions import AstropyDeprecationWarning
 


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

The JSON tests now use the mixin framework.
Also cleaned up some of the ECSV tests.


### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
