### PR TITLE
BUG: spectral coordinates redshift should be Quantity

### DIFF
--- a/astropy/coordinates/spectral_coordinate.py
+++ b/astropy/coordinates/spectral_coordinate.py
@@ -24,7 +24,6 @@ class NoDistanceWarning(AstropyUserWarning):
 
 
 KMS = u.km / u.s
-C_KMS = c.to(KMS)
 ZERO_VELOCITIES = CartesianDifferential([0, 0, 0] * KMS)
 
 # Default distance to use for target when none is provided
@@ -457,10 +456,10 @@ class SpectralCoord(SpectralQuantity):
 
         Returns
         -------
-        float
+        `astropy.units.Quantity`
             Redshift of target.
         """
-        return self.radial_velocity.to(u.dimensionless_unscaled, u.doppler_redshift()).value
+        return self.radial_velocity.to(u.dimensionless_unscaled, u.doppler_redshift())
 
     @staticmethod
     def _calculate_radial_velocity(observer, target, as_scalar=False):

--- a/astropy/coordinates/tests/test_spectral_coordinate.py
+++ b/astropy/coordinates/tests/test_spectral_coordinate.py
@@ -314,6 +314,7 @@ def test_rv_redshift_initialization():
     # Check that setting the redshift sets the radial velocity appropriately,
     # and that the redshift can be recovered
     sc_init = SpectralCoord([4000, 5000]*u.AA, redshift=1)
+    assert isinstance(sc_init.redshift, u.Quantity)
     assert_quantity_allclose(sc_init.redshift, 1*u.dimensionless_unscaled)
     assert_quantity_allclose(sc_init.radial_velocity, 0.6 * c)
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to fix a bug I introduced in #12709 because I did not realize the docstring was wrong. As a result, this broke `specutils` because it expects redshift as `Quantity`.

```
>       assert_allclose(spec_coll.spectral_axis.redshift.value, 0.1)
E       AttributeError: 'numpy.float64' object has no attribute 'value'
```

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes spacetelescope/jdaviz#1039

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
