### PR TITLE
Improve support for `'latex_inline'` unit format

### DIFF
--- a/astropy/coordinates/angles.py
+++ b/astropy/coordinates/angles.py
@@ -252,6 +252,9 @@ class Angle(u.SpecificTypeQuantity):
 
             - 'latex': Return a LaTeX-formatted string
 
+            - 'latex_inline': Return a LaTeX-formatted string which is the
+              same as with ``format='latex'`` for |Angle| instances
+
             - 'unicode': Return a string containing non-ASCII unicode
               characters, such as the degree symbol
 
@@ -278,6 +281,9 @@ class Angle(u.SpecificTypeQuantity):
                 u.degree: '°′″',
                 u.hourangle: 'ʰᵐˢ'}
         }
+        # 'latex_inline' provides no functionality beyond what 'latex' offers,
+        # but it should be implemented to avoid ValueErrors in user code.
+        separators['latex_inline'] = separators['latex']
 
         if sep == 'fromunit':
             if format not in separators:
@@ -328,7 +334,7 @@ class Angle(u.SpecificTypeQuantity):
             elif sep == 'fromunit':
                 values = self.to_value(unit)
                 unit_string = unit.to_string(format=format)
-                if format == 'latex':
+                if format == 'latex' or format == 'latex_inline':
                     unit_string = unit_string[1:-1]
 
                 if precision is not None:
@@ -355,7 +361,7 @@ class Angle(u.SpecificTypeQuantity):
                 s = func(float(val))
                 if alwayssign and not s.startswith('-'):
                     s = '+' + s
-                if format == 'latex':
+                if format == 'latex' or format == 'latex_inline':
                     s = f'${s}$'
                 return s
             s = f"{val}"

--- a/astropy/coordinates/tests/test_formatting.py
+++ b/astropy/coordinates/tests/test_formatting.py
@@ -61,15 +61,20 @@ def test_to_string_decimal():
 
 def test_to_string_formats():
     a = Angle(1.113355, unit=u.deg)
-    assert a.to_string(format='latex') == r'$1^\circ06{}^\prime48.078{}^{\prime\prime}$'
+    latex_str = r'$1^\circ06{}^\prime48.078{}^{\prime\prime}$'
+    assert a.to_string(format='latex') == latex_str
+    assert a.to_string(format='latex_inline') == latex_str
     assert a.to_string(format='unicode') == '1°06′48.078″'
 
     a = Angle(1.113355, unit=u.hour)
-    assert a.to_string(format='latex') == r'$1^{\mathrm{h}}06^{\mathrm{m}}48.078^{\mathrm{s}}$'
+    latex_str = r'$1^{\mathrm{h}}06^{\mathrm{m}}48.078^{\mathrm{s}}$'
+    assert a.to_string(format='latex') == latex_str
+    assert a.to_string(format='latex_inline') == latex_str
     assert a.to_string(format='unicode') == '1ʰ06ᵐ48.078ˢ'
 
     a = Angle(1.113355, unit=u.radian)
     assert a.to_string(format='latex') == r'$1.11336\mathrm{rad}$'
+    assert a.to_string(format='latex_inline') == r'$1.11336\mathrm{rad}$'
     assert a.to_string(format='unicode') == '1.11336rad'
 
 

