### PR TITLE
MNT: Remove jinja2 from build dependency

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -68,7 +68,7 @@ jobs:
       if: matrix.language == 'cpp'
       run: |
        pip install -U pip setuptools_scm wheel
-       pip install extension-helpers jinja2 cython numpy pyerfa
+       pip install extension-helpers cython numpy pyerfa
        python setup.py build_ext --inplace
 
     - name: Perform CodeQL Analysis

--- a/docs/development/workflow/get_devel_version.rst
+++ b/docs/development/workflow/get_devel_version.rst
@@ -228,8 +228,8 @@ ahead to the more sophisticated method look at :ref:`virtual_envs`).
 
 If you have decided to use the recommended "activation" method with
 ``pip``, please note the following: Before trying to install,
-check that you have the required dependencies: "cython" and "jinja2".
-If not, install them with ``pip``. Note that on some platforms,
+check that you have the required dependency: "cython".
+If not, install it with ``pip``. Note that on some platforms,
 the pip command is ``pip3`` instead of ``pip``, so be sure to use
 this instead in the examples below if that is the case.
 If you have any problem with different versions of ``pip`` installed,

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -246,8 +246,7 @@ Prerequisites
 
 You will need a compiler suite and the development headers for Python in order
 to build ``astropy``. You do not need to install any other specific build
-dependencies (such as `Cython <https://cython.org/>`_ or
-`jinja2 <https://jinja.palletsprojects.com/en/master/>`_) since these are
+dependencies (such as `Cython <https://cython.org/>`_) since these are
 declared in the ``pyproject.toml`` file and will be automatically installed into
 a temporary build environment by pip.
 
@@ -261,11 +260,11 @@ package for your Linux distribution, as well as pip.
 
 For Debian/Ubuntu::
 
-    sudo apt-get install python3-dev python3-numpy-dev python3-setuptools cython3 python3-jinja2 python3-pytest-astropy
+    sudo apt-get install python3-dev python3-numpy-dev python3-setuptools cython3 python3-pytest-astropy
 
 For Fedora/RHEL::
 
-    sudo yum install python3-devel python3-numpy python3-setuptools python3-Cython python3-jinja2 python3-pytest-astropy
+    sudo yum install python3-devel python3-numpy python3-setuptools python3-Cython python3-pytest-astropy
 
 .. note:: Building the developer version of ``astropy`` may require
           newer versions of the above packages than are available in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,6 @@ requires = ["setuptools",
             "setuptools_scm>=6.2",
             "wheel",
             "cython==0.29.22",
-            "jinja2==2.10.3",
             "oldest-supported-numpy",
             "extension-helpers"]
 build-backend = 'setuptools.build_meta'


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to completely remove jinja2 as a build requirement. I don't think we need it anymore with #12558 (v5.1). Please let me know if we need a change log.

Close #12875 and open a direct backport of that to v5.0.x branch instead.

Fix astropy/astrowidgets#151

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
