### PR TITLE
Add fixed-width variant of ECSV

### DIFF
--- a/astropy/io/ascii/__init__.py
+++ b/astropy/io/ascii/__init__.py
@@ -31,7 +31,7 @@ from .fastbasic import (FastBasic,
                         FastRdb)
 from .cds import Cds
 from .mrt import Mrt
-from .ecsv import Ecsv
+from .ecsv import Ecsv, EcsvFixedWidth
 from .latex import Latex, AASTex, latexdicts
 from .html import HTML
 from .ipac import Ipac

--- a/astropy/io/ascii/ecsv.py
+++ b/astropy/io/ascii/ecsv.py
@@ -4,7 +4,6 @@ Define the Enhanced Character-Separated-Values (ECSV) which allows for reading a
 writing all the meta data associated with an astropy Table object.
 """
 
-import itertools
 import re
 from collections import OrderedDict
 import warnings
@@ -512,7 +511,7 @@ class EcsvFixedWidthData(EcsvData):
 
         # Make the column header line
         lines.append(self._join_fixed([col.info.name for col in self.cols],
-                                     widths))
+                                      widths))
 
         # Make the data lines, using zip(*) to transpose the columns and write
         # one row at a time.
@@ -537,26 +536,33 @@ class EcsvFixedWidth(Ecsv):
     Examples
     --------
 
+    >>> from astropy.table import Table
+    >>> import astropy.units as u
+    >>> from astropy.io import ascii
     >>> t = Table()
-    >>> t['col0'] = [1, 2, 30000, -5]
-    >>> t['col1'] = ['x z', 'y,z', 'z, x', 'hello!']
-    >>> t['col2'] = [1.0, -20000.0, 3.0, 4.0]
+    >>> t['velocity'] = [1, 2, 30000, -5] * u.m / u.s
+    >>> t['text'] = ['x z', 'y,z', 'z, x', 'hello!']
+    >>> t['number'] = [1.0, -20000.0, 3.0, 4.0]
 
     >>> ascii.write(t, format='ecsv_fixed_width')
     # %ECSV 1.0
     # ---
     # datatype:
-    # - {name: col0, datatype: int64}
-    # - {name: col1, datatype: string}
-    # - {name: col2, datatype: float64}
+    # - {name: velocity, unit: m / s, datatype: float64}
+    # - {name: text, datatype: string}
+    # - {name: number, datatype: float64}
     # schema: astropy-2.0
-    col0   col1     col2
-        1  "x z"      1.0
-        2    y,z -20000.0
-    30000 "z, x"      3.0
-       -5 hello!      4.0
+    velocity    text    number
+         1.0   "x z"       1.0
+         2.0     y,z  -20000.0
+     30000.0  "z, x"       3.0
+        -5.0  hello!       4.0
     """
     _format_name = 'ecsv_fixed_width'
     _description = 'Enhanced CSV Fixed Width'
+
+    # Disable inherited .ecsv suffix for the FixedWidth flavor of ECSV so the
+    # base ECSV always gets used for *.ecsv files.
+    _io_registry_suffix = ''
 
     data_class = EcsvFixedWidthData

--- a/astropy/io/ascii/tests/test_ecsv.py
+++ b/astropy/io/ascii/tests/test_ecsv.py
@@ -22,6 +22,7 @@ from astropy.units import QuantityInfo
 
 from astropy.utils.compat import NUMPY_LT_1_19_1
 from astropy.io.ascii.ecsv import DELIMITERS, InvalidEcsvDatatypeWarning
+from astropy.io.ascii.tests.test_c_reader import assert_table_equal
 from astropy.io import ascii
 from astropy import units as u
 
@@ -251,7 +252,7 @@ def test_csv_ecsv_colnames_mismatch():
 @pytest.mark.parametrize('delimiter', [' ', ','])
 def test_ecsv_fixed_width(delimiter):
     t = Table()
