### PR TITLE
Bugfix for `units_mapping` asdf schema.

### DIFF
--- a/astropy/io/misc/asdf/data/schemas/astropy.org/astropy/transform/units_mapping-1.0.0.yaml
+++ b/astropy/io/misc/asdf/data/schemas/astropy.org/astropy/transform/units_mapping-1.0.0.yaml
@@ -17,20 +17,20 @@ examples:
     - Assign units of seconds to dimensionless input.
     - |
       !<tag:astropy.org:astropy/transform/units_mapping-1.0.0>
-        inputs:
+        unit_inputs:
           - name: x
             unit: !unit/unit-1.0.0
-        outputs:
+        unit_outputs:
           - name: x
             unit: !unit/unit-1.0.0 s
   -
     - Convert input to meters, then assign dimensionless units.
     - |
       !<tag:astropy.org:astropy/transform/units_mapping-1.0.0>
-        inputs:
+        unit_inputs:
           - name: x
             unit: !unit/unit-1.0.0 m
-        outputs:
+        unit_outputs:
           - name: x
             unit: !unit/unit-1.0.0
 
@@ -38,19 +38,19 @@ examples:
     - Convert input to meters, then drop units entirely.
     - |
       !<tag:astropy.org:astropy/transform/units_mapping-1.0.0>
-        inputs:
+        unit_inputs:
           - name: x
             unit: !unit/unit-1.0.0 m
-        outputs:
+        unit_outputs:
           - name: x
 
   -
     - Accept any units, then replace with meters.
     - |
       !<tag:astropy.org:astropy/transform/units_mapping-1.0.0>
-        inputs:
+        unit_inputs:
           - name: x
-        outputs:
+        unit_outputs:
           - name: x
             unit: !unit/unit-1.0.0 m
 
@@ -58,19 +58,19 @@ allOf:
   - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.2.0"
   - type: object
     properties:
-      inputs:
+      unit_inputs:
         description: |
           Array of input configurations.
         type: array
         items:
           $ref: "#/definitions/value_configuration"
-      outputs:
+      unit_outputs:
         description: |
           Array of output configurations.
         type: array
         items:
           $ref: "#/definitions/value_configuration"
-    required: [inputs, outputs]
+    required: [unit_inputs, unit_outputs]
 
 definitions:
   value_configuration:

--- a/astropy/io/misc/asdf/tags/transform/basic.py
+++ b/astropy/io/misc/asdf/tags/transform/basic.py
@@ -265,18 +265,18 @@ class UnitsMappingType(AstropyType):
                 output["unit"] = m[-1]
             outputs.append(output)
 
-        tree["inputs"] = inputs
-        tree["outputs"] = outputs
+        tree["unit_inputs"] = inputs
+        tree["unit_outputs"] = outputs
 
         return tree
 
     @classmethod
     def from_tree(cls, tree, ctx):
         mapping = tuple((i.get("unit"), o.get("unit"))
-                        for i, o in zip(tree["inputs"], tree["outputs"]))
+                        for i, o in zip(tree["unit_inputs"], tree["unit_outputs"]))
 
         equivalencies = None
-        for i in tree["inputs"]:
+        for i in tree["unit_inputs"]:
             if "equivalencies" in i:
                 if equivalencies is None:
                     equivalencies = {}
@@ -285,7 +285,7 @@ class UnitsMappingType(AstropyType):
         kwargs = {
             "input_units_equivalencies": equivalencies,
             "input_units_allow_dimensionless": {
-                i["name"]: i.get("allow_dimensionless", False) for i in tree["inputs"]},
+                i["name"]: i.get("allow_dimensionless", False) for i in tree["unit_inputs"]},
         }
 
         if "name" in tree:

--- a/docs/changes/io.misc/12800.bugfix.rst
+++ b/docs/changes/io.misc/12800.bugfix.rst
@@ -1,0 +1,3 @@
+Bugfix for ``units_mapping`` schema's property name conflicts. Changes:
+    * ``inputs`` to ``unit_inputs``
+    * ``outputs`` to ``unit_outputs``


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

In asdf-format/asdf-transform-schemas#33, the `inputs` and `outputs` properties were formally added to the transform schema. This conflicts with the use of those fields in the `units_mapping` schema for other purposes. This PR fixes the bugs that result from this.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] ~Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?~
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
