### PR TITLE
Changes to `ssl` and `concurrent.futures` imports to allow `astropy` to run in `pyodide`

### DIFF
--- a/astropy/utils/console.py
+++ b/astropy/utils/console.py
@@ -14,7 +14,8 @@ import struct
 import sys
 import threading
 import time
-from concurrent.futures import ProcessPoolExecutor, as_completed
+# concurrent.futures imports moved inside functions using them to avoid
+# import failure when running in pyodide/Emscripten
 
 try:
     import fcntl
@@ -785,6 +786,9 @@ class ProgressBar:
             other anomalies occur with the "fork" method (the default on
             Linux).
         """
+        # concurrent.futures import here to avoid import failure when running
+        # in pyodide/Emscripten
+        from concurrent.futures import ProcessPoolExecutor, as_completed
 
         results = []
 

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -12,7 +12,8 @@ import os
 import io
 import re
 import shutil
-import ssl
+# import ssl moved inside functions using ssl to avoid import failure
+# when running in pyodide/Emscripten
 import sys
 import urllib.request
 import urllib.error
@@ -1047,6 +1048,8 @@ def _build_urlopener(ftp_tls=False, ssl_context=None, allow_insecure=False):
     """
     Helper for building a `urllib.request.build_opener` which handles TLS/SSL.
     """
+    # Import ssl here to avoid import failure when running in pyodide/Emscripten
+    import ssl
 
     ssl_context = dict(it for it in ssl_context) if ssl_context else {}
     cert_chain = {}
@@ -1086,6 +1089,8 @@ def _build_urlopener(ftp_tls=False, ssl_context=None, allow_insecure=False):
 def _try_url_open(source_url, timeout=None, http_headers=None, ftp_tls=False,
                   ssl_context=None, allow_insecure=False):
     """Helper for opening a URL while handling TLS/SSL verification issues."""
+    # Import ssl here to avoid import failure when running in pyodide/Emscripten
+    import ssl
 
     # Always try first with a secure connection
     # _build_urlopener uses lru_cache, so the ssl_context argument must be


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

Fixes #12904. See extended discussion there for the reason for these patches. I've put a bunch of comments in to make it clear why these imports were moved and to avoid moving them to the top level again...

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->



### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
