### PR TITLE
isort modeling

### DIFF
--- a/astropy/modeling/__init__.py
+++ b/astropy/modeling/__init__.py
@@ -7,8 +7,7 @@ and fitting with parameter constraints. It has some predefined models
 and fitting routines.
 """
 
-from . import fitting
-from . import models
+from . import fitting, models
 from .core import *
 from .parameters import *
 from .separable import *

--- a/astropy/modeling/bounding_box.py
+++ b/astropy/modeling/bounding_box.py
@@ -7,16 +7,14 @@ This module is to contain an improved bounding box
 
 import abc
 import copy
-
-from collections import namedtuple
-from typing import Dict, List, Tuple, Callable, Any
-
-from astropy.utils import isiterable
-from astropy.units import Quantity
-
 import warnings
+from collections import namedtuple
+from typing import Any, Callable, Dict, List, Tuple
+
 import numpy as np
 
+from astropy.units import Quantity
+from astropy.utils import isiterable
 
 __all__ = ['ModelBoundingBox', 'CompoundBoundingBox']
 

--- a/astropy/modeling/convolution.py
+++ b/astropy/modeling/convolution.py
@@ -4,7 +4,7 @@
 # pylint: disable=line-too-long, too-many-lines, too-many-arguments, invalid-name
 import numpy as np
 
-from .core import CompoundModel, SPECIAL_OPERATORS
+from .core import SPECIAL_OPERATORS, CompoundModel
 
 
 class Convolution(CompoundModel):

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -15,34 +15,30 @@ parameters in each model making up the set.
 # pylint: disable=invalid-name, protected-access, redefined-outer-name
 import abc
 import copy
+import functools
 import inspect
 import itertools
-import functools
 import numbers
 import operator
 import types
-
 from collections import defaultdict, deque
 from inspect import signature
 from itertools import chain
 
 import numpy as np
 
-from astropy.utils import indent, metadata
+from astropy.nddata.utils import add_array, extract_array
 from astropy.table import Table
 from astropy.units import Quantity, UnitsError, dimensionless_unscaled
 from astropy.units.utils import quantity_asanyarray
-from astropy.utils import (sharedmethod, find_current_module,
-                           check_broadcast, IncompatibleShapeError, isiterable)
+from astropy.utils import (IncompatibleShapeError, check_broadcast, find_current_module, indent,
+                           isiterable, metadata, sharedmethod)
 from astropy.utils.codegen import make_function_with_signature
-from astropy.nddata.utils import add_array, extract_array
-from .utils import (combine_labels, make_binary_operator_eval,
-                    get_inputs_and_params, _combine_equivalency_dict,
-                    _ConstraintsDict, _SpecialOperatorsDict)
-from .bounding_box import ModelBoundingBox, CompoundBoundingBox
-from .parameters import (Parameter, InputParameterError,
-                         param_repr_oneline, _tofloat)
 
+from .bounding_box import CompoundBoundingBox, ModelBoundingBox
+from .parameters import InputParameterError, Parameter, _tofloat, param_repr_oneline
+from .utils import (_combine_equivalency_dict, _ConstraintsDict, _SpecialOperatorsDict,
+                    combine_labels, get_inputs_and_params, make_binary_operator_eval)
 
 __all__ = ['Model', 'FittableModel', 'Fittable1DModel', 'Fittable2DModel',
            'CompoundModel', 'fix_inputs', 'custom_model', 'ModelDefinitionError',

--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -26,21 +26,20 @@ import abc
 import inspect
 import operator
 import warnings
-from importlib.metadata import entry_points
-
 from functools import reduce, wraps
+from importlib.metadata import entry_points
 
 import numpy as np
 
 from astropy.units import Quantity
-from astropy.utils.exceptions import AstropyUserWarning
 from astropy.utils.decorators import deprecated
-from .utils import poly_map_domain, _combine_equivalency_dict
-from .optimizers import (SLSQP, Simplex)
-from .statistic import (leastsquare)
-from .optimizers import (DEFAULT_MAXITER, DEFAULT_EPS, DEFAULT_ACC)
-from .spline import (SplineInterpolateFitter, SplineSmoothingFitter,
-                     SplineExactKnotsFitter, SplineSplrepFitter)
+from astropy.utils.exceptions import AstropyUserWarning
+
+from .optimizers import DEFAULT_ACC, DEFAULT_EPS, DEFAULT_MAXITER, SLSQP, Simplex
+from .spline import (SplineExactKnotsFitter, SplineInterpolateFitter, SplineSmoothingFitter,
+                     SplineSplrepFitter)
+from .statistic import leastsquare
+from .utils import _combine_equivalency_dict, poly_map_domain
 
 __all__ = ['LinearLSQFitter', 'LevMarLSQFitter', 'FittingWithOutlierRemoval',
            'SLSQPLSQFitter', 'SimplexLSQFitter', 'JointFitter', 'Fitter',

--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -6,11 +6,10 @@ import numpy as np
 
 from astropy import units as u
 from astropy.units import Quantity, UnitsError
-from .core import (Fittable1DModel, Fittable2DModel)
 
-from .parameters import Parameter, InputParameterError
+from .core import Fittable1DModel, Fittable2DModel
+from .parameters import InputParameterError, Parameter
 from .utils import ellipse_extent
-
 
 __all__ = ['AiryDisk2D', 'Moffat1D', 'Moffat2D', 'Box1D', 'Box2D', 'Const1D',
            'Const2D', 'Ellipse2D', 'Disk2D', 'Gaussian1D', 'Gaussian2D',

--- a/astropy/modeling/mappings.py
+++ b/astropy/modeling/mappings.py
@@ -4,9 +4,9 @@ which outputs from a source model are mapped to which inputs of a target model.
 """
 # pylint: disable=invalid-name
 
-from .core import FittableModel, Model
 from astropy.units import Quantity
 
+from .core import FittableModel, Model
 
 __all__ = ['Mapping', 'Identity', 'UnitsMapping']
 

