### PR TITLE
Deprecate asdf support in astropy

### DIFF
--- a/astropy/io/misc/asdf/__init__.py
+++ b/astropy/io/misc/asdf/__init__.py
@@ -1,0 +1,10 @@
+import warnings
+
+from astropy.utils.exceptions import AstropyDeprecationWarning
+
+warnings.warn(
+    "ASDF functionality for astropy is being moved out of the astropy"
+    " package to the new asdf-astropy package. Please use this package"
+    " instead. astropy.io.misc.asdf is deprecated since astropy 5.1 and will be removed in a future release.",
+    AstropyDeprecationWarning
+)

--- a/astropy/io/misc/asdf/connect.py
+++ b/astropy/io/misc/asdf/connect.py
@@ -1,9 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # -*- coding: utf-8 -*-
 # This file connects ASDF to the astropy.table.Table class
-
-import functools
-
 from astropy.io import registry as io_registry
 from astropy.table import Table
 

--- a/astropy/io/misc/asdf/tags/coordinates/angle.py
+++ b/astropy/io/misc/asdf/tags/coordinates/angle.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # -*- coding: utf-8 -*-
-
 from astropy.coordinates import Angle, Latitude, Longitude
 
 from astropy.io.misc.asdf.tags.unit.quantity import QuantityType

--- a/astropy/io/misc/asdf/tags/coordinates/earthlocation.py
+++ b/astropy/io/misc/asdf/tags/coordinates/earthlocation.py
@@ -1,8 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # -*- coding: utf-8 -*-
 from astropy.coordinates import EarthLocation
-
-from ...types import AstropyType
+from astropy.io.misc.asdf.types import AstropyType
 
 
 class EarthLocationType(AstropyType):

--- a/astropy/io/misc/asdf/tags/coordinates/frames.py
+++ b/astropy/io/misc/asdf/tags/coordinates/frames.py
@@ -10,7 +10,6 @@ import astropy.coordinates
 from astropy.coordinates.baseframe import frame_transform_graph
 from astropy.units import Quantity
 from astropy.coordinates import ICRS, Longitude, Latitude, Angle
-
 from astropy.io.misc.asdf.types import AstropyType
 
 

--- a/astropy/io/misc/asdf/tags/coordinates/representation.py
+++ b/astropy/io/misc/asdf/tags/coordinates/representation.py
@@ -1,7 +1,6 @@
 import astropy.units as u
 import astropy.coordinates.representation
 from astropy.coordinates.representation import BaseRepresentationOrDifferential
-
 from astropy.io.misc.asdf.types import AstropyType
 
 

--- a/astropy/io/misc/asdf/tags/coordinates/skycoord.py
+++ b/astropy/io/misc/asdf/tags/coordinates/skycoord.py
@@ -2,8 +2,7 @@
 # -*- coding: utf-8 -*-
 from astropy.coordinates import SkyCoord
 from astropy.io.misc.asdf.tags.helpers import skycoord_equal
-
-from ...types import AstropyType
+from astropy.io.misc.asdf.types import AstropyType
 
 
 class SkyCoordType(AstropyType):

--- a/astropy/io/misc/asdf/tags/coordinates/spectralcoord.py
+++ b/astropy/io/misc/asdf/tags/coordinates/spectralcoord.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # -*- coding: utf-8 -*-
-
 from asdf.tags.core import NDArrayType
 
 from astropy.coordinates.spectral_coordinate import SpectralCoord

--- a/astropy/io/misc/asdf/tags/fits/fits.py
+++ b/astropy/io/misc/asdf/tags/fits/fits.py
@@ -1,7 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # -*- coding: utf-8 -*-
-
-import numpy as np
 from numpy.testing import assert_array_equal
 
 from astropy import table

--- a/astropy/io/misc/asdf/tags/helpers.py
+++ b/astropy/io/misc/asdf/tags/helpers.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # -*- coding: utf-8 -*-
-
 import numpy as np
 
 

--- a/astropy/io/misc/asdf/tags/time/time.py
+++ b/astropy/io/misc/asdf/tags/time/time.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # -*- coding: utf-8 -*-
-
 import numpy as np
 from numpy.testing import assert_array_equal
 

--- a/astropy/io/misc/asdf/tags/time/timedelta.py
+++ b/astropy/io/misc/asdf/tags/time/timedelta.py
@@ -5,8 +5,7 @@ import functools
 import numpy as np
 
 from astropy.time import TimeDelta
-
-from ...types import AstropyType
+from astropy.io.misc.asdf.types import AstropyType
 
 __all__ = ['TimeDeltaType']
 

--- a/astropy/io/misc/asdf/tags/transform/compound.py
+++ b/astropy/io/misc/asdf/tags/transform/compound.py
@@ -2,9 +2,9 @@
 # -*- coding: utf-8 -*-
 from asdf import tagged
 from asdf.tests.helpers import assert_tree_match
-from .basic import TransformType
 from astropy.modeling.core import Model, CompoundModel
 from astropy.modeling.models import Identity, Mapping, Const1D
+from astropy.io.misc.asdf.tags.transform.basic import TransformType
 
 
 __all__ = ['CompoundType', 'RemapAxesType']

--- a/astropy/io/misc/asdf/tags/transform/functional_models.py
+++ b/astropy/io/misc/asdf/tags/transform/functional_models.py
@@ -1,10 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # -*- coding: utf-8 -*-
-
 from numpy.testing import assert_array_equal
 
 from astropy.modeling import functional_models
-from .basic import TransformType
+from astropy.io.misc.asdf.tags.transform.basic import TransformType
 from . import _parameter_to_value
 
 

