### PR TITLE
Quantity dtype option to not upcast

### DIFF
--- a/astropy/coordinates/angles.py
+++ b/astropy/coordinates/angles.py
@@ -105,7 +105,7 @@ class Angle(u.SpecificTypeQuantity):
     _equivalent_unit = u.radian
     _include_easy_conversion_members = True
 
-    def __new__(cls, angle, unit=None, dtype=np.floating, copy=True, **kwargs):
+    def __new__(cls, angle, unit=None, dtype=np.inexact, copy=True, **kwargs):
 
         if not isinstance(angle, u.Quantity):
             if unit is not None:

--- a/astropy/coordinates/angles.py
+++ b/astropy/coordinates/angles.py
@@ -105,7 +105,7 @@ class Angle(u.SpecificTypeQuantity):
     _equivalent_unit = u.radian
     _include_easy_conversion_members = True
 
-    def __new__(cls, angle, unit=None, dtype=None, copy=True, **kwargs):
+    def __new__(cls, angle, unit=None, dtype=np.floating, copy=True, **kwargs):
 
         if not isinstance(angle, u.Quantity):
             if unit is not None:

--- a/astropy/coordinates/distances.py
+++ b/astropy/coordinates/distances.py
@@ -100,8 +100,8 @@ class Distance(u.SpecificTypeQuantity):
     _include_easy_conversion_members = True
 
     def __new__(cls, value=None, unit=None, z=None, cosmology=None,
-                distmod=None, parallax=None, dtype=None, copy=True, order=None,
-                subok=False, ndmin=0, allow_negative=False):
+                distmod=None, parallax=None, dtype=np.floating, copy=True,
+                order=None, subok=False, ndmin=0, allow_negative=False):
 
         n_not_none = sum(x is not None for x in [value, z, distmod, parallax])
         if n_not_none == 0:

--- a/astropy/coordinates/distances.py
+++ b/astropy/coordinates/distances.py
@@ -100,7 +100,7 @@ class Distance(u.SpecificTypeQuantity):
     _include_easy_conversion_members = True
 
     def __new__(cls, value=None, unit=None, z=None, cosmology=None,
-                distmod=None, parallax=None, dtype=np.floating, copy=True,
+                distmod=None, parallax=None, dtype=np.inexact, copy=True,
                 order=None, subok=False, ndmin=0, allow_negative=False):
 
         n_not_none = sum(x is not None for x in [value, z, distmod, parallax])

--- a/astropy/table/tests/test_column.py
+++ b/astropy/table/tests/test_column.py
@@ -423,6 +423,16 @@ class TestColumn():
         with pytest.raises(AttributeError):
             t['a'].mask = [True, False]
 
+    def test_numpy_style_dtype_inspect(self, Column):
+        """Test that if ``dtype=Ellipsis``, NumPy's dtype inspection is used."""
+        q1 = Column([1, 2], dtype=None)
+        assert np.issubdtype(q1.dtype, np.integer)
+
+        q2 = Column([1, 2], dtype=...)
+        assert np.issubdtype(q2.dtype, np.integer)
+
+        assert q1.dtype == q2.dtype
+
 
 class TestAttrEqual():
     """Bunch of tests originally from ATpy that test the attrs_equal method."""

--- a/astropy/table/tests/test_column.py
+++ b/astropy/table/tests/test_column.py
@@ -423,16 +423,6 @@ class TestColumn():
         with pytest.raises(AttributeError):
             t['a'].mask = [True, False]
 
-    def test_numpy_style_dtype_inspect(self, Column):
-        """Test that if ``dtype=Ellipsis``, NumPy's dtype inspection is used."""
-        q1 = Column([1, 2], dtype=None)
-        assert np.issubdtype(q1.dtype, np.integer)
-
-        q2 = Column([1, 2], dtype=...)
-        assert np.issubdtype(q2.dtype, np.integer)
-
-        assert q1.dtype == q2.dtype
-
 
 class TestAttrEqual():
     """Bunch of tests originally from ATpy that test the attrs_equal method."""

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -824,7 +824,7 @@ class UnitBase:
         # Cannot handle this as Unit, re-try as Quantity.
         try:
             from .quantity import Quantity
-            return Quantity(1, self) * m
+            return Quantity(1, unit=self) * m
         except TypeError:
             return NotImplemented
 
@@ -842,7 +842,7 @@ class UnitBase:
                 result *= self
                 return result
             else:
