### PR TITLE
add units to isorted modules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.0.1
+  rev: v4.2.0
   hooks:
   - id: check-added-large-files
   - id: check-case-conflict

--- a/astropy/cosmology/flrw/tests/test_base.py
+++ b/astropy/cosmology/flrw/tests/test_base.py
@@ -22,8 +22,8 @@ from astropy.cosmology.flrw.base import _a_B_c2, _critdens_const, _H0units_to_in
 from astropy.cosmology.parameter import Parameter
 from astropy.cosmology.tests.helper import get_redshift_methods
 from astropy.cosmology.tests.test_core import CosmologySubclassTest as CosmologyTest
-from astropy.cosmology.tests.test_core import (FlatCosmologyMixinTest, ParameterTestMixin,
-                                               invalid_zs, valid_zs)
+from astropy.cosmology.tests.test_core import (
+    FlatCosmologyMixinTest, ParameterTestMixin, invalid_zs, valid_zs)
 from astropy.utils.compat.optional_deps import HAS_SCIPY
 
 ##############################################################################

--- a/astropy/cosmology/tests/test_connect.py
+++ b/astropy/cosmology/tests/test_connect.py
@@ -8,8 +8,8 @@ import pytest
 from astropy import cosmology
 from astropy.cosmology import Cosmology, w0wzCDM
 from astropy.cosmology.connect import readwrite_registry
-from astropy.cosmology.io.tests import (test_cosmology, test_ecsv, test_json, test_mapping,
-                                        test_model, test_row, test_table, test_yaml)
+from astropy.cosmology.io.tests import (
+    test_cosmology, test_ecsv, test_json, test_mapping, test_model, test_row, test_table, test_yaml)
 from astropy.table import QTable, Row
 
 ###############################################################################

--- a/astropy/cosmology/tests/test_funcs.py
+++ b/astropy/cosmology/tests/test_funcs.py
@@ -10,8 +10,8 @@ import pytest
 from astropy import units as u
 from astropy.cosmology import core, flrw
 from astropy.cosmology.funcs import _z_at_scalar_value, z_at_value
-from astropy.cosmology.realizations import (WMAP1, WMAP3, WMAP5, WMAP7, WMAP9, Planck13, Planck15,
-                                            Planck18)
+from astropy.cosmology.realizations import (
+    WMAP1, WMAP3, WMAP5, WMAP7, WMAP9, Planck13, Planck15, Planck18)
 from astropy.units import allclose
 from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa
 from astropy.utils.exceptions import AstropyUserWarning

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -31,14 +31,16 @@ from astropy.nddata.utils import add_array, extract_array
 from astropy.table import Table
 from astropy.units import Quantity, UnitsError, dimensionless_unscaled
 from astropy.units.utils import quantity_asanyarray
-from astropy.utils import (IncompatibleShapeError, check_broadcast, find_current_module, indent,
-                           isiterable, metadata, sharedmethod)
+from astropy.utils import (
+    IncompatibleShapeError, check_broadcast, find_current_module, indent, isiterable, metadata,
+    sharedmethod)
 from astropy.utils.codegen import make_function_with_signature
 
 from .bounding_box import CompoundBoundingBox, ModelBoundingBox
 from .parameters import InputParameterError, Parameter, _tofloat, param_repr_oneline
