### PR TITLE
refactor conftest as tests helper

### DIFF
--- a/astropy/cosmology/flrw/tests/conftest.py
+++ b/astropy/cosmology/flrw/tests/conftest.py
@@ -1,0 +1,6 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+"""Configure the tests for :mod:`astropy.cosmology`."""
+
+from astropy.cosmology.tests.helper import clean_registry
+from astropy.tests.helper import pickle_protocol

--- a/astropy/cosmology/flrw/tests/test_base.py
+++ b/astropy/cosmology/flrw/tests/test_base.py
@@ -17,10 +17,10 @@ import astropy.constants as const
 # LOCAL
 import astropy.units as u
 from astropy.cosmology import FLRW, FlatLambdaCDM, LambdaCDM, Planck18
-from astropy.cosmology.conftest import get_redshift_methods
 from astropy.cosmology.core import _COSMOLOGY_CLASSES
 from astropy.cosmology.flrw.base import H0units_to_invs, a_B_c2, critdens_const, quad
 from astropy.cosmology.parameter import Parameter
+from astropy.cosmology.tests.helper import get_redshift_methods
 from astropy.cosmology.tests.test_core import CosmologySubclassTest as CosmologyTest
 from astropy.cosmology.tests.test_core import (FlatCosmologyMixinTest, ParameterTestMixin,
                                                invalid_zs, valid_zs)
@@ -761,7 +761,7 @@ class FLRWSubclassTest(TestFLRW):
     # ===============================================================
     # Method & Attribute Tests
 
-    _FLRW_redshift_methods = get_redshift_methods(FLRW, allow_private=True, allow_z2=False)
+    _FLRW_redshift_methods = get_redshift_methods(FLRW, include_private=True, include_z2=False)
 
     @pytest.mark.skipif(not HAS_SCIPY, reason="scipy is not installed")
     @pytest.mark.parametrize("z, exc", invalid_zs)

--- a/astropy/cosmology/flrw/tests/test_lambdacdm.py
+++ b/astropy/cosmology/flrw/tests/test_lambdacdm.py
@@ -13,8 +13,8 @@ import pytest
 # LOCAL
 import astropy.units as u
 from astropy.cosmology import FlatLambdaCDM, LambdaCDM
-from astropy.cosmology.conftest import get_redshift_methods
 from astropy.cosmology.flrw.lambdacdm import ellipkinc, hyp2f1
+from astropy.cosmology.tests.helper import get_redshift_methods
 from astropy.cosmology.tests.test_core import invalid_zs, valid_zs
 from astropy.utils.compat.optional_deps import HAS_SCIPY
 
@@ -49,7 +49,7 @@ class TestLambdaCDM(FLRWSubclassTest):
     # ===============================================================
     # Method & Attribute Tests
 
