### PR TITLE
Enhance `quantity_support` and add childeren formatters of `latex`.

### DIFF
--- a/astropy/units/format/latex.py
+++ b/astropy/units/format/latex.py
@@ -45,7 +45,7 @@ class Latex(base.Base):
                 # a superscript, we need to spell out the unit to avoid double
                 # superscripts. For example, the logic below ensures that
                 # `u.deg**2` returns `deg^{2}` instead of `{}^{\circ}^{2}`.
-                if re.match(r".*\^{[^}]*}$", base_latex): # ends w/ superscript?
+                if re.match(r".*\^{[^}]*}$", base_latex):  # ends w/ superscript?
                     base_latex = base.short_names[0]
                 out.append(f'{base_latex}^{{{utils.format_power(power)}}}')
         return r'\,'.join(out)
@@ -53,7 +53,7 @@ class Latex(base.Base):
     @classmethod
     def _format_bases(cls, unit):
         positives, negatives = utils.get_grouped_by_powers(
-                unit.bases, unit.powers)
+            unit.bases, unit.powers)
 
         if len(negatives):
             if len(positives):
@@ -144,3 +144,28 @@ class LatexInline(Latex):
     @classmethod
     def _format_bases(cls, unit):
         return cls._format_unit_list(zip(unit.bases, unit.powers))
+
+
+class LatexInline2(Latex):
+    """
+    Output LaTeX to display the unit using slash instead of \\flac.
+    """
+    name = 'latex_inline2'
+
+    @classmethod
+    def _format_bases(cls, unit):
+        positives, negatives = utils.get_grouped_by_powers(
+            unit.bases, unit.powers)
+
+        if len(negatives):
+            if len(positives):
+                positives = cls._format_unit_list(positives)
+            else:
+                positives = '1'
+            negatives = cls._format_unit_list(negatives)
+            s = r'{0}/{1}'.format(positives, negatives)
+        else:
+            positives = cls._format_unit_list(positives)
+            s = positives
+
+        return s

--- a/astropy/units/format/latex.py
+++ b/astropy/units/format/latex.py
@@ -137,6 +137,31 @@ class Latex(base.Base):
                 return r'-\infty'
 
 
+class Latex2(Latex):
+    """
+    Output LaTeX to display the unit using \\dfrac instead of \\flac.
+    """
+    name = 'latex2'
+
+    @classmethod
+    def _format_bases(cls, unit):
+        positives, negatives = utils.get_grouped_by_powers(
+            unit.bases, unit.powers)
+
+        if len(negatives):
+            if len(positives):
+                positives = cls._format_unit_list(positives)
+            else:
+                positives = '1'
+            negatives = cls._format_unit_list(negatives)
+            s = fr'\dfrac{{{positives}}}{{{negatives}}}'
+        else:
+            positives = cls._format_unit_list(positives)
+            s = positives
+
+        return s
+
+
 class LatexInline(Latex):
     """
     Output LaTeX to display the unit based on IAU style guidelines with negative

--- a/astropy/units/format/latex.py
+++ b/astropy/units/format/latex.py
@@ -4,11 +4,14 @@
 Handles the "LaTeX" unit format.
 """
 
+from email.policy import default
 import re
 
 import numpy as np
 
 from . import base, core, utils
+
+default_format_spec = ".8g"
 
 
 class Latex(base.Base):
@@ -91,7 +94,7 @@ class Latex(base.Base):
         return fr'$\mathrm{{{s}}}$'
 
     @classmethod
-    def format_exponential_notation(cls, val, format_spec=".8g"):
+    def format_exponential_notation(cls, val, format_spec=None):
         """
         Formats a value in exponential notation for LaTeX.
 
@@ -108,8 +111,13 @@ class Latex(base.Base):
         latex_string : str
             The value in exponential notation in a format suitable for LaTeX.
         """
+        if format_spec is None:
+            fmt_spec = default_format_spec
+        else:
+            fmt_spec = format_spec
+
         if np.isfinite(val):
-            m, ex = utils.split_mantissa_exponent(val, format_spec)
+            m, ex = utils.split_mantissa_exponent(val, fmt_spec)
 
             parts = []
             if m:

