### PR TITLE
Fix Pillow deprecation warnings for all versions

### DIFF
--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -12,6 +12,8 @@ from matplotlib.transforms import Affine2D, Bbox, Transform
 
 import astropy.units as u
 from astropy.coordinates import SkyCoord, BaseCoordinateFrame
+from astropy.utils import minversion
+from astropy.utils.compat.optional_deps import HAS_PIL
 from astropy.wcs import WCS
 from astropy.wcs.wcsapi import BaseHighLevelWCS, BaseLowLevelWCS
 
@@ -195,17 +197,15 @@ class WCSAxes(Axes):
         elif origin == 'upper':
             raise ValueError("Cannot use images with origin='upper' in WCSAxes.")
 
-        # To check whether the image is a PIL image we can check if the data
-        # has a 'getpixel' attribute - this is what Matplotlib's AxesImage does
-
-        try:
+        if HAS_PIL:
             from PIL.Image import Image
-            from PIL.Image.Transform import FLIP_TOP_BOTTOM
-        except ImportError:
-            # We don't need to worry since PIL is not installed, so user cannot
-            # have passed RGB image.
-            pass
-        else:
+
+            if minversion('PIL', '9.1'):
+                from PIL.Image import Transpose
+                FLIP_TOP_BOTTOM = Transpose.FLIP_TOP_BOTTOM
+            else:
+                from PIL.Image import FLIP_TOP_BOTTOM
+
             if isinstance(X, Image) or hasattr(X, 'getpixel'):
                 X = X.transpose(FLIP_TOP_BOTTOM)
 


### PR DESCRIPTION
### Description

This PR fixes the `Pillow` deprecation fix in #13045.

#13045 changed the import to ` from PIL.Image.Transform import FLIP_TOP_BOTTOM`, but that does not exist.  The constant is now defined in `Image.Transpose`.

This PR also makes it possible to use PIL versions < 9.1 by catching the `DeprecationWarning`.

`Pillow` is not an optional dependency of `astropy`, so I can't add a test.  However, I have tested this with the following notebook:

https://gist.github.com/larrybradley/ae7f88d3f9881b58172861aeabe6354a


<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #13044.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
