### PR TITLE
Fixes for broken bounding_box ignore

### DIFF
--- a/astropy/modeling/bounding_box.py
+++ b/astropy/modeling/bounding_box.py
@@ -724,10 +724,17 @@ class ModelBoundingBox(_BoundingDomain):
         else:
             self._validate_sequence(bounding_box, order)
 
+    def _validate_single_input(self, bounding_box):
+        model_input_index = [self._get_index(_input) for _input in self._model.inputs]
+        avaliable_input_index = [_input for _input in model_input_index if _input not in self._ignored]
+        index = avaliable_input_index.pop(0)
+
+        self[index] = bounding_box
+
     def _validate(self, bounding_box, order: str = None):
         """Validate and set any representation"""
         if self._n_inputs == 1 and not isinstance(bounding_box, dict):
-            self[0] = bounding_box
+            self._validate_single_input(bounding_box)
         else:
             self._validate_iterable(bounding_box, order)
 

--- a/astropy/modeling/bounding_box.py
+++ b/astropy/modeling/bounding_box.py
@@ -694,6 +694,12 @@ class ModelBoundingBox(_BoundingDomain):
         for key, value in bounding_box.items():
             self[key] = value
 
+    @property
+    def _available_input_index(self):
+        model_input_index = [self._get_index(_input) for _input in self._model.inputs]
+
+        return [_input for _input in model_input_index if _input not in self._ignored]
+
     def _validate_sequence(self, bounding_box, order: str = None):
         """Validate passing tuple of tuples representation (or related) and setting them."""
         order = self._get_order(order)
@@ -703,7 +709,7 @@ class ModelBoundingBox(_BoundingDomain):
             bounding_box = bounding_box[::-1]
 
         for index, value in enumerate(bounding_box):
-            self[index] = value
+            self[self._available_input_index[index]] = value
 
     @property
     def _n_inputs(self) -> int:
@@ -724,17 +730,10 @@ class ModelBoundingBox(_BoundingDomain):
         else:
             self._validate_sequence(bounding_box, order)
 
-    def _validate_single_input(self, bounding_box):
-        model_input_index = [self._get_index(_input) for _input in self._model.inputs]
-        avaliable_input_index = [_input for _input in model_input_index if _input not in self._ignored]
-        index = avaliable_input_index.pop(0)
-
-        self[index] = bounding_box
-
     def _validate(self, bounding_box, order: str = None):
         """Validate and set any representation"""
         if self._n_inputs == 1 and not isinstance(bounding_box, dict):
-            self._validate_single_input(bounding_box)
+            self[self._available_input_index[0]] = bounding_box
         else:
             self._validate_iterable(bounding_box, order)
 
@@ -758,7 +757,7 @@ class ModelBoundingBox(_BoundingDomain):
             order = bounding_box.order
             if _preserve_ignore:
                 ignored = bounding_box.ignored
-            bounding_box = bounding_box.intervals
+            bounding_box = bounding_box.named_intervals
 
         new = cls({}, model, ignored=ignored, order=order)
         new._validate(bounding_box)

--- a/astropy/modeling/tests/test_bounding_box.py
+++ b/astropy/modeling/tests/test_bounding_box.py
@@ -2661,3 +2661,12 @@ class TestCompoundBoundingBox:
         assert bbox._bounding_boxes[(1,)] == (-np.inf, np.inf)
         assert bbox._bounding_boxes[(1,)].order == 'F'
         assert len(bbox._bounding_boxes) == 2
+
+    def test_complex_compound_bounding_box(self):
+        model = Identity(4)
+        bounding_boxes = {(2.5, 1.3): ((-1, 1), (-3, 3)), (2.5, 2.71): ((-3, 3), (-1, 1))}
+        selector_args = (('x0', True), ('x1', True))
+
+        bbox = CompoundBoundingBox.validate(model, bounding_boxes, selector_args)
+        assert bbox[(2.5, 1.3)] == ModelBoundingBox(((-1, 1), (-3, 3)), model, ignored=['x0', 'x1'])
+        assert bbox[(2.5, 2.71)] == ModelBoundingBox(((-3, 3), (-1, 1)), model, ignored=['x0', 'x1'])

--- a/astropy/modeling/tests/test_bounding_box.py
+++ b/astropy/modeling/tests/test_bounding_box.py
@@ -12,7 +12,7 @@ from astropy.modeling.bounding_box import (CompoundBoundingBox, ModelBoundingBox
                                            _ignored_interval, _Interval, _SelectorArgument,
                                            _SelectorArguments)
 from astropy.modeling.core import Model, fix_inputs
-from astropy.modeling.models import Gaussian1D, Gaussian2D, Identity, Scale, Shift
+from astropy.modeling.models import Gaussian1D, Gaussian2D, Identity, Polynomial2D, Scale, Shift
 
 
 class Test_Interval:
@@ -1632,6 +1632,15 @@ class TestModelBoundingBox:
         assert len(valid_index) == 1
         assert (valid_index[0] == []).all()
         assert all_out and isinstance(all_out, bool)
+
+    def test_bounding_box_ignore(self):
+        """Regression test for #13028"""
+
+        bbox_x = ModelBoundingBox((9, 10), Polynomial2D(1), ignored=["x"])
+        assert bbox_x.ignored_inputs == ['x']
+
+        bbox_y = ModelBoundingBox((11, 12), Polynomial2D(1), ignored=["y"])
+        assert bbox_y.ignored_inputs == ['y']
 
 
 class Test_SelectorArgument:

--- a/astropy/modeling/tests/test_bounding_box.py
+++ b/astropy/modeling/tests/test_bounding_box.py
@@ -2107,15 +2107,17 @@ class TestCompoundBoundingBox:
             "    bounding_boxes={\n" + \
             "        (1,) = ModelBoundingBox(\n" + \
             "                intervals={\n" + \
-            "                    x: Interval(lower=-1, upper=1)\n" + \
+            "                    y: Interval(lower=-1, upper=1)\n" + \
             "                }\n" + \
+            "                ignored=['x']\n" + \
             "                model=Gaussian2D(inputs=('x', 'y'))\n" + \
             "                order='C'\n" + \
             "            )\n" + \
             "        (2,) = ModelBoundingBox(\n" + \
             "                intervals={\n" + \
-            "                    x: Interval(lower=-2, upper=2)\n" + \
+            "                    y: Interval(lower=-2, upper=2)\n" + \
             "                }\n" + \
+            "                ignored=['x']\n" + \
             "                model=Gaussian2D(inputs=('x', 'y'))\n" + \
             "                order='C'\n" + \
             "            )\n" + \

--- a/docs/changes/modeling/13032.bugfix.rst
+++ b/docs/changes/modeling/13032.bugfix.rst
@@ -1,0 +1,2 @@
+Bugfix for ``ignore`` functionality failing in ``ModelBoundingBox`` when using
+``ignore`` option alongside passing bounding box data as tuples.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This PR fixes the bug reported in #13028

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #13028

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