--- a/astropy/units/format/utils.py
+++ b/astropy/units/format/utils.py
@@ -61,7 +61,7 @@ def split_mantissa_exponent(v, format_spec=".8g"):
     mantissa, exponent : tuple of strings
     """
     x = format(v, format_spec).split('e')
-    if x[0] != '1.' + '0' * (len(x[0]) - 2):
+    if x[0] != '1.' + '0' * (len(x[0]) - 2) and x[0] != "1":
         m = x[0]
     else:
         m = ''

--- a/astropy/visualization/units.py
+++ b/astropy/visualization/units.py
@@ -119,7 +119,7 @@ def quantity_support(xlabel="", ylabel="", format=None):
                     label=self.axislabel(unit, axis),
                 )
             elif unit is not None:
-                return units.AxisInfo(label=self.axislabel(unit, axis, format=fmt))
+                return units.AxisInfo(label=self.axislabel(unit, axis, fmt))
             return None
 
         @staticmethod

--- a/astropy/visualization/units.py
+++ b/astropy/visualization/units.py
@@ -96,7 +96,10 @@ def quantity_support(xlabel="", ylabel="", format=None):
                         u.dimensionless_angles]:
                 label = axis_label
             else:
-                label = "{}({})".format(axis_label, unit.to_string(format))
+                if isinstance(format, str) and format.startswith("latex"):
+                    label = r"{}$\left({}\right)$".format(axis_label, unit.to_string(format)[1:-1])
+                else:
+                    label = "{}({})".format(axis_label, unit.to_string(format))
 
             return label
 

--- a/astropy/visualization/units.py
+++ b/astropy/visualization/units.py
@@ -7,7 +7,7 @@ import numpy as np
 __doctest_skip__ = ['quantity_support']
 
 
-def quantity_support(format='latex_inline'):
+def quantity_support(xlabel="", ylabel="", format='latex_inline'):
     """
     Enable support for plotting `astropy.units.Quantity` instances in
     matplotlib.
@@ -42,6 +42,7 @@ def quantity_support(format='latex_inline'):
 
     from matplotlib import units
     from matplotlib import ticker
+    import matplotlib
 
     # Get all subclass for Quantity, since matplotlib checks on class,
     # not subclass.
@@ -77,21 +78,37 @@ def quantity_support(format='latex_inline'):
                 units.registry[cls] = self
 
         @staticmethod
-        def axisinfo(unit, axis):
+        def axislabel(unit, axis, format=None):
+            if isinstance(axis, matplotlib.axis.XAxis):
+                axis_label = f"{xlabel} "
+            elif isinstance(axis, matplotlib.axis.YAxis):
+                axis_label = f"{ylabel} "
+            else:
+                axis_label = ""
+
+            if unit in [None, u.dimensionless_unscaled,
+                        u.dimensionless_angles]:
+                label = axis_label
+            else:
+                label = "{}({})".format(axis_label, unit.to_string(format))
+
+            return label
+
+        def axisinfo(self, unit, axis):
             if unit == u.radian:
                 return units.AxisInfo(
-                    majloc=ticker.MultipleLocator(base=np.pi/2),
+                    majloc=ticker.MultipleLocator(base=np.pi / 2),
                     majfmt=ticker.FuncFormatter(rad_fn),
-                    label=unit.to_string(),
+                    label=self.axislabel(unit, axis),
                 )
             elif unit == u.degree:
                 return units.AxisInfo(
                     majloc=ticker.AutoLocator(),
                     majfmt=ticker.FormatStrFormatter('%i°'),
-                    label=unit.to_string(),
+                    label=self.axislabel(unit, axis),
                 )
             elif unit is not None:
-                return units.AxisInfo(label=unit.to_string(format))
+                return units.AxisInfo(label=self.axislabel(unit, axis, format=format))
             return None
 
         @staticmethod

--- a/astropy/visualization/units.py
+++ b/astropy/visualization/units.py
@@ -6,8 +6,10 @@ import numpy as np
 
 __doctest_skip__ = ['quantity_support']
 
+default_formt = 'latex_inline'
 
-def quantity_support(xlabel="", ylabel="", format='latex_inline'):
+
+def quantity_support(xlabel="", ylabel="", format=None):
     """
     Enable support for plotting `astropy.units.Quantity` instances in
     matplotlib.
@@ -27,6 +29,10 @@ def quantity_support(xlabel="", ylabel="", format='latex_inline'):
 
     Parameters
     ----------
+    xlable : str
+        The label for x-axis
+    ylabel : str
+        The label for y-axis
     format : `astropy.units.format.Base` instance or str
         The name of a format or a formatter object.  If not
         provided, defaults to ``latex_inline``.
@@ -95,6 +101,11 @@ def quantity_support(xlabel="", ylabel="", format='latex_inline'):
             return label
 
         def axisinfo(self, unit, axis):
+            if format is None:
+                fmt = default_formt
+            else:
+                fmt = format
+
             if unit == u.radian:
                 return units.AxisInfo(
                     majloc=ticker.MultipleLocator(base=np.pi / 2),
@@ -108,7 +119,7 @@ def quantity_support(xlabel="", ylabel="", format='latex_inline'):
                     label=self.axislabel(unit, axis),
                 )
             elif unit is not None:
-                return units.AxisInfo(label=self.axislabel(unit, axis, format=format))
+                return units.AxisInfo(label=self.axislabel(unit, axis, format=fmt))
             return None
 
         @staticmethod


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

* Add label arguments to `quantity_support`.
* Add new LaTeX formatters with monir changes.
* Make defualt `format` of `quantity_support` customizable.
* Make defualt `format_spec` of series of `latex` formatter customizable.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #9768

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
