### PR TITLE
remove outdated note

### DIFF
--- a/astropy/cosmology/connect.py
+++ b/astropy/cosmology/connect.py
@@ -43,14 +43,6 @@ class CosmologyRead(io_registry.UnifiedReadWrite):
 
     See also: https://docs.astropy.org/en/stable/io/unified.html
 
-    .. note::
-
-        :meth:`~astropy.cosmology.Cosmology.read` and
-        :meth:`~astropy.cosmology.Cosmology.from_format` currently access the
-        same registry. This will be deprecated and formats intended for
-        ``from_format`` should not be used here. Use ``Cosmology.read.help()``
-        to confirm that the format may be used to read a file.
-
     Parameters
     ----------
     *args
@@ -112,14 +104,6 @@ class CosmologyWrite(io_registry.UnifiedReadWrite):
       >>> Cosmology.write.help(format='<format>')  # Get detailed help on format
       >>> Cosmology.write.list_formats()  # Print list of available formats
 
-    .. note::
-
-        :meth:`~astropy.cosmology.Cosmology.write` and
-        :meth:`~astropy.cosmology.Cosmology.to_format` currently access the
-        same registry. This will be deprecated and formats intended for
-        ``to_format`` should not be used here. Use ``Cosmology.write.help()``
-        to confirm that the format may be used to write to a file.
-
     Parameters
     ----------
     *args
@@ -170,14 +154,6 @@ class CosmologyFromFormat(io_registry.UnifiedReadWrite):
       >>> Cosmology.from_format.list_formats()  # Print list of available formats
 
     See also: https://docs.astropy.org/en/stable/io/unified.html
-
-    .. note::
-
-        :meth:`~astropy.cosmology.Cosmology.from_format` and
-        :meth:`~astropy.cosmology.Cosmology.read` currently access the
-        same registry. This will be deprecated and formats intended for
-        ``read`` should not be used here. Use ``Cosmology.to_format.help()``
-        to confirm that the format may be used to convert to a Cosmology.
 
     Parameters
     ----------
@@ -244,14 +220,6 @@ class CosmologyToFormat(io_registry.UnifiedReadWrite):
       >>> Cosmology.to_format.help()  # Get help and list supported formats
       >>> Cosmology.to_format.help('<format>')  # Get detailed help on format
       >>> Cosmology.to_format.list_formats()  # Print list of available formats
-
-    .. note::
-
-        :meth:`~astropy.cosmology.Cosmology.to_format` and
-        :meth:`~astropy.cosmology.Cosmology.write` currently access the
-        same registry. This will be deprecated and formats intended for
-        ``write`` should not be used here. Use ``Cosmology.to_format.help()``
-        to confirm that the format may be used to convert a Cosmology.
 
     Parameters
     ----------


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

There's an incorrect note about shared registries in Cosmology I/O.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
