### PR TITLE
Cosmo: make flrw semi-private API private

### DIFF
--- a/astropy/cosmology/flrw/__init__.py
+++ b/astropy/cosmology/flrw/__init__.py
@@ -9,11 +9,5 @@ from .w0wacdm import *  # noqa: F401, F403
 from .w0wzcdm import *  # noqa: F401, F403
 from .wpwazpcdm import *  # noqa: F401, F403
 
-# isort: split
-# Importing private API for backward compatibility.
-from .base import (H0units_to_invs, a_B_c2, critdens_const, kB_evK, quad, radian_in_arcmin,
-                   radian_in_arcsec, sec_to_Gyr)
-from .lambdacdm import ellipkinc, hyp2f1
-
 __all__ = (base.__all__ + lambdacdm.__all__ + w0cdm.__all__ + w0wacdm.__all__
            + wpwazpcdm.__all__ + w0wzcdm.__all__)

--- a/astropy/cosmology/flrw/__init__.py
+++ b/astropy/cosmology/flrw/__init__.py
@@ -9,5 +9,32 @@ from .w0wacdm import *  # noqa: F401, F403
 from .w0wzcdm import *  # noqa: F401, F403
 from .wpwazpcdm import *  # noqa: F401, F403
 
-__all__ = (base.__all__ + lambdacdm.__all__ + w0cdm.__all__ + w0wacdm.__all__
-           + wpwazpcdm.__all__ + w0wzcdm.__all__)
+__all__ = (base.__all__ + lambdacdm.__all__ + w0cdm.__all__
+           + w0wacdm.__all__ + wpwazpcdm.__all__ + w0wzcdm.__all__)
+
+
+def __getattr__(attr):
+    """Lazy import deprecated private API."""
+
+    base_attrs = ("H0units_to_invs", "a_B_c2", "critdens_const", "kB_evK",
+                  "radian_in_arcmin", "radian_in_arcsec", "sec_to_Gyr")
+
+    if attr in base_attrs + ("quad", ) + ("ellipkinc", "hyp2f1"):
+        import warnings
+
+        from astropy.utils.exceptions import AstropyDeprecationWarning
+
+        from . import base, lambdacdm
+
+        msg = (f"`astropy.cosmology.flrw.{attr}` is a private variable (since "
+               "v5.1) and in future will raise an exception.")
+        warnings.warn(msg, AstropyDeprecationWarning)
+
+        if attr in base_attrs:
+            return getattr(base, "_" + attr)
+        elif attr == "quad":
+            return getattr(base, attr)
+        elif attr in ("ellipkinc", "hyp2f1"):
+            return getattr(lambdacdm, attr)
+
+    raise AttributeError(f"module {__name__!r} has no attribute {attr!r}.")

--- a/astropy/cosmology/flrw/base.py
+++ b/astropy/cosmology/flrw/base.py
@@ -31,17 +31,17 @@ __doctest_requires__ = {'*': ['scipy']}
 
 # Some conversion constants -- useful to compute them once here and reuse in
 # the initialization rather than have every object do them.
-H0units_to_invs = (u.km / (u.s * u.Mpc)).to(1.0 / u.s)
-sec_to_Gyr = u.s.to(u.Gyr)
+_H0units_to_invs = (u.km / (u.s * u.Mpc)).to(1.0 / u.s)
+_sec_to_Gyr = u.s.to(u.Gyr)
 # const in critical density in cgs units (g cm^-3)
-critdens_const = (3 / (8 * pi * const.G)).cgs.value
+_critdens_const = (3 / (8 * pi * const.G)).cgs.value
 # angle conversions
-radian_in_arcsec = (1 * u.rad).to(u.arcsec)
-radian_in_arcmin = (1 * u.rad).to(u.arcmin)
+_radian_in_arcsec = (1 * u.rad).to(u.arcsec)
+_radian_in_arcmin = (1 * u.rad).to(u.arcmin)
 # Radiation parameter over c^2 in cgs (g cm^-3 K^-4)
-a_B_c2 = (4 * const.sigma_sb / const.c ** 3).cgs.value
+_a_B_c2 = (4 * const.sigma_sb / const.c ** 3).cgs.value
 # Boltzmann constant in eV / K
-kB_evK = const.k_B.to(u.eV / u.K)
+_kB_evK = const.k_B.to(u.eV / u.K)
 
 
 class FLRW(Cosmology):
@@ -139,16 +139,16 @@ class FLRW(Cosmology):
         # Hubble distance
         self._hubble_distance = (const.c / self._H0).to(u.Mpc)
         # H0 in s^-1
-        H0_s = self._H0.value * H0units_to_invs
+        H0_s = self._H0.value * _H0units_to_invs
         # Hubble time
-        self._hubble_time = (sec_to_Gyr / H0_s) << u.Gyr
+        self._hubble_time = (_sec_to_Gyr / H0_s) << u.Gyr
 
         # Critical density at z=0 (grams per cubic cm)
-        cd0value = critdens_const * H0_s ** 2
+        cd0value = _critdens_const * H0_s ** 2
         self._critical_density0 = cd0value << u.g / u.cm ** 3
 
         # Compute photon density from Tcmb
-        self._Ogamma0 = a_B_c2 * self._Tcmb0.value ** 4 / self._critical_density0.value
+        self._Ogamma0 = _a_B_c2 * self._Tcmb0.value ** 4 / self._critical_density0.value
 
         # Compute Neutrino temperature:
         # The constant in front is (4/11)^1/3 -- see any cosmology book for an
