### PR TITLE
Bug Fix: `discretize_model` does not accept `CompoundModel`s

### DIFF
--- a/astropy/convolution/tests/test_discretize.py
+++ b/astropy/convolution/tests/test_discretize.py
@@ -62,6 +62,24 @@ def test_pixel_sum_2D(model_class, mode):
     assert_allclose(values.sum(), models_2D[model_class]['integral'], atol=0.0001)
 
 
+@pytest.mark.parametrize(('model_class', 'mode'), list(itertools.product(test_models_2D, modes)))
+def test_pixel_sum_compound_2D(model_class, mode):
+    """
+    Test if the sum of all pixels of a compound model corresponds nearly to the integral.
+    """
+    if model_class == Box2D and mode == "center":
+        pytest.skip("Non integrating mode. Skip integral test.")
+
+    parameters = models_2D[model_class]
+    model = create_model(model_class, parameters)
+
+    values = discretize_model(model + model, models_2D[model_class]['x_lim'],
+                              models_2D[model_class]['y_lim'], mode=mode)
+
+    model_integral = 2 * models_2D[model_class]['integral']
+    assert_allclose(values.sum(), model_integral, atol=0.0001)
+
+
 @pytest.mark.parametrize('mode', modes)
 def test_gaussian_eval_2D(mode):
     """

--- a/astropy/convolution/utils.py
+++ b/astropy/convolution/utils.py
@@ -3,7 +3,7 @@ import ctypes
 
 import numpy as np
 
-from astropy.modeling.core import FittableModel, custom_model
+from astropy.modeling.core import Model, custom_model
 
 __all__ = ['discretize_model', 'KernelSizeError']
 
@@ -89,9 +89,9 @@ def discretize_model(model, x_range, y_range=None, mode='center', factor=10):
 
     Parameters
     ----------
-    model : `~astropy.modeling.FittableModel` or callable.
+    model : `~astropy.modeling.Model` or callable.
         Analytic model function to be discretized. Callables, which are not an
-        instances of `~astropy.modeling.FittableModel` are passed to
+        instances of `~astropy.modeling.Model` are passed to
         `~astropy.modeling.custom_model` and then evaluated.
     x_range : tuple
         x range in which the model is evaluated. The difference between the
@@ -153,7 +153,7 @@ def discretize_model(model, x_range, y_range=None, mode='center', factor=10):
     """
     if not callable(model):
         raise TypeError('Model must be callable.')
-    if not isinstance(model, FittableModel):
+    if not isinstance(model, Model):
         model = custom_model(model)()
     ndim = model.n_inputs
     if ndim > 2:

--- a/docs/changes/convolution/12959.bugfix.rst
+++ b/docs/changes/convolution/12959.bugfix.rst
@@ -1,0 +1,3 @@
+
+Bugfix in ``astropy.convolution.utils.discretize_model`` which allows the function to handle a ``CompoundModel``.
+Before this fix, ``discretize_model`` was confusing ``CompoundModel`` with a callable function.

--- a/docs/changes/convolution/12959.bugfix.rst
+++ b/docs/changes/convolution/12959.bugfix.rst
@@ -1,3 +1,2 @@
-
 Bugfix in ``astropy.convolution.utils.discretize_model`` which allows the function to handle a ``CompoundModel``.
 Before this fix, ``discretize_model`` was confusing ``CompoundModel`` with a callable function.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

#### Cause and Description
This PR fixes a bug in `astropy.convolution.utils.discretize_model` in which `CompoundModel`s are confused to be callables that need to be wrapped as a custom model. The way it is [implemented now](https://github.com/astropy/astropy/blob/d21dc232d8626b3aff24784628a6e85d177784ae/astropy/convolution/utils.py#L154-L157) is as follows:

```
if not callable(model):
    raise TypeError('Model must be callable.')
if not isinstance(model, FittableModel):
    model = custom_model(model)()
```

#### Bug
In this case `not isinstance(model, FittableModel)` is `True` if `model` is a `CompoundModel` (`CompoundModel` is a subclass of `Model` not `FittableModel`). This is a bug because when `custom_model` tries to convert the mistaken `CompoundModel`, the following comes up: 

```
~/miniconda3/envs/astroconda/lib/python3.7/site-packages/astropy/convolution/utils.py in discretize_model(model, x_range, y_range, mode, factor)
    154         raise TypeError('Model must be callable.')
    155     if not isinstance(model, FittableModel):
--> 156         model = custom_model(model)()
    157     ndim = model.n_inputs
    158     if ndim > 2:

~/miniconda3/envs/astroconda/lib/python3.7/site-packages/astropy/modeling/core.py in custom_model(fit_deriv, *args, **kwargs)
   3696 
   3697     if len(args) == 1 and callable(args[0]):
-> 3698         return _custom_model_wrapper(args[0], fit_deriv=fit_deriv)
   3699     elif not args:
   3700         return functools.partial(_custom_model_wrapper, fit_deriv=fit_deriv)

~/miniconda3/envs/astroconda/lib/python3.7/site-packages/astropy/modeling/core.py in _custom_model_wrapper(func, fit_deriv)
   3728             "callable object")
   3729 
-> 3730     model_name = func.__name__
   3731 
   3732     inputs, params = get_inputs_and_params(func)

~/miniconda3/envs/astroconda/lib/python3.7/site-packages/astropy/modeling/core.py in __getattr__(self, name)
   2930             return self.__dict__[name]
   2931         else:
-> 2932             raise AttributeError(f'Attribute "{name}" not found')
   2933 
   2934     def __getitem__(self, index):

AttributeError: Attribute "__name__" not found
```

#### Proposed Fix

Change `instance(model, FittableModel)` to `instance(model, Model)` 
```
if not callable(model):
    raise TypeError('Model must be callable.')
if not isinstance(model, Model):
    model = custom_model(model)()
```
 

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
