### PR TITLE
Finalizing changelog for v5.0.2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,10 +7,9 @@ Bug Fixes
 astropy.io.ascii
 ^^^^^^^^^^^^^^^^
 
-- Bugfix to add backwards compatibility for reading ECSV
-  version 0.9 files with non-standard column datatypes
-  (such as ``object``, ``str``, ``datetime64``, etc.), which would
-  raise a ValueError in ECSV version 1.0. [#12880]
+- Bugfix to add backwards compatibility for reading ECSV version 0.9 files with
+  non-standard column datatypes (such as ``object``, ``str``, ``datetime64``,
+  etc.), which would raise a ValueError in ECSV version 1.0. [#12880]
 
 astropy.io.misc
 ^^^^^^^^^^^^^^^
@@ -22,7 +21,10 @@ astropy.io.misc
 astropy.io.votable
 ^^^^^^^^^^^^^^^^^^
 
-- Fixed a bug where ``astropy.io.votable.validate`` was printing output to ``sys.stdout`` when the ``output`` paramter was set to ``None``. ``validate`` now returns a string when ``output`` is set to ``None``, as documented. [#12604]
+- Fixed a bug where ``astropy.io.votable.validate`` was printing output to
+  ``sys.stdout`` when the ``output`` paramter was set to ``None``. ``validate``
+  now returns a string when ``output`` is set to ``None``, as documented.
+  [#12604]
 
 astropy.modeling
 ^^^^^^^^^^^^^^^^
@@ -32,14 +34,18 @@ astropy.modeling
 - Indexing on models can now be used with all types of integers
   (like ``numpy.int64``) instead of just ``int``. [#12561]
 
-- Fix computation of the separability of a ``CompoundModel`` where another ``CompoundModel`` is on the right hand side of the ``&`` operator. [#12907]
+- Fix computation of the separability of a ``CompoundModel`` where another
+  ``CompoundModel`` is on the right hand side of the ``&`` operator. [#12907]
 
-- Provide a hook (``Model._calculate_separability_matrix``) to allow subclasses of ``Model`` to define how to compute their separability matrix. [#12900]
+- Provide a hook (``Model._calculate_separability_matrix``) to allow subclasses
+  of ``Model`` to define how to compute their separability matrix. [#12900]
 
 astropy.stats
 ^^^^^^^^^^^^^
 
-- Fixed a bug in which running ``kuiper_false_positive_probability(D,N)`` on distributions with many data points could produce NaN values for the false positive probability of the Kuiper statistic. [#12896]
+- Fixed a bug in which running ``kuiper_false_positive_probability(D,N)`` on
+  distributions with many data points could produce NaN values for the false
+  positive probability of the Kuiper statistic. [#12896]
 
 astropy.wcs
 ^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -50,7 +50,7 @@ astropy.wcs
   ``FITSFixedWarning`` warning issued during unpiclikng of the WCS objects
   related to the number of axes. This fix also eliminates errors when
   unpickling WCS objects originally created using non-default values for
-  `key`, `colsel`, and `keysel` parameters. [#12844]
+  ``key``, ``colsel``, and ``keysel`` parameters. [#12844]
 
 5.0.1 (2022-01-26)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,57 @@
+5.0.2 (2022-03-10)
+==================
+
+Bug Fixes
+---------
+
+astropy.io.ascii
+^^^^^^^^^^^^^^^^
+
+- Bugfix to add backwards compatibility for reading ECSV
+  version 0.9 files with non-standard column datatypes
+  (such as ``object``, ``str``, ``datetime64``, etc.), which would
+  raise a ValueError in ECSV version 1.0. [#12880]
+
+astropy.io.misc
+^^^^^^^^^^^^^^^
+
+- Bugfix for ``units_mapping`` schema's property name conflicts. Changes:
+      * ``inputs`` to ``unit_inputs``
+      * ``outputs`` to ``unit_outputs`` [#12800]
+
+astropy.io.votable
+^^^^^^^^^^^^^^^^^^
+
+- Fixed a bug where ``astropy.io.votable.validate`` was printing output to ``sys.stdout`` when the ``output`` paramter was set to ``None``. ``validate`` now returns a string when ``output`` is set to ``None``, as documented. [#12604]
+
+astropy.modeling
+^^^^^^^^^^^^^^^^
+
+- Fix handling of units on ``scale`` parameter in BlackBody model. [#12318]
+
+- Indexing on models can now be used with all types of integers
+  (like ``numpy.int64``) instead of just ``int``. [#12561]
+
+- Fix computation of the separability of a ``CompoundModel`` where another ``CompoundModel`` is on the right hand side of the ``&`` operator. [#12907]
+
+- Provide a hook (``Model._calculate_separability_matrix``) to allow subclasses of ``Model`` to define how to compute their separability matrix. [#12900]
+
+astropy.stats
+^^^^^^^^^^^^^
+
+- Fixed a bug in which running ``kuiper_false_positive_probability(D,N)`` on distributions with many data points could produce NaN values for the false positive probability of the Kuiper statistic. [#12896]
+
+astropy.wcs
+^^^^^^^^^^^
+
+- Fixed a bug due to which ``naxis``, ``pixel_shape``, and
+  ``pixel_bounds`` attributes of ``astropy.wcs.WCS`` were not restored when
+  an ``astropy.wcs.WCS`` object was unpickled. This fix also eliminates
+  ``FITSFixedWarning`` warning issued during unpiclikng of the WCS objects
+  related to the number of axes. This fix also eliminates errors when
+  unpickling WCS objects originally created using non-default values for
+  `key`, `colsel`, and `keysel` parameters. [#12844]
+
 5.0.1 (2022-01-26)
 ==================
 

--- a/docs/changes/io.ascii/12880.bugfix.rst
+++ b/docs/changes/io.ascii/12880.bugfix.rst
@@ -1,4 +1,0 @@
-Bugfix to add backwards compatibility for reading ECSV
-version 0.9 files with non-standard column datatypes
-(such as ``object``, ``str``, ``datetime64``, etc.), which would
-raise a ValueError in ECSV version 1.0.

--- a/docs/changes/io.misc/12800.bugfix.rst
+++ b/docs/changes/io.misc/12800.bugfix.rst
@@ -1,3 +1,0 @@
-Bugfix for ``units_mapping`` schema's property name conflicts. Changes:
-    * ``inputs`` to ``unit_inputs``
-    * ``outputs`` to ``unit_outputs``

--- a/docs/changes/io.votable/12604.bugfix.rst
+++ b/docs/changes/io.votable/12604.bugfix.rst
@@ -1,1 +1,0 @@
-Fixed a bug where ``astropy.io.votable.validate`` was printing output to ``sys.stdout`` when the ``output`` paramter was set to ``None``. ``validate`` now returns a string when ``output`` is set to ``None``, as documented.

--- a/docs/changes/modeling/12318.bugfix.rst
+++ b/docs/changes/modeling/12318.bugfix.rst
@@ -1,1 +1,0 @@
-Fix handling of units on ``scale`` parameter in BlackBody model.

--- a/docs/changes/modeling/12561.bugfix.rst
+++ b/docs/changes/modeling/12561.bugfix.rst
@@ -1,2 +1,0 @@
-Indexing on models can now be used with all types of integers
-(like ``numpy.int64``) instead of just ``int``.

--- a/docs/changes/modeling/12900.feature.rst
+++ b/docs/changes/modeling/12900.feature.rst
@@ -1,1 +1,0 @@
-Provide a hook (``Model._calculate_separability_matrix``) to allow subclasses of ``Model`` to define how to compute their separability matrix.

--- a/docs/changes/modeling/12907.bugfix.rst
+++ b/docs/changes/modeling/12907.bugfix.rst
@@ -1,1 +1,0 @@
-Fix computation of the separability of a ``CompoundModel`` where another ``CompoundModel`` is on the right hand side of the ``&`` operator.

--- a/docs/changes/stats/12896.bugfix.rst
+++ b/docs/changes/stats/12896.bugfix.rst
@@ -1,1 +1,0 @@
-Fixed a bug in which running ``kuiper_false_positive_probability(D,N)`` on distributions with many data points could produce NaN values for the false positive probability of the Kuiper statistic.

--- a/docs/changes/wcs/12844.bugfix.rst
+++ b/docs/changes/wcs/12844.bugfix.rst
@@ -1,7 +1,0 @@
-Fixed a bug due to which ``naxis``, ``pixel_shape``, and
-``pixel_bounds`` attributes of ``astropy.wcs.WCS`` were not restored when
-an ``astropy.wcs.WCS`` object was unpickled. This fix also eliminates
-``FITSFixedWarning`` warning issued during unpiclikng of the WCS objects
-related to the number of axes. This fix also eliminates errors when
-unpickling WCS objects originally created using non-default values for
-`key`, `colsel`, and `keysel` parameters.


### PR DESCRIPTION
### Description

The changelog consistency scripts are happy with these changes.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
