### PR TITLE
Add asdf support for splines

### DIFF
--- a/astropy/io/misc/asdf/extension.py
+++ b/astropy/io/misc/asdf/extension.py
@@ -28,6 +28,7 @@ from .tags.transform.math import *  # noqa
 from .tags.transform.polynomial import *  # noqa
 from .tags.transform.powerlaws import *  # noqa
 from .tags.transform.projections import *  # noqa
+from .tags.transform.spline import *  # noqa
 from .tags.transform.tabular import *  # noqa
 from .tags.unit.quantity import *  # noqa
 from .tags.unit.unit import *  # noqa

--- a/astropy/io/misc/asdf/tags/transform/spline.py
+++ b/astropy/io/misc/asdf/tags/transform/spline.py
@@ -1,0 +1,25 @@
+from .basic import TransformType
+from astropy.modeling.models import Spline1D
+
+
+__all__ = ['SplineType']
+
+
+class SplineType(TransformType):
+    name = 'transform/spline1d'
+    version = '1.0.0'
+    types = ['astropy.modeling.spline.Spline1D']
+
+    @classmethod
+    def from_tree_transform(cls, node, ctx):
+        return Spline1D(knots=node['knots'],
+                        coeffs=node['coefficients'],
+                        degree=node['degree'])
+
+    @classmethod
+    def to_tree_transform(cls, model, ctx):
+        return {
+            "knots": model.t,
+            "coefficients": model.c,
+            "degree": model.degree
+        }

--- a/astropy/io/misc/asdf/tags/transform/tests/test_transform.py
+++ b/astropy/io/misc/asdf/tags/transform/tests/test_transform.py
@@ -93,6 +93,9 @@ test_models = [
     astmodels.LogParabola1D(amplitude=10, x_0=0.5, alpha=2., beta=3.,),
     astmodels.PowerLaw1D(amplitude=10., x_0=0.5, alpha=2.0),
     astmodels.SmoothlyBrokenPowerLaw1D(amplitude=10., x_break=5.0, alpha_1=2.0, alpha_2=3.0, delta=0.5),
+    astmodels.Spline1D(np.array([-3., -3., -3., -3., -1., 0., 1., 3.,  3.,  3.,  3.]),
+                       np.array([0.10412331, 0.07013616, -0.18799552, 1.35953147, -0.15282581, 0.03923, -0.04297299, 0., 0., 0., 0.]),
+                       3),
     custom_and_analytical_inverse(),
     custom_inputs_outputs(),
 ]

--- a/astropy/io/misc/asdf/tags/transform/tests/test_transform.py
+++ b/astropy/io/misc/asdf/tags/transform/tests/test_transform.py
@@ -19,6 +19,8 @@ import astropy.units as u
 from astropy.modeling.core import fix_inputs
 from astropy.modeling import models as astmodels
 
+from astropy.utils.compat.optional_deps import HAS_SCIPY
+
 
 def custom_and_analytical_inverse():
     p1 = astmodels.Polynomial1D(1)
@@ -93,13 +95,14 @@ test_models = [
     astmodels.LogParabola1D(amplitude=10, x_0=0.5, alpha=2., beta=3.,),
     astmodels.PowerLaw1D(amplitude=10., x_0=0.5, alpha=2.0),
     astmodels.SmoothlyBrokenPowerLaw1D(amplitude=10., x_break=5.0, alpha_1=2.0, alpha_2=3.0, delta=0.5),
-    astmodels.Spline1D(np.array([-3., -3., -3., -3., -1., 0., 1., 3.,  3.,  3.,  3.]),
-                       np.array([0.10412331, 0.07013616, -0.18799552, 1.35953147, -0.15282581, 0.03923, -0.04297299, 0., 0., 0., 0.]),
-                       3),
     custom_and_analytical_inverse(),
     custom_inputs_outputs(),
 ]
 
+if HAS_SCIPY:
+    test_models.append(astmodels.Spline1D(np.array([-3., -3., -3., -3., -1., 0., 1., 3.,  3.,  3.,  3.]),
+                       np.array([0.10412331, 0.07013616, -0.18799552, 1.35953147, -0.15282581, 0.03923, -0.04297299, 0., 0., 0., 0.]),
+                       3))
 
 math_models = []
 

--- a/docs/changes/io.misc/12897.feature.rst
+++ b/docs/changes/io.misc/12897.feature.rst
@@ -1,0 +1,1 @@
+Add asdf support for ``Spline1D`` models.

--- a/setup.cfg
+++ b/setup.cfg
@@ -80,7 +80,7 @@ all =
     pytz
     jplephem
     mpmath
-    asdf>=2.9.2
+    asdf>=2.10.0
     bottleneck
     ipython>=4.2
     pytest


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

Adds asdf support for the splines introduced in #11634.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] ~Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?~
- [ ] ~Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).~
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] ~Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?~
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] ~At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.~
