### PR TITLE
Backport Allow a model to override calculation of it's separability matrix

### DIFF
--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -802,6 +802,15 @@ class Model(metaclass=_ModelMeta):
 
         return self.__class__.n_outputs
 
+    def _calculate_separability_matrix(self):
+        """
+        This is a hook which customises the behavior of modeling.separable.
+
+        This allows complex subclasses to customise the separability matrix.
+        If it returns `NotImplemented` the default behavior is used.
+        """
+        return NotImplemented
+
     def _initialize_unit_support(self):
         """
         Convert self._input_units_strict and

--- a/astropy/modeling/separable.py
+++ b/astropy/modeling/separable.py
@@ -301,7 +301,9 @@ def _separable(transform):
         An array of shape (transform.n_outputs,) of boolean type
         Each element represents the separablity of the corresponding output.
     """
-    if isinstance(transform, CompoundModel):
+    if (transform_matrix := transform._calculate_separability_matrix()) is not NotImplemented:
+        return transform_matrix
+    elif isinstance(transform, CompoundModel):
         sepleft = _separable(transform.left)
         sepright = _separable(transform.right)
         return _operators[transform.op](sepleft, sepright)

--- a/astropy/modeling/tests/test_models.py
+++ b/astropy/modeling/tests/test_models.py
@@ -16,11 +16,12 @@ from astropy import units as u
 from astropy.modeling import fitting, models
 from astropy.modeling.models import Gaussian2D
 from astropy.modeling.bounding_box import ModelBoundingBox
-from astropy.modeling.core import FittableModel
+from astropy.modeling.core import FittableModel, Model
 from astropy.modeling.parameters import Parameter
 from astropy.modeling.polynomial import PolynomialBase
 from astropy.modeling.powerlaws import SmoothlyBrokenPowerLaw1D
 from astropy.modeling.parameters import InputParameterError
+from astropy.modeling.separable import separability_matrix
 from astropy.tests.helper import assert_quantity_allclose
 from astropy.utils import NumpyRNGContext
 from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa
@@ -1023,3 +1024,26 @@ def test_SmoothlyBrokenPowerLaw1D_fit_deriv():
                                          estimate_jacobian=True)
     assert_allclose(new_model_with_deriv.parameters,
                     new_model_no_deriv.parameters, atol=0.5)
+
+
+class ModelDefault(Model):
+    slope = Parameter()
+    intercept = Parameter()
+    _separable = False
+
+    @staticmethod
+    def evaluate(x, slope, intercept):
+        return slope * x + intercept
+
+
+class ModelCustom(ModelDefault):
+    def _calculate_separability_matrix(self):
+        return np.array([[0, ]])
+
+
+def test_custom_separability_matrix():
+    original = separability_matrix(ModelDefault(slope=1, intercept=2))
+    assert original.all()
+
+    custom = separability_matrix(ModelCustom(slope=1, intercept=2))
+    assert not custom.any()

--- a/docs/changes/modeling/12900.feature.rst
+++ b/docs/changes/modeling/12900.feature.rst
@@ -1,0 +1,1 @@
+Provide a hook (``Model._calculate_separability_matrix``) to allow subclasses of ``Model`` to define how to compute their separability matrix.

--- a/docs/modeling/models.rst
+++ b/docs/modeling/models.rst
@@ -3,7 +3,7 @@
 .. _models:
 
 ******
-MODELS
+Models
 ******
 
 .. _basics-models:
@@ -657,6 +657,11 @@ For example, it may be easier to define inverses using the independent parts of 
 than the entire model.
 In other cases, tools using `Generalized World Coordinate System (GWCS)`_,
 can be more flexible and take advantage of separable spectral and spatial transforms.
+
+If a custom subclass of `~astropy.modeling.Model` needs to override the
+computation of its separability it can implement the
+``_calculate_separability_matrix`` method which should return the separability
+matrix for that model.
 
 
 .. _modeling-model-sets:


### PR DESCRIPTION
This is a backport of #12900