### PR TITLE
Add warning for unitless numerical input to TimeDelta

### DIFF
--- a/astropy/io/misc/asdf/tags/time/tests/test_timedelta.py
+++ b/astropy/io/misc/asdf/tags/time/tests/test_timedelta.py
@@ -24,7 +24,7 @@ def test_timedelta(fmt, tmpdir):
 @pytest.mark.parametrize('scale', list(TimeDelta.SCALES) + [None])
 def test_timedelta_scales(scale, tmpdir):
 
-    tree = dict(timedelta=TimeDelta(0.125, scale=scale))
+    tree = dict(timedelta=TimeDelta(0.125, scale=scale, format="jd"))
     assert_roundtrip_tree(tree, tmpdir)
 
 

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -2284,7 +2284,10 @@ class TimeDelta(TimeBase):
     val2 : sequence, ndarray, number, or `~astropy.units.Quantity`; optional
         Additional values, as needed to preserve precision.
     format : str, optional
-        Format of input value(s)
+        Format of input value(s). For numerical inputs without units,
+        "jd" is assumed and values are interpreted as days.
+        A deprecation warning is raised in this case. To avoid the warning,
+        either specify the format or add units to the input values.
     scale : str, optional
         Time scale of input value(s), must be one of the following values:
         ('tdb', 'tt', 'ut1', 'tcg', 'tcb', 'tai'). If not given (or

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -24,7 +24,7 @@ from astropy.units import UnitConversionError
 from astropy.utils import ShapedLikeNDArray
 from astropy.utils.compat.misc import override__dir__
 from astropy.utils.data_info import MixinInfo, data_info_factory
-from astropy.utils.exceptions import AstropyWarning
+from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyWarning
 from .utils import day_frac
 from .formats import (TIME_FORMATS, TIME_DELTA_FORMATS,
                       TimeJD, TimeUnique, TimeAstropyTime, TimeDatetime)
@@ -36,7 +36,7 @@ from astropy.extern import _strptime
 
 __all__ = ['TimeBase', 'Time', 'TimeDelta', 'TimeInfo', 'update_leap_seconds',
            'TIME_SCALES', 'STANDARD_TIME_SCALES', 'TIME_DELTA_SCALES',
-           'ScaleValueError', 'OperandTypeError']
+           'ScaleValueError', 'OperandTypeError', 'TimeDeltaMissingUnitWarning']
 
 
 STANDARD_TIME_SCALES = ('tai', 'tcb', 'tcg', 'tdb', 'tt', 'ut1', 'utc')
@@ -2241,6 +2241,11 @@ class Time(TimeBase):
     to_datetime.__doc__ = TimeDatetime.to_value.__doc__
 
 
