### PR TITLE
Move `coordinates` tests to use `get_pkg_data_filename` for download

### DIFF
--- a/astropy/coordinates/tests/test_velocity_corrs.py
+++ b/astropy/coordinates/tests/test_velocity_corrs.py
@@ -8,7 +8,7 @@ from astropy import units as u
 from astropy.time import Time
 from astropy.coordinates import EarthLocation, SkyCoord, Angle, Distance
 from astropy.coordinates.sites import get_builtin_sites
-from astropy.utils.data import download_file
+from astropy.utils.data import get_pkg_data_filename
 from astropy.constants import c as speed_of_light
 from astropy.table import Table
 
@@ -413,8 +413,9 @@ def test_regression_10094():
     """
     # Wright & Eastman (2014) Table2
     # Corrections for tau Ceti
+
     wright_table = Table.read(
-        download_file('http://data.astropy.org/coordinates/wright_eastmann_2014_tau_ceti.fits')
+        get_pkg_data_filename('coordinates/wright_eastmann_2014_tau_ceti.fits')
     )
     reduced_jds = wright_table['JD-2400000']
     tempo2 = wright_table['TEMPO2']


### PR DESCRIPTION
### Description
This pull request is to address the only remaining direct downloads from http://data.astropy.org/
which has led to timeout failures whenever the primary server is down (like today).
Then there is
https://github.com/astropy/astropy/blob/22485a8e402d1658afccb6b07bc48247c414acf6/astropy/coordinates/tests/test_solar_system.py#L432-L433
explicitly triggering on an non-existent URL; this is still failing as the timeout will raise `URLError` instead of the expected `HTTPError`.
So either through `get_pkg_data_filename` or direct download that test would need to be changed to
` pytest.raises((HTTPError, URLError))`
but is this still testing the desired functionality?

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
