### PR TITLE
Added `where` kwarg to `astropy.units.Quantity`'s reduction-like methods

### DIFF
--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -18,6 +18,7 @@ import numpy as np
 
 # LOCAL
 from astropy import config as _config
+from astropy.utils.compat import NUMPY_LT_1_20, NUMPY_LT_1_22
 from astropy.utils.compat.misc import override__dir__
 from astropy.utils.data_info import ParentDtypeInfo
 from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyWarning
@@ -1788,19 +1789,34 @@ class Quantity(np.ndarray):
     def trace(self, offset=0, axis1=0, axis2=1, dtype=None, out=None):
         return self._wrap_function(np.trace, offset, axis1, axis2, dtype,
                                    out=out)
+    if NUMPY_LT_1_20:
+        def var(self, axis=None, dtype=None, out=None, ddof=0, keepdims=False):
+            return self._wrap_function(np.var, axis, dtype,
+                                       out=out, ddof=ddof, keepdims=keepdims,
+                                       unit=self.unit**2)
+    else:
+        def var(self, axis=None, dtype=None, out=None, ddof=0, keepdims=False, *, where=True):
+            return self._wrap_function(np.var, axis, dtype,
+                                       out=out, ddof=ddof, keepdims=keepdims, where=where,
+                                       unit=self.unit**2)
 
-    def var(self, axis=None, dtype=None, out=None, ddof=0, keepdims=False):
-        return self._wrap_function(np.var, axis, dtype,
-                                   out=out, ddof=ddof, keepdims=keepdims,
-                                   unit=self.unit**2)
+    if NUMPY_LT_1_20:
+        def std(self, axis=None, dtype=None, out=None, ddof=0, keepdims=False):
+            return self._wrap_function(np.std, axis, dtype, out=out, ddof=ddof,
+                                       keepdims=keepdims)
+    else:
+        def std(self, axis=None, dtype=None, out=None, ddof=0, keepdims=False, *, where=True):
+            return self._wrap_function(np.std, axis, dtype, out=out, ddof=ddof,
+                                       keepdims=keepdims, where=where)
 
-    def std(self, axis=None, dtype=None, out=None, ddof=0, keepdims=False):
-        return self._wrap_function(np.std, axis, dtype, out=out, ddof=ddof,
-                                   keepdims=keepdims)
-
-    def mean(self, axis=None, dtype=None, out=None, keepdims=False):
-        return self._wrap_function(np.mean, axis, dtype, out=out,
-                                   keepdims=keepdims)
+    if NUMPY_LT_1_20:
+        def mean(self, axis=None, dtype=None, out=None, keepdims=False):
+            return self._wrap_function(np.mean, axis, dtype, out=out,
+                                       keepdims=keepdims)
+    else:
+        def mean(self, axis=None, dtype=None, out=None, keepdims=False, *, where=True):
+            return self._wrap_function(np.mean, axis, dtype, out=out,
+                                       keepdims=keepdims, where=where)
 
     def round(self, decimals=0, out=None):
         return self._wrap_function(np.round, decimals, out=out)
@@ -1827,9 +1843,14 @@ class Quantity(np.ndarray):
     def ediff1d(self, to_end=None, to_begin=None):
         return self._wrap_function(np.ediff1d, to_end, to_begin)
 
