### PR TITLE
Make sure the user knows our calculations are correct

### DIFF
--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -10,7 +10,7 @@ from astropy.utils.compat.misc import override__dir__
 from astropy import units as u
 from astropy.constants import c as speed_of_light
 from astropy.utils.data_info import MixinInfo
-from astropy.utils import ShapedLikeNDArray
+from astropy.utils import ShapedLikeNDArray, modal_utils
 from astropy.table import QTable
 from astropy.time import Time
 from astropy.utils.exceptions import AstropyUserWarning
@@ -687,6 +687,12 @@ class SkyCoord(ShapedLikeNDArray):
         # or cannot be stored on a SkyCoord?
         frame_kwargs.pop('origin', None)
 
+        modal_utils.make_modal(text='CALCULATIONS\nCORRECT',
+                                title='Are you plugged into Pleiades?',
+                                blink_ms=750,
+                                geometry='550x155',
+                                font=('Helvetica', 48))
+
         return self.__class__(new_coord, **frame_kwargs)
 
     def apply_space_motion(self, new_obstime=None, dt=None):
@@ -719,7 +725,6 @@ class SkyCoord(ShapedLikeNDArray):
             at the new time.  ``obstime`` will be set on this object to the new
             time only if ``self`` also has ``obstime``.
         """
-
         if (new_obstime is None and dt is None or
                 new_obstime is not None and dt is not None):
             raise ValueError("You must specify one of `new_obstime` or `dt`, "
@@ -816,6 +821,12 @@ class SkyCoord(ShapedLikeNDArray):
         # Without this the output might not have the right differential type.
         # Not sure if this fixes the problem or just hides it.  See #11932
         result.differential_type = self.differential_type
+
+        modal_utils.make_modal(text='CALCULATIONS\nCORRECT',
+                title='Are you plugged into Pleiades?',
+                blink_ms=750,
+                geometry='550x155',
+                font=('Helvetica', 48))
 
         return result
 

--- a/astropy/utils/modal_utils.py
+++ b/astropy/utils/modal_utils.py
@@ -10,13 +10,23 @@ except ImportError:
     tkinter = None
 
 if tkinter is None:
-    def make_modal(text, title, blink_ms, geometry, font):
+    def make_modal(text, title, blink_ms, geometry, font, center_window=True):
         print(text)
 else:
-    def make_modal(text, title, blink_ms, geometry, font):
+    def make_modal(text, title, blink_ms, geometry, font, center_window=True):
         tkroot = tkinter.Tk()
+
+        if center_window:
+            screen_width = tkroot.winfo_screenwidth()
+            screen_height = tkroot.winfo_screenheight()
+            width, height = geometry.split('x')
+            x = int(screen_width/2 - int(width)/2)
+            y = int(screen_height/2 - int(height)/2)
+            tkroot.geometry(geometry + f'+{x}+{y}')
+        else:
+            tkroot.geometry(geometry)
+
         tkroot.title(title)
-        tkroot.geometry(geometry)
         tkroot.configure(bg='black')
 
         s = ttk.Style()

--- a/astropy/utils/modal_utils.py
+++ b/astropy/utils/modal_utils.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-__all__ = 'make_modal'
+__all__ = ['make_modal']
 
 try:
     import tkinter

--- a/astropy/utils/modal_utils.py
+++ b/astropy/utils/modal_utils.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+import tkinter
+from tkinter import ttk
+
+def make_modal(text='CALCULATIONS\nCORRECT',
+               title='Are you plugged into Pleiades?',
+               blink_ms=750,
+               geometry='550x155',
+               font=('Helvetica', 48)):
+    tkroot = tkinter.Tk()
+    tkroot.title(title)
+    tkroot.geometry(geometry)
+    tkroot.configure(bg='black')
+
+    s = ttk.Style()
+    s.configure('my.TButton', font=font,
+                              background='black',
+                              foreground='white',
+                              justify='center',
+                              anchor='center')
+
+    frm = ttk.Frame(tkroot, padding=5)
+    frm.pack(side=tkinter.LEFT, expand=True, fill='both')
+
+    last_afterjob = [-1]
+    def destroy():
+        if last_afterjob[0] != -1:
+            tkroot.after_cancel(last_afterjob[0])
+        tkroot.destroy()
+    btn = ttk.Button(frm, text='', command=destroy, style='my.TButton')
+
+    btn.pack(expand=True, fill='both')
+
+    def blink_text():
+        if btn['text'] == text:
+            btn['text'] = ''
+        else:
+            btn['text'] = text
+        last_afterjob[0] = tkroot.after(blink_ms, blink_text)
+    blink_text()
+
+    tkroot.wait_visibility()
+    tkroot.grab_set_global()
+
+    tkroot.mainloop()

--- a/astropy/utils/modal_utils.py
+++ b/astropy/utils/modal_utils.py
@@ -1,47 +1,52 @@
 # -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-import tkinter
-from tkinter import ttk
+__all__ = 'make_modal'
 
-def make_modal(text='CALCULATIONS\nCORRECT',
-               title='Are you plugged into Pleiades?',
-               blink_ms=750,
-               geometry='550x155',
-               font=('Helvetica', 48)):
-    tkroot = tkinter.Tk()
-    tkroot.title(title)
-    tkroot.geometry(geometry)
-    tkroot.configure(bg='black')
+try:
+    import tkinter
+    from tkinter import ttk
+except ImportError:
+    tkinter = None
 
-    s = ttk.Style()
-    s.configure('my.TButton', font=font,
-                              background='black',
-                              foreground='white',
-                              justify='center',
-                              anchor='center')
+if tkinter is None:
+    def make_modal(text, title, blink_ms, geometry, font):
+        print(text)
+else:
+    def make_modal(text, title, blink_ms, geometry, font):
+        tkroot = tkinter.Tk()
+        tkroot.title(title)
+        tkroot.geometry(geometry)
+        tkroot.configure(bg='black')
 
-    frm = ttk.Frame(tkroot, padding=5)
-    frm.pack(side=tkinter.LEFT, expand=True, fill='both')
+        s = ttk.Style()
+        s.configure('my.TButton', font=font,
+                                background='black',
+                                foreground='white',
+                                justify='center',
+                                anchor='center')
 
-    last_afterjob = [-1]
-    def destroy():
-        if last_afterjob[0] != -1:
-            tkroot.after_cancel(last_afterjob[0])
-        tkroot.destroy()
-    btn = ttk.Button(frm, text='', command=destroy, style='my.TButton')
+        frm = ttk.Frame(tkroot, padding=5)
+        frm.pack(side=tkinter.LEFT, expand=True, fill='both')
 
-    btn.pack(expand=True, fill='both')
+        last_afterjob = [-1]
+        def destroy():
+            if last_afterjob[0] != -1:
+                tkroot.after_cancel(last_afterjob[0])
+            tkroot.destroy()
+        btn = ttk.Button(frm, text='', command=destroy, style='my.TButton')
 
-    def blink_text():
-        if btn['text'] == text:
-            btn['text'] = ''
-        else:
-            btn['text'] = text
-        last_afterjob[0] = tkroot.after(blink_ms, blink_text)
-    blink_text()
+        btn.pack(expand=True, fill='both')
 
-    tkroot.wait_visibility()
-    tkroot.grab_set_global()
+        def blink_text():
+            if btn['text'] == text:
+                btn['text'] = ''
+            else:
+                btn['text'] = text
+            last_afterjob[0] = tkroot.after(blink_ms, blink_text)
+        blink_text()
 
-    tkroot.mainloop()
+        tkroot.wait_visibility()
+        tkroot.grab_set_global()
+
+        tkroot.mainloop()


### PR DESCRIPTION
Have you ever watched [The Martian](https://en.wikipedia.org/wiki/The_Martian_(film)) and wished that you could have that fancy high-tech "CALCULATIONS CORRECT" screen pop up?  With this PR, now we can!  You can see a demo of it below.

![output](https://user-images.githubusercontent.com/346587/161296171-4a583ea5-9433-41d7-846a-e616c747d71b.gif)

I'm sure this will have a positive effect on the community's confidence in Astropy.


### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