-    t['col0'] = [1, 2, 30000, -5]
+    t['col0'] = np.array([1, 2, 30000, -5], dtype=np.int64)
     t['col1'] = ['x z', 'y,z', 'z, x', 'hello!']
     t['col2'] = [1.0, -20000.0, 3.0, 4.0]
     out = StringIO()
@@ -286,6 +287,12 @@ def test_ecsv_fixed_width(delimiter):
 
     t.write(out, format='ascii.ecsv_fixed_width', delimiter=delimiter)
     assert out.getvalue() == exp
+
+    t2 = Table.read(out.getvalue(), format='ascii.ecsv_fixed_width', delimiter=delimiter)
+    assert_table_equal(t, t2)
+
+    t2 = Table.read(out.getvalue(), format='ascii.ecsv', delimiter=delimiter)
+    assert_table_equal(t, t2)
 
 
 def test_regression_5604():

--- a/astropy/io/ascii/tests/test_ecsv.py
+++ b/astropy/io/ascii/tests/test_ecsv.py
@@ -248,6 +248,46 @@ def test_csv_ecsv_colnames_mismatch():
     assert "column names from ECSV header ['a', 'b', 'c']" in str(err.value)
 
 
+@pytest.mark.parametrize('delimiter', [' ', ','])
+def test_ecsv_fixed_width(delimiter):
+    t = Table()
+    t['col0'] = [1, 2, 30000, -5]
+    t['col1'] = ['x z', 'y,z', 'z, x', 'hello!']
+    t['col2'] = [1.0, -20000.0, 3.0, 4.0]
+    out = StringIO()
+
+    exp = """\
+# %ECSV 1.0
+# ---
+# datatype:
+# - {name: col0, datatype: int64}
+# - {name: col1, datatype: string}
+# - {name: col2, datatype: float64}
+"""
+    if delimiter == ' ':
+        exp += """\
+# schema: astropy-2.0
+ col0    col1      col2
+    1   "x z"       1.0
+    2     y,z  -20000.0
+30000  "z, x"       3.0
+   -5  hello!       4.0
+"""
+    else:
+        exp += """\
+# delimiter: ','
+# schema: astropy-2.0
+ col0,   col1,     col2
+    1,    x z,      1.0
+    2,  "y,z", -20000.0
+30000, "z, x",      3.0
+   -5, hello!,      4.0
+"""
+
+    t.write(out, format='ascii.ecsv_fixed_width', delimiter=delimiter)
+    assert out.getvalue() == exp
+
+
 def test_regression_5604():
     """
     See https://github.com/astropy/astropy/issues/5604 for more.

--- a/astropy/io/ascii/tests/test_write.py
+++ b/astropy/io/ascii/tests/test_write.py
@@ -904,7 +904,7 @@ def test_multidim_column_error(fmt_name_class):
     # Skip tests for ecsv or HTML without bs4. See the comment in latex.py
     # Latex class where max_ndim = None is defined regarding latex and aastex.
     if ((fmt_name == 'html' and not HAS_BS4)
-            or fmt_name in ('ecsv', 'latex', 'aastex')):
+            or fmt_name in ('ecsv', 'ecsv_fixed_width', 'latex', 'aastex')):
         return
 
     out = StringIO()

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -874,7 +874,6 @@ def test_bad_info_class():
 
     t = Table()
     t['tm'] = MyArrayWrapper([0, 1, 2])
-    out = StringIO()
     match = r"failed to represent column 'tm' \(MyArrayWrapper\) as one or more Column subclasses"
     with pytest.raises(TypeError, match=match):
         represent_mixins_as_columns(t)

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -1106,7 +1106,7 @@ class TimeBase(ShapedLikeNDArray):
         new_format = self.format if format is None else format
 
         if callable(method):
-            apply_method = lambda array: method(array, *args, **kwargs)
+            apply_method = lambda array: method(array, *args, **kwargs)  # noqa: E731
 
         else:
             if method == 'replicate':

--- a/docs/changes/io.ascii/12821.feature.rst
+++ b/docs/changes/io.ascii/12821.feature.rst
@@ -1,0 +1,5 @@
+Add a "human readable" variant of ECSV to the ``io.ascii`` formats that adds
+spaces to the data values so that they are aligned in columns (i.e. fixed
+width). This is done as a new format name ``'ecsv_fixed_width'`` to make it
+clear that this is not strictly ECSV although the output is readable by the
+Python ECSV reader for both space and comma-delimited outputs.

--- a/docs/io/ascii/extension_classes.rst
+++ b/docs/io/ascii/extension_classes.rst
@@ -17,6 +17,8 @@ well-defined but idiosyncratic formats.
 * :class:`~astropy.io.ascii.CommentedHeader`: column names given in a line that begins with the comment character.
 * :class:`~astropy.io.ascii.Csv`: comma-separated values.
 * :class:`~astropy.io.ascii.Daophot`: table from the IRAF DAOphot package.
+* :class:`~astropy.io.ascii.Ecsv`: :ref:`ecsv_format` for lossless round-trip of data tables
+* :class:`~astropy.io.ascii.EcsvFixedWidth`: ECSV but with fixed width output
 * :class:`~astropy.io.ascii.FixedWidth`: table with fixed-width columns (see also :ref:`fixed_width_gallery`).
 * :class:`~astropy.io.ascii.FixedWidthNoHeader`: table with fixed-width columns and no header.
 * :class:`~astropy.io.ascii.FixedWidthTwoLine`: table with fixed-width columns and a two-line header.

--- a/docs/io/ascii/index.rst
+++ b/docs/io/ascii/index.rst
@@ -192,6 +192,7 @@ are compatible with the fast Cython/C engine for reading and writing.
 ``csv``                     Yes  Yes :class:`~astropy.io.ascii.Csv`: Basic table with comma-separated values
 ``daophot``                          :class:`~astropy.io.ascii.Daophot`: IRAF DAOphot format table
 ``ecsv``                    Yes      :class:`~astropy.io.ascii.Ecsv`: Enhanced CSV format (**recommended**)
+``ecsv_fixed_width``        Yes      :class:`~astropy.io.ascii.EcsvFixedWidth`: ECSV but with fixed width output
 ``fixed_width``             Yes      :class:`~astropy.io.ascii.FixedWidth`: Fixed width
 ``fixed_width_no_header``   Yes      :class:`~astropy.io.ascii.FixedWidthNoHeader`: Fixed-width with no header
 ``fixed_width_two_line``    Yes      :class:`~astropy.io.ascii.FixedWidthTwoLine`: Fixed-width with second header line

--- a/docs/io/unified.rst
+++ b/docs/io/unified.rst
@@ -195,6 +195,7 @@ detection.
                   ascii.csv    Yes    .csv  :class:`~astropy.io.ascii.Csv`: Basic table with comma-separated values
               ascii.daophot     No          :class:`~astropy.io.ascii.Daophot`: IRAF DAOphot format table
                  ascii.ecsv    Yes   .ecsv  :class:`~astropy.io.ascii.Ecsv`: Basic table with Enhanced CSV (supporting metadata)
+     ascii.ecsv_fixed_width    Yes          :class:`~astropy.io.ascii.EcsvFixedWidth`: ECSV but with fixed width output
           ascii.fixed_width    Yes          :class:`~astropy.io.ascii.FixedWidth`: Fixed width
 ascii.fixed_width_no_header    Yes          :class:`~astropy.io.ascii.FixedWidthNoHeader`: Fixed width with no header
  ascii.fixed_width_two_line    Yes          :class:`~astropy.io.ascii.FixedWidthTwoLine`: Fixed width with second header line

--- a/docs/whatsnew/5.1.rst
+++ b/docs/whatsnew/5.1.rst
@@ -15,6 +15,7 @@ In particular, this release includes:
 * :ref:`whatsnew-5.1-cosmology`
 * :ref:`whatsnew-doppler-redshift-eq`
 * :ref:`whatsnew-io-ascii-converters`
+* :ref:`whatsnew-io-ascii-fixed-width-ecsv`
 * :ref:`whatsnew-structured-columns`
 * :ref:`whatsnew-fitters`
 * :ref:`whatsnew-iers-handling`
@@ -92,6 +93,43 @@ value as a ``list`` even for only one element::
 Note that the previous syntax is still supported for backwards compatibility
 and there is no intent to remove this. See :ref:`io-ascii-read-converters` for
 details.
+
+.. _whatsnew-io-ascii-fixed-width-ecsv:
+
+Fixed width ASCII table output with units and meta-data
+=======================================================
+
+A long-time feature request in astropy has been to write tables in a
+human-readable fixed-width format that also includes column units and
+potentially other meta-data. This is now available in as a fixed-width variant
+of the ECSV format which captures all units, data types and other meta-data in
+the header. This is done as a new format name ``'ecsv_fixed_width'`` to make it
+clear that this is not strictly ECSV although the output is readable by the
+Python ECSV reader for both space and comma-delimited outputs.
+
+Example::
+
+    >>> from astropy.table import Table
+    >>> import astropy.units as u
+    >>> from astropy.io import ascii
+    >>> t = Table()
+    >>> t['velocity'] = [1, 2, 30000, -5] * u.m / u.s
+    >>> t['text'] = ['x z', 'y,z', 'z, x', 'hello!']
+    >>> t['number'] = [1.0, -20000.0, 3.0, 4.0]
+
+    >>> ascii.write(t, format='ecsv_fixed_width')
+    # %ECSV 1.0
+    # ---
+    # datatype:
+    # - {name: velocity, unit: m / s, datatype: float64}
+    # - {name: text, datatype: string}
+    # - {name: number, datatype: float64}
+    # schema: astropy-2.0
+    velocity    text    number
+         1.0   "x z"       1.0
+         2.0     y,z  -20000.0
+     30000.0  "z, x"       3.0
+        -5.0  hello!       4.0
 
 .. _whatsnew-structured-columns:
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to make a "human readable" variant of ECSV that adds spaces to the data values so that they are aligned in columns (i.e. fixed width). This is done as a new format to make it clear that this is not strictly ECSV although the output is readable by the Python ECSV reader for both space and comma-delimited outputs. 

The behavior of non-astropy CSV readers with the extra spaces is not guaranteed.

I'd like to say this can close the issue of including table meta data (units in particular) in fixed width tables, starting from #386 almost 10 years ago.

To do:
- [x] Tests
- [x] Docs
- [x] Change log
- [x] What's new

```
>>> t = Table()
>>> t['col0'] = [1, 2, 30000, -5]
>>> t['col1'] = ['x z', 'y,z', 'z, x', 'hello!']
>>> t['col2'] = [1.0, -20000.0, 3.0, 4.0]

>>> ascii.write(t, format='ecsv_fixed_width')
# %ECSV 1.0
# ---
# datatype:
# - {name: col0, datatype: int64}
# - {name: col1, datatype: string}
# - {name: col2, datatype: float64}
# schema: astropy-2.0
 col0    col1      col2
    1   "x z"       1.0
    2     y,z  -20000.0
30000  "z, x"       3.0
   -5  hello!       4.0

>>> ascii.write(t, format='ecsv_fixed_width', delimiter=',')
# %ECSV 1.0
# ---
# datatype:
# - {name: col0, datatype: int64}
# - {name: col1, datatype: string}
# - {name: col2, datatype: float64}
# delimiter: ','
# schema: astropy-2.0
 col0,   col1,     col2
    1,    x z,      1.0
    2,  "y,z", -20000.0
30000, "z, x",      3.0
   -5, hello!,      4.0
```

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #12803
Fixes #386

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
