### PR TITLE
flake8 cosmology

### DIFF
--- a/astropy/cosmology/__init__.py
+++ b/astropy/cosmology/__init__.py
@@ -10,7 +10,7 @@ detailed usage examples and references.
 
 from . import core, flrw, funcs, parameter, units, utils  # noqa F401
 
-from . import io  # needed before 'realizations'  # isort: split
+from . import io  # needed before 'realizations'  # noqa: F401  # isort: split
 from . import realizations
 from .core import *  # noqa F401, F403
 from .flrw import *  # noqa F401, F403

--- a/astropy/cosmology/connect.py
+++ b/astropy/cosmology/connect.py
@@ -237,5 +237,4 @@ class CosmologyToFormat(io_registry.UnifiedReadWrite):
         super().__init__(instance, cls, "write", registry=convert_registry)
 
     def __call__(self, format, *args, **kwargs):
-        return self.registry.write(self._instance, None, *args, format=format,
-                                    **kwargs)
+        return self.registry.write(self._instance, None, *args, format=format, **kwargs)

--- a/astropy/cosmology/flrw/tests/conftest.py
+++ b/astropy/cosmology/flrw/tests/conftest.py
@@ -2,5 +2,5 @@
 
 """Configure the tests for :mod:`astropy.cosmology`."""
 
-from astropy.cosmology.tests.helper import clean_registry
-from astropy.tests.helper import pickle_protocol
+from astropy.cosmology.tests.helper import clean_registry  # noqa: F401, F403
+from astropy.tests.helper import pickle_protocol  # noqa: F401, F403

--- a/astropy/cosmology/flrw/tests/test_init.py
+++ b/astropy/cosmology/flrw/tests/test_init.py
@@ -39,4 +39,4 @@ def test_deprecated_private_variables(attr):
 def test_getattr_error_attr_not_found():
     """Test getattr raises error for DNE."""
     with pytest.raises(ImportError):
-        from astropy.cosmology.flrw import this_is_not_a_variable
+        from astropy.cosmology.flrw import this_is_not_a_variable  # noqa: F401

--- a/astropy/cosmology/flrw/tests/test_lambdacdm.py
+++ b/astropy/cosmology/flrw/tests/test_lambdacdm.py
@@ -49,8 +49,9 @@ class TestLambdaCDM(FLRWSubclassTest):
     # ===============================================================
     # Method & Attribute Tests
 
-    _FLRW_redshift_methods = (get_redshift_methods(LambdaCDM, include_private=True, include_z2=False)
-                              - {"_dS_age"})
+    _FLRW_redshift_methods = (
+        get_redshift_methods(LambdaCDM, include_private=True, include_z2=False)
+        - {"_dS_age"})
     # `_dS_age` is removed because it doesn't strictly rely on the value of `z`,
     # so any input that doesn't trip up ``np.shape`` is "valid"
 

--- a/astropy/cosmology/funcs.py
+++ b/astropy/cosmology/funcs.py
@@ -19,7 +19,7 @@ __doctest_requires__ = {'*': ['scipy']}
 
 
 def _z_at_scalar_value(func, fval, zmin=1e-8, zmax=1000, ztol=1e-8, maxfun=500,
-                      method='Brent', bracket=None, verbose=False):
+                       method='Brent', bracket=None, verbose=False):
     """
     Find the redshift ``z`` at which ``func(z) = fval``.
     See :func:`astropy.cosmology.funcs.z_at_value`.
@@ -348,10 +348,10 @@ def z_at_value(func, fval, zmin=1e-8, zmax=1000, ztol=1e-8, maxfun=500,
     # make multi-dimensional iterator for all but `method`, `verbose`
     with np.nditer(
         [fval, zmin, zmax, ztol, maxfun, bracket, None],
-        flags = ['refs_ok'],
-        op_flags = [*[['readonly']] * 6,  # ← inputs  output ↓
-                    ['writeonly', 'allocate', 'no_subtype']],
-        op_dtypes = (*(None,)*6, fval.dtype),
+        flags=['refs_ok'],
+        op_flags=[*[['readonly']] * 6,  # ← inputs  output ↓
+                  ['writeonly', 'allocate', 'no_subtype']],
+        op_dtypes=(*(None,)*6, fval.dtype),
         casting="no",
     ) as it:
         for fv, zmn, zmx, zt, mfe, bkt, zs in it:  # ← eltwise unpack & eval ↓

--- a/astropy/cosmology/io/__init__.py
+++ b/astropy/cosmology/io/__init__.py
@@ -6,4 +6,4 @@ Read/Write/Interchange methods for `astropy.cosmology`. **NOT public API**.
 """
 
 # Import to register with the I/O machinery
