### PR TITLE
Add parameter to `CCDData.to_hdu` to get an `ImageHDU` from a `CCDData` object

### DIFF
--- a/astropy/nddata/ccddata.py
+++ b/astropy/nddata/ccddata.py
@@ -301,7 +301,7 @@ class CCDData(NDDataArray):
         as_image_hdu : bool
             If this option is `True`, the first item of the returned
             `~astropy.io.fits.HDUList` is a `~astropy.io.fits.ImageHDU`, instead
-             of the default `~astropy.io.fits.PrimaryHDU`.
+            of the default `~astropy.io.fits.PrimaryHDU`.
 
         Raises
         ------

--- a/astropy/nddata/tests/test_ccddata.py
+++ b/astropy/nddata/tests/test_ccddata.py
@@ -291,6 +291,14 @@ def test_to_hdu():
     np.testing.assert_array_equal(fits_hdulist[0].data, ccd_data.data)
 
 
+def test_to_hdu_as_imagehdu():
+    ccd_data = create_ccd_data()
+    fits_hdulist = ccd_data.to_hdu(as_image_hdu=False)
+    assert isinstance(fits_hdulist[0], fits.PrimaryHDU)
+    fits_hdulist = ccd_data.to_hdu(as_image_hdu=True)
+    assert isinstance(fits_hdulist[0], fits.ImageHDU)
+
+
 def test_copy():
     ccd_data = create_ccd_data()
     ccd_copy = ccd_data.copy()

--- a/astropy/nddata/tests/test_ccddata.py
+++ b/astropy/nddata/tests/test_ccddata.py
@@ -203,8 +203,9 @@ def test_ccddata_writer_as_imagehdu(tmpdir):
     with fits.open('test.fits') as hdus:
         assert len(hdus) == 1
 
+    filename = tmpdir.join('test2.fits').strpath
     ccd_data.write(filename, as_image_hdu=True)
-    with fits.open('test.fits') as hdus:
+    with fits.open('test2.fits') as hdus:
         assert len(hdus) == 2
         assert isinstance(hdus[1], fits.ImageHDU)
 

--- a/astropy/nddata/tests/test_ccddata.py
+++ b/astropy/nddata/tests/test_ccddata.py
@@ -196,6 +196,19 @@ def test_ccddata_writer(tmpdir):
     np.testing.assert_array_equal(ccd_data.data, ccd_disk.data)
 
 
+def test_ccddata_writer_as_imagehdu(tmpdir):
+    ccd_data = create_ccd_data()
+    filename = tmpdir.join('test.fits').strpath
+    ccd_data.write(filename, as_image_hdu=False)
+    with fits.open('test.fits') as hdus:
+        assert len(hdus) == 1
+
+    ccd_data.write(filename, as_image_hdu=True)
+    with fits.open('test.fits') as hdus:
+        assert len(hdus) == 2
+        assert isinstance(hdus[1], fits.ImageHDU)
+
+
 def test_ccddata_meta_is_case_sensitive():
     ccd_data = create_ccd_data()
     key = 'SoMeKEY'

--- a/astropy/nddata/tests/test_ccddata.py
+++ b/astropy/nddata/tests/test_ccddata.py
@@ -200,12 +200,12 @@ def test_ccddata_writer_as_imagehdu(tmpdir):
     ccd_data = create_ccd_data()
     filename = tmpdir.join('test.fits').strpath
     ccd_data.write(filename, as_image_hdu=False)
-    with fits.open('test.fits') as hdus:
+    with fits.open(filename) as hdus:
         assert len(hdus) == 1
 
     filename = tmpdir.join('test2.fits').strpath
     ccd_data.write(filename, as_image_hdu=True)
-    with fits.open('test2.fits') as hdus:
+    with fits.open(filename) as hdus:
         assert len(hdus) == 2
         assert isinstance(hdus[1], fits.ImageHDU)
 

--- a/docs/changes/nddata/12962.feature.rst
+++ b/docs/changes/nddata/12962.feature.rst
@@ -1,0 +1,4 @@
+The ``as_image_hdu`` option is now available for ``CCDData.to_hdu``. This option
+allows the user to get an ``ImageHDU`` as the first item of the returned
+``HDUList``, instead of the default ``PrimaryHDU``. Before this feature, there
+was no trivial way to get an ``ImageHDU`` from a ``CCDData`` object.

--- a/docs/changes/nddata/12962.feature.rst
+++ b/docs/changes/nddata/12962.feature.rst
@@ -1,4 +1,3 @@
-The ``as_image_hdu`` option is now available for ``CCDData.to_hdu``. This option
-allows the user to get an ``ImageHDU`` as the first item of the returned
-``HDUList``, instead of the default ``PrimaryHDU``. Before this feature, there
-was no trivial way to get an ``ImageHDU`` from a ``CCDData`` object.
+The ``as_image_hdu`` option is now available for ``CCDData.to_hdu`` and
+``CCDData.write``. This option allows the user to get an ``ImageHDU`` as the
+first item of the returned ``HDUList``, instead of the default ``PrimaryHDU``.


### PR DESCRIPTION
### Description
This pull request is to address the lack of a trivial way to get an `ImageHDU` from a `CCDData` object. It does so by adding a new `as_image_hdu` parameter to `CCDData.to_hdu`. The parameter is also added to `fits_ccddata_writer`, which passes it on to `CCDData.to_hdu` and inserts an empty `PrimaryHDU`.

Fixes #12933

Note: This pull request likely needs some work, especially in the  docstrings and documentation.

### Checklist for package maintainer(s)
This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
