### PR TITLE
Check for the correct `numpy` version in a test

### DIFF
--- a/astropy/io/ascii/tests/test_ecsv.py
+++ b/astropy/io/ascii/tests/test_ecsv.py
@@ -21,7 +21,7 @@ from astropy.units import allclose as quantity_allclose
 from astropy.units import QuantityInfo
 
 from astropy.utils.exceptions import AstropyUserWarning
-from astropy.utils.compat import NUMPY_LT_1_19
+from astropy.utils.compat import NUMPY_LT_1_19_1
 
 from astropy.io.ascii.ecsv import DELIMITERS
 from astropy.io import ascii
@@ -647,8 +647,8 @@ a
         Table.read(txt, format='ascii.ecsv')
 
 
-@pytest.mark.skipif(NUMPY_LT_1_19,
-                    reason="numpy cannot parse 'complex' as string until 1.19+")
+@pytest.mark.skipif(NUMPY_LT_1_19_1,
+                    reason="numpy<=1.19.0 cannot parse 'complex' as string")
 def test_read_complex_v09():
     """Test an ECSV file with a complex column for version 0.9
     Note: ECSV Version <=0.9 files should not raise ValueError

--- a/astropy/utils/compat/numpycompat.py
+++ b/astropy/utils/compat/numpycompat.py
@@ -7,13 +7,15 @@ earlier versions of Numpy.
 import numpy as np
 from astropy.utils import minversion
 
-__all__ = ['NUMPY_LT_1_19', 'NUMPY_LT_1_20', 'NUMPY_LT_1_21_1',
-           'NUMPY_LT_1_22', 'NUMPY_LT_1_22_1', 'NUMPY_LT_1_23']
+__all__ = ['NUMPY_LT_1_19', 'NUMPY_LT_1_19_1', 'NUMPY_LT_1_20',
+           'NUMPY_LT_1_21_1', 'NUMPY_LT_1_22', 'NUMPY_LT_1_22_1',
+           'NUMPY_LT_1_23']
 
 # TODO: It might also be nice to have aliases to these named for specific
 # features/bugs we're checking for (ex:
 # astropy.table.table._BROKEN_UNICODE_TABLE_SORT)
 NUMPY_LT_1_19 = not minversion(np, '1.19')
+NUMPY_LT_1_19_1 = not minversion(np, '1.19.1')
 NUMPY_LT_1_20 = not minversion(np, '1.20')
 NUMPY_LT_1_21_1 = not minversion(np, '1.21.1')
 NUMPY_LT_1_22 = not minversion(np, '1.22')


### PR DESCRIPTION
### Description

One of the tests in `astropy/io/ascii/tests/test_ecsv.py` was skipped if `numpy` version was below 1.19, but it fails with `numpy` 1.19.0. The test in question was added in #12880, and backported in #12884.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