-from . import cosmology, ecsv, mapping, model, row, table, yaml  # noqa: F403
+from . import cosmology, ecsv, mapping, model, row, table, yaml  # noqa: F401, F403

--- a/astropy/cosmology/io/tests/test_json.py
+++ b/astropy/cosmology/io/tests/test_json.py
@@ -127,9 +127,9 @@ class ReadWriteJSONTestMixin(ReadWriteTestMixinBase):
         # partial information
         with open(fp, "r") as file:
             L = file.readlines()[0]
-        L = L[: L.index('"cosmology":')] + L[L.index(", ") + 2 :]  # remove cosmology
+        L = L[: L.index('"cosmology":')] + L[L.index(", ") + 2 :]  # remove cosmology  # noqa: #203
         i = L.index('"Tcmb0":')  # delete Tcmb0
-        L = L[:i] + L[L.index(", ", L.index(", ", i) + 1) + 2 :]  # second occurence
+        L = L[:i] + L[L.index(", ", L.index(", ", i) + 1) + 2 :]  # second occurence  # noqa: #203
 
         tempfname = tmp_path / f"{cosmo.name}_temp.json"
         with open(tempfname, "w") as file:

--- a/astropy/cosmology/io/tests/test_yaml.py
+++ b/astropy/cosmology/io/tests/test_yaml.py
@@ -98,7 +98,7 @@ class ToFromYAMLTestMixin(ToFromTestMixinBase):
         # see test_from_yaml_autoidentify
 
     def test_from_yaml_autoidentify(self, cosmo, to_format, from_format,
-                                      xfail_if_not_registered_with_yaml):
+                                    xfail_if_not_registered_with_yaml):
         """As a non-path string, it does NOT auto-identifies 'format'.
 
         TODO! this says there should be different types of I/O registries.

--- a/astropy/cosmology/parameters.py
+++ b/astropy/cosmology/parameters.py
@@ -44,7 +44,8 @@ WMAP 5 year (WMAP5) parameters from Komatsu et al. 2009, ApJS, 180, 330,
 doi: 10.1088/0067-0049/180/2/330. Table 1 (WMAP + BAO + SN ML).
 
 WMAP 3 year (WMAP3) parameters from Spergel et al. 2007, ApJS, 170, 377,
-doi:  10.1086/513700. Table 6. (WMAP + SNGold) Obtained from https://lambda.gsfc.nasa.gov/product/map/dr2/params/lcdm_wmap_sngold.cfm
+doi:  10.1086/513700. Table 6. (WMAP + SNGold) Obtained from
+https://lambda.gsfc.nasa.gov/product/map/dr2/params/lcdm_wmap_sngold.cfm
 Tcmb0 and Neff are the standard values as also used for WMAP5, 7, 9.
 Pending WMAP team approval and subject to change.
 

--- a/astropy/cosmology/tests/conftest.py
+++ b/astropy/cosmology/tests/conftest.py
@@ -2,5 +2,5 @@
 
 """Configure the tests for :mod:`astropy.cosmology`."""
 
-from astropy.cosmology.tests.helper import clean_registry
-from astropy.tests.helper import pickle_protocol
+from astropy.cosmology.tests.helper import clean_registry  # noqa: F401, F403
+from astropy.tests.helper import pickle_protocol  # noqa: F401, F403

--- a/astropy/cosmology/tests/test_connect.py
+++ b/astropy/cosmology/tests/test_connect.py
@@ -8,7 +8,6 @@ import pytest
 from astropy import cosmology
 from astropy.cosmology import Cosmology, w0wzCDM
 from astropy.cosmology.connect import readwrite_registry
-from astropy.cosmology.core import Cosmology
 from astropy.cosmology.io.tests import (test_cosmology, test_ecsv, test_json, test_mapping,
                                         test_model, test_row, test_table, test_yaml)
 from astropy.table import QTable, Row

--- a/astropy/cosmology/tests/test_core.py
+++ b/astropy/cosmology/tests/test_core.py
@@ -247,7 +247,7 @@ class TestCosmology(ParameterTestMixin, MetaTestMixin,
     def test_clone_fail_unexpected_arg(self, cosmo):
         """Test when ``.clone()`` gets an unexpected argument."""
         with pytest.raises(TypeError, match="unexpected keyword argument"):
-            newclone = cosmo.clone(not_an_arg=4)
+            cosmo.clone(not_an_arg=4)
 
     def test_clone_fail_positional_arg(self, cosmo):
         with pytest.raises(TypeError, match="1 positional argument"):

--- a/astropy/cosmology/tests/test_cosmology.py
+++ b/astropy/cosmology/tests/test_cosmology.py
@@ -78,7 +78,7 @@ def test_varyde_lumdist_mathematica():
 # TODO! sort and refactor following tests.
 # overall systems tests stay here, specific tests go to new test suite.
 
-@pytest.mark.skipif('not HAS_SCIPY')
+@pytest.mark.skipif(not HAS_SCIPY, reason="test requires scipy")
 def test_units():
     """ Test if the right units are being returned"""
 
@@ -107,7 +107,7 @@ def test_units():
     assert cosmo.distmod(1.0).unit == u.mag
 
 
-@pytest.mark.skipif('not HAS_SCIPY')
+@pytest.mark.skipif(not HAS_SCIPY, reason="test requires scipy")
 def test_distance_broadcast():
     """ Test array shape broadcasting for functions with single
     redshift inputs"""
@@ -213,7 +213,7 @@ class test_cos_subnu(flrw.FLRW):
         return self._w0 * np.ones_like(z)
 
 
-@pytest.mark.skipif('not HAS_SCIPY')
+@pytest.mark.skipif(not HAS_SCIPY, reason="test requires scipy")
 def test_de_subclass():
     # This is the comparison object
     z = [0.2, 0.4, 0.6, 0.9]
@@ -239,7 +239,7 @@ def test_de_subclass():
     # Add neutrinos for efunc, inv_efunc
 
 
-@pytest.mark.skipif('not HAS_SCIPY')
+@pytest.mark.skipif(not HAS_SCIPY, reason="test requires scipy")
 def test_matter():
     # Test non-relativistic matter evolution
     tcos = flrw.FlatLambdaCDM(70.0, 0.3, Ob0=0.045)
@@ -259,7 +259,7 @@ def test_matter():
     assert allclose(tcos.Ob(z) + tcos.Odm(z), tcos.Om(z))
 
 
-@pytest.mark.skipif('not HAS_SCIPY')
+@pytest.mark.skipif(not HAS_SCIPY, reason="test requires scipy")
 def test_ocurv():
     # Test Ok evolution
     # Flat, boring case
@@ -282,7 +282,7 @@ def test_ocurv():
                     [1.0, 1.0, 1.0, 1.0], rtol=1e-5)
 
 
-@pytest.mark.skipif('not HAS_SCIPY')
+@pytest.mark.skipif(not HAS_SCIPY, reason="test requires scipy")
 def test_ode():
     # Test Ode evolution, turn off neutrinos, cmb
     tcos = flrw.FlatLambdaCDM(70.0, 0.3, Tcmb0=0)
@@ -293,7 +293,7 @@ def test_ode():
                     rtol=1e-5)
 
 
-@pytest.mark.skipif('not HAS_SCIPY')
+@pytest.mark.skipif(not HAS_SCIPY, reason="test requires scipy")
 def test_ogamma():
     """Tests the effects of changing the temperature of the CMB"""
 
@@ -360,7 +360,7 @@ def test_ogamma():
     assert allclose(cosmo.comoving_distance(z), targvals, rtol=1e-5)
 
 
-@pytest.mark.skipif('not HAS_SCIPY')
+@pytest.mark.skipif(not HAS_SCIPY, reason="test requires scipy")
 def test_tcmb():
     cosmo = flrw.FlatLambdaCDM(70.4, 0.272, Tcmb0=2.5)
     assert allclose(cosmo.Tcmb0, 2.5 * u.K)
@@ -374,7 +374,7 @@ def test_tcmb():
                     [2.5, 5.0, 7.5, 10.0, 25.0] * u.K, rtol=1e-6)
 
 
-@pytest.mark.skipif('not HAS_SCIPY')
+@pytest.mark.skipif(not HAS_SCIPY, reason="test requires scipy")
 def test_tnu():
     cosmo = flrw.FlatLambdaCDM(70.4, 0.272, Tcmb0=3.0)
     assert allclose(cosmo.Tnu0, 2.1412975665108247 * u.K, rtol=1e-6)
@@ -388,7 +388,7 @@ def test_tnu():
     assert allclose(cosmo.Tnu(z), expected, rtol=1e-6)
 
 
-@pytest.mark.skipif('not HAS_SCIPY')
+@pytest.mark.skipif(not HAS_SCIPY, reason="test requires scipy")
 def test_efunc_vs_invefunc_flrw():
     """ Test that efunc and inv_efunc give inverse values"""
     z0 = 0.5
@@ -406,20 +406,20 @@ def test_efunc_vs_invefunc_flrw():
     assert allclose(cosmo.efunc(z), 1.0 / cosmo.inv_efunc(z))
 
 
-@pytest.mark.skipif('not HAS_SCIPY')
+@pytest.mark.skipif(not HAS_SCIPY, reason="test requires scipy")
 def test_kpc_methods():
     cosmo = flrw.FlatLambdaCDM(70.4, 0.272, Tcmb0=0.0)
     assert allclose(cosmo.arcsec_per_kpc_comoving(3),
-                             0.0317179167 * u.arcsec / u.kpc)
+                    0.0317179167 * u.arcsec / u.kpc)
     assert allclose(cosmo.arcsec_per_kpc_proper(3),
-                             0.1268716668 * u.arcsec / u.kpc)
+                    0.1268716668 * u.arcsec / u.kpc)
     assert allclose(cosmo.kpc_comoving_per_arcmin(3),
-                             1891.6753126 * u.kpc / u.arcmin)
+                    1891.6753126 * u.kpc / u.arcmin)
     assert allclose(cosmo.kpc_proper_per_arcmin(3),
-                             472.918828 * u.kpc / u.arcmin)
+                    472.918828 * u.kpc / u.arcmin)
 
 
-@pytest.mark.skipif('not HAS_SCIPY')
+@pytest.mark.skipif(not HAS_SCIPY, reason="test requires scipy")
 def test_comoving_volume():
 
     c_flat = flrw.LambdaCDM(H0=70, Om0=0.27, Ode0=0.73, Tcmb0=0.0)
@@ -437,14 +437,14 @@ def test_comoving_volume():
     # The wright calculator isn't very accurate, so we use a rather
     # modest precision
     assert allclose(c_flat.comoving_volume(redshifts), wright_flat,
-                             rtol=1e-2)
+                    rtol=1e-2)
     assert allclose(c_open.comoving_volume(redshifts),
-                             wright_open, rtol=1e-2)
+                    wright_open, rtol=1e-2)
     assert allclose(c_closed.comoving_volume(redshifts),
-                             wright_closed, rtol=1e-2)
+                    wright_closed, rtol=1e-2)
 
 
-@pytest.mark.skipif('not HAS_SCIPY')
+@pytest.mark.skipif(not HAS_SCIPY, reason="test requires scipy")
 def test_differential_comoving_volume():
     from scipy.integrate import quad
 
@@ -463,9 +463,9 @@ def test_differential_comoving_volume():
                               358.992]) * u.Gpc**3
     # The wright calculator isn't very accurate, so we use a rather
     # modest precision.
-    ftemp = lambda x: c_flat.differential_comoving_volume(x).value
-    otemp = lambda x: c_open.differential_comoving_volume(x).value
-    ctemp = lambda x: c_closed.differential_comoving_volume(x).value
+    def ftemp(x): return c_flat.differential_comoving_volume(x).value
+    def otemp(x): return c_open.differential_comoving_volume(x).value
+    def ctemp(x): return c_closed.differential_comoving_volume(x).value
     # Multiply by solid_angle (4 * pi)
     assert allclose(np.array([4.0 * np.pi * quad(ftemp, 0, redshift)[0]
                               for redshift in redshifts]) * u.Mpc**3,
@@ -478,7 +478,7 @@ def test_differential_comoving_volume():
                     wright_closed, rtol=1e-2)
 
 
-@pytest.mark.skipif('not HAS_SCIPY')
+@pytest.mark.skipif(not HAS_SCIPY, reason="test requires scipy")
 def test_flat_open_closed_icosmo():
     """ Test against the tabulated values generated from icosmo.org
     with three example cosmologies (flat, open and closed).
