### PR TITLE
Get rid of `modeling.fitting` warnings and `WCS` `FITSFixedWarning` in RTD

### DIFF
--- a/docs/modeling/compound-models.rst
+++ b/docs/modeling/compound-models.rst
@@ -36,6 +36,7 @@ These new compound models can also be fitted to data, like most other models
 .. plot::
     :include-source:
 
+    import warnings
     import numpy as np
     import matplotlib.pyplot as plt
     from astropy.modeling import models, fitting
@@ -51,7 +52,10 @@ These new compound models can also be fitted to data, like most other models
     # guesses for the parameters:
     gg_init = models.Gaussian1D(1, 0, 0.1) + models.Gaussian1D(2, 0.5, 0.1)
     fitter = fitting.SLSQPLSQFitter()
-    gg_fit = fitter(gg_init, x, y)
+    with warnings.catch_warnings():
+        # Ignore "Values in x were outside bounds" warning from the fitter
+        warnings.simplefilter('ignore')
+        gg_fit = fitter(gg_init, x, y)
 
     # Plot the data with the best-fit model
     plt.figure(figsize=(8,5))

--- a/docs/modeling/compound-models.rst
+++ b/docs/modeling/compound-models.rst
@@ -52,9 +52,11 @@ These new compound models can also be fitted to data, like most other models
     # guesses for the parameters:
     gg_init = models.Gaussian1D(1, 0, 0.1) + models.Gaussian1D(2, 0.5, 0.1)
     fitter = fitting.SLSQPLSQFitter()
+
     with warnings.catch_warnings():
-        # Ignore "Values in x were outside bounds" warning from the fitter
-        warnings.simplefilter('ignore')
+        # Ignore a warning on clipping to bounds from the fitter
+        warnings.filterwarnings('ignore', message='Values in x were outside bounds',
+                                category=RuntimeWarning)
         gg_fit = fitter(gg_init, x, y)
 
     # Plot the data with the best-fit model

--- a/docs/modeling/example-fitting-constraints.rst
+++ b/docs/modeling/example-fitting-constraints.rst
@@ -130,10 +130,11 @@ and fit Gaussians to the lines simultaneously while linking the flux of the OIII
 
     hbeta_combo = h_beta + o3_1 + o3_2 + poly_cont
 
-    # Fit all lines simultaneously.
+    # Fit all lines simultaneously -
+    # this will need one iteration more than the default of 100.
 
     fitter = fitting.LevMarLSQFitter()
-    fitted_model = fitter(hbeta_combo, wave, flux)
+    fitted_model = fitter(hbeta_combo, wave, flux, maxiter=111)
     fitted_lines = fitted_model(wave)
 
     from matplotlib import pyplot as plt

--- a/docs/modeling/fitting.rst
+++ b/docs/modeling/fitting.rst
@@ -93,6 +93,7 @@ background in an image.
     import numpy as np
     import matplotlib.pyplot as plt
     from astropy.modeling import models, fitting
+    from astropy.utils.exceptions import AstropyUserWarning
 
     # Generate fake data
     np.random.seed(0)
@@ -106,7 +107,8 @@ background in an image.
 
     with warnings.catch_warnings():
         # Ignore model linearity warning from the fitter
-        warnings.simplefilter('ignore')
+        warnings.filterwarnings('ignore', message='Model is linear in parameters',
+                                category=AstropyUserWarning)
         p = fit_p(p_init, x, y, z)
 
     # Plot the data with the best-fit model

--- a/docs/wcs/wcstools.rst
+++ b/docs/wcs/wcstools.rst
@@ -27,15 +27,20 @@ More information on using WCSAxes can be found :ref:`here <wcsaxes>`.
     :include-source:
     :align: center
 
+    import warnings
     from matplotlib import pyplot as plt
     from astropy.io import fits
-    from astropy.wcs import WCS
+    from astropy.wcs import WCS, FITSFixedWarning
     from astropy.utils.data import get_pkg_data_filename
 
     filename = get_pkg_data_filename('tutorials/FITS-images/HorseHead.fits')
 
     hdu = fits.open(filename)[0]
-    wcs = WCS(hdu.header)
+    with warnings.catch_warnings():
+        # Ignore a warning on using DATE-OBS in place of MJD-OBS
+        warnings.filterwarnings('ignore', message="'datfix' made the change",
+                                category=FITSFixedWarning)
+        wcs = WCS(hdu.header)
 
     fig = plt.figure()
     fig.add_subplot(111, projection=wcs)


### PR DESCRIPTION
### Description
Additional cleanup of RTD build to fix the (non-critical) warnings in the modelling section.
Fixes part of #12784 :
1. `RunTimeWarning: Values in x were outside bounds during a minimize step` – silenced by filter as in `fitting.rst`.
I have played around a bit trying to find better bounds or starting values, but without success.
2. `WARNING: The fit may be unsuccessful; check fit_info['message'] for more information` due to the fitter taking 101 iterations to converge; fixed by increasing `maxiter`.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