--- a/astropy/units/function/core.py
+++ b/astropy/units/function/core.py
@@ -356,15 +356,15 @@ class FunctionUnitBase(metaclass=ABCMeta):
             The name of a format or a formatter object.  If not
             provided, defaults to the generic format.
         """
-        if format not in ('generic', 'unscaled', 'latex'):
-            raise ValueError("Function units cannot be written in {} format. "
-                             "Only 'generic', 'unscaled' and 'latex' are "
-                             "supported.".format(format))
+        if format not in ('generic', 'unscaled', 'latex', 'latex_inline'):
+            raise ValueError(f"Function units cannot be written in {format} "
+                             "format. Only 'generic', 'unscaled', 'latex' and "
+                             "'latex_inline' are supported.")
         self_str = self.function_unit.to_string(format)
         pu_str = self.physical_unit.to_string(format)
         if pu_str == '':
             pu_str = '1'
-        if format == 'latex':
+        if format.startswith('latex'):
             self_str += r'$\mathrm{{\left( {0} \right)}}$'.format(
                 pu_str[1:-1])   # need to strip leading and trailing "$"
         else:

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -1307,9 +1307,13 @@ class Quantity(np.ndarray):
 
             - 'latex': Return a LaTeX-formatted string
 
+            - 'latex_inline': Return a LaTeX-formatted string that uses
+              negative exponents instead of fractions
+
         subfmt : str, optional
-            Subformat of the result. For the moment,
-            only used for format="latex". Supported values are:
+            Subformat of the result. For the moment, only used for
+            ``format='latex'`` and ``format='latex_inline'``. Supported
+            values are:
 
             - 'inline': Use ``$ ... $`` as delimiters.
 
@@ -1332,6 +1336,7 @@ class Quantity(np.ndarray):
                 "display": (r"$\displaystyle ", r"$"),
             },
         }
+        formats['latex_inline'] = formats['latex']
 
         if format not in formats:
             raise ValueError(f"Unknown format '{format}'")
@@ -1344,7 +1349,7 @@ class Quantity(np.ndarray):
                 return np.array2string(self.value, precision=precision,
                                        floatmode="fixed") + self._unitstr
 
-        # else, for the moment we assume format="latex"
+        # else, for the moment we assume format="latex" or "latex_inline".
 
         # Set the precision if set, otherwise use numpy default
         pops = np.get_printoptions()
@@ -1375,9 +1380,12 @@ class Quantity(np.ndarray):
 
         # Format unit
         # [1:-1] strips the '$' on either side needed for math mode
-        latex_unit = (self.unit._repr_latex_()[1:-1]  # note this is unicode
-                      if self.unit is not None
-                      else _UNIT_NOT_INITIALISED)
+        if self.unit is None:
+            latex_unit = _UNIT_NOT_INITIALISED
+        elif format == 'latex':
+            latex_unit = self.unit._repr_latex_()[1:-1] # note this is unicode
+        elif format == 'latex_inline':
+            latex_unit = self.unit.to_string(format='latex_inline')[1:-1]
 
         delimiter_left, delimiter_right = formats[format][subfmt]
 

--- a/astropy/units/structured.py
+++ b/astropy/units/structured.py
@@ -416,7 +416,7 @@ class StructuredUnit:
         """
         parts = [part.to_string(format) for part in self.values()]
         out_fmt = '({})' if len(self) > 1 else '({},)'
-        if format == 'latex':
+        if format.startswith('latex'):
             # Strip $ from parts and add them on the outside.
             parts = [part[1:-1] for part in parts]
             out_fmt = '$' + out_fmt + '$'

--- a/astropy/units/tests/test_logarithmic.py
+++ b/astropy/units/tests/test_logarithmic.py
@@ -196,9 +196,17 @@ class TestLogUnitStrings:
 
         lu4 = u.mag(u.ct)
         assert lu4.to_string('generic') == 'mag(ct)'
-        assert lu4.to_string('latex') == ('$\\mathrm{mag}$$\\mathrm{\\left( '
-                                          '\\mathrm{ct} \\right)}$')
-        assert lu4._repr_latex_() == lu4.to_string('latex')
+        latex_str = r'$\mathrm{mag}$$\mathrm{\left( \mathrm{ct} \right)}$'
+        assert lu4.to_string('latex') == latex_str
+        assert lu4.to_string('latex_inline') == latex_str
+        assert lu4._repr_latex_() == latex_str
+
+        lu5 = u.mag(u.ct/u.s)
+        assert lu5.to_string('latex') == (r'$\mathrm{mag}$$\mathrm{\left( '
+                                          r'\mathrm{\frac{ct}{s}} \right)}$')
+        latex_str = (r'$\mathrm{mag}$$\mathrm{\left( \mathrm{ct\,s^{-1}} '
+                     r'\right)}$')
+        assert lu5.to_string('latex_inline') == latex_str
 
 
 class TestLogUnitConversion:

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -929,6 +929,9 @@ class TestQuantityDisplay:
         res = r'$\displaystyle 1.5 \times 10^{14} \; \mathrm{m\,s^{-1}}$'
         assert qscalar.to_string(format="latex_inline", subfmt="display") == res
 
+        res = '[0 1 2] (Unit not initialised)'
+        assert np.arange(3).view(u.Quantity).to_string() == res
+
     def test_repr_latex(self):
         from astropy.units.quantity import conf
 

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -919,12 +919,15 @@ class TestQuantityDisplay:
 
         res = r'$1.5 \times 10^{14} \; \mathrm{\frac{m}{s}}$'
         assert qscalar.to_string(format="latex") == res
