### PR TITLE
Manual backport of PR-12953 to v5.0.x

### DIFF
--- a/astropy/modeling/tests/test_core.py
+++ b/astropy/modeling/tests/test_core.py
@@ -838,25 +838,20 @@ def test_print_special_operator_CompoundModel(capsys):
     """
 
     model = convolve_models(models.Sersic2D(), models.Gaussian2D())
-    print(model)
-
-    true_out = "Model: CompoundModel\n" +\
-               "Inputs: ('x', 'y')\n" +\
-               "Outputs: ('z',)\n" +\
-               "Model set size: 1\n" +\
-               "Expression: convolve_fft (([0]), ([1]))\n" +\
-               "Components: \n" +\
-               "    [0]: <Sersic2D(amplitude=1., r_eff=1., n=4., x_0=0., y_0=0., ellip=0., theta=0.)>\n" +\
-               "\n" +\
-               "    [1]: <Gaussian2D(amplitude=1., x_mean=0., y_mean=0., x_stddev=1., y_stddev=1., theta=0.)>\n" +\
-               "Parameters:\n" +\
-               "    amplitude_0 r_eff_0 n_0 x_0_0 y_0_0 ... y_mean_1 x_stddev_1 y_stddev_1 theta_1\n" +\
-               "    ----------- ------- --- ----- ----- ... -------- ---------- ---------- -------\n" +\
-               "            1.0     1.0 4.0   0.0   0.0 ...      0.0        1.0        1.0     0.0\n"
-
-    out, err = capsys.readouterr()
-    assert err == ''
-    assert out == true_out
+    with astropy.conf.set_temp('max_width', 80):
+        assert str(model) == "Model: CompoundModel\n" +\
+                             "Inputs: ('x', 'y')\n" +\
+                             "Outputs: ('z',)\n" +\
+                             "Model set size: 1\n" +\
+                             "Expression: convolve_fft (([0]), ([1]))\n" +\
+                             "Components: \n" +\
+                             "    [0]: <Sersic2D(amplitude=1., r_eff=1., n=4., x_0=0., y_0=0., ellip=0., theta=0.)>\n" +\
+                             "\n" +\
+                             "    [1]: <Gaussian2D(amplitude=1., x_mean=0., y_mean=0., x_stddev=1., y_stddev=1., theta=0.)>\n" +\
+                             "Parameters:\n" +\
+                             "    amplitude_0 r_eff_0 n_0 x_0_0 y_0_0 ... y_mean_1 x_stddev_1 y_stddev_1 theta_1\n" +\
+                             "    ----------- ------- --- ----- ----- ... -------- ---------- ---------- -------\n" +\
+                             "            1.0     1.0 4.0   0.0   0.0 ...      0.0        1.0        1.0     0.0"
 
 
 def test__validate_input_shape():

--- a/astropy/modeling/tests/test_polynomial.py
+++ b/astropy/modeling/tests/test_polynomial.py
@@ -14,7 +14,7 @@ import unittest.mock as mk
 from numpy.testing import assert_allclose
 
 from astropy.modeling import fitting
-from astropy import wcs
+from astropy import conf, wcs
 from astropy.io import fits
 from astropy.modeling.polynomial import (
     Chebyshev1D, Hermite1D, Legendre1D, Polynomial1D,
@@ -353,47 +353,48 @@ def test_sip_hst():
         "<_SIP1D(4, 'B', B_2_0=-0.00000175, B_3_0=0., B_4_0=-0., B_0_2=-0.00000722, " +\
         "B_0_3=-0., B_0_4=-0., B_1_1=0.00000618, B_1_2=-0., B_1_3=0., " +\
         "B_2_1=-0., B_2_2=-0., B_3_1=-0.)>])>"
-    assert str(sip) ==\
-        "Model: SIP\n" +\
-        "    Model: Shift\n" +\
-        "    Inputs: ('x',)\n" +\
-        "    Outputs: ('y',)\n" +\
-        "    Model set size: 1\n" +\
-        "    Parameters:\n" +\
-        "         offset\n" +\
-        "        -------\n" +\
-        "        -2048.0\n" +\
-        "\n" +\
-        "    Model: Shift\n" +\
-        "    Inputs: ('x',)\n" +\
-        "    Outputs: ('y',)\n" +\
-        "    Model set size: 1\n" +\
-        "    Parameters:\n" +\
-        "         offset\n" +\
-        "        -------\n" +\
-        "        -1024.0\n" +\
-        "\n" +\
-        "    Model: _SIP1D\n" +\
-        "    Inputs: ('x', 'y')\n" +\
-        "    Outputs: ('z',)\n" +\
-        "    Model set size: 1\n" +\
-        "    Order: 4\n" +\
-        "    Coeff. Prefix: A\n" +\
-        "    Parameters:\n" +\
-        "                A_2_0                 A_3_0          ...         A_3_1        \n" +\
-        "        --------------------- ---------------------- ... ---------------------\n" +\
-        "        8.551277582556502e-06 -4.730444829222791e-10 ... 1.971022971660309e-15\n" +\
-        "\n" +\
-        "    Model: _SIP1D\n" +\
-        "    Inputs: ('x', 'y')\n" +\
-        "    Outputs: ('z',)\n" +\
-        "    Model set size: 1\n" +\
-        "    Order: 4\n" +\
-        "    Coeff. Prefix: B\n" +\
-        "    Parameters:\n" +\
-        "                B_2_0                  B_3_0         ...         B_3_1         \n" +\
-        "        ---------------------- --------------------- ... ----------------------\n" +\
-        "        -1.746491877058669e-06 8.567635427816317e-11 ... -3.779506805487476e-15\n"
+    with conf.set_temp('max_width', 80):
+        assert str(sip) ==\
+            "Model: SIP\n" +\
+            "    Model: Shift\n" +\
+            "    Inputs: ('x',)\n" +\
+            "    Outputs: ('y',)\n" +\
+            "    Model set size: 1\n" +\
+            "    Parameters:\n" +\
+            "         offset\n" +\
+            "        -------\n" +\
+            "        -2048.0\n" +\
+            "\n" +\
+            "    Model: Shift\n" +\
+            "    Inputs: ('x',)\n" +\
+            "    Outputs: ('y',)\n" +\
+            "    Model set size: 1\n" +\
+            "    Parameters:\n" +\
+            "         offset\n" +\
+            "        -------\n" +\
+            "        -1024.0\n" +\
+            "\n" +\
+            "    Model: _SIP1D\n" +\
+            "    Inputs: ('x', 'y')\n" +\
+            "    Outputs: ('z',)\n" +\
+            "    Model set size: 1\n" +\
+            "    Order: 4\n" +\
+            "    Coeff. Prefix: A\n" +\
+            "    Parameters:\n" +\
+            "                A_2_0                 A_3_0          ...         A_3_1        \n" +\
+            "        --------------------- ---------------------- ... ---------------------\n" +\
+            "        8.551277582556502e-06 -4.730444829222791e-10 ... 1.971022971660309e-15\n" +\
+            "\n" +\
+            "    Model: _SIP1D\n" +\
+            "    Inputs: ('x', 'y')\n" +\
+            "    Outputs: ('z',)\n" +\
+            "    Model set size: 1\n" +\
+            "    Order: 4\n" +\
+            "    Coeff. Prefix: B\n" +\
+            "    Parameters:\n" +\
+            "                B_2_0                  B_3_0         ...         B_3_1         \n" +\
+            "        ---------------------- --------------------- ... ----------------------\n" +\
+            "        -1.746491877058669e-06 8.567635427816317e-11 ... -3.779506805487476e-15\n"
 
     # Test get num of coeffs
     assert sip.sip1d_a.get_num_coeff(1) == 6


### PR DESCRIPTION
Bugfix for terminal width changing test outcomes

<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This is a manual backport of #12953

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
