### PR TITLE
Cosmo `is_close`

### DIFF
--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -206,7 +206,7 @@ class Cosmology(metaclass=abc.ABCMeta):
         In cosmology, what does "close" mean?
         Different cosmological properties are differently sensitive to
         different parameter values. In short, there's not really a good
-        "distance" metric in the space of cosmological parameters. Perhaps you 
+        "distance" metric in the space of cosmological parameters. Perhaps you
         mean that the scale parameters evolve similarly. Or maybe you don't.
         This method leaves this definition to the user by providing a tolerance
         parameter which sets how close each cosmology parameter must be.
@@ -401,6 +401,8 @@ class Cosmology(metaclass=abc.ABCMeta):
     def __equiv__(self, other, tolerance=...):
         """Cosmology equivalence. Use ``.is_equivalent()`` for actual check!
 
+        .. versionadded:: 5.0
+
         Parameters
         ----------
         other : `~astropy.cosmology.Cosmology` subclass instance
@@ -413,6 +415,8 @@ class Cosmology(metaclass=abc.ABCMeta):
             If `numbers.Number` this is the tolerance for all parameters.
             If `dict` each parameter's tolerance can be specified by key,
             defaulting to `Ellipsis` for missing keys.
+
+            .. versionadded:: 5.1
 
         Returns
         -------

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -123,14 +123,31 @@ class Cosmology(metaclass=abc.ABCMeta):
         """The name of the Cosmology instance."""
         return self._name
 
-    @property
     @abc.abstractmethod
-    def is_flat(self):
-        """
-        Return bool; `True` if the cosmology is flat.
+    def is_close_to_flat(self, *, tolerance=...):
+        """Return bool; `True` if the cosmology is close to flat.
+
         This is abstract and must be defined in subclasses.
+
+        .. versionadded:: 5.1
+
+        Parameters
+        ----------
+        tolerance : None or Ellipsis or `numbers.Number` or dict[str, number], optional
+            The tolerance for each parameter to be considered equivalent.
+            If `Ellipsis` (default) the parameters can match to each
+            parameter's precision (set by the dtype).
+            If `None` the parameters must be equal.
+            If `numbers.Number` this is the tolerance for all parameters.
+            If `dict` each parameter's tolerance can be specified by key,
+            defaulting to `Ellipsis` for missing keys.
         """
-        raise NotImplementedError("is_flat is not implemented")
+        raise NotImplementedError("is_close_to_flat is not implemented")
+
+    @property
+    def is_flat(self):
+        """Return bool; `True` if the cosmology is flat."""
+        return self.is_close_to_flat(tolerance=None)
 
     def clone(self, *, meta=None, **kwargs):
         """Returns a copy of this object with updated parameters, as specified.
@@ -229,7 +246,7 @@ class Cosmology(metaclass=abc.ABCMeta):
         ----------
         other : `~astropy.cosmology.Cosmology` subclass instance
             The object in which to compare.
-        tolerance : None or Ellipsis or Number or dict[str, number], optional
+        tolerance : None or Ellipsis or `numbers.Number` or dict[str, number], optional
             The tolerance for each parameter to be considered equivalent.
             If `Ellipsis` (default) the parameters can match to each
             parameter's precision (set by the dtype).
@@ -287,7 +304,7 @@ class Cosmology(metaclass=abc.ABCMeta):
             >>> cosmo3.is_close(cosmo2)
             False
 
-        The `tolerance` argument can be used to specify how close two
+        The tolerance argument can be used to specify how close two
         parameters must be. All non-specified parameters must be close to
         within that parameter's `numpy.dtype` precision.
 
@@ -407,7 +424,7 @@ class Cosmology(metaclass=abc.ABCMeta):
         ----------
         other : `~astropy.cosmology.Cosmology` subclass instance
             The object in which to compare.
-        tolerance : None or Ellipsis or Number or dict[str, number], optional
+        tolerance : None or Ellipsis or `numbers.Number` or dict[str, number], optional
             The tolerance for each parameter to be considered equivalent.
             If `Ellipsis` (default) the parameters can match to each
             parameter's precision (set by the dtype).
@@ -508,11 +525,17 @@ class FlatCosmologyMixin(metaclass=abc.ABCMeta):
     but ``FlatLambdaCDM`` **will** be flat.
     """
 