@@ -617,7 +617,7 @@ def test_flat_open_closed_icosmo():
     assert allclose(cosmo.luminosity_distance(redshifts), dl)
 
 
-@pytest.mark.skipif('not HAS_SCIPY')
+@pytest.mark.skipif(not HAS_SCIPY, reason="test requires scipy")
 def test_integral():
     # Test integer vs. floating point inputs
     cosmo = flrw.LambdaCDM(H0=73.2, Om0=0.3, Ode0=0.50)
@@ -633,7 +633,7 @@ def test_integral():
                     cosmo.inv_efunc([1.0, 2.0, 6.0]), rtol=1e-7)
 
 
-@pytest.mark.skipif('not HAS_SCIPY')
+@pytest.mark.skipif(not HAS_SCIPY, reason="test requires scipy")
 def test_de_densityscale():
     cosmo = flrw.LambdaCDM(H0=70, Om0=0.3, Ode0=0.70)
     z = np.array([0.1, 0.2, 0.5, 1.5, 2.5])
@@ -641,9 +641,9 @@ def test_de_densityscale():
                     [1.0, 1.0, 1.0, 1.0, 1.0])
     # Integer check
     assert allclose(cosmo.de_density_scale(3),
-                       cosmo.de_density_scale(3.0), rtol=1e-7)
+                    cosmo.de_density_scale(3.0), rtol=1e-7)
     assert allclose(cosmo.de_density_scale([1, 2, 3]),
-                       cosmo.de_density_scale([1., 2., 3.]), rtol=1e-7)
+                    cosmo.de_density_scale([1., 2., 3.]), rtol=1e-7)
 
     cosmo = flrw.wCDM(H0=70, Om0=0.3, Ode0=0.60, w0=-0.5)
     assert allclose(cosmo.de_density_scale(z),
@@ -668,9 +668,9 @@ def test_de_densityscale():
                     [0.9934201, 0.9767912, 0.897450,
                      0.622236, 0.4458753], rtol=1e-4)
     assert allclose(cosmo.de_density_scale(3),
-                       cosmo.de_density_scale(3.0), rtol=1e-7)
+                    cosmo.de_density_scale(3.0), rtol=1e-7)
     assert allclose(cosmo.de_density_scale([1, 2, 3]),
-                       cosmo.de_density_scale([1., 2., 3.]), rtol=1e-7)
+                    cosmo.de_density_scale([1., 2., 3.]), rtol=1e-7)
 
     cosmo = flrw.wpwaCDM(H0=70, Om0=0.3, Ode0=0.70, wp=-0.9,
                          wa=0.2, zp=0.5)
