### PR TITLE
deprecate Cosmology Parameter “fmt”

### DIFF
--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -346,15 +346,11 @@ class Cosmology(metaclass=abc.ABCMeta):
     # ---------------------------------------------------------------
 
     def __repr__(self):
-        ps = {k: getattr(self, k) for k in self.__parameters__}  # values
-        cps = {k: getattr(self.__class__, k) for k in self.__parameters__}  # Parameter objects
-
         namelead = f"{self.__class__.__qualname__}("
         if self.name is not None:
             namelead += f"name=\"{self.name}\", "
         # nicely formatted parameters
-        fmtps = (k + '=' + format(v, cps[k].format_spec if v is not None else '')
-                 for k, v in ps.items())
+        fmtps = (f'{k}={getattr(self, k)}' for k in self.__parameters__)
 
         return namelead + ", ".join(fmtps) + ")"
 

--- a/astropy/cosmology/flrw/tests/test_base.py
+++ b/astropy/cosmology/flrw/tests/test_base.py
@@ -288,7 +288,6 @@ class Parameterm_nuTestMixin(ParameterTestMixin):
         assert "Mass of neutrino species" in cosmo_cls.m_nu.__doc__
         assert cosmo_cls.m_nu.unit == u.eV
         assert cosmo_cls.m_nu.equivalencies == u.mass_energy()
-        assert cosmo_cls.m_nu.format_spec == ""
 
         # on the instance
         # assert cosmo.m_nu is cosmo._m_nu

--- a/astropy/cosmology/io/tests/test_table.py
+++ b/astropy/cosmology/io/tests/test_table.py
@@ -83,7 +83,6 @@ class ToFromTableTestMixin(ToFromTestMixinBase):
             # Compare the two
             assert col.info.name == P.name
             assert col.info.description == P.__doc__
-            assert col.info.format == (None if col[0] is None else P.format_spec)
             assert col.info.meta == (cosmo.meta.get(n) or {})
 
     # -----------------------

--- a/astropy/cosmology/io/utils.py
+++ b/astropy/cosmology/io/utils.py
@@ -33,14 +33,13 @@ def convert_parameter_to_column(parameter, value, meta=None):
     -------
     `astropy.table.Column`
     """
-    format = None if value is None else parameter.format_spec
     shape = (1,) + np.shape(value)  # minimum of 1d
 
     col = Column(data=np.reshape(value, shape),
                  name=parameter.name,
                  dtype=None,  # inferred from the data
                  description=parameter.__doc__,
-                 format=format,
+                 format=None,
                  meta=meta)
 
     return col

--- a/astropy/cosmology/tests/test_core.py
+++ b/astropy/cosmology/tests/test_core.py
@@ -305,10 +305,10 @@ class TestCosmology(ParameterTestMixin, MetaTestMixin,
         ps = {k: getattr(cosmo, k) for k in cosmo.__parameters__}
         cps = {k: getattr(cosmo_cls, k) for k in cosmo.__parameters__}
         for k, v in ps.items():
-            sv = format(v, cps[k].format_spec if v is not None else '')
-            assert (k + '=' + sv) in r
+            sv = f"{k}={v}"
+            assert sv in r
             assert r.index(k) == 0
-            r = r[len((k + '=' + sv)) + 2:]  # remove
+            r = r[len(sv) + 2:]  # remove
 
     # ------------------------------------------------
 

--- a/docs/changes/cosmology/13072.api.rst
+++ b/docs/changes/cosmology/13072.api.rst
@@ -1,0 +1,3 @@
+The Cosmology Parameter argument "fmt" for specifying a format spec
+has been deprecated in favor of using the built-in string representation from
+the Parameter's value's dtype.


### PR DESCRIPTION
### Description

It wasn’t used and the numpy string representation is better, anyway.
PR arose from discussion with @adrn 

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
