### PR TITLE
Add unit format option in read_table_fits

### DIFF
--- a/astropy/io/fits/connect.py
+++ b/astropy/io/fits/connect.py
@@ -112,7 +112,8 @@ def _decode_mixins(tbl):
 
 
 def read_table_fits(input, hdu=None, astropy_native=False, memmap=False,
-                    character_as_bytes=True, unit_parse_strict='warn'):
+                    character_as_bytes=True, unit_parse_strict='warn',
+                    unit_format='fits'):
     """
     Read a Table object from an FITS file
 
@@ -158,6 +159,14 @@ def read_table_fits(input, hdu=None, astropy_native=False, memmap=False,
         :class:`~astropy.units.core.UnrecognizedUnit`.
         Values are the ones allowed by the ``parse_strict`` argument of
         :class:`~astropy.units.core.Unit`.
+    unit_format : str, optional
+        By default units are parsed with the ``fits`` format, defined in the
+        Units section of the FITS Standard. This parameter allows to use a
+        less restrictive set of units, using for example the ``generic`` format
+        for units that are not compliant with the FITS standard.
+        Values are the ones allowed by the ``format`` argument of
+        :class:`~astropy.units.core.Unit`.
+
     """
 
     if isinstance(input, HDUList):
@@ -221,6 +230,7 @@ def read_table_fits(input, hdu=None, astropy_native=False, memmap=False,
                 hdulist, hdu=hdu,
                 astropy_native=astropy_native,
                 unit_parse_strict=unit_parse_strict,
+                unit_format=unit_format,
             )
         finally:
             hdulist.close()
@@ -258,7 +268,8 @@ def read_table_fits(input, hdu=None, astropy_native=False, memmap=False,
 
         # Copy over units
         if col.unit is not None:
-            column.unit = u.Unit(col.unit, format='fits', parse_strict=unit_parse_strict)
+            column.unit = u.Unit(col.unit, format=unit_format,
+                                 parse_strict=unit_parse_strict)
 
         # Copy over display format
         if col.disp is not None:

--- a/astropy/io/fits/tests/test_connect.py
+++ b/astropy/io/fits/tests/test_connect.py
@@ -675,6 +675,22 @@ def test_unit_warnings_read_write(tmpdir):
         Table.read(filename, hdu=1)
 
 
+def test_unit_format(tmpdir):
+    filename = str(tmpdir.join('test_unit.fits'))
+    t1 = Table([[1, 2], [3, 4]], names=['a', 'b'])
+    t1['a'].unit = 'm/s'
+    t1['b'].unit = 'ampere'
+    t1.write(filename, overwrite=True)
+    fits.setval(filename, 'TUNIT2', value='ampere', ext=1)
+
+    with pytest.warns(u.UnitsWarning, match="'ampere' did not parse as fits unit"):
+        t = Table.read(filename, hdu=1)
+    assert isinstance(t['b'].unit, u.UnrecognizedUnit)
+
+    t = Table.read(filename, hdu=1, unit_format='generic')
+    assert t['b'].unit == u.ampere
+
+
 def test_convert_comment_convention(tmpdir):
     """
     Regression test for https://github.com/astropy/astropy/issues/6079

--- a/docs/changes/io.fits/12808.feature.rst
+++ b/docs/changes/io.fits/12808.feature.rst
@@ -1,3 +1,4 @@
-Add option ``unit_format`` to ``astropy.io.fits.connect.read_table_fits`` to
-enable using a wider range of units for files not compliant with the units
-defined in the FITS Standard.
+Add option ``unit_format`` to ``astropy.io.fits.connect.read_table_fits``
+(and thus to ``Table.read(format='fits')``) to enable using a wider
+range of units for files not compliant with the units defined in the
+FITS Standard.

--- a/docs/changes/io.fits/12808.feature.rst
+++ b/docs/changes/io.fits/12808.feature.rst
@@ -1,0 +1,3 @@
+Add option ``unit_format`` to ``astropy.io.fits.connect.read_table_fits`` to
+enable using a wider range of units for files not compliant with the units
+defined in the FITS Standard.


### PR DESCRIPTION
Second part of #11842, allowing to fallback to the generic format.

Closes #11842.

<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address ...

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
