### PR TITLE
Do not call wcstab after wcscopy

### DIFF
--- a/astropy/wcs/src/wcslib_wrap.c
+++ b/astropy/wcs/src/wcslib_wrap.c
@@ -650,38 +650,6 @@ PyWcsprm_copy(
       return NULL;
     }
 
-    if (self->x.ntab) {
-      wcstab(&copy->x);
-
-      for (j = 0; j < copy->x.nwtb; j++) {
-        wtb0 = self->x.wtb + j;
-        wtb = copy->x.wtb + j;
-        for (i = 0; i < wtb0->ndim - 1; i++) {
-          wtb->dimlen[i] = wtb0->dimlen[i];
-        }
-        /* Allocate memory for the array. */
-        if (wtb->kind == 'c') {
-          nelem = ndim = wtb->ndim - 1;
-          for (i = 0; i < ndim; i++) {
-            nelem *= wtb->dimlen[i];
-          }
-        } else {
-          nelem = *(wtb->dimlen);
-        }
-
-        if (!((*wtb->arrayp) = calloc((size_t)nelem, sizeof(double)))) {
-          PyErr_SetString(PyExc_MemoryError, "Out of memory: can't allocate "
-                                             "coordinate or index array.");
-          Py_DECREF(copy);
-          return NULL;
-        }
-
-        for (i = 0; i < nelem; i++) {
-          (*wtb->arrayp)[i] = (*wtb0->arrayp)[i];
-        }
-      }
-    }
-
     wcsprm_c2python(&copy->x);
     return (PyObject*)copy;
   } else {

--- a/docs/changes/wcs/13063.bugfix.rst
+++ b/docs/changes/wcs/13063.bugfix.rst
@@ -1,0 +1,1 @@
+Do not call ``wcstab`` on ``wcscopy`` and copy ``wtb`` members from the original WCS.


### PR DESCRIPTION
### Description

This pull request is to address a segfault that occurs during a call to `deepcopy` and other functions that call `wcscopy()` following a call to `sub`. `sub` creates a copy of the WCS with some axes extracted/swapped. This removes info about `wtab` structure in the `Wcsprm`. The old code was attempting to copy that info which now had a pointer `0x0` resulting in segfault. Per conversations with Mark Calabretta, this structure is no longer needed (after `Tabprm` was initialized) and therefore we should not be trying to copy it from the original WCS to the deep copy. This PR removes this copying of the `wtab` member of `Wcsprm`. 

@pllim Please note, that even though after this PR the code will not crash, I believe you will still not be able to obtain a sub-WCS with the `-TAB` axes due to what I believe to be a bug in WCSLIB.

Fixes #13036

### Checklist for package maintainer(s)

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