@@ -683,7 +683,7 @@ def test_de_densityscale():
                     cosmo.de_density_scale([1., 2., 3.]), rtol=1e-7)
 
 
-@pytest.mark.skipif('not HAS_SCIPY')
+@pytest.mark.skipif(not HAS_SCIPY, reason="test requires scipy")
 def test_age():
     # WMAP7 but with Omega_relativisitic = 0
     tcos = flrw.FlatLambdaCDM(70.4, 0.272, Tcmb0=0.0)
@@ -705,7 +705,7 @@ def test_age():
     assert allclose(tcos.age([1, 5]), [5.88448152, 1.18383759] * u.Gyr)
 
 
-@pytest.mark.skipif('not HAS_SCIPY')
+@pytest.mark.skipif(not HAS_SCIPY, reason="test requires scipy")
 def test_distmod():
     # WMAP7 but with Omega_relativisitic = 0
     tcos = flrw.FlatLambdaCDM(70.4, 0.272, Tcmb0=0.0)
@@ -716,7 +716,7 @@ def test_distmod():
                     [44.124857, 48.40167258] * u.mag)
 
 
-@pytest.mark.skipif('not HAS_SCIPY')
+@pytest.mark.skipif(not HAS_SCIPY, reason="test requires scipy")
 def test_neg_distmod():
     # Cosmology with negative luminosity distances (perfectly okay,
     #  if obscure)
