### PR TITLE
TST: Use pytest-dev for py310 in v5.0.x

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -63,8 +63,8 @@ jobs:
 
           - name: Python 3.10 with minimal dependencies
             os: ubuntu-latest
-            python: '3.10.0-alpha - 3.10.0'
-            toxenv: py310-test-devdeps
+            python: '3.10'
+            toxenv: py310-test
 
           # NOTE: In the build below we also check that tests do not open and
           # leave open any files. This has a performance impact on running the

--- a/tox.ini
+++ b/tox.ini
@@ -71,6 +71,9 @@ deps =
     image: scipy
     image: pytest-mpl
 
+    # https://github.com/pytest-dev/pytest/issues/9169 + asdf
+    py310: git+https://github.com/pytest-dev/pytest
+
     # Temporary pin pytest-astropy-header
     test: pytest-astropy-header==0.1.2
 


### PR DESCRIPTION
I don't understand why this is not cropping up in `main` and I don't have time to dig, but it is a known issue. xref pytest-dev/pytest#9169 . As long as CI is green again, good enough until next pytest release?

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
