### PR TITLE
isort select submodules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,10 +12,13 @@ repos:
   - id: trailing-whitespace
     exclude: ".*(data.*|extern.*|licenses.*|_parsetab.py|test_cds.py)$"
 
-# - repo: https://github.com/timothycrosley/isort
-#   rev: 5.9.2
-#   hooks:
-#   - id: isort
+- repo: https://github.com/pycqa/isort
+  rev: 5.10.1
+  hooks:
+  - id: isort
+    name: isort (python)
+
+
 # - repo: https://github.com/asottile/pyupgrade
 #   rev: v2.21.0
 #   hooks:

--- a/astropy/cosmology/io/cosmology.py
+++ b/astropy/cosmology/io/cosmology.py
@@ -7,8 +7,8 @@ The following are private functions. These functions are registered into
 via these methods.
 """
 
-from astropy.cosmology.core import _COSMOLOGY_CLASSES, Cosmology
 from astropy.cosmology.connect import convert_registry
+from astropy.cosmology.core import _COSMOLOGY_CLASSES, Cosmology
 
 __all__ = []  # nothing is publicly scoped
 

--- a/astropy/cosmology/io/ecsv.py
+++ b/astropy/cosmology/io/ecsv.py
@@ -2,9 +2,9 @@
 
 import astropy.cosmology.units as cu
 import astropy.units as u
-from astropy.table import QTable
 from astropy.cosmology.connect import readwrite_registry
 from astropy.cosmology.core import Cosmology
+from astropy.table import QTable
 
 from .table import from_table, to_table
 

--- a/astropy/cosmology/io/mapping.py
+++ b/astropy/cosmology/io/mapping.py
@@ -13,8 +13,8 @@ from collections.abc import Mapping
 
 import numpy as np
 
-from astropy.cosmology.core import _COSMOLOGY_CLASSES, Cosmology
 from astropy.cosmology.connect import convert_registry
+from astropy.cosmology.core import _COSMOLOGY_CLASSES, Cosmology
 
 __all__ = []  # nothing is publicly scoped
 

--- a/astropy/cosmology/io/row.py
+++ b/astropy/cosmology/io/row.py
@@ -5,9 +5,9 @@ from collections import defaultdict
 
 import numpy as np
 
-from astropy.table import Row, QTable
 from astropy.cosmology.connect import convert_registry
 from astropy.cosmology.core import Cosmology
+from astropy.table import QTable, Row
 
 from .mapping import from_mapping
 

--- a/astropy/cosmology/io/table.py
+++ b/astropy/cosmology/io/table.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from astropy.cosmology.connect import convert_registry
 from astropy.cosmology.core import Cosmology
-from astropy.table import QTable, Table, Column
+from astropy.table import Column, QTable, Table
 
 from .mapping import to_mapping
 from .row import from_row

--- a/astropy/cosmology/io/tests/test_cosmology.py
+++ b/astropy/cosmology/io/tests/test_cosmology.py
@@ -7,8 +7,7 @@ import pytest
 from astropy.cosmology import Cosmology
 from astropy.cosmology.io.cosmology import from_cosmology, to_cosmology
 
-from .base import ToFromTestMixinBase, IODirectTestBase
-
+from .base import IODirectTestBase, ToFromTestMixinBase
 
 ###############################################################################
 

--- a/astropy/cosmology/io/tests/test_mapping.py
+++ b/astropy/cosmology/io/tests/test_mapping.py
@@ -5,10 +5,9 @@ import copy
 import inspect
 from collections import OrderedDict
 
-import pytest
-
 # THIRD PARTY
 import numpy as np
+import pytest
 
 # LOCAL
 from astropy.cosmology import Cosmology

--- a/astropy/cosmology/io/tests/test_mapping.py
+++ b/astropy/cosmology/io/tests/test_mapping.py
@@ -5,9 +5,10 @@ import copy
 import inspect
 from collections import OrderedDict
 
+import pytest
+
 # THIRD PARTY
 import numpy as np
-import pytest
 
 # LOCAL
 from astropy.cosmology import Cosmology

--- a/astropy/cosmology/io/tests/test_model.py
+++ b/astropy/cosmology/io/tests/test_model.py
@@ -5,9 +5,8 @@ import inspect
 import random
 
 # THIRD PARTY
-import pytest
-
 import numpy as np
+import pytest
 
 # LOCAL
 from astropy.cosmology.core import _COSMOLOGY_CLASSES, Cosmology

--- a/astropy/cosmology/io/tests/test_table.py
+++ b/astropy/cosmology/io/tests/test_table.py
@@ -11,7 +11,6 @@ from astropy.table import QTable, Table, vstack
 
 from .base import ToFromDirectTestBase, ToFromTestMixinBase
 
-
 ###############################################################################
 
 

--- a/astropy/cosmology/io/utils.py
+++ b/astropy/cosmology/io/utils.py
@@ -3,8 +3,8 @@
 import numpy as np
 
 from astropy.cosmology.parameter import Parameter
-from astropy.table import Column
 from astropy.modeling import Parameter as ModelParameter
+from astropy.table import Column
 
 
 def convert_parameter_to_column(parameter, value, meta=None):

--- a/astropy/cosmology/io/yaml.py
+++ b/astropy/cosmology/io/yaml.py
@@ -10,8 +10,8 @@ via these methods.
 
 import astropy.cosmology.units as cu
 import astropy.units as u
-from astropy.cosmology.core import _COSMOLOGY_CLASSES, Cosmology
 from astropy.cosmology.connect import convert_registry
+from astropy.cosmology.core import _COSMOLOGY_CLASSES, Cosmology
 from astropy.io.misc.yaml import AstropyDumper, AstropyLoader, dump, load
 
 from .mapping import from_mapping

--- a/astropy/cosmology/realizations.py
+++ b/astropy/cosmology/realizations.py
@@ -11,7 +11,6 @@ from astropy.utils.state import ScienceState
 
 from .core import Cosmology
 
-
 _COSMOLOGY_DATA_DIR = pathlib.Path(get_pkg_data_path("cosmology", "data", package="astropy"))
 available = tuple(sorted([p.stem for p in _COSMOLOGY_DATA_DIR.glob("*.ecsv")]))
 

--- a/astropy/cosmology/tests/conftest.py
+++ b/astropy/cosmology/tests/conftest.py
@@ -15,9 +15,9 @@ import pytest
 from astropy.cosmology import core
 from astropy.tests.helper import pickle_protocol  # noqa: F403
 
-
 ###############################################################################
 # FUNCTIONS
+
 
 def get_redshift_methods(cosmology, allow_private=True, allow_z2=True):
     """Get redshift methods from a cosmology.