@@ -727,7 +727,7 @@ def test_neg_distmod():
                     [46.102167189, 48.355437790944] * u.mag)
 
 
-@pytest.mark.skipif('not HAS_SCIPY')
+@pytest.mark.skipif(not HAS_SCIPY, reason="test requires scipy")
 def test_critical_density():
     from astropy.constants import codata2014
 
@@ -749,7 +749,7 @@ def test_critical_density():
         [2.70352772e-29, 5.53739080e-28] * (u.g / u.cm**3))
 
 
-@pytest.mark.skipif('not HAS_SCIPY')
+@pytest.mark.skipif(not HAS_SCIPY, reason="test requires scipy")
 def test_comoving_distance_z1z2():
     tcos = flrw.LambdaCDM(100, 0.3, 0.8, Tcmb0=0.0)
     with pytest.raises(ValueError):  # test diff size z1, z2 fail
@@ -770,7 +770,7 @@ def test_comoving_distance_z1z2():
                     results)
 
 
-@pytest.mark.skipif('not HAS_SCIPY')
+@pytest.mark.skipif(not HAS_SCIPY, reason="test requires scipy")
 def test_age_in_special_cosmologies():
     """Check that age in de Sitter and Einstein-de Sitter Universes work.
 
@@ -789,7 +789,7 @@ def test_age_in_special_cosmologies():
     assert allclose(c_EdS.lookback_time(z=1), 4.213936442699092 * u.Gyr)
 
 
-@pytest.mark.skipif('not HAS_SCIPY')
+@pytest.mark.skipif(not HAS_SCIPY, reason="test requires scipy")
 def test_distance_in_special_cosmologies():
     """Check that de Sitter and Einstein-de Sitter Universes both work.
 
@@ -812,7 +812,7 @@ def test_distance_in_special_cosmologies():
     assert allclose(c_EdS.comoving_distance(z=1), 1756.1435599923348 * u.Mpc)
 
 
-@pytest.mark.skipif('not HAS_SCIPY')
+@pytest.mark.skipif(not HAS_SCIPY, reason="test requires scipy")
 def test_comoving_transverse_distance_z1z2():
     tcos = flrw.FlatLambdaCDM(100, 0.3, Tcmb0=0.0)
     with pytest.raises(ValueError):  # test diff size z1, z2 fail
@@ -837,7 +837,7 @@ def test_comoving_transverse_distance_z1z2():
                1559.51679971,
                -643.21002593,
                1408.36365679,
