### PR TITLE
Require `pytest` 7.0 or later for installation

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -51,10 +51,14 @@ asdf_extensions =
 
 [options.extras_require]
 test =  # Required to run the astropy test suite.
+    pytest>=7.0
+    pytest-doctestplus>=0.12
     pytest-astropy>=0.9
     pytest-astropy-header!=0.2.0
     pytest-xdist
 test_all =  # Required for testing, plus packages used by particular tests.
+    pytest>=7.0
+    pytest-doctestplus>=0.12
     pytest-astropy>=0.9
     pytest-xdist
     objgraph
@@ -83,12 +87,12 @@ all =
     asdf>=2.10.0
     bottleneck
     ipython>=4.2
-    pytest
+    pytest>=7.0
     typing_extensions>=3.10.0.1
 docs =
     sphinx<4
     sphinx-astropy>=1.6
-    pytest
+    pytest>=7.0
     scipy>=1.3
     matplotlib>=3.1,!=3.4.0
     sphinx-changelog>=1.1.0


### PR DESCRIPTION
### Description

Using older versions of `pytest` is not possible since #12823 (backported in #12849). But while setting `minversion = 7.0` in the `[tool:pytest]` section of `setup.cfg` does prevent older versions of `pytest` from attempting to run the tests, it alone does not prevent `pip` from being happy with an older version. Additionally, `pytest-doctestplus` was made compatible with `pytest` 7.0 in astropy/pytest-doctestplus#171, so its minimum required version has to be updated too.

See also astropy/pytest-astropy#49

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