-                return Quantity(m, self)
+                return Quantity(m, unit=self)
         except TypeError:
             return NotImplemented
 

--- a/astropy/units/function/core.py
+++ b/astropy/units/function/core.py
@@ -483,7 +483,7 @@ class FunctionQuantity(Quantity):
     _supported_ufuncs = SUPPORTED_UFUNCS
     _supported_functions = SUPPORTED_FUNCTIONS
 
-    def __new__(cls, value, unit=None, dtype=np.floating, copy=True, order=None,
+    def __new__(cls, value, unit=None, dtype=np.inexact, copy=True, order=None,
                 subok=False, ndmin=0):
 
         if unit is not None:

--- a/astropy/units/function/core.py
+++ b/astropy/units/function/core.py
@@ -483,7 +483,7 @@ class FunctionQuantity(Quantity):
     _supported_ufuncs = SUPPORTED_UFUNCS
     _supported_functions = SUPPORTED_FUNCTIONS
 
-    def __new__(cls, value, unit=None, dtype=None, copy=True, order=None,
+    def __new__(cls, value, unit=None, dtype=np.floating, copy=True, order=None,
                 subok=False, ndmin=0):
 
         if unit is not None:

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -405,19 +405,17 @@ class Quantity(np.ndarray):
         # TODO: ensure we do interact with NDArray.__class_getitem__.
         return Annotated.__class_getitem__((cls, unit))
 
-    def __new__(cls, value, unit=None, dtype=np.floating, copy=True, order=None,
+    def __new__(cls, value, unit=None, dtype=np.inexact, copy=True, order=None,
                 subok=False, ndmin=0):
 
         if unit is not None:
             # convert unit first, to avoid multiple string->unit conversions
             unit = Unit(unit)
 
-        # floating -> upcast to float dtype
-        if dtype is np.floating:
+        # inexact -> upcast to float dtype
+        float_default = dtype is np.inexact
+        if float_default:
             dtype = None
-            odtype = np.floating
-        else:
-            odtype = None
 
         # optimize speed for Quantity with no dtype given, copy=False
         if isinstance(value, Quantity):
@@ -430,7 +428,7 @@ class Quantity(np.ndarray):
                                                isinstance(value, cls)):
                 value = value.view(cls)
 
-            if dtype is None and value.dtype.kind in 'iu' and odtype is np.floating:
+            if float_default and value.dtype.kind in 'iu':
                 dtype = float
 
             return np.array(value, dtype=dtype, copy=copy, order=order,
@@ -519,7 +517,7 @@ class Quantity(np.ndarray):
                             "Numpy numeric type.")
 
         # by default, cast any integer, boolean, etc., to float
-        if dtype is None and value.dtype.kind in 'iuO' and odtype is np.floating:
+        if float_default and value.dtype.kind in 'iuO':
             value = value.astype(float)
 
         # if we allow subclasses, allow a class from the unit.

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -139,12 +139,26 @@ class TestQuantityCreation:
         assert q5.dtype == object
 
     def test_numpy_style_dtype_inspect(self):
-        """Test that if ``dtype=Ellipsis``, NumPy's dtype inspection is used."""
-        q1 = u.Quantity(12, dtype=None)
-        assert not np.issubdtype(q1.dtype, np.integer)
-
-        q2 = u.Quantity(12, dtype=...)
+        """Test that if ``dtype=None``, NumPy's dtype inspection is used."""
+        q2 = u.Quantity(12, dtype=None)
         assert np.issubdtype(q2.dtype, np.integer)
+
+    def test_float_dtype_promotion(self):
+        """Test that if ``dtype=numpy.floating``, the minimum precision is float64."""
+        q1 = u.Quantity(12, dtype=np.floating)
+        assert not np.issubdtype(q1.dtype, np.integer)
+        assert q1.dtype == np.float64
+
+        q2 = u.Quantity(np.float64(12), dtype=np.floating)
+        assert q2.dtype == np.float64
+
+        if hasattr(np, "float16"):
+            q3 = u.Quantity(np.float16(12), dtype=np.floating)
+            assert q3.dtype == np.float16
+
+        if hasattr(np, "float128"):
+            q4 = u.Quantity(np.float128(12), dtype=np.floating)
+            assert q4.dtype == np.float128
 
     def test_copy(self):
 

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -144,20 +144,23 @@ class TestQuantityCreation:
         assert np.issubdtype(q2.dtype, np.integer)
 
     def test_float_dtype_promotion(self):
-        """Test that if ``dtype=numpy.floating``, the minimum precision is float64."""
-        q1 = u.Quantity(12, dtype=np.floating)
+        """Test that if ``dtype=numpy.inexact``, the minimum precision is float64."""
+        q1 = u.Quantity(12, dtype=np.inexact)
         assert not np.issubdtype(q1.dtype, np.integer)
         assert q1.dtype == np.float64
 
-        q2 = u.Quantity(np.float64(12), dtype=np.floating)
+        q2 = u.Quantity(np.float64(12), dtype=np.inexact)
         assert q2.dtype == np.float64
 
+        q3 = u.Quantity(np.float32(12), dtype=np.inexact)
+        assert q3.dtype == np.float32
+
         if hasattr(np, "float16"):
-            q3 = u.Quantity(np.float16(12), dtype=np.floating)
+            q3 = u.Quantity(np.float16(12), dtype=np.inexact)
             assert q3.dtype == np.float16
 
         if hasattr(np, "float128"):
-            q4 = u.Quantity(np.float128(12), dtype=np.floating)
+            q4 = u.Quantity(np.float128(12), dtype=np.inexact)
             assert q4.dtype == np.float128
 
     def test_copy(self):

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -138,6 +138,14 @@ class TestQuantityCreation:
         q5 = u.Quantity(decimal.Decimal('10.25'), u.m, dtype=object)
         assert q5.dtype == object
 
+    def test_numpy_style_dtype_inspect(self):
+        """Test that if ``dtype=Ellipsis``, NumPy's dtype inspection is used."""
+        q1 = u.Quantity(12, dtype=None)
+        assert not np.issubdtype(q1.dtype, np.integer)
+
+        q2 = u.Quantity(12, dtype=...)
+        assert np.issubdtype(q2.dtype, np.integer)
+
     def test_copy(self):
 
         # By default, a new quantity is constructed, but not if copy=False

--- a/astropy/units/tests/test_utils.py
+++ b/astropy/units/tests/test_utils.py
@@ -16,10 +16,15 @@ def test_quantity_asanyarray():
     array_of_quantities = [Quantity(1), Quantity(2), Quantity(3)]
     quantity_array = quantity_asanyarray(array_of_quantities)
     assert isinstance(quantity_array, Quantity)
+    assert np.issubdtype(quantity_array.dtype, np.inexact)
 
     array_of_integers = [1, 2, 3]
     np_array = quantity_asanyarray(array_of_integers)
     assert isinstance(np_array, np.ndarray)
+    assert np.issubdtype(np_array.dtype, np.integer)
+
+    np_array = quantity_asanyarray(array_of_integers, dtype=np.inexact)
+    assert np.issubdtype(np_array.dtype, np.inexact)
 
 
 def test_sanitize_scale():

--- a/astropy/units/utils.py
+++ b/astropy/units/utils.py
@@ -286,9 +286,11 @@ def resolve_fractions(a, b):
     return a, b
 
 
-def quantity_asanyarray(a, dtype=None):
+def quantity_asanyarray(a, dtype=np.floating):
     from .quantity import Quantity
     if not isinstance(a, np.ndarray) and not np.isscalar(a) and any(isinstance(x, Quantity) for x in a):
         return Quantity(a, dtype=dtype)
     else:
+        # skip over floating64-related deprecation.
+        dtype = dtype if dtype is not np.floating else np.float64
         return np.asanyarray(a, dtype=dtype)

--- a/astropy/units/utils.py
+++ b/astropy/units/utils.py
@@ -286,11 +286,11 @@ def resolve_fractions(a, b):
     return a, b
 
 
-def quantity_asanyarray(a, dtype=np.floating):
+def quantity_asanyarray(a, dtype=None):
     from .quantity import Quantity
     if not isinstance(a, np.ndarray) and not np.isscalar(a) and any(isinstance(x, Quantity) for x in a):
         return Quantity(a, dtype=dtype)
     else:
-        # skip over floating64-related deprecation.
-        dtype = dtype if dtype is not np.floating else np.float64
+        # skip over some dtype deprecation deprecation.
+        dtype = np.float64 if dtype is np.inexact else dtype
         return np.asanyarray(a, dtype=dtype)

--- a/docs/changes/units/12941.api.rst
+++ b/docs/changes/units/12941.api.rst
@@ -1,5 +1,4 @@
 Quantity normally upcasts integer dtypes to floats, unless the dtype is
 specifically provided.
-Now, to force |Quantity| to use a similar ``dtype`` inspection as `numpy` when
-the dtype is not specified, |Quantity| accepts ``dtype=...`` (aka `Ellipsis`)
-as a valid argument.
+Before this happened when ``dtype=None``; now the default has been changed to
+``dtype=numpy.floating`` and ``dtype=None`` has the same meaning as in `numpy`.

--- a/docs/changes/units/12941.api.rst
+++ b/docs/changes/units/12941.api.rst
@@ -1,0 +1,5 @@
+Quantity normally upcasts integer dtypes to floats, unless the dtype is
+specifically provided.
+Now, to force |Quantity| to use a similar ``dtype`` inspection as `numpy` when
+the dtype is not specified, |Quantity| accepts ``dtype=...`` (aka `Ellipsis`)
+as a valid argument.

--- a/docs/changes/units/12941.api.rst
+++ b/docs/changes/units/12941.api.rst
@@ -1,4 +1,4 @@
 Quantity normally upcasts integer dtypes to floats, unless the dtype is
 specifically provided.
 Before this happened when ``dtype=None``; now the default has been changed to
-``dtype=numpy.floating`` and ``dtype=None`` has the same meaning as in `numpy`.
+``dtype=numpy.inexact`` and ``dtype=None`` has the same meaning as in `numpy`.

--- a/docs/units/quantity.rst
+++ b/docs/units/quantity.rst
@@ -528,26 +528,31 @@ argument.
     >>> q.dtype
     dtype('float32')
 
-Like for `numpy.ndarray`, ``dtype`` does not have to be specified (a value of
-`None`), in which case the data is inspected to find the best ``dtype``.
-For `numpy` this means integer inputs remain integers, while |Quantity|
-instead upcasts integers to floats.
+Like for `numpy.ndarray`, ``dtype`` does not have to be specified, in which
+case the data is inspected to find the best ``dtype``. For `numpy` this means
+integers remain integers, while |Quantity| instead upcasts integers to floats.
 
-    >>> v = np.array(1, dtype=None)
+    >>> v = np.array(1)
     >>> np.issubdtype(v.dtype, np.integer)
     True
 
-    >>> q = u.Quantity(1, dtype=None)
+    >>> q = u.Quantity(1)
     >>> np.issubdtype(q.dtype, np.integer)
     False
 
-To force |Quantity| to use a similar ``dtype`` inspection as `numpy`,
-|Quantity| accepts ``dtype=...`` (aka `Ellipsis`) as a valid argument. Note
-that this is not a valid argument for `numpy.ndarray`.
+|Quantity| promotes integer to floating types because it has a different
+default value for ``dtype`` than `numpy` -- `numpy.floating` versus `None`.
+For |Quantity| to use the same ``dtype`` inspection as `numpy`,
+|Quantity| likewise accepts ``dtype=None``.
 
-    >>> q = u.Quantity(1, dtype=...)
+    >>> q = u.Quantity(1, dtype=None)
     >>> np.issubdtype(q.dtype, np.integer)
     True
+
+Note that `numpy.floating` is a deprecated ``dtype`` argument for
+`numpy.ndarray`, currently an alias for `numpy.float64`. |Quantity| instead
+sets `numpy.float64` as default type, but not change data that is already a
+float.
 
 
 QTable

--- a/docs/units/quantity.rst
+++ b/docs/units/quantity.rst
@@ -517,6 +517,39 @@ It can also be used for in-place conversion::
     >>> a  # doctest: +FLOAT_CMP
     array([-100.,  100.,  200.,  300.,  400.])
 
+
+The `numpy.dtype` of a Quantity
+===============================
+
+|Quantity| subclasses `numpy.ndarray` and similarly accepts a ``dtype``
+argument.
+
+    >>> q = u.Quantity(1.0, dtype=np.float32)
+    >>> q.dtype
+    dtype('float32')
+
+Like for `numpy.ndarray`, ``dtype`` does not have to be specified (a value of
+`None`), in which case the data is inspected to find the best ``dtype``.
+For `numpy` this means integer inputs remain integers, while |Quantity|
+instead upcasts integers to floats.
+
+    >>> v = np.array(1, dtype=None)
+    >>> np.issubdtype(v.dtype, np.integer)
+    True
+
+    >>> q = u.Quantity(1, dtype=None)
+    >>> np.issubdtype(q.dtype, np.integer)
+    False
+
+To force |Quantity| to use a similar ``dtype`` inspection as `numpy`,
+|Quantity| accepts ``dtype=...`` (aka `Ellipsis`) as a valid argument. Note
+that this is not a valid argument for `numpy.ndarray`.
+
+    >>> q = u.Quantity(1, dtype=...)
+    >>> np.issubdtype(q.dtype, np.integer)
+    True
+
+
 QTable
 ======
 

--- a/docs/units/quantity.rst
+++ b/docs/units/quantity.rst
@@ -528,8 +528,8 @@ argument.
     >>> q.dtype
     dtype('float32')
 
-Like for `numpy.ndarray`, ``dtype`` does not have to be specified, in which
-case the data is inspected to find the best ``dtype``. For `numpy` this means
+Like for `numpy.ndarray`, ``dtype`` does not have to be specified, in which case
+the data is inspected to find the best ``dtype``. For `numpy` this means
 integers remain integers, while |Quantity| instead upcasts integers to floats.
 
     >>> v = np.array(1)
@@ -540,19 +540,17 @@ integers remain integers, while |Quantity| instead upcasts integers to floats.
     >>> np.issubdtype(q.dtype, np.integer)
     False
 
-|Quantity| promotes integer to floating types because it has a different
-default value for ``dtype`` than `numpy` -- `numpy.floating` versus `None`.
-For |Quantity| to use the same ``dtype`` inspection as `numpy`,
-|Quantity| likewise accepts ``dtype=None``.
+|Quantity| promotes integer to floating types because it has a different default
+value for ``dtype`` than `numpy` -- `numpy.inexact` versus `None`. For |Quantity|
+to use the same ``dtype`` inspection as `numpy`, use ``dtype=None``.
 
     >>> q = u.Quantity(1, dtype=None)
     >>> np.issubdtype(q.dtype, np.integer)
     True
 
-Note that `numpy.floating` is a deprecated ``dtype`` argument for
-`numpy.ndarray`, currently an alias for `numpy.float64`. |Quantity| instead
-sets `numpy.float64` as default type, but not change data that is already a
-float.
+Note that `numpy.inexact` is a deprecated ``dtype`` argument for
+`numpy.ndarray`. |Quantity| changes `numpy.inexact` to `numpy.float64`, but does
+not change data that are already floating point or complex.
 
 
 QTable

--- a/docs/whatsnew/5.2.rst
+++ b/docs/whatsnew/5.2.rst
@@ -18,10 +18,10 @@ In particular, this release includes:
 ``Quantity`` data types
 =======================
 
-The default dtype argument for ``Quantity`` has been changed from `None`
-to ``numpy.floating``. With this dtype, Quantity will still upcast integers
-to floats, with a default dtype of ``float64``. Now ``dtype=None`` means the
-same thing as ``numpy``.
+The default dtype argument for ``Quantity`` has been changed, so that one can
+now explicitly give ``dtype=None`` to get the same behaviour as :mod:`numpy`.
+Without an explicit argument, any integer values are still upcast to floating
+point, since that makes more sense for physical quantities.
 
 
 Full change log

--- a/docs/whatsnew/5.2.rst
+++ b/docs/whatsnew/5.2.rst
@@ -12,7 +12,17 @@ the 5.1 release.
 
 In particular, this release includes:
 
-* nothing yet
+
+.. _whatsnew-quantity-dtype:
+
+``Quantity`` data types
+=======================
+
+The default dtype argument for ``Quantity`` has been changed from `None`
+to ``numpy.floating``. With this dtype, Quantity will still upcast integers
+to floats, with a default dtype of ``float64``. Now ``dtype=None`` means the
+same thing as ``numpy``.
+
 
 Full change log
 ===============


### PR DESCRIPTION
### Description

Resolves https://github.com/astropy/astropy/pull/12505#issuecomment-981847425

Quantity normally upcasts integer dtypes to floats, unless the dtype is 
specifically provided.
Now, to force |Quantity| to use a similar ``dtype`` inspection as `numpy` when
the dtype is not specified, |Quantity| accepts ``dtype=...`` (aka `Ellipsis`)
as a valid argument.

Edit:  instead of the above, the default dtype is being changed to ``floating`` and `None` will work the same as numpy.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
