### PR TITLE
Fix Sphinx>4 warnings with units and coordinates

### DIFF
--- a/astropy/wcs/utils.py
+++ b/astropy/wcs/utils.py
@@ -1145,7 +1145,8 @@ def fit_wcs_from_points(xy, world_coords, proj_point='center',
 
 def obsgeo_to_frame(obsgeo, obstime):
     """
-    Convert a WCS obsgeo property into an `~.builtin_frames.ITRS` coordinate frame.
+    Convert a WCS obsgeo property into an `~astropy.coordinates.ITRS`
+    coordinate frame.
 
     Parameters
     ----------
@@ -1155,12 +1156,12 @@ def obsgeo_to_frame(obsgeo, obstime):
 
     obstime : time-like
         The time associated with the coordinate, will be passed to
-        `~.builtin_frames.ITRS` as the obstime keyword.
+        `~astropy.coordinates.ITRS` as the obstime keyword.
 
     Returns
     -------
-    `~.builtin_frames.ITRS`
-        An `~.builtin_frames.ITRS` coordinate frame
+    `~astropy.coordinates.ITRS`
+        An `~astropy.coordinates.ITRS` coordinate frame
         representing the coordinates.
 
     Notes

--- a/docs/coordinates/index.rst
+++ b/docs/coordinates/index.rst
@@ -547,11 +547,6 @@ coordinate systems implemented here include:
 Built-in Frame Classes
 ======================
 
-.. automodapi:: astropy.coordinates.builtin_frames
-    :skip: make_transform_graph_docs
-    :no-inheritance-diagram:
-
-
 .. _astropy-coordinates-api:
 
 Reference/API

--- a/docs/units/index.rst
+++ b/docs/units/index.rst
@@ -254,6 +254,8 @@ Reference/API
 
 .. automodapi:: astropy.units.equivalencies
 
+.. automodapi:: astropy.units.function
+
 .. automodapi:: astropy.units.deprecated
 
 .. automodapi:: astropy.units.required_by_vounit

--- a/docs/units/index.rst
+++ b/docs/units/index.rst
@@ -254,11 +254,6 @@ Reference/API
 
 .. automodapi:: astropy.units.equivalencies
 
-.. automodapi:: astropy.units.function
-
-.. automodapi:: astropy.units.function.logarithmic
-   :include-all-objects:
-
 .. automodapi:: astropy.units.deprecated
 
 .. automodapi:: astropy.units.required_by_vounit

--- a/setup.cfg
+++ b/setup.cfg
@@ -94,13 +94,11 @@ all =
     pytest>=7.0
     typing_extensions>=3.10.0.1
 docs =
-    sphinx<4
     sphinx-astropy>=1.6
     pytest>=7.0
     scipy>=1.3
     matplotlib>=3.1,!=3.4.0
     sphinx-changelog>=1.1.0
-    Jinja2<3.1
 
 [options.package_data]
 * = data/*, data/*/*, data/*/*/*, data/*/*/*/*, data/*/*/*/*/*, data/*/*/*/*/*/*


### PR DESCRIPTION
Another attempt to fix #11725.

<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address ...

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
