### PR TITLE
Refactor core package release notes

### DIFF
--- a/docs/development/astropy-package-template.rst
+++ b/docs/development/astropy-package-template.rst
@@ -13,6 +13,8 @@ repository, as well as reusing much of the helper code used to organize
 for instructions on using the package template.
 
 
+.. _simple-release-docs:
+
 Releasing a Python package
 **************************
 

--- a/docs/development/releasing.rst
+++ b/docs/development/releasing.rst
@@ -268,8 +268,9 @@ Tagging the first release candidate
 
 Assuming all the CI passes, you should now be ready to do a first release
 candidate! Ensure you have a GPG key pair available for when git needs to sign
-the tag you create for the release.  See :ref:`key-signing-info` for more on
-this.
+the tag you create for the release (see e.g.,
+`GitHub's documentation <https://docs.github.com/en/authentication/managing-commit-signature-verification/generating-a-new-gpg-key>`_
+for how to generate a key pair).
 
 Make sure your local release branch is up-to-date with the upstream release
 branch, then tag the latest commit with the ``-s`` option, including an ``rc1``
@@ -643,132 +644,6 @@ will involve followup commits that need to back backported as well.  Most bug
 fixes will have an issues associated with it in the issue tracker, so make sure
 to reference all commits related to that issue in the commit message.  That way
 it's harder for commits that need to be backported from getting lost.
-
-.. _key-signing-info:
-
-Creating a GPG Signing Key and a Signed Tag
--------------------------------------------
-
-One of the main steps in performing a release is to create a tag in the git
-repository representing the exact state of the repository that represents the
-version being released.  For Astropy we will always use `signed tags`_: A
-signed tag is annotated with the name and e-mail address of the signer, a date
-and time, and a checksum of the code in the tag.  This information is then
-signed with a GPG private key and stored in the repository.
-
-Using a signed tag ensures the integrity of the contents of that tag for the
-future.  On a distributed VCS like git, anyone can create a tag of Astropy
-called "0.1" in their repository--and where it's easy to monkey around even
-after the tag has been created.  But only one "0.1" will be signed by one of
-the Astropy Project coordinators and will be verifiable with their public key.
-
-Generating a public/private key pair
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Git uses GPG to created signed tags, so in order to perform an Astropy release
-you will need GPG installed and will have to generated a signing key pair.
-Most \*NIX installations come with GPG installed by default (as it is used to
-verify the integrity of system packages).  If you don't have the ``gpg``
-command, consult the documentation for your system on how to install it.
-
-For OSX, GPG can be installed from MacPorts using ``sudo port install gnupg``.
-
-To create a new public/private key pair, run::
-
-    $ gpg --gen-key
-
-This will take you through a few interactive steps. For the encryption
-and expiry settings, it should be safe to use the default settings (I use
-a key size of 4096 just because what does a couple extra kilobytes
-hurt?) Enter your full name, preferably including your middle name or
-middle initial, and an e-mail address that you expect to be active for a
-decent amount of time. Note that this name and e-mail address must match
-the info you provide as your git configuration, so you should either
-choose the same name/e-mail address when you create your key, or update
-your git configuration to match the key info. Finally, choose a very good
-pass phrase that won't be easily subject to brute force attacks.
-
-
-If you expect to use the same key for some time, it's good to make a backup of
-both your public and private key::
-
-    $ gpg --export --armor > public.key
-    $ gpg --export-secret-key --armor > private.key
-
-Back up these files to a trusted location--preferably a write-once physical
-medium that can be stored safely somewhere.  One may also back up their keys to
-a trusted online encrypted storage, though some might not find that secure
-enough--it's up to you and what you're comfortable with.
-
-Add your public key to a keyserver
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Now that you have a public key, you can publish this anywhere you like--in your
-e-mail, in a public code repository, etc.  You can also upload it to a
-dedicated public OpenPGP keyserver.  This will store the public key
-indefinitely (until you manually revoke it), and will be automatically synced
-with other keyservers around the world.  That makes it easy to retrieve your
-public key using the gpg command-line tool.
-
-To do this you will need your public key's keyname.  To find this enter::
-
-    $ gpg --list-keys
-
-This will output something like::
-
-    /path/to/.gnupg/pubring.gpg
-    ---------------------------------------------
-    pub   4096D/1234ABCD 2012-01-01
-    uid                  Your Name <your_email>
-    sub   4096g/567890EF 2012-01-01
-
-The 8 digit hex number on the line starting with "pub"--in this example the
-"1234ABCD" unique keyname for your public key.  To push it to a keyserver
-enter::
-
-    $ gpg --send-keys 1234ABCD
-
-But replace the 1234ABCD with the keyname for your public key.  Most systems
-come configured with a sensible default keyserver, so you shouldn't have to
-specify any more than that.
-
-Create a tag
-^^^^^^^^^^^^
-
-Now test creating a signed tag in git.  It's safe to experiment with this--you
-can always delete the tag before pushing it to a remote repository::
-
-    $ git tag -s v0.1 -m "Astropy version 0.1"
-
-This will ask for the password to unlock your private key in order to sign
-the tag with it.  Confirm that the default signing key selected by git is the
-correct one (it will be if you only have one key).
-
-Once the tag has been created, you can verify it with::
-
-    $ git tag -v v0.1
-
-This should output something like::
-
-    object e8e3e3edc82b02f2088f4e974dbd2fe820c0d934
-    type commit
-    tag v0.1
-    tagger Your Name <your_email> 1339779534 -0400
-
-    Astropy version 0.1
-    gpg: Signature made Fri 15 Jun 2012 12:59:04 PM EDT using DSA key ID 0123ABCD
-    gpg: Good signature from "Your Name <your_email>"
-
-You can use this to verify signed tags from any repository as long as you have
-the signer's public key in your keyring.  In this case you signed the tag
-yourself, so you already have your public key.
-
-Note that if you are planning to do a release following the steps below, you
-will want to delete the tag you just created, because the release script does
-that for you.  You can delete this tag by doing::
-
-    $ git tag -d v0.1
-
 
 .. _astropy core repository: https://github.com/astropy/astropy
 .. _signed tags: https://git-scm.com/book/en/v2/Git-Basics-Tagging#Signed-Tags

