### PR TITLE
Support mixin columns for group aggregation operations

### DIFF
--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -340,7 +340,9 @@ class ColumnInfo(BaseColumnInfo):
     This is required when the object is used as a mixin column within a table,
     but can be used as a general way to store meta information.
     """
-    attrs_from_parent = BaseColumnInfo.attr_names
+    attr_names = BaseColumnInfo.attr_names | {'groups'}
+    _attrs_no_copy = BaseColumnInfo._attrs_no_copy | {'groups'}
+    attrs_from_parent = attr_names
     _supports_indexing = True
 
     def new_like(self, cols, length, metadata_conflicts='warn', name=None):

--- a/astropy/table/groups.py
+++ b/astropy/table/groups.py
@@ -238,7 +238,8 @@ class ColumnGroups(BaseGroups):
             return self._keys
 
     def aggregate(self, func):
-        from .column import MaskedColumn
+        from .column import MaskedColumn, Column
+        from astropy.utils.compat import NUMPY_LT_1_20
 
         i0s, i1s = self.indices[:-1], self.indices[1:]
         par_col = self.parent_column
@@ -248,6 +249,15 @@ class ColumnGroups(BaseGroups):
         mean_case = func is np.mean
         try:
             if not masked and (reduceat or sum_case or mean_case):
+                # For numpy < 1.20 there is a bug where reduceat will fail to
+                # raise an exception for mixin columns that do not support the
+                # operation. For details see:
+                # https://github.com/astropy/astropy/pull/12825#issuecomment-1082412447
+                # Instead we try the function directly with a 2-element version
+                # of the column
+                if NUMPY_LT_1_20 and not isinstance(par_col, Column) and len(par_col) > 0:
+                    func(par_col[[0, 0]])
+
                 if mean_case:
                     vals = np.add.reduceat(par_col, i0s) / np.diff(self.indices)
                 else:

--- a/astropy/table/tests/conftest.py
+++ b/astropy/table/tests/conftest.py
@@ -178,16 +178,17 @@ def mixin_cols(request):
 
 @pytest.fixture(params=[False, True])
 def T1(request):
-    T = Table.read([' a b c d',
-                    ' 2 c 7.0 0',
-                    ' 2 b 5.0 1',
-                    ' 2 b 6.0 2',
-                    ' 2 a 4.0 3',
-                    ' 0 a 0.0 4',
-                    ' 1 b 3.0 5',
-                    ' 1 a 2.0 6',
-                    ' 1 a 1.0 7',
-                    ], format='ascii')
+    T = QTable.read([' a b c d',
+                     ' 2 c 7.0 0',
+                     ' 2 b 5.0 1',
+                     ' 2 b 6.0 2',
+                     ' 2 a 4.0 3',
+                     ' 0 a 0.0 4',
+                     ' 1 b 3.0 5',
+                     ' 1 a 2.0 6',
+                     ' 1 a 1.0 7',
+                     ], format='ascii')
+    T['q'] = np.arange(len(T)) * u.m
     T.meta.update({'ta': 1})
     T['c'].meta.update({'a': 1})
     T['c'].description = 'column c'

--- a/astropy/table/tests/test_groups.py
+++ b/astropy/table/tests/test_groups.py
@@ -643,14 +643,14 @@ def test_group_mixins():
     assert np.all(idxg == [1, 3, 2, 0])
 
 
-def test_group_mixins_unsupported():
+@pytest.mark.parametrize(
+    'col', [time.TimeDelta([1, 2], format='sec'),
+            time.Time([1, 2], format='cxcsec'),
+            coordinates.SkyCoord([1, 2], [3, 4], unit='deg,deg')])
+def test_group_mixins_unsupported(col):
     """Test that aggregating unsupported mixins produces a warning only"""
-    td = time.TimeDelta([1, 2], format='sec')
-    tm = time.Time([1, 2], format='cxcsec')
-    sc = coordinates.SkyCoord([1, 2], [3, 4], unit='deg,deg')
 
-    for col in [td, sc, tm]:
-        t = Table([[1, 1], [3, 4], col], names=['a', 'b', 'mix'])
-        tg = t.group_by('a')
-        with pytest.warns(AstropyUserWarning, match="Cannot aggregate column 'mix'"):
-            tg.groups.aggregate(np.sum)
+    t = Table([[1, 1], [3, 4], col], names=['a', 'b', 'mix'])
+    tg = t.group_by('a')
+    with pytest.warns(AstropyUserWarning, match="Cannot aggregate column 'mix'"):
+        tg.groups.aggregate(np.sum)

--- a/astropy/table/tests/test_groups.py
+++ b/astropy/table/tests/test_groups.py
@@ -17,7 +17,7 @@ def sort_eq(list1, list2):
 
 def test_column_group_by(T1):
     for masked in (False, True):
-        t1 = Table(T1, masked=masked)
+        t1 = QTable(T1, masked=masked)
         t1a = t1['a'].copy()
 
         # Group by a Column (i.e. numpy array)
@@ -39,7 +39,7 @@ def test_table_group_by(T1):
     masked/unmasked tables.
     """
     for masked in (False, True):
