### PR TITLE
Draft: An equivalency for geometric conversions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -77,9 +77,6 @@ astropy.units
   and also pickled and unpicked also for ``protocol`` >= 2.
   This does not work for big-endian architecture with older ``numpy<1.21.1``. [#12583]
 
-- Added a ``mass_length_time`` equivalency for converting mass, length, and time
-  based on geometric units.
-
 astropy.utils
 ^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -77,6 +77,9 @@ astropy.units
   and also pickled and unpicked also for ``protocol`` >= 2.
   This does not work for big-endian architecture with older ``numpy<1.21.1``. [#12583]
 
+- Added a ``mass_length_time`` equivalency for converting mass, length, and time
+  based on geometric units.
+
 astropy.utils
 ^^^^^^^^^^^^^
 

--- a/astropy/units/equivalencies.py
+++ b/astropy/units/equivalencies.py
@@ -654,10 +654,10 @@ class GeometricUnitConversionFactors:
 
         Parameters
         ----------
-        source_quantity_value: float
+        source_quantity: astropy.units.Quantity
             source quantity value
-        source_units: list
-            list of units
+        target_unit: astropy.units.Quantity
+            target quantity
 
         """
         assert len(source_quantity.unit.bases) == len(target_unit.bases) == 1
@@ -679,9 +679,9 @@ class GeometricUnitConversionFactors:
 
         Parameters
         ----------
-        source_quantity_value: float
+        source_quantity: float
             source quantity value
-        source_units: list
+        target_unit: astropy.units.Quantity, astropy.units.Unit
             list of units
         """
         source_quantity_decomposed = source_quantity.decompose()

--- a/astropy/units/tests/test_equivalencies.py
+++ b/astropy/units/tests/test_equivalencies.py
@@ -9,6 +9,7 @@ from numpy.testing import assert_allclose
 
 # LOCAL
 from astropy import units as u
+from astropy.units import equivalencies
 from astropy.units.equivalencies import Equivalency
 from astropy import constants
 from astropy.tests.helper import assert_quantity_allclose
@@ -218,20 +219,35 @@ def test_massenergy():
 @pytest.mark.parametrize(
     'mass,length,time',
     [[2 * u.solMass, 3 * u.km, 10 * u.microsecond],
-     [1 * u.kg, 7.54e-31 * u.km, 2.47e-36 * u.s]]
+     [1 * u.kg, 7.54e-31 * u.km, 2.47e-36 * u.s],]
 )
-def test_mass_length_time(mass, length, time):
-    """Test known cases of equivalencies. An example being
+def test_mass_length_time_geometrized_equivalency(mass, length, time):
+    """Known cases of mass, length, time equivalencies. An example being
     Schwarzschild radius for sun is 3 km, which is about 10 microsecond
     of light crossing time.
     """
-    converted_mass = mass.to('kg', equivalencies=u.mass_length_time()).value
-    converted_length = length.to('m', equivalencies=u.mass_length_time()).value
-    converted_time = time.to('s', equivalencies=u.mass_length_time()).value
+    converted_mass = mass.to('kg', equivalencies=u.geometrized('mass')).value
+    converted_length = length.to('m', equivalencies=u.geometrized('length')).value
+    converted_time = time.to('s', equivalencies=u.geometrized('time')).value
 
     assert mass.to('kg').value == pytest.approx(converted_mass)
     assert length.to('m').value == pytest.approx(converted_length)
     assert time.to('s').value == pytest.approx(converted_time)
+
+
+@pytest.mark.parametrize(
+    'si_qty,geometrized_qty,physical_type',
+    [[1 * u.lightsecond**2, 1 * u.s**2, 'area'],
+     [1 * u.lightsecond**3, 1 * u.s**3, 'volume'],]
+)
+def test_area_volume_geometric_equivalency(si_qty, geometrized_qty,
+                                           physical_type):
+    """Geometric units of area and volume"""
+    converted_si_qty = geometrized_qty.to(
+        si_qty.unit,
+        equivalencies=u.geometrized(physical_type)
+    )
+    assert converted_si_qty == si_qty
 
 
 def test_is_equivalent():

--- a/astropy/units/tests/test_equivalencies.py
+++ b/astropy/units/tests/test_equivalencies.py
@@ -8,6 +8,7 @@ import numpy as np
 from numpy.testing import assert_allclose
 
 # LOCAL
+from astropy import cosmology
 from astropy import units as u
 from astropy.units import equivalencies
 from astropy.units.equivalencies import Equivalency
@@ -248,6 +249,27 @@ def test_area_volume_geometric_equivalency(si_qty, geometrized_qty,
         equivalencies=u.geometrized(physical_type)
     )
     assert converted_si_qty == si_qty
+
+
+def test_mass_density_geometric_equivalency():
+    """Mass density converted to {mass, length, time}**-2"""
+    rho_c = 3 * cosmology.Planck18.H0**2
+    rho_c /= 8 * np.pi * constants.G
+
+    rho_c_in_time_units = rho_c.to(
+        '1/s2', equivalencies=u.geometrized('mass_density')
+    )
+    rho_c_in_mass_units = rho_c.to(
+        '1/kg2', equivalencies=u.geometrized('mass_density')
+    )
+    rho_c_in_length_units = rho_c.to(
+        '1/m2', equivalencies=u.geometrized('mass_density')
+    )
+    for converted_rho in (rho_c_in_time_units, rho_c_in_mass_units,
+                          rho_c_in_length_units):
+        assert converted_rho.to(
+            'kg/m3', equivalencies=u.geometrized('mass_density')
+        ).value == pytest.approx(rho_c.to('kg/m3').value)
 
 
 def test_is_equivalent():

--- a/astropy/units/tests/test_equivalencies.py
+++ b/astropy/units/tests/test_equivalencies.py
@@ -291,6 +291,14 @@ def test_is_equivalent():
     assert not u.L.is_equivalent((u.m, u.s, u.kg))
     assert not (u.km / u.s).is_equivalent((u.m, u.s, u.kg))
 
+    # geometrized equivalencies
+    assert u.kg.is_equivalent(
+        (u.m, u.s), equivalencies=u.geometrized('mass'))
+    assert u.kg.is_equivalent(
+        (u.m, u.s), equivalencies=u.geometrized('length'))
+    assert u.kg.is_equivalent(
+        (u.m, u.s), equivalencies=u.geometrized('time'))
+
 
 def test_parallax():
     a = u.arcsecond.to(u.pc, 10, u.parallax())

--- a/astropy/units/tests/test_equivalencies.py
+++ b/astropy/units/tests/test_equivalencies.py
@@ -215,6 +215,25 @@ def test_massenergy():
                        pow_eV.value, rtol=1e-7)
 
 
+@pytest.mark.parametrize(
+    'mass,length,time',
+    [[2 * u.solMass, 3 * u.km, 10 * u.microsecond],
+     [1 * u.kg, 7.54e-31 * u.km, 2.47e-36 * u.s]]
+)
+def test_mass_length_time(mass, length, time):
+    """Test known cases of equivalencies. An example being
+    Schwarzschild radius for sun is 3 km, which is about 10 microsecond
+    of light crossing time.
+    """
+    converted_mass = mass.to('kg', equivalencies=u.mass_length_time()).value
+    converted_length = length.to('m', equivalencies=u.mass_length_time()).value
+    converted_time = time.to('s', equivalencies=u.mass_length_time()).value
+
+    assert mass.to('kg').value == pytest.approx(converted_mass)
+    assert length.to('m').value == pytest.approx(converted_length)
+    assert time.to('s').value == pytest.approx(converted_time)
+
+
 def test_is_equivalent():
     assert u.m.is_equivalent(u.pc)
     assert u.cycle.is_equivalent(u.mas)

--- a/docs/changes/units/12847.feature.rst
+++ b/docs/changes/units/12847.feature.rst
@@ -1,1 +1,1 @@
-Added a ``geometrized`` equivalency to get geometric equivalent of physical quantities like mass, length, time.
+Added a ``geometrized`` equivalency to get geometric equivalent of physical quantities like mass, length, time, area, mass density.

--- a/docs/changes/units/12847.feature.rst
+++ b/docs/changes/units/12847.feature.rst
@@ -1,0 +1,1 @@
+Added a ``mass_length_time`` equivalency for converting mass, length, and time based on geometric units.

--- a/docs/changes/units/12847.feature.rst
+++ b/docs/changes/units/12847.feature.rst
@@ -1,1 +1,1 @@
-Added a ``mass_length_time`` equivalency for converting mass, length, and time based on geometric units.
+Added a ``geometrized`` equivalency to get geometric equivalent of physical quantities like mass, length, time.

--- a/docs/units/equivalencies.rst
+++ b/docs/units/equivalencies.rst
@@ -519,7 +519,9 @@ physical types like area and volume.::
     >>> area = (1 * u.lightsecond)**2
     >>> vol = (1 * u.lightsecond)**3
     >>> area.to(u.s**2, equivalencies=u.geometrized('area'))  # doctest: +FLOAT_CMP
+    <Quantity 1. s2>
     >>> vol.to(u.s**3, equivalencies=u.geometrized('volume'))  # doctest: +FLOAT_CMP
+    <Quantity 1. s3>
 
 .. EXAMPLE END
 

--- a/docs/units/equivalencies.rst
+++ b/docs/units/equivalencies.rst
@@ -502,6 +502,22 @@ In a special relativity context it can be convenient to use the
 
 .. EXAMPLE END
 
+Mass-Length-Time Equivalency
+----------------------------
+
+.. EXAMPLE START: Using the Mass-Length-Time Equivalency
+
+In geometric units, mass, length, time, are equivalent, and can be converted
+into each other. This can be useful in the context of general relativity.
+As an example of the Schwarzchild radius for the sun, which is around 3 kilometers,
+use the :func:`~astropy.units.equivalencies.mass_length_time` equivalency to get
+the equivalent in solar mass (about twice the solar mass) ::
+
+    >>> (3 * u.km).to(u.solMass, equivalencies=u.mass_length_time())  # doctest: +FLOAT_CMP
+    <Quantity 2.03165998 solMass>
+
+.. EXAMPLE END
+
 Doppler Redshift Equivalency
 ----------------------------
 

--- a/docs/units/equivalencies.rst
+++ b/docs/units/equivalencies.rst
@@ -510,11 +510,16 @@ Geometrized Equivalency
 In geometric units, mass, length, time, are equivalent, and can be converted
 into each other. This can be useful in the context of general relativity.
 As an example of the Schwarzchild radius for the sun, which is around 3 kilometers,
-use the :func:`~astropy.units.equivalencies.mass_length_time` equivalency to get
-the equivalent in solar mass (about twice the solar mass) ::
+is equivalent to twice its mass. Use the :func:`~astropy.units.equivalencies.geometrized`
+equivalency to perform this conversion. One can also convert other allowed
+physical types like area and volume.::
 
     >>> (3 * u.km).to(u.solMass, equivalencies=u.geometrized('length'))  # doctest: +FLOAT_CMP
     <Quantity 2.03165998 solMass>
+    >>> area = (1 * u.lightsecond)**2
+    >>> vol = (1 * u.lightsecond)**3
+    >>> area.to(u.s**2, equivalencies=u.geometrized('area'))  # doctest: +FLOAT_CMP
+    >>> vol.to(u.s**3, equivalencies=u.geometrized('volume'))  # doctest: +FLOAT_CMP
 
 .. EXAMPLE END
 

--- a/docs/units/equivalencies.rst
+++ b/docs/units/equivalencies.rst
@@ -502,10 +502,10 @@ In a special relativity context it can be convenient to use the
 
 .. EXAMPLE END
 
-Mass-Length-Time Equivalency
-----------------------------
+Geometrized Equivalency
+-----------------------
 
-.. EXAMPLE START: Using the Mass-Length-Time Equivalency
+.. EXAMPLE START: Using the Geometrized Equivalency
 
 In geometric units, mass, length, time, are equivalent, and can be converted
 into each other. This can be useful in the context of general relativity.
@@ -513,7 +513,7 @@ As an example of the Schwarzchild radius for the sun, which is around 3 kilomete
 use the :func:`~astropy.units.equivalencies.mass_length_time` equivalency to get
 the equivalent in solar mass (about twice the solar mass) ::
 
-    >>> (3 * u.km).to(u.solMass, equivalencies=u.mass_length_time())  # doctest: +FLOAT_CMP
+    >>> (3 * u.km).to(u.solMass, equivalencies=u.geometrized('length'))  # doctest: +FLOAT_CMP
     <Quantity 2.03165998 solMass>
 
 .. EXAMPLE END


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request adds a new unit equivalency called `mass_length_time` for converting mass, length, time in geometric units. As an example, by using this equivalency, one can express the Schwarzchild radius for sun in km or in solar masses.
```
>>> import astropy.units as u
>>> (3 * u.km).to(u.solMass, equivalencies=u.mass_length_time())
<Quantity 2.03165998 solMass>
```

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