--- a/docs/development/releasing.rst
+++ b/docs/development/releasing.rst
@@ -341,6 +341,11 @@ Releasing the final version of the major release
 Rendering the changelog
 -----------------------
 
+.. warning:: Make sure that you have a very recent version of towncrier - at the time of
+             writing you will need the 21.9.0rc1 pre-release for things to work correctly::
+
+                $ pip install towncrier==21.9.0rc1
+
 We now need to render the changelog with towncrier. Since it is a good idea to
 review the changelog and fix any line wrap and other issues, we do this on
 a separate branch and open a pull request into the release branch to allow for
@@ -351,7 +356,10 @@ branch, e.g.::
 
 Next, run towncrier and confirm that the fragments can be deleted::
 
-      towncrier --version 5.0
+      towncrier build --version 5.0
+
+Check the ``CHANGES.rst`` file and remove any empty sections from the new
+changelog section.
 
 Then add and commit those changes with::
 
@@ -398,8 +406,17 @@ Post-Release procedures
       $ git reset --hard v<version>
       $ git push upstream stable --force
 
+#. If this is an LTS release (whether or not it is being supported alongside
+   a more recent version), update the "LTS" branch to ponit to the new LTS
+   release:
+
+      $ git checkout LTS
+      $ git reset --hard v<version>
+      $ git push upstream LTS --force
+
 #. Update Readthedocs so that it builds docs for the version you just released.
-   You'll find this in the "admin" tab, with checkboxes next to each github tag.
+   You'll find this in the "Admin" tab, in the "Edit Versions" section --
+   click on "Activate" for the tag of the release you have just done.
    Also verify that the ``stable`` Readthedocs version builds correctly for
    the new version (it should trigger automatically once you've done the
    previous step).