--- a/astropy/cosmology/tests/conftest.py
+++ b/astropy/cosmology/tests/conftest.py
@@ -8,7 +8,7 @@
 # STDLIB
 import inspect
 
-# THIRD-PARTY
+# THIRD PARTY
 import pytest
 
 # LOCAL

--- a/astropy/cosmology/tests/test_core.py
+++ b/astropy/cosmology/tests/test_core.py
@@ -12,9 +12,8 @@ import pickle
 from types import MappingProxyType
 
 # THIRD PARTY
-import pytest
-
 import numpy as np
+import pytest
 
 # LOCAL
 import astropy.cosmology.units as cu

--- a/astropy/cosmology/tests/test_cosmology.py
+++ b/astropy/cosmology/tests/test_cosmology.py
@@ -4,9 +4,8 @@
 
 from io import StringIO
 
-import pytest
-
 import numpy as np
+import pytest
 
 import astropy.constants as const
 import astropy.units as u

--- a/astropy/cosmology/tests/test_flrw.py
+++ b/astropy/cosmology/tests/test_flrw.py
@@ -18,8 +18,8 @@ import astropy.constants as const
 # LOCAL
 import astropy.cosmology.units as cu
 import astropy.units as u
-from astropy.cosmology import (FLRW, FlatLambdaCDM, Flatw0waCDM, FlatwCDM,
-                               LambdaCDM, Planck18, w0waCDM, w0wzCDM, wCDM, wpwaCDM)
+from astropy.cosmology import (FLRW, FlatLambdaCDM, Flatw0waCDM, FlatwCDM, LambdaCDM, Planck18,
+                               w0waCDM, w0wzCDM, wCDM, wpwaCDM)
 from astropy.cosmology.core import _COSMOLOGY_CLASSES
 from astropy.cosmology.flrw import H0units_to_invs, a_B_c2, critdens_const, ellipkinc, hyp2f1, quad
 from astropy.cosmology.parameter import Parameter
