### PR TITLE
Allow a model to override calculation of it's separability matrix

### DIFF
--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -805,6 +805,15 @@ class Model(metaclass=_ModelMeta):
 
         return self.__class__.n_outputs
 
+    def _calculate_separability_matrix(self):
+        """
+        This is a hook which customises the behavior of modeling.separable.
+
+        This allows complex subclasses to customise the separability matrix.
+        If it returns `NotImplemented` the default behavior is used.
+        """
+        return NotImplemented
+
     def _initialize_unit_support(self):
         """
         Convert self._input_units_strict and

--- a/astropy/modeling/separable.py
+++ b/astropy/modeling/separable.py
@@ -301,7 +301,9 @@ def _separable(transform):
         An array of shape (transform.n_outputs,) of boolean type
         Each element represents the separablity of the corresponding output.
     """
-    if isinstance(transform, CompoundModel):
+    if (transform_matrix := transform._calculate_separability_matrix()) is not NotImplemented:
+        return transform_matrix
+    elif isinstance(transform, CompoundModel):
         sepleft = _separable(transform.left)
         sepright = _separable(transform.right)
         return _operators[transform.op](sepleft, sepright)

--- a/docs/changes/modeling/12900.feature.rst
+++ b/docs/changes/modeling/12900.feature.rst
@@ -1,0 +1,1 @@
+Provide a hook (``Model._calculate_separability_matrix``) to allow subclasses of ``Model`` to define how to compute their separability matrix.

--- a/docs/modeling/models.rst
+++ b/docs/modeling/models.rst
@@ -3,7 +3,7 @@
 .. _models:
 
 ******
-MODELS
+Models
 ******
 
 .. _basics-models:
@@ -740,6 +740,11 @@ For example, it may be easier to define inverses using the independent parts of 
 than the entire model.
 In other cases, tools using `Generalized World Coordinate System (GWCS)`_,
 can be more flexible and take advantage of separable spectral and spatial transforms.
+
+If a custom subclass of `~astropy.modeling.Model` needs to override the
+computation of its separability it can implement the
+``_calculate_separability_matrix`` method which should return the separability
+matrix for that model.
 
 
 .. _modeling-model-sets:


### PR DESCRIPTION
For some DKIST work I have (for better or for worse) had to [subclass `CompoundModel`](https://github.com/DKISTDC/dkist/blob/main/dkist/wcs/models.py#L234) the changes to the behaviour mean that the default computation of the separability matrix is incorrect and I need a hook to override it from my subclass.

This approach seems the least likely to cause unexpected issues, and is the least magic :mage:.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