@@ -410,11 +427,9 @@ Post-Release procedures
    cluttering the list of versions that users see in the version dropdown
    (the previous versions are still accessible by their URL though).
 
-#. Update the Astropy web site by editing the ``index.html`` page at
-   https://github.com/astropy/astropy.github.com by changing the "current
-   version" link and/or updating the list of older versions if this is an LTS
-   bugfix or a new major version.  You may also need to update the contributor
-   list on the web site if you updated the ``docs/credits.rst`` at the outset.
+#. If you have updated the list of contributors during the release, update the
+   equivalent list on the Astropy web site at
+   https://github.com/astropy/astropy.github.com.
 
 #. Cherry-pick the commit rendering the changelog and deleting the fragments and
    open a PR to the astropy *main* branch. Also make sure you cherry-pick the
@@ -434,7 +449,7 @@ Post-Release procedures
 
 #. Upload the release to Zenodo by creating a GitHub Release off the GitHub tag.
    Click on the tag in https://github.com/astropy/astropy/tags and then click on
-   the "Edit tag" button on the upper right. The release title is the same as the
+   "Create release from tag" on the upper right. The release title is the same as the
    tag. In the description, you can copy and paste a description from the previous
    release, as it should be a one-liner that points to ``CHANGES.rst``. When you
    are ready, click "Publish release" (the green button on bottom left).
@@ -502,6 +517,7 @@ in a similar way to the initial major release:
 
 * :ref:`release-procedure-update-iers` (this should be done in ``main`` and backport it)
 * :ref:`release-procedure-check-ci`
+* :ref:`render-changelog`
 
 You can then proceed with tagging the bugfix release. Make sure your local
 release branch is up-to-date with the upstream release branch, then tag the

--- a/docs/development/releasing.rst
+++ b/docs/development/releasing.rst
@@ -259,7 +259,7 @@ Do not render the changelog with towncrier at this point. This should only be do
 release. However, it is up to the discretion of the release manager whether to
 open 'practice' pull requests to do this as part of the beta/release candidate
 process (but they should not be merged in) - if so the process for rendering the changelog is described
-in :ref:`render-changelog`.
+in :ref:`release-procedure-render-changelog`.
 
 .. _release-procedure-tagging:
 
@@ -336,7 +336,7 @@ come up with a release candidate, you are ready to proceed to the next section.
 Releasing the final version of the major release
 ================================================
 
-.. _render-changelog:
+.. _release-procedure-render-changelog:
 
 Rendering the changelog
 -----------------------
@@ -379,6 +379,16 @@ rendering from the non-LTS release branch should be forward-ported to ``main``.
    rather than rendering on ``main`` and backporting, since the latter would
    render all news fragments into the changelog rather than only the ones
    intended for the e.g. v5.0.x release branch.
+
+.. _release-procedure-checking-changelog:
+
+Checking the changelog
+----------------------
+
+Scripts are provided at https://github.com/astropy/astropy-tools/tree/main/pr_consistency
+to check for consistency between milestones, labels, the presence of pull requests
+in release branches, and the changelog. Follow the instructions in that repository
+to make sure everything is correct for the present release.
 
 Tagging the final release
 -------------------------
@@ -517,7 +527,8 @@ in a similar way to the initial major release:
 
 * :ref:`release-procedure-update-iers` (this should be done in ``main`` and backport it)
 * :ref:`release-procedure-check-ci`
-* :ref:`render-changelog`
+* :ref:`release-procedure-render-changelog`
+* :ref:`release-procedure-checking-changelog`
 
 You can then proceed with tagging the bugfix release. Make sure your local
 release branch is up-to-date with the upstream release branch, then tag the
@@ -632,76 +643,6 @@ will involve followup commits that need to back backported as well.  Most bug
 fixes will have an issues associated with it in the issue tracker, so make sure
 to reference all commits related to that issue in the commit message.  That way
 it's harder for commits that need to be backported from getting lost.
