### PR TITLE
Backport PR #13032 on branch v5.0.x (Fixes for broken bounding_box ignore)

### DIFF
--- a/astropy/modeling/bounding_box.py
+++ b/astropy/modeling/bounding_box.py
@@ -693,6 +693,12 @@ class ModelBoundingBox(_BoundingDomain):
         for key, value in bounding_box.items():
             self[key] = value
 
+    @property
+    def _available_input_index(self):
+        model_input_index = [self._get_index(_input) for _input in self._model.inputs]
+
+        return [_input for _input in model_input_index if _input not in self._ignored]
+
     def _validate_sequence(self, bounding_box, order: str = None):
         """Validate passing tuple of tuples representation (or related) and setting them."""
         order = self._get_order(order)
@@ -702,7 +708,7 @@ class ModelBoundingBox(_BoundingDomain):
             bounding_box = bounding_box[::-1]
 
         for index, value in enumerate(bounding_box):
-            self[index] = value
+            self[self._available_input_index[index]] = value
 
     @property
     def _n_inputs(self) -> int:
@@ -726,7 +732,7 @@ class ModelBoundingBox(_BoundingDomain):
     def _validate(self, bounding_box, order: str = None):
         """Validate and set any representation"""
         if self._n_inputs == 1 and not isinstance(bounding_box, dict):
-            self[0] = bounding_box
+            self[self._available_input_index[0]] = bounding_box
         else:
             self._validate_iterable(bounding_box, order)
 
@@ -748,7 +754,7 @@ class ModelBoundingBox(_BoundingDomain):
         """
         if isinstance(bounding_box, ModelBoundingBox):
             order = bounding_box.order
-            bounding_box = bounding_box.intervals
+            bounding_box = bounding_box.named_intervals
 
         new = cls({}, model, ignored=ignored, order=order)
         new._validate(bounding_box)

--- a/docs/changes/modeling/13032.bugfix.rst
+++ b/docs/changes/modeling/13032.bugfix.rst
@@ -1,0 +1,2 @@
+Bugfix for ``ignore`` functionality failing in ``ModelBoundingBox`` when using
+``ignore`` option alongside passing bounding box data as tuples.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

Manual backport of #13032

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
