### PR TITLE
Allow extending equivalence with `from_format`

### DIFF
--- a/astropy/cosmology/connect.py
+++ b/astropy/cosmology/connect.py
@@ -185,8 +185,9 @@ class CosmologyFromFormat(io_registry.UnifiedReadWrite):
         The object to parse according to 'format'
     *args
         Positional arguments passed through to data parser.
-    format : str (optional, keyword-only)
-        Object format specifier.
+    format : str or None, optional keyword-only
+        Object format specifier. For `None` (default) CosmologyFromFormat tries
+        to identify the correct format.
     **kwargs
         Keyword arguments passed through to data parser.
 
@@ -200,7 +201,7 @@ class CosmologyFromFormat(io_registry.UnifiedReadWrite):
     def __init__(self, instance, cosmo_cls):
         super().__init__(instance, cosmo_cls, "read", registry=convert_registry)
 
-    def __call__(self, obj, *args, **kwargs):
+    def __call__(self, obj, *args, format=None, **kwargs):
         from astropy.cosmology.core import Cosmology
 
         # so subclasses can override, also pass the class as a kwarg.
@@ -217,7 +218,7 @@ class CosmologyFromFormat(io_registry.UnifiedReadWrite):
                     f"{valid[0]} or its qualified name '{valid[1]}'")
 
         with add_enabled_units(cu):
-            cosmo = self.registry.read(self._cls, obj, *args, **kwargs)
+            cosmo = self.registry.read(self._cls, obj, *args, format=format, **kwargs)
 
         return cosmo
 

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -243,14 +243,16 @@ class Cosmology(metaclass=abc.ABCMeta):
             False
 
         Also, using the keyword argument, the notion of equivalence is extended
-        to any Python object that can be converted to a |Cosmology|. The list
-        of valid formats, e.g. the |Table| in this example, may be checked with
-        ``Cosmology.from_format.list_formats()``
+        to any Python object that can be auto-identified and converted to a
+        |Cosmology|.
 
             >>> from astropy.cosmology import Planck18
             >>> tbl = Planck18.to_format("astropy.table")
             >>> Planck18.is_equivalent(tbl, strict_format=False)
             True
+
+        The list of valid formats, e.g. the |Table| in this example, may be
+        checked with ``Cosmology.from_format.list_formats()``
         """
         # Allow for different formats to be considered equivalent.
         if not strict_format:

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -202,7 +202,7 @@ class Cosmology(metaclass=abc.ABCMeta):
     # ---------------------------------------------------------------
     # comparison methods
 
-    def is_equivalent(self, other):
+    def is_equivalent(self, other, *, strict_format=True):
         r"""Check equivalence between Cosmologies.
 
         Two cosmologies may be equivalent even if not the same class.
@@ -213,12 +213,52 @@ class Cosmology(metaclass=abc.ABCMeta):
         ----------
         other : `~astropy.cosmology.Cosmology` subclass instance
             The object in which to compare.
+        strict_format : bool, optional keyword-only
+            Whether to allow, before equivalence is checked, the object to be
+            converted to a |Cosmology|. This allows, e.g. a |Table| to be
+            equivalent to a Cosmology.
 
         Returns
         -------
         bool
             True if cosmologies are equivalent, False otherwise.
