### PR TITLE
Add specific clear() function for `CompImageHeader` class

### DIFF
--- a/astropy/io/fits/hdu/compressed.py
+++ b/astropy/io/fits/hdu/compressed.py
@@ -7,7 +7,6 @@ import math
 import re
 import time
 import warnings
-import collections
 from contextlib import suppress
 
 import numpy as np
@@ -380,9 +379,7 @@ class CompImageHeader(Header):
         Remove all cards from the header.
         """
 
-        self._table_header._cards = []
-        self._table_header._keyword_indices = collections.defaultdict(list)
-        self._table_header._rvkc_indices = collections.defaultdict(list)
+        self._table_header.clear()
         super().clear()
 
 

--- a/astropy/io/fits/hdu/compressed.py
+++ b/astropy/io/fits/hdu/compressed.py
@@ -7,6 +7,7 @@ import math
 import re
 import time
 import warnings
+import collections
 from contextlib import suppress
 
 import numpy as np
@@ -373,6 +374,16 @@ class CompImageHeader(Header):
                                                  repeat))
 
         return idx
+
+    def clear(self):
+        """
+        Remove all cards from the header.
+        """
+
+        self._table_header._cards = []
+        self._table_header._keyword_indices = collections.defaultdict(list)
+        self._table_header._rvkc_indices = collections.defaultdict(list)
+        super().clear()
 
 
 # TODO: Fix this class so that it doesn't actually inherit from BinTableHDU,

--- a/astropy/io/fits/hdu/table.py
+++ b/astropy/io/fits/hdu/table.py
@@ -537,27 +537,28 @@ class _TableBaseHDU(ExtensionHDU, _TableLikeHDU):
         """
 
         errs = super()._verify(option=option)
-        if not (isinstance(self._header[0], str) and
-                self._header[0].rstrip() == self._extension):
+        if (len(self._header) > 1):
+            if not (isinstance(self._header[0], str) and
+                    self._header[0].rstrip() == self._extension):
 
-            err_text = 'The XTENSION keyword must match the HDU type.'
-            fix_text = f'Converted the XTENSION keyword to {self._extension}.'
+                err_text = 'The XTENSION keyword must match the HDU type.'
+                fix_text = f'Converted the XTENSION keyword to {self._extension}.'
 
-            def fix(header=self._header):
-                header[0] = (self._extension, self._ext_comment)
+                def fix(header=self._header):
+                    header[0] = (self._extension, self._ext_comment)
 
-            errs.append(self.run_option(option, err_text=err_text,
-                                        fix_text=fix_text, fix=fix))
+                errs.append(self.run_option(option, err_text=err_text,
+                                            fix_text=fix_text, fix=fix))
 
-        self.req_cards('NAXIS', None, lambda v: (v == 2), 2, option, errs)
-        self.req_cards('BITPIX', None, lambda v: (v == 8), 8, option, errs)
-        self.req_cards('TFIELDS', 7,
-                       lambda v: (_is_int(v) and v >= 0 and v <= 999), 0,
-                       option, errs)
-        tfields = self._header['TFIELDS']
-        for idx in range(tfields):
-            self.req_cards('TFORM' + str(idx + 1), None, None, None, option,
-                           errs)
+            self.req_cards('NAXIS', None, lambda v: (v == 2), 2, option, errs)
+            self.req_cards('BITPIX', None, lambda v: (v == 8), 8, option, errs)
+            self.req_cards('TFIELDS', 7,
+                           lambda v: (_is_int(v) and v >= 0 and v <= 999), 0,
+                           option, errs)
+            tfields = self._header['TFIELDS']
+            for idx in range(tfields):
+                self.req_cards('TFORM' + str(idx + 1), None, None, None, option,
+                               errs)
         return errs
 
     def _summary(self):

--- a/docs/changes/io.fits/13102.bugfix.rst
+++ b/docs/changes/io.fits/13102.bugfix.rst
@@ -1,1 +1,1 @@
-Add specific ``clear()`` function for ``CompImageHDU`` class.
+Fix ``CompImageHeader.clear()``.

--- a/docs/changes/io.fits/13102.bugfix.rst
+++ b/docs/changes/io.fits/13102.bugfix.rst
@@ -1,0 +1,1 @@
+Add specific ``clear()`` function for ``CompImageHDU`` class.


### PR DESCRIPTION
### Description

This pull request adds the `clear()` function for `CompImageHDU` class.

It fixes #3526.

Tests are added using the code snippet in the issue.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