-    def nansum(self, axis=None, out=None, keepdims=False):
-        return self._wrap_function(np.nansum, axis,
-                                   out=out, keepdims=keepdims)
+    if NUMPY_LT_1_22:
+        def nansum(self, axis=None, out=None, keepdims=False):
+            return self._wrap_function(np.nansum, axis,
+                                       out=out, keepdims=keepdims)
+    else:
+        def nansum(self, axis=None, out=None, keepdims=False, *, initial=None, where=True):
+            return self._wrap_function(np.nansum, axis,
+                                       out=out, keepdims=keepdims, initial=initial, where=where)
 
     def insert(self, obj, values, axis=None):
         """

--- a/astropy/units/tests/test_quantity_array_methods.py
+++ b/astropy/units/tests/test_quantity_array_methods.py
@@ -7,7 +7,7 @@ import pytest
 from numpy.testing import assert_array_equal
 
 from astropy import units as u
-from astropy.utils.compat import NUMPY_LT_1_21_1
+from astropy.utils.compat import NUMPY_LT_1_20, NUMPY_LT_1_21_1, NUMPY_LT_1_22
 
 
 class TestQuantityArrayCopy:
@@ -168,6 +168,11 @@ class TestQuantityStatsFuncs:
         assert qi2 is qi
         assert qi == 3.6 * u.m
 
+    @pytest.mark.xfail(NUMPY_LT_1_20, reason="'where' keyword argument not supported for numpy < 1.20")
+    def test_mean_where(self):
+        q1 = np.array([1., 2., 4., 5., 6., 7.]) * u.m
+        assert_array_equal(np.mean(q1, where=q1 < 7 * u.m), 3.6 * u.m)
+
     def test_std(self):
         q1 = np.array([1., 2.]) * u.m
         assert_array_equal(np.std(q1), 0.5 * u.m)
@@ -179,6 +184,11 @@ class TestQuantityStatsFuncs:
         np.std(q1, out=qi)
         assert qi == 0.5 * u.m
 
+    @pytest.mark.xfail(NUMPY_LT_1_20, reason="'where' keyword argument not supported for numpy < 1.20")
+    def test_std_where(self):
+        q1 = np.array([1., 2., 3.]) * u.m
+        assert_array_equal(np.std(q1, where=q1 < 3 * u.m), 0.5 * u.m)
+
     def test_var(self):
         q1 = np.array([1., 2.]) * u.m
         assert_array_equal(np.var(q1), 0.25 * u.m ** 2)
@@ -189,6 +199,11 @@ class TestQuantityStatsFuncs:
         qi = 1.5 * u.s
         np.var(q1, out=qi)
         assert qi == 0.25 * u.m ** 2
+
+    @pytest.mark.xfail(NUMPY_LT_1_20, reason="'where' keyword argument not supported for numpy < 1.20")
+    def test_var_where(self):
+        q1 = np.array([1., 2., 3.]) * u.m
+        assert_array_equal(np.var(q1, where=q1 < 3 * u.m), 0.25 * u.m ** 2)
 
     def test_median(self):
         q1 = np.array([1., 2., 4., 5., 6.]) * u.m
@@ -210,6 +225,10 @@ class TestQuantityStatsFuncs:
         np.min(q1, out=qi)
         assert qi == 1. * u.m
 
+    def test_min_where(self):
+        q1 = np.array([0., 1., 2., 4., 5., 6.]) * u.m
+        assert np.min(q1, initial=10 * u.m, where=q1 > 0 * u.m) == 1. * u.m
+
     def test_argmin(self):
         q1 = np.array([6., 2., 4., 5., 6.]) * u.m
         assert np.argmin(q1) == 1
@@ -223,6 +242,10 @@ class TestQuantityStatsFuncs:
         qi = 1.5 * u.s
         np.max(q1, out=qi)
         assert qi == 6. * u.m
+
+    def test_max_where(self):
+        q1 = np.array([1., 2., 4., 5., 6., 7.]) * u.m
+        assert np.max(q1, initial=0 * u.m, where=q1 < 7 * u.m) == 6. * u.m
 
     def test_argmax(self):
         q1 = np.array([5., 2., 4., 5., 6.]) * u.m
@@ -285,6 +308,14 @@ class TestQuantityStatsFuncs:
         np.sum(q1, out=qi)
         assert qi == 9. * u.m
 
+    def test_sum_where(self):
+
+        q1 = np.array([1., 2., 6., 7.]) * u.m
+        initial = 0 * u.m
+        where = q1 < 7 * u.m
+        assert np.all(q1.sum(initial=initial, where=where) == 9. * u.m)
+        assert np.all(np.sum(q1, initial=initial, where=where) == 9. * u.m)
+
     def test_cumsum(self):
 
         q1 = np.array([1, 2, 6]) * u.m
@@ -326,6 +357,15 @@ class TestQuantityStatsFuncs:
         qout2 = np.nansum(q1, out=qi2)
         assert qout2 is qi2
         assert qi2 == np.nansum(q1.value) * q1.unit
+
+    @pytest.mark.xfail(NUMPY_LT_1_22, reason="'where' keyword argument not supported for numpy < 1.22")
+    def test_nansum_where(self):
+
+        q1 = np.array([1., 2., np.nan, 4.]) * u.m
+        initial = 0 * u.m
+        where = q1 < 4 * u.m
+        assert np.all(q1.nansum(initial=initial, where=where) == 3. * u.m)
+        assert np.all(np.nansum(q1, initial=initial, where=where) == 3. * u.m)
 
     def test_prod(self):
 

--- a/docs/changes/units/12891.feature.rst
+++ b/docs/changes/units/12891.feature.rst
@@ -1,0 +1,2 @@
+Added the ``where`` keyword argument to the ``mean()``,``var()``, ``std()`` and ``nansum()`` methods of
+``astropy.units.Quantity``. Also added the ``intial`` keyword argument to ``astropy.units.Quantity.nansum()``.

--- a/docs/changes/utils/12891.feature.rst
+++ b/docs/changes/utils/12891.feature.rst
@@ -1,0 +1,2 @@
+Added the ``where`` keyword argument to the ``mean()``, ``var()``, ``std()``, ``any()``, and ``all()`` methods of
+``astropy.utils.masked.MaskedNDArray``.


### PR DESCRIPTION
Added `where` keyword (and `initial` keyword where appropriate) to the following methods:
 - `astropy.units.Quantity.var()`
 - `astropy.units.Quantity.std()`
 - `astropy.units.Quantity.mean()`
 - `astropy.units.Quantity.nansum()`

<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address issues with the `where` keyword added to `numpy.mean()` in numpy version 1.20.0.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #12890

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
