### PR TITLE
TST: Clear plot before replotting in visualization tests

### DIFF
--- a/astropy/visualization/tests/test_norm.py
+++ b/astropy/visualization/tests/test_norm.py
@@ -6,7 +6,6 @@ import numpy as np
 from numpy import ma
 from numpy.testing import assert_allclose, assert_equal
 
-from astropy.utils.exceptions import AstropyDeprecationWarning
 from astropy.visualization.mpl_normalize import ImageNormalize, simple_norm, imshow_norm
 from astropy.visualization.interval import ManualInterval, PercentileInterval
 from astropy.visualization.stretch import LogStretch, PowerStretch, SqrtStretch
@@ -265,6 +264,7 @@ def test_imshow_norm():
     import matplotlib.pyplot as plt
     image = np.random.randn(10, 10)
 
+    plt.clf()
     ax = plt.subplot(label='test_imshow_norm')
     imshow_norm(image, ax=ax)
 
@@ -276,9 +276,11 @@ def test_imshow_norm():
         # illegal to manually pass in normalization since that defeats the point
         imshow_norm(image, ax=ax, norm=ImageNormalize())
 
+    plt.clf()
     imshow_norm(image, ax=ax, vmin=0, vmax=1)
 
     # make sure the pyplot version works
+    plt.clf()
     imres, norm = imshow_norm(image, ax=None)
 
     assert isinstance(norm, ImageNormalize)

--- a/astropy/visualization/wcsaxes/tests/test_misc.py
+++ b/astropy/visualization/wcsaxes/tests/test_misc.py
@@ -196,6 +196,7 @@ def test_slicing_warnings(ignore_matplotlibrc, tmpdir):
     with warnings.catch_warnings():
         # https://github.com/astropy/astropy/issues/9690
         warnings.filterwarnings('ignore', message=r'.*PY_SSIZE_T_CLEAN.*')
+        plt.clf()
         plt.subplot(1, 1, 1, projection=wcs3d, slices=('x', 'y', 2))
         plt.savefig(tmpdir.join('test.png').strpath)
 
@@ -348,20 +349,26 @@ def test_invalid_slices_errors(ignore_matplotlibrc):
     wcs2d = WCS(naxis=2)
     wcs2d.wcs.ctype = ['x', 'y']
 
+    plt.clf()
     ax = plt.subplot(1, 1, 1, projection=wcs2d)
     assert ax.frame_class is RectangularFrame
+    plt.clf()
     ax = plt.subplot(1, 1, 1, projection=wcs2d, slices=('x', 'y'))
     assert ax.frame_class is RectangularFrame
+    plt.clf()
     ax = plt.subplot(1, 1, 1, projection=wcs2d, slices=('y', 'x'))
     assert ax.frame_class is RectangularFrame
+    plt.clf()
     ax = plt.subplot(1, 1, 1, projection=wcs2d, slices=['x', 'y'])
     assert ax.frame_class is RectangularFrame
+    plt.clf()
     ax = plt.subplot(1, 1, 1, projection=wcs2d, slices=(1, 'x'))
     assert ax.frame_class is RectangularFrame1D
 
     wcs1d = WCS(naxis=1)
     wcs1d.wcs.ctype = ['x']
 
+    plt.clf()
     ax = plt.subplot(1, 1, 1, projection=wcs1d)
     assert ax.frame_class is RectangularFrame1D
 
@@ -408,6 +415,7 @@ def test_repr(ignore_matplotlibrc):
 
     # Now slice in a way that all world coordinates are still present:
 
+    plt.clf()
     ax = plt.subplot(1, 1, 1, projection=wcs3d, slices=('x', 'y', 1))
     assert repr(ax.coords) == EXPECTED_REPR_2
 

--- a/astropy/visualization/wcsaxes/tests/test_wcsapi.py
+++ b/astropy/visualization/wcsaxes/tests/test_wcsapi.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-import os
 import warnings
 from textwrap import dedent
 
@@ -343,7 +342,7 @@ def test_apply_slices(sub_wcs, wcs_slice, wcsaxes_slices, world_map, ndim):
 
 
 # parametrize here to pass to the fixture
-@pytest.mark.parametrize("wcs_slice", [np.s_[:,:,0,:]])
+@pytest.mark.parametrize("wcs_slice", [np.s_[:, :, 0, :]])
 def test_sliced_ND_input(wcs_4d, sub_wcs, wcs_slice, plt_close):
     slices_wcsaxes = [0, 'x', 'y']
 
@@ -367,6 +366,7 @@ def test_sliced_ND_input(wcs_4d, sub_wcs, wcs_slice, plt_close):
         assert coord_meta['default_ticks_position'] == ['', 'bltr', 'bltr']
 
         # Validate the axes initialize correctly
+        plt.clf()
         plt.subplot(projection=sub_wcs, slices=slices_wcsaxes)
 
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is an attempt to get rid of `MatplotlibDeprecationWarning: Auto-removal of overlapping axes is deprecated` in some tests.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #13013

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
