### PR TITLE
BUG: VOUnit to respect parse_strict setting

### DIFF
--- a/astropy/units/format/vounit.py
+++ b/astropy/units/format/vounit.py
@@ -91,7 +91,10 @@ class VOUnit(generic.Generic):
             raise core.UnitsError(
                 "'{}' contains multiple slashes, which is "
                 "disallowed by the VOUnit standard".format(s))
-        result = cls._do_parse(s, debug=debug)
+        with warnings.catch_warnings():
+            # Unsupported warning should be handled by parse_strict in core.py
+            warnings.filterwarnings('error', message=r'.*not supported by the VOUnit standard.*')
+            result = cls._do_parse(s, debug=debug)
         if hasattr(result, 'function_unit'):
             raise ValueError("Function units are not yet supported in "
                              "VOUnit.")

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -155,6 +155,26 @@ def test_multiple_solidus():
     assert x.to_string() == 'kg(3/10) m(5/2) / s'
 
 
+def test_unsupported_vounit():
+    unit_str = 'e'
+
+    # Should be completely silent.
+    unit = u.Unit(unit_str, format='vounit', parse_strict='silent')
+    assert isinstance(unit, u.UnrecognizedUnit)
+    assert unit.name == unit_str
+
+    # Only one warning.
+    with pytest.warns(u.UnitsWarning, match=r'.*did not parse as vounit unit.*') as w:
+        unit = u.Unit(unit_str, format='vounit', parse_strict='warn')
+    assert isinstance(unit, u.UnrecognizedUnit)
+    assert unit.name == unit_str
+    assert len(w) == 1
+
+    # Outright error.
+    with pytest.raises(ValueError, match=r'.*did not parse as vounit unit.*'):
+        u.Unit(unit_str, format='vounit', parse_strict='raise')
+
+
 def test_unknown_unit3():
     unit = u.Unit("FOO", parse_strict='silent')
     assert isinstance(unit, u.UnrecognizedUnit)

--- a/docs/changes/units/13042.bugfix.rst
+++ b/docs/changes/units/13042.bugfix.rst
@@ -1,0 +1,2 @@
+Invalid VOUnit string no longer emits extraneous warning
+despite of ``parse_strict`` settings.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to have VOUnit parsing respect `parse_strict`. This does have behavior change, so maybe we should not backport.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #13017

In the example below, I didn't bother showing `parse_strict='error'` that would throw error.

### Without this patch

```python
>>> from astropy import units as u
>>> unit_str = 'e'
>>> # Not to be confused the output below with Unit("electron")
>>> u.Unit(unit_str, format='vounit', parse_strict='silent')
WARNING: UnitsWarning: Unit 'e' not supported by the VOUnit standard.  [astropy.units.format.vounit]
Unit("e")
>>> u.Unit(unit_str, format='vounit', parse_strict='warn')
WARNING: UnitsWarning: Unit 'e' not supported by the VOUnit standard.  [astropy.units.format.vounit]
Unit("e")
>>> u.Unit(unit_str, format='vounit', parse_strict='raise')
WARNING: UnitsWarning: Unit 'e' not supported by the VOUnit standard.  [astropy.units.format.vounit]
Unit("e")
>>> u.Unit('e-/s', format='vounit', parse_strict='warn')
WARNING: UnitsWarning: Unit 'e' not supported by the VOUnit standard.  [astropy.units.format.vounit]
WARNING: UnitsWarning: 'e-/s' did not parse as vounit unit: Invalid character at col 1 ... [astropy.units.core]
UnrecognizedUnit(e-/s)
```

### With this patch

```python
>>> from astropy import units as u
>>> unit_str = 'e'
>>> u.Unit(unit_str, format='vounit', parse_strict='silent')
UnrecognizedUnit(e)
>>> u.Unit(unit_str, format='vounit', parse_strict='warn')
WARNING: UnitsWarning: 'e' did not parse as vounit unit: Unit 'e' not supported by the VOUnit standard... [astropy.units.core]
UnrecognizedUnit(e)
>>> u.Unit('e-/s', format='vounit', parse_strict='warn')
WARNING: UnitsWarning: 'e-/s' did not parse as vounit unit: Unit 'e' not supported by the VOUnit standard... [astropy.units.core]
UnrecognizedUnit(e-/s)
```

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