--- a/astropy/modeling/math_functions.py
+++ b/astropy/modeling/math_functions.py
@@ -7,7 +7,6 @@ import numpy as np
 from astropy.modeling.core import Model
 from astropy.utils.exceptions import AstropyUserWarning
 
-
 trig_ufuncs = ["sin", "cos", "tan", "arcsin", "arccos", "arctan", "arctan2",
                "hypot", "sinh", "cosh", "tanh", "arcsinh", "arccosh",
                "arctanh", "deg2rad", "rad2deg"]

--- a/astropy/modeling/models.py
+++ b/astropy/modeling/models.py
@@ -6,18 +6,17 @@ Creates a common namespace for all pre-defined models.
 
 # pylint: disable=unused-wildcard-import, unused-import, wildcard-import
 
-from .core import custom_model, hide_inverse, fix_inputs # pylint: disable=W0611
+from . import math_functions as math
+from .core import custom_model, fix_inputs, hide_inverse  # pylint: disable=W0611
+from .functional_models import *
 from .mappings import *
+from .physical_models import *
+from .polynomial import *
+from .powerlaws import *
 from .projections import *
 from .rotations import *
-from .polynomial import *
-from .functional_models import *
-from .physical_models import *
-from .powerlaws import *
 from .spline import *
 from .tabular import *
-from . import math_functions as math
-
 
 # Attach a docstring explaining constraints to all models which support them.
 # Note: add new models to this list

--- a/astropy/modeling/optimizers.py
+++ b/astropy/modeling/optimizers.py
@@ -5,9 +5,11 @@
 Optimization algorithms used in `~astropy.modeling.fitting`.
 """
 
-import warnings
 import abc
+import warnings
+
 import numpy as np
+
 from astropy.utils.exceptions import AstropyUserWarning
 
 __all__ = ["Optimization", "SLSQP", "Simplex"]

--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -17,9 +17,8 @@ import numpy as np
 
 from astropy.units import Quantity
 from astropy.utils import isiterable
-from .utils import array_repr_oneline
-from .utils import get_inputs_and_params
 
+from .utils import array_repr_oneline, get_inputs_and_params
 
 __all__ = ['Parameter', 'InputParameterError', 'ParameterError']
 

--- a/astropy/modeling/physical_models.py
+++ b/astropy/modeling/physical_models.py
@@ -11,8 +11,9 @@ import numpy as np
 from astropy import constants as const
 from astropy import units as u
 from astropy.utils.exceptions import AstropyUserWarning
+
 from .core import Fittable1DModel
-from .parameters import Parameter, InputParameterError
+from .parameters import InputParameterError, Parameter
 
 __all__ = ["BlackBody", "Drude1D", "Plummer1D", "NFW"]
 

--- a/astropy/modeling/polynomial.py
+++ b/astropy/modeling/polynomial.py
@@ -6,12 +6,12 @@ This module contains models representing polynomials and polynomial series.
 # pylint: disable=invalid-name
 import numpy as np
 
-from astropy.utils import indent, check_broadcast
+from astropy.utils import check_broadcast, indent
+
 from .core import FittableModel, Model
 from .functional_models import Shift
 from .parameters import Parameter
-from .utils import poly_map_domain, comb, _validate_domain_window
-
+from .utils import _validate_domain_window, comb, poly_map_domain
 
 __all__ = [
     'Chebyshev1D', 'Chebyshev2D', 'Hermite1D', 'Hermite2D',

--- a/astropy/modeling/powerlaws.py
+++ b/astropy/modeling/powerlaws.py
@@ -6,9 +6,9 @@ Power law model variants
 import numpy as np
 
 from astropy.units import Quantity
-from .core import Fittable1DModel
-from .parameters import Parameter, InputParameterError
 
+from .core import Fittable1DModel
+from .parameters import InputParameterError, Parameter
 
 __all__ = ['PowerLaw1D', 'BrokenPowerLaw1D', 'SmoothlyBrokenPowerLaw1D',
            'ExponentialCutoffPowerLaw1D', 'LogParabola1D']

--- a/astropy/modeling/projections.py
+++ b/astropy/modeling/projections.py
@@ -23,9 +23,8 @@ from astropy import units as u
 from astropy import wcs
 
 from .core import Model
-from .parameters import Parameter, InputParameterError
-from .utils import _to_radian, _to_orig_unit
-
+from .parameters import InputParameterError, Parameter
+from .utils import _to_orig_unit, _to_radian
 
 # List of tuples of the form
 # (long class name without suffix, short WCSLIB projection code):

--- a/astropy/modeling/rotations.py
+++ b/astropy/modeling/rotations.py
@@ -24,11 +24,12 @@ import math
 
 import numpy as np
 
-from astropy.coordinates.matrix_utilities import rotation_matrix, matrix_product
 from astropy import units as u
+from astropy.coordinates.matrix_utilities import matrix_product, rotation_matrix
+
 from .core import Model
 from .parameters import Parameter
-from .utils import _to_radian, _to_orig_unit
+from .utils import _to_orig_unit, _to_radian
 
 __all__ = ['RotateCelestial2Native', 'RotateNative2Celestial', 'Rotation2D',
            'EulerAngleRotation', 'RotationSequence3D', 'SphericalRotationSequence']

--- a/astropy/modeling/separable.py
+++ b/astropy/modeling/separable.py
@@ -17,9 +17,8 @@ returns an array of shape (``n_outputs``, ``n_inputs``).
 
 import numpy as np
 
-from .core import Model, ModelDefinitionError, CompoundModel
+from .core import CompoundModel, Model, ModelDefinitionError
 from .mappings import Mapping
-
 
 __all__ = ["is_separable", "separability_matrix"]
 

--- a/astropy/modeling/setup_package.py
+++ b/astropy/modeling/setup_package.py
@@ -1,13 +1,11 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import os
-from os.path import join
 from collections import defaultdict
-
-from setuptools import Extension
+from os.path import join
 
 from extension_helpers import import_file
-
+from setuptools import Extension
 
 # This defines the set of projection functions that we want to wrap.
 # The key is the projection name, and the value is the number of

--- a/astropy/modeling/spline.py
+++ b/astropy/modeling/spline.py
@@ -3,18 +3,17 @@
 """Spline models and fitters."""
 # pylint: disable=line-too-long, too-many-lines, too-many-arguments, invalid-name
 
-import warnings
-
 import abc
 import functools
+import warnings
+
 import numpy as np
 
-from astropy.utils.exceptions import (AstropyUserWarning,)
 from astropy.utils import isiterable
-from .core import (FittableModel, ModelDefinitionError)
+from astropy.utils.exceptions import AstropyUserWarning
 
+from .core import FittableModel, ModelDefinitionError
 from .parameters import Parameter
-
 
 __all__ = ['Spline1D', 'SplineInterpolateFitter', 'SplineSmoothingFitter',
            'SplineExactKnotsFitter', 'SplineSplrepFitter']

--- a/astropy/modeling/tabular.py
+++ b/astropy/modeling/tabular.py
@@ -22,6 +22,7 @@ import abc
 import numpy as np
 
 from astropy import units as u
+
 from .core import Model
 
 try:

--- a/astropy/modeling/tests/example_models.py
+++ b/astropy/modeling/tests/example_models.py
@@ -50,21 +50,20 @@ Explanation of keywords of the dictionaries:
 """
 
 
