### PR TITLE
Cosmo parameters format

### DIFF
--- a/astropy/cosmology/flrw/base.py
+++ b/astropy/cosmology/flrw/base.py
@@ -153,6 +153,23 @@ class FLRW(Cosmology):
     Ob0 = Parameter(
         doc="Omega baryon; baryonic matter density/critical density at z=0."
     )
+    # Add format_spec type info (private API)
+    H0._format_spec_type = {"latex": r"$$H_{0}$$", "latex_inline": r"$H_{0}$"}
+    Om0._format_spec_type = {
+        "latex": r"$$\Omega_{m,0}$$",
+        "latex_inline": r"$\Omega_{m,0}$",
+    }
+    Ode0._format_spec_type = {
+        "latex": r"$$\Omega_{\Lambda,0}$$",
+        "latex_inline": r"$\Omega_{\Lambda,0}$",
+    }
+    Tcmb0._format_spec_type = {"latex": r"$$T_{0}$$", "latex_inline": r"$T_{0}$"}
+    Neff._format_spec_type = {"latex": r"$$N_{eff}$$", "latex_inline": r"$N_{eff}$"}
+    m_nu._format_spec_type = {"latex": r"$$m_{nu}$$", "latex_inline": r"$m_{nu}$"}
+    Ob0._format_spec_type = {
+        "latex": r"$$\Omega_{b,0}$$",
+        "latex_inline": r"$\Omega_{b,0}$",
+    }
 
     def __init__(
         self,

--- a/astropy/cosmology/flrw/w0cdm.py
+++ b/astropy/cosmology/flrw/w0cdm.py
@@ -79,6 +79,8 @@ class wCDM(FLRW):
     """
 
     w0 = Parameter(doc="Dark energy equation of state.", fvalidate="float")
+    # Add format_spec type info (private API)
+    w0._format_spec_type = {"latex": r"$$w_{0}$$", "latex_inline": r"$w_{0}$"}
 
     def __init__(
         self,

--- a/astropy/cosmology/flrw/w0wacdm.py
+++ b/astropy/cosmology/flrw/w0wacdm.py
@@ -94,6 +94,9 @@ class w0waCDM(FLRW):
         doc="Negative derivative of dark energy equation of state w.r.t. a.",
         fvalidate="float",
     )
+    # Add format_spec type info (private API)
+    w0._format_spec_type = {"latex": r"$$w_{0}$$", "latex_inline": r"$w_{0}$"}
+    wa._format_spec_type = {"latex": r"$$w_{a}$$", "latex_inline": r"$w_{a}$"}
 
     def __init__(
         self,

--- a/astropy/cosmology/flrw/w0wzcdm.py
+++ b/astropy/cosmology/flrw/w0wzcdm.py
@@ -88,6 +88,9 @@ class w0wzCDM(FLRW):
         doc="Derivative of the dark energy equation of state w.r.t. z.",
         fvalidate="float",
     )
+    # Add format_spec type info (private API)
+    w0._format_spec_type = {"latex": r"$$w_{0}$$", "latex_inline": r"$w_{0}$"}
+    wz._format_spec_type = {"latex": r"$$w_{z}$$", "latex_inline": r"$w_{z}$"}
 
     def __init__(
         self,

--- a/astropy/cosmology/flrw/wpwazpcdm.py
+++ b/astropy/cosmology/flrw/wpwazpcdm.py
@@ -108,6 +108,10 @@ class wpwaCDM(FLRW):
         fvalidate="float",
     )
     zp = Parameter(doc="The pivot redshift, where w(z) = wp.", unit=cu.redshift)
+    # Add format_spec type info (private API)
+    wp._format_spec_type = {"latex": r"$$w_{p}$$", "latex_inline": r"$w_{p}$"}
+    wa._format_spec_type = {"latex": r"$$w_{a}$$", "latex_inline": r"$w_{a}$"}
+    zp._format_spec_type = {"latex": r"$$z_{p}$$", "latex_inline": r"$z_{p}$"}
 
     def __init__(
         self,

--- a/astropy/cosmology/tests/test_parameter.py
+++ b/astropy/cosmology/tests/test_parameter.py
@@ -75,6 +75,7 @@ class ParameterTestMixin:
         assert parameter.equivalencies == []
         assert parameter.derived is False
         assert parameter.name is None
+        assert parameter.__doc__ is None
 
         # setting all kwargs
         parameter = Parameter(
@@ -84,10 +85,12 @@ class ParameterTestMixin:
             equivalencies=[u.mass_energy()],
             derived=True,
         )
+        parameter._format_spec_type = {"latex": "P"}
         assert parameter.fvalidate is _validate_to_float
         assert parameter.unit is u.km
         assert parameter.equivalencies == [u.mass_energy()]
         assert parameter.derived is True
+        assert parameter.__doc__ == "DOCSTRING"
 
     def test_Parameter_instance_attributes(self, all_parameter):
         """Test :class:`astropy.cosmology.Parameter` attributes from init."""
@@ -100,6 +103,7 @@ class ParameterTestMixin:
         assert hasattr(all_parameter, "_unit")
         assert hasattr(all_parameter, "_equivalencies")
         assert hasattr(all_parameter, "_derived")
+        assert hasattr(all_parameter, "_format_spec_type")
 
         # __set_name__
         assert hasattr(all_parameter, "_attr_name")
@@ -251,6 +255,7 @@ class TestParameter(ParameterTestMixin):
                 unit=u.m,
                 equivalencies=u.mass_energy(),
             )
+            param._format_spec_type = dict(latex=r"$p_0$")
 
             def __init__(self, param=15):
                 self.param = param
@@ -338,6 +343,13 @@ class TestParameter(ParameterTestMixin):
         super().test_Parameter_derived(cosmo_cls, param)
 
         assert param.derived is False
+
+    def test_Parameter_format_spec_type_example(self, param):
+        """
+        Test :attr:`astropy.cosmology.Parameter._format_spec_type` with a
+        specific example.
+        """
+        assert param._format_spec_type["latex"] == r"$p_0$"
 
     # -------------------------------------------
     # descriptor methods


### PR DESCRIPTION
Cosmology Parameters now have ``_format_spec_types`` to store format-specific
representations of a Parameter. While private API, this PR will make #12356 and #12355 much easier.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
