### PR TITLE
Instance descriptor

### DIFF
--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -418,10 +418,10 @@ class PprintIncludeExclude(InstanceDescriptor, TableAttribute):
         return TableAttribute.__get__(self, instance, instance.__class__)
 
     def __repr__(self):
-        if hasattr(self, '_parent_ref'):
-            out = f'<{self.__class__.__name__} name={self.name} value={self()}>'
-        else:
+        if self._parent_ref is None:  # not linked to enclosing instance
             out = super().__repr__()
+        else:
+            out = f'<{self.__class__.__name__} name={self.name} value={self()}>'
         return out
 
     def _add_remove_setup(self, names):

--- a/astropy/utils/descriptors.py
+++ b/astropy/utils/descriptors.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+
+"""Descriptors."""
+
+# STDLIB
+import weakref
+from typing import Any, Optional, Type, TypeVar
+
+__all__ = ["InstanceDescriptor", "SlotsInstanceDescriptor"]
+
+
+_EnclType = TypeVar("_EnclType")
+_SIDT = TypeVar("_SIDT", bound="SlotsInstanceDescriptor")
+
+
+class SlotsInstanceDescriptor:
+    """Descriptor that provides access to its parent instance."""
+
+    __slots__ = ("_parent_attr", "_parent_ref")
+
+    _parent_attr: str
+    _parent_ref: weakref.ReferenceType
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__()
+
+    @property
+    def _parent(self) -> _EnclType:
+        """Parent instance."""
+        if isinstance(getattr(self, "_parent_ref", None), weakref.ReferenceType):
+            parent = self._parent_ref()
+        else:
+            parent = None
+
+        if parent is None:
+            raise ValueError("no reference exists to the original parent object")
+
+        return parent
+
+    def __set_name__(self, _: Any, name: str) -> None:
+        self._parent_attr = name
+
+    def __get__(self: _SIDT, obj: Optional[_EnclType], objcls: Optional[Type[_EnclType]], **kwargs: Any) -> _SIDT:
+        # When called without an instance, return self to allow access
+        # to descriptor attributes.
+        if obj is None:
+            return self
+
+        # accessed from an obj
+        descriptor: Optional[_SIDT] = obj.__dict__.get(self._parent_attr)  # get from obj
+        if descriptor is None:  # hasn't been created on the obj
+            # Make a new ``self``-like descriptor
+            descriptor = type(self)(**kwargs)
+            # Copy over attributes from ``__set_name__``.
+            # If a subclass has others, either set them in that ``__get__``
+            # or use the ``deepcopy`` option.
+            descriptor._parent_attr = self._parent_attr
+            # put descriptor in parent instance's dictionary
+            obj.__dict__[self._parent_attr] = descriptor
+
+        # We set `_parent_ref` on every call, since if one makes copies of objs,
+        # 'descriptor' will be copied as well, which will lose the reference.
+        descriptor._parent_ref = weakref.ref(obj)  # type: ignore
+
+        return descriptor
+
+
+class InstanceDescriptor(SlotsInstanceDescriptor):
+    __slots__ = ("__dict__", "_parent_attr", "_parent_ref")

--- a/astropy/utils/masked/core.py
+++ b/astropy/utils/masked/core.py
@@ -481,12 +481,15 @@ class MaskedNDArray(Masked, np.ndarray, base_cls=np.ndarray, data_cls=np.ndarray
             cls.__new__ = __new__
 
         if 'info' not in cls.__dict__ and hasattr(cls._data_cls, 'info'):
+            # Make a MaskedInfo from an Info
             data_info = cls._data_cls.info
             attr_names = data_info.attr_names | {'serialize_method'}
             new_info = type(cls.__name__+'Info',
                             (MaskedArraySubclassInfo, data_info.__class__),
                             dict(attr_names=attr_names))
+            # Attach MaskedInfo descriptor, also setting the parent_attr
             cls.info = new_info()
+            cls.info._parent_attr = data_info._parent_attr
 
     # The two pieces typically overridden.
     @classmethod

--- a/docs/changes/utils/13098.feature.rst
+++ b/docs/changes/utils/13098.feature.rst
@@ -1,0 +1,3 @@
+New bases classes -- ``SlotsInstanceDescriptor`` and ``InstanceDescriptor`` --
+have been added for creating descriptors that are stored on and can access the
+enclosing instance.

--- a/docs/utils/index.rst
+++ b/docs/utils/index.rst
@@ -57,6 +57,9 @@ Reference/API
 .. automodapi:: astropy.utils.decorators
     :no-inheritance-diagram:
 
+.. automodapi:: astropy.utils.descriptors
+    :no-inheritance-diagram:
+
 .. automodapi:: astropy.utils.diff
     :no-inheritance-diagram:
 


### PR DESCRIPTION
### Description

Astropy has a few descriptors that reference and are stored on the enclosing class's instance. This PR factors the common code into a useful base class.

For a followup:
In another project I've used this code to make a ``.plot`` descriptor that holds relevant plotting methods.
We might add that to ``Table`` so columns can be easily plotted, like what `pandas` offers.


### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
