### PR TITLE
Add cron job for auto-updating IERS tables

### DIFF
--- a/.github/workflows/update_iers.yml
+++ b/.github/workflows/update_iers.yml
@@ -3,8 +3,9 @@ name: Auto-update IERS tables
 on:
   schedule:
     - cron: '0 0 * * 0'
+  workflow_dispatch:
 
-jobs:
+    jobs:
   update-iers:
     name: Auto-update IERS tables
     runs-on: ubuntu-latest

--- a/.github/workflows/update_iers.yml
+++ b/.github/workflows/update_iers.yml
@@ -5,7 +5,7 @@ on:
     - cron: '0 0 * * 0'
   workflow_dispatch:
 
-    jobs:
+jobs:
   update-iers:
     name: Auto-update IERS tables
     runs-on: ubuntu-latest

--- a/.github/workflows/update_iers.yml
+++ b/.github/workflows/update_iers.yml
@@ -1,0 +1,35 @@
+name: Auto-update IERS tables
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'
+
+jobs:
+  update-iers:
+    name: Auto-update IERS tables
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Download latest IERS files
+      run: ./update_builtin_iers.sh
+      working-directory: astropy/utils/iers/data
+    - name: Commit changes
+      run: |
+        git config user.name github-actions
+        git config user.email github-actions@github.com
+        git add astropy/utils/iers/data/Leap_Second.dat
+        git add astropy/utils/iers/data/eopc04_IAU2000.62-now
+        git commit -m "Update IERS Earth rotation and leap second tables"
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v3
+      with:
+        branch: update-iers
+        branch-suffix: timestamp
+        delete-branch: true
+        labels: no-changelog-entry-needed, utils.iers
+        title: Update IERS Earth rotation and leap second tables
+        body: |
+          This is an automated update of the IERS Earth rotation and leap second tables.
+
+          **Note to maintainers:** please label this to be backported to all current release branches!

--- a/.github/workflows/update_iers.yml
+++ b/.github/workflows/update_iers.yml
@@ -2,7 +2,7 @@ name: Auto-update IERS tables
 
 on:
   schedule:
-    - cron: '0 0 * * 0'
+    - cron: '0 0 1 * *'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/update_iers.yml
+++ b/.github/workflows/update_iers.yml
@@ -21,7 +21,9 @@ jobs:
         git config user.email github-actions@github.com
         git add astropy/utils/iers/data/Leap_Second.dat
         git add astropy/utils/iers/data/eopc04_IAU2000.62-now
-        git commit -m "Update IERS Earth rotation and leap second tables"
+        if ! git diff --cached --exit-code; then
+          git commit -m "Update IERS Earth rotation and leap second tables"
+        fi
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v3
       with:

--- a/docs/development/releasing.rst
+++ b/docs/development/releasing.rst
@@ -225,7 +225,8 @@ Also make sure that the ReadTheDocs build is passing for the release branch.
 
 One of the continuous integration tasks that should be run periodically is the updates to the
 IERS tables in ``astropy.utils.iers``, so check that the last run from this has been
-successfully run and that related pull requests have been merged (and back-ported if needed).
+successfully run and that related pull requests have been merged (and backported if needed).
+You can also manually trigger it using its workflow dispatch option.
 
 You may also want to locally run the tests (with remote data on to ensure all
 of the tests actually run), using tox to do a thorough test in an isolated

--- a/docs/development/releasing.rst
+++ b/docs/development/releasing.rst
@@ -125,20 +125,6 @@ branch while you are in the middle of following release steps. If you wish to do
 you can go to the core package repository settings, and under 'Branches' and 'Branch
 protection rules' you can then add a rule which restricts who can push to the branch.
 
-.. _release-procedure-update-iers:
-
-Updating the IERS parameter and leap second tables
---------------------------------------------------
-
-Ensure the built-in IERS earth rotation parameter and leap second tables are up
-to date by changing directory to ``astropy/utils/iers/data`` and executing
-``update_builtin_iers.sh``. Check the result with ``git diff`` (do not be
-surprised to find many lines in the ``eopc04_IAU2000.62-now`` file change; those
-data are reanalyzed periodically) and committing. This update should be done via a
-pull request to the ``main`` branch, and then backported to the release branch,
-as it is important for the ``main`` branch to have up-to-date values, and donig it
-via a pull request allows us to check for any failures the update introduces.
-
 .. _release-procedure-update-whatsnew:
 
 Updating the What's new and contributors
@@ -227,34 +213,6 @@ and commit this and the ``.mailmap`` changes::
 Open a pull request to merge this into ``main`` and mark it as requiring backporting to
 the release branch.
 
-
-.. _release-procedure-update-ci:
-
-Update continuous integration configuration
--------------------------------------------
-
-Update the continuous integration configuration in the release branch
-to run on all commits rather than use cron jobs. For example, for GitHub actions,
-you should edit the ``ci_cron*.yml`` files and replace the existing ``on`` section
-with e.g.::
-
-   on:
-   push:
-      branches:
-      - v5.0.x
-   pull_request:
-      branches:
-      - v5.0.x
-
-(with the branch name replaced by the appropriate one), and remove any lines that
-look like e.g.::
-
-        if: (github.repository == 'astropy/astropy' && (github.event_name == 'schedule' ...
-
-This is important because once you are on a release branch, it is necessary to make sure
-we are much more careful about not introducing regressions and we cannot always wait for the
-cron jobs to run to carry out the release.
-
 .. _release-procedure-check-ci:
 
 Ensure continuous integration and intensive tests pass
@@ -264,6 +222,10 @@ Make sure that the continuous integration services (e.g., GitHub Actions or Circ
 for the `astropy core repository`_ branch you are going to release. Also check that
 the `Azure core package pipeline`_ which builds wheels on the ``v*`` branches is passing.
 Also make sure that the ReadTheDocs build is passing for the release branch.
+
+One of the continuous integration tasks that should be run periodically is the updates to the
+IERS tables in ``astropy.utils.iers``, so check that the last run from this has been
+successfully run and that related pull requests have been merged (and back-ported if needed).
 
 You may also want to locally run the tests (with remote data on to ensure all
 of the tests actually run), using tox to do a thorough test in an isolated
@@ -344,7 +306,6 @@ fixes is described in :ref:`release-procedure-bug-fix-backport`.
 Once you have backported any required fixes, repeat the following steps
 you did for the first release candidate:
 
-* :ref:`release-procedure-update-iers` (optional, only do this if it has been a while since it was done before the first release candidate)
 * :ref:`release-procedure-update-whatsnew` (this should only involve updating the numbers of issues and so on, as well as potentially adding a few new contributors)
 * :ref:`release-procedure-check-ci`
 
@@ -439,7 +400,7 @@ Post-Release procedures
 
 #. If this is an LTS release (whether or not it is being supported alongside
    a more recent version), update the "LTS" branch to ponit to the new LTS
-   release:
+   release::
 
       $ git checkout LTS
       $ git reset --hard v<version>
@@ -550,7 +511,6 @@ in :ref:`release-procedure-bug-fix-backport`.
 Once you have backported any required fixes, go through the following steps
 in a similar way to the initial major release:
 
-* :ref:`release-procedure-update-iers` (this should be done in ``main`` and backport it)
 * :ref:`release-procedure-check-ci`
 * :ref:`release-procedure-render-changelog`
 * :ref:`release-procedure-checking-changelog`


### PR DESCRIPTION
### Description

This is an example of how we could use a cron job to auto-update IERS files every e.g month.

Fixes https://github.com/astropy/astropy/issues/12758

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
