### PR TITLE
Add wcs temporal properties

### DIFF
--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -1534,10 +1534,24 @@ def test_pixlist_wcs_colsel():
     _WCSLIB_VER < Version('7.8'),
     reason="TIME axis extraction only works with wcslib 7.8 or later"
 )
-def test_time_axis_selection(tab_wcs_2di_f):
+def test_time_axis_selection():
     w = wcs.WCS(naxis=3)
     w.wcs.ctype = ['RA---TAN', 'DEC--TAN', 'TIME']
     w.wcs.set()
     assert list(w.sub([wcs.WCSSUB_TIME]).wcs.ctype) == ['TIME']
     assert (w.wcs_pix2world([[1, 2, 3]], 0)[0, 2] ==
             w.sub([wcs.WCSSUB_TIME]).wcs_pix2world([[3]], 0)[0, 0])
+
+
+@pytest.mark.skipif(
+    _WCSLIB_VER < Version('7.8'),
+    reason="TIME axis extraction only works with wcslib 7.8 or later"
+)
+def test_temporal():
+    w = wcs.WCS(naxis=3)
+    w.wcs.ctype = ['RA---TAN', 'DEC--TAN', 'TIME']
+    w.wcs.set()
+    assert w.has_temporal
+    assert w.sub([wcs.WCSSUB_TIME]).is_temporal
+    assert (w.wcs_pix2world([[1, 2, 3]], 0)[0, 2] ==
+            w.temporal.wcs_pix2world([[3]], 0)[0, 0])

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -3227,6 +3227,21 @@ reduce these to 2 dimensions using the naxis kwarg.
             return False
 
     @property
+    def temporal(self):
+        """
+        A copy of the current WCS with only the time axes included
+        """
+        return self.sub([WCSSUB_TIME])  # Defined by C-ext  # noqa: F821
+
+    @property
+    def is_temporal(self):
+        return self.has_temporal and self.naxis == 1
+
+    @property
+    def has_temporal(self):
+        return any(t // 1000 == 4 for t in self.wcs.axis_types)
+
+    @property
     def has_distortion(self):
         """
         Returns `True` if any distortion terms are present.

--- a/docs/changes/wcs/13094.feature.rst
+++ b/docs/changes/wcs/13094.feature.rst
@@ -1,0 +1,2 @@
+Add ``temporal`` properties for convenient access of/selection of/testing for
+the ``TIME`` axis introduced in WCSLIB version 7.8.


### PR DESCRIPTION
### Description
This PR add "temporal" properties to access 'TIME' axis in the WCS. This is the second part of the original PR - https://github.com/astropy/astropy/pull/13062

### Checklist for package maintainer(s)

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
