### PR TITLE
Avoid using strings in minversion() wherever possible

### DIFF
--- a/astropy/io/misc/parquet.py
+++ b/astropy/io/misc/parquet.py
@@ -357,7 +357,7 @@ def get_pyarrow():
     except ImportError:
         raise Exception("pyarrow is required to read and write parquet files")
 
-    if minversion('pyarrow', '6.0.0'):
+    if minversion(pa, '6.0.0'):
         writer_version = '2.4'
     else:
         writer_version = '2.0'

--- a/astropy/utils/compat/numpycompat.py
+++ b/astropy/utils/compat/numpycompat.py
@@ -3,6 +3,8 @@
 This is a collection of monkey patches and workarounds for bugs in
 earlier versions of Numpy.
 """
+
+import numpy as np
 from astropy.utils import minversion
 
 __all__ = ['NUMPY_LT_1_19', 'NUMPY_LT_1_20', 'NUMPY_LT_1_21_1',
@@ -11,9 +13,9 @@ __all__ = ['NUMPY_LT_1_19', 'NUMPY_LT_1_20', 'NUMPY_LT_1_21_1',
 # TODO: It might also be nice to have aliases to these named for specific
 # features/bugs we're checking for (ex:
 # astropy.table.table._BROKEN_UNICODE_TABLE_SORT)
-NUMPY_LT_1_19 = not minversion('numpy', '1.19')
-NUMPY_LT_1_20 = not minversion('numpy', '1.20')
-NUMPY_LT_1_21_1 = not minversion('numpy', '1.21.1')
-NUMPY_LT_1_22 = not minversion('numpy', '1.22')
-NUMPY_LT_1_22_1 = not minversion('numpy', '1.22.1')
-NUMPY_LT_1_23 = not minversion('numpy', '1.23dev0')
+NUMPY_LT_1_19 = not minversion(np, '1.19')
+NUMPY_LT_1_20 = not minversion(np, '1.20')
+NUMPY_LT_1_21_1 = not minversion(np, '1.21.1')
+NUMPY_LT_1_22 = not minversion(np, '1.22')
+NUMPY_LT_1_22_1 = not minversion(np, '1.22.1')
+NUMPY_LT_1_23 = not minversion(np, '1.23dev0')


### PR DESCRIPTION
### Description

Using strings can cause KeyError when bundling astropy in an application with pyinstaller - and in any case we might as well avoid all the repeated conversions of string to module in ``numpycompat.py``.

I don't know how we deal with this issue in general though - it seems that using strings in ``minversion`` is just fundamentally broken when bundling astropy in an application.

<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->


### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
