### PR TITLE
WCS documentation: fix bad section label

### DIFF
--- a/docs/wcs/index.rst
+++ b/docs/wcs/index.rst
@@ -148,6 +148,8 @@ Other Information
    that
 .. include:: performance.inc.rst
 
+.. _wcs-reference-api:
+
 
 Reference/API
 =============
@@ -162,7 +164,6 @@ See Also
 
 - `wcslib`_
 
-.. _wcs-reference-api:
 
 
 Acknowledgments and Licenses


### PR DESCRIPTION
On the [WCS API page](https://docs.astropy.org/en/stable/wcs/wcsapi.html#basic-usage), there is a link to [the wcs reference API](https://docs.astropy.org/en/stable/wcs/index.html#wcs-reference-api) that gets rendered as
![image](https://user-images.githubusercontent.com/143715/153775700-c339a8f2-d57b-49b2-aadb-ed609056d39f.png)

I think this PR will fix that by moving the .rst label a bit