### PR TITLE
TST: Test against dev infrastructure weekly, add scipy dev to devdeps

### DIFF
--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -43,7 +43,12 @@ jobs:
           # that gives too many false positives due to URL timeouts. We also
           # install all dependencies via pip here so we pick up the latest
           # releases.
-          - name: Python 3.10 with dev version of key and infrastructure dependencies
+          - name: Python 3.10 with dev version of key dependencies
+            os: ubuntu-latest
+            python: '3.10'
+            toxenv: py310-test-devdeps
+
+          - name: Python 3.10 with dev version of infrastructure dependencies
             os: ubuntu-latest
             python: '3.10'
             toxenv: py310-test-devinfra

--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -43,10 +43,10 @@ jobs:
           # that gives too many false positives due to URL timeouts. We also
           # install all dependencies via pip here so we pick up the latest
           # releases.
-          - name: Python 3.10 with dev version of key dependencies
+          - name: Python 3.10 with dev version of key and infrastructure dependencies
             os: ubuntu-latest
             python: '3.10'
-            toxenv: py310-test-devdeps
+            toxenv: py310-test-devinfra
 
           - name: Documentation link check
             os: ubuntu-latest

--- a/tox.ini
+++ b/tox.ini
@@ -111,6 +111,7 @@ extras =
 
 commands =
     devdeps: pip install -U --pre --only-binary :all: -i https://pypi.anaconda.org/scipy-wheels-nightly/simple numpy
