### PR TITLE
Add property `equivalent_nonflat` to flat cosmologies

### DIFF
--- a/astropy/cosmology/flrw/lambdacdm.py
+++ b/astropy/cosmology/flrw/lambdacdm.py
@@ -603,6 +603,12 @@ class FlatLambdaCDM(FlatFLRWMixin, LambdaCDM):
 
     >>> z = 0.5
     >>> dc = cosmo.comoving_distance(z)
+
+    To get an equivalent cosmology, but of type `astropy.cosmology.LambdaCDM`,
+    use :attr:`astropy.cosmology.FlatFLRWMixin.equivalent_nonflat`.
+
+    >>> cosmo.equivalent_nonflat
+    LambdaCDM(H0=70.0 km / (Mpc s), Om0=0.3, ...
     """
 
     def __init__(self, H0, Om0, Tcmb0=0.0*u.K, Neff=3.04, m_nu=0.0*u.eV,

--- a/astropy/cosmology/flrw/w0cdm.py
+++ b/astropy/cosmology/flrw/w0cdm.py
@@ -253,6 +253,12 @@ class FlatwCDM(FlatFLRWMixin, wCDM):
 
     >>> z = 0.5
     >>> dc = cosmo.comoving_distance(z)
+
+    To get an equivalent cosmology, but of type `astropy.cosmology.wCDM`,
+    use :attr:`astropy.cosmology.FlatFLRWMixin.equivalent_nonflat`.
+
+    >>> cosmo.equivalent_nonflat
+    wCDM(H0=70.0 km / (Mpc s), Om0=0.3, ...
     """
 
     def __init__(self, H0, Om0, w0=-1.0, Tcmb0=0.0*u.K, Neff=3.04, m_nu=0.0*u.eV,

--- a/astropy/cosmology/flrw/w0wacdm.py
+++ b/astropy/cosmology/flrw/w0wacdm.py
@@ -236,6 +236,12 @@ class Flatw0waCDM(FlatFLRWMixin, w0waCDM):
     >>> z = 0.5
     >>> dc = cosmo.comoving_distance(z)
 
+    To get an equivalent cosmology, but of type `astropy.cosmology.w0waCDM`,
+    use :attr:`astropy.cosmology.FlatFLRWMixin.equivalent_nonflat`.
+
+    >>> cosmo.equivalent_nonflat
+    w0waCDM(H0=70.0 km / (Mpc s), Om0=0.3, ...
+
     References
     ----------
     .. [1] Chevallier, M., & Polarski, D. (2001). Accelerating Universes with

--- a/docs/changes/cosmology/13076.feature.rst
+++ b/docs/changes/cosmology/13076.feature.rst
@@ -1,0 +1,3 @@
+A new property ``equivalent_nonflat`` has been added to flat cosmologies
+(``FlatCosmologyMixin`` subclasses) to get an equivalent cosmology, but of the
+corresponding non-flat class.

--- a/docs/whatsnew/5.1.rst
+++ b/docs/whatsnew/5.1.rst
@@ -42,6 +42,14 @@ The list of valid formats, e.g. the Table in this example, may be
 checked with ``Cosmology.from_format.list_formats()``
 
 
+A new property ``equivalent_nonflat`` has been added to flat cosmologies
+(``FlatCosmologyMixin`` subclasses) to get an equivalent cosmology, but of the
+corresponding non-flat class.
+
+    >>> Planck18.equivalent_nonflat
+    LambdaCDM(name="Planck18", ...
+
+
 .. _whatsnew-doppler-redshift-eq:
 
 ``doppler_redshift`` equivalency


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

A new property ``equivalent_nonflat`` has been added to ``FlatCosmologyMixin``
to get an equivalent cosmology, but of the corresponding non-flat class.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
