### PR TITLE
Enable formatting `Quantity` units through string format specification

### DIFF
--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -901,6 +901,7 @@ class TestQuantityDisplay:
     def test_dimensionless_quantity_format(self):
         q1 = u.Quantity(3.14)
         assert format(q1, '.2f') == '3.14'
+        assert f"{q1:cds}" == "3.14"
 
     def test_scalar_quantity_str(self):
         assert str(self.scalarintq) == "1 m"
@@ -920,6 +921,8 @@ class TestQuantityDisplay:
         assert format(self.scalarintq, '02d') == "01 m"
         assert format(self.scalarfloatq, '.1f') == "1.3 m"
         assert format(self.scalarfloatq, '.0f') == "1 m"
+        assert f"{self.scalarintq:cds}" == "1 m"
+        assert f"{self.scalarfloatq:cds}" == "1.3 m"
 
     def test_uninitialized_unit_format(self):
         bad_quantity = np.arange(10.).view(u.Quantity)

--- a/docs/changes/units/13050.feature.rst
+++ b/docs/changes/units/13050.feature.rst
@@ -1,0 +1,3 @@
+It is now possible to use unit format names as string format specifiers for a
+``Quantity``, e.g. ``f'{1e12*u.m/u.s:latex_inline}'`` now produces the string
+``'$1 \\times 10^{12} \\; \\mathrm{m\\,s^{-1}}$'``.

--- a/docs/coordinates/angles.rst
+++ b/docs/coordinates/angles.rst
@@ -98,6 +98,12 @@ There are many ways to represent the value of an |Angle|::
     signed_dms_tuple(sign=-1.0, d=57.0, m=17.0, s=44.806247096362313)
     >>> a.arcminute  # doctest: +FLOAT_CMP
     3437.7467707849396
+    >>> f"{a}"
+    '1.0 rad'
+    >>> f"{a:latex}"
+    '$1\\mathrm{rad}$'
+    >>> f"{a.to(u.deg):latex}"
+    '$57^\\circ17{}^\\prime44.8062471{}^{\\prime\\prime}$'
     >>> a.to_string()
     '1rad'
     >>> a.to_string(unit=u.degree)

--- a/docs/units/format.rst
+++ b/docs/units/format.rst
@@ -12,10 +12,13 @@ strings using the `Python Format String Syntax
 (demonstrated below using `f-strings
 <https://www.python.org/dev/peps/pep-0498/>`_).
 
-For quantities, format specifiers, like ``.3f`` will be applied to
-the |Quantity| value, without affecting the unit. Specifiers like
-``^20s``, which would only apply to a string, will be applied to the
-whole string representation of the |Quantity|.
+For a |Quantity|, format specifiers that are names of `Built-In Formats`_ are
+applied to the |Quantity| unit, and if possible also to the value. Format
+specifiers for numerical values, like ``.3f``, will be applied to the
+|Quantity| value, without affecting the unit. Finally, specifiers like
+``^20s``, which would apply to a string, will be applied to the string
+representation of the |Quantity| as a whole. Format specifiers that apply to
+the unit part of a |Quantity| are also applicable to a |Unit| instance.
 
 Examples
 --------
@@ -30,6 +33,8 @@ To render |Quantity| or |Unit| objects as strings::
     <Quantity  10.5 km>
     >>> f"{q}"
     '10.5 km'
+    >>> f"{q:latex}"
+    '$10.5 \\; \\mathrm{km}$'
     >>> f"{q:+.3f}"
     '+10.500 km'
     >>> f"{q:^20}"
@@ -51,6 +56,8 @@ to use the `Quantity.to_string() <astropy.units.Quantity.to_string()>`
 method::
 
     >>> q = 1.2478e12 * u.pc/u.Myr
+    >>> f"{q:latex}"  # Might not have the number of digits we would like
+    '$1.2478 \\times 10^{12} \\; \\mathrm{\\frac{pc}{Myr}}$'
     >>> f"{q.value:.3e} {q.unit:latex}"  # The value is not in LaTeX
     '1.248e+12 $\\mathrm{\\frac{pc}{Myr}}$'
     >>> q.to_string(format="latex", precision=4)  # Right number of LaTeX digits
@@ -79,8 +86,8 @@ framework, including user-defined units. The format specifier (and
 take an optional parameter to select a different format::
 
     >>> q = 10 * u.km
-    >>> f"{q.value:0.003f} in {q.unit:latex}"
-    '10.000 in $\\mathrm{km}$'
+    >>> f"{q:latex}"
+    '$10 \\; \\mathrm{km}$'
     >>> fluxunit = u.erg / (u.cm ** 2 * u.s)
     >>> f"{fluxunit}"
     'erg / (cm2 s)'


### PR DESCRIPTION
### Description

This pull request enables using unit format names as string format specifiers for `Quantity` objects, e.g.
```python
>>> from astropy import units as u
>>> f'{1*u.m/u.s:latex_inline}'
'$1 \\; \\mathrm{m\\,s^{-1}}$'
```

~~When I was updating the documentation I saw the potential for a few improvements which seemed too small for a separate pull request, so I included them here in a separate commit.~~
(EDIT: The documentation fixes were moved to a separate pull request)

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