-    _FLRW_redshift_methods = (get_redshift_methods(LambdaCDM, allow_private=True, allow_z2=False)
+    _FLRW_redshift_methods = (get_redshift_methods(LambdaCDM, include_private=True, include_z2=False)
                               - {"_dS_age"})
     # `_dS_age` is removed because it doesn't strictly rely on the value of `z`,
     # so any input that doesn't trip up ``np.shape`` is "valid"

--- a/astropy/cosmology/io/tests/test_model.py
+++ b/astropy/cosmology/io/tests/test_model.py
@@ -9,9 +9,9 @@ import numpy as np
 import pytest
 
 # LOCAL
-from astropy.cosmology.conftest import get_redshift_methods
 from astropy.cosmology.core import Cosmology
 from astropy.cosmology.io.model import _CosmologyModel, from_model, to_model
+from astropy.cosmology.tests.helper import get_redshift_methods
 from astropy.modeling.models import Gaussian1D
 from astropy.utils.compat.optional_deps import HAS_SCIPY
 
@@ -33,7 +33,7 @@ class ToFromModelTestMixin(ToFromTestMixinBase):
     @pytest.fixture(scope="class")
     def method_name(self, cosmo):
         # get methods, ignoring private and dunder
-        methods = get_redshift_methods(cosmo, allow_private=False, allow_z2=True)
+        methods = get_redshift_methods(cosmo, include_private=False, include_z2=True)
 
         # dynamically detect ABC and optional dependencies
         for n in tuple(methods):

--- a/astropy/cosmology/tests/conftest.py
+++ b/astropy/cosmology/tests/conftest.py
@@ -1,0 +1,6 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+"""Configure the tests for :mod:`astropy.cosmology`."""
+
+from astropy.cosmology.tests.helper import clean_registry
+from astropy.tests.helper import pickle_protocol

--- a/astropy/cosmology/tests/helper.py
+++ b/astropy/cosmology/tests/helper.py
@@ -1,6 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-"""Configure the tests for :mod:`astropy.cosmology`."""
+"""
+This module provides the tools used to internally run the cosmology test suite
+from the installed astropy.  It makes use of the `pytest`_ testing framework.
+"""
 
 ##############################################################################
 # IMPORTS
@@ -13,23 +16,32 @@ import pytest
 
 # LOCAL
 from astropy.cosmology import core
-from astropy.tests.helper import pickle_protocol  # noqa: F401
+
+__all__ = ["get_redshift_methods", "clean_registry"]
 
 ###############################################################################
 # FUNCTIONS
 
 
-def get_redshift_methods(cosmology, allow_private=True, allow_z2=True):
+def get_redshift_methods(cosmology, include_private=True, include_z2=True):
     """Get redshift methods from a cosmology.
 
     Parameters
     ----------
     cosmology : |Cosmology| class or instance
+    include_private : bool
+        Whether to include private methods, i.e. starts with an underscore.
+    include_z2 : bool
+        Whether to include methods that are functions of 2 (or more) redshifts,
+        not the more common 1 redshift argument.
 
     Returns
     -------
     set[str]
+        The names of the redshift methods on `cosmology`, satisfying
+        `include_private` and `include_z2`.
     """
+    # Get all the method names, optionally sieving out private methods
     methods = set()
     for n in dir(cosmology):
         try:  # get method, some will error on ABCs
@@ -38,7 +50,7 @@ def get_redshift_methods(cosmology, allow_private=True, allow_z2=True):
             continue
 
         # Add anything callable, optionally excluding private methods.
-        if callable(m) and (not n.startswith('_') or allow_private):
+        if callable(m) and (not n.startswith('_') or include_private):
             methods.add(n)
 
     # Sieve out incompatible methods.
@@ -60,7 +72,7 @@ def get_redshift_methods(cosmology, allow_private=True, allow_z2=True):
         elif len(params) >= iz1 + 1 and not params[iz1].startswith("z"):  # First non-self arg is z.
             methods.discard(n)
         # If methods with 2 z args are not allowed, the following arg is checked.
-        elif not allow_z2 and (len(params) >= iz1 + 2) and params[iz1 + 1].startswith("z"):
+        elif not include_z2 and (len(params) >= iz1 + 2) and params[iz1 + 1].startswith("z"):
             methods.discard(n)
 
     return methods
@@ -71,6 +83,7 @@ def get_redshift_methods(cosmology, allow_private=True, allow_z2=True):
 
 @pytest.fixture
 def clean_registry():
+    """`pytest.fixture` for clearing and restoring ``_COSMOLOGY_CLASSES``."""
     # TODO! with monkeypatch instead for thread safety.
     ORIGINAL_COSMOLOGY_CLASSES = core._COSMOLOGY_CLASSES
     core._COSMOLOGY_CLASSES = {}  # set as empty dict

--- a/astropy/cosmology/tests/test_realizations.py
+++ b/astropy/cosmology/tests/test_realizations.py
@@ -13,8 +13,6 @@ from astropy import cosmology
 from astropy.cosmology import parameters, realizations
 from astropy.cosmology.realizations import Planck13, default_cosmology
 
-from astropy.tests.helper import pickle_protocol  # isort: skip
-
 
 def test_realizations_in_toplevel_dir():
     """Test the realizations are in ``dir`` of :mod:`astropy.cosmology`."""

--- a/docs/changes/cosmology/12966.feature.rst
+++ b/docs/changes/cosmology/12966.feature.rst
@@ -1,0 +1,2 @@
+The new module ``cosmology/tests/helper.py`` has been added to provide tools
+for testing the cosmology module and related extensions.


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

Refactors some private API to make a public module ``cosmology/tests/helper.py``
For convenience, `conftest.py` was moved to the top level of `cosmology` in #12957. I don't think this is good for users, so this PR moves test-related functions back to the test suite.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