--- a/astropy/io/misc/asdf/tags/transform/math.py
+++ b/astropy/io/misc/asdf/tags/transform/math.py
@@ -1,13 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # -*- coding: utf-8 -*-
-
-from numpy.testing import assert_array_equal
-
-from astropy import modeling
 from astropy.modeling.math_functions import __all__ as math_classes
 from astropy.modeling.math_functions import *
 from astropy.modeling import math_functions
-from .basic import TransformType
+from astropy.io.misc.asdf.tags.transform.basic import TransformType
 
 
 __all__ = ['NpUfuncType']

--- a/astropy/io/misc/asdf/tags/transform/physical_models.py
+++ b/astropy/io/misc/asdf/tags/transform/physical_models.py
@@ -1,11 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # -*- coding: utf-8 -*-
-
 from numpy.testing import assert_array_equal
 
-
-from astropy.modeling import functional_models, physical_models
-from .basic import TransformType
+from astropy.modeling import physical_models
+from astropy.io.misc.asdf.tags.transform.basic import TransformType
 from . import _parameter_to_value
 
 

--- a/astropy/io/misc/asdf/tags/transform/polynomial.py
+++ b/astropy/io/misc/asdf/tags/transform/polynomial.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # -*- coding: utf-8 -*-
-
 import numpy as np
 from numpy.testing import assert_array_equal
 
@@ -8,7 +7,7 @@ from asdf.versioning import AsdfVersion
 
 import astropy.units as u
 from astropy import modeling
-from .basic import TransformType
+from astropy.io.misc.asdf.tags.transform.basic import TransformType
 from . import _parameter_to_value
 
 __all__ = ['ShiftType', 'ScaleType', 'Linear1DType']

--- a/astropy/io/misc/asdf/tags/transform/powerlaws.py
+++ b/astropy/io/misc/asdf/tags/transform/powerlaws.py
@@ -1,10 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # -*- coding: utf-8 -*-
-
 from numpy.testing import assert_array_equal
 
 from astropy.modeling import powerlaws
-from .basic import TransformType
+from astropy.io.misc.asdf.tags.transform.basic import TransformType
 from . import _parameter_to_value
 
 

--- a/astropy/io/misc/asdf/tags/transform/projections.py
+++ b/astropy/io/misc/asdf/tags/transform/projections.py
@@ -1,10 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # -*- coding: utf-8 -*-
-
 from numpy.testing import assert_array_equal
 
 from astropy import modeling
-from .basic import TransformType
+from astropy.io.misc.asdf.tags.transform.basic import TransformType
 from . import _parameter_to_value
 
 

--- a/astropy/io/misc/asdf/tags/transform/spline.py
+++ b/astropy/io/misc/asdf/tags/transform/spline.py
@@ -1,5 +1,5 @@
-from .basic import TransformType
 from astropy.modeling.models import Spline1D
+from astropy.io.misc.asdf.tags.transform.basic import TransformType
 
 
 __all__ = ['SplineType']

--- a/astropy/io/misc/asdf/tags/transform/tabular.py
+++ b/astropy/io/misc/asdf/tags/transform/tabular.py
@@ -1,13 +1,12 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # -*- coding: utf-8 -*-
-
 import numpy as np
 from numpy.testing import assert_array_equal
 
 from astropy import modeling
 from astropy import units as u
-from .basic import TransformType
 from astropy.modeling.bounding_box import ModelBoundingBox
+from astropy.io.misc.asdf.tags.transform.basic import TransformType
 
 __all__ = ['TabularType']
 

--- a/astropy/io/misc/asdf/tags/unit/equivalency.py
+++ b/astropy/io/misc/asdf/tags/unit/equivalency.py
@@ -1,10 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # -*- coding: utf-8 -*-
-
 from astropy.units.equivalencies import Equivalency
 from astropy.units import equivalencies
-from astropy.units.quantity import Quantity
-
 from astropy.io.misc.asdf.types import AstropyType
 
 

--- a/astropy/io/misc/asdf/tags/unit/quantity.py
+++ b/astropy/io/misc/asdf/tags/unit/quantity.py
@@ -1,10 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # -*- coding: utf-8 -*-
-
-from astropy.units import Quantity
-
 from asdf.tags.core import NDArrayType
 
+from astropy.units import Quantity
 from astropy.io.misc.asdf.types import AstropyAsdfType
 
 

--- a/astropy/io/misc/asdf/tags/unit/unit.py
+++ b/astropy/io/misc/asdf/tags/unit/unit.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # -*- coding: utf-8 -*-
-
 from astropy.units import Unit, UnitBase
 from astropy.io.misc.asdf.types import AstropyAsdfType
 

--- a/astropy/io/misc/asdf/types.py
+++ b/astropy/io/misc/asdf/types.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # -*- coding: utf-8 -*-
-
 from asdf.types import CustomType, ExtensionTypeMeta
 
 __all__ = ['AstropyType', 'AstropyAsdfType']

--- a/docs/changes/io.misc/12903.api.rst
+++ b/docs/changes/io.misc/12903.api.rst
@@ -1,0 +1,1 @@
+Deprecate asdf in astropy core in favor of the asdf-astropy package.

--- a/setup.cfg
+++ b/setup.cfg
@@ -146,6 +146,8 @@ filterwarnings =
     ignore:parallel reading does not currently work, so falling back to serial
     # numpy configurable allocator now wants memory policy set
     ignore:Trying to dealloc data, but a memory policy is not set.
+    # Ignore deprecation warning for asdf in astropy
+    ignore:ASDF functionality for astropy is being moved.*
 doctest_norecursedirs =
     */setup_package.py
 doctest_subpackage_requires =


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

Per astropy telecon, this PR deprecates asdf support in astropy core package. This support is being moved to the [asdf-astropy](https://github.com/astropy/asdf-astropy) in order to support the differing release schedule for asdf.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