@@ -188,7 +188,7 @@ class FLRW(Cosmology):
         # to do integrals with (perhaps surprisingly! But small python lists
         # are more efficient than small NumPy arrays).
         if self._massivenu:  # (`_massivenu` set in `m_nu`)
-            nu_y = self._massivenu_mass / (kB_evK * self._Tnu0)
+            nu_y = self._massivenu_mass / (_kB_evK * self._Tnu0)
             self._nu_y = nu_y.value
             self._nu_y_list = self._nu_y.tolist()
             self._Onu0 = self._Ogamma0 * self.nu_relative_density(0)
@@ -1341,7 +1341,7 @@ class FLRW(Cosmology):
             The distance in comoving kpc corresponding to an arcmin at each
             input redshift.
         """
-        return self.comoving_transverse_distance(z).to(u.kpc) / radian_in_arcmin
+        return self.comoving_transverse_distance(z).to(u.kpc) / _radian_in_arcmin
 
     def kpc_proper_per_arcmin(self, z):
         """
@@ -1359,7 +1359,7 @@ class FLRW(Cosmology):
             The distance in proper kpc corresponding to an arcmin at each input
             redshift.
         """
-        return self.angular_diameter_distance(z).to(u.kpc) / radian_in_arcmin
+        return self.angular_diameter_distance(z).to(u.kpc) / _radian_in_arcmin
 
     def arcsec_per_kpc_comoving(self, z):
         """
@@ -1377,7 +1377,7 @@ class FLRW(Cosmology):
             The angular separation in arcsec corresponding to a comoving kpc at
             each input redshift.
         """
-        return radian_in_arcsec / self.comoving_transverse_distance(z).to(u.kpc)
+        return _radian_in_arcsec / self.comoving_transverse_distance(z).to(u.kpc)
 
     def arcsec_per_kpc_proper(self, z):
         """
@@ -1395,7 +1395,7 @@ class FLRW(Cosmology):
             The angular separation in arcsec corresponding to a proper kpc at
             each input redshift.
         """
-        return radian_in_arcsec / self.angular_diameter_distance(z).to(u.kpc)
+        return _radian_in_arcsec / self.angular_diameter_distance(z).to(u.kpc)
 
 
 class FlatFLRWMixin(FlatCosmologyMixin):

--- a/astropy/cosmology/flrw/tests/test_base.py
+++ b/astropy/cosmology/flrw/tests/test_base.py
@@ -18,7 +18,7 @@ import astropy.constants as const
 import astropy.units as u
 from astropy.cosmology import FLRW, FlatLambdaCDM, LambdaCDM, Planck18
 from astropy.cosmology.core import _COSMOLOGY_CLASSES
-from astropy.cosmology.flrw.base import H0units_to_invs, a_B_c2, critdens_const, quad
+from astropy.cosmology.flrw.base import _a_B_c2, _critdens_const, _H0units_to_invs, quad
 from astropy.cosmology.parameter import Parameter
 from astropy.cosmology.tests.helper import get_redshift_methods
 from astropy.cosmology.tests.test_core import CosmologySubclassTest as CosmologyTest
@@ -610,7 +610,7 @@ class TestFLRW(CosmologyTest,
         assert cosmo.critical_density0 is cosmo._critical_density0
         assert cosmo.critical_density0.unit == u.g / u.cm ** 3
 
-        cd0value = critdens_const * (cosmo.H0.value * H0units_to_invs) ** 2
+        cd0value = _critdens_const * (cosmo.H0.value * _H0units_to_invs) ** 2
         assert cosmo.critical_density0.value == cd0value
 
     def test_Ogamma0(self, cosmo_cls, cosmo):
@@ -622,7 +622,7 @@ class TestFLRW(CosmologyTest,
         # on the instance
         assert cosmo.Ogamma0 is cosmo._Ogamma0
         # Ogamma cor \propto T^4/rhocrit
-        expect = a_B_c2 * cosmo.Tcmb0.value ** 4 / cosmo.critical_density0.value
+        expect = _a_B_c2 * cosmo.Tcmb0.value ** 4 / cosmo.critical_density0.value
         assert np.allclose(cosmo.Ogamma0, expect)
         # check absolute equality to 0 if Tcmb0 is 0
         if cosmo.Tcmb0 == 0:

--- a/astropy/cosmology/flrw/tests/test_init.py
+++ b/astropy/cosmology/flrw/tests/test_init.py
@@ -1,0 +1,42 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+"""Testing :mod:`astropy.cosmology.flrw.__init__.py`."""
+
+##############################################################################
+# IMPORTS
+
+import pytest
+
+from astropy.utils import resolve_name
+from astropy.utils.exceptions import AstropyDeprecationWarning
+
+##############################################################################
+# TESTS
+##############################################################################
+
+
+@pytest.mark.parametrize(
+    "attr",
+    [
+        "H0units_to_invs",
+        "a_B_c2",
+        "critdens_const",
+        "kB_evK",
+        "quad",
+        "radian_in_arcmin",
+        "radian_in_arcsec",
+        "sec_to_Gyr",
+        "ellipkinc",
+        "hyp2f1",
+    ],
+)
+def test_deprecated_private_variables(attr):
+    """Test deprecation warnings are raised for private variables."""
+    with pytest.warns(AstropyDeprecationWarning):
+        resolve_name("astropy", "cosmology", "flrw", attr)
+
+
+def test_getattr_error_attr_not_found():
+    """Test getattr raises error for DNE."""
+    with pytest.raises(ImportError):
+        from astropy.cosmology.flrw import this_is_not_a_variable


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

@eerovaher, as discussed, a followup PR to make semi-private API actually private 👍 

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
