### PR TITLE
Expose mechanism of selecting TIME axis in WCS

### DIFF
--- a/astropy/wcs/docstrings.py
+++ b/astropy/wcs/docstrings.py
@@ -2312,6 +2312,8 @@ axes : int or a sequence.
 
     - ``'stokes'`` / ``WCSSUB_STOKES``: Stokes axis
 
+    - ``'temporal'`` / WCSSUB_TIME: Time axis
+
     - ``'celestial'`` / ``WCSSUB_CELESTIAL``: An alias for the
       combination of ``'longitude'``, ``'latitude'`` and ``'cubeface'``.
 

--- a/astropy/wcs/src/wcslib_wrap.c
+++ b/astropy/wcs/src/wcslib_wrap.c
@@ -1895,6 +1895,8 @@ PyWcsprm_sub(
           element_val = WCSSUB_SPECTRAL;
         } else if (strncmp(element_str, "stokes", 7) == 0) {
           element_val = WCSSUB_STOKES;
+        } else if (strncmp(element_str, "temporal", 9) == 0) {
+          element_val = WCSSUB_TIME;
         } else if (strncmp(element_str, "celestial", 10) == 0) {
           element_val = WCSSUB_CELESTIAL;
         } else {
@@ -4206,6 +4208,7 @@ _setup_wcsprm_type(
     CONSTANT(WCSSUB_CUBEFACE)  ||
     CONSTANT(WCSSUB_SPECTRAL)  ||
     CONSTANT(WCSSUB_STOKES)    ||
+    CONSTANT(WCSSUB_TIME)      ||
     CONSTANT(WCSSUB_CELESTIAL) ||
     CONSTANT(WCSHDR_IMGHEAD)   ||
     CONSTANT(WCSHDR_BIMGARR)   ||

--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -1528,3 +1528,16 @@ def test_pixlist_wcs_colsel():
     assert np.allclose(w.wcs.pc, [[1, 0], [0, 1]])
     assert np.allclose(w.wcs.cdelt, [-0.00013666666666666, 0.00013666666666666])
     assert np.allclose(w.wcs.lonpole, 180.)
+
+
+@pytest.mark.skipif(
+    _WCSLIB_VER < Version('7.8'),
+    reason="TIME axis extraction only works with wcslib 7.8 or later"
+)
+def test_time_axis_selection(tab_wcs_2di_f):
+    w = wcs.WCS(naxis=3)
+    w.wcs.ctype = ['RA---TAN', 'DEC--TAN', 'TIME']
+    w.wcs.set()
+    assert list(w.sub([wcs.WCSSUB_TIME]).wcs.ctype) == ['TIME']
+    assert (w.wcs_pix2world([[1, 2, 3]], 0)[0, 2] ==
+            w.sub([wcs.WCSSUB_TIME]).wcs_pix2world([[3]], 0)[0, 0])

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -3061,7 +3061,7 @@ reduce these to 2 dimensions using the naxis kwarg.
         the spectral axis, followed by any others.
         Assumes at least celestial axes are present.
         """
-        return self.sub([WCSSUB_CELESTIAL, WCSSUB_SPECTRAL, WCSSUB_STOKES])  # Defined by C-ext  # noqa: F821 E501
+        return self.sub([WCSSUB_CELESTIAL, WCSSUB_SPECTRAL, WCSSUB_STOKES, WCSSUB_TIME])  # Defined by C-ext  # noqa: F821 E501
 
     def slice(self, view, numpy_order=True):
         """

--- a/docs/changes/wcs/13062.bugfix.rst
+++ b/docs/changes/wcs/13062.bugfix.rst
@@ -1,0 +1,1 @@
+Expose the ability to select TIME axis introduced in WCSLIB version 7.8.


### PR DESCRIPTION
### Description
Since WCSLIB 7.8 subimage extraction by coordinate type now recognises time coordinate axis types via `WCSSUB_TIME`. This PR exposes this extraction mechanism from WCSLIB to Python objects.

### Checklist for package maintainer(s)

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