-
-        res = r'$1.5 \times 10^{14} \; \mathrm{\frac{m}{s}}$'
         assert qscalar.to_string(format="latex", subfmt="inline") == res
-
         res = r'$\displaystyle 1.5 \times 10^{14} \; \mathrm{\frac{m}{s}}$'
         assert qscalar.to_string(format="latex", subfmt="display") == res
+
+        res = r'$1.5 \times 10^{14} \; \mathrm{m\,s^{-1}}$'
+        assert qscalar.to_string(format="latex_inline") == res
+        assert qscalar.to_string(format="latex_inline", subfmt="inline") == res
+        res = r'$\displaystyle 1.5 \times 10^{14} \; \mathrm{m\,s^{-1}}$'
+        assert qscalar.to_string(format="latex_inline", subfmt="display") == res
 
     def test_repr_latex(self):
         from astropy.units.quantity import conf

--- a/astropy/units/tests/test_structured.py
+++ b/astropy/units/tests/test_structured.py
@@ -187,6 +187,13 @@ class TestStructuredUnitBasics(StructuredTestBase):
         assert ldbody_unit == StructuredUnit(
             (u.Msun, Unit(u.rad**2 / 2), (u.AU, u.AU / u.day)))
 
+    def test_to_string(self):
+        su = StructuredUnit((u.km, u.km/u.s))
+        latex_str = r'$(\mathrm{km}, \mathrm{\frac{km}{s}})$'
+        assert su.to_string(format='latex') == latex_str
+        latex_str = r'$(\mathrm{km}, \mathrm{km\,s^{-1}})$'
+        assert su.to_string(format='latex_inline') == latex_str
+
     def test_str(self):
         su = StructuredUnit(((u.km, u.km/u.s), u.yr))
         assert str(su) == '((km, km / s), yr)'

--- a/docs/changes/coordinates/13056.feature.rst
+++ b/docs/changes/coordinates/13056.feature.rst
@@ -1,0 +1,1 @@
+``Angle.to_string()`` now accepts the ``'latex_inline'`` unit format.

--- a/docs/changes/units/13056.feature.rst
+++ b/docs/changes/units/13056.feature.rst
@@ -1,0 +1,4 @@
+``Quantity.to_string()`` and ``FunctionUnitBase.to_string()`` now accept the
+``'latex_inline'`` unit format. The output of ``StructuredUnit.to_string()``
+when called with ``format='latex_inline'`` is now more consistent with the
+output when called with ``format='latex'``.


### PR DESCRIPTION
### Description

There are currently a handful of classes that accept the `'latex'` unit format in their `to_string()` method, but not the very similar `'latex_inline'` format:
```python
>>> u.mag(u.km/u.s).to_string('latex_inline')
    ...
ValueError: Function units cannot be written in latex_inline format. Only 'generic', 'unscaled' and 'latex' are supported.
>>> Angle(1*u.rad).to_string(format='latex_inline')
    ...
ValueError: Unknown format 'latex_inline'
>>> (1*u.km/u.s).to_string(format='latex_inline')
    ...
ValueError: Unknown format 'latex_inline'
```
This pull request enables applying the `'latex_inline'` unit format to those classes:
```python
>>> u.mag(u.km/u.s).to_string('latex_inline')
'$\\mathrm{mag}$$\\mathrm{\\left( \\mathrm{km\\,s^{-1}} \\right)}$'
>>> Angle(1*u.rad).to_string(format='latex_inline')
'$1\\mathrm{rad}$'
>>> (1*u.km/u.s).to_string(format='latex_inline')
'$1 \\; \\mathrm{km\\,s^{-1}}$'
```
`StructuredUnit` does already support `'latex_inline'`, but the output is not what might be expected based on `'latex'`:
```python
>>> u.StructuredUnit((u.km, u.km/u.s)).to_string('latex')  # One pair of '$'
'$(\\mathrm{km}, \\mathrm{\\frac{km}{s}})$'
>>> u.StructuredUnit((u.km, u.km/u.s)).to_string('latex_inline')  # Two pairs of '$'
'($\\mathrm{km}$, $\\mathrm{km\\,s^{-1}}$)'
```
This pull request updates the `StructuredUnit.to_string()` method to ensure a more consistent output for `'latex'` and `'latex_inline'`:
```python
>>> u.StructuredUnit((u.km, u.km/u.s)).to_string('latex_inline')  # One pair of '$'
'$(\\mathrm{km}, \\mathrm{km\\,s^{-1}})$'
```
### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