-                 85.09286258) * u.Mpc
+               85.09286258) * u.Mpc
 
     assert allclose(tcos._comoving_transverse_distance_z1z2(z1, z2),
                     results)
@@ -876,7 +876,7 @@ def test_comoving_transverse_distance_z1z2():
                     results)
 
 
-@pytest.mark.skipif('not HAS_SCIPY')
+@pytest.mark.skipif(not HAS_SCIPY, reason="test requires scipy")
 def test_angular_diameter_distance_z1z2():
     tcos = flrw.FlatLambdaCDM(70.4, 0.272, Tcmb0=0.0)
     with pytest.raises(ValueError):  # test diff size z1, z2 fail
@@ -921,7 +921,7 @@ def test_angular_diameter_distance_z1z2():
                     228.42914659246014 * u.Mpc)
 
 
-@pytest.mark.skipif('not HAS_SCIPY')
+@pytest.mark.skipif(not HAS_SCIPY, reason="test requires scipy")
 def test_absorption_distance():
     tcos = flrw.FlatLambdaCDM(70.4, 0.272, Tcmb0=0.0)
     assert allclose(tcos.absorption_distance([1, 3]),
@@ -932,7 +932,7 @@ def test_absorption_distance():
     assert allclose(tcos.absorption_distance(3.), 7.98685853)
 
 
-@pytest.mark.skipif('not HAS_SCIPY')
+@pytest.mark.skipif(not HAS_SCIPY, reason="test requires scipy")
 def test_distances():
     # Test distance calculations for various special case
     #  scenarios (no relativistic species, normal, massive neutrinos)
@@ -964,12 +964,12 @@ def test_distances():
                     [3180.83488552, 5060.82054204, 6253.6721173,
                      7083.5374303] * u.Mpc, rtol=1e-4)
     cos = flrw.FlatLambdaCDM(75.0, 0.25, Tcmb0=3.0, Neff=3,
-                              m_nu=u.Quantity(0.0, u.eV))
+                             m_nu=u.Quantity(0.0, u.eV))
     assert allclose(cos.comoving_distance(z),
                     [3180.42662867, 5059.60529655, 6251.62766102,
                      7080.71698117] * u.Mpc, rtol=1e-4)
     cos = flrw.FlatLambdaCDM(75.0, 0.25, Tcmb0=3.0, Neff=3,
-                              m_nu=u.Quantity(10.0, u.eV))
+                             m_nu=u.Quantity(10.0, u.eV))
     assert allclose(cos.comoving_distance(z),
                     [2337.54183142, 3371.91131264, 3988.40711188,
                      4409.09346922] * u.Mpc, rtol=1e-4)
@@ -979,12 +979,12 @@ def test_distances():
                     [3216.8296894, 5117.2097601, 6317.05995437,
                      7149.68648536] * u.Mpc, rtol=1e-4)
     cos = flrw.FlatwCDM(75.0, 0.25, w0=-0.95, Tcmb0=3.0, Neff=3,
-                    m_nu=u.Quantity(0.0, u.eV))
+                        m_nu=u.Quantity(0.0, u.eV))
     assert allclose(cos.comoving_distance(z),
                     [3143.56537758, 5000.32196494, 6184.11444601,
                      7009.80166062] * u.Mpc, rtol=1e-4)
     cos = flrw.FlatwCDM(75.0, 0.25, w0=-0.9, Tcmb0=3.0, Neff=3,
-                    m_nu=u.Quantity(10.0, u.eV))
+                        m_nu=u.Quantity(10.0, u.eV))
     assert allclose(cos.comoving_distance(z),
                     [2337.76035371, 3372.1971387, 3988.71362289,
                      4409.40817174] * u.Mpc, rtol=1e-4)
@@ -1090,7 +1090,7 @@ def test_distances():
                      4901.96669755] * u.Mpc, rtol=1e-4)
 
 
-@pytest.mark.skipif('not HAS_SCIPY')
+@pytest.mark.skipif(not HAS_SCIPY, reason="test requires scipy")
 def test_massivenu_density():
     # Testing neutrino density calculation
 
@@ -1117,8 +1117,7 @@ def test_massivenu_density():
                               m_nu=u.Quantity(0.25, u.eV))
     nurel_exp = nuprefac * tcos.Neff * np.array([429.924, 214.964, 143.312,
                                                  39.1005, 1.11086])