-        t1 = Table(T1, masked=masked)
+        t1 = QTable(T1, masked=masked)
         # Group by a single column key specified by name
         tg = t1.group_by('a')
         assert np.all(tg.groups.indices == np.array([0, 1, 4, 8]))
@@ -47,16 +47,17 @@ def test_table_group_by(T1):
         assert str(tg['a'].groups) == "<ColumnGroups indices=[0 1 4 8]>"
 
         # Sorted by 'a' and in original order for rest
-        assert tg.pformat() == [' a   b   c   d ',
-                                '--- --- --- ---',
-                                '  0   a 0.0   4',
-                                '  1   b 3.0   5',
-                                '  1   a 2.0   6',
-                                '  1   a 1.0   7',
-                                '  2   c 7.0   0',
-                                '  2   b 5.0   1',
-                                '  2   b 6.0   2',
-                                '  2   a 4.0   3']
+        assert tg.pformat() == [' a   b   c   d   q ',
+                                '                 m ',
+                                '--- --- --- --- ---',
+                                '  0   a 0.0   4 4.0',
+                                '  1   b 3.0   5 5.0',
+                                '  1   a 2.0   6 6.0',
+                                '  1   a 1.0   7 7.0',
+                                '  2   c 7.0   0 0.0',
+                                '  2   b 5.0   1 1.0',
+                                '  2   b 6.0   2 2.0',
+                                '  2   a 4.0   3 3.0']
         assert tg.meta['ta'] == 1
         assert tg['c'].meta['a'] == 1
         assert tg['c'].description == 'column c'
@@ -70,16 +71,17 @@ def test_table_group_by(T1):
             tg = t1.group_by(keys)
             assert np.all(tg.groups.indices == np.array([0, 1, 3, 4, 5, 7, 8]))
             # Sorted by 'a', 'b' and in original order for rest
-            assert tg.pformat() == [' a   b   c   d ',
-                                    '--- --- --- ---',
-                                    '  0   a 0.0   4',
-                                    '  1   a 2.0   6',
-                                    '  1   a 1.0   7',
-                                    '  1   b 3.0   5',
-                                    '  2   a 4.0   3',
-                                    '  2   b 5.0   1',
-                                    '  2   b 6.0   2',
-                                    '  2   c 7.0   0']
+            assert tg.pformat() == [' a   b   c   d   q ',
+                                    '                 m ',
+                                    '--- --- --- --- ---',
+                                    '  0   a 0.0   4 4.0',
+                                    '  1   a 2.0   6 6.0',
+                                    '  1   a 1.0   7 7.0',
+                                    '  1   b 3.0   5 5.0',
+                                    '  2   a 4.0   3 3.0',
+                                    '  2   b 5.0   1 1.0',
+                                    '  2   b 6.0   2 2.0',
+                                    '  2   c 7.0   0 0.0']
 
         # Group by a Table
         tg2 = t1.group_by(t1['a', 'b'])
@@ -92,16 +94,17 @@ def test_table_group_by(T1):
         # Group by a simple ndarray
         tg = t1.group_by(np.array([0, 1, 0, 1, 2, 1, 0, 0]))
         assert np.all(tg.groups.indices == np.array([0, 4, 7, 8]))
-        assert tg.pformat() == [' a   b   c   d ',
-                                '--- --- --- ---',
-                                '  2   c 7.0   0',
-                                '  2   b 6.0   2',
-                                '  1   a 2.0   6',
-                                '  1   a 1.0   7',
-                                '  2   b 5.0   1',
-                                '  2   a 4.0   3',
-                                '  1   b 3.0   5',
-                                '  0   a 0.0   4']
+        assert tg.pformat() == [' a   b   c   d   q ',
+                                '                 m ',
+                                '--- --- --- --- ---',
+                                '  2   c 7.0   0 0.0',
+                                '  2   b 6.0   2 2.0',
+                                '  1   a 2.0   6 6.0',
+                                '  1   a 1.0   7 7.0',
+                                '  2   b 5.0   1 1.0',
+                                '  2   a 4.0   3 3.0',
+                                '  1   b 3.0   5 5.0',
+                                '  0   a 0.0   4 4.0']
 
 
 def test_groups_keys(T1):
