### PR TITLE
Simplify specifying data types when reading ASCII tables

### DIFF
--- a/astropy/io/ascii/docs.py
+++ b/astropy/io/ascii/docs.py
@@ -37,9 +37,12 @@ READ_DOCSTRING = """
         Line index for the end of data not counting comment or blank lines.
         This value can be negative to count from the end.
     converters : dict
-        Dictionary of converters. Keys in the dictionary are columns names,
-        values are converter functions. In addition to single column names
-        you can use wildcards via `fnmatch` to select multiple columns.
+        Dictionary of converters to specify output column dtypes. Each key in
+        the dictionary is a column name or else a name matching pattern
+        including wildcards. The value is either a data type such as ``int`` or
+        ``np.float32``; a list of such types which is tried in order until a
+        successful conversion is achieved; or a list of converter tuples (see
+        the `~astropy.io.ascii.convert_numpy` function for details).
     data_Splitter : `~astropy.io.ascii.BaseSplitter`
         Splitter class to split data columns
     header_Splitter : `~astropy.io.ascii.BaseSplitter`

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -1721,8 +1721,12 @@ def test_read_converters_simplified():
         '    2.0     4.0 False false     6'
     ]
 
-    # Test failure
-    converters = {'*': [int, 1, bool, str]}
-    with pytest.raises(ValueError, match='Error: invalid format for converters'):
-        t2 = Table.read(out.getvalue(), format='ascii.basic', converters=converters,
-                        guess=False)
+    # Test failures
+    for converters in ({'*': [int, 1, bool, str]},  # bad converter type
+                       # Tuple converter where 2nd element is not a subclass of NoType
+                       {'a': [(int, int)]},
+                       # Tuple converter with 3 elements not 2
+                       {'a': [(int, int, int)]}):
+        with pytest.raises(ValueError, match='Error: invalid format for converters'):
+            t2 = Table.read(out.getvalue(), format='ascii.basic',
+                            converters=converters, guess=False)

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -1686,3 +1686,43 @@ def test_read_converters_wildcard():
     t = ascii.read(['Fabc Iabc', '1 2'], converters=converters)
     assert np.issubdtype(t['Fabc'].dtype, np.float32)
     assert not np.issubdtype(t['Iabc'].dtype, np.float32)
+
+
+def test_read_converters_simplified():
+    """Test providing io.ascii read converters as type or dtypes instead of
+    convert_numpy(type) outputs"""
+    t = Table()
+    t['a'] = [1, 2]
+    t['b'] = [3.5, 4]
+    t['c'] = ['True', 'False']
+    t['d'] = ['true', 'false']  # Looks kindof like boolean but actually a string
+    t['e'] = [5, 6]
+
+    out = StringIO()
+    t.write(out, format='ascii.basic')
+
+    converters = {'a': str, 'e': np.float32}
+    t2 = Table.read(out.getvalue(), format='ascii.basic', converters=converters)
+    assert t2.pformat(show_dtype=True) == [
+        ' a      b      c     d      e   ',
+        'str1 float64  str5  str5 float32',
+        '---- ------- ----- ----- -------',
+        '   1     3.5  True  true     5.0',
+        '   2     4.0 False false     6.0'
+    ]
+
+    converters = {'a': float, '*': [np.int64, float, bool, str]}
+    t2 = Table.read(out.getvalue(), format='ascii.basic', converters=converters)
+    assert t2.pformat_all(show_dtype=True) == [
+        '   a       b      c     d     e  ',
+        'float64 float64  bool  str5 int64',
+        '------- ------- ----- ----- -----',
+        '    1.0     3.5  True  true     5',
+        '    2.0     4.0 False false     6'
+    ]
+
+    # Test failure
+    converters = {'*': [int, 1, bool, str]}
+    with pytest.raises(ValueError, match='Error: invalid format for converters'):
+        t2 = Table.read(out.getvalue(), format='ascii.basic', converters=converters,
+                        guess=False)

--- a/docs/changes/io.ascii/13073.feature.rst
+++ b/docs/changes/io.ascii/13073.feature.rst
@@ -1,0 +1,7 @@
+Simplify the way that the ``converters`` argument of ``io.ascii.read`` is
+provided. Previously this required wrapping each data type as the tuple returned
+by the ``io.ascii.convert_numpy()`` function and ensuring that the value is a
+``list``. With this update you can write ``converters={'col1': bool}`` to force
+conversion as a ``bool`` instead of the previous syntax ``converters={'col1':
+[io.ascii.convert_numpy(bool)]}``. Note that this update is back-compatible with
+the old behavior.

--- a/docs/io/ascii/index.rst
+++ b/docs/io/ascii/index.rst
@@ -83,6 +83,13 @@ If guessing the format does not work, as in the case for unusually formatted
 tables, you may need to give `astropy.io.ascii` additional hints about
 the format.
 
+To specify specific data types for one or more columns, use the ``converters``
+argument (see :ref:`io-ascii-read-converters` for details). For instance if the
+``obsid`` is actually a string identifier (instead of an integer) you can read
+the table with::
+
+  >>> data = ascii.read("sources.dat", converters={'obsid': str})  # doctest: +SKIP
+
 Writing Tables
 --------------
 

--- a/docs/io/ascii/index.rst
+++ b/docs/io/ascii/index.rst
@@ -38,7 +38,7 @@ interface <pandas>` is an option to consider.
 
 .. note::
 
-    It is also possible and encouraged to use the functionality from
+    It is strongly encouraged to use the functionality from
     :mod:`astropy.io.ascii` through a higher level interface in the
     :ref:`Data Tables <astropy-table>` package. See :ref:`table_io` for more details.
 
@@ -86,9 +86,22 @@ the format.
 To specify specific data types for one or more columns, use the ``converters``
 argument (see :ref:`io-ascii-read-converters` for details). For instance if the
 ``obsid`` is actually a string identifier (instead of an integer) you can read
-the table with::
+the table with the code below. This also illustrates using the preferred
+:ref:`Table interface <table_io>` for reading::
 
-  >>> data = ascii.read("sources.dat", converters={'obsid': str})  # doctest: +SKIP
+  >>> from astropy.table import Table
+  >>> sources = """
+  ... target observatory obsid
+  ... TW_Hya Chandra     22178
+  ... MP_Mus XMM         0406030101"""
+  >>> data = Table.read(sources, format='ascii', converters={'obsid': str})
+  >>> data
+  <Table length=2>
+  target observatory   obsid
+   str6      str7      str10
+  ------ ----------- ----------
+  TW_Hya     Chandra      22178
+  MP_Mus         XMM 0406030101
 
 Writing Tables
 --------------

--- a/docs/io/ascii/read.rst
+++ b/docs/io/ascii/read.rst
@@ -153,9 +153,15 @@ Parameters for ``read()``
   the default behavior of the built-in `open` when no ``mode`` argument is
   provided.
 
-**converters** : ``dict`` of data type converters
-  Specify the data type or types for columns. See the
-  :ref:`io-ascii-read-converters` section for more information.
+**converters** : ``dict`` specifying output data types
+  See the :ref:`io-ascii-read-converters` section for examples. Each key in the
+  dictionary is a column name or else a name matching pattern including
+  wildcards. The value is one of:
+
+  - Python data type or numpy dtype such as ``int`` or ``np.float32``
+  - list of such types which is tried in order until conversion is successful
+  - list of converter tuples (this is not common, but see the
+    `~astropy.io.ascii.convert_numpy` function for an example).
 
 **names** : list of names corresponding to each data column
   Define the complete list of names for each data column. This will override

--- a/docs/io/ascii/read.rst
+++ b/docs/io/ascii/read.rst
@@ -154,7 +154,8 @@ Parameters for ``read()``
   provided.
 
 **converters** : ``dict`` of data type converters
-  See the `Converters`_ section for more information.
+  Specify the data type or types for columns. See the
+  :ref:`io-ascii-read-converters` section for more information.
 
 **names** : list of names corresponding to each data column
   Define the complete list of names for each data column. This will override
@@ -539,34 +540,25 @@ comments. Here is one example, where comments are of the form "# KEY = VALUE"::
 ..
   EXAMPLE END
 
-Converters
-==========
+.. _io-ascii-read-converters:
+
+Converters for Specifying Dtype
+===============================
 
 :mod:`astropy.io.ascii` converts the raw string values from the table into
 numeric data types by using converter functions such as the Python ``int`` and
-``float`` functions. For example, ``int("5.0")`` will fail while float("5.0")
-will succeed and return 5.0 as a Python float.
+``float`` functions or numpy dtype types such as ``np.float64``.
 
 The default converters are::
 
-    default_converters = [astropy.io.ascii.convert_numpy(numpy.int),
-                          astropy.io.ascii.convert_numpy(numpy.float),
-                          astropy.io.ascii.convert_numpy(numpy.str)]
-
-These take advantage of the :func:`~astropy.io.ascii.convert_numpy`
-function which returns a two-element tuple ``(converter_func, converter_type)``
-as described in the previous section. The type provided to
-:func:`~astropy.io.ascii.convert_numpy` must be a valid `NumPy type
-<https://numpy.org/doc/stable/user/basics.types.html>`_ such as
-``numpy.int``, ``numpy.uint``, ``numpy.int8``, ``numpy.int64``,
-``numpy.float``, ``numpy.float64``, or ``numpy.str``.
+    default_converters = [int, float, str]
 
 The default converters for each column can be overridden with the
 ``converters`` keyword::
 
   >>> import numpy as np
-  >>> converters = {'col1': [ascii.convert_numpy(np.uint)],
-  ...               'col2': [ascii.convert_numpy(np.float32)]}
+  >>> converters = {'col1': np.uint,
+  ...               'col2': np.float32}
   >>> ascii.read('file.dat', converters=converters)  # doctest: +SKIP
 
 In addition to single column names you can use wildcards via `fnmatch` to
@@ -575,9 +567,50 @@ with a name starting with "col" to an unsigned integer while applying default
 converters to all other columns in the table::
 
   >>> import numpy as np
-  >>> converters = {'col*': [ascii.convert_numpy(np.uint)]}
+  >>> converters = {'col*': np.uint}
   >>> ascii.read('file.dat', converters=converters)  # doctest: +SKIP
 
+..
+  EXAMPLE START
+  Reading True / False values as boolean type
+
+The value in the converters ``dict`` can also be a list of types, in which case
+these will be tried in order. This allows for flexible type conversions. For
+example, imagine you get read the following table::
+
+  >>> txt = """\
+  ...   a   b    c
+  ... --- --- -----
+  ...   1 3.5  True
+  ...   2 4.0 False"""
+  >>> t = ascii.read(txt, format='fixed_width_two_line')
+
+By default the ``True`` and ``False`` values will be interpreted as strings.
+However, if you want those values to be read as booleans you can do the
+following::
+
+  >>> converters = {'*': [int, float, bool, str]}
+  >>> t = ascii.read(txt, format='fixed_width_two_line', converters=converters)
+  >>> print(t['c'].dtype)
+  bool
+
+..
+  EXAMPLE END
+
+Advanced usage
+--------------
+
+Internally type conversion uses the :func:`~astropy.io.ascii.convert_numpy`
+function which returns a two-element tuple ``(converter_func, converter_type)``.
+This two-element tuple can be used as the value in a ``converters`` dict.
+The type provided to
+:func:`~astropy.io.ascii.convert_numpy` must be a valid `NumPy type
+<https://numpy.org/doc/stable/user/basics.types.html>`_ such as
+``numpy.int``, ``numpy.uint``, ``numpy.int8``, ``numpy.int64``,
+``numpy.float``, ``numpy.float64``, or ``numpy.str``.
+
+It is also possible to directly pass an arbitary conversion function as the
+``converter_func`` element of the two-element tuple.
 
 .. _fortran_style_exponents:
 

--- a/docs/whatsnew/5.1.rst
+++ b/docs/whatsnew/5.1.rst
@@ -14,6 +14,7 @@ In particular, this release includes:
 
 * :ref:`whatsnew-5.1-cosmology`
 * :ref:`whatsnew-doppler-redshift-eq`
+* :ref:`whatsnew-io-ascii-converters`
 
 .. _whatsnew-5.1-cosmology:
 
@@ -49,6 +50,30 @@ checked with ``Cosmology.from_format.list_formats()``
 
 New :func:`astropy.units.equivalencies.doppler_redshift` is added to
 provide conversion between Doppler redshift and radial velocity.
+
+.. _whatsnew-io-ascii-converters:
+
+Specifying data types when reading ASCII tables
+===============================================
+
+The syntax for specifying the data type of columns when reading a table using
+:func:`astropy.io.ascii.read` has been simplified considerably. For instance,
+to force every column in a table to be read as a ``float`` you can now do:
+
+    >>> from astropy.table import Table
+    >>> t = Table.read('table.dat', format='ascii', converters={'*': float})  # doctest: +SKIP
+
+Previously, doing the same data type specification required using the
+:func:`~astropy.io.ascii.convert_numpy` function and providing the ``dict``
+value as a ``list`` even for only one element::
+
+    >>> from astropy.io.ascii import convert_numpy
+    >>> t = Table.read('table.dat', format='ascii',
+    ...                converters={'*': [convert_numpy(float)]})  # doctest: +SKIP
+
+Note that the previous syntax is still supported for backwards compatibility
+and there is no intent to remove this. See :ref:`io-ascii-read-converters` for
+details.
 
 Full change log
 ===============


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

The current syntax for specifying data types when reading ASCII tables using `converters`
is needlessly complex, requiring an import of `io.ascii.convert_numpy`. This PR simplifies to no longer need that wrapper and also allow providing a single type instead of requiring it be wrapped in a `list`.

FYI the `converters` arg now for ASCII read basically matches the same arg in `pandas.read_csv` except that it is more powerful in allowing file globs.

I took some effort in the documentation updates to refer to "data type" and "dtype" so that people looking for `dtype` or `type` might find `converters`. 

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #12828
Closes #11896
Closes #11278

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
