### PR TITLE
Access subdtypes of structured Distributions

### DIFF
--- a/astropy/uncertainty/core.py
+++ b/astropy/uncertainty/core.py
@@ -302,7 +302,11 @@ class ArrayDistribution(Distribution, np.ndarray):
 
     # Override __getitem__ so that 'samples' is returned as the sample class.
     def __getitem__(self, item):
-        result = super().__getitem__(item)
+        if isinstance(item, str) and item != "samples":  # structured array access of sub-dtypes
+            result = Distribution(self["samples"][item])
+        else:  # normal access
+            result = super().__getitem__(item)
+
         if item == 'samples':
             # Here, we need to avoid our own redefinition of view.
             return super(ArrayDistribution, result).view(self._samples_cls)

--- a/docs/changes/uncertainty/12908.api.rst
+++ b/docs/changes/uncertainty/12908.api.rst
@@ -1,0 +1,2 @@
+Structured distributions now allow access to the underlying structure,
+while remaining a Distribution.

--- a/docs/uncertainty/index.rst
+++ b/docs/uncertainty/index.rst
@@ -216,6 +216,18 @@ attribute::
   >>> distr.distribution.shape
   (4, 1000)
 
+For structured Distributions, the sub-arrays may be accessed as Distributions
+themselves:
+
+  >>> x = np.array([(0, 0.6), (0.1, 0.59)], dtype=[("n1", float), ("n2", float)])
+  >>> f = unc.Distribution(x)
+  >>> f["n1"]
+  NdarrayDistribution([0. , 0.1]) with n_samples=2
+
+Note that structured |Quantity| Distributions are not yet supported
+(https://github.com/astropy/astropy/issues/12909).
+
+
 .. EXAMPLE END
 
 .. EXAMPLE START: Interaction Between Quantity Objects and Distributions


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

### Description

Structured distributions do not allow access to the underlying structure, while remaining a Distribution.
This PR fixes this problem.

Already allowed:
```python
>>> from astropy.uncertainty import Distribution

>>> x = np.array([(0, 0, 0.6), (0.1, -0.01, 0.59)], dtype=[("nu1", float), ("nu2", float), ("nu3", np.float128)])
>>> f = Distribution(x)
>>> f
NdarrayDistribution([(0. ,  0.  , 0.6 ), (0.1, -0.01, 0.59)],
      dtype=[('nu1', '<f8'), ('nu2', '<f8'), ('nu3', '<f16')]) with n_samples=2
```

Added:
```python
>>> f["nu1"]
NdarrayDistribution([0. , 0.1]) with n_samples=2
```


### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