-from astropy.modeling.functional_models import (
-    Gaussian1D,
-    Sine1D, Cosine1D, Tangent1D, ArcSine1D, ArcCosine1D, ArcTangent1D,
-    Box1D, Linear1D, Lorentz1D,
-    RickerWavelet1D, Trapezoid1D, Const1D, Moffat1D,
-    Gaussian2D, Const2D, Box2D, RickerWavelet2D,
-    TrapezoidDisk2D, AiryDisk2D, Moffat2D, Disk2D,
-    Ring2D, Sersic1D, Sersic2D, Voigt1D, Planar2D, KingProjectedAnalytic1D,
-    Exponential1D, Logarithmic1D)
+import numpy as np
+
+from astropy.modeling.functional_models import (AiryDisk2D, ArcCosine1D, ArcSine1D, ArcTangent1D,
+                                                Box1D, Box2D, Const1D, Const2D, Cosine1D, Disk2D,
+                                                Exponential1D, Gaussian1D, Gaussian2D,
+                                                KingProjectedAnalytic1D, Linear1D, Logarithmic1D,
+                                                Lorentz1D, Moffat1D, Moffat2D, Planar2D,
+                                                RickerWavelet1D, RickerWavelet2D, Ring2D, Sersic1D,
+                                                Sersic2D, Sine1D, Tangent1D, Trapezoid1D,
+                                                TrapezoidDisk2D, Voigt1D)
 from astropy.modeling.physical_models import Drude1D, Plummer1D
 from astropy.modeling.polynomial import Polynomial1D, Polynomial2D
