### PR TITLE
Finalizing changelog for v5.0.3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,36 @@
+5.0.3 (2022-03-25)
+==================
+
+Bug Fixes
+---------
+
+astropy.convolution
+^^^^^^^^^^^^^^^^^^^
+
+- Bugfix in ``astropy.convolution.utils.discretize_model`` which allows the function to handle a ``CompoundModel``.
+  Before this fix, ``discretize_model`` was confusing ``CompoundModel`` with a callable function. [#12959]
+
+astropy.io.fits
+^^^^^^^^^^^^^^^
+
+- Fix write and read FITS tables with multidimensional items, using ``from_columns``
+  without previousely defined ``ColDefs`` structure. [#12863]
+
+astropy.io.votable
+^^^^^^^^^^^^^^^^^^
+
+- Fix VOTable linting to avoid use of shell option. [#12985]
+
+astropy.utils
+^^^^^^^^^^^^^
+
+- Fix XML linting to avoid use of shell option. [#12985]
+
+Other Changes and Additions
+---------------------------
+
+- Updated the bundled CFITSIO library to 4.1.0. [#12967]
+
 5.0.2 (2022-03-10)
 ==================
 

--- a/docs/changes/12967.other.rst
+++ b/docs/changes/12967.other.rst
@@ -1,1 +1,0 @@
-Updated the bundled CFITSIO library to 4.1.0.

--- a/docs/changes/convolution/12959.bugfix.rst
+++ b/docs/changes/convolution/12959.bugfix.rst
@@ -1,2 +1,0 @@
-Bugfix in ``astropy.convolution.utils.discretize_model`` which allows the function to handle a ``CompoundModel``.
-Before this fix, ``discretize_model`` was confusing ``CompoundModel`` with a callable function.

--- a/docs/changes/io.fits/12863.bugfix.rst
+++ b/docs/changes/io.fits/12863.bugfix.rst
@@ -1,2 +1,0 @@
-Fix write and read FITS tables with multidimensional items, using ``from_columns``
-without previousely defined ``ColDefs`` structure.

--- a/docs/changes/io.votable/12985.bugfix.rst
+++ b/docs/changes/io.votable/12985.bugfix.rst
@@ -1,1 +1,0 @@
-Fix VOTable linting to avoid use of shell option.

--- a/docs/changes/utils/12985.bugfix.rst
+++ b/docs/changes/utils/12985.bugfix.rst
@@ -1,1 +1,0 @@
-Fix XML linting to avoid use of shell option.


### PR DESCRIPTION
### Description

Last step before the 5.0.3 release!

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
