### PR TITLE
bugfix: add ``cosmology`` argument to ``from_yaml``

### DIFF
--- a/astropy/cosmology/connect.py
+++ b/astropy/cosmology/connect.py
@@ -166,6 +166,10 @@ class CosmologyFromFormat(io_registry.UnifiedReadWrite):
         to identify the correct format.
     **kwargs
         Keyword arguments passed through to data parser.
+        Parsers should accept the following keyword arguments:
+
+        - cosmology : the class (or string name thereof) to use / check when
+                      constructing the cosmology instance.
 
     Returns
     -------

--- a/astropy/cosmology/io/tests/base.py
+++ b/astropy/cosmology/io/tests/base.py
@@ -47,6 +47,10 @@ class ToFromTestMixinBase(IOTestBase):
         """Convert Cosmology instance using ``.to_format()``."""
         return cosmo.to_format
 
+    def can_autodentify(self, format):
+        """Check whether a format can auto-identify."""
+        return format in Cosmology.from_format.registry._identifiers
+
 
 class ReadWriteTestMixinBase(IOTestBase):
     """Tests for a Cosmology[Read/Write].

--- a/astropy/cosmology/io/tests/test_yaml.py
+++ b/astropy/cosmology/io/tests/test_yaml.py
@@ -74,20 +74,19 @@ class ToFromYAMLTestMixin(ToFromTestMixinBase):
 
     # ===============================================================
 
-    def test_tofrom_yaml_instance(self, cosmo, to_format, from_format,
-                                  xfail_if_not_registered_with_yaml):
-        """Test cosmology -> YAML -> cosmology."""
-        # ------------
-        # To YAML
-
+    def test_to_yaml(self, cosmo, to_format, xfail_if_not_registered_with_yaml):
+        """Test cosmology -> YAML."""
         yml = to_format('yaml')
+
         assert isinstance(yml, str)  # test type
         assert yml.startswith("!astropy.cosmology.")
 
-        # ------------
-        # From YAML
+    def test_from_yaml_default(self, cosmo, to_format, from_format,
+                               xfail_if_not_registered_with_yaml):
+        """Test cosmology -> YAML -> cosmology."""
+        yml = to_format('yaml')
 
-        got = from_format(yml, format="yaml")
+        got = from_format(yml, format="yaml")  # (cannot autoidentify)
 
         assert got.name == cosmo.name
         assert got.meta == cosmo.meta
@@ -98,15 +97,19 @@ class ToFromYAMLTestMixin(ToFromTestMixinBase):
         assert got.meta == cosmo.meta
 
         # auto-identify test moved because it doesn't work.
-        # see test_tofrom_yaml_autoidentify
+        # see test_from_yaml_autoidentify
 
-    def test_tofrom_yaml_autoidentify(self, cosmo, to_format, from_format,
+    def test_from_yaml_autoidentify(self, cosmo, to_format, from_format,
                                       xfail_if_not_registered_with_yaml):
         """As a non-path string, it does NOT auto-identifies 'format'.
 
         TODO! this says there should be different types of I/O registries.
               not just hacking object conversion on top of file I/O.
         """
+        assert self.can_autodentify("yaml") is False
+
+        # Showing the specific error. The str is interpreted as a file location
+        # but is too long a file name.
         yml = to_format('yaml')
         with pytest.raises((FileNotFoundError, OSError)):  # OSError in Windows
             from_format(yml)
@@ -117,6 +120,8 @@ class ToFromYAMLTestMixin(ToFromTestMixinBase):
     #     Test writing from an instance and reading from that class.
     #     This works with missing information.
     #     """
+
+    # -----------------------------------------------------
 
     @pytest.mark.parametrize("format", [True, False, None])
     def test_is_equivalent_to_yaml(self, cosmo, to_format, format,
@@ -164,7 +169,7 @@ class TestToFromYAML(ToFromDirectTestBase, ToFromYAMLTestMixin):
         """
         yield  # run tests
 
-    def test_tofrom_yaml_autoidentify(self, cosmo, to_format, from_format):
+    def test_from_yaml_autoidentify(self, cosmo, to_format, from_format):
         """
         If directly calling the function there's no auto-identification.
         So this overrides the test from `ToFromYAMLTestMixin`

--- a/astropy/cosmology/io/yaml.py
+++ b/astropy/cosmology/io/yaml.py
@@ -121,20 +121,38 @@ def register_cosmology_yaml(cosmo_cls):
 # Unified-I/O Functions
 
 
-def from_yaml(yml):
+def from_yaml(yml, *, cosmology=None):
     """Load `~astropy.cosmology.Cosmology` from :mod:`yaml` object.
 
     Parameters
     ----------
     yml : str
         :mod:`yaml` representation of |Cosmology| object
+    cosmology : str, `~astropy.cosmology.Cosmology` class, or None (optional, keyword-only)
+        The expected cosmology class (or string name thereof). This argument is
+        is only checked for correctness if not `None`.
 
     Returns
     -------
     `~astropy.cosmology.Cosmology` subclass instance
+
+    Raises
+    ------
+    TypeError
+        If the |Cosmology| object loaded from ``yml`` is not an instance of
+        the ``cosmology`` (and ``cosmology`` is not `None`).
     """
     with u.add_enabled_units(cu):
-        return load(yml)
+        cosmo = load(yml)
+
+    # Check argument `cosmology`, if not None
+    # This kwarg is required for compatibility with |Cosmology.from_format|
+    if isinstance(cosmology, str):
+        cosmology = _COSMOLOGY_CLASSES[cosmology]
+    if cosmology is not None and not isinstance(cosmo, cosmology):
+        raise TypeError(f"cosmology {cosmo} is not an {cosmology} instance.")
+
+    return cosmo
 
 
 def to_yaml(cosmology, *args):

--- a/docs/changes/cosmology/12279.feature.rst
+++ b/docs/changes/cosmology/12279.feature.rst
@@ -1,2 +1,2 @@
-Register "yaml" into Cosmology's ``to/from_format`` I/O, allowing
-a Cosmology instance to be parsed from or converted to a YAML string.
+Cosmology instance can be parsed from or converted to a YAML string using
+the new "yaml" format in Cosmology's ``to/from_format`` I/O.


### PR DESCRIPTION
This argument is required for compatibility with the standard set of keyword arguments `astropy.cosmology.Cosmology.from_format`.

No changelog entry needed because "yaml" was added after v5.0.

@mhvk, I've discovered some other I/O functions will require similar bug fixes. I think thankfully all these are v5.1, so 🤞no backports will be necessary.

Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>


### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