+
+        Examples
+        --------
+        Two cosmologies may be equivalent even if not of the same class.
+        In this examples the ``LambdaCDM`` has ``Ode0`` set to the same value
+        calculated in ``FlatLambdaCDM``.
+
+            >>> import astropy.units as u
+            >>> from astropy.cosmology import LambdaCDM, FlatLambdaCDM
+            >>> cosmo1 = LambdaCDM(70 * (u.km/u.s/u.Mpc), 0.3, 0.7)
+            >>> cosmo2 = FlatLambdaCDM(70 * (u.km/u.s/u.Mpc), 0.3)
+            >>> cosmo1.is_equivalent(cosmo2)
+            True
+
+        While in this example, the cosmologies are not equivalent.
+
+            >>> cosmo3 = FlatLambdaCDM(70 * (u.km/u.s/u.Mpc), 0.3, Tcmb0=3 * u.K)
+            >>> cosmo3.is_equivalent(cosmo2)
+            False
+
+        Also, using the keyword argument, the notion of equivalence is extended
+        to any Python object that can be converted to a |Cosmology|. The list
+        of valid formats, e.g. the |Table| in this example, may be checked with
+        ``Cosmology.from_format.list_formats()``
+
+            >>> from astropy.cosmology import Planck18
+            >>> tbl = Planck18.to_format("astropy.table")
+            >>> Planck18.is_equivalent(tbl, strict_format=False)
+            True
         """
+        # Allow for different formats to be considered equivalent.
+        if not strict_format:
+            try:
+                other = Cosmology.from_format(other)
+            except Exception:
+                return False
+
         # The options are: 1) same class & parameters; 2) same class, different
         # parameters; 3) different classes, equivalent parameters; 4) different
         # classes, different parameters. (1) & (3) => True, (2) & (4) => False.
@@ -266,7 +306,7 @@ class Cosmology(metaclass=abc.ABCMeta):
         Returns
         -------
         bool
-            True if Parameters and names are the same, False otherwise.
+            `True` if Parameters and names are the same, `False` otherwise.
         """
         if other.__class__ is not self.__class__:
             return NotImplemented  # allows other.__eq__

--- a/astropy/cosmology/io/tests/test_cosmology.py
+++ b/astropy/cosmology/io/tests/test_cosmology.py
@@ -38,6 +38,21 @@ class ToFromCosmologyTestMixin(ToFromTestMixinBase):
         newcosmo = from_format(cosmo)
         assert newcosmo is cosmo
 
+    @pytest.mark.parametrize("strict_format", [True, False])
+    def test_is_equivalent_to_cosmology(self, cosmo, to_format, strict_format):
+        """Test :meth:`astropy.cosmology.Cosmology.is_equivalent`.
+
+        This test checks that Cosmology equivalency can be extended to any
+        Python object that can be converted to a Cosmology -- in this case
+        a Cosmology! Since it's the identity conversion, the cosmology is
+        always equivalent to itself, regardless of ``strict_format``.
+        """
+        obj = to_format("astropy.cosmology")
+        assert obj is cosmo
+
+        is_equiv = cosmo.is_equivalent(obj, strict_format=strict_format)
+        assert is_equiv is True  # equivalent to self
+
 
 class TestToFromCosmology(IODirectTestBase, ToFromCosmologyTestMixin):
     """Directly test ``to/from_cosmology``."""

--- a/astropy/cosmology/io/tests/test_cosmology.py
+++ b/astropy/cosmology/io/tests/test_cosmology.py
@@ -38,19 +38,19 @@ class ToFromCosmologyTestMixin(ToFromTestMixinBase):
         newcosmo = from_format(cosmo)
         assert newcosmo is cosmo
 
-    @pytest.mark.parametrize("strict_format", [True, False])
-    def test_is_equivalent_to_cosmology(self, cosmo, to_format, strict_format):
+    @pytest.mark.parametrize("format", [True, False, None, "astropy.cosmology"])
+    def test_is_equivalent_to_cosmology(self, cosmo, to_format, format):
         """Test :meth:`astropy.cosmology.Cosmology.is_equivalent`.
 
         This test checks that Cosmology equivalency can be extended to any
         Python object that can be converted to a Cosmology -- in this case
         a Cosmology! Since it's the identity conversion, the cosmology is
-        always equivalent to itself, regardless of ``strict_format``.
+        always equivalent to itself, regardless of ``format``.
         """
         obj = to_format("astropy.cosmology")
         assert obj is cosmo
 
-        is_equiv = cosmo.is_equivalent(obj, strict_format=strict_format)
+        is_equiv = cosmo.is_equivalent(obj, format=format)
         assert is_equiv is True  # equivalent to self
 
 

--- a/astropy/cosmology/io/tests/test_mapping.py
+++ b/astropy/cosmology/io/tests/test_mapping.py
@@ -185,6 +185,20 @@ class ToFromMappingTestMixin(ToFromTestMixinBase):
         # but the metadata is the same
         assert got.meta == cosmo.meta
 
