### PR TITLE
Fix write and read FITS tables without `ColDefs` structure

### DIFF
--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -1437,10 +1437,10 @@ class ColDefs(NotifierMixin):
             format = self._col_format_cls.from_recformat(ftype)
 
             # Determine the appropriate dimensions for items in the column
-            # (typically just 1D)
             dim = array.dtype[idx].shape[::-1]
             if dim and (len(dim) > 0 or 'A' in format):
                 if 'A' in format:
+                    # should take into account multidimensional items in the column
                     dimel = int(re.findall('[0-9]+', str(ftype.subdtype[0]))[0])
                     # n x m string arrays must include the max string
                     # length in their dimensions (e.g. l x n x m)
@@ -2370,7 +2370,7 @@ def _convert_record2fits(format):
                              and dtype.subdtype[0].char == 'U'):
         # Unicode dtype--itemsize is 4 times actual ASCII character length,
         # which what matters for FITS column formats
-        # Use dtype.base and dtype.subdtype --dtype may be a multi-dimensional dtype
+        # Use dtype.base and dtype.subdtype --dtype for multi-dimensional items
         itemsize = itemsize // 4
 
     option = str(itemsize)

--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -1441,9 +1441,10 @@ class ColDefs(NotifierMixin):
             dim = array.dtype[idx].shape[::-1]
             if dim and (len(dim) > 0 or 'A' in format):
                 if 'A' in format:
+                    dimel = int(re.findall('[0-9]+', str(ftype.subdtype[0]))[0])
                     # n x m string arrays must include the max string
                     # length in their dimensions (e.g. l x n x m)
-                    dim = (array.dtype[idx].base.itemsize,) + dim
+                    dim = (dimel,) + dim
                 dim = '(' + ','.join(str(d) for d in dim) + ')'
             else:
                 dim = None
@@ -2365,10 +2366,11 @@ def _convert_record2fits(format):
     recformat, kind, dtype = _dtype_to_recformat(format)
     shape = dtype.shape
     itemsize = dtype.base.itemsize
-    if dtype.char == 'U':
+    if dtype.char == 'U' or (dtype.subdtype is not None
+                             and dtype.subdtype[0].char == 'U'):
         # Unicode dtype--itemsize is 4 times actual ASCII character length,
         # which what matters for FITS column formats
-        # Use dtype.base--dtype may be a multi-dimensional dtype
+        # Use dtype.base and dtype.subdtype --dtype may be a multi-dimensional dtype
         itemsize = itemsize // 4
 
     option = str(itemsize)

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -987,22 +987,20 @@ class TestTableFunctions(FitsTestCase):
         data['y'][1] = ['X', 'YZ', 'PQR', '999']
         table = Table(data)
 
-        testfile = self.temp('test.fits')
         # Test convenience functions io.fits.writeto / getdata
-        fits.writeto(testfile, data)
-        with fits.open(testfile):
-            dx = fits.getdata(testfile)
-            assert data['x'].dtype == dx['x'].dtype
-            assert data['y'].dtype == dx['y'].dtype
-            assert np.all(data['x'] == dx['x']), 'x: {} != {}'.format(data['x'], dx['x'])
-            assert np.all(data['y'] == dx['y']), 'y: {} != {}'.format(data['y'], dx['y'])
+        fits.writeto(self.temp('test.fits'), data)
+        dx = fits.getdata(self.temp('test.fits'))
+        assert data['x'].dtype == dx['x'].dtype
+        assert data['y'].dtype == dx['y'].dtype
+        assert np.all(data['x'] == dx['x']), 'x: {} != {}'.format(data['x'], dx['x'])
+        assert np.all(data['y'] == dx['y']), 'y: {} != {}'.format(data['y'], dx['y'])
 
         # Test fits.BinTableHDU(data) and avoid convenience functions
         hdu0 = fits.PrimaryHDU()
         hdu1 = fits.BinTableHDU(data)
         hx = fits.HDUList([hdu0, hdu1])
-        hx.writeto(testfile, overwrite=True)
-        fx = fits.open(testfile)
+        hx.writeto(self.temp('test2.fits'))
+        fx = fits.open(self.temp('test2.fits'))
         dx = fx[1].data
         fx.close()
         assert data['x'].dtype == dx['x'].dtype
@@ -1011,8 +1009,8 @@ class TestTableFunctions(FitsTestCase):
         assert np.all(data['y'] == dx['y']), 'y: {} != {}'.format(data['y'], dx['y'])
 
         # Test Table write and read
-        table.write(testfile, overwrite=True)
-        tx = Table.read(testfile, character_as_bytes=False)
+        table.write(self.temp('test3.fits'))
+        tx = Table.read(self.temp('test3.fits'), character_as_bytes=False)
         assert table['x'].dtype == tx['x'].dtype
         assert table['y'].dtype == tx['y'].dtype
         assert np.all(table['x'] == tx['x']), 'x: {} != {}'.format(table['x'], tx['x'])

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -990,11 +990,12 @@ class TestTableFunctions(FitsTestCase):
         testfile = self.temp('test.fits')
         # Test convenience functions io.fits.writeto / getdata
         fits.writeto(testfile, data)
-        dx = fits.getdata(testfile)
-        assert data['x'].dtype == dx['x'].dtype
-        assert data['y'].dtype == dx['y'].dtype
-        assert np.all(data['x'] == dx['x']), 'x: {} != {}'.format(data['x'], dx['x'])
-        assert np.all(data['y'] == dx['y']), 'y: {} != {}'.format(data['y'], dx['y'])
+        with fits.open(testfile):
+            dx = fits.getdata(testfile)
+            assert data['x'].dtype == dx['x'].dtype
+            assert data['y'].dtype == dx['y'].dtype
+            assert np.all(data['x'] == dx['x']), 'x: {} != {}'.format(data['x'], dx['x'])
+            assert np.all(data['y'] == dx['y']), 'y: {} != {}'.format(data['y'], dx['y'])
 
         # Test fits.BinTableHDU(data) and avoid convenience functions
         hdu0 = fits.PrimaryHDU()

--- a/docs/changes/io.fits/12863.bugfix.rst
+++ b/docs/changes/io.fits/12863.bugfix.rst
@@ -1,0 +1,2 @@
+Fix write and read FITS tables with multidimensional items, using ``from_columns``
+without previousely defined ``ColDefs`` structure.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address the issues described in #5280 and #5287.
It improve the conversion of table columns from record format spec to FITS format spec in the case of multidimensional objects.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #5280, fixes #5287.

Thank you for considering it.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
