### PR TITLE
mypy incremental adoption settings

### DIFF
--- a/astropy/__init__.py
+++ b/astropy/__init__.py
@@ -133,7 +133,7 @@ class astronomical_constants(base_constants_version):
 # Create the test() function
 from .tests.runner import TestRunner  # noqa: E402
 
-test = TestRunner.make_test_runner_in(__path__[0])  # noqa: F821
+test = TestRunner.make_test_runner_in(locals()["__path__"][0])  # noqa: F821
 
 
 # if we are *not* in setup mode, import the logger and possibly populate the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,46 @@ write_to = "astropy/_version.py"
     group_by_package = true
     indented_import_headings = false
 
+
+[tool.mypy]
+python_version = "3.9"
+files = ["astropy/**/*.py"]
+plugins = ["numpy.typing.mypy_plugin"]
+ignore_missing_imports = true
+follow_imports = "skip"
+
+    [[tool.mypy.overrides]]
+    module = [
+        "astropy/logger",
+        "*/_erfa/*",
+        "*/config/*",
+        "*/constants/*",
+        "*/convolution/*",
+        "*/coordinates/*",
+        "*/cosmology/*",
+        "*/extern/*",
+        "*/io/*",
+        "*/modeling/*",
+        "*/nddata/*",
+        "*/samp/*",
+        "*/stats/*",
+        "*/table/*",
+        "*/tests/*",
+        "*/time/*",
+        "*/timeseries/*",
+        "*/uncertainty/*",
+        "*/units/*",
+        "*/utils/*",
+        "*/visualization/*",
+        "*/wcs/*",
+    ]
+    ignore_errors = true
+
+    [[tool.mypy.overrides]]
+    module = "*/tests/*"
+    ignore_errors = true
+
+
 [tool.towncrier]
     package = "astropy"
     filename = "CHANGES.rst"


### PR DESCRIPTION
A ``mypy`` configuration where all folders are ignored.
As a sub-package adds type hints the module may be removed from the top ``[[tool.mypy.overrides]]`` that ignores all errors and sub-package specific settings added in a new ``[[tool.mypy.overrides]]``, below.

e.g.

```
    [[tool.mypy.overrides]]
    module="*/astropy/cosmology/*"
    ignore_errors = false
    ...
```

todo:
- [ ]  add a mypy pre-commit hook to check the type hints.


**If anyone is familiar with setting up a mypy configuration, please suggest improvements!**


**Non-goals**

1. type-hint anything in this PR.
2. force any sub-package to start adding type hints
3. decide *where* type hints will be stored: in the code, or as type stubs in a separate directory.4. 

**Goals**

have a quality setup that:

1.  allows any sub-package to start adding type hints. 
2. works for either type hint location.


### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. —>

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
