### PR TITLE
test aszarr

### DIFF
--- a/astropy/cosmology/tests/test_utils.py
+++ b/astropy/cosmology/tests/test_utils.py
@@ -6,8 +6,11 @@ import pytest
 
 import numpy as np
 
-from astropy.cosmology.utils import inf_like, vectorize_if_needed, vectorize_redshift_method
+from astropy.cosmology.utils import aszarr, vectorize_redshift_method
+from astropy.cosmology.utils import inf_like, vectorize_if_needed
 from astropy.utils.exceptions import AstropyDeprecationWarning
+
+from .test_core import _zarr, invalid_zs, valid_zs
 
 
 def test_vectorize_redshift_method():
@@ -71,3 +74,23 @@ def test_inf_like(arr, expected):
     """
     with pytest.warns(AstropyDeprecationWarning):
         assert np.all(inf_like(arr) == expected)
+
+
+# -------------------------------------------------------------------
+
+
+class Test_aszarr:
+
+    @pytest.mark.parametrize("z, expect", list(zip(valid_zs, [
+        0, 1, 1100, np.float64(3300), 2.0, 3.0, _zarr, _zarr, _zarr, _zarr
+    ])))
+    def test_valid(self, z, expect):
+        """Test :func:`astropy.cosmology.utils.aszarr`."""
+        got = aszarr(z)
+        assert np.array_equal(got, expect)
+
+    @pytest.mark.parametrize("z, exc", invalid_zs)
+    def test_invalid(self, z, exc):
+        """Test :func:`astropy.cosmology.utils.aszarr`."""
+        with pytest.raises(exc):
+            aszarr(z)


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

Add tests for the utility function `aszarr`

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