@@ -29,9 +29,9 @@ from .conftest import get_redshift_methods
 from .test_core import CosmologySubclassTest as CosmologyTest
 from .test_core import FlatCosmologyMixinTest, ParameterTestMixin, invalid_zs, valid_zs
 
-
 ##############################################################################
 # SETUP / TEARDOWN
+
 
 class SubFLRW(FLRW):
     def w(self, z):

--- a/astropy/cosmology/tests/test_flrw.py
+++ b/astropy/cosmology/tests/test_flrw.py
@@ -10,9 +10,8 @@ import abc
 import copy
 
 # THIRD PARTY
-import pytest
-
 import numpy as np
+import pytest
 
 import astropy.constants as const
 # LOCAL

--- a/astropy/cosmology/tests/test_funcs.py
+++ b/astropy/cosmology/tests/test_funcs.py
@@ -4,9 +4,8 @@ import inspect
 import sys
 from io import StringIO
 
-import pytest
-
 import numpy as np
+import pytest
 
 from astropy import units as u
 from astropy.cosmology import core, flrw

--- a/astropy/cosmology/tests/test_funcs.py
+++ b/astropy/cosmology/tests/test_funcs.py
@@ -11,8 +11,8 @@ import numpy as np
 from astropy import units as u
 from astropy.cosmology import core, flrw
 from astropy.cosmology.funcs import _z_at_scalar_value, z_at_value
-from astropy.cosmology.realizations import (WMAP1, WMAP3, WMAP5, WMAP7, WMAP9,
-                                            Planck13, Planck15, Planck18)
+from astropy.cosmology.realizations import (WMAP1, WMAP3, WMAP5, WMAP7, WMAP9, Planck13, Planck15,
+                                            Planck18)
 from astropy.units import allclose
 from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa
 from astropy.utils.exceptions import AstropyUserWarning

--- a/astropy/cosmology/tests/test_parameter.py
+++ b/astropy/cosmology/tests/test_parameter.py
@@ -11,9 +11,8 @@ import inspect
 import sys
 
 # THIRD PARTY
-import pytest
-
 import numpy as np
+import pytest
 
 # LOCAL
 import astropy.units as u

--- a/astropy/cosmology/tests/test_parameters.py
+++ b/astropy/cosmology/tests/test_parameters.py
@@ -3,9 +3,10 @@
 # STDLIB
 from types import MappingProxyType
 
+import pytest
+
 # THIRD PARTY
 import numpy as np
-import pytest
 
 # LOCAL
 from astropy.cosmology import parameters, realizations

--- a/astropy/cosmology/tests/test_parameters.py
+++ b/astropy/cosmology/tests/test_parameters.py
@@ -3,10 +3,9 @@
 # STDLIB
 from types import MappingProxyType
 
-import pytest
-
 # THIRD PARTY
 import numpy as np
+import pytest
 
 # LOCAL
 from astropy.cosmology import parameters, realizations

--- a/astropy/cosmology/tests/test_utils.py
+++ b/astropy/cosmology/tests/test_utils.py
@@ -2,9 +2,8 @@
 
 from math import inf
 
-import pytest
-
 import numpy as np
+import pytest
 
 from astropy.cosmology.utils import aszarr, inf_like, vectorize_if_needed, vectorize_redshift_method
 from astropy.utils.exceptions import AstropyDeprecationWarning

--- a/astropy/cosmology/tests/test_utils.py
+++ b/astropy/cosmology/tests/test_utils.py
@@ -6,8 +6,7 @@ import pytest
 
 import numpy as np
 
-from astropy.cosmology.utils import aszarr, vectorize_redshift_method
-from astropy.cosmology.utils import inf_like, vectorize_if_needed
+from astropy.cosmology.utils import aszarr, inf_like, vectorize_if_needed, vectorize_redshift_method
 from astropy.utils.exceptions import AstropyDeprecationWarning
 
 from .test_core import _zarr, invalid_zs, valid_zs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,42 @@ write_to = "astropy/_version.py"
     [tool.astropy-bot.changelog_checker]
         enabled = false
 