@@ -134,7 +137,7 @@ def test_grouped_copy(T1):
     Test that copying a table or column copies the groups properly
     """
     for masked in (False, True):
-        t1 = Table(T1, masked=masked)
+        t1 = QTable(T1, masked=masked)
         tg = t1.group_by('a')
         tgc = tg.copy()
         assert np.all(tgc.groups.indices == tg.groups.indices)
@@ -155,7 +158,7 @@ def test_grouped_slicing(T1):
     """
 
     for masked in (False, True):
-        t1 = Table(T1, masked=masked)
+        t1 = QTable(T1, masked=masked)
 
         # Regular slice of a table
         tg = t1.group_by('a')
@@ -266,11 +269,11 @@ def test_mutable_operations(T1):
     but adding or removing or renaming a column should retain grouping.
     """
     for masked in (False, True):
-        t1 = Table(T1, masked=masked)
+        t1 = QTable(T1, masked=masked)
 
         # add row
         tg = t1.group_by('a')
-        tg.add_row((0, 'a', 3.0, 4))
+        tg.add_row((0, 'a', 3.0, 4, 4 * u.m))
         assert np.all(tg.groups.indices == np.array([0, len(tg)]))
         assert tg.groups.keys is None
 
@@ -312,19 +315,20 @@ def test_mutable_operations(T1):
 
 
 def test_group_by_masked(T1):
-    t1m = Table(T1, masked=True)
+    t1m = QTable(T1, masked=True)
     t1m['c'].mask[4] = True
     t1m['d'].mask[5] = True
-    assert t1m.group_by('a').pformat() == [' a   b   c   d ',
-                                           '--- --- --- ---',
-                                           '  0   a  --   4',
-                                           '  1   b 3.0  --',
-                                           '  1   a 2.0   6',
-                                           '  1   a 1.0   7',
-                                           '  2   c 7.0   0',
-                                           '  2   b 5.0   1',
-                                           '  2   b 6.0   2',
-                                           '  2   a 4.0   3']
+    assert t1m.group_by('a').pformat() == [' a   b   c   d   q ',
+                                           '                 m ',
+                                           '--- --- --- --- ---',
+                                           '  0   a  --   4 4.0',
+                                           '  1   b 3.0  -- 5.0',
+                                           '  1   a 2.0   6 6.0',
+                                           '  1   a 1.0   7 7.0',
+                                           '  2   c 7.0   0 0.0',
+                                           '  2   b 5.0   1 1.0',
+                                           '  2   b 6.0   2 2.0',
+                                           '  2   a 4.0   3 3.0']
 
 
 def test_group_by_errors(T1):
@@ -348,7 +352,7 @@ def test_group_by_errors(T1):
         T1.group_by(None)
 
     # Masked key column
-    t1 = Table(T1, masked=True)
+    t1 = QTable(T1, masked=True)
     t1['a'].mask[4] = True
     with pytest.raises(ValueError):
         t1.group_by('a')
@@ -408,23 +412,24 @@ def test_table_aggregate(T1):
     # Aggregate with np.sum with masked elements.  This results
     # in one group with no elements, hence a nan result and conversion
     # to float for the 'd' column.
-    t1m = Table(t1, masked=True)
+    t1m = QTable(T1, masked=True)
     t1m['c'].mask[4:6] = True
     t1m['d'].mask[4:6] = True
     tg = t1m.group_by('a')
     with pytest.warns(UserWarning, match="converting a masked element to nan"):
         tga = tg.groups.aggregate(np.sum)
 
-    assert tga.pformat() == [' a   c    d  ',
-                             '--- ---- ----',
-                             '  0  nan  nan',
-                             '  1  3.0 13.0',
-                             '  2 22.0  6.0']
+    assert tga.pformat() == [' a   c    d    q  ',
+                             '               m  ',
+                             '--- ---- ---- ----',
+                             '  0  nan  nan  4.0',
+                             '  1  3.0 13.0 18.0',
+                             '  2 22.0  6.0  6.0']
 
     # Aggregrate with np.sum with masked elements, but where every
     # group has at least one remaining (unmasked) element.  Then
     # the int column stays as an int.
-    t1m = Table(t1, masked=True)
+    t1m = QTable(t1, masked=True)
     t1m['c'].mask[5] = True
     t1m['d'].mask[5] = True
     tg = t1m.group_by('a')
@@ -440,11 +445,12 @@ def test_table_aggregate(T1):
     tg = T1.group_by('a')
     with pytest.warns(AstropyUserWarning, match="Cannot aggregate column"):
         tga = tg.groups.aggregate(np.sum)
-    assert tga.pformat() == [' a   c    d ',
-                             '--- ---- ---',
-                             '  0  0.0   4',
-                             '  1  6.0  18',
-                             '  2 22.0   6']
+    assert tga.pformat() == [' a   c    d   q  ',
+                             '              m  ',
+                             '--- ---- --- ----',
+                             '  0  0.0   4  4.0',
+                             '  1  6.0  18 18.0',
+                             '  2 22.0   6  6.0']
 
 
 def test_table_aggregate_reduceat(T1):
@@ -504,7 +510,7 @@ def test_column_aggregate(T1):
     Aggregate a single table column
     """
     for masked in (False, True):