-    @property
-    def is_flat(self):
-        """Return `True`, the cosmology is flat."""
+    def is_close_to_flat(self, tolerance=...):
+        """Return `True` since the cosmology is guaranteed to be flat.
+
+        .. versionadded:: 5.1
+        """
         return True
 
+    @property
+    def is_flat(self):
+        """Return `True` since the cosmology is guaranteed to be flat."""
+        return True
 
 # -----------------------------------------------------------------------------
 

--- a/astropy/cosmology/flrw/tests/test_base.py
+++ b/astropy/cosmology/flrw/tests/test_base.py
@@ -864,7 +864,7 @@ class ParameterFlatOde0TestMixin(ParameterOde0TestMixin):
         newclone = cosmo.clone(Om0=cosmo.Om0 + 1e-12)
         assert not newclone.is_close(cosmo, tolerance=...)  # not close for dtype
         assert newclone.is_close(cosmo, tolerance=1e-10)  # can be made "close"
-        
+
         # Watch out, because some parameters can influence each other!
         assert not newclone.is_close(cosmo, tolerance=dict(Om0=1e-10))
         assert newclone.is_close(cosmo, tolerance=dict(Om0=1e-10, Ode0=1e-10))

--- a/astropy/cosmology/tests/test_core.py
+++ b/astropy/cosmology/tests/test_core.py
@@ -302,7 +302,7 @@ class TestCosmology(ParameterTestMixin, MetaTestMixin,
             # For FLRW classes this is tested specifically.
             # (TestFLRW.test_is_close_parameter_influence)
             # For non-FLRW classes, please write a test for this.
-            
+
         # `tolerance` can be a dict
         assert newclone.is_close(cosmo, tolerance={n: 1e-10 for n in newclone.__all_parameters__})
         # Note __all_parameters__, because there are some fixed params that
@@ -462,7 +462,7 @@ class FlatCosmologyMixinTest:
 
     def test_is_close(self, cosmo):
         """Test :meth:`astropy.cosmology.core.FlatCosmologyMixin.is_close`.
-        
+
         Normally this would pass up via super(), but ``__equiv__`` is meant
         to be overridden, so we skip super().
         e.g. FlatFLRWMixinTest -> FlatCosmologyMixinTest -> TestCosmology

--- a/astropy/cosmology/tests/test_funcs.py
+++ b/astropy/cosmology/tests/test_funcs.py
@@ -230,7 +230,7 @@ def test_z_at_value_roundtrip(cosmo):
     # nu_relative_density is not redshift-dependent in the WMAP cosmologies
     skip = ('Ok', 'Otot',
             'angular_diameter_distance_z1z2',
-            'clone', 'is_equivalent',
+            'clone', 'is_equivalent', "is_close", "is_equal",
             'de_density_scale', 'w')
     if str(cosmo.name).startswith('WMAP'):
         skip += ('nu_relative_density', )

--- a/astropy/cosmology/tests/test_funcs.py
+++ b/astropy/cosmology/tests/test_funcs.py
@@ -230,7 +230,7 @@ def test_z_at_value_roundtrip(cosmo):
     # nu_relative_density is not redshift-dependent in the WMAP cosmologies
     skip = ('Ok', 'Otot',
             'angular_diameter_distance_z1z2',
-            'clone', 'is_equivalent', "is_close", "is_equal",
+            'clone', 'is_equivalent', "is_close",
             'de_density_scale', 'w')
     if str(cosmo.name).startswith('WMAP'):
         skip += ('nu_relative_density', )

--- a/astropy/cosmology/tests/test_funcs.py
+++ b/astropy/cosmology/tests/test_funcs.py
@@ -230,7 +230,7 @@ def test_z_at_value_roundtrip(cosmo):
     # nu_relative_density is not redshift-dependent in the WMAP cosmologies
     skip = ('Ok', 'Otot',
             'angular_diameter_distance_z1z2',
-            'clone', 'is_equivalent', "is_close",
+            'clone', 'is_equivalent', "is_close", "is_close_to_flat",
             'de_density_scale', 'w')
     if str(cosmo.name).startswith('WMAP'):
         skip += ('nu_relative_density', )

--- a/astropy/cosmology/tests/test_parameter.py
+++ b/astropy/cosmology/tests/test_parameter.py
@@ -223,9 +223,8 @@ class ParameterTestMixin:
             def __init__(self, param, *, name=None, meta=None):
                 self.param = param
 
-            @property
-            def is_flat(self):
-                return super().is_flat()
+            def is_close_to_flat(self, tolerance=...):
+                return super().is_close_to_flat(tolerance=tolerance)
 
         assert Example(1).param == 1 * u.eV
         assert Example(1 * u.eV).param == 1 * u.eV
@@ -250,9 +249,8 @@ class TestParameter(ParameterTestMixin):
             def __init__(self, param=15):
                 self.param = param
 
-            @property
-            def is_flat(self):
-                return super().is_flat()
+            def is_close_to_flat(self, tolerance=...):
+                return super().is_close_to_flat(tolerance=tolerance)
 
         # with validator
         class Example2(Example1):

--- a/astropy/cosmology/utils.py
+++ b/astropy/cosmology/utils.py
@@ -148,7 +148,7 @@ def _parameters_close(param1, param2, tolerance, name):
     ----------
     param1, param2 : number or array[number] or None
         The parameter values.
-    tolerance : None or Ellipsis or dict[str, number]
+    tolerance : None or Ellipsis or Number or dict[str, number]
         The tolerance for each parameter to be considered equivalent.
         If `Ellipsis` the parameters can match to the `numpy.dtype` precision.
         If `None` the parameters must be equal.
@@ -167,11 +167,13 @@ def _parameters_close(param1, param2, tolerance, name):
         return np.all(param1 == param2)
 
     # Some measure of closeness
-    if tolerance is Ellipsis or name not in tolerance:
+    if isinstance(tolerance, Number):
+        tol = tolerance
+    elif tolerance is Ellipsis or name not in tolerance:
         r1 = np.finfo(getattr(param1, "dtype", type(param1))).resolution
         r2 = np.finfo(getattr(param2, "dtype", type(param2))).resolution
         tol = min(r1, r2)
     else:  # specific to the parameter
-        tol = tolerance[k]
+        tol = tolerance[name]
 
     return np.all(np.isclose(param1, param2, rtol=tol, atol=tol))

--- a/astropy/cosmology/utils.py
+++ b/astropy/cosmology/utils.py
@@ -139,3 +139,39 @@ def aszarr(z):
         return z
     # not one of the preferred types: Number / array ducktype
     return Quantity(z, cu.redshift).value
+
+
+def _parameters_close(param1, param2, tolerance, name):
+    """Check if two cosmology values are close, within a tolerance.
+
+    Parameters
+    ----------
+    param1, param2 : number or array[number] or None
+        The parameter values.
+    tolerance : None or Ellipsis or dict[str, number]
+        The tolerance for each parameter to be considered equivalent.
+        If `Ellipsis` the parameters can match to the `numpy.dtype` precision.
+        If `None` the parameters must be equal.
+        If `dict` each parameter's tolerance can be specified by key,
+        defaulting to `Ellipsis` if the key is missing.
+    name : str
+        The name of the parameter that might be in `tolerance`.
+
+    Returns
+    -------
+    bool
+        Whether `param1` and `param2` are close within the tolerance.
+    """
+    # exact equality
+    if tolerance is None or param1 is None or param2 is None:
+        return np.all(param1 == param2)
+
+    # Some measure of closeness
+    if tolerance is Ellipsis or name not in tolerance:
+        r1 = np.finfo(getattr(param1, "dtype", type(param1))).resolution
+        r2 = np.finfo(getattr(param2, "dtype", type(param2))).resolution
+        tol = min(r1, r2)
+    else:  # specific to the parameter
+        tol = tolerance[k]
+
+    return np.all(np.isclose(param1, param2, rtol=tol, atol=tol))

--- a/astropy/cosmology/utils.py
+++ b/astropy/cosmology/utils.py
@@ -148,7 +148,7 @@ def _parameters_close(param1, param2, tolerance, name):
     ----------
     param1, param2 : number or array[number] or None
         The parameter values.
-    tolerance : None or Ellipsis or Number or dict[str, number]
+    tolerance : None or Ellipsis or `numbers.Number` or dict[str, number]
         The tolerance for each parameter to be considered equivalent.
         If `Ellipsis` the parameters can match to the `numpy.dtype` precision.
         If `None` the parameters must be equal.
@@ -160,7 +160,7 @@ def _parameters_close(param1, param2, tolerance, name):
     Returns
     -------
     bool
-        Whether `param1` and `param2` are close within the tolerance.
+        Whether `param1` and `param2` are close within the `tolerance`.
     """
     # exact equality
     if tolerance is None or param1 is None or param2 is None:

--- a/docs/changes/cosmology/12606.feature.rst
+++ b/docs/changes/cosmology/12606.feature.rst
@@ -1,4 +1,4 @@
 Add property ``is_flat`` to cosmologies to calculate the curvature of the Universe.
 
 ``Cosmology`` is now an abstract class and subclasses must override the
-abstract property ``is_flat``.
+abstract method ``is_close_to_flat``.

--- a/docs/changes/cosmology/12925.api.rst
+++ b/docs/changes/cosmology/12925.api.rst
@@ -1,0 +1,7 @@
+The "magic" method ``__equiv__`` now takes a new argument, tolerance, that
+specifies how close two parameters must be and still considered equivalent.
+
+Cosmology equivalence, as checked by ``Cosmology.is_equivalent``, has been
+relaxed from strict parameter equality to each parameter's `numpy.dtype`'s
+maximum precision, so a difference of e.g. 1e-18 for a `numpy.float64` is
+considered equivalent.

--- a/docs/changes/cosmology/12925.feature.rst
+++ b/docs/changes/cosmology/12925.feature.rst
@@ -1,5 +1,5 @@
-A new method ``.is_close()`` has been added to ``Cosmology`` to check if the
-parameters in two cosmologies are close to within a specified tolerance.
+A new method -- ``.is_close()`` -- has been added to ``Cosmology`` to check if
+the parameters in two cosmologies are close to within a specified tolerance.
 The tolerance can be `None` (for strict equality), `Ellipsis` to infer the
 parameter's `numpy.dtype`'s maximum precision, or a dictionary of tolerances
 keyed by the parameter's name.
@@ -7,6 +7,6 @@ Like ``Cosmology.is_equivalent``, the method works on any Python object that
 can be converted to a Cosmology.
 
 A new abstract method -- ``.is_close_to_flat()`` -- has been added to
-``Cosmology`` to check if a cosmology is clost to being flat. The abstract
-property ``is_flat`` now calls ``is_close_to_flat``. ``.is_close_to_flat()``
-accepts the same tolerance parameter as ``is_close``.
+``Cosmology`` to check if a cosmology is clost to being flat. The property
+``is_flat`` now calls ``is_close_to_flat``, which accepts the same tolerance
+parameter as ``is_close``.

--- a/docs/changes/cosmology/12925.feature.rst
+++ b/docs/changes/cosmology/12925.feature.rst
@@ -1,0 +1,12 @@
+A new method ``.is_close()`` has been added to ``Cosmology`` to check if the
+parameters in two cosmologies are close to within a specified tolerance.
+The tolerance can be `None` (for strict equality), `Ellipsis` to infer the
+parameter's `numpy.dtype`'s maximum precision, or a dictionary of tolerances
+keyed by the parameter's name.
+Like ``Cosmology.is_equivalent``, the method works on any Python object that
+can be converted to a Cosmology.
+
+A new abstract method -- ``.is_close_to_flat()`` -- has been added to
+``Cosmology`` to check if a cosmology is clost to being flat. The abstract
+property ``is_flat`` now calls ``is_close_to_flat``. ``.is_close_to_flat()``
+accepts the same tolerance parameter as ``is_close``.


### PR DESCRIPTION
A new method ``.is_close()`` has been added to ``Cosmology`` to check if the
parameters in two cosmologies are close to within a specified tolerance.
The tolerance can be `None` (for strict equality), `Ellipsis` to infer the
parameter's `numpy.dtype`'s maximum precision, or a dictionary of tolerances
keyed by the parameter's name.
Like ``Cosmology.is_equivalent``, the method works on any Python object that
can be converted to a Cosmology.

A new abstract method -- ``.is_close_to_flat()`` -- has been added to
``Cosmology`` to check if a cosmology is clost to being flat. The
property ``is_flat`` now calls ``is_close_to_flat(tolerance=None)``. ``.is_close_to_flat()``
accepts the same tolerance parameter as ``is_close``.

The pseudo-"magic" method ``__equiv__`` now takes a new argument, tolerance, that
specifies how close two parameters must be and still considered equivalent.

Cosmology equivalence, as checked by ``Cosmology.is_equivalent``, has been
relaxed from strict parameter equality to each parameter's `numpy.dtype`'s
maximum precision, so a difference of e.g. 1e-18 for a `numpy.float64` is
considered equivalent.

Fixes #12781 

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