+[tool.isort]
+    extend_skip_glob = [
+        "docs/*",
+        "examples/*",
+        "astropy/_dev/*",
+        "astropy/_erfa/*",
+        "astropy/config/*",
+        "astropy/constants/*",
+        "astropy/convolution/*",
+        "astropy/coordinates/*",
+        "astropy/cosmology/*",
+        "astropy/extern/*",
+        "astropy/io/*",
+        "astropy/modeling/*",
+        "astropy/nddata/*",
+        "astropy/samp/*",
+        "astropy/stats/*",
+        "astropy/table/*",
+        "astropy/tests/*",
+        "astropy/time/*",
+        "astropy/timeseries/*",
+        "astropy/uncertainty/*",
+        "astropy/units/*",
+        "astropy/utils/*",
+        "astropy/visualization/*",
+        "astropy/wcs/*",
+        "astropy/logger.py",
+        "setup.py"]
+    line_length = 100
+    sections = ["FUTURE", "STDLIB", "THIRDPARTY", "NUMPY", "FIRSTPARTY", "LOCALFOLDER"]
+    known_third_party = ["erfa", "PyYAML", "packaging", "pytest", "scipy", "matplotlib"]
+    known_numpy = ["numpy"]
+    known_first_party = ["astropy"]
+    multi_line_output = 0
+    group_by_package = true
+
 [tool.towncrier]
     package = "astropy"
     filename = "CHANGES.rst"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ write_to = "astropy/_version.py"
         "astropy/constants/*",
         "astropy/convolution/*",
         "astropy/coordinates/*",
-        "astropy/cosmology/*",
         "astropy/extern/*",
         "astropy/io/*",
         "astropy/modeling/*",
@@ -51,6 +50,7 @@ write_to = "astropy/_version.py"
     known_third_party = ["erfa", "PyYAML", "packaging", "pytest", "scipy", "matplotlib"]
     known_numpy = ["numpy"]
     known_first_party = ["astropy"]
+    known_local_folder = ["mypackage"]
     multi_line_output = 0
     group_by_package = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,16 +43,16 @@ write_to = "astropy/_version.py"
         "astropy/utils/*",
         "astropy/visualization/*",
         "astropy/wcs/*",
+        "astropy/__init__.py",
         "astropy/logger.py",
         "setup.py"]
     line_length = 100
-    sections = ["FUTURE", "STDLIB", "THIRDPARTY", "NUMPY", "FIRSTPARTY", "LOCALFOLDER"]
     known_third_party = ["erfa", "PyYAML", "packaging", "pytest", "scipy", "matplotlib"]
-    known_numpy = ["numpy"]
     known_first_party = ["astropy"]
     known_local_folder = ["mypackage"]
     multi_line_output = 0
     group_by_package = true
+    indented_import_headings = false
 
 [tool.towncrier]
     package = "astropy"

--- a/setup.cfg
+++ b/setup.cfg
@@ -165,16 +165,6 @@ exclude = extern,*parsetab.py,*lextab.py,astropy/_erfa/core.py
 max-line-length = 100
 exclude = extern,*parsetab.py,*lextab.py,astropy/_erfa/core.py
 
-[isort]
-line_length = 99
-sections = FUTURE,STDLIB,THIRDPARTY,NUMPY,FIRSTPARTY,LOCALFOLDER
-default_section = THIRDPARTY
-known_first_party = astropy
-known_numpy = numpy
-multi_line_output = 0
-balanced_wrapping = True
-include_trailing_comma = false
-
 [coverage:run]
 omit =
   astropy/__init__*


### PR DESCRIPTION
Astropy's existing isort options are moved to pyproject.toml and integrated with pre-commit.
Almost everything in astropy is ignored by default except for specific submodules.
To allow a submodule to have consistent, sorted imports, the relevant ignore glob may be removed.

@WilliamJamieson. Feel free to un-skip modeling and add a commit to this PR!

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
