### PR TITLE
Removed warning about towncrier pre-release

### DIFF
--- a/docs/development/releasing.rst
+++ b/docs/development/releasing.rst
@@ -324,16 +324,11 @@ Releasing the final version of the major release
 Rendering the changelog
 -----------------------
 
-.. warning:: Make sure that you have a very recent version of towncrier - at the time of
-             writing you will need the 21.9.0rc1 pre-release for things to work correctly::
-
-                $ pip install towncrier==21.9.0rc1
-
-We now need to render the changelog with towncrier. Since it is a good idea to
-review the changelog and fix any line wrap and other issues, we do this on
-a separate branch and open a pull request into the release branch to allow for
-easy review. First, create and switch to a new branch based off the release
-branch, e.g.::
+We now need to render the changelog with towncrier (21.9.0 or later). Since it
+is a good idea to review the changelog and fix any line wrap and other issues,
+we do this on a separate branch and open a pull request into the release branch
+to allow for easy review. First, create and switch to a new branch based off the
+release branch, e.g.::
 
    $ git checkout -b v5.0-changelog
 


### PR DESCRIPTION
### Description

towncrier 21.9.0 is now released so we don't need this to be a warning.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
