### PR TITLE
Cosmo clone equivalent

### DIFF
--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -462,7 +462,7 @@ class FlatCosmologyMixin(metaclass=abc.ABCMeta):
         return True
 
     @abc.abstractmethod
-    def equivalent_nonflat(self: _FlatCosmoT) -> _CosmoT:
+    def nonflat(self: _FlatCosmoT) -> _CosmoT:
         """Return the equivalent non-flat-class instance of this cosmology."""
 
     def clone(self, *, meta: Optional[Mapping] = None, to_nonflat: bool = False, **kwargs):
@@ -514,7 +514,7 @@ class FlatCosmologyMixin(metaclass=abc.ABCMeta):
             LambdaCDM(name="Planck13 (modified)", H0=70.0 km / (Mpc s), ...
         """
         if to_nonflat:
-            return self.equivalent_nonflat.clone(meta=meta, **kwargs)
+            return self.nonflat.clone(meta=meta, **kwargs)
         return super().clone(meta=meta, **kwargs)
 
 

--- a/astropy/cosmology/flrw/base.py
+++ b/astropy/cosmology/flrw/base.py
@@ -1437,7 +1437,7 @@ class FlatFLRWMixin(FlatCosmologyMixin):
         self._Ode0 = 1.0 - (self._Om0 + self._Ogamma0 + self._Onu0 + self._Ok0)
 
     @lazyproperty
-    def equivalent_nonflat(self: _FlatFLRWMixinT) -> _FLRWT:
+    def nonflat(self: _FlatFLRWMixinT) -> _FLRWT:
         # Create BoundArgument to handle args versus kwargs.
         # This also handles all errors from mismatched arguments
         ba = self._nonflat_cls_._init_signature.bind_partial(**self._init_arguments,

--- a/astropy/cosmology/flrw/base.py
+++ b/astropy/cosmology/flrw/base.py
@@ -6,7 +6,7 @@ import warnings
 from abc import abstractmethod
 from math import exp, floor, log, pi, sqrt
 from numbers import Number
-from typing import TypeVar
+from typing import Any, Mapping, Optional, TypeVar
 
 import numpy as np
 from numpy import inf, sin
@@ -1449,6 +1449,62 @@ class FlatFLRWMixin(FlatCosmologyMixin):
             setattr(inst, "_" + n, getattr(self, n))
 
         return inst
+
+    def clone(self, *, meta: Optional[Mapping] = None, to_nonflat: bool = None, **kwargs: Any):
+        """Returns a copy of this object with updated parameters, as specified.
+
+        This cannot be used to change the type of the cosmology, except for
+        changing to the non-flat version of this cosmology.
+
+        Parameters
+        ----------
+        meta : mapping or None (optional, keyword-only)
+            Metadata that will update the current metadata.
+        to_nonflat : bool or None, optional keyword-only
+            Whether to change to the non-flat version of this cosmology.
+        **kwargs
+            Cosmology parameter (and name) modifications. If any parameter is
+            changed and a new name is not given, the name will be set to "[old
+            name] (modified)".
+
+        Returns
+        -------
+        newcosmo : `~astropy.cosmology.Cosmology` subclass instance
+            A new instance of this class with updated parameters as specified.
+            If no arguments are given, then a reference to this object is
+            returned instead of copy.
+
+        Examples
+        --------
+        To make a copy of the ``Planck13`` cosmology with a different matter
+        density (``Om0``), and a new name:
+
+            >>> from astropy.cosmology import Planck13
+            >>> Planck13.clone(name="Modified Planck 2013", Om0=0.35)
+            FlatLambdaCDM(name="Modified Planck 2013", H0=67.77 km / (Mpc s),
+              Om0=0.35, ...
+
+        If no name is specified, the new name will note the modification.
+
+            >>> Planck13.clone(Om0=0.35).name
+            'Planck13 (modified)'
+
+        The keyword 'to_nonflat' can be used to clone on the non-flat equivalent
+        cosmology.
+
+            >>> Planck13.clone(to_nonflat=True)
+            LambdaCDM(name="Planck13", ...
+
+            >>> Planck13.clone(H0=70, to_nonflat=True)
+            LambdaCDM(name="Planck13 (modified)", H0=70.0 km / (Mpc s), ...
+
+        With 'to_nonflat' `True`, ``Ode0`` can be modified.
+
+            >>> Planck13.clone(to_nonflat=True, Ode0=1)
+            LambdaCDM(name="Planck13 (modified)", H0=67.77 km / (Mpc s),
+                      Om0=0.30712, Ode0=1.0, ...
+        """
+        return super().clone(meta=meta, to_nonflat=to_nonflat, **kwargs)
 
     @property
     def Otot0(self):

--- a/astropy/cosmology/flrw/lambdacdm.py
+++ b/astropy/cosmology/flrw/lambdacdm.py
@@ -605,9 +605,9 @@ class FlatLambdaCDM(FlatFLRWMixin, LambdaCDM):
     >>> dc = cosmo.comoving_distance(z)
 
     To get an equivalent cosmology, but of type `astropy.cosmology.LambdaCDM`,
-    use :attr:`astropy.cosmology.FlatFLRWMixin.equivalent_nonflat`.
+    use :attr:`astropy.cosmology.FlatFLRWMixin.nonflat`.
 
-    >>> cosmo.equivalent_nonflat
+    >>> cosmo.nonflat
     LambdaCDM(H0=70.0 km / (Mpc s), Om0=0.3, ...
     """
 

--- a/astropy/cosmology/flrw/tests/test_base.py
+++ b/astropy/cosmology/flrw/tests/test_base.py
@@ -693,10 +693,10 @@ class TestFLRW(CosmologyTest,
         # don't change any values
         kwargs = cosmo._init_arguments.copy()
         kwargs.pop("name", None)  # make sure not setting name
+        kwargs.pop("meta", None)  # make sure not setting name
         c = cosmo.clone(**kwargs)
         assert c.__class__ == cosmo.__class__
-        assert c.name == cosmo.name + " (modified)"
-        assert c.is_equivalent(cosmo)
+        assert c == cosmo
 
         # change ``H0``
         # Note that H0 affects Ode0 because it changes Ogamma0
@@ -916,6 +916,25 @@ class FlatFLRWMixinTest(FlatCosmologyMixinTest, ParameterFlatOde0TestMixin):
     def test_redshift_method_bad_input(self, cosmo, method, z, exc):
         """Test all the redshift methods for bad input."""
         super().test_redshift_method_bad_input(cosmo, method, z, exc)
+
+    # ---------------------------------------------------------------
+
+    def test_clone_to_nonflat_change_param(self, cosmo):
+        """Test method ``.clone()`` changing a(many) Parameter(s)."""
+        super().test_clone_to_nonflat_change_param(cosmo)
+
+        # change Ode0, without non-flat
+        with pytest.raises(TypeError):
+            cosmo.clone(Ode0=1)
+
+        # change to non-flat
+        nc = cosmo.clone(to_nonflat=True, Ode0=cosmo.Ode0)
+        assert isinstance(nc, cosmo._nonflat_cls_)
+        assert nc == cosmo.equivalent_nonflat
+
+        nc = cosmo.clone(to_nonflat=True, Ode0=1)
+        assert nc.Ode0 == 1.0
+        assert nc.name == cosmo.name + " (modified)"
 
     # ---------------------------------------------------------------
 

--- a/astropy/cosmology/flrw/tests/test_base.py
+++ b/astropy/cosmology/flrw/tests/test_base.py
@@ -930,7 +930,7 @@ class FlatFLRWMixinTest(FlatCosmologyMixinTest, ParameterFlatOde0TestMixin):
         # change to non-flat
         nc = cosmo.clone(to_nonflat=True, Ode0=cosmo.Ode0)
         assert isinstance(nc, cosmo._nonflat_cls_)
-        assert nc == cosmo.equivalent_nonflat
+        assert nc == cosmo.nonflat
 
         nc = cosmo.clone(to_nonflat=True, Ode0=1)
         assert nc.Ode0 == 1.0

--- a/astropy/cosmology/flrw/w0cdm.py
+++ b/astropy/cosmology/flrw/w0cdm.py
@@ -255,9 +255,9 @@ class FlatwCDM(FlatFLRWMixin, wCDM):
     >>> dc = cosmo.comoving_distance(z)
 
     To get an equivalent cosmology, but of type `astropy.cosmology.wCDM`,
-    use :attr:`astropy.cosmology.FlatFLRWMixin.equivalent_nonflat`.
+    use :attr:`astropy.cosmology.FlatFLRWMixin.nonflat`.
 
-    >>> cosmo.equivalent_nonflat
+    >>> cosmo.nonflat
     wCDM(H0=70.0 km / (Mpc s), Om0=0.3, ...
     """
 

--- a/astropy/cosmology/flrw/w0wacdm.py
+++ b/astropy/cosmology/flrw/w0wacdm.py
@@ -237,9 +237,9 @@ class Flatw0waCDM(FlatFLRWMixin, w0waCDM):
     >>> dc = cosmo.comoving_distance(z)
 
     To get an equivalent cosmology, but of type `astropy.cosmology.w0waCDM`,
-    use :attr:`astropy.cosmology.FlatFLRWMixin.equivalent_nonflat`.
+    use :attr:`astropy.cosmology.FlatFLRWMixin.nonflat`.
 
-    >>> cosmo.equivalent_nonflat
+    >>> cosmo.nonflat
     w0waCDM(H0=70.0 km / (Mpc s), Om0=0.3, ...
 
     References

--- a/astropy/cosmology/tests/test_core.py
+++ b/astropy/cosmology/tests/test_core.py
@@ -425,11 +425,11 @@ class FlatCosmologyMixinTest:
         # it's always True
         assert cosmo.is_flat is True
 
-    def test_equivalent_nonflat(self, cosmo):
-        """Test :attr:`astropy.cosmology.core.FlatCosmologyMixin.equivalent_nonflat`.
+    def test_nonflat(self, cosmo):
+        """Test :attr:`astropy.cosmology.core.FlatCosmologyMixin.nonflat`.
         """
-        assert cosmo.equivalent_nonflat.is_equivalent(cosmo)
-        assert cosmo.is_equivalent(cosmo.equivalent_nonflat)
+        assert cosmo.nonflat.is_equivalent(cosmo)
+        assert cosmo.is_equivalent(cosmo.nonflat)
 
     # ------------------------------------------------
     # clone
@@ -439,7 +439,7 @@ class FlatCosmologyMixinTest:
         # just converting the class
         nc = cosmo.clone(to_nonflat=True)
         assert isinstance(nc, cosmo._nonflat_cls_)
-        assert nc == cosmo.equivalent_nonflat
+        assert nc == cosmo.nonflat
 
     @abc.abstractmethod
     def test_clone_to_nonflat_change_param(self, cosmo):
@@ -451,7 +451,7 @@ class FlatCosmologyMixinTest:
         # send to non-flat
         nc = cosmo.clone(to_nonflat=True)
         assert isinstance(nc, cosmo._nonflat_cls_)
-        assert nc == cosmo.equivalent_nonflat
+        assert nc == cosmo.nonflat
 
     # ------------------------------------------------
 
@@ -516,7 +516,7 @@ def test_nonflat_cls_multiple_nonflat_inheritance():
         class FlatSubCosmology(FlatCosmologyMixin, SubCosmology, SubCosmology2):
 
             @property
-            def equivalent_nonflat(self):
+            def nonflat(self):
                 pass
 
 

--- a/astropy/cosmology/tests/test_core.py
+++ b/astropy/cosmology/tests/test_core.py
@@ -223,7 +223,7 @@ class TestCosmology(ParameterTestMixin, MetaTestMixin,
         assert c.meta == cosmo.meta
 
         # now change a different parameter and see how 'name' changes
-        c = cosmo.clone(meta={})
+        c = cosmo.clone(meta={"test_clone_name": True})
         assert c.name == cosmo.name + " (modified)"
 
     def test_clone_meta(self, cosmo):
@@ -394,6 +394,11 @@ class CosmologySubclassTest(TestCosmology):
 class FlatCosmologyMixinTest:
     """Tests for :class:`astropy.cosmology.core.FlatCosmologyMixin` subclasses.
 
+    The test suite structure mirrors the implementation of the tested code.
+    Just like :class:`astropy.cosmology.FlatCosmologyMixin` is an abstract
+    base class (ABC) that cannot be used by itself, so too is this corresponding
+    test class an ABC mixin.
+
     E.g to use this class::
 
         class TestFlatSomeCosmology(FlatCosmologyMixinTest, TestSomeCosmology):
@@ -425,6 +430,30 @@ class FlatCosmologyMixinTest:
         """
         assert cosmo.equivalent_nonflat.is_equivalent(cosmo)
         assert cosmo.is_equivalent(cosmo.equivalent_nonflat)
+
+    # ------------------------------------------------
+    # clone
+
+    def test_clone_to_nonflat_equivalent(self, cosmo):
+        """Test method ``.clone()``to_nonflat argument."""
+        # just converting the class
+        nc = cosmo.clone(to_nonflat=True)
+        assert isinstance(nc, cosmo._nonflat_cls_)
+        assert nc == cosmo.equivalent_nonflat
+
+    @abc.abstractmethod
+    def test_clone_to_nonflat_change_param(self, cosmo):
+        """
+        Test method ``.clone()`` changing a(many) Parameter(s). No parameters
+        are changed here because FlatCosmologyMixin has no Parameters.
+        See class docstring for why this test method exists.
+        """
+        # send to non-flat
+        nc = cosmo.clone(to_nonflat=True)
+        assert isinstance(nc, cosmo._nonflat_cls_)
+        assert nc == cosmo.equivalent_nonflat
+
+    # ------------------------------------------------
 
     def test_is_equivalent(self, cosmo):
         """Test :meth:`astropy.cosmology.core.FlatCosmologyMixin.is_equivalent`.

--- a/docs/changes/cosmology/13076.feature.rst
+++ b/docs/changes/cosmology/13076.feature.rst
@@ -1,3 +1,3 @@
-A new property ``equivalent_nonflat`` has been added to flat cosmologies
+A new property ``nonflat`` has been added to flat cosmologies
 (``FlatCosmologyMixin`` subclasses) to get an equivalent cosmology, but of the
 corresponding non-flat class.

--- a/docs/changes/cosmology/13099.feature.rst
+++ b/docs/changes/cosmology/13099.feature.rst
@@ -1,0 +1,2 @@
+``clone`` has been enhanced to allow for flat cosmologies to clone on the
+equivalent non-flat cosmology.

--- a/docs/whatsnew/5.1.rst
+++ b/docs/whatsnew/5.1.rst
@@ -43,11 +43,11 @@ The list of valid formats, e.g. the Table in this example, may be
 checked with ``Cosmology.from_format.list_formats()``
 
 
-A new property ``equivalent_nonflat`` has been added to flat cosmologies
-(``FlatCosmologyMixin`` subclasses) to get an equivalent cosmology, but of the
-corresponding non-flat class.
+A new property ``nonflat`` has been added to flat cosmologies
+(:class:`astropy.cosmology.FlatCosmologyMixin` subclasses) to get an equivalent
+cosmology, but of the corresponding non-flat class.
 
-    >>> Planck18.equivalent_nonflat
+    >>> Planck18.nonflat
     LambdaCDM(name="Planck18", H0=67.66 km / (Mpc s), ...
 
 

--- a/docs/whatsnew/5.1.rst
+++ b/docs/whatsnew/5.1.rst
@@ -48,7 +48,14 @@ A new property ``equivalent_nonflat`` has been added to flat cosmologies
 corresponding non-flat class.
 
     >>> Planck18.equivalent_nonflat
-    LambdaCDM(name="Planck18", ...
+    LambdaCDM(name="Planck18", H0=67.66 km / (Mpc s), ...
+
+
+:meth:`astropy.cosmology.FlatCosmologyMixin.clone` has been enhanced to allow
+for flat cosmologies to clone on the equivalent non-flat cosmology. For example,
+
+    >>> Planck18.clone(to_nonflat=True, Ode0=1)
+    LambdaCDM(name="Planck18 (modified)", H0=67.66 km / (Mpc s), Om0=0.30966, Ode0=1.0, ...
 
 
 .. _whatsnew-doppler-redshift-eq:


### PR DESCRIPTION
``clone`` has been enhanced to allow for flat cosmologies to modify the
parameters that make the cosmology flat. If modified, the returned cosmology
is an instance of the corresponding non-flat class.

Follow-up to #13076 


### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