-from .utils import (_combine_equivalency_dict, _ConstraintsDict, _SpecialOperatorsDict,
-                    combine_labels, get_inputs_and_params, make_binary_operator_eval)
+from .utils import (
+    _combine_equivalency_dict, _ConstraintsDict, _SpecialOperatorsDict, combine_labels,
+    get_inputs_and_params, make_binary_operator_eval)
 
 __all__ = ['Model', 'FittableModel', 'Fittable1DModel', 'Fittable2DModel',
            'CompoundModel', 'fix_inputs', 'custom_model', 'ModelDefinitionError',

--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -36,8 +36,8 @@ from astropy.utils.decorators import deprecated
 from astropy.utils.exceptions import AstropyUserWarning
 
 from .optimizers import DEFAULT_ACC, DEFAULT_EPS, DEFAULT_MAXITER, SLSQP, Simplex
-from .spline import (SplineExactKnotsFitter, SplineInterpolateFitter, SplineSmoothingFitter,
-                     SplineSplrepFitter)
+from .spline import (
+    SplineExactKnotsFitter, SplineInterpolateFitter, SplineSmoothingFitter, SplineSplrepFitter)
 from .statistic import leastsquare
 from .utils import _combine_equivalency_dict, poly_map_domain
 

--- a/astropy/modeling/tests/example_models.py
+++ b/astropy/modeling/tests/example_models.py
@@ -52,18 +52,16 @@ Explanation of keywords of the dictionaries:
 
 import numpy as np
 
-from astropy.modeling.functional_models import (AiryDisk2D, ArcCosine1D, ArcSine1D, ArcTangent1D,
-                                                Box1D, Box2D, Const1D, Const2D, Cosine1D, Disk2D,
-                                                Exponential1D, Gaussian1D, Gaussian2D,
-                                                KingProjectedAnalytic1D, Linear1D, Logarithmic1D,
-                                                Lorentz1D, Moffat1D, Moffat2D, Planar2D,
-                                                RickerWavelet1D, RickerWavelet2D, Ring2D, Sersic1D,
-                                                Sersic2D, Sine1D, Tangent1D, Trapezoid1D,
-                                                TrapezoidDisk2D, Voigt1D)
+from astropy.modeling.functional_models import (
+    AiryDisk2D, ArcCosine1D, ArcSine1D, ArcTangent1D, Box1D, Box2D, Const1D, Const2D, Cosine1D,
+    Disk2D, Exponential1D, Gaussian1D, Gaussian2D, KingProjectedAnalytic1D, Linear1D, Logarithmic1D,
+    Lorentz1D, Moffat1D, Moffat2D, Planar2D, RickerWavelet1D, RickerWavelet2D, Ring2D, Sersic1D,
+    Sersic2D, Sine1D, Tangent1D, Trapezoid1D, TrapezoidDisk2D, Voigt1D)
 from astropy.modeling.physical_models import Drude1D, Plummer1D
 from astropy.modeling.polynomial import Polynomial1D, Polynomial2D
-from astropy.modeling.powerlaws import (BrokenPowerLaw1D, ExponentialCutoffPowerLaw1D,
-                                        LogParabola1D, PowerLaw1D, SmoothlyBrokenPowerLaw1D)
+from astropy.modeling.powerlaws import (
+    BrokenPowerLaw1D, ExponentialCutoffPowerLaw1D, LogParabola1D, PowerLaw1D,
+    SmoothlyBrokenPowerLaw1D)
 
 # 1D Models
 models_1D = {

--- a/astropy/modeling/tests/test_bounding_box.py
+++ b/astropy/modeling/tests/test_bounding_box.py
@@ -7,10 +7,9 @@ import pytest
 
 import astropy.units as u
 from astropy.coordinates import SpectralCoord
-from astropy.modeling.bounding_box import (CompoundBoundingBox, ModelBoundingBox, _BaseInterval,
-                                           _BaseSelectorArgument, _BoundingDomain,
-                                           _ignored_interval, _Interval, _SelectorArgument,
-                                           _SelectorArguments)
+from astropy.modeling.bounding_box import (
+    CompoundBoundingBox, ModelBoundingBox, _BaseInterval, _BaseSelectorArgument, _BoundingDomain,
+    _ignored_interval, _Interval, _SelectorArgument, _SelectorArguments)
 from astropy.modeling.core import Model, fix_inputs
 from astropy.modeling.models import Gaussian1D, Gaussian2D, Identity, Polynomial2D, Scale, Shift
 

--- a/astropy/modeling/tests/test_compound.py
+++ b/astropy/modeling/tests/test_compound.py
@@ -10,10 +10,9 @@ from numpy.testing import assert_allclose, assert_array_equal
 import astropy.units as u
 from astropy.modeling.core import CompoundModel, Model, ModelDefinitionError
 from astropy.modeling.fitting import LevMarLSQFitter
-from astropy.modeling.models import (Chebyshev1D, Chebyshev2D, Const1D, Gaussian1D, Gaussian2D,
-                                     Identity, Legendre1D, Legendre2D, Linear1D, Mapping,
-                                     Polynomial1D, Polynomial2D, Rotation2D, Scale, Shift,
-                                     Tabular1D, fix_inputs)
+from astropy.modeling.models import (
+    Chebyshev1D, Chebyshev2D, Const1D, Gaussian1D, Gaussian2D, Identity, Legendre1D, Legendre2D,
+    Linear1D, Mapping, Polynomial1D, Polynomial2D, Rotation2D, Scale, Shift, Tabular1D, fix_inputs)
 from astropy.modeling.parameters import Parameter
 from astropy.utils import minversion
 from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa

--- a/astropy/modeling/tests/test_core.py
+++ b/astropy/modeling/tests/test_core.py
@@ -16,9 +16,9 @@ import astropy.units as u
 from astropy.convolution import convolve_models
 from astropy.modeling import models
 from astropy.modeling.bounding_box import CompoundBoundingBox, ModelBoundingBox
-from astropy.modeling.core import (SPECIAL_OPERATORS, CompoundModel, Model, _add_special_operator,
-                                   bind_bounding_box, bind_compound_bounding_box, custom_model,
-                                   fix_inputs)
+from astropy.modeling.core import (
+    SPECIAL_OPERATORS, CompoundModel, Model, _add_special_operator, bind_bounding_box,
+    bind_compound_bounding_box, custom_model, fix_inputs)
 from astropy.modeling.parameters import Parameter
 from astropy.modeling.separable import separability_matrix
 from astropy.tests.helper import assert_quantity_allclose

--- a/astropy/modeling/tests/test_fitters.py
+++ b/astropy/modeling/tests/test_fitters.py
@@ -16,9 +16,9 @@ from numpy.testing import assert_allclose, assert_almost_equal, assert_equal
 
 from astropy.modeling import models
 from astropy.modeling.core import Fittable2DModel, Parameter
-from astropy.modeling.fitting import (Fitter, FittingWithOutlierRemoval, JointFitter,
-                                      LevMarLSQFitter, LinearLSQFitter, NonFiniteValueError,
-                                      SimplexLSQFitter, SLSQPLSQFitter, populate_entry_points)
+from astropy.modeling.fitting import (
+    Fitter, FittingWithOutlierRemoval, JointFitter, LevMarLSQFitter, LinearLSQFitter,
+    NonFiniteValueError, SimplexLSQFitter, SLSQPLSQFitter, populate_entry_points)
 from astropy.modeling.optimizers import Optimization
 from astropy.stats import sigma_clip
 from astropy.utils import NumpyRNGContext

--- a/astropy/modeling/tests/test_model_sets.py
+++ b/astropy/modeling/tests/test_model_sets.py
@@ -9,8 +9,9 @@ from numpy.testing import assert_allclose
 
 from astropy.modeling.core import Model
 from astropy.modeling.fitting import FittingWithOutlierRemoval, LinearLSQFitter
-from astropy.modeling.models import (Chebyshev1D, Chebyshev2D, Hermite1D, Hermite2D, Legendre1D,
-                                     Legendre2D, Linear1D, Planar2D, Polynomial1D, Polynomial2D)
+from astropy.modeling.models import (
+    Chebyshev1D, Chebyshev2D, Hermite1D, Hermite2D, Legendre1D, Legendre2D, Linear1D, Planar2D,
+    Polynomial1D, Polynomial2D)
 from astropy.modeling.parameters import Parameter
 from astropy.stats import sigma_clip
 from astropy.utils import NumpyRNGContext

--- a/astropy/modeling/tests/test_models.py
+++ b/astropy/modeling/tests/test_models.py
@@ -19,8 +19,9 @@ from astropy.modeling.core import FittableModel, Model, _ModelMeta
 from astropy.modeling.models import Gaussian2D
 from astropy.modeling.parameters import InputParameterError, Parameter
 from astropy.modeling.polynomial import PolynomialBase
-from astropy.modeling.powerlaws import (BrokenPowerLaw1D, ExponentialCutoffPowerLaw1D,
-                                        LogParabola1D, PowerLaw1D, SmoothlyBrokenPowerLaw1D)
+from astropy.modeling.powerlaws import (
+    BrokenPowerLaw1D, ExponentialCutoffPowerLaw1D, LogParabola1D, PowerLaw1D,
+    SmoothlyBrokenPowerLaw1D)
 from astropy.modeling.separable import separability_matrix
 from astropy.tests.helper import assert_quantity_allclose
 from astropy.utils import NumpyRNGContext

--- a/astropy/modeling/tests/test_models_quantities.py
+++ b/astropy/modeling/tests/test_models_quantities.py
@@ -8,19 +8,18 @@ from astropy import units as u
 from astropy.modeling.bounding_box import ModelBoundingBox
 from astropy.modeling.core import fix_inputs
 from astropy.modeling.fitting import LevMarLSQFitter
-from astropy.modeling.functional_models import (AiryDisk2D, ArcCosine1D, ArcSine1D, ArcTangent1D,
-                                                Box1D, Box2D, Const1D, Const2D, Cosine1D, Disk2D,
-                                                Ellipse2D, Exponential1D, Gaussian1D, Gaussian2D,
-                                                KingProjectedAnalytic1D, Linear1D, Logarithmic1D,
-                                                Lorentz1D, Moffat1D, Moffat2D, Multiply, Planar2D,
-                                                RickerWavelet1D, RickerWavelet2D, Ring2D, Scale,
-                                                Sersic1D, Sersic2D, Sine1D, Tangent1D, Trapezoid1D,
-                                                TrapezoidDisk2D, Voigt1D)
+from astropy.modeling.functional_models import (
+    AiryDisk2D, ArcCosine1D, ArcSine1D, ArcTangent1D, Box1D, Box2D, Const1D, Const2D, Cosine1D,
+    Disk2D, Ellipse2D, Exponential1D, Gaussian1D, Gaussian2D, KingProjectedAnalytic1D, Linear1D,
+    Logarithmic1D, Lorentz1D, Moffat1D, Moffat2D, Multiply, Planar2D, RickerWavelet1D,
+    RickerWavelet2D, Ring2D, Scale, Sersic1D, Sersic2D, Sine1D, Tangent1D, Trapezoid1D,
+    TrapezoidDisk2D, Voigt1D)
 from astropy.modeling.parameters import InputParameterError
 from astropy.modeling.physical_models import Drude1D, Plummer1D
 from astropy.modeling.polynomial import Polynomial1D, Polynomial2D
-from astropy.modeling.powerlaws import (BrokenPowerLaw1D, ExponentialCutoffPowerLaw1D,
-                                        LogParabola1D, PowerLaw1D, SmoothlyBrokenPowerLaw1D)
+from astropy.modeling.powerlaws import (
+    BrokenPowerLaw1D, ExponentialCutoffPowerLaw1D, LogParabola1D, PowerLaw1D,
+    SmoothlyBrokenPowerLaw1D)
 from astropy.tests.helper import assert_quantity_allclose
 from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa
 

--- a/astropy/modeling/tests/test_polynomial.py
+++ b/astropy/modeling/tests/test_polynomial.py
@@ -16,9 +16,9 @@ from astropy.io import fits
 from astropy.modeling import fitting
 from astropy.modeling.functional_models import Linear1D
 from astropy.modeling.mappings import Identity
-from astropy.modeling.polynomial import (SIP, Chebyshev1D, Chebyshev2D, Hermite1D, Hermite2D,
-                                         Legendre1D, Legendre2D, OrthoPolynomialBase, Polynomial1D,
-                                         Polynomial2D, PolynomialBase)
+from astropy.modeling.polynomial import (
+    SIP, Chebyshev1D, Chebyshev2D, Hermite1D, Hermite2D, Legendre1D, Legendre2D,
+    OrthoPolynomialBase, Polynomial1D, Polynomial2D, PolynomialBase)
 from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa
 from astropy.utils.data import get_pkg_data_filename
 from astropy.utils.exceptions import AstropyUserWarning

--- a/astropy/modeling/tests/test_separable.py
+++ b/astropy/modeling/tests/test_separable.py
@@ -11,8 +11,8 @@ from numpy.testing import assert_allclose
 from astropy.modeling import custom_model, models
 from astropy.modeling.core import ModelDefinitionError
 from astropy.modeling.models import Mapping
-from astropy.modeling.separable import (_arith_oper, _cdot, _coord_matrix, _cstack, is_separable,
-                                        separability_matrix)
+from astropy.modeling.separable import (
+    _arith_oper, _cdot, _coord_matrix, _cstack, is_separable, separability_matrix)
 
 sh1 = models.Shift(1, name='shift1')
 sh2 = models.Shift(2, name='sh2')

--- a/astropy/modeling/tests/test_spline.py
+++ b/astropy/modeling/tests/test_spline.py
@@ -8,8 +8,8 @@ import pytest
 from numpy.testing import assert_allclose
 
 from astropy.modeling.core import FittableModel, ModelDefinitionError
-from astropy.modeling.fitting import (SplineExactKnotsFitter, SplineInterpolateFitter,
-                                      SplineSmoothingFitter, SplineSplrepFitter)
+from astropy.modeling.fitting import (
+    SplineExactKnotsFitter, SplineInterpolateFitter, SplineSmoothingFitter, SplineSplrepFitter)
 from astropy.modeling.parameters import Parameter
 from astropy.modeling.spline import Spline1D, _Spline, _SplineFitter
 from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa

--- a/astropy/modeling/tests/test_utils.py
+++ b/astropy/modeling/tests/test_utils.py
@@ -5,8 +5,8 @@ from inspect import Parameter
 import numpy as np
 import pytest
 
-from astropy.modeling.utils import (_SpecialOperatorsDict, _validate_domain_window,
-                                    get_inputs_and_params, poly_map_domain)
+from astropy.modeling.utils import (
+    _SpecialOperatorsDict, _validate_domain_window, get_inputs_and_params, poly_map_domain)
 
 
 def test_poly_map_domain():

--- a/astropy/units/__init__.py
+++ b/astropy/units/__init__.py
@@ -16,28 +16,29 @@ code under a BSD license.
 from .core import *
 from .quantity import *
 
-from . import si
-from . import cgs
-from . import astrophys
-from . import photometric
-from . import misc
+# isort: split
+from . import astrophys, cgs, misc, photometric, si
 from .function import units as function_units
 
-from .si import *
+# isort: split
 from .astrophys import *
-from .photometric import *
 from .cgs import *
-from .physical import *
 from .function.units import *
 from .misc import *
+from .photometric import *
+from .physical import *
+from .si import *
 
+# isort: split
 from .equivalencies import *
 
+# isort: split
 from .function.core import *
 from .function.logarithmic import *
 
-from .structured import *
+# isort: split
 from .decorators import *
+from .structured import *
 
 del bases
 

--- a/astropy/units/__init__.py
+++ b/astropy/units/__init__.py
@@ -9,36 +9,36 @@ This code is adapted from the `pynbody
 Pontzen, who has granted the Astropy project permission to use the
 code under a BSD license.
 """
+
+# Import order matters here -- circular dependencies abound!
 # Lots of things to import - go from more basic to advanced, so that
 # whatever advanced ones need generally has been imported already;
-# this helps prevent circular imports and makes it easier to understand
-# where most time is spent (e.g., using python -X importtime).
+# this also makes it easier to understand where most time is spent
+# (e.g., using python -X importtime).
+
+# isort: off
 from .core import *
 from .quantity import *
 
-# isort: split
 from . import astrophys, cgs, misc, photometric, si
 from .function import units as function_units
 
-# isort: split
+from .si import *
 from .astrophys import *
+from .photometric import *
 from .cgs import *
+from .physical import *
 from .function.units import *
 from .misc import *
-from .photometric import *
-from .physical import *
-from .si import *
 
-# isort: split
 from .equivalencies import *
 
-# isort: split
 from .function.core import *
 from .function.logarithmic import *
 
-# isort: split
 from .decorators import *
 from .structured import *
+# isort: on
 
 del bases
 

--- a/astropy/units/astrophys.py
+++ b/astropy/units/astrophys.py
@@ -7,10 +7,10 @@ available in the `astropy.units` namespace.
 """
 
 
-from . import si
 from astropy.constants import si as _si
-from .core import (UnitBase, def_unit, si_prefixes, binary_prefixes,
-                   set_enabled_units)
+
+from . import si
+from .core import UnitBase, binary_prefixes, def_unit, set_enabled_units, si_prefixes
 
 # To ensure si units of the constants can be interpreted.
 set_enabled_units([si])
@@ -137,6 +137,7 @@ del si
 # This generates a docstring for this module that describes all of the
 # standard units defined here.
 from .utils import generate_unit_summary as _generate_unit_summary
+
 if __doc__ is not None:
     __doc__ += _generate_unit_summary(globals())
 
@@ -146,6 +147,7 @@ if __doc__ is not None:
 def __getattr__(attr):
     if attr == "littleh":
         import warnings
+
         from astropy.cosmology.units import littleh
         from astropy.utils.exceptions import AstropyDeprecationWarning
 

--- a/astropy/units/cds.py
+++ b/astropy/units/cds.py
@@ -23,17 +23,19 @@ To include them in `~astropy.units.UnitBase.compose` and the results of
     >>> cds.enable()  # doctest: +SKIP
 """
 
-
 _ns = globals()
 
 
 def _initialize_module():
+    """Initialize CDS units module."""
+
     # Local imports to avoid polluting top-level namespace
     import numpy as np
 
-    from . import core
     from astropy import units as u
     from astropy.constants import si as _si
+
+    from . import core
 
     # The CDS format also supports power-of-2 prefixes as defined here:
     # http://physics.nist.gov/cuu/Units/binary.html
@@ -166,6 +168,7 @@ _initialize_module()
 # This generates a docstring for this module that describes all of the
 # standard units defined here.
 from .utils import generate_unit_summary as _generate_unit_summary
+
 if __doc__ is not None:
     __doc__ += _generate_unit_summary(globals())
 
@@ -181,8 +184,9 @@ def enable():
     This may be used with the ``with`` statement to enable CDS
     units only temporarily.
     """
-    # Local import to avoid cyclical import
-    from .core import set_enabled_units
-    # Local import to avoid polluting namespace
+    # Local imports to avoid cyclical import and polluting namespace
     import inspect
+
+    from .core import set_enabled_units
+
     return set_enabled_units(inspect.getmodule(enable))

--- a/astropy/units/cgs.py
+++ b/astropy/units/cgs.py
@@ -11,7 +11,6 @@ from fractions import Fraction
 from . import si
 from .core import UnitBase, def_unit
 
-
 _ns = globals()
 
 def_unit(['cm', 'centimeter'], si.cm, namespace=_ns, prefixes=False)
@@ -133,5 +132,6 @@ del Fraction
 # This generates a docstring for this module that describes all of the
 # standard units defined here.
 from .utils import generate_unit_summary as _generate_unit_summary
+
 if __doc__ is not None:
     __doc__ += _generate_unit_summary(globals())

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -15,10 +15,9 @@ import numpy as np
 from astropy.utils.decorators import lazyproperty
 from astropy.utils.exceptions import AstropyWarning
 from astropy.utils.misc import isiterable
-from .utils import (is_effectively_unity, sanitize_scale, validate_power,
-                    resolve_fractions)
-from . import format as unit_format
 
+from . import format as unit_format
+from .utils import is_effectively_unity, resolve_fractions, sanitize_scale, validate_power
 
 __all__ = [
     'UnitsError', 'UnitsWarning', 'UnitConversionError', 'UnitTypeError',

--- a/astropy/units/decorators.py
+++ b/astropy/units/decorators.py
@@ -4,20 +4,18 @@
 __all__ = ['quantity_input']
 
 import inspect
-from numbers import Number
 from collections.abc import Sequence
 from functools import wraps
+from numbers import Number
 
 import numpy as np
 
 from . import _typing as T
-from .core import (Unit, UnitBase, UnitsError,
-                   add_enabled_equivalencies, dimensionless_unscaled)
+from .core import Unit, UnitBase, UnitsError, add_enabled_equivalencies, dimensionless_unscaled
 from .function.core import FunctionUnitBase
 from .physical import PhysicalType, get_physical_type
 from .quantity import Quantity
 from .structured import StructuredUnit
-
 
 NoneType = type(None)
 

--- a/astropy/units/deprecated.py
+++ b/astropy/units/deprecated.py
@@ -23,9 +23,8 @@ _ns = globals()
 
 def _initialize_module():
     # Local imports to avoid polluting top-level namespace
-    from . import cgs
-    from . import astrophys
-    from .core import def_unit, _add_prefixes
+    from . import astrophys, cgs
+    from .core import _add_prefixes, def_unit
 
     def_unit(['emu'], cgs.Bi, namespace=_ns,
              doc='Biot: CGS (EMU) unit of current')
@@ -45,8 +44,9 @@ _initialize_module()
 
 # This generates a docstring for this module that describes all of the
 # standard units defined here.
-from .utils import (generate_unit_summary as _generate_unit_summary,
-                    generate_prefixonly_unit_summary as _generate_prefixonly_unit_summary)
+from .utils import generate_prefixonly_unit_summary as _generate_prefixonly_unit_summary
+from .utils import generate_unit_summary as _generate_unit_summary
+
 if __doc__ is not None:
     __doc__ += _generate_unit_summary(globals())
     __doc__ += _generate_prefixonly_unit_summary(globals())
@@ -61,8 +61,9 @@ def enable():
     This may be used with the ``with`` statement to enable deprecated
     units only temporarily.
     """
-    # Local import to avoid cyclical import
-    from .core import add_enabled_units
-    # Local import to avoid polluting namespace
     import inspect
+
+    # Local import to avoid cyclical import
+    # Local import to avoid polluting namespace
+    from .core import add_enabled_units
     return add_enabled_units(inspect.getmodule(enable))

--- a/astropy/units/equivalencies.py
+++ b/astropy/units/equivalencies.py
@@ -1,24 +1,20 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """A set of standard astronomical equivalencies."""
 
+import warnings
 from collections import UserList
 
 # THIRD-PARTY
 import numpy as np
-import warnings
 
 # LOCAL
 from astropy.constants import si as _si
 from astropy.utils.exceptions import AstropyDeprecationWarning
 from astropy.utils.misc import isiterable
-from . import si
-from . import cgs
-from . import astrophys
-from . import misc
-from .function import units as function_units
-from . import dimensionless_unscaled
-from .core import UnitsError, Unit
 
+from . import astrophys, cgs, dimensionless_unscaled, misc, si
+from .core import Unit, UnitsError
+from .function import units as function_units
 
 __all__ = ['parallax', 'spectral', 'spectral_density', 'doppler_radio',
            'doppler_optical', 'doppler_relativistic', 'doppler_redshift', 'mass_energy',
@@ -825,6 +821,7 @@ def plate_scale(platescale):
 def __getattr__(attr):
     if attr == "with_H0":
         import warnings
+
         from astropy.cosmology.units import with_H0
         from astropy.utils.exceptions import AstropyDeprecationWarning
 

--- a/astropy/units/format/__init__.py
+++ b/astropy/units/format/__init__.py
@@ -9,18 +9,18 @@ A collection of different unit formats.
 # formatters that need access to the units.core module An entry for it should
 # exist in sys.modules since astropy.units.core imports this module
 import sys
+
 core = sys.modules['astropy.units.core']
 
 from .base import Base  # noqa
-from .generic import Generic, Unscaled  # noqa
 from .cds import CDS  # noqa
 from .console import Console  # noqa
 from .fits import Fits  # noqa
+from .generic import Generic, Unscaled  # noqa
 from .latex import Latex, LatexInline  # noqa
 from .ogip import OGIP  # noqa
 from .unicode_format import Unicode  # noqa
 from .vounit import VOUnit  # noqa
-
 
 __all__ = [
     'Base', 'Generic', 'CDS', 'Console', 'Fits', 'Latex', 'LatexInline',

--- a/astropy/units/format/cds.py
+++ b/astropy/units/format/cds.py
@@ -11,24 +11,19 @@
 # You can then commit the changes to the re-generated _lextab.py and
 # _parsetab.py files.
 
-"""
-Handles the CDS string format for units
-"""
-
+"""Handles the CDS string format for units."""
 
 import operator
 import os
 import re
 
-
-from .base import Base
-from . import core, utils
 from astropy.units.utils import is_effectively_unity
 from astropy.utils import classproperty, parsing
 from astropy.utils.misc import did_you_mean
 
+from . import core, utils
+from .base import Base
 
-# TODO: Support logarithmic units using bracketed syntax
 
 class CDS(Base):
     """
@@ -69,8 +64,8 @@ class CDS(Base):
 
     @staticmethod
     def _generate_unit_names():
-        from astropy.units import cds
         from astropy import units as u
+        from astropy.units import cds
 
         names = {}
 
@@ -160,8 +155,8 @@ class CDS(Base):
                  | OPEN_BRACKET DIMENSIONLESS CLOSE_BRACKET
                  | factor
             '''
-            from astropy.units.core import Unit
             from astropy.units import dex
+            from astropy.units.core import Unit
             if len(p) == 3:
                 p[0] = Unit(p[1] * p[2])
             elif len(p) == 4:

--- a/astropy/units/format/fits.py
+++ b/astropy/units/format/fits.py
@@ -5,11 +5,11 @@ Handles the "FITS" unit format.
 """
 
 
-import numpy as np
-
 import copy
 import keyword
 import operator
+
+import numpy as np
 
 from . import core, generic, utils
 

--- a/astropy/units/format/generic.py
+++ b/astropy/units/format/generic.py
@@ -15,14 +15,15 @@ Handles a "generic" string format for units
 """
 
 import re
+import unicodedata
 import warnings
 from fractions import Fraction
-import unicodedata
+
+from astropy.utils import classproperty, parsing
+from astropy.utils.misc import did_you_mean
 
 from . import core, utils
 from .base import Base
-from astropy.utils import classproperty, parsing
-from astropy.utils.misc import did_you_mean
 
 
 def _to_string(cls, unit):

--- a/astropy/units/format/ogip.py
+++ b/astropy/units/format/ogip.py
@@ -17,16 +17,16 @@ FITS files
 <https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/general/ogip_93_001/>`__.
 """
 
+import copy
 import keyword
 import math
 import os
-import copy
 import warnings
 from fractions import Fraction
 
-from . import core, generic, utils
-
 from astropy.utils import parsing
+
+from . import core, generic, utils
 
 
 class OGIP(generic.Generic):

--- a/astropy/units/format/utils.py
+++ b/astropy/units/format/utils.py
@@ -9,6 +9,7 @@ import warnings
 from fractions import Fraction
 
 from astropy.utils.misc import did_you_mean
+
 from ..utils import maybe_simple_fraction
 
 

--- a/astropy/units/function/core.py
+++ b/astropy/units/function/core.py
@@ -6,8 +6,9 @@ from abc import ABCMeta, abstractmethod
 
 import numpy as np
 
-from astropy.units import (Quantity, Unit, UnitBase, UnitConversionError, UnitsError, UnitTypeError,
-                           dimensionless_unscaled)
+from astropy.units import (
+    Quantity, Unit, UnitBase, UnitConversionError, UnitsError, UnitTypeError,
+    dimensionless_unscaled)
 
 __all__ = ['FunctionUnitBase', 'FunctionQuantity']
 

--- a/astropy/units/function/core.py
+++ b/astropy/units/function/core.py
@@ -6,8 +6,8 @@ from abc import ABCMeta, abstractmethod
 
 import numpy as np
 
-from astropy.units import (Unit, UnitBase, UnitsError, UnitTypeError, UnitConversionError,
-                           dimensionless_unscaled, Quantity)
+from astropy.units import (Quantity, Unit, UnitBase, UnitConversionError, UnitsError, UnitTypeError,
+                           dimensionless_unscaled)
 
 __all__ = ['FunctionUnitBase', 'FunctionQuantity']
 

--- a/astropy/units/function/logarithmic.py
+++ b/astropy/units/function/logarithmic.py
@@ -4,8 +4,9 @@ import numbers
 
 import numpy as np
 
-from astropy.units import (CompositeUnit, Unit, UnitConversionError, UnitsError, UnitTypeError,
-                           dimensionless_unscaled, photometric)
+from astropy.units import (
+    CompositeUnit, Unit, UnitConversionError, UnitsError, UnitTypeError, dimensionless_unscaled,
+    photometric)
 
 from .core import FunctionQuantity, FunctionUnitBase
 from .units import dB, dex, mag

--- a/astropy/units/function/logarithmic.py
+++ b/astropy/units/function/logarithmic.py
@@ -1,15 +1,14 @@
 # -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import numbers
+
 import numpy as np
 
-from astropy.units import (dimensionless_unscaled, photometric, Unit,
-                           CompositeUnit, UnitsError, UnitTypeError,
-                           UnitConversionError)
+from astropy.units import (CompositeUnit, Unit, UnitConversionError, UnitsError, UnitTypeError,
+                           dimensionless_unscaled, photometric)
 
-from .core import FunctionUnitBase, FunctionQuantity
-from .units import dex, dB, mag
-
+from .core import FunctionQuantity, FunctionUnitBase
+from .units import dB, dex, mag
 
 __all__ = ['LogUnit', 'MagUnit', 'DexUnit', 'DecibelUnit',
            'LogQuantity', 'Magnitude', 'Decibel', 'Dex',

--- a/astropy/units/function/units.py
+++ b/astropy/units/function/units.py
@@ -7,8 +7,8 @@ unit (e.g., ``u.mag(u.ct/u.s)``).  Note that the prefixed versions cannot be
 called, as it would be unclear what, e.g., ``u.mmag(u.ct/u.s)`` would mean.
 """
 from astropy.units.core import _add_prefixes
-from .mixin import RegularFunctionUnit, IrreducibleFunctionUnit
 
+from .mixin import IrreducibleFunctionUnit, RegularFunctionUnit
 
 _ns = globals()
 
@@ -42,5 +42,6 @@ del IrreducibleFunctionUnit
 # This generates a docstring for this module that describes all of the
 # standard units defined here.
 from astropy.units.utils import generate_unit_summary as _generate_unit_summary
+
 if __doc__ is not None:
     __doc__ += _generate_unit_summary(globals())

--- a/astropy/units/imperial.py
+++ b/astropy/units/imperial.py
@@ -19,8 +19,8 @@ To include them in `~astropy.units.UnitBase.compose` and the results of
 """
 
 
-from .core import UnitBase, def_unit
 from . import si
+from .core import UnitBase, def_unit
 
 _ns = globals()
 
@@ -148,6 +148,7 @@ del def_unit
 # This generates a docstring for this module that describes all of the
 # standard units defined here.
 from .utils import generate_unit_summary as _generate_unit_summary
+
 if __doc__ is not None:
     __doc__ += _generate_unit_summary(globals())
 
@@ -162,7 +163,8 @@ def enable():
     units only temporarily.
     """
     # Local import to avoid cyclical import
-    from .core import add_enabled_units
     # Local import to avoid polluting namespace
     import inspect
+
+    from .core import add_enabled_units
     return add_enabled_units(inspect.getmodule(enable))

--- a/astropy/units/misc.py
+++ b/astropy/units/misc.py
@@ -7,10 +7,10 @@ available in the `astropy.units` namespace.
 """
 
 
-from . import si
 from astropy.constants import si as _si
-from .core import (UnitBase, def_unit, si_prefixes, binary_prefixes,
-                   set_enabled_units)
+
+from . import si
+from .core import UnitBase, binary_prefixes, def_unit, set_enabled_units, si_prefixes
 
 # To ensure si units of the constants can be interpreted.
 set_enabled_units([si])
@@ -96,5 +96,6 @@ del si
 # This generates a docstring for this module that describes all of the
 # standard units defined here.
 from .utils import generate_unit_summary as _generate_unit_summary
+
 if __doc__ is not None:
     __doc__ += _generate_unit_summary(globals())

--- a/astropy/units/photometric.py
+++ b/astropy/units/photometric.py
@@ -10,11 +10,11 @@ The corresponding magnitudes are given in the description of each unit
 
 
 import numpy as _numpy
-from .core import UnitBase, def_unit, Unit
 
 from astropy.constants import si as _si
-from . import cgs, si, astrophys
 
+from . import astrophys, cgs, si
+from .core import Unit, UnitBase, def_unit
 
 _ns = globals()
 
@@ -65,5 +65,6 @@ del cgs, si, astrophys
 # This generates a docstring for this module that describes all of the
 # standard units defined here.
 from .utils import generate_unit_summary as _generate_unit_summary
+
 if __doc__ is not None:
     __doc__ += _generate_unit_summary(globals())

--- a/astropy/units/physical.py
+++ b/astropy/units/physical.py
@@ -5,14 +5,10 @@
 import numbers
 import warnings
 
-from . import core
-from . import si
-from . import astrophys
-from . import cgs
-from . import imperial  # Need this for backward namespace compat, see issues 11975 and 11977  # noqa
-from . import misc
-from . import quantity
 from astropy.utils.exceptions import AstropyDeprecationWarning
+
+from . import imperial  # noqa  # Needed for backward namespace compat, see #11975 and #11977
+from . import astrophys, cgs, core, misc, quantity, si
 
 __all__ = ["def_physical_type", "get_physical_type", "PhysicalType"]
 

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -6,33 +6,31 @@ associated units. `Quantity` objects support operations like ordinary numbers,
 but will deal with unit conversions internally.
 """
 
-
-# Standard library
-import re
+# STDLIB
 import numbers
-from fractions import Fraction
 import operator
+import re
 import warnings
+from fractions import Fraction
 
+# THIRD PARTY
 import numpy as np
 
-# AstroPy
-from .core import (Unit, dimensionless_unscaled, get_current_unit_registry,
-                   UnitBase, UnitsError, UnitConversionError, UnitTypeError)
-from .structured import StructuredUnit
-from .utils import is_effectively_unity
-from .format.latex import Latex
+# LOCAL
+from astropy import config as _config
 from astropy.utils.compat.misc import override__dir__
+from astropy.utils.data_info import ParentDtypeInfo
 from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyWarning
 from astropy.utils.misc import isiterable
-from astropy.utils.data_info import ParentDtypeInfo
-from astropy import config as _config
-from .quantity_helper import (converters_and_unit, can_have_arbitrary_unit,
-                              check_output)
-from .quantity_helper.function_helpers import (
-    SUBCLASS_SAFE_FUNCTIONS, FUNCTION_HELPERS, DISPATCHED_FUNCTIONS,
-    UNSUPPORTED_FUNCTIONS)
 
+from .core import (Unit, UnitBase, UnitConversionError, UnitsError, UnitTypeError,
+                   dimensionless_unscaled, get_current_unit_registry)
+from .format.latex import Latex
+from .quantity_helper import can_have_arbitrary_unit, check_output, converters_and_unit
+from .quantity_helper.function_helpers import (DISPATCHED_FUNCTIONS, FUNCTION_HELPERS,
+                                               SUBCLASS_SAFE_FUNCTIONS, UNSUPPORTED_FUNCTIONS)
+from .structured import StructuredUnit
+from .utils import is_effectively_unity
 
 __all__ = ["Quantity", "SpecificTypeQuantity",
            "QuantityInfoBase", "QuantityInfo", "allclose", "isclose"]

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -23,12 +23,13 @@ from astropy.utils.data_info import ParentDtypeInfo
 from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyWarning
 from astropy.utils.misc import isiterable
 
-from .core import (Unit, UnitBase, UnitConversionError, UnitsError, UnitTypeError,
-                   dimensionless_unscaled, get_current_unit_registry)
+from .core import (
+    Unit, UnitBase, UnitConversionError, UnitsError, UnitTypeError, dimensionless_unscaled,
+    get_current_unit_registry)
 from .format.latex import Latex
 from .quantity_helper import can_have_arbitrary_unit, check_output, converters_and_unit
-from .quantity_helper.function_helpers import (DISPATCHED_FUNCTIONS, FUNCTION_HELPERS,
-                                               SUBCLASS_SAFE_FUNCTIONS, UNSUPPORTED_FUNCTIONS)
+from .quantity_helper.function_helpers import (
+    DISPATCHED_FUNCTIONS, FUNCTION_HELPERS, SUBCLASS_SAFE_FUNCTIONS, UNSUPPORTED_FUNCTIONS)
 from .structured import StructuredUnit
 from .utils import is_effectively_unity
 

--- a/astropy/units/quantity_helper/__init__.py
+++ b/astropy/units/quantity_helper/__init__.py
@@ -4,11 +4,13 @@
 In particular, this implements the logic that determines scaling and result
 units for a given ufunc, given input units.
 """
+
 from .converters import *
+
+# isort: split
 # By importing helpers, all the unit conversion functions needed for
 # numpy ufuncs and functions are defined.
-from . import helpers, function_helpers
 # For scipy.special and erfa, importing the helper modules ensures
 # the definitions are added as modules to UFUNC_HELPERS, to be loaded
 # on demand.
-from . import scipy_special, erfa
+from . import erfa, function_helpers, helpers, scipy_special

--- a/astropy/units/quantity_helper/converters.py
+++ b/astropy/units/quantity_helper/converters.py
@@ -6,8 +6,8 @@ import threading
 
 import numpy as np
 
-from astropy.units.core import (UnitConversionError, UnitsError, UnitTypeError,
-                                dimensionless_unscaled)
+from astropy.units.core import (
+    UnitConversionError, UnitsError, UnitTypeError, dimensionless_unscaled)
 
 __all__ = ['can_have_arbitrary_unit', 'converters_and_unit',
            'check_output', 'UFUNC_HELPERS', 'UNSUPPORTED_UFUNCS']

--- a/astropy/units/quantity_helper/converters.py
+++ b/astropy/units/quantity_helper/converters.py
@@ -6,7 +6,7 @@ import threading
 
 import numpy as np
 
-from astropy.units.core import (UnitsError, UnitConversionError, UnitTypeError,
+from astropy.units.core import (UnitConversionError, UnitsError, UnitTypeError,
                                 dimensionless_unscaled)
 
 __all__ = ['can_have_arbitrary_unit', 'converters_and_unit',

--- a/astropy/units/quantity_helper/erfa.py
+++ b/astropy/units/quantity_helper/erfa.py
@@ -3,14 +3,15 @@
 """Quantity helpers for the ERFA ufuncs."""
 # Tests for these are in coordinates, not in units.
 
-from erfa import ufunc as erfa_ufunc, dt_pv, dt_eraLDBODY, dt_eraASTROM
+from erfa import dt_eraASTROM, dt_eraLDBODY, dt_pv
+from erfa import ufunc as erfa_ufunc
 
 from astropy.units.core import UnitsError, UnitTypeError, dimensionless_unscaled
 from astropy.units.structured import StructuredUnit
-from . import UFUNC_HELPERS
-from .helpers import (get_converter, helper_invariant, helper_multiplication,
-                      helper_twoarg_invariant, _d)
 
+from . import UFUNC_HELPERS
+from .helpers import (_d, get_converter, helper_invariant, helper_multiplication,
+                      helper_twoarg_invariant)
 
 erfa_ufuncs = ('s2c', 's2p', 'c2s', 'p2s', 'pm', 'pdp', 'pxp', 'rxp',
                'cpv', 'p2pv', 'pv2p', 'pv2s', 'pvdpv', 'pvm', 'pvmpv', 'pvppv',
@@ -143,7 +144,7 @@ def helper_pvm(f, unit1):
 
 def helper_pvstar(f, unit1):
     from astropy.units.astrophys import AU
-    from astropy.units.si import km, s, radian, day, year, arcsec
+    from astropy.units.si import arcsec, day, km, radian, s, year
 
     return [get_converter(unit1, StructuredUnit((AU, AU/day)))], (
         radian, radian, radian / year, radian / year, arcsec, km / s, None)
@@ -151,8 +152,8 @@ def helper_pvstar(f, unit1):
 
 def helper_starpv(f, unit_ra, unit_dec, unit_pmr, unit_pmd,
                   unit_px, unit_rv):
-    from astropy.units.si import km, s, day, year, radian, arcsec
     from astropy.units.astrophys import AU
+    from astropy.units.si import arcsec, day, km, radian, s, year
 
     return [get_converter(unit_ra, radian),
             get_converter(unit_dec, radian),
@@ -164,7 +165,7 @@ def helper_starpv(f, unit_ra, unit_dec, unit_pmr, unit_pmd,
 
 def helper_pvtob(f, unit_elong, unit_phi, unit_hm,
                  unit_xp, unit_yp, unit_sp, unit_theta):
-    from astropy.units.si import m, s, radian
+    from astropy.units.si import m, radian, s
 
     return [get_converter(unit_elong, radian),
             get_converter(unit_phi, radian),
@@ -192,16 +193,16 @@ def helper_s2xpv(f, unit1, unit2, unit_pv):
 
 
 def ldbody_unit():
+    from astropy.units.astrophys import AU, Msun
     from astropy.units.si import day, radian
-    from astropy.units.astrophys import Msun, AU
 
     return StructuredUnit((Msun, radian, (AU, AU/day)),
                           erfa_ufunc.dt_eraLDBODY)
 
 
 def astrom_unit():
-    from astropy.units.si import rad, year
     from astropy.units.astrophys import AU
+    from astropy.units.si import rad, year
     one = rel2c = dimensionless_unscaled
 
     return StructuredUnit((year, AU, one, AU, rel2c, one, one, rad, rad, rad, rad,
@@ -231,7 +232,7 @@ def helper_aper(f, unit_theta, unit_astrom):
 
 def helper_apio(f, unit_sp, unit_theta, unit_elong, unit_phi, unit_hm,
                 unit_xp, unit_yp, unit_refa, unit_refb):
-    from astropy.units.si import radian, m
+    from astropy.units.si import m, radian
     return [get_converter(unit_sp, radian),
             get_converter(unit_theta, radian),
             get_converter(unit_elong, radian),
@@ -244,7 +245,7 @@ def helper_apio(f, unit_sp, unit_theta, unit_elong, unit_phi, unit_hm,
 
 
 def helper_atciq(f, unit_rc, unit_dc, unit_pr, unit_pd, unit_px, unit_rv, unit_astrom):
-    from astropy.units.si import radian, arcsec, year, km, s
+    from astropy.units.si import arcsec, km, radian, s, year
     return [get_converter(unit_rc, radian),
             get_converter(unit_dc, radian),
             get_converter(unit_pr, radian / year),
@@ -256,7 +257,7 @@ def helper_atciq(f, unit_rc, unit_dc, unit_pr, unit_pd, unit_px, unit_rv, unit_a
 
 def helper_atciqn(f, unit_rc, unit_dc, unit_pr, unit_pd, unit_px, unit_rv, unit_astrom,
                   unit_b):
-    from astropy.units.si import radian, arcsec, year, km, s
+    from astropy.units.si import arcsec, km, radian, s, year
     return [get_converter(unit_rc, radian),
             get_converter(unit_dc, radian),
             get_converter(unit_pr, radian / year),

--- a/astropy/units/quantity_helper/erfa.py
+++ b/astropy/units/quantity_helper/erfa.py
@@ -10,8 +10,8 @@ from astropy.units.core import UnitsError, UnitTypeError, dimensionless_unscaled
 from astropy.units.structured import StructuredUnit
 
 from . import UFUNC_HELPERS
-from .helpers import (_d, get_converter, helper_invariant, helper_multiplication,
-                      helper_twoarg_invariant)
+from .helpers import (
+    _d, get_converter, helper_invariant, helper_multiplication, helper_twoarg_invariant)
 
 erfa_ufuncs = ('s2c', 's2p', 'c2s', 'p2s', 'pm', 'pdp', 'pxp', 'rxp',
                'cpv', 'p2pv', 'pv2p', 'pv2s', 'pvdpv', 'pvm', 'pvmpv', 'pvppv',

--- a/astropy/units/quantity_helper/function_helpers.py
+++ b/astropy/units/quantity_helper/function_helpers.py
@@ -41,10 +41,9 @@ import operator
 import numpy as np
 from numpy.lib import recfunctions as rfn
 
-from astropy.units.core import (
-    UnitsError, UnitTypeError, dimensionless_unscaled)
-from astropy.utils.compat import NUMPY_LT_1_20, NUMPY_LT_1_23
+from astropy.units.core import UnitsError, UnitTypeError, dimensionless_unscaled
 from astropy.utils import isiterable
+from astropy.utils.compat import NUMPY_LT_1_20, NUMPY_LT_1_23
 
 # In 1.17, overrides are enabled by default, but it is still possible to
 # turn them off using an environment variable.  We use getattr since it

--- a/astropy/units/quantity_helper/helpers.py
+++ b/astropy/units/quantity_helper/helpers.py
@@ -12,11 +12,11 @@ from fractions import Fraction
 
 import numpy as np
 
+from astropy.units.core import (UnitConversionError, UnitsError, UnitTypeError,
+                                dimensionless_unscaled, get_current_unit_registry,
+                                unit_scale_converter)
+
 from . import UFUNC_HELPERS, UNSUPPORTED_UFUNCS
-from astropy.units.core import (
-    UnitsError, UnitConversionError, UnitTypeError,
-    dimensionless_unscaled, get_current_unit_registry,
-    unit_scale_converter)
 
 
 def _d(unit):

--- a/astropy/units/quantity_helper/helpers.py
+++ b/astropy/units/quantity_helper/helpers.py
@@ -12,9 +12,9 @@ from fractions import Fraction
 
 import numpy as np
 
-from astropy.units.core import (UnitConversionError, UnitsError, UnitTypeError,
-                                dimensionless_unscaled, get_current_unit_registry,
-                                unit_scale_converter)
+from astropy.units.core import (
+    UnitConversionError, UnitsError, UnitTypeError, dimensionless_unscaled,
+    get_current_unit_registry, unit_scale_converter)
 
 from . import UFUNC_HELPERS, UNSUPPORTED_UFUNCS
 

--- a/astropy/units/quantity_helper/scipy_special.py
+++ b/astropy/units/quantity_helper/scipy_special.py
@@ -8,12 +8,10 @@ https://docs.scipy.org/doc/scipy/reference/special.html
 import numpy as np
 
 from astropy.units.core import UnitsError, UnitTypeError, dimensionless_unscaled
-from . import UFUNC_HELPERS
-from .helpers import (get_converter,
-                      helper_dimensionless_to_dimensionless,
-                      helper_cbrt,
-                      helper_two_arg_dimensionless)
 
+from . import UFUNC_HELPERS
+from .helpers import (get_converter, helper_cbrt, helper_dimensionless_to_dimensionless,
+                      helper_two_arg_dimensionless)
 
 # ufuncs that require dimensionless input and give dimensionless output.
 dimensionless_to_dimensionless_sps_ufuncs = (
@@ -52,7 +50,7 @@ def helper_degree_to_dimensionless(f, unit):
 
 
 def helper_degree_minute_second_to_radian(f, unit1, unit2, unit3):
-    from astropy.units.si import degree, arcmin, arcsec, radian
+    from astropy.units.si import arcmin, arcsec, degree, radian
     try:
         return [get_converter(unit1, degree),
                 get_converter(unit2, arcmin),

--- a/astropy/units/quantity_helper/scipy_special.py
+++ b/astropy/units/quantity_helper/scipy_special.py
@@ -10,8 +10,8 @@ import numpy as np
 from astropy.units.core import UnitsError, UnitTypeError, dimensionless_unscaled
 
 from . import UFUNC_HELPERS
-from .helpers import (get_converter, helper_cbrt, helper_dimensionless_to_dimensionless,
-                      helper_two_arg_dimensionless)
+from .helpers import (
+    get_converter, helper_cbrt, helper_dimensionless_to_dimensionless, helper_two_arg_dimensionless)
 
 # ufuncs that require dimensionless input and give dimensionless output.
 dimensionless_to_dimensionless_sps_ufuncs = (

--- a/astropy/units/required_by_vounit.py
+++ b/astropy/units/required_by_vounit.py
@@ -16,9 +16,8 @@ _ns = globals()
 
 def _initialize_module():
     # Local imports to avoid polluting top-level namespace
-    from . import cgs
-    from . import astrophys
-    from .core import def_unit, _add_prefixes
+    from . import astrophys, cgs
+    from .core import _add_prefixes, def_unit
 
     _add_prefixes(astrophys.solMass, namespace=_ns, prefixes=True)
     _add_prefixes(astrophys.solRad, namespace=_ns, prefixes=True)
@@ -33,8 +32,9 @@ _initialize_module()
 
 # This generates a docstring for this module that describes all of the
 # standard units defined here.
-from .utils import (generate_unit_summary as _generate_unit_summary,
-                    generate_prefixonly_unit_summary as _generate_prefixonly_unit_summary)
+from .utils import generate_prefixonly_unit_summary as _generate_prefixonly_unit_summary
+from .utils import generate_unit_summary as _generate_unit_summary
+
 if __doc__ is not None:
     __doc__ += _generate_unit_summary(globals())
     __doc__ += _generate_prefixonly_unit_summary(globals())
@@ -48,9 +48,10 @@ def _enable():
     idiom.
     """
     # Local import to avoid cyclical import
-    from .core import add_enabled_units
     # Local import to avoid polluting namespace
     import inspect
+
+    from .core import add_enabled_units
     return add_enabled_units(inspect.getmodule(_enable))
 
 

--- a/astropy/units/si.py
+++ b/astropy/units/si.py
@@ -6,10 +6,11 @@ This package defines the SI units.  They are also available in the
 
 """
 
-from astropy.constants import si as _si
-from .core import UnitBase, Unit, def_unit
-
 import numpy as _numpy
+
+from astropy.constants import si as _si
+
+from .core import Unit, UnitBase, def_unit
 
 _ns = globals()
 
@@ -236,5 +237,6 @@ del def_unit
 # This generates a docstring for this module that describes all of the
 # standard units defined here.
 from .utils import generate_unit_summary as _generate_unit_summary
+
 if __doc__ is not None:
     __doc__ += _generate_unit_summary(globals())

--- a/astropy/units/structured.py
+++ b/astropy/units/structured.py
@@ -9,8 +9,7 @@ import operator
 
 import numpy as np
 
-from .core import Unit, UnitBase, UNITY
-
+from .core import UNITY, Unit, UnitBase
 
 __all__ = ['StructuredUnit']
 

--- a/astropy/units/tests/test_aliases.py
+++ b/astropy/units/tests/test_aliases.py
@@ -5,7 +5,6 @@ import pytest
 
 import astropy.units as u
 
-
 trials = [
     ({"Angstroms": u.AA}, "Angstroms", u.AA),
     ({"counts": u.count}, "counts/s", u.count / u.s),

--- a/astropy/units/tests/test_deprecated.py
+++ b/astropy/units/tests/test_deprecated.py
@@ -7,8 +7,8 @@ because they are required for VOUnit support but are not in common use."""
 
 import pytest
 
-from astropy.units import deprecated, required_by_vounit
 from astropy import units as u
+from astropy.units import deprecated, required_by_vounit
 
 
 def test_emu():

--- a/astropy/units/tests/test_equivalencies.py
+++ b/astropy/units/tests/test_equivalencies.py
@@ -2,16 +2,16 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Separate tests specifically for equivalencies."""
 
+import numpy as np
 # THIRD-PARTY
 import pytest
-import numpy as np
 from numpy.testing import assert_allclose
 
 # LOCAL
-from astropy import units as u
-from astropy.units.equivalencies import Equivalency
 from astropy import constants
+from astropy import units as u
 from astropy.tests.helper import assert_quantity_allclose
+from astropy.units.equivalencies import Equivalency
 from astropy.utils.exceptions import AstropyDeprecationWarning
 
 

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -8,13 +8,13 @@ import warnings
 from contextlib import nullcontext
 from fractions import Fraction
 
-import pytest
 import numpy as np
+import pytest
 from numpy.testing import assert_allclose
 
 from astropy import units as u
 from astropy.constants import si
-from astropy.units import core, dex, UnitsWarning
+from astropy.units import UnitsWarning, core, dex
 from astropy.units import format as u_format
 from astropy.units.utils import is_effectively_unity
 

--- a/astropy/units/tests/test_logarithmic.py
+++ b/astropy/units/tests/test_logarithmic.py
@@ -4,15 +4,16 @@
     Test the Logarithmic Units and Quantities
 """
 
-import pickle
 import itertools
+import pickle
 
-import pytest
 import numpy as np
+import pytest
 from numpy.testing import assert_allclose
 
+from astropy import constants as c
+from astropy import units as u
 from astropy.tests.helper import assert_quantity_allclose
-from astropy import units as u, constants as c
 
 lu_units = [u.dex, u.mag, u.decibel]
 

--- a/astropy/units/tests/test_photometric.py
+++ b/astropy/units/tests/test_photometric.py
@@ -8,9 +8,7 @@ with magnidues are in `test_logarithmic.py`
 """
 
 from astropy.tests.helper import assert_quantity_allclose
-
-from astropy.units import Magnitude, mgy, nmgy, ABflux, STflux, zero_point_flux, Jy
-from astropy.units import erg, cm, s, AA
+from astropy.units import AA, ABflux, Jy, Magnitude, STflux, cm, erg, mgy, nmgy, s, zero_point_flux
 
 
 def test_maggies():

--- a/astropy/units/tests/test_physical.py
+++ b/astropy/units/tests/test_physical.py
@@ -8,10 +8,9 @@ import pickle
 import pytest
 
 from astropy import units as u
-from astropy.units import physical
 from astropy.constants import hbar
+from astropy.units import physical
 from astropy.utils.exceptions import AstropyDeprecationWarning
-
 
 unit_physical_type_pairs = [
     (u.m, "length"),

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -3,21 +3,19 @@
 """Test the Quantity class and related."""
 
 import copy
-import pickle
 import decimal
 import numbers
+import pickle
 from fractions import Fraction
 
-import pytest
 import numpy as np
-from numpy.testing import (assert_allclose, assert_array_equal,
-                           assert_array_almost_equal)
+import pytest
+from numpy.testing import assert_allclose, assert_array_almost_equal, assert_array_equal
 
-from astropy.utils import isiterable, minversion
-from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyWarning
 from astropy import units as u
 from astropy.units.quantity import _UNIT_NOT_INITIALISED
-
+from astropy.utils import isiterable, minversion
+from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyWarning
 
 """ The Quantity class will represent a number + unit + uncertainty """
 
@@ -1408,7 +1406,8 @@ def test_quantity_from_table():
 
 def test_assign_slice_with_quantity_like():
     # Regression tests for gh-5961
-    from astropy.table import Table, Column
+    from astropy.table import Column, Table
+
     # first check directly that we can use a Column to assign to a slice.
     c = Column(np.arange(10.), unit=u.mm)
     q = u.Quantity(c)

--- a/astropy/units/tests/test_quantity_array_methods.py
+++ b/astropy/units/tests/test_quantity_array_methods.py
@@ -2,8 +2,8 @@
 # array methods returns quantities with the right units, or raises exceptions.
 import sys
 
-import pytest
 import numpy as np
+import pytest
 from numpy.testing import assert_array_equal
 
 from astropy import units as u

--- a/astropy/units/tests/test_quantity_decorator.py
+++ b/astropy/units/tests/test_quantity_decorator.py
@@ -6,8 +6,8 @@ import sys
 import typing
 
 # THIRD PARTY
-import pytest
 import numpy as np
+import pytest
 
 # LOCAL
 from astropy import units as u

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -1,19 +1,19 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-import itertools
 import inspect
+import itertools
 
 import numpy as np
 import numpy.lib.recfunctions as rfn
+import pytest
 from numpy.testing import assert_array_equal
 
-import pytest
-
 from astropy import units as u
-from astropy.units.quantity_helper.function_helpers import (
-    ARRAY_FUNCTION_ENABLED, SUBCLASS_SAFE_FUNCTIONS, UNSUPPORTED_FUNCTIONS,
-    FUNCTION_HELPERS, DISPATCHED_FUNCTIONS, IGNORED_FUNCTIONS, TBD_FUNCTIONS)
+from astropy.units.quantity_helper.function_helpers import (ARRAY_FUNCTION_ENABLED,
+                                                            DISPATCHED_FUNCTIONS, FUNCTION_HELPERS,
+                                                            IGNORED_FUNCTIONS,
+                                                            SUBCLASS_SAFE_FUNCTIONS, TBD_FUNCTIONS,
+                                                            UNSUPPORTED_FUNCTIONS)
 from astropy.utils.compat import NUMPY_LT_1_20, NUMPY_LT_1_23
-
 
 needs_array_function = pytest.mark.xfail(
     not ARRAY_FUNCTION_ENABLED,

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -8,11 +8,9 @@ import pytest
 from numpy.testing import assert_array_equal
 
 from astropy import units as u
-from astropy.units.quantity_helper.function_helpers import (ARRAY_FUNCTION_ENABLED,
-                                                            DISPATCHED_FUNCTIONS, FUNCTION_HELPERS,
-                                                            IGNORED_FUNCTIONS,
-                                                            SUBCLASS_SAFE_FUNCTIONS, TBD_FUNCTIONS,
-                                                            UNSUPPORTED_FUNCTIONS)
+from astropy.units.quantity_helper.function_helpers import (
+    ARRAY_FUNCTION_ENABLED, DISPATCHED_FUNCTIONS, FUNCTION_HELPERS, IGNORED_FUNCTIONS,
+    SUBCLASS_SAFE_FUNCTIONS, TBD_FUNCTIONS, UNSUPPORTED_FUNCTIONS)
 from astropy.utils.compat import NUMPY_LT_1_20, NUMPY_LT_1_23
 
 needs_array_function = pytest.mark.xfail(

--- a/astropy/units/tests/test_quantity_typing.py
+++ b/astropy/units/tests/test_quantity_typing.py
@@ -9,7 +9,7 @@ import numpy as np
 import pytest
 
 from astropy import units as u
-from astropy.units._typing import Annotated, HAS_ANNOTATED
+from astropy.units._typing import HAS_ANNOTATED, Annotated
 
 
 @pytest.mark.skipif(sys.version_info < (3, 9), reason="requires py3.9+")

--- a/astropy/units/tests/test_quantity_ufuncs.py
+++ b/astropy/units/tests/test_quantity_ufuncs.py
@@ -5,17 +5,16 @@ import concurrent.futures
 import warnings
 from collections import namedtuple
 
-import pytest
 import numpy as np
-from numpy.testing import assert_allclose
+import pytest
 from erfa import ufunc as erfa_ufunc
+from numpy.testing import assert_allclose
 
 from astropy import units as u
 from astropy.units import quantity_helper as qh
 from astropy.units.quantity_helper.converters import UfuncHelpers
 from astropy.units.quantity_helper.helpers import helper_sqrt
 from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa
-
 
 testcase = namedtuple('testcase', ['f', 'q_in', 'q_out'])
 testexc = namedtuple('testexc', ['f', 'q_in', 'exc', 'msg'])

--- a/astropy/units/tests/test_structured.py
+++ b/astropy/units/tests/test_structured.py
@@ -5,14 +5,14 @@ Test Structured units and quantities.
 """
 import copy
 
-import pytest
 import numpy as np
 import numpy.lib.recfunctions as rfn
+import pytest
 from numpy.testing import assert_array_equal
 
 from astropy import units as u
-from astropy.units import StructuredUnit, Unit, UnitBase, Quantity
-from astropy.tests.helper import pickle_protocol, check_pickling_recovery
+from astropy.tests.helper import check_pickling_recovery, pickle_protocol
+from astropy.units import Quantity, StructuredUnit, Unit, UnitBase
 from astropy.utils.compat import NUMPY_LT_1_21_1
 from astropy.utils.masked import Masked
 

--- a/astropy/units/tests/test_structured_erfa_ufuncs.py
+++ b/astropy/units/tests/test_structured_erfa_ufuncs.py
@@ -3,16 +3,15 @@
 """
 Test Structured units and quantities specifically with the ERFA ufuncs.
 """
-import pytest
-import numpy as np
-from numpy.testing import assert_array_equal
 import erfa
+import numpy as np
+import pytest
 from erfa import ufunc as erfa_ufunc
+from numpy.testing import assert_array_equal
 
 from astropy import units as u
 from astropy.tests.helper import assert_quantity_allclose
 from astropy.utils.introspection import minversion
-
 
 ERFA_LE_2_0_0 = not minversion(erfa, '2.0.0.1')
 

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -4,12 +4,12 @@
 import pickle
 from fractions import Fraction
 
-import pytest
 import numpy as np
+import pytest
 from numpy.testing import assert_allclose
 
-from astropy import units as u
 from astropy import constants as c
+from astropy import units as u
 from astropy.units import utils
 
 
@@ -256,8 +256,8 @@ def test_decompose_bases():
     From issue #576
     """
 
-    from astropy.units import cgs
     from astropy.constants import e
+    from astropy.units import cgs
 
     d = e.esu.unit.decompose(bases=cgs.bases)
     assert d._bases == [u.cm, u.g, u.s]

--- a/astropy/units/tests/test_utils.py
+++ b/astropy/units/tests/test_utils.py
@@ -5,9 +5,9 @@
 """
 import numpy as np
 from numpy import finfo
-from astropy.units.utils import sanitize_scale
-from astropy.units.utils import quantity_asanyarray
+
 from astropy.units.quantity import Quantity
+from astropy.units.utils import quantity_asanyarray, sanitize_scale
 
 _float_finfo = finfo(float)
 

--- a/astropy/units/utils.py
+++ b/astropy/units/utils.py
@@ -13,7 +13,6 @@ from fractions import Fraction
 import numpy as np
 from numpy import finfo
 
-
 _float_finfo = finfo(float)
 # take float here to ensure comparison with another float is fast
 # give a little margin since often multiple calculations happened

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,6 @@ write_to = "astropy/_version.py"
         "astropy/time/*",
         "astropy/timeseries/*",
         "astropy/uncertainty/*",
-        "astropy/units/*",
         "astropy/utils/*",
         "astropy/visualization/*",
         "astropy/wcs/*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ write_to = "astropy/_version.py"
     line_length = 100
     known_third_party = ["erfa", "PyYAML", "packaging", "pytest", "scipy", "matplotlib"]
     known_first_party = ["astropy"]
-    multi_line_output = 0
+    multi_line_output = 4
     group_by_package = true
     indented_import_headings = false
 


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

### Description

Module units is not not ignored by ``isort``. 
``tox -e codestyle`` is all that's needed to both check and fix import order, unless you have a circular dependency, in which case this will probably make you need to add an ``isort: skip`` flag, making it very obvious that shenanigans are afoot. Win, win?


### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
