### PR TITLE
Fix underline lengths in docstrings to fix RTD

### DIFF
--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -1259,7 +1259,7 @@ class SLSQPLSQFitter(Fitter):
         A linear model is passed to a nonlinear fitter
 
     Notes
-    ------
+    -----
     See also the `~astropy.modeling.optimizers.SLSQP` optimizer.
 
     """

--- a/astropy/modeling/projections.py
+++ b/astropy/modeling/projections.py
@@ -207,7 +207,7 @@ class Pix2Sky_ZenithalPerspective(Pix2SkyProjection, Zenithal):
         R &= \sqrt{x^2 + y^2 \cos^2 \gamma}
 
     Parameters
-    --------------
+    ----------
     mu : float
         Distance from point of projection to center of sphere
         in spherical radii, μ.  Default is 0.
@@ -297,7 +297,7 @@ class Pix2Sky_SlantZenithalPerspective(Pix2SkyProjection, Zenithal):
     Corresponds to the ``SZP`` projection in FITS WCS.
 
     Parameters
-    --------------
+    ----------
     mu : float
         Distance from point of projection to center of sphere
         in spherical radii, μ.  Default is 0.

--- a/astropy/nddata/ccddata.py
+++ b/astropy/nddata/ccddata.py
@@ -79,7 +79,7 @@ class CCDData(NDDataArray):
     information for a single CCD image.
 
     Parameters
-    -----------
+    ----------
     data : `~astropy.nddata.CCDData`-like or array-like
         The actual data contained in this `~astropy.nddata.CCDData` object.
         Note that the data will always be saved by *reference*, so you should
@@ -298,7 +298,7 @@ class CCDData(NDDataArray):
             .. versionadded:: 3.1
 
         Raises
-        -------
+        ------
         ValueError
             - If ``self.mask`` is set but not a `numpy.ndarray`.
             - If ``self.uncertainty`` is set but not a astropy uncertainty type.
@@ -695,7 +695,7 @@ def fits_ccddata_writer(
         All additional keywords are passed to :py:mod:`astropy.io.fits`
 
     Raises
-    -------
+    ------
     ValueError
         - If ``self.mask`` is set but not a `numpy.ndarray`.
         - If ``self.uncertainty`` is set but not a

--- a/astropy/nddata/compat.py
+++ b/astropy/nddata/compat.py
@@ -31,7 +31,7 @@ class NDDataArray(NDArithmeticMixin, NDSlicingMixin, NDIOMixin, NDData):
     See also: https://docs.astropy.org/en/stable/nddata/
 
     Parameters
-    -----------
+    ----------
     data : ndarray or `NDData`
         The actual data contained in this `NDData` object. Not that this
         will always be copies by *reference* , so you should make copy

--- a/astropy/nddata/nddata.py
+++ b/astropy/nddata/nddata.py
@@ -32,7 +32,7 @@ class NDData(NDDataBase):
     See also: https://docs.astropy.org/en/stable/nddata/
 
     Parameters
-    -----------
+    ----------
     data : `numpy.ndarray`-like or `NDData`-like
         The dataset.
 

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -1779,7 +1779,7 @@ class Time(TimeBase):
         """Calculate local Earth rotation angle.
 
         Parameters
-        ---------------
+        ----------
         longitude : `~astropy.units.Quantity`, `~astropy.coordinates.EarthLocation`, str, or None; optional
             The longitude on the Earth at which to compute the Earth rotation
             angle (taken from a location as needed).  If `None` (default), taken
@@ -1830,7 +1830,7 @@ class Time(TimeBase):
         """Calculate sidereal time.
 
         Parameters
-        ---------------
+        ----------
         kind : str
             ``'mean'`` or ``'apparent'``, i.e., accounting for precession
             only, or also for nutation.

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -1013,7 +1013,7 @@ def check_free_space_in_dir(path, size):
         A proposed filesize. If not a Quantity, assume it is in bytes.
 
     Raises
-    -------
+    ------
     OSError
         There is not enough room on the filesystem.
     """


### PR DESCRIPTION
### Description

Hopefully this will fix the RTD build - let's see.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
