### PR TITLE
Import cosmology io

### DIFF
--- a/astropy/cosmology/io/__init__.py
+++ b/astropy/cosmology/io/__init__.py
@@ -6,4 +6,4 @@ Read/Write/Interchange methods for `astropy.cosmology`. **NOT public API**.
 """
 
 # Import to register with the I/O machinery
-from . import ecsv, mapping, model, row, table, yaml  # noqa: F403
+from . import cosmology, ecsv, mapping, model, row, table, yaml  # noqa: F403

--- a/astropy/cosmology/io/tests/test_.py
+++ b/astropy/cosmology/io/tests/test_.py
@@ -1,0 +1,27 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+"""Test that all expected methods are present, before I/O tests import.
+
+This file is weirdly named so that it's the first test of I/O.
+"""
+
+from astropy.cosmology.connect import convert_registry, readwrite_registry
+
+
+def test_expected_readwrite_io():
+    """Test that ONLY the expected I/O is registered."""
+
+    got = {k for k, _ in readwrite_registry._readers.keys()}
+    expected = {"ascii.ecsv"}
+
+    assert got == expected
+
+
+def test_expected_convert_io():
+    """Test that ONLY the expected I/O is registered."""
+
+    got = {k for k, _ in convert_registry._readers.keys()}
+    expected = {"astropy.cosmology", "mapping", "astropy.model", "astropy.row",
+                "astropy.table", "yaml"}
+
+    assert got == expected


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

Oops. Forgot an important import. Luckily not yet in a release.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
