### PR TITLE
Make ndarray Parameters read-only

### DIFF
--- a/astropy/cosmology/parameter.py
+++ b/astropy/cosmology/parameter.py
@@ -1,5 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+import copy
+
 import astropy.units as u
 from astropy.utils.decorators import classproperty
 
@@ -110,19 +112,26 @@ class Parameter:
     # descriptor and property-like methods
 
     def __get__(self, cosmology, cosmo_cls=None):
-        # get from class
+        # Get from class
         if cosmology is None:
             return self
+        # Get from instance
         return getattr(cosmology, self._attr_name_private)
 
     def __set__(self, cosmology, value):
         """Allows attribute setting once. Raises AttributeError subsequently."""
-        # raise error if setting 2nd time.
+        # Raise error if setting 2nd time.
         if hasattr(cosmology, self._attr_name_private):
-            raise AttributeError("can't set attribute")
+            raise AttributeError(f"can't set attribute {self._attr_name} again")
 
-        # validate value, generally setting units if present
-        value = self.validate(cosmology, value)
+        # Validate value, generally setting units if present
+        value = self.validate(cosmology, copy.deepcopy(value))
+
+        # Make the value read-only, if ndarray-like
+        if hasattr(value, "setflags"):
+            value.setflags(write=False)
+
+        # Set the value on the cosmology
         setattr(cosmology, self._attr_name_private, value)
 
     # -------------------------------------------
@@ -130,7 +139,7 @@ class Parameter:
 
     @property
     def fvalidate(self):
-        """Function to validate a potential value of this Parameter.."""
+        """Function to validate a potential value of this Parameter."""
         return self._fvalidate
 
     def validator(self, fvalidate):


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

More immutability protections.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
