### PR TITLE
Move Context of ScienceState out of method

### DIFF
--- a/astropy/utils/state.py
+++ b/astropy/utils/state.py
@@ -7,6 +7,26 @@ A simple class to manage a piece of global science state.  See
 __all__ = ['ScienceState']
 
 
+class _ScienceStateContext:
+    def __init__(self, parent, value):
+        self._value = value
+        self._parent = parent
+
+    def __enter__(self):
+        pass
+
+    def __exit__(self, type, value, tb):
+        self._parent._value = self._value
+
+    def __repr__(self):
+        # Ensure we have a single-line repr, just in case our
+        # value is not something simple like a string.
+        value_repr, lb, _ = repr(self._parent._value).partition("\n")
+        if lb:
+            value_repr += "..."
+        return f"<ScienceState {self._parent.__name__}: {value_repr}>"
+
+
 class ScienceState:
     """
     Science state subclasses are used to manage global items that can
@@ -29,8 +49,7 @@ class ScienceState:
     """
 
     def __init__(self):
-        raise RuntimeError(
-            "This class is a singleton.  Do not instantiate.")
+        raise RuntimeError("This class is a singleton.  Do not instantiate.")
 
     @classmethod
     def get(cls):
@@ -41,31 +60,15 @@ class ScienceState:
 
     @classmethod
     def set(cls, value):
-        """
-        Set the current science state value.
-        """
-        class _Context:
-            def __init__(self, parent, value):
-                self._value = value
-                self._parent = parent
+        """Set the current science state value."""
+        # Create context with current value
+        ctx = _ScienceStateContext(cls, cls._value)
 
-            def __enter__(self):
-                pass
-
-            def __exit__(self, type, value, tb):
-                self._parent._value = self._value
-
-            def __repr__(self):
-                # Ensure we have a single-line repr, just in case our
-                # value is not something simple like a string.
-                value_repr, lb, _ = repr(self._parent._value).partition('\n')
-                if lb:
-                    value_repr += '...'
-                return (f'<ScienceState {self._parent.__name__}: {value_repr}>')
-
-        ctx = _Context(cls, cls._value)
+        # Set new value
         value = cls.validate(value)
         cls._value = value
+
+        # Return context manager
         return ctx
 
     @classmethod


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

Just some code cleanup.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