-        tg = Table(T1, masked=masked).group_by('a')
+        tg = QTable(T1, masked=masked).group_by('a')
         tga = tg['c'].groups.aggregate(np.sum)
         assert tga.pformat() == [' c  ',
                                  '----',
@@ -635,3 +641,16 @@ def test_group_mixins():
     # Column group_by() with mixins
     idxg = qt['idx'].group_by(qt[mixin_keys])
     assert np.all(idxg == [1, 3, 2, 0])
+
+
+def test_group_mixins_unsupported():
+    """Test that aggregating unsupported mixins produces a warning only"""
+    td = time.TimeDelta([1, 2], format='sec')
+    tm = time.Time([1, 2], format='cxcsec')
+    sc = coordinates.SkyCoord([1, 2], [3, 4], unit='deg,deg')
+
+    for col in [td, sc, tm]:
+        t = Table([[1, 1], [3, 4], col], names=['a', 'b', 'mix'])
+        tg = t.group_by('a')
+        with pytest.warns(AstropyUserWarning, match="Cannot aggregate column 'mix'"):
+            tg.groups.aggregate(np.sum)

--- a/astropy/utils/data_info.py
+++ b/astropy/utils/data_info.py
@@ -511,7 +511,7 @@ class BaseColumnInfo(DataInfo):
     Note that this class is defined here so that mixins can use it
     without importing the table package.
     """
-    attr_names = DataInfo.attr_names.union(['parent_table', 'indices'])
+    attr_names = DataInfo.attr_names | {'parent_table', 'indices'}
     _attrs_no_copy = set(['parent_table', 'indices'])
 
     # Context for serialization.  This can be set temporarily via
@@ -751,6 +751,15 @@ class MixinInfo(BaseColumnInfo):
             self.parent_table.columns._rename_column(self.name, new_name)
 
         self._attrs['name'] = name
+
+    @property
+    def groups(self):
+        # This implementation for mixin columns essentially matches the Column
+        # property definition.  `groups` is a read-only property here and
+        # depends on the parent table of the column having `groups`. This will
+        # allow aggregating mixins as long as they support those operations.
+        from astropy.table import groups
+        return self._attrs.setdefault('groups', groups.ColumnGroups(self._parent))
 
 
 class ParentDtypeInfo(MixinInfo):

--- a/docs/changes/table/12825.feature.rst
+++ b/docs/changes/table/12825.feature.rst
@@ -1,0 +1,4 @@
+Add support for using mixin columns in group aggregation operations when the
+mixin supports the specified operation (e.g. ``np.sum`` works for ``Quantity``
+but not ``Time``). In cases where the operation is not supported the code now
+issues a warning and drops the column instead of raising an exception.

--- a/docs/table/mixin_columns.rst
+++ b/docs/table/mixin_columns.rst
@@ -200,28 +200,6 @@ work.
 Masking of mixin columns is enabled by the |Masked| class. See
 :ref:`utils-masked` for details.
 
-**High-level table operations**
-
-Some :ref:`grouped-operations` can be used with a |QTable| with |Quantity|
-columns, but performing aggregation on such a |QTable| fails::
-
-  >>> import numpy as np
-  >>> t = QTable()
-  >>> t['name'] = ['foo', 'foo', 'bar']
-  >>> t['a'] = np.arange(3)*u.m
-  >>> t_grouped = t.group_by('name')
-  >>> print(t_grouped)
-  name  a
-        m
-  ---- ---
-   bar 2.0
-   foo 0.0
-   foo 1.0
-  >>> t_grouped.groups.aggregate(np.mean)
-  Traceback (most recent call last):
-  ...
-  AttributeError: 'Quantity' object has no 'groups' member
-
 **ASCII table writing**
 
 Tables with mixin columns can be written out to file using the

--- a/docs/table/mixin_columns.rst
+++ b/docs/table/mixin_columns.rst
@@ -356,6 +356,7 @@ This can be done for data classes that are defined in third-party packages and w
 you have no control over. As an example, we define a class
 that is not numpy-like and stores the data in a private attribute::
 
+    >>> import numpy as np
     >>> class ExampleDataClass:
     ...     def __init__(self):
     ...         self._data = np.array([0, 1, 3, 4], dtype=float)

--- a/docs/table/operations.rst
+++ b/docs/table/operations.rst
@@ -278,7 +278,7 @@ For the example grouped table ``obs_by_name`` from above, we compute the group
 means with the :meth:`~astropy.table.groups.TableGroups.aggregate` method::
 
   >>> obs_mean = obs_by_name.groups.aggregate(np.mean)  # doctest: +SHOW_WARNINGS
-  AstropyUserWarning: Cannot aggregate column 'obs_date' with type '<U10'
+  WARNING: Cannot aggregate column 'obs_date' with type '<U10': cannot perform reduceat with flexible type [astropy.table.groups]
   >>> print(obs_mean)
   name mag_b mag_v
   ---- ----- -----
@@ -289,7 +289,7 @@ means with the :meth:`~astropy.table.groups.TableGroups.aggregate` method::
 It seems the magnitude values were successfully averaged, but what about the
 :class:`~astropy.utils.exceptions.AstropyUserWarning`? Since the ``obs_date``
 column is a string-type array, the :func:`numpy.mean` function failed and
-raised an exception.  Any time this happens
+raised an exception ``cannot perform reduceat with flexible type``.  Any time this happens
 :meth:`~astropy.table.groups.TableGroups.aggregate` will issue a warning and
 then drop that column from the output result. Note that the ``name`` column is
 one of the ``keys`` used to determine the grouping so it is automatically

--- a/docs/table/operations.rst
+++ b/docs/table/operations.rst
@@ -278,7 +278,7 @@ For the example grouped table ``obs_by_name`` from above, we compute the group
 means with the :meth:`~astropy.table.groups.TableGroups.aggregate` method::
 
   >>> obs_mean = obs_by_name.groups.aggregate(np.mean)  # doctest: +SHOW_WARNINGS
-  AstropyUserWarning: Cannot aggregate column 'obs_date' with type '<U10': ufunc 'add' did not contain a loop with signature matching types (dtype('<U10'), dtype('<U10')) -> None
+  AstropyUserWarning: Cannot aggregate column 'obs_date' with type '<U10': ...
   >>> print(obs_mean)
   name mag_b mag_v
   ---- ----- -----

--- a/docs/table/operations.rst
+++ b/docs/table/operations.rst
@@ -278,7 +278,7 @@ For the example grouped table ``obs_by_name`` from above, we compute the group
 means with the :meth:`~astropy.table.groups.TableGroups.aggregate` method::
 
   >>> obs_mean = obs_by_name.groups.aggregate(np.mean)  # doctest: +SHOW_WARNINGS
-  WARNING: Cannot aggregate column 'obs_date' with type '<U10': cannot perform reduceat with flexible type [astropy.table.groups]
+  AstropyUserWarning: Cannot aggregate column 'obs_date' with type '<U10': ufunc 'add' did not contain a loop with signature matching types (dtype('<U10'), dtype('<U10')) -> None
   >>> print(obs_mean)
   name mag_b mag_v
   ---- ----- -----


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request adds support for using mixin columns in group aggregation operations when the mixin supports the specified operation (e.g. ``np.sum`` works for ``Quantity`` but not ``Time``). In cases where the operation is not supported the code now issues a warning and drops the column instead of raising an exception.

Notes:
- To support mixins the `groups` attribute was added to the `info` property. For `Column` this is taken from the parent, while for mixins this is a distinct new attribute.
- The tests were updated to include a `Quantity` column in most grouping tests.
- As before, when a column cannot be aggregated for any reason it is dropped from the output and a warning is issued. Now the text of the warning includes the exception that caused the problem.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #12249 

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
