### PR TITLE
Correctly calculate the separability of a nested compound model

### DIFF
--- a/astropy/modeling/separable.py
+++ b/astropy/modeling/separable.py
@@ -242,7 +242,7 @@ def _cstack(left, right):
         cright = _coord_matrix(right, 'right', noutp)
     else:
         cright = np.zeros((noutp, right.shape[1]))
-        cright[-right.shape[0]:, -right.shape[1]:] = 1
+        cright[-right.shape[0]:, -right.shape[1]:] = right
 
     return np.hstack([cleft, cright])
 

--- a/astropy/modeling/tests/test_separable.py
+++ b/astropy/modeling/tests/test_separable.py
@@ -28,6 +28,13 @@ p22 = models.Polynomial2D(2, name='p22')
 p1 = models.Polynomial1D(1, name='p1')
 
 
+cm_4d_expected = (np.array([False, False, True, True]),
+                  np.array([[True,  True,  False, False],
+                            [True,  True,  False, False],
+                            [False, False, True,  False],
+                            [False, False, False, True]]))
+
+
 compound_models = {
     'cm1': (map3 & sh1 | rot & sh1 | sh1 & sh2 & sh1,
             (np.array([False, False, True]),
@@ -53,13 +60,16 @@ compound_models = {
             (np.array([False, True]),
              np.array([[True, False], [False, True]]))
             ),
-    'cm8': (rot & (sh1 & sh2),
-            (np.array([False, False, True, True]),
-             np.array([[True, True, False, False],
-                       [True, True, False, False],
-                       [False, False, True, False],
-                       [False, False, False, True]]))
-            ),
+    'cm8': (rot & (sh1 & sh2), cm_4d_expected),
+    'cm9': (rot & sh1 & sh2, cm_4d_expected),
+    'cm10': ((rot & sh1) & sh2, cm_4d_expected),
+    'cm11': (rot & sh1 & (scl1 & scl2),
+             (np.array([False, False, True, True, True]),
+              np.array([[True,  True,  False, False, False],
+                        [True,  True,  False, False, False],
+                        [False, False, True,  False, False],
+                        [False, False, False, True,  False],
+                        [False, False, False, False, True]]))),
 }
 
 

--- a/astropy/modeling/tests/test_separable.py
+++ b/astropy/modeling/tests/test_separable.py
@@ -52,7 +52,14 @@ compound_models = {
     'cm7': (map2 | p2 & sh1,
             (np.array([False, True]),
              np.array([[True, False], [False, True]]))
-            )
+            ),
+    'cm8': (rot & (sh1 & sh2),
+            (np.array([False, False, True, True]),
+             np.array([[True, True, False, False],
+                       [True, True, False, False],
+                       [False, False, True, False],
+                       [False, False, False, True]]))
+            ),
 }
 
 

--- a/docs/changes/modeling/12907.bugfix.rst
+++ b/docs/changes/modeling/12907.bugfix.rst
@@ -1,0 +1,1 @@
+Fix computation of the separability of a ``CompoundModel`` where another ``CompoundModel`` is on the right hand side of the ``&`` operator.


### PR DESCRIPTION
It appeared the issue was in calculating the separability when there was a compound model on the right of the & operand.

Fixes #12906