### PR TITLE
Restore naxis-related attributes when unpickling WCS objects

### DIFF
--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -382,6 +382,12 @@ class WCS(FITSWCSAPIMixin, WCSBase):
                  fix=True, translate_units='', _do_set=True):
         close_fds = []
 
+        # these parameters are stored to be used when unpickling a WCS object:
+        self._init_kwargs = {
+            'keysel': copy.copy(keysel),
+            'colsel': copy.copy(colsel),
+        }
+
         if header is None:
             if naxis is None:
                 naxis = 2
@@ -2994,8 +3000,11 @@ reduce these to 2 dimensions using the naxis kwarg.
         buffer = io.BytesIO()
         hdulist.writeto(buffer)
 
+        dct = self.__dict__.copy()
+        dct['_alt_wcskey'] = self.wcs.alt
+
         return (__WCS_unpickle__,
-                (self.__class__, self.__dict__, buffer.getvalue(),))
+                (self.__class__, dct, buffer.getvalue(),))
 
     def dropaxis(self, dropax):
         """
@@ -3288,9 +3297,11 @@ def __WCS_unpickle__(cls, dct, fits_data):
         for k, na in enumerate(naxes):
             hdulist[0].header[f'naxis{k + 1:d}'] = na
 
+    kwargs = dct.pop('_init_kwargs', {})
     self.__dict__.update(dct)
 
-    WCS.__init__(self, hdulist[0].header, hdulist)
+    wcskey = dct.pop('_alt_wcskey', ' ')
+    WCS.__init__(self, hdulist[0].header, hdulist, key=wcskey, **kwargs)
     self.pixel_bounds = dct.get('_pixel_bounds', None)
 
     return self

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -3277,12 +3277,21 @@ def __WCS_unpickle__(cls, dct, fits_data):
     """
 
     self = cls.__new__(cls)
-    self.__dict__.update(dct)
 
     buffer = io.BytesIO(fits_data)
     hdulist = fits.open(buffer)
 
+    naxis = dct.pop('naxis', None)
+    if naxis:
+        hdulist[0].header['naxis'] = naxis
+        naxes = dct.pop('_naxis', [])
+        for k, na in enumerate(naxes):
+            hdulist[0].header[f'naxis{k + 1:d}'] = na
+
+    self.__dict__.update(dct)
+
     WCS.__init__(self, hdulist[0].header, hdulist)
+    self.pixel_bounds = dct.get('_pixel_bounds', None)
 
     return self
 

--- a/docs/changes/wcs/12844.bugfix.rst
+++ b/docs/changes/wcs/12844.bugfix.rst
@@ -1,0 +1,5 @@
+Fixed a bug due to which ``naxis``, ``pixel_shape``, and
+``pixel_bounds`` attributes of ``astropy.wcs.WCS`` were not restored when
+an ``astropy.wcs.WCS`` object was unpickled. This fix also eliminates
+``FITSFixedWarning`` warning issued during unpiclikng of the WCS objects
+related to the number of axes.

--- a/docs/changes/wcs/12844.bugfix.rst
+++ b/docs/changes/wcs/12844.bugfix.rst
@@ -2,4 +2,6 @@ Fixed a bug due to which ``naxis``, ``pixel_shape``, and
 ``pixel_bounds`` attributes of ``astropy.wcs.WCS`` were not restored when
 an ``astropy.wcs.WCS`` object was unpickled. This fix also eliminates
 ``FITSFixedWarning`` warning issued during unpiclikng of the WCS objects
-related to the number of axes.
+related to the number of axes. This fix also eliminates errors when
+unpickling WCS objects originally created using non-default values for
+`key`, `colsel`, and `keysel` parameters.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request fixes a bug in `astropy.wcs.WCS` due to which `naxis`, `pixel_shape`, and `pixel_bounds` attributes of the `WCS` object are not restored during unpickling. This, in turn, raises `FITSFixedWarning` warning reported in https://github.com/astropy/astropy/issues/12834.

This PR also fixes `test_subclass` which would always pass since the expected value of `foo` would be restored at object initialization. I also added a unit test that tests that `naxis`, `pixel_shape`, and `pixel_bounds` attributes are restored after a unpickling

CC: @svank

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #12834

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