+    devdeps: pip install -U --pre --only-binary :all: -i https://pypi.anaconda.org/scipy-wheels-nightly/simple scipy
     pip freeze
     !cov-!double: pytest --pyargs astropy {toxinidir}/docs {env:MPLFLAGS} {posargs}
     cov-!double: pytest --pyargs astropy {toxinidir}/docs {env:MPLFLAGS} --cov astropy --cov-config={toxinidir}/pyproject.toml {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{38,39,310,dev}-test{,-image,-recdeps,-alldeps,-oldestdeps,-devdeps,-predeps,-numpy118,-numpy119,-numpy120,-numpy121,-mpl311}{,-cov}{,-clocale}
+    py{38,39,310,dev}-test{,-image,-recdeps,-alldeps,-oldestdeps,-devdeps,-devinfra,-predeps,-numpy118,-numpy119,-numpy120,-numpy121,-mpl311}{,-cov}{,-clocale}
     build_docs
     linkcheck
     codestyle
@@ -46,6 +46,7 @@ description =
     recdeps: with recommended optional dependencies
     alldeps: with all optional and test dependencies
     devdeps: with the latest developer version of key dependencies
+    devinfra: like devdeps but also dev version of infrastructure
     oldestdeps: with the oldest supported version of key dependencies
     cov: and test coverage
     numpy118: with numpy 1.18.*
@@ -89,6 +90,17 @@ deps =
     devdeps,mpldev: git+https://github.com/matplotlib/matplotlib.git#egg=matplotlib
     devdeps: git+https://github.com/asdf-format/asdf.git#egg=asdf
     devdeps: git+https://github.com/liberfa/pyerfa.git#egg=pyerfa
+
+    # Latest developer version of infrastructure packages.
+    devinfra: git+https://github.com/astropy/extension-helpers.git
+    devinfra: git+https://github.com/astropy/pytest-doctestplus.git
+    devinfra: git+https://github.com/astropy/pytest-remotedata.git
+    devinfra: git+https://github.com/astropy/pytest-openfiles.git
+    devinfra: git+https://github.com/astropy/pytest-astropy-header.git
+    devinfra: git+https://github.com/astropy/pytest-arraydiff.git
+    devinfra: git+https://github.com/astropy/pytest-filter-subpackage.git
+    devinfra: git+https://github.com/matplotlib/pytest-mpl.git
+    devinfra: git+https://github.com/astropy/pytest-astropy.git
 
 # The following indicates which extras_require from setup.cfg will be installed
 extras =


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to test against dev versions of infrastructure packages as discussed in https://github.com/astropy/astropy/pull/12853#issuecomment-1039663585 . I try to cover the usual suspects that we can control.

Pro: We catch breakage from our infrastructure packages before they are released. Given that most of them are low-traffic, weekly should be enough without affecting PR CI jobs.

Con: We won't catch breakage soon enough. Someone needs to check the cron jobs weekly (who is going to check it when I am away?).

Out of scope:

* Dev Sphinx stuff for doc build.
* Include dev version of every possible thing we use in a test job.

- [x] Check the logs carefully to make sure intended versions are actually installed.

### devinfra (this PR, weekly)

Numpy: 1.23.0
Scipy: not available
Matplotlib: 3.5.2
h5py: not available
Pandas: not available
PyERFA: 2.0.0.1
Cython: not available
Scikit-image: not available
asdf: not available
pyarrow: not available

Using Astropy options: remote_data: none.

plugins: doctestplus-0.12.1.dev3+g64d38f2, mock-3.8.1, astropy-0.10.1.dev3+gf64de38, forked-1.4.0, openfiles-0.5.1.dev18+g2bc5b0f, mpl-0.16.1.dev3+g48e652f, cov-3.0.0, xdist-2.5.0, arraydiff-0.5.1.dev13+ga74f2e3, astropy-header-0.2.2.dev10+gf57bdc8, hypothesis-6.46.7, remotedata-0.3.4.dev2+g3e82525, filter-subpackage-0.1.2.dev11+gaacb510

### devdeps (weekly)

Numpy: 1.24.0.dev0+427.gf9bed20bf
Scipy: 1.10.0.dev0+0.df3fe4e
Matplotlib: 3.6.0.dev2618+g9fb42c9d5
h5py: not available
Pandas: not available
PyERFA: 2.0.0.2.dev7+gc23e4df
Cython: not available
Scikit-image: not available
asdf: 2.12.1.dev58+ge0a6081
pyarrow: not available

Using Astropy options: remote_data: none.

plugins: asdf-2.12.1.dev58+ge0a6081, mock-3.8.1, forked-1.4.0, astropy-header-0.2.1, cov-3.0.0, xdist-2.5.0, openfiles-0.5.0, arraydiff-0.5.0, filter-subpackage-0.1.1, hypothesis-6.46.7, astropy-0.10.0, doctestplus-0.12.0, remotedata-0.3.3

### devdeps (usual CI)

Numpy: 1.24.0.dev0+427.gf9bed20bf
Scipy: 1.10.0.dev0+0.df3fe4e
Matplotlib: 3.6.0.dev2618+g9fb42c9d5
h5py: not available
Pandas: not available
PyERFA: 2.0.0.2.dev7+gc23e4df
Cython: not available
Scikit-image: not available
asdf: 2.12.1.dev58+ge0a6081
pyarrow: not available

Using Astropy options: remote_data: any.

plugins: asdf-2.12.1.dev58+ge0a6081, mock-3.8.1, forked-1.4.0, astropy-header-0.2.1, cov-3.0.0, xdist-2.5.0, openfiles-0.5.0, arraydiff-0.5.0, filter-subpackage-0.1.1, hypothesis-6.46.7, astropy-0.10.0, doctestplus-0.12.0, remotedata-0.3.3

### alldeps (usual CI)

Numpy: 1.23.0
Scipy: 1.8.1
Matplotlib: 3.5.1
h5py: 3.7.0
Pandas: 1.4.3
PyERFA: 2.0.0.1
Cython: not available
Scikit-image: not available
asdf: 2.12.0
pyarrow: 8.0.0

Using Astropy options: remote_data: none.

plugins: mock-3.8.1, forked-1.4.0, astropy-header-0.2.1, cov-3.0.0, xdist-2.5.0, arraydiff-0.5.0, filter-subpackage-0.1.1, hypothesis-6.46.7, astropy-0.10.0, doctestplus-0.12.0, remotedata-0.3.3, asdf-2.12.0, openfiles-0.4.0

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