+    @pytest.mark.parametrize("strict_format", [True, False])
+    def test_is_equivalent_to_mapping(self, cosmo, to_format, strict_format):
+        """Test :meth:`astropy.cosmology.Cosmology.is_equivalent`.
+
+        This test checks that Cosmology equivalency can be extended to any
+        Python object that can be converted to a Cosmology -- in this case
+        a mapping.
+        """
+        obj = to_format("mapping")
+        assert not isinstance(obj, Cosmology)
+
+        is_equiv = cosmo.is_equivalent(obj, strict_format=strict_format)
+        assert is_equiv is not strict_format
+
 
 class TestToFromMapping(ToFromDirectTestBase, ToFromMappingTestMixin):
     """Directly test ``to/from_mapping``."""

--- a/astropy/cosmology/io/tests/test_mapping.py
+++ b/astropy/cosmology/io/tests/test_mapping.py
@@ -185,8 +185,8 @@ class ToFromMappingTestMixin(ToFromTestMixinBase):
         # but the metadata is the same
         assert got.meta == cosmo.meta
 
-    @pytest.mark.parametrize("strict_format", [True, False])
-    def test_is_equivalent_to_mapping(self, cosmo, to_format, strict_format):
+    @pytest.mark.parametrize("format", [True, False, None, "mapping"])
+    def test_is_equivalent_to_mapping(self, cosmo, to_format, format):
         """Test :meth:`astropy.cosmology.Cosmology.is_equivalent`.
 
         This test checks that Cosmology equivalency can be extended to any
@@ -196,8 +196,8 @@ class ToFromMappingTestMixin(ToFromTestMixinBase):
         obj = to_format("mapping")
         assert not isinstance(obj, Cosmology)
 
-        is_equiv = cosmo.is_equivalent(obj, strict_format=strict_format)
-        assert is_equiv is not strict_format
+        is_equiv = cosmo.is_equivalent(obj, format=format)
+        assert is_equiv is (True if format is not False else False)
 
 
 class TestToFromMapping(ToFromDirectTestBase, ToFromMappingTestMixin):

--- a/astropy/cosmology/io/tests/test_model.py
+++ b/astropy/cosmology/io/tests/test_model.py
@@ -159,6 +159,23 @@ class ToFromModelTestMixin(ToFromTestMixinBase):
         """
         pass  # there's no partial information with a Model
 
+    @pytest.mark.parametrize("strict_format", [True, False])
+    def test_is_equivalent_to_model(self, cosmo, method_name, to_format, strict_format):
+        """Test :meth:`astropy.cosmology.Cosmology.is_equivalent`.
+
+        This test checks that Cosmology equivalency can be extended to any
+        Python object that can be converted to a Cosmology -- in this case
+        a model.
+        """
+        if method_name is None:  # no test if no method
+            return
+
+        obj = to_format("astropy.model", method=method_name)
+        assert not isinstance(obj, Cosmology)
+
+        is_equiv = cosmo.is_equivalent(obj, strict_format=strict_format)
+        assert is_equiv is not strict_format
+
 
 class TestToFromModel(ToFromDirectTestBase, ToFromModelTestMixin):
     """Directly test ``to/from_model``."""

--- a/astropy/cosmology/io/tests/test_model.py
+++ b/astropy/cosmology/io/tests/test_model.py
@@ -159,8 +159,8 @@ class ToFromModelTestMixin(ToFromTestMixinBase):
         """
         pass  # there's no partial information with a Model
 
-    @pytest.mark.parametrize("strict_format", [True, False])
-    def test_is_equivalent_to_model(self, cosmo, method_name, to_format, strict_format):
+    @pytest.mark.parametrize("format", [True, False, None, "astropy.model"])
+    def test_is_equivalent_to_model(self, cosmo, method_name, to_format, format):
         """Test :meth:`astropy.cosmology.Cosmology.is_equivalent`.
 
         This test checks that Cosmology equivalency can be extended to any
@@ -173,8 +173,8 @@ class ToFromModelTestMixin(ToFromTestMixinBase):
         obj = to_format("astropy.model", method=method_name)
         assert not isinstance(obj, Cosmology)
 
