### PR TITLE
bug fixed in _convert_images_to_uint8 method

### DIFF
--- a/astropy/modeling/polynomial.py
+++ b/astropy/modeling/polynomial.py
@@ -969,7 +969,7 @@ class Polynomial1D(_PolyDomainWindow1D):
 
 
 class Polynomial2D(PolynomialModel):
-    """
+    r"""
     2D Polynomial  model.
 
     Represents a general polynomial of degree n:
@@ -985,8 +985,10 @@ class Polynomial2D(PolynomialModel):
     Parameters
     ----------
     degree : int
-        highest power of the polynomial,
-        the number of terms is degree+1
+        Polynomial degree: largest sum of exponents (:math:`i + j`) of
+        variables in each monomial term of the form :math:`x^i y^j`. The
+        number of terms in a 2D polynomial of degree ``n`` is given by binomial
+        coefficient :math:`C(n + 2, 2) = (n + 2)! / (2!\,n!) = (n + 1)(n + 2) / 2`.
     x_domain : tuple or None, optional
         domain of the x independent variable
         If None, it is set to (-1, 1)

--- a/astropy/visualization/lupton_rgb.py
+++ b/astropy/visualization/lupton_rgb.py
@@ -153,7 +153,7 @@ class Mapping:
 
         image_rgb = [image_r, image_g, image_b]
         for c in image_rgb:
-            c *= fac
+            c = c * fac
             with np.errstate(invalid='ignore'):
                 c[c < 0] = 0                # individual bands can still be < 0, even if fac isn't
 


### PR DESCRIPTION
[](https://user-images.githubusercontent.com/64039143/110371767-a77bf080-8062-11eb-82e4-3ec7d5129e0c.png)There was an error when I used the lupton_rgb function. The error was like the following:

astropy_lupton_rgb

UFuncTypeError: Cannot cast ufunc 'multiply' output from dtype('float64') to dtype('uint16') with casting rule 'same_kind'

My NumPy version is: numpy=1.20.1

According to https://stackoverflow.com/questions/38673531/numpy-cannot-cast-ufunc-multiply-output-from-dtype,
I replaced c *= fac in line 156 with c = c * fac and this change fixed my problem.

Description
This pull request is to address ...

Fixes #