### PR TITLE
Fixed an issue where formally finite values were approximated with nu…

### DIFF
--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -1361,8 +1361,14 @@ def kuiper_false_positive_probability(D, N):
                            - y**2 * t * (3 - 2 / N)
                            + y * t * (t - 1) * (3 - 2 / N) / N
                            - t * (t - 1) * (t - 2) / N**2)
-        term = Tt * comb(N, t) * (1 - D - t / N)**(N - t - 1)
-        return term.sum()
+        term1 = comb(N, t)
+        term2 = (1 - D - t / N)**(N - t - 1)
+        # term1 is formally finite, but is approximated by numpy as np.inf for
+        # large values, so we set them to zero manually when they would be
+        # multiplied by zero anyway
+        term1[(term1 == np.inf) & (term2 == 0)] = 0.
+        final_term = Tt * term1 * term2
+        return final_term.sum()
     else:
         z = D * np.sqrt(N)
         # When m*z>18.82 (sqrt(-log(finfo(double))/2)), exp(-2m**2z**2)

--- a/astropy/stats/tests/test_funcs.py
+++ b/astropy/stats/tests/test_funcs.py
@@ -736,6 +736,12 @@ def test_fpp_kuiper_two(N, M):
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
+def test_kuiper_false_positive_probability():
+    fpp = funcs.kuiper_false_positive_probability(0.5353333333333409, 1500.)
+    assert fpp == 0
+
+
+@pytest.mark.skipif('not HAS_SCIPY')
 def test_histogram():
     from scipy.stats import chi2
 

--- a/docs/changes/stats/12896.bugfix.rst
+++ b/docs/changes/stats/12896.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug in which running ``kuiper_false_positive_probability(D,N)`` on distributions with many data points could produce NaN values for the false positive probability of the Kuiper statistic.


### PR DESCRIPTION
…mpy.inf, producing NaN probabilities

<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request fixes the issue where returned probabilities are NaNs.  The [combination calculation](https://github.com/astropy/astropy/blob/0867721075391c359f7c5e7ab6ac7d92b037b64e/astropy/stats/funcs.py#L1364) can return large values for distributions with many points, which are approximated as numpy.inf.  When these are multiplied by zero, NaNs are returned.  I have implemented a check to modify array values where numpy.inf is multiplied by zero to give zero instead because all values are formally finite.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #12833 

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
