### PR TITLE
Bugfix: `Masked` arrays break `numpy.interp`

### DIFF
--- a/astropy/utils/masked/function_helpers.py
+++ b/astropy/utils/masked/function_helpers.py
@@ -789,8 +789,8 @@ def interp(x, xp, fp, *args, **kwargs):
         if xp.ndim == fp.ndim == 1:
             # Avoid making arrays 1-D; will just raise below.
             m = xpm | fpm
-            xp = xp[m]
-            fp = fp[m]
+            xp = xp[~m]
+            fp = fp[~m]
 
     result = np.interp(xd, xp, fp, *args, **kwargs)
     return result if xm is None else Masked(result, xm.copy())

--- a/astropy/utils/masked/tests/test_function_helpers.py
+++ b/astropy/utils/masked/tests/test_function_helpers.py
@@ -998,7 +998,7 @@ class TestInterpolationFunctions(MaskedArraySetup):
         mask_x = np.array([False, True])
         mx = Masked(x, mask=mask_x)
         out = np.interp(mx, xp, mfp)
-        expected = np.interp(x, xp[mask_fp], fp[mask_fp])
+        expected = np.interp(x, xp[~mask_fp], fp[~mask_fp])
         assert_array_equal(out.unmasked, expected)
         assert_array_equal(out.mask, mask_x)
 
@@ -1021,6 +1021,22 @@ class TestInterpolationFunctions(MaskedArraySetup):
 
         with pytest.raises(ValueError, match='with 2 condition'):
             np.piecewise(self.ma, condlist2, [])
+
+    def test_regression_12978(self):
+        """Regression tests for https://github.com/astropy/astropy/pull/12978"""
+        # This case produced incorrect results
+        mask = [False, True, False]
+        x = np.array([1, 2, 3])
+        xp = Masked(np.array([1, 2, 3]), mask=mask)
+        fp =  Masked(np.array([1, 2, 3]), mask=mask)
+        result = np.interp(x, xp, fp)
+        assert_array_equal(result, x)
+
+        # This case raised a ValueError
+        xp = np.array([1, 3])
+        fp =  Masked(np.array([1, 3]))
+        result = np.interp(x, xp, fp)
+        assert_array_equal(result, x)
 
 
 class TestBincount(MaskedArraySetup):

--- a/docs/changes/utils/12978.bugfix.rst
+++ b/docs/changes/utils/12978.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed a bug which caused ``numpy.interp`` to produce incorrect
+results when ``Masked`` arrays were passed.


### PR DESCRIPTION
### Description

This PR fixes a bug in `astropy.utils.masked` which causes `numpy.interp` to produce incorrect results when it is used with `Masked` arrays.  This bug was first identified by @keyuxing over in https://github.com/lightkurve/lightkurve/pull/1172.

### Reproducing the bug

#### Example 1: incorrect result

The following example produces an incorrect result.  The expected result is `array([1., 2., 3.])`.

```python
>>> import numpy as np
>>> from astropy.utils.masked import Masked
>>> x = np.array([1, 2, 3])
>>> mask = [False, True, False]
>>> xp = Masked(np.array([1, 2, 3]), mask=mask)
>>> fp =  Masked(np.array([1, 2, 3]), mask=mask)
>>> np.interp(x, xp, fp)
array([2., 2., 2.])
```

#### Example 2: ValueError

The following example raises a `ValueError`.  The expected result is also `array([1., 2., 3.])`.

```python
>>> x = np.array([1, 2, 3])
>>> xp = np.array([1, 3])
>>> fp =  Masked(np.array([1, 3]))
>>> np.interp(x, xp, fp)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<__array_function__ internals>", line 5, in interp
  File "/Users/gb/dev/astropy/astropy/utils/masked/core.py", line 830, in __array_function__
    dispatched_result = dispatched_function(*args, **kwargs)
  File "/Users/gb/dev/astropy/astropy/utils/masked/function_helpers.py", line 795, in interp
    result = np.interp(xd, xp, fp, *args, **kwargs)
  File "<__array_function__ internals>", line 5, in interp
  File "/Users/gb/.pyenv/versions/astropy/lib/python3.9/site-packages/numpy/lib/function_base.py", line 1439, in interp
    return interp_func(x, xp, fp, left, right)
ValueError: array of sample points is empty
```

I believe this PR fixes the underlying issue and adds regression tests.