-        is_equiv = cosmo.is_equivalent(obj, strict_format=strict_format)
-        assert is_equiv is not strict_format
+        is_equiv = cosmo.is_equivalent(obj, format=format)
+        assert is_equiv is (True if format is not False else False)
 
 
 class TestToFromModel(ToFromDirectTestBase, ToFromModelTestMixin):

--- a/astropy/cosmology/io/tests/test_row.py
+++ b/astropy/cosmology/io/tests/test_row.py
@@ -108,8 +108,8 @@ class ToFromRowTestMixin(ToFromTestMixinBase):
         """
         pass  # there are no partial info options
 
-    @pytest.mark.parametrize("strict_format", [True, False])
-    def test_is_equivalent_to_row(self, cosmo, to_format, strict_format):
+    @pytest.mark.parametrize("format", [True, False, None, "astropy.row"])
+    def test_is_equivalent_to_row(self, cosmo, to_format, format):
         """Test :meth:`astropy.cosmology.Cosmology.is_equivalent`.
 
         This test checks that Cosmology equivalency can be extended to any
@@ -119,8 +119,8 @@ class ToFromRowTestMixin(ToFromTestMixinBase):
         obj = to_format("astropy.row")
         assert not isinstance(obj, Cosmology)
 
-        is_equiv = cosmo.is_equivalent(obj, strict_format=strict_format)
-        assert is_equiv is not strict_format
+        is_equiv = cosmo.is_equivalent(obj, format=format)
+        assert is_equiv is (True if format is not False else False)
 
 
 class TestToFromTable(ToFromDirectTestBase, ToFromRowTestMixin):

--- a/astropy/cosmology/io/tests/test_row.py
+++ b/astropy/cosmology/io/tests/test_row.py
@@ -108,6 +108,20 @@ class ToFromRowTestMixin(ToFromTestMixinBase):
         """
         pass  # there are no partial info options
 
+    @pytest.mark.parametrize("strict_format", [True, False])
+    def test_is_equivalent_to_row(self, cosmo, to_format, strict_format):
+        """Test :meth:`astropy.cosmology.Cosmology.is_equivalent`.
+
+        This test checks that Cosmology equivalency can be extended to any
+        Python object that can be converted to a Cosmology -- in this case
+        a Row.
+        """
+        obj = to_format("astropy.row")
+        assert not isinstance(obj, Cosmology)
+
+        is_equiv = cosmo.is_equivalent(obj, strict_format=strict_format)
+        assert is_equiv is not strict_format
+
 
 class TestToFromTable(ToFromDirectTestBase, ToFromRowTestMixin):
     """

--- a/astropy/cosmology/io/tests/test_table.py
+++ b/astropy/cosmology/io/tests/test_table.py
@@ -208,8 +208,8 @@ class ToFromTableTestMixin(ToFromTestMixinBase):
         with pytest.raises(ValueError, match="more than one"):
             from_format(tbls, index=cosmo.name, format="astropy.table")
 
-    @pytest.mark.parametrize("strict_format", [True, False])
-    def test_is_equivalent_to_table(self, cosmo, to_format, strict_format):
+    @pytest.mark.parametrize("format", [True, False, None, "astropy.table"])
+    def test_is_equivalent_to_table(self, cosmo, to_format, format):
         """Test :meth:`astropy.cosmology.Cosmology.is_equivalent`.
 
         This test checks that Cosmology equivalency can be extended to any
@@ -219,8 +219,8 @@ class ToFromTableTestMixin(ToFromTestMixinBase):
         obj = to_format("astropy.table")
         assert not isinstance(obj, Cosmology)
 
-        is_equiv = cosmo.is_equivalent(obj, strict_format=strict_format)
-        assert is_equiv is not strict_format
+        is_equiv = cosmo.is_equivalent(obj, format=format)
+        assert is_equiv is (True if format is not False else False)
 
 
 class TestToFromTable(ToFromDirectTestBase, ToFromTableTestMixin):

--- a/astropy/cosmology/io/tests/test_table.py
+++ b/astropy/cosmology/io/tests/test_table.py
@@ -208,6 +208,20 @@ class ToFromTableTestMixin(ToFromTestMixinBase):
         with pytest.raises(ValueError, match="more than one"):
             from_format(tbls, index=cosmo.name, format="astropy.table")
 
+    @pytest.mark.parametrize("strict_format", [True, False])
+    def test_is_equivalent_to_table(self, cosmo, to_format, strict_format):
+        """Test :meth:`astropy.cosmology.Cosmology.is_equivalent`.
+
+        This test checks that Cosmology equivalency can be extended to any
+        Python object that can be converted to a Cosmology -- in this case
+        a |Table|.
+        """
+        obj = to_format("astropy.table")
+        assert not isinstance(obj, Cosmology)
+
+        is_equiv = cosmo.is_equivalent(obj, strict_format=strict_format)
+        assert is_equiv is not strict_format
+
 
 class TestToFromTable(ToFromDirectTestBase, ToFromTableTestMixin):
     """Directly test ``to/from_table``."""

--- a/astropy/cosmology/io/tests/test_yaml.py
+++ b/astropy/cosmology/io/tests/test_yaml.py
@@ -118,21 +118,28 @@ class ToFromYAMLTestMixin(ToFromTestMixinBase):
     #     This works with missing information.
     #     """
 
