### PR TITLE
Raise error when objective function passes non-finite values in `LevMarLSQFitter`

### DIFF
--- a/astropy/modeling/tests/test_models.py
+++ b/astropy/modeling/tests/test_models.py
@@ -19,7 +19,8 @@ from astropy.modeling.core import FittableModel, Model, _ModelMeta
 from astropy.modeling.models import Gaussian2D
 from astropy.modeling.parameters import InputParameterError, Parameter
 from astropy.modeling.polynomial import PolynomialBase
-from astropy.modeling.powerlaws import SmoothlyBrokenPowerLaw1D
+from astropy.modeling.powerlaws import (BrokenPowerLaw1D, ExponentialCutoffPowerLaw1D,
+                                        LogParabola1D, PowerLaw1D, SmoothlyBrokenPowerLaw1D)
 from astropy.modeling.separable import separability_matrix
 from astropy.tests.helper import assert_quantity_allclose
 from astropy.utils import NumpyRNGContext
@@ -354,6 +355,16 @@ class Fittable1DModelTester:
     This can be used as a base class for user defined model testing.
     """
 
+    # These models will fail fitting test, because built in fitting data
+    #   will produce non-finite values
+    _non_finite_models = [
+        BrokenPowerLaw1D,
+        ExponentialCutoffPowerLaw1D,
+        LogParabola1D,
+        PowerLaw1D,
+        SmoothlyBrokenPowerLaw1D
+    ]
+
     def setup_class(self):
         self.N = 100
         self.M = 100
@@ -486,6 +497,9 @@ class Fittable1DModelTester:
         Test the derivative of a model by comparing results with an estimated
         derivative.
         """
+
+        if model_class in self._non_finite_models:
+            return
 
         x_lim = test_parameters['x_lim']
 

--- a/astropy/modeling/tests/test_models_quantities.py
+++ b/astropy/modeling/tests/test_models_quantities.py
@@ -247,6 +247,15 @@ MODELS = FUNC_MODELS_1D + SCALE_MODELS + FUNC_MODELS_2D + POWERLAW_MODELS +\
 
 SCIPY_MODELS = set([Sersic1D, Sersic2D, AiryDisk2D])
 
+# These models will fail fitting test, because built in fitting data
+#   will produce non-finite values
+NON_FINITE_MODELS = [
+    Sersic1D,
+    PowerLaw1D,
+    ExponentialCutoffPowerLaw1D,
+    LogParabola1D
+]
+
 
 @pytest.mark.parametrize('model', MODELS)
 def test_models_evaluate_without_units(model):
@@ -402,6 +411,8 @@ def test_compound_model_input_units_equivalencies_defaults(model):
 @pytest.mark.filterwarnings(r'ignore:The fit may be unsuccessful.*')
 @pytest.mark.parametrize('model', MODELS)
 def test_models_fitting(model):
+    if model['class'] in NON_FINITE_MODELS:
+        return
 
     m = model['class'](**model['parameters'])
     if len(model['evaluation'][0]) == 2:

--- a/docs/changes/modeling/12811.feature.rst
+++ b/docs/changes/modeling/12811.feature.rst
@@ -1,0 +1,1 @@
+Add error to non-finite inputs to the ``LevMarLSQFitter``, to protect against soft scipy failure.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

The `scipy.optimize.leastsq` algorithm used by the `LevMarLSQFitter` fails silently when the input data or results from the objective function (formed from the model and other inputs to fitting) contain non-finite values (`np.nan`, `-np.inf`, `np.inf`).

This PR checks for these non-finite values and raises an error when one is output by the objective function.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #3575 and fixes #12809.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
