### PR TITLE
register to/from cosmology

### DIFF
--- a/astropy/cosmology/io/cosmology.py
+++ b/astropy/cosmology/io/cosmology.py
@@ -1,0 +1,86 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+"""
+The following are private functions. These functions are registered into
+:meth:`~astropy.cosmology.Cosmology.to_format` and
+:meth:`~astropy.cosmology.Cosmology.from_format` and should only be accessed
+via these methods.
+"""
+
+from astropy.cosmology.core import _COSMOLOGY_CLASSES, Cosmology
+from astropy.cosmology.connect import convert_registry
+
+__all__ = []  # nothing is publicly scoped
+
+
+def from_cosmology(cosmo, /, **kwargs):
+    """Return the |Cosmology| unchanged.
+
+    Parameters
+    ----------
+    cosmo : `~astropy.cosmology.Cosmology`
+        The cosmology to return.
+    **kwargs
+        This argument is required for compatibility with the standard set of
+        keyword arguments in format `~astropy.cosmology.Cosmology.from_format`,
+        e.g. "cosmology". If "cosmology" is included and is not `None`,
+        ``cosmo`` is checked for correctness.
+
+    Returns
+    -------
+    `~astropy.cosmology.Cosmology` subclass instance
+        Just ``cosmo`` passed through.
+
+    Raises
+    ------
+    TypeError
+        If the |Cosmology| object is not an instance of ``cosmo`` (and
+        ``cosmology`` is not `None`).
+    """
+    # Check argument `cosmology`
+    cosmology = kwargs.get("cosmology")
+    if isinstance(cosmology, str):
+        cosmology = _COSMOLOGY_CLASSES[cosmology]
+    if cosmology is not None and not isinstance(cosmo, cosmology):
+        raise TypeError(f"cosmology {cosmo} is not an {cosmology} instance.")
+
+    return cosmo
+
+
+def to_cosmology(cosmo, *args):
+    """Return the |Cosmology| unchanged.
+
+    Parameters
+    ----------
+    cosmo : `~astropy.cosmology.Cosmology`
+        The cosmology to return.
+    *args
+        Not used.
+
+    Returns
+    -------
+    `~astropy.cosmology.Cosmology` subclass instance
+        Just ``cosmo`` passed through.
+    """
+    return cosmo
+
+
+def cosmology_identify(origin, format, *args, **kwargs):
+    """Identify if object is a `~astropy.cosmology.Cosmology`.
+
+    Returns
+    -------
+    bool
+    """
+    itis = False
+    if origin == "read":
+        itis = isinstance(args[1], Cosmology) and (format in (None, "astropy.cosmology"))
+    return itis
+
+
+# ===================================================================
+# Register
+
+convert_registry.register_reader("astropy.cosmology", Cosmology, from_cosmology)
+convert_registry.register_writer("astropy.cosmology", Cosmology, to_cosmology)
+convert_registry.register_identifier("astropy.cosmology", Cosmology, cosmology_identify)

--- a/astropy/cosmology/io/tests/test_cosmology.py
+++ b/astropy/cosmology/io/tests/test_cosmology.py
@@ -1,0 +1,46 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+# THIRD PARTY
+import pytest
+
+# LOCAL
+from astropy.cosmology import Cosmology
+from astropy.cosmology.io.cosmology import from_cosmology, to_cosmology
+
+from .base import ToFromTestMixinBase, IODirectTestBase
+
+
+###############################################################################
+
+
+class ToFromCosmologyTestMixin(ToFromTestMixinBase):
+    """
+    Tests for a Cosmology[To/From]Format with ``format="astropy.cosmology"``.
+    This class will not be directly called by :mod:`pytest` since its name does
+    not begin with ``Test``. To activate the contained tests this class must
+    be inherited in a subclass. Subclasses must define a :func:`pytest.fixture`
+    ``cosmo`` that returns/yields an instance of a |Cosmology|.
+    See ``TestCosmology`` for an example.
+    """
+
+    def test_to_cosmology_default(self, cosmo, to_format):
+        """Test cosmology -> cosmology."""
+        newcosmo = to_format("astropy.cosmology")
+        assert newcosmo is cosmo
+
+    def test_from_not_cosmology(self, cosmo, from_format):
+        """Test incorrect type in ``Cosmology``."""
+        with pytest.raises(TypeError):
+            from_format("NOT A COSMOLOGY", format="astropy.cosmology")
+
+    def test_from_cosmology_default(self, cosmo, from_format):
+        """Test cosmology -> cosmology."""
+        newcosmo = from_format(cosmo)
+        assert newcosmo is cosmo
+
+
+class TestToFromCosmology(IODirectTestBase, ToFromCosmologyTestMixin):
+    """Directly test ``to/from_cosmology``."""
+
+    def setup_class(self):
+        self.functions = {"to": to_cosmology, "from": from_cosmology}

--- a/docs/changes/cosmology/12736.feature.rst
+++ b/docs/changes/cosmology/12736.feature.rst
@@ -1,0 +1,1 @@
+Register format "astropy.cosmology" with Cosmology I/O.

--- a/docs/cosmology/io.rst
+++ b/docs/cosmology/io.rst
@@ -95,14 +95,15 @@ To see the a list of the available conversion formats:
 
     >>> from astropy.cosmology import Cosmology
     >>> Cosmology.to_format.list_formats()
-        Format    Read Write Auto-identify
-    ------------- ---- ----- -------------
-    astropy.model  Yes   Yes           Yes
-      astropy.row  Yes   Yes           Yes
-    astropy.table  Yes   Yes           Yes
-          mapping  Yes   Yes           Yes
-        mypackage  Yes   Yes           Yes
-             yaml  Yes   Yes            No
+          Format      Read Write Auto-identify
+    ----------------- ---- ----- -------------
+    astropy.cosmology  Yes   Yes           Yes
+        astropy.model  Yes   Yes           Yes
+          astropy.row  Yes   Yes           Yes
+        astropy.table  Yes   Yes           Yes
+              mapping  Yes   Yes           Yes
+            mypackage  Yes   Yes           Yes
+                 yaml  Yes   Yes            No
 
 This list will include both built-in and registered 3rd-party formats.
 For instance, in the above, "mapping" is built-in while "mypackage" and


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

Mostly for completeness and symmetry if/when 3rd party I/O is registered. Also it means cosmologies don't have to be checked before passing them through `Cosmology.from_format`

This could be a nice way to process arbitrary input that might be a cosmology, even if it's a dictionary or table or something else.
```python
some_obj = pickle.load(...)
try:
    cosmo = Cosmology.from_format(some_obj)
except...
```

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