-    assert allclose(tcos.nu_relative_density(ztest), nurel_exp,
-                       rtol=5e-3)
+    assert allclose(tcos.nu_relative_density(ztest), nurel_exp, rtol=5e-3)
 
     # For this one also test Onu directly
     onu_exp = np.array([0.01890217, 0.05244681, 0.0638236,
@@ -1144,9 +1143,8 @@ def test_massivenu_density():
     # Now a mixture of neutrino masses, with non-integer Neff
     tcos = flrw.FlatLambdaCDM(80.0, 0.30, Tcmb0=3.0, Neff=3.04,
                               m_nu=u.Quantity([0.0, 0.01, 0.25], u.eV))
-    nurel_exp = nuprefac * tcos.Neff * \
-                np.array([149.386233, 74.87915, 50.0518,
-                          14.002403, 1.03702333])
+    nurel_exp = (nuprefac * tcos.Neff
+                 * np.array([149.386233, 74.87915, 50.0518, 14.002403, 1.03702333]))
     assert allclose(tcos.nu_relative_density(ztest), nurel_exp,
                     rtol=5e-3)
     onu_exp = np.array([0.00584959, 0.01493142, 0.01772291,
@@ -1160,7 +1158,7 @@ def test_massivenu_density():
     assert allclose(tcos.Onu(ztest), onu_exp, rtol=5e-3)
 
 
-@pytest.mark.skipif('not HAS_SCIPY')
+@pytest.mark.skipif(not HAS_SCIPY, reason="test requires scipy")
 def test_elliptic_comoving_distance_z1z2():
     """Regression test for #8388."""
     cosmo = flrw.LambdaCDM(70., 2.3, 0.05, Tcmb0=0)
@@ -1186,7 +1184,7 @@ ITERABLE_REDSHIFTS = [
 ]
 
 
-@pytest.mark.skipif('not HAS_SCIPY')
+@pytest.mark.skipif(not HAS_SCIPY, reason="test requires scipy")
 @pytest.mark.parametrize('cosmo', SPECIALIZED_COMOVING_DISTANCE_COSMOLOGIES)
 @pytest.mark.parametrize('z', ITERABLE_REDSHIFTS)
 def test_comoving_distance_iterable_argument(cosmo, z):
@@ -1199,7 +1197,7 @@ def test_comoving_distance_iterable_argument(cosmo, z):
                     cosmo._integral_comoving_distance_z1z2(0., z))
 
 
-@pytest.mark.skipif('not HAS_SCIPY')
+@pytest.mark.skipif(not HAS_SCIPY, reason="test requires scipy")
 @pytest.mark.parametrize('cosmo', SPECIALIZED_COMOVING_DISTANCE_COSMOLOGIES)
 def test_comoving_distance_broadcast(cosmo):
     """

--- a/astropy/cosmology/tests/test_funcs.py
+++ b/astropy/cosmology/tests/test_funcs.py
@@ -94,7 +94,7 @@ class Test_ZatValue:
             z_at_value(self.cosmo.age, 2 * u.Gyr, bracket=np.array([0, 4]))
 
         # now an object array of brackets
-        bracket=np.array([[0, 4], [0, 3, 4]], dtype=object)
+        bracket = np.array([[0, 4], [0, 3, 4]], dtype=object)
         assert allclose(
             z_at_value(self.cosmo.age, 2 * u.Gyr, bracket=bracket),
             [3.1981206134773115, 3.1981206134773115], rtol=1e-6)

--- a/astropy/cosmology/tests/test_parameter.py
+++ b/astropy/cosmology/tests/test_parameter.py
@@ -193,7 +193,8 @@ class ParameterTestMixin:
         class ExampleBase(cosmo_cls):
             param = Parameter()
 
-        class Example(ExampleBase): pass
+        class Example(ExampleBase):
+            pass
 
         assert Example.param is ExampleBase.param
         assert Example.__parameters__ == ExampleBase.__parameters__
@@ -298,7 +299,7 @@ class TestParameter(ParameterTestMixin):
         assert param._unit == u.m
         assert param._equivalencies == u.mass_energy()
         assert param._fmt == ""
-        assert param._derived == False
+        assert param._derived == np.False_
 
         # custom from set_name
         assert param._attr_name == "param"
@@ -388,10 +389,12 @@ class TestParameter(ParameterTestMixin):
             param.__class__.register_validator("default", None)
 
         # validator not None
+        def notnonefunc(x):
+            return x
+
         try:
-            func = lambda x: x
-            validator = param.__class__.register_validator("newvalidator", func)
-            assert validator is func
+            validator = param.__class__.register_validator("newvalidator", notnonefunc)
+            assert validator is notnonefunc
         finally:
             param.__class__._registry_validators.pop("newvalidator", None)
 
@@ -480,7 +483,8 @@ class TestParameter(ParameterTestMixin):
 
             param = Parameter(doc="example parameter")
 
-        class Example(ExampleBase): pass
+        class Example(ExampleBase):
+            pass
 
         assert Example.param is ExampleBase.param
 
@@ -488,7 +492,8 @@ class TestParameter(ParameterTestMixin):
         """Cosmology reinitializes all descriptors when a subclass is defined."""
 
         # define subclass to show param is same
-        class Example(cosmo_cls): pass
+        class Example(cosmo_cls):
+            pass
 
         assert Example.param is cosmo_cls.param
 

--- a/astropy/cosmology/tests/test_realizations.py
+++ b/astropy/cosmology/tests/test_realizations.py
@@ -42,11 +42,11 @@ class Test_default_cosmology(object):
         """Test bad inputs to :meth:`astropy.cosmology.default_cosmology.get`."""
         # a not-valid option, but still a str
         with pytest.raises(ValueError, match="Unknown cosmology"):
-            cosmo = default_cosmology.get("fail!")
+            default_cosmology.get("fail!")
 
         # a not-valid type
         with pytest.raises(TypeError, match="'key' must be must be"):
-            cosmo = default_cosmology.get(object())
+            default_cosmology.get(object())
 
     def test_get_current(self):
         """Test :meth:`astropy.cosmology.default_cosmology.get` current value."""

--- a/astropy/cosmology/tests/test_units.py
+++ b/astropy/cosmology/tests/test_units.py
@@ -220,9 +220,7 @@ class Test_with_redshift:
 
     def test_temperature_off(self, cosmo):
         """Test ``with_redshift`` with the temperature off."""
-        default_cosmo = default_cosmology.get()
         z = 15 * cu.redshift
-        Tcmb = cosmo.Tcmb(z)
 
         # 1) Default (without specifying the cosmology)
         with default_cosmology.set(cosmo):
@@ -268,9 +266,7 @@ class Test_with_redshift:
     def test_hubble_off(self, cosmo):
         """Test ``with_redshift`` with Hubble off."""
         unit = u.km / u.s / u.Mpc
-        default_cosmo = default_cosmology.get()
         z = 15 * cu.redshift
-        H = cosmo.H(z)
 
         # 1) Default (without specifying the cosmology)
         with default_cosmology.set(cosmo):
@@ -326,7 +322,6 @@ class Test_with_redshift:
 
     def test_distance_off(self, cosmo):
         """Test ``with_redshift`` with the distance off."""
-        default_cosmo = default_cosmology.get()
         z = 15 * cu.redshift
 
         # 1) Default (without specifying the cosmology)

--- a/astropy/cosmology/tests/test_utils.py
+++ b/astropy/cosmology/tests/test_utils.py
@@ -48,7 +48,8 @@ def test_vectorize_if_needed():
     `numpy.vectorize` which thoroughly tests the various inputs.
 
     """
-    func = lambda x: x ** 2
+    def func(x):
+        return x ** 2
 
     with pytest.warns(AstropyDeprecationWarning):
         # not vectorized
@@ -62,7 +63,7 @@ def test_vectorize_if_needed():
                           (1, inf),  # integer scalar should give float output
                           ([0.0, 1.0, 2.0, 3.0], (inf, inf, inf, inf)),
                           ([0, 1, 2, 3], (inf, inf, inf, inf)),  # integer list
-                         ])
+                          ])
 def test_inf_like(arr, expected):
     """
     Test :func:`astropy.cosmology.utils.inf_like`.

--- a/astropy/cosmology/units.py
+++ b/astropy/cosmology/units.py
@@ -315,6 +315,7 @@ def with_redshift(cosmology=None, *,
 
 # ===================================================================
 
+
 def with_H0(H0=None):
     """
     Convert between quantities with little-h and the equivalent physical units.
@@ -334,9 +335,10 @@ def with_H0(H0=None):
     """
     if H0 is None:
         from .realizations import default_cosmology
+
         H0 = default_cosmology.get().H0
 
-    h100_val_unit = u.Unit(100/(H0.to_value(u.km / u.s / u.Mpc)) * littleh)
+    h100_val_unit = u.Unit(100 / (H0.to_value((u.km / u.s) / u.Mpc)) * littleh)
 
     return u.Equivalency([(h100_val_unit, None)], "with_H0", kwargs={"H0": H0})
 

--- a/astropy/cosmology/utils.py
+++ b/astropy/cosmology/utils.py
@@ -91,7 +91,8 @@ def vectorize_if_needed(f, *x, **vkw):
 
 @deprecated(
     since="5.0",
-    message="inf_like has been removed because it duplicates functionality provided by numpy.full_like()",
+    message=("inf_like has been removed because it duplicates "
+             "functionality provided by numpy.full_like()"),
     alternative="Use numpy.full_like(z, numpy.inf) instead for a target array 'z'"
 )
 def inf_like(x):


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

### Description

Just ran flake8 on the cosmology module.
Added a few ``noqa`` to make it all work.

flake8 doesn't run very much on the CI. Maybe we should add more?

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