-
-.. _pr-consistency:
-
-Checking for consistency between pull request milestones, release branches, and changelog entries
--------------------------------------------------------------------------------------------------
-
-There are a series of scripts in the
-`astropy-tools repository`_, in the ``pr_consistency`` directory that can be used to make sure
-that all milestoned and merged pull requests are included in the appropriate release branches
-and in the changelog.Detailed documentation
-for these scripts is given in their repository, but here we summarize the basic
-workflow.  Run the scripts in order (they are numbered ``1.<something>.py``,
-``2.<something>.py``, etc.), entering your github login credentials as needed
-(if you are going to run them multiple times, using a ``~/.netrc`` file is
-recommended - see `this Stack Overflow post
-<https://stackoverflow.com/questions/5343068/is-there-a-way-to-cache-github-credentials-for-pushing-commits/18362082#18362082>`_
-for more on how to do that, or
-`a similar github help page <https://help.github.com/en/articles/caching-your-github-password-in-git>`_).
-The script to actually check consistency should be run like::
-
-    $ python 4.check_consistency.py > consistency.html
-
-Which will generate a simple web page that shows all of the areas where either
-a pull request was merged into ``main`` but is *not* in the relevant release that
-it has been milestoned for, as well as any changelog irregularities (i.e., PRs
-that are in the wrong section for what the github milestone indicates).  You'll
-want to correct those irregularities *first* before starting the backport
-process (re-running the scripts in order as needed).
-
-The end of the ``consistency.html`` page will then show a series of
-``git cherry-pick`` commands to update the maintenance branch with the PRs that
-are needed to make the milestones and branches consistent.  Make sure you're in
-the correct maintenance branch with e.g.,
-
-::
-
-    $ git checkout v1.3.x
-    $ git pull upstream v1.3.x  # Or possibly a rebase if conflicts exist
-
-if you are doing bugfixes for the 1.3.x series. Go through the commands one at a
-time, following the cherry-picking procedure described above. If for some reason
-you determine the github milestone was in error and the backporting is
-impossible, re-label the issue on github and move on.  Also, whenever you
-backport a PR, it's useful to leave a comment in the issue along the lines of
-"backported this to v1.3.x as <SHA>" so that it's clear that the backport
-happened to others who might later look.
-
-.. warning::
-
-    Automated scripts are never perfect, and can either miss issues that need to
-    be backported, or in some cases can report false positives.
-
-    It's always a good idea before finalizing a bug fix release to look on
-    GitHub through the list of closed issues in the release milestone and check
-    that each one has a fix in the bug fix branch.  Usually a quick way to do
-    this is for each issue to run::
-
-        $ git log --oneline <bugfix-branch> | grep #<issue>
-
-    Most fixes will mention their related issue in the commit message, so this
-    tends to be pretty reliable.  Some issues won't show up in the commit log,
-    however, as their fix is in a separate pull request.  Usually GitHub makes
-    this clear by cross-referencing the issue with its PR.
-
-Finally, not all issues assigned to a release milestone need to be fixed before
-making that release.  Usually, in the interest of getting a release with
-existing fixes out within some schedule, it's best to triage issues that won't
-be fixed soon to a new release milestone.  If the upcoming bug fix release is
-'v5.0.2', then go ahead and create a 'v5.0.3' milestone and reassign to it any
-issues that you don't expect to be fixed in time for 'v5.0.2'.
 
 .. _key-signing-info:
 


### PR DESCRIPTION
### Description

This is an attempt to start refactoring the core package release notes to make things a bit more chronological/linear (to avoid having it as sections e.g. 'modifications for bugfix releases' and instead just outlining what the process is).

There is a LOT of stuff in this page - I wonder if e.g. the 'common procedures' could be split on to a separate page for example, especially things like creating GPG keys. I'll leave some more detailed inline comments below with ideas on simplifying this.

Also it's a bit of a challenge to avoid duplication but I've tried my best to avoid this. If we can manage to simplify the overall process we might be able to afford a little duplication between sections.

I'm going through the bugfix process right now while doing 5.0.1 so will be updating the section 'live'

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