-    def test_is_equivalent_to_yaml(self, cosmo, to_format,
+    @pytest.mark.parametrize("format", [True, False, None])
+    def test_is_equivalent_to_yaml(self, cosmo, to_format, format,
                                    xfail_if_not_registered_with_yaml):
         """Test :meth:`astropy.cosmology.Cosmology.is_equivalent`.
 
         This test checks that Cosmology equivalency can be extended to any
         Python object that can be converted to a Cosmology -- in this case
-        a YAML string. YAML can't be identified without "format" specified,
-        which it can't be in :meth:`astropy.cosmology.Cosmology.is_equivalent`,
-        so ``is_equivalent`` is always `False`.
+        a YAML string. YAML can't be identified without "format" specified.
         """
         obj = to_format("yaml")
         assert not isinstance(obj, Cosmology)
 
-        is_equiv = cosmo.is_equivalent(obj, strict_format=False)
+        is_equiv = cosmo.is_equivalent(obj, format=format)
         assert is_equiv is False
+
+    def test_is_equivalent_to_yaml_specify_format(self, cosmo, to_format,
+                                                  xfail_if_not_registered_with_yaml):
+        """Test :meth:`astropy.cosmology.Cosmology.is_equivalent`.
+
+        Same as ``test_is_equivalent_to_yaml`` but with ``format="yaml"``.
+        """
+        assert cosmo.is_equivalent(to_format("yaml"), format="yaml") is True
 
 
 class TestToFromYAML(ToFromDirectTestBase, ToFromYAMLTestMixin):

--- a/astropy/cosmology/io/tests/test_yaml.py
+++ b/astropy/cosmology/io/tests/test_yaml.py
@@ -1,28 +1,20 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 # STDLIB
-import copy
 import inspect
-from collections import OrderedDict
 
 # THIRD PARTY
 import pytest
 
 # LOCAL
-import astropy.cosmology.units as cu
 import astropy.units as u
-from astropy.cosmology import Cosmology, FlatLambdaCDM, Planck18, realizations
-from astropy.cosmology.core import _COSMOLOGY_CLASSES, Parameter
+from astropy.cosmology import Cosmology, FlatLambdaCDM, Planck18
+from astropy.cosmology import units as cu
 from astropy.cosmology.io.yaml import from_yaml, to_yaml, yaml_constructor, yaml_representer
-from astropy.cosmology.parameters import available
-from astropy.io.misc.yaml import AstropyDumper, AstropyLoader, dump, load
+from astropy.io.misc.yaml import AstropyDumper, dump, load
 from astropy.table import QTable, vstack
 
 from .base import ToFromDirectTestBase, ToFromTestMixinBase
-
-cosmo_instances = [getattr(realizations, name) for name in available]
-# cosmo_instances.append("TestToFromYAML.setup.<locals>.CosmologyWithKwargs")
-
 
 ##############################################################################
 # Test Serializer
@@ -71,20 +63,20 @@ class ToFromYAMLTestMixin(ToFromTestMixinBase):
     """
 
     @pytest.fixture
-    def registered_with_yaml(self, cosmo_cls):
+    def xfail_if_not_registered_with_yaml(self, cosmo_cls):
         """
         YAML I/O only works on registered classes. So the thing to check is
-        if this class is registered. If not, skip this test.
+        if this class is registered. If not, :func:`pytest.xfail` this test.
         Some of the tests define custom cosmologies. They are not registered.
         """
-        return True if cosmo_cls in AstropyDumper.yaml_representers else False
+        if cosmo_cls not in AstropyDumper.yaml_representers:
+            pytest.xfail(f"Cosmologies of type {cosmo_cls} are not registered with YAML.")
+
+    # ===============================================================
 
     def test_tofrom_yaml_instance(self, cosmo, to_format, from_format,
-                                  registered_with_yaml):
+                                  xfail_if_not_registered_with_yaml):
         """Test cosmology -> YAML -> cosmology."""
-        if not registered_with_yaml:
-            return
-
         # ------------
         # To YAML
 
@@ -106,17 +98,15 @@ class ToFromYAMLTestMixin(ToFromTestMixinBase):
         assert got.meta == cosmo.meta
 
         # auto-identify test moved because it doesn't work.
+        # see test_tofrom_yaml_autoidentify
 
     def test_tofrom_yaml_autoidentify(self, cosmo, to_format, from_format,
-                                      registered_with_yaml):
+                                      xfail_if_not_registered_with_yaml):
         """As a non-path string, it does NOT auto-identifies 'format'.
 
         TODO! this says there should be different types of I/O registries.
               not just hacking object conversion on top of file I/O.
         """
-        if not registered_with_yaml:
-            return
-
         yml = to_format('yaml')
         with pytest.raises((FileNotFoundError, OSError)):  # OSError in Windows
             from_format(yml)
@@ -127,6 +117,22 @@ class ToFromYAMLTestMixin(ToFromTestMixinBase):
     #     Test writing from an instance and reading from that class.
     #     This works with missing information.
     #     """
+
+    def test_is_equivalent_to_yaml(self, cosmo, to_format,
+                                   xfail_if_not_registered_with_yaml):
+        """Test :meth:`astropy.cosmology.Cosmology.is_equivalent`.
+
+        This test checks that Cosmology equivalency can be extended to any
+        Python object that can be converted to a Cosmology -- in this case
+        a YAML string. YAML can't be identified without "format" specified,
+        which it can't be in :meth:`astropy.cosmology.Cosmology.is_equivalent`,
+        so ``is_equivalent`` is always `False`.
+        """
+        obj = to_format("yaml")
+        assert not isinstance(obj, Cosmology)
+
+        is_equiv = cosmo.is_equivalent(obj, strict_format=False)
+        assert is_equiv is False
 
 
 class TestToFromYAML(ToFromDirectTestBase, ToFromYAMLTestMixin):

--- a/astropy/cosmology/tests/test_connect.py
+++ b/astropy/cosmology/tests/test_connect.py
@@ -163,8 +163,8 @@ class ToFromFormatTestMixin(test_cosmology.ToFromCosmologyTestMixin,
         got = Cosmology.from_format(obj, format=format)
         # and autodetect
         got2 = Cosmology.from_format(obj)
-
         assert got2 == got  # internal consistency
+
         assert got == cosmo  # external consistency
         assert got.meta == cosmo.meta
 
@@ -182,8 +182,8 @@ class ToFromFormatTestMixin(test_cosmology.ToFromCosmologyTestMixin,
         # read with the same class that wrote.
         got = cosmo_cls.from_format(obj, format=format)
         got2 = Cosmology.from_format(obj)  # and autodetect
-
         assert got2 == got  # internal consistency
+
         assert got == cosmo  # external consistency
         assert got.meta == cosmo.meta
 

--- a/astropy/cosmology/tests/test_core.py
+++ b/astropy/cosmology/tests/test_core.py
@@ -269,7 +269,7 @@ class TestCosmology(ParameterTestMixin, MetaTestMixin,
         assert cosmo.is_equivalent(newclone)
         assert newclone.is_equivalent(cosmo)
 
-        # different class
+        # different class and not convertible to Cosmology.
         assert not cosmo.is_equivalent(2)
 
     def test_equality(self, cosmo):

--- a/docs/changes/cosmology/12740.feature.rst
+++ b/docs/changes/cosmology/12740.feature.rst
@@ -1,4 +1,4 @@
 Cosmological equivalency (``Cosmology.is_equivalent``) can now be extended
 to any Python object that can be converted to a Cosmology, using the new
-keyword argument ``strict_format``.
+keyword argument ``format``.
 This allows e.g. a properly formatted Table to be equivalent to a Cosmology.

--- a/docs/changes/cosmology/12740.feature.rst
+++ b/docs/changes/cosmology/12740.feature.rst
@@ -1,0 +1,4 @@
+Cosmological equivalency (``Cosmology.is_equivalent``) can now be extended
+to any Python object that can be converted to a Cosmology, using the new
+keyword argument ``strict_format``.
+This allows e.g. a properly formatted Table to be equivalent to a Cosmology.

--- a/docs/whatsnew/5.1.rst
+++ b/docs/whatsnew/5.1.rst
@@ -30,13 +30,12 @@ Astropy v5.0 introduced Cosmological equivalency -- with method
 be equivalent even if not of the same class. For example, an instance of
 :class:`~astropy.cosmology.LambdaCDM` might have :math:`\Omega_0=1` and
 :math:`\Omega_k=0` and therefore be flat, like ``FlatLambdaCDM``.
-Now the keyword argument ``strict_format`` is added to extend the notion of
-equivalence to any Python object that can be auto-identified and converted to a
-Cosmology.
+Now the keyword argument ``format`` is added to extend the notion of
+equivalence to any Python object that can be converted to a Cosmology.
 
     >>> from astropy.cosmology import Planck18
     >>> tbl = Planck18.to_format("astropy.table")
-    >>> Planck18.is_equivalent(tbl, strict_format=False)
+    >>> Planck18.is_equivalent(tbl, format=True)
     True
 
 The list of valid formats, e.g. the Table in this example, may be

--- a/docs/whatsnew/5.1.rst
+++ b/docs/whatsnew/5.1.rst
@@ -12,10 +12,10 @@ the 5.0 LTS release.
 
 In particular, this release includes:
 
-* :ref:`whatsnew-5.0-cosmology`
+* :ref:`whatsnew-5.1-cosmology`
 * :ref:`whatsnew-doppler-redshift-eq`
 
-.. _whatsnew-5.0-cosmology:
+.. _whatsnew-5.1-cosmology:
 
 Updates to ``Cosmology``
 ========================
@@ -23,7 +23,25 @@ Updates to ``Cosmology``
 :class:`~astropy.cosmology.Cosmology` is now an abstract base class,
 and subclasses must override the abstract property ``is_flat``.
 For :class:`~astropy.cosmology.FLRW`, ``is_flat`` checks that ``Ok0=0`` and
-``Omtot0=1``.
+``Otot0=1``.
+
+Astropy v5.0 introduced Cosmological equivalency -- with method
+:meth:`~astropy.cosmology.Cosmology.is_equivalent` -- where two cosmologies may
+be equivalent even if not of the same class. For example, an instance of
+:class:`~astropy.cosmology.LambdaCDM` might have :math:`\Omega_0=1` and
+:math:`\Omega_k=0` and therefore be flat, like ``FlatLambdaCDM``.
+Now the keyword argument ``strict_format`` is added to extend the notion of
+equivalence to any Python object that can be auto-identified and converted to a
+Cosmology.
+
+    >>> from astropy.cosmology import Planck18
+    >>> tbl = Planck18.to_format("astropy.table")
+    >>> Planck18.is_equivalent(tbl, strict_format=False)
+    True
+
+The list of valid formats, e.g. the Table in this example, may be
+checked with ``Cosmology.from_format.list_formats()``
+
 
 .. _whatsnew-doppler-redshift-eq:
 


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

Cosmological equivalency (``Cosmology.is_equivalent``) can now be extended
 to any Python object that can be converted to a Cosmology, using the new
 keyword argument ``strict_format``.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