-from astropy.modeling.powerlaws import (
-    PowerLaw1D, BrokenPowerLaw1D, SmoothlyBrokenPowerLaw1D, ExponentialCutoffPowerLaw1D,
-    LogParabola1D)
-import numpy as np
+from astropy.modeling.powerlaws import (BrokenPowerLaw1D, ExponentialCutoffPowerLaw1D,
+                                        LogParabola1D, PowerLaw1D, SmoothlyBrokenPowerLaw1D)
 
 # 1D Models
 models_1D = {

--- a/astropy/modeling/tests/irafutil.py
+++ b/astropy/modeling/tests/irafutil.py
@@ -4,9 +4,9 @@ This module provides functions to help with testing against iraf tasks
 """
 
 
-from astropy.logger import log
 import numpy as np
 
+from astropy.logger import log
 
 iraf_models_map = {1.: 'Chebyshev',
                    2.: 'Legendre',

--- a/astropy/modeling/tests/test_bounding_box.py
+++ b/astropy/modeling/tests/test_bounding_box.py
@@ -1,17 +1,18 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-import pytest
-import numpy as np
 import unittest.mock as mk
 
-from astropy.modeling.bounding_box import (_BaseInterval, _Interval, _ignored_interval,
-                                           _BoundingDomain, ModelBoundingBox,
-                                           _BaseSelectorArgument, _SelectorArgument, _SelectorArguments,
-                                           CompoundBoundingBox)
-from astropy.modeling.models import Gaussian1D, Gaussian2D, Shift, Scale, Identity
-from astropy.modeling.core import Model, fix_inputs
-from astropy.coordinates import SpectralCoord
+import numpy as np
+import pytest
+
 import astropy.units as u
+from astropy.coordinates import SpectralCoord
+from astropy.modeling.bounding_box import (CompoundBoundingBox, ModelBoundingBox, _BaseInterval,
+                                           _BaseSelectorArgument, _BoundingDomain,
+                                           _ignored_interval, _Interval, _SelectorArgument,
+                                           _SelectorArguments)
+from astropy.modeling.core import Model, fix_inputs
+from astropy.modeling.models import Gaussian1D, Gaussian2D, Identity, Scale, Shift
 
 
 class Test_Interval:

--- a/astropy/modeling/tests/test_compound.py
+++ b/astropy/modeling/tests/test_compound.py
@@ -2,22 +2,20 @@
 # pylint: disable=invalid-name, pointless-statement
 
 import pickle
-import pytest
 
 import numpy as np
-
+import pytest
 from numpy.testing import assert_allclose, assert_array_equal
 
-from astropy.utils import minversion
-from astropy.modeling.core import Model, ModelDefinitionError, CompoundModel
-from astropy.modeling.parameters import Parameter
-from astropy.modeling.models import (Const1D, Shift, Scale, Rotation2D, Gaussian1D,
-                                     Gaussian2D, Polynomial1D, Polynomial2D,
-                                     Chebyshev2D, Legendre2D, Chebyshev1D, Legendre1D,
-                                     Identity, Mapping, Linear1D,
-                                     Tabular1D, fix_inputs,)
-from astropy.modeling.fitting import LevMarLSQFitter
 import astropy.units as u
+from astropy.modeling.core import CompoundModel, Model, ModelDefinitionError
+from astropy.modeling.fitting import LevMarLSQFitter
+from astropy.modeling.models import (Chebyshev1D, Chebyshev2D, Const1D, Gaussian1D, Gaussian2D,
+                                     Identity, Legendre1D, Legendre2D, Linear1D, Mapping,
+                                     Polynomial1D, Polynomial2D, Rotation2D, Scale, Shift,
+                                     Tabular1D, fix_inputs)
+from astropy.modeling.parameters import Parameter
+from astropy.utils import minversion
 from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa
 
 

--- a/astropy/modeling/tests/test_constraints.py
+++ b/astropy/modeling/tests/test_constraints.py
@@ -4,17 +4,16 @@
 import types
 import warnings
 
-import pytest
 import numpy as np
-from numpy.testing import assert_allclose
+import pytest
 from numpy.random import default_rng
+from numpy.testing import assert_allclose
 
+from astropy.modeling import fitting, models
 from astropy.modeling.core import Fittable1DModel
 from astropy.modeling.parameters import Parameter
-from astropy.modeling import models
-from astropy.modeling import fitting
-from astropy.utils.exceptions import AstropyUserWarning
 from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa
+from astropy.utils.exceptions import AstropyUserWarning
 
 
 class TestNonLinearConstraints:

--- a/astropy/modeling/tests/test_convolution.py
+++ b/astropy/modeling/tests/test_convolution.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # pylint: disable=invalid-name
-import pytest
 import numpy as np
+import pytest
 
 from astropy.convolution import convolve_models_fft
 from astropy.modeling.models import Const1D, Const2D

--- a/astropy/modeling/tests/test_core.py
+++ b/astropy/modeling/tests/test_core.py
@@ -1,29 +1,28 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # pylint: disable=invalid-name
 import os
-import sys
 import subprocess
-
-import pytest
+import sys
 import unittest.mock as mk
-import numpy as np
 from inspect import signature
+
+import numpy as np
+import pytest
 from numpy.testing import assert_allclose, assert_equal
 
 import astropy
-from astropy.modeling.core import (Model, CompoundModel, custom_model,
-                                   SPECIAL_OPERATORS, _add_special_operator,
-                                   bind_bounding_box, bind_compound_bounding_box,
-                                   fix_inputs)
-from astropy.modeling.bounding_box import ModelBoundingBox, CompoundBoundingBox
-from astropy.modeling.separable import separability_matrix
-from astropy.modeling.parameters import Parameter
-from astropy.modeling import models
-from astropy.convolution import convolve_models
+import astropy.modeling.core as core
 import astropy.units as u
+from astropy.convolution import convolve_models
+from astropy.modeling import models
+from astropy.modeling.bounding_box import CompoundBoundingBox, ModelBoundingBox
+from astropy.modeling.core import (SPECIAL_OPERATORS, CompoundModel, Model, _add_special_operator,
+                                   bind_bounding_box, bind_compound_bounding_box, custom_model,
+                                   fix_inputs)
+from astropy.modeling.parameters import Parameter
+from astropy.modeling.separable import separability_matrix
 from astropy.tests.helper import assert_quantity_allclose
 from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa
-import astropy.modeling.core as core
 
 
 class NonFittableModel(Model):

--- a/astropy/modeling/tests/test_fitters.py
+++ b/astropy/modeling/tests/test_fitters.py
@@ -4,29 +4,28 @@ Module to test fitting routines
 """
 # pylint: disable=invalid-name
 import os.path
-import warnings
-from unittest import mock
-from importlib.metadata import EntryPoint
-
-import pytest
-import numpy as np
 import unittest.mock as mk
+import warnings
+from importlib.metadata import EntryPoint
+from unittest import mock
+
+import numpy as np
+import pytest
 from numpy import linalg
 from numpy.testing import assert_allclose, assert_almost_equal, assert_equal
 
 from astropy.modeling import models
 from astropy.modeling.core import Fittable2DModel, Parameter
-from astropy.modeling.fitting import (
-    SimplexLSQFitter, SLSQPLSQFitter, LinearLSQFitter, LevMarLSQFitter,
-    JointFitter, Fitter, FittingWithOutlierRemoval)
+from astropy.modeling.fitting import (Fitter, FittingWithOutlierRemoval, JointFitter,
+                                      LevMarLSQFitter, LinearLSQFitter, SimplexLSQFitter,
+                                      SLSQPLSQFitter, populate_entry_points)
 from astropy.modeling.optimizers import Optimization
-from astropy.utils import NumpyRNGContext
-from astropy.utils.data import get_pkg_data_filename
 from astropy.stats import sigma_clip
-
+from astropy.utils import NumpyRNGContext
 from astropy.utils.compat.optional_deps import HAS_SCIPY
+from astropy.utils.data import get_pkg_data_filename
 from astropy.utils.exceptions import AstropyUserWarning
-from astropy.modeling.fitting import populate_entry_points
+
 from . import irafutil
 
 if HAS_SCIPY:

--- a/astropy/modeling/tests/test_functional_models.py
+++ b/astropy/modeling/tests/test_functional_models.py
@@ -1,16 +1,15 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 # pylint: disable=invalid-name
-import pytest
 import numpy as np
+import pytest
 from numpy.testing import assert_allclose, assert_array_equal, assert_array_less
 
 from astropy import units as u
-from astropy.modeling import models, InputParameterError
 from astropy.coordinates import Angle
-from astropy.modeling import fitting
-from astropy.utils.exceptions import AstropyUserWarning
+from astropy.modeling import InputParameterError, fitting, models
 from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa
+from astropy.utils.exceptions import AstropyUserWarning
 
 
 def test_sigma_constant():
@@ -20,8 +19,8 @@ def test_sigma_constant():
     it manually in astropy.modeling to avoid importing from
     astropy.stats.
     """
-    from astropy.stats.funcs import gaussian_sigma_to_fwhm
     from astropy.modeling.functional_models import GAUSSIAN_SIGMA_TO_FWHM
+    from astropy.stats.funcs import gaussian_sigma_to_fwhm
     assert gaussian_sigma_to_fwhm == GAUSSIAN_SIGMA_TO_FWHM
 
 

--- a/astropy/modeling/tests/test_input.py
+++ b/astropy/modeling/tests/test_input.py
@@ -3,16 +3,14 @@
 This module tests fitting and model evaluation with various inputs
 """
 
-import pytest
 import numpy as np
+import pytest
 from numpy.testing import assert_allclose
 
-from astropy.modeling import models
-from astropy.modeling import fitting
-from astropy.modeling.core import Model, FittableModel, Fittable1DModel
+from astropy.modeling import fitting, models
+from astropy.modeling.core import Fittable1DModel, FittableModel, Model
 from astropy.modeling.parameters import Parameter
 from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa
-
 
 model1d_params = [
     (models.Polynomial1D, [2]),

--- a/astropy/modeling/tests/test_mappings.py
+++ b/astropy/modeling/tests/test_mappings.py
@@ -1,12 +1,12 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # pylint: disable=invalid-name
-import pytest
 import numpy as np
+import pytest
 from numpy.testing import assert_allclose, assert_array_equal
 
-from astropy.modeling.fitting import LevMarLSQFitter
-from astropy.modeling.models import Shift, Rotation2D, Gaussian1D, Identity, Mapping, UnitsMapping
 from astropy import units as u
+from astropy.modeling.fitting import LevMarLSQFitter
+from astropy.modeling.models import Gaussian1D, Identity, Mapping, Rotation2D, Shift, UnitsMapping
 from astropy.utils import NumpyRNGContext
 from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa
 

--- a/astropy/modeling/tests/test_model_sets.py
+++ b/astropy/modeling/tests/test_model_sets.py
@@ -2,20 +2,18 @@
 """
 This module tests model set evaluation and fitting for some common use cases.
 """
+import numpy as np
 # pylint: disable=invalid-name
 import pytest
-import numpy as np
 from numpy.testing import assert_allclose
 
-from astropy.modeling.models import (Polynomial1D, Polynomial2D, Legendre1D, Legendre2D,
-                                     Chebyshev2D, Chebyshev1D, Hermite1D, Hermite2D,
-                                     Linear1D, Planar2D)
-from astropy.modeling.fitting import LinearLSQFitter, FittingWithOutlierRemoval
 from astropy.modeling.core import Model
+from astropy.modeling.fitting import FittingWithOutlierRemoval, LinearLSQFitter
+from astropy.modeling.models import (Chebyshev1D, Chebyshev2D, Hermite1D, Hermite2D, Legendre1D,
+                                     Legendre2D, Linear1D, Planar2D, Polynomial1D, Polynomial2D)
 from astropy.modeling.parameters import Parameter
-from astropy.utils import NumpyRNGContext
 from astropy.stats import sigma_clip
-
+from astropy.utils import NumpyRNGContext
 
 x = np.arange(4)
 xx = np.array([x, x + 10])

--- a/astropy/modeling/tests/test_models.py
+++ b/astropy/modeling/tests/test_models.py
@@ -4,27 +4,27 @@
 Tests for model evaluation.
 Compare the results of some models with other programs.
 """
+import unittest.mock as mk
+
+import numpy as np
 # pylint: disable=invalid-name, no-member
 import pytest
-import numpy as np
-import unittest.mock as mk
-import astropy.modeling.tabular as tabular_models
-
 from numpy.testing import assert_allclose, assert_equal
 
+import astropy.modeling.tabular as tabular_models
 from astropy import units as u
 from astropy.modeling import fitting, models
-from astropy.modeling.models import Gaussian2D
 from astropy.modeling.bounding_box import ModelBoundingBox
-from astropy.modeling.core import FittableModel, _ModelMeta, Model
-from astropy.modeling.parameters import Parameter
+from astropy.modeling.core import FittableModel, Model, _ModelMeta
+from astropy.modeling.models import Gaussian2D
+from astropy.modeling.parameters import InputParameterError, Parameter
 from astropy.modeling.polynomial import PolynomialBase
 from astropy.modeling.powerlaws import SmoothlyBrokenPowerLaw1D
-from astropy.modeling.parameters import InputParameterError
 from astropy.modeling.separable import separability_matrix
 from astropy.tests.helper import assert_quantity_allclose
 from astropy.utils import NumpyRNGContext
 from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa
+
 from .example_models import models_1D, models_2D
 
 

--- a/astropy/modeling/tests/test_models_quantities.py
+++ b/astropy/modeling/tests/test_models_quantities.py
@@ -1,38 +1,28 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # pylint: disable=invalid-name, no-member
 
-import pytest
 import numpy as np
+import pytest
 
 from astropy import units as u
+from astropy.modeling.bounding_box import ModelBoundingBox
+from astropy.modeling.core import fix_inputs
+from astropy.modeling.fitting import LevMarLSQFitter
+from astropy.modeling.functional_models import (AiryDisk2D, ArcCosine1D, ArcSine1D, ArcTangent1D,
+                                                Box1D, Box2D, Const1D, Const2D, Cosine1D, Disk2D,
+                                                Ellipse2D, Exponential1D, Gaussian1D, Gaussian2D,
+                                                KingProjectedAnalytic1D, Linear1D, Logarithmic1D,
+                                                Lorentz1D, Moffat1D, Moffat2D, Multiply, Planar2D,
+                                                RickerWavelet1D, RickerWavelet2D, Ring2D, Scale,
+                                                Sersic1D, Sersic2D, Sine1D, Tangent1D, Trapezoid1D,
+                                                TrapezoidDisk2D, Voigt1D)
+from astropy.modeling.parameters import InputParameterError
+from astropy.modeling.physical_models import Drude1D, Plummer1D
+from astropy.modeling.polynomial import Polynomial1D, Polynomial2D
+from astropy.modeling.powerlaws import (BrokenPowerLaw1D, ExponentialCutoffPowerLaw1D,
+                                        LogParabola1D, PowerLaw1D, SmoothlyBrokenPowerLaw1D)
 from astropy.tests.helper import assert_quantity_allclose
 from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa
-from astropy.modeling.core import fix_inputs
-
-from astropy.modeling.functional_models import (
-    Gaussian1D, Sersic1D,
-    Sine1D, Cosine1D, Tangent1D, ArcSine1D, ArcCosine1D, ArcTangent1D,
-    Linear1D, Lorentz1D, Voigt1D, Const1D,
-    Box1D, Trapezoid1D, RickerWavelet1D,
-    Moffat1D, Gaussian2D, Const2D, Ellipse2D,
-    Disk2D, Ring2D, Box2D, TrapezoidDisk2D,
-    RickerWavelet2D, AiryDisk2D, Moffat2D, Sersic2D,
-    KingProjectedAnalytic1D,
-    Scale, Multiply,
-    Planar2D, Logarithmic1D, Exponential1D)
-
-from astropy.modeling.physical_models import Plummer1D, Drude1D
-
-from astropy.modeling.powerlaws import (
-    PowerLaw1D, BrokenPowerLaw1D, SmoothlyBrokenPowerLaw1D,
-    ExponentialCutoffPowerLaw1D, LogParabola1D)
-
-from astropy.modeling.polynomial import Polynomial1D, Polynomial2D
-
-from astropy.modeling.fitting import LevMarLSQFitter
-from astropy.modeling.bounding_box import ModelBoundingBox
-
-from astropy.modeling.parameters import InputParameterError
 
 FUNC_MODELS_1D = [
 {'class': Gaussian1D,

--- a/astropy/modeling/tests/test_parameters.py
+++ b/astropy/modeling/tests/test_parameters.py
@@ -4,18 +4,19 @@ Tests models.parameters
 """
 # pylint: disable=invalid-name
 
-import itertools
 import functools
-
-import pytest
-import numpy as np
+import itertools
 import unittest.mock as mk
 
-from astropy.modeling import models, fitting
-from astropy.modeling.core import Model, FittableModel
-from astropy.modeling.parameters import Parameter, InputParameterError, _tofloat, param_repr_oneline
+import numpy as np
+import pytest
+
 from astropy import units as u
+from astropy.modeling import fitting, models
+from astropy.modeling.core import FittableModel, Model
+from astropy.modeling.parameters import InputParameterError, Parameter, _tofloat, param_repr_oneline
 from astropy.utils.data import get_pkg_data_filename
+
 from . import irafutil
 
 

--- a/astropy/modeling/tests/test_physical_models.py
+++ b/astropy/modeling/tests/test_physical_models.py
@@ -1,18 +1,16 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Tests for physical functions."""
 # pylint: disable=no-member, invalid-name
-import pytest
 import numpy as np
+import pytest
 
-from astropy.modeling.physical_models import BlackBody, NFW
-from astropy.modeling.fitting import LevMarLSQFitter
-
-from astropy.tests.helper import assert_quantity_allclose
-from astropy import units as u
-from astropy.utils.exceptions import AstropyUserWarning
 from astropy import cosmology
+from astropy import units as u
+from astropy.modeling.fitting import LevMarLSQFitter
+from astropy.modeling.physical_models import NFW, BlackBody
+from astropy.tests.helper import assert_quantity_allclose
 from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa
-
+from astropy.utils.exceptions import AstropyUserWarning
 
 __doctest_skip__ = ["*"]
 

--- a/astropy/modeling/tests/test_polynomial.py
+++ b/astropy/modeling/tests/test_polynomial.py
@@ -3,28 +3,25 @@
 """Tests for polynomial models."""
 # pylint: disable=invalid-name
 import os
+import unittest.mock as mk
 import warnings
-
 from itertools import product
 
-import pytest
 import numpy as np
-import unittest.mock as mk
-
+import pytest
 from numpy.testing import assert_allclose
 
-from astropy.modeling import fitting
 from astropy import wcs
 from astropy.io import fits
-from astropy.modeling.polynomial import (
-    Chebyshev1D, Hermite1D, Legendre1D, Polynomial1D,
-    Chebyshev2D, Hermite2D, Legendre2D, Polynomial2D, SIP,
-    PolynomialBase, OrthoPolynomialBase)
+from astropy.modeling import fitting
 from astropy.modeling.functional_models import Linear1D
 from astropy.modeling.mappings import Identity
+from astropy.modeling.polynomial import (SIP, Chebyshev1D, Chebyshev2D, Hermite1D, Hermite2D,
+                                         Legendre1D, Legendre2D, OrthoPolynomialBase, Polynomial1D,
+                                         Polynomial2D, PolynomialBase)
+from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa
 from astropy.utils.data import get_pkg_data_filename
 from astropy.utils.exceptions import AstropyUserWarning
-from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa
 
 linear1d = {
     Chebyshev1D: {

--- a/astropy/modeling/tests/test_projections.py
+++ b/astropy/modeling/tests/test_projections.py
@@ -3,20 +3,19 @@
 """Test sky projections defined in WCS Paper II"""
 # pylint: disable=invalid-name, no-member
 import os
-
-import pytest
-import numpy as np
 import unittest.mock as mk
+
+import numpy as np
+import pytest
 from numpy.testing import assert_allclose, assert_almost_equal
 
+from astropy import units as u
+from astropy import wcs
+from astropy.io import fits
 from astropy.modeling import projections
 from astropy.modeling.parameters import InputParameterError
-
-from astropy import units as u
-from astropy.io import fits
-from astropy import wcs
-from astropy.utils.data import get_pkg_data_filename
 from astropy.tests.helper import assert_quantity_allclose
+from astropy.utils.data import get_pkg_data_filename
 
 
 def test_new_wcslib_projections():

--- a/astropy/modeling/tests/test_quantities_evaluation.py
+++ b/astropy/modeling/tests/test_quantities_evaluation.py
@@ -9,12 +9,11 @@ import numpy as np
 import pytest
 from numpy.testing import assert_allclose
 
-from astropy.modeling.core import Model
-from astropy.modeling.models import Gaussian1D, Shift, Scale, Pix2Sky_TAN
 from astropy import units as u
-from astropy.units import UnitsError
+from astropy.modeling.core import Model
+from astropy.modeling.models import Gaussian1D, Pix2Sky_TAN, Scale, Shift
 from astropy.tests.helper import assert_quantity_allclose
-
+from astropy.units import UnitsError
 
 # We start off by taking some simple cases where the units are defined by
 # whatever the model is initialized with, and we check that the model evaluation

--- a/astropy/modeling/tests/test_quantities_fitting.py
+++ b/astropy/modeling/tests/test_quantities_fitting.py
@@ -7,15 +7,13 @@ import numpy as np
 import pytest
 
 from astropy import units as u
-from astropy.units import UnitsError
-from astropy.tests.helper import assert_quantity_allclose
-from astropy.utils import NumpyRNGContext
-from astropy.modeling import fitting
-from astropy.modeling import models
+from astropy.modeling import fitting, models
 from astropy.modeling.core import Fittable1DModel
 from astropy.modeling.parameters import Parameter
+from astropy.tests.helper import assert_quantity_allclose
+from astropy.units import UnitsError
+from astropy.utils import NumpyRNGContext
 from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa
-
 
 # Fitting should be as intuitive as possible to the user. Essentially, models
 # and fitting should work without units, but if one has units, the other should

--- a/astropy/modeling/tests/test_quantities_model.py
+++ b/astropy/modeling/tests/test_quantities_model.py
@@ -5,11 +5,10 @@ import warnings
 import pytest
 
 from astropy import units as u
-from astropy.tests.helper import assert_quantity_allclose
-
-from astropy.modeling.models import Mapping, Pix2Sky_TAN, Gaussian1D
 from astropy.modeling import models
 from astropy.modeling.core import _ModelMeta
+from astropy.modeling.models import Gaussian1D, Mapping, Pix2Sky_TAN
+from astropy.tests.helper import assert_quantity_allclose
 
 
 def test_gaussian1d_bounding_box():

--- a/astropy/modeling/tests/test_quantities_parameters.py
+++ b/astropy/modeling/tests/test_quantities_parameters.py
@@ -8,14 +8,13 @@ Tests that relate to using quantities/units on parameters of models.
 import numpy as np
 import pytest
 
-from astropy.modeling.core import Fittable1DModel, InputParameterError
-from astropy.modeling.parameters import Parameter, ParameterDefinitionError
-from astropy.modeling.models import (Gaussian1D, Pix2Sky_TAN, RotateNative2Celestial,
-                                     Rotation2D)
-from astropy import units as u
-from astropy.units import UnitsError
-from astropy.tests.helper import assert_quantity_allclose
 from astropy import coordinates as coord
+from astropy import units as u
+from astropy.modeling.core import Fittable1DModel, InputParameterError
+from astropy.modeling.models import Gaussian1D, Pix2Sky_TAN, RotateNative2Celestial, Rotation2D
+from astropy.modeling.parameters import Parameter, ParameterDefinitionError
+from astropy.tests.helper import assert_quantity_allclose
+from astropy.units import UnitsError
 
 
 class BaseTestModel(Fittable1DModel):

--- a/astropy/modeling/tests/test_quantities_rotations.py
+++ b/astropy/modeling/tests/test_quantities_rotations.py
@@ -1,14 +1,14 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # pylint: disable=invalid-name, no-member
 
-import pytest
 import numpy as np
+import pytest
 from numpy.testing import assert_allclose
 
-from astropy.wcs import wcs
-from astropy.modeling import models
 from astropy import units as u
+from astropy.modeling import models
 from astropy.tests.helper import assert_quantity_allclose
+from astropy.wcs import wcs
 
 
 @pytest.mark.parametrize(('inp'), [(0, 0), (4000, -20.56), (-2001.5, 45.9),

--- a/astropy/modeling/tests/test_rotations.py
+++ b/astropy/modeling/tests/test_rotations.py
@@ -1,18 +1,16 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 # pylint: disable=invalid-name
+import unittest.mock as mk
 from math import cos, sin
 
-import pytest
-import unittest.mock as mk
 import numpy as np
+import pytest
 from numpy.testing import assert_allclose
 
 import astropy.units as u
+from astropy.modeling import models, rotations
 from astropy.tests.helper import assert_quantity_allclose
-
-from astropy.modeling import models
-from astropy.modeling import rotations
 from astropy.wcs import wcs
 
 

--- a/astropy/modeling/tests/test_separable.py
+++ b/astropy/modeling/tests/test_separable.py
@@ -3,17 +3,16 @@
 Test separability of models.
 
 """
+import numpy as np
 # pylint: disable=invalid-name
 import pytest
-import numpy as np
 from numpy.testing import assert_allclose
 
 from astropy.modeling import custom_model, models
-from astropy.modeling.models import Mapping
-from astropy.modeling.separable import (_coord_matrix, is_separable, _cdot,
-                                        _cstack, _arith_oper, separability_matrix)
 from astropy.modeling.core import ModelDefinitionError
-
+from astropy.modeling.models import Mapping
+from astropy.modeling.separable import (_arith_oper, _cdot, _coord_matrix, _cstack, is_separable,
+                                        separability_matrix)
 
 sh1 = models.Shift(1, name='shift1')
 sh2 = models.Shift(2, name='sh2')

--- a/astropy/modeling/tests/test_spline.py
+++ b/astropy/modeling/tests/test_spline.py
@@ -1,23 +1,20 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 """Tests for spline models and fitters"""
-# pylint: disable=invalid-name
-from astropy.utils.exceptions import AstropyUserWarning
-
-import pytest
 import unittest.mock as mk
 
 import numpy as np
+import pytest
 from numpy.testing import assert_allclose
 
-from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa
-
-from astropy.utils.exceptions import (AstropyUserWarning,)
-from astropy.modeling.core import (FittableModel, ModelDefinitionError)
-from astropy.modeling.spline import (_Spline, Spline1D, _SplineFitter)
-from astropy.modeling.fitting import (SplineInterpolateFitter, SplineSmoothingFitter,
-                                      SplineExactKnotsFitter, SplineSplrepFitter)
+from astropy.modeling.core import FittableModel, ModelDefinitionError
+from astropy.modeling.fitting import (SplineExactKnotsFitter, SplineInterpolateFitter,
+                                      SplineSmoothingFitter, SplineSplrepFitter)
 from astropy.modeling.parameters import Parameter
+from astropy.modeling.spline import Spline1D, _Spline, _SplineFitter
+from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa
+# pylint: disable=invalid-name
+from astropy.utils.exceptions import AstropyUserWarning
 
 npts = 50
 nknots = 10
@@ -1293,7 +1290,7 @@ class TestSpline1D:
         self.check_coeffs_created(fit_spl)
         assert fit_spl._bounding_box is None
 
-        from scipy.interpolate import splrep, BSpline
+        from scipy.interpolate import BSpline, splrep
         tck, spline_fp, spline_ier, spline_msg = splrep(self.x, self.y,
                                                         w=w, k=k, s=s, full_output=1)
         assert_allclose(fit_spl.t, tck[0])
@@ -1334,7 +1331,7 @@ class TestSpline1D:
         self.check_coeffs_created(fit_spl)
         assert fit_spl._bounding_box is None
 
-        from scipy.interpolate import splrep, BSpline
+        from scipy.interpolate import BSpline, splrep
         tck, spline_fp, spline_ier, spline_msg = splrep(self.x, self.y,
                                                         w=w, k=k, t=knots, full_output=1)
         assert_allclose(fit_spl.t, tck[0])
@@ -1367,7 +1364,7 @@ class TestSpline1D:
         self.check_coeffs_created(fit_spl)
         assert fit_spl._bounding_box is None
 
-        from scipy.interpolate import splrep, BSpline
+        from scipy.interpolate import BSpline, splrep
         tck = splrep(self.x, self.y, w=w, k=k, t=knots)
         assert_allclose(fit_spl.t, tck[0])
         assert_allclose(fit_spl.c, tck[1])
@@ -1384,7 +1381,7 @@ class TestSpline1D:
         if k is None:
             k = 3
 
-        from scipy.interpolate import splrep, BSpline
+        from scipy.interpolate import BSpline, splrep
 
         tck = splrep(self.x, self.y, w=w, xb=bbox[0], xe=bbox[1],
                      k=k, s=s, t=t)

--- a/astropy/modeling/tests/test_statistics.py
+++ b/astropy/modeling/tests/test_statistics.py
@@ -2,20 +2,14 @@
 """
 Module to test statistic functions
 """
+import numpy as np
 # pylint: disable=invalid-name
 import pytest
-
-import numpy as np
 from numpy.testing import assert_almost_equal
 
-from astropy.modeling.models import Identity, Mapping
 from astropy.modeling.fitting import LinearLSQFitter
-from astropy.modeling.statistic import (
-    leastsquare,
-    leastsquare_1d,
-    leastsquare_2d,
-    leastsquare_3d,
-)
+from astropy.modeling.models import Identity, Mapping
+from astropy.modeling.statistic import leastsquare, leastsquare_1d, leastsquare_2d, leastsquare_3d
 
 
 class TestLeastSquare_XD:

--- a/astropy/modeling/tests/test_units_mapping.py
+++ b/astropy/modeling/tests/test_units_mapping.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-import pytest
 import numpy as np
+import pytest
 
 from astropy import units as u
 from astropy.modeling.core import Model, fix_inputs

--- a/astropy/modeling/tests/test_utils.py
+++ b/astropy/modeling/tests/test_utils.py
@@ -1,12 +1,12 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # pylint: disable=invalid-name
-import pytest
-import numpy as np
-
 from inspect import Parameter
 
-from astropy.modeling.utils import (poly_map_domain, _validate_domain_window,
-                                    get_inputs_and_params, _SpecialOperatorsDict)
+import numpy as np
+import pytest
+
+from astropy.modeling.utils import (_SpecialOperatorsDict, _validate_domain_window,
+                                    get_inputs_and_params, poly_map_domain)
 
 
 def test_poly_map_domain():

--- a/astropy/modeling/utils.py
+++ b/astropy/modeling/utils.py
@@ -3,13 +3,13 @@
 """
 This module provides utility functions for the models package.
 """
+import warnings
 # pylint: disable=invalid-name
 from collections import UserDict
 from collections.abc import MutableMapping
 from inspect import signature
 
 import numpy as np
-import warnings
 
 from astropy import units as u
 from astropy.utils.decorators import deprecated

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ write_to = "astropy/_version.py"
         "astropy/coordinates/*",
         "astropy/extern/*",
         "astropy/io/*",
-        "astropy/modeling/*",
         "astropy/nddata/*",
         "astropy/samp/*",
         "astropy/stats/*",


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

Now that #12932 is merged with a reasonable isort configuration. This PR brings isort to `astropy.modeling`.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