+class TimeDeltaMissingUnitWarning(AstropyDeprecationWarning):
+    """Warning for missing unit or format in TimeDelta"""
+    pass
+
+
 class TimeDelta(TimeBase):
     """
     Represent the time difference between two times.
@@ -2312,13 +2317,22 @@ class TimeDelta(TimeBase):
             if scale is not None:
                 self._set_scale(scale)
         else:
-            if format is None:
-                format = 'datetime' if isinstance(val, timedelta) else 'jd'
-
+            format = format or self._get_format(val)
             self._init_from_vals(val, val2, format, scale, copy)
 
             if scale is not None:
                 self.SCALES = TIME_DELTA_TYPES[scale]
+
+    @staticmethod
+    def _get_format(val):
+        if isinstance(val, timedelta):
+            return 'datetime'
+
+        if getattr(val, 'unit', None) is None:
+            warn('Numerical value without unit or explicit format passed to'
+                 ' TimeDelta, assuming days', TimeDeltaMissingUnitWarning)
+
+        return 'jd'
 
     def replicate(self, *args, **kwargs):
         out = super().replicate(*args, **kwargs)

--- a/astropy/time/tests/test_precision.py
+++ b/astropy/time/tests/test_precision.py
@@ -622,7 +622,7 @@ def test_datetime_difference_agrees_with_timedelta(scale, dt1, dt2):
 def test_datetime_to_timedelta(scale, days, microseconds):
     td = timedelta(days=days, microseconds=microseconds)
     assert (TimeDelta(td, scale=scale)
-            == TimeDelta(days, microseconds/(86400*1e6), scale=scale))
+            == TimeDelta(days, microseconds/(86400*1e6), scale=scale, format="jd"))
 
 
 @given(days=integers(-3000*365, 3000*365),
@@ -647,8 +647,9 @@ def test_timedelta_datetime_roundtrip(scale, days, day_frac):
 @example(days=262144, day_frac=2.314815006343452e-11)
 @pytest.mark.parametrize("scale", _utc_bad)
 def test_timedelta_from_parts(scale, days, day_frac):
-    whole = TimeDelta(days, day_frac, format="jd", scale=scale)
-    from_parts = TimeDelta(days, scale=scale) + TimeDelta(day_frac, scale=scale)
+    kwargs = dict(format="jd", scale=scale)
+    whole = TimeDelta(days, day_frac, **kwargs)
+    from_parts = TimeDelta(days, **kwargs) + TimeDelta(day_frac, **kwargs)
     assert whole == from_parts
 
 

--- a/astropy/timeseries/tests/test_binned.py
+++ b/astropy/timeseries/tests/test_binned.py
@@ -74,7 +74,7 @@ def test_initialization_time_bin_size():
     # TimeDelta for time_bin_size
     ts = BinnedTimeSeries(data={"time": ["2016-03-22T12:30:31"]},
                           time_bin_start="2016-03-22T12:30:31",
-                          time_bin_size=TimeDelta(1))
+                          time_bin_size=TimeDelta(1, format="jd"))
     assert isinstance(ts.time_bin_size, u.quantity.Quantity)
 
 

--- a/docs/changes/time/12888.api.rst
+++ b/docs/changes/time/12888.api.rst
@@ -1,0 +1,7 @@
+Creating an `~astropy.time.TimeDelta` object with numerical inputs
+that do not have a unit and without specifying an explicit format,
+for example ``TimeDelta(5)``,
+now results in a `~astropy.time.TimeDeltaMissingUnitWarning`.
+This also affects statements like ``Time("2020-01-01") + 5`` or
+``Time("2020-01-05") - Time("2020-01-03") < 5``, which implicitly
+transform the right-hand side into an `~astropy.time.TimeDelta` instance.

--- a/docs/time/index.rst
+++ b/docs/time/index.rst
@@ -142,6 +142,12 @@ can only have scales in which one day is always equal to 86400 seconds.
   >>> t.sidereal_time('apparent', 'greenwich')  # doctest: +FLOAT_CMP +REMOTE_DATA
   <Longitude [6.68050179, 6.70281947] hourangle>
 
+You can also use time-based `~astropy.units.Quantity` for time arithmetic:
+
+  >>> import astropy.units as u
+  >>> Time("2020-01-01") + 5 * u.day
+  <Time object: scale='utc' format='iso' value=2020-01-06 00:00:00.000>
+
 Using `astropy.time`
 ====================
 
@@ -754,7 +760,7 @@ The operations available with |Time| objects include:
 - Get a new time object for the same time value(s) but referenced to a different
   `time scale`_.
 - Calculate `sidereal time and Earth rotation angle`_ corresponding to the time value(s).
-- Do time arithmetic involving |Time| and/or |TimeDelta| objects.
+- Do time arithmetic involving |Time|, |TimeDelta| and/or |Quantity| objects with units of time.
 
 Get and Set Values
 ^^^^^^^^^^^^^^^^^^
@@ -1182,6 +1188,8 @@ The |TimeDelta| class is derived from the |Time| class and shares many of its
 properties. One difference is that the time scale has to be one for which one
 day is exactly 86400 seconds. Hence, the scale cannot be UTC.
 
+|Quantity| objects with time units can also be used in place of |TimeDelta|.
+
 The available time formats are:
 
 =========  ===================================================
@@ -1224,6 +1232,15 @@ Use of the |TimeDelta| object is illustrated in the few examples below::
   <Time object: scale='utc' format='iso' value=['2010-01-01 00:00:00.000'
   '2010-01-08 18:00:00.000' '2010-01-16 12:00:00.000' '2010-01-24 06:00:00.000'
   '2010-02-01 00:00:00.000']>
+
+  >>> import astropy.units as u
+  >>> t1 + 1 * u.hour
+  <Time object: scale='utc' format='iso' value=2010-01-01 01:00:00.000>
+
+  # The now deprecated default assumes days for numeric inputs
+  >>> t1 + 5.0  # doctest: +SHOW_WARNINGS +ELLIPSIS
+  <Time object: scale='utc' format='iso' value=2010-01-06 00:00:00.000>
+  TimeDeltaMissingUnitWarning: Numerical value without unit or explicit format passed to TimeDelta, assuming days
 
 The |TimeDelta| has a `~astropy.time.TimeDelta.to_value` method which supports
 controlling the type of the output representation by providing either a format


### PR DESCRIPTION


<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description

* Code like `TimeDelta(5)` or `Time("2020-01-01") + 5` now raises an
  `AstropyDeprecationWarning`.
  The warning can be avoided by specifying a unit or a format explicitly:
  `TimeDelta(5 * u.day)`, `TimeDelta(5, format="jd")`


<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->


<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #12887

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
