### PR TITLE
Backport PR 12659: Unpin pytest-astropy-header

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -56,12 +56,13 @@ asdf_extensions =
 test =  # Required to run the astropy test suite.
     pytest>=7.0
     pytest-doctestplus>=0.12
+    pytest-astropy-header>=0.2.1
     pytest-astropy>=0.9
-    pytest-astropy-header!=0.2.0
     pytest-xdist
 test_all =  # Required for testing, plus packages used by particular tests.
     pytest>=7.0
     pytest-doctestplus>=0.12
+    pytest-astropy-header>=0.2.1
     pytest-astropy>=0.9
     pytest-xdist
     objgraph

--- a/tox.ini
+++ b/tox.ini
@@ -72,9 +72,6 @@ deps =
     # https://github.com/pytest-dev/pytest/issues/9169 + asdf
     py310: git+https://github.com/pytest-dev/pytest
 
-    # Temporary pin pytest-astropy-header
-    test: pytest-astropy-header==0.1.2
-
     # The oldestdeps factor is intended to be used to install the oldest versions of all
     # dependencies that have a minimum version.
     oldestdeps: numpy==1.18.*


### PR DESCRIPTION
Manual backport of #12659 