### PR TITLE
Ensure `table.row` is tested in Cosmology `ReadWriteTestMixin`

### DIFF
--- a/astropy/cosmology/tests/test_connect.py
+++ b/astropy/cosmology/tests/test_connect.py
@@ -12,7 +12,7 @@ from astropy.cosmology.connect import CosmologyRead, readwrite_registry
 from astropy.cosmology.core import Cosmology
 from astropy.cosmology.io.tests import (test_cosmology, test_ecsv, test_json, test_mapping,
                                         test_model, test_row, test_table, test_yaml)
-from astropy.table import QTable
+from astropy.table import QTable, Row
 
 ###############################################################################
 # SETUP
@@ -27,7 +27,7 @@ readwrite_formats = {"ascii.ecsv", "json"}
 #                 (format, data type)
 tofrom_formats = [("mapping", dict),
                   ("astropy.cosmology", Cosmology),
-                  ("astropy.table", QTable)]
+                  ("astropy.row", Row), ("astropy.table", QTable)]
 
 ###############################################################################
 


### PR DESCRIPTION
Unfortunately collecting all the registered to/from formats  is NOT automatic since the output format class is not stored on the registry.

Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>


### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
