### PR TITLE
Support opening file paths given relative to home directory with tildes

### DIFF
--- a/astropy/io/ascii/tests/test_write.py
+++ b/astropy/io/ascii/tests/test_write.py
@@ -390,22 +390,59 @@ a,b,c
 ]
 
 
-def check_write_table(test_def, table, fast_writer):
-    out = StringIO()
+@pytest.fixture
+def home_is_tmpdir(monkeypatch, tmpdir):
+    """
+    Pytest fixture to run a test case with tilde-prefixed paths.
+
+    In the tilde-path case, environment variables are temporarily
+    modified so that '~' resolves to the temp directory.
+    """
+    # For Unix
+    monkeypatch.setenv('HOME', str(tmpdir))
+    # For Windows
+    monkeypatch.setenv('USERPROFILE', str(tmpdir))
+
+
+def check_write_table(test_def, table, fast_writer, to_dir=None):
+    if to_dir is None:
+        out = StringIO()
+    else:
+        out = os.path.join(to_dir, 'table')
+
     try:
         ascii.write(table, out, fast_writer=fast_writer, **test_def['kwargs'])
     except ValueError as e:  # if format doesn't have a fast writer, ignore
         if 'not in the list of formats with fast writers' not in str(e.value):
             raise e
         return
+
+    if to_dir is None:
+        # Output went to a buffer
+        actual = out.getvalue()
+    else:
+        # Output went to a file
+        if out.startswith('~'):
+            # Ensure a file hasn't been accidentally written to a literal tilde
+            # path
+            assert not os.path.exists(out)
+            out = os.path.expanduser(out)
+        assert os.path.exists(out)
+        with open(out) as f:
+            actual = f.read()
+        os.remove(out)
+
     print(f"Expected:\n{test_def['out']}")
-    print(f'Actual:\n{out.getvalue()}')
-    assert [x.strip() for x in out.getvalue().strip().splitlines()] == [
+    print(f'Actual:\n{actual}')
+    assert [x.strip() for x in actual.strip().splitlines()] == [
         x.strip() for x in test_def['out'].strip().splitlines()]
 
 
-def check_write_table_via_table(test_def, table, fast_writer):
-    out = StringIO()
+def check_write_table_via_table(test_def, table, fast_writer, to_dir=None):
+    if to_dir is None:
+        out = StringIO()
+    else:
+        out = os.path.join(to_dir, 'table-via-table')
 
     test_def = copy.deepcopy(test_def)
     if 'Writer' in test_def['kwargs']:
@@ -420,9 +457,25 @@ def check_write_table_via_table(test_def, table, fast_writer):
         if 'not in the list of formats with fast writers' not in str(e.value):
             raise e
         return
+
+    if to_dir is None:
+        # Output went to a buffer
+        actual = out.getvalue()
+    else:
+        # Output went to a file
+        if out.startswith('~'):
+            # Ensure a file hasn't been accidentally written to a literal tilde
+            # path
+            assert not os.path.exists(out)
+            out = os.path.expanduser(out)
+        assert os.path.exists(out)
+        with open(out) as f:
+            actual = f.read()
+        os.remove(out)
+
     print(f"Expected:\n{test_def['out']}")
-    print(f'Actual:\n{out.getvalue()}')
-    assert [x.strip() for x in out.getvalue().strip().splitlines()] == [
+    print(f'Actual:\n{actual}')
+    assert [x.strip() for x in actual.strip().splitlines()] == [
         x.strip() for x in test_def['out'].strip().splitlines()]
 
 
@@ -434,6 +487,20 @@ def test_write_table(fast_writer):
     for test_def in test_defs:
         check_write_table(test_def, data, fast_writer)
         check_write_table_via_table(test_def, data, fast_writer)
+
+
+@pytest.mark.parametrize("fast_writer", [True, False])
+@pytest.mark.parametrize("to_tilde_path", [True, False])
+def test_write_table_to_tilde_file(
+        fast_writer, tmpdir, home_is_tmpdir, to_tilde_path):
+    table = ascii.get_reader(Reader=ascii.Daophot)
+    data = table.read('data/daophot.dat')
+
+    out_dir = '~' if to_tilde_path else tmpdir
+    for test_def in test_defs:
+        check_write_table(test_def, data, fast_writer, to_dir=out_dir)
+        check_write_table_via_table(
+            test_def, data, fast_writer, to_dir=out_dir)
 
 
 @pytest.mark.parametrize("fast_writer", [True, False])
@@ -686,10 +753,17 @@ def test_write_empty_table(fast_writer):
 @pytest.mark.parametrize("format", ['ascii', 'csv', 'html', 'latex',
                                     'ascii.fixed_width', 'html'])
 @pytest.mark.parametrize("fast_writer", [True, False])
-def test_write_overwrite_ascii(format, fast_writer, tmpdir):
+@pytest.mark.parametrize("to_tilde_path", [True, False])
+def test_write_overwrite_ascii(format, fast_writer, tmpdir, home_is_tmpdir,
+        to_tilde_path):
     """Test overwrite argument for various ASCII writers"""
-    filename = tmpdir.join("table-tmp.dat").strpath
-    with open(filename, 'w'):
+    true_filename = tmpdir.join("table-tmp.dat").strpath
+    if to_tilde_path:
+        filename = os.path.join("~", "table-tmp.dat")
+    else:
+        filename = true_filename
+
+    with open(true_filename, 'w'):
         # create empty file
         pass
     t = table.Table([['Hello', ''], ['', '']], dtype=['S10', 'S10'])
@@ -701,11 +775,15 @@ def test_write_overwrite_ascii(format, fast_writer, tmpdir):
             fast_writer=fast_writer)
 
     # If the output is a file object, overwrite is ignored
-    with open(filename, 'w') as fp:
+    with open(true_filename, 'w') as fp:
         t.write(fp, overwrite=False, format=format,
                 fast_writer=fast_writer)
         t.write(fp, overwrite=True, format=format,
                 fast_writer=fast_writer)
+
+    if to_tilde_path:
+        # Ensure no files have been accidentally written to a literal tilde path
+        assert not os.path.exists(filename)
 
 
 fmt_name_classes = list(chain(ascii.core.FAST_CLASSES.items(),

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -80,7 +80,8 @@ def _probably_html(table, maxchars=100000):
             return True
 
         # Filename ending in .htm or .html which exists
-        if re.search(r'\.htm[l]?$', table[-5:], re.IGNORECASE) and os.path.exists(table):
+        if (re.search(r'\.htm[l]?$', table[-5:], re.IGNORECASE) and
+                os.path.exists(os.path.expanduser(table))):
             return True
 
         # Table starts with HTML document type declaration
@@ -346,6 +347,13 @@ def read(table, guess=None, **kwargs):
         if format is None:
             reader = get_reader(**new_kwargs)
             format = reader._format_name
+
+        if isinstance(table, (str, bytes, os.PathLike)):
+            # Conservatively attempt to expand `table`, which could be a file
+            # path or the actual data of a table.
+            ex_user = os.path.expanduser(table)
+            if os.path.exists(ex_user):
+                table = ex_user
 
         # Try the fast reader version of `format` first if applicable.  Note that
         # if user specified a fast format (e.g. format='fast_basic') this test
@@ -801,7 +809,8 @@ def write(table, output=None, format=None, Writer=None, fast_writer=True, *,
     _validate_read_write_kwargs('write', format=format, fast_writer=fast_writer,
                                 overwrite=overwrite, **kwargs)
 
-    if isinstance(output, str):
+    if isinstance(output, (str, bytes, os.PathLike)):
+        output = os.path.expanduser(output)
         if not overwrite and os.path.lexists(output):
             raise OSError(NOT_OVERWRITING_MSG.format(output))
 

--- a/astropy/io/fits/convenience.py
+++ b/astropy/io/fits/convenience.py
@@ -68,7 +68,7 @@ from .hdu.image import PrimaryHDU, ImageHDU
 from .hdu.table import BinTableHDU
 from .header import Header
 from .util import (fileobj_closed, fileobj_name, fileobj_mode, _is_int,
-                   _is_dask_array)
+                   _is_dask_array, path_like)
 from astropy.utils.exceptions import AstropyUserWarning
 
 
@@ -657,6 +657,8 @@ def append(filename, data, header=None, checksum=False, verify=True, **kwargs):
         - Otherwise no additional arguments can be used.
 
     """
+    if isinstance(filename, path_like):
+        filename = os.path.expanduser(filename)
     name, closed, noexist_or_empty = _stat_filename_or_fileobj(filename)
 
     if noexist_or_empty:

--- a/astropy/io/fits/diff.py
+++ b/astropy/io/fits/diff.py
@@ -26,6 +26,7 @@ from .header import Header
 # HDUList is used in one of the doctests
 from .hdu.hdulist import fitsopen, HDUList  # pylint: disable=W0611
 from .hdu.table import _TableLikeHDU
+from .util import path_like
 from astropy.utils.diff import (report_diff_values, fixed_width_indent,
                                 where_not_allclose, diff_values)
 from astropy.utils.misc import NOT_OVERWRITING_MSG
@@ -150,7 +151,8 @@ class _BaseDiff:
         return_string = False
         filepath = None
 
-        if isinstance(fileobj, str):
+        if isinstance(fileobj, path_like):
+            fileobj = os.path.expanduser(fileobj)
             if os.path.exists(fileobj) and not overwrite:
                 raise OSError(NOT_OVERWRITING_MSG.format(fileobj))
             else:

--- a/astropy/io/fits/file.py
+++ b/astropy/io/fits/file.py
@@ -18,7 +18,7 @@ from functools import reduce
 import numpy as np
 
 from .util import (isreadable, iswritable, isfile, fileobj_name,
-                   fileobj_closed, fileobj_mode, _array_from_file,
+                   fileobj_closed, fileobj_mode, path_like, _array_from_file,
                    _array_to_file, _write_string)
 from astropy.utils.data import download_file, _is_url
 from astropy.utils.decorators import classproperty
@@ -156,6 +156,8 @@ class _File:
                     f"Mode {mode} not supported for HTTPResponse")
             fileobj = io.BytesIO(fileobj.read())
         else:
+            if isinstance(fileobj, path_like):
+                fileobj = os.path.expanduser(fileobj)
             self.name = fileobj_name(fileobj)
 
         self.mode = mode

--- a/astropy/io/fits/hdu/streaming.py
+++ b/astropy/io/fits/hdu/streaming.py
@@ -70,6 +70,8 @@ class StreamingHDU:
         # handle a file object instead of a file name
         filename = fileobj_name(name) or ''
 
+        filename = os.path.expanduser(filename)
+
         # Check if the file already exists.  If it does not, check to see
         # if we were provided with a Primary Header.  If not we will need
         # to prepend a default PrimaryHDU to the file before writing the

--- a/astropy/io/fits/hdu/table.py
+++ b/astropy/io/fits/hdu/table.py
@@ -25,7 +25,7 @@ from astropy.io.fits.column import (FITS2NUMPY, KEYWORD_NAMES, KEYWORD_TO_ATTRIB
                       _cmp_recformats)
 from astropy.io.fits.fitsrec import FITS_rec, _get_recarray_field, _has_unicode_fields
 from astropy.io.fits.header import Header, _pad_length
-from astropy.io.fits.util import _is_int, _str_to_num
+from astropy.io.fits.util import _is_int, _str_to_num, path_like
 
 from astropy.utils import lazyproperty
 from astropy.utils.exceptions import AstropyDeprecationWarning
@@ -1084,12 +1084,18 @@ class BinTableHDU(_TableBaseHDU):
         plain text (ASCII) files.
         """
 
+        if isinstance(datafile, path_like):
+            datafile = os.path.expanduser(datafile)
+        if isinstance(cdfile, path_like):
+            cdfile = os.path.expanduser(cdfile)
+        if isinstance(hfile, path_like):
+            hfile = os.path.expanduser(hfile)
         # check if the output files already exist
         exist = []
         files = [datafile, cdfile, hfile]
 
         for f in files:
-            if isinstance(f, str):
+            if isinstance(f, path_like):
                 if os.path.exists(f) and os.path.getsize(f) != 0:
                     if overwrite:
                         os.remove(f)
@@ -1309,7 +1315,8 @@ class BinTableHDU(_TableBaseHDU):
 
         close_file = False
 
-        if isinstance(fileobj, str):
+        if isinstance(fileobj, path_like):
+            fileobj = os.path.expanduser(fileobj)
             fileobj = open(fileobj, 'r')
             close_file = True
 
@@ -1452,7 +1459,8 @@ class BinTableHDU(_TableBaseHDU):
 
         close_file = False
 
-        if isinstance(fileobj, str):
+        if isinstance(fileobj, path_like):
+            fileobj = os.path.expanduser(fileobj)
             fileobj = open(fileobj, 'r')
             close_file = True
 

--- a/astropy/io/fits/header.py
+++ b/astropy/io/fits/header.py
@@ -4,6 +4,7 @@ import collections
 import copy
 import itertools
 import numbers
+import os
 import re
 import warnings
 
@@ -500,6 +501,7 @@ class Header:
             #
             # Otherwise assume we are reading from an actual FITS file and open
             # in binary mode.
+            fileobj = os.path.expanduser(fileobj)
             if sep:
                 fileobj = open(fileobj, 'r', encoding='latin1')
             else:

--- a/astropy/io/fits/tests/test_convenience.py
+++ b/astropy/io/fits/tests/test_convenience.py
@@ -18,7 +18,7 @@ from astropy.io.fits.connect import REMOVE_KEYWORDS
 from astropy.utils.exceptions import AstropyUserWarning
 
 from astropy.io.fits.tests.test_table import _assert_attr_col
-from . import FitsTestCase
+from . import FitsTestCase, home_is_temp
 
 
 class TestConvenience(FitsTestCase):
@@ -190,7 +190,7 @@ class TestConvenience(FitsTestCase):
         h_out = fits.getheader(filename, ext=1)
         assert h_out['ANSWER'] == 42
 
-    def test_image_extension_update_header(self):
+    def test_image_extension_update_header(self, home_is_temp):
         """
         Test that _makehdu correctly includes the header. For example in the
         fits.update convenience function.
@@ -199,6 +199,13 @@ class TestConvenience(FitsTestCase):
 
         hdus = [fits.PrimaryHDU(np.zeros((10, 10))),
                 fits.ImageHDU(np.zeros((10, 10)))]
+
+        # Try to update a non-existant file
+        with pytest.raises(FileNotFoundError, match="No such file"):
+            fits.update(filename,
+                        np.zeros((10, 10)),
+                        header=fits.Header([('WHAT', 100)]),
+                        ext=1)
 
         fits.HDUList(hdus).writeto(filename)
 
@@ -302,7 +309,7 @@ class TestConvenience(FitsTestCase):
         with fits.open(self.temp(tablename)) as hdul:
             _assert_attr_col(new_tbhdu, hdul[1])
 
-    def test_append_filename(self):
+    def test_append_filename(self, home_is_temp):
         """
         Test fits.append with a filename argument.
         """

--- a/astropy/io/fits/tests/test_core.py
+++ b/astropy/io/fits/tests/test_core.py
@@ -14,7 +14,7 @@ from unittest.mock import patch
 import pytest
 import numpy as np
 
-from . import FitsTestCase
+from . import FitsTestCase, home_is_temp
 
 from astropy.io.fits.convenience import _getext
 from astropy.io.fits.diff import FITSDiff
@@ -563,7 +563,7 @@ class TestCore(FitsTestCase):
 
 
 class TestConvenienceFunctions(FitsTestCase):
-    def test_writeto(self):
+    def test_writeto(self, home_is_temp):
         """
         Simple test for writing a trivial header and some data to a file
         with the `writeto()` convenience function.
@@ -593,6 +593,24 @@ class TestConvenienceFunctions(FitsTestCase):
             assert (data == hdul[0].data).all()
             assert 'CRPIX1' in hdul[0].header
             assert hdul[0].header['CRPIX1'] == 1.0
+
+    def test_writeto_overwrite(self, home_is_temp):
+        """
+        Ensure the `overwrite` keyword works as it should
+        """
+        filename = self.temp('array.fits')
+        data = np.zeros((100, 100))
+        header = fits.Header()
+        fits.writeto(filename, data, header=header)
+
+        with pytest.raises(OSError, match=_NOT_OVERWRITING_MSG_MATCH):
+            fits.writeto(filename, data, header=header, overwrite=False)
+
+        fits.writeto(filename, data, header=header, overwrite=True)
+
+        with fits.open(filename) as hdul:
+            assert len(hdul) == 1
+            assert (data == hdul[0].data).all()
 
 
 class TestFileFunctions(FitsTestCase):
@@ -906,7 +924,7 @@ class TestFileFunctions(FitsTestCase):
             assert h[0].header['EXPFLAG'] == 'ABNORMAL'
             assert h[1].data[0, 0] == 1
 
-    def test_write_read_gzip_file(self):
+    def test_write_read_gzip_file(self, home_is_temp):
         """
         Regression test for https://github.com/astropy/astropy/issues/2794
 
@@ -917,7 +935,7 @@ class TestFileFunctions(FitsTestCase):
         hdu = fits.PrimaryHDU(data=data)
         hdu.writeto(self.temp('test.fits.gz'))
 
-        with open(self.temp('test.fits.gz'), 'rb') as f:
+        with open(os.path.expanduser(self.temp('test.fits.gz')), 'rb') as f:
             assert f.read(3) == GZIP_MAGIC
 
         with fits.open(self.temp('test.fits.gz')) as hdul:
@@ -1279,7 +1297,7 @@ class TestFileFunctions(FitsTestCase):
 
         return gzfile
 
-    def test_write_overwrite(self):
+    def test_write_overwrite(self, home_is_temp):
         filename = self.temp('test_overwrite.fits')
         hdu = fits.PrimaryHDU(data=np.arange(10))
         hdu.writeto(filename)
@@ -1341,11 +1359,19 @@ class TestFileFunctions(FitsTestCase):
 class TestStreamingFunctions(FitsTestCase):
     """Test functionality of the StreamingHDU class."""
 
-    def test_streaming_hdu(self):
+    def test_streaming_hdu(self, home_is_temp):
         shdu = self._make_streaming_hdu(self.temp('new.fits'))
         assert isinstance(shdu.size, int)
         assert shdu.size == 100
+
+        arr = np.arange(25, dtype=np.int32).reshape((5, 5))
+        shdu.write(arr)
+        assert shdu.writecomplete
         shdu.close()
+
+        with fits.open(self.temp('new.fits')) as hdul:
+            assert len(hdul) == 1
+            assert (hdul[0].data == arr).all()
 
     def test_streaming_hdu_file_wrong_mode(self):
         """

--- a/astropy/io/fits/tests/test_groups.py
+++ b/astropy/io/fits/tests/test_groups.py
@@ -6,9 +6,10 @@ import time
 import pytest
 import numpy as np
 
-from . import FitsTestCase
+from . import FitsTestCase, home_is_temp
 from .test_table import comparerecords
 from astropy.io import fits
+from astropy.utils.misc import _NOT_OVERWRITING_MSG_MATCH
 
 
 class TestGroupsFunctions(FitsTestCase):
@@ -134,7 +135,7 @@ class TestGroupsFunctions(FitsTestCase):
             assert s[1] == g[2]
             assert s[2] == g[4]
 
-    def test_create_groupdata(self):
+    def test_create_groupdata(self, home_is_temp):
         """
         Basic test for creating GroupData from scratch.
         """
@@ -155,9 +156,15 @@ class TestGroupsFunctions(FitsTestCase):
         assert ghdu.parnames == ['abc', 'xyz']
         assert ghdu.header['GCOUNT'] == 10
 
-        ghdu.writeto(self.temp('test.fits'))
+        filename = self.temp('test.fits')
+        ghdu.writeto(filename)
 
-        with fits.open(self.temp('test.fits')) as h:
+        # Exercise the `overwrite` flag
+        with pytest.raises(OSError, match=_NOT_OVERWRITING_MSG_MATCH):
+            ghdu.writeto(filename, overwrite=False)
+        ghdu.writeto(filename, overwrite=True)
+
+        with fits.open(filename) as h:
             hdr = h[0].header
             assert hdr['GCOUNT'] == 10
             assert hdr['PCOUNT'] == 2

--- a/astropy/io/fits/tests/test_hdulist.py
+++ b/astropy/io/fits/tests/test_hdulist.py
@@ -15,8 +15,9 @@ from astropy.io.fits.verify import VerifyError, VerifyWarning
 from astropy.io import fits
 from astropy.utils.exceptions import AstropyUserWarning
 from astropy.utils.data import get_pkg_data_filenames
+from astropy.utils.misc import _NOT_OVERWRITING_MSG_MATCH
 
-from . import FitsTestCase
+from . import FitsTestCase, home_is_temp, home_is_data
 
 
 class TestHDUListFunctions(FitsTestCase):
@@ -334,12 +335,12 @@ class TestHDUListFunctions(FitsTestCase):
 
         assert fits.info(self.temp('test-insert.fits'), output=False) == info
 
-    def test_filename(self):
+    def test_filename(self, home_is_data):
         """Tests the HDUList filename method."""
 
         with fits.open(self.data('tb.fits')) as hdul:
             name = hdul.filename()
-        assert name == self.data('tb.fits')
+        assert name == os.path.expanduser(self.data('tb.fits'))
 
     def test_file_like(self):
         """
@@ -537,7 +538,7 @@ class TestHDUListFunctions(FitsTestCase):
         assert 'EXTEND' in hdu.header
         assert hdu.header['EXTEND'] is True
 
-    def test_replace_memmaped_array(self):
+    def test_replace_memmaped_array(self, home_is_temp):
         # Copy the original before we modify it
         with fits.open(self.data('test0.fits')) as hdul:
             hdul.writeto(self.temp('temp.fits'))
@@ -636,7 +637,7 @@ class TestHDUListFunctions(FitsTestCase):
         with fits.open(self.temp('temp.fits')) as hdul:
             assert (hdul[0].data == data).all()
 
-    def test_update_resized_header(self):
+    def test_update_resized_header(self, home_is_temp):
         """
         Test saving updates to a file where the header is one block smaller
         than before, and in the case where the heade ris one block larger than
@@ -673,7 +674,7 @@ class TestHDUListFunctions(FitsTestCase):
             assert hdul[0].data[0] == 27
             assert (hdul[0].data[1:] == data[1:]).all()
 
-    def test_update_resized_header2(self):
+    def test_update_resized_header2(self, home_is_temp):
         """
         Regression test for https://aeon.stsci.edu/ssb/trac/pyfits/ticket/150
 
@@ -681,7 +682,6 @@ class TestHDUListFunctions(FitsTestCase):
         case of multiple consecutive flush() calls on the same HDUList object,
         where each flush() requires a resize.
         """
-
         data1 = np.arange(100)
         data2 = np.arange(100) + 100
         phdu = fits.PrimaryHDU(data=data1)
@@ -764,7 +764,7 @@ class TestHDUListFunctions(FitsTestCase):
         pytest.raises(TypeError, fits.HDUList.fromstring, ['a', 'b', 'c'])
 
     @pytest.mark.filterwarnings('ignore:Saving a backup')
-    def test_save_backup(self):
+    def test_save_backup(self, home_is_temp):
         """Test for https://aeon.stsci.edu/ssb/trac/pyfits/ticket/121
 
         Save backup of file before flushing changes.
@@ -781,7 +781,7 @@ class TestHDUListFunctions(FitsTestCase):
             # pytest.mark.filterwarnings level.
             hdul[0].data[0] = 0
 
-        assert os.path.exists(self.temp('scale.fits.bak'))
+        assert os.path.exists(os.path.expanduser(self.temp('scale.fits.bak')))
         with fits.open(self.data('scale.fits'),
                        do_not_scale_image_data=True) as hdul1:
             with fits.open(self.temp('scale.fits.bak'),
@@ -795,8 +795,10 @@ class TestHDUListFunctions(FitsTestCase):
             hdul[0].header['TEST2'] = 'TEST'
             hdul[0].data[0] = 1
 
-        assert os.path.exists(self.temp('scale.fits.bak'))
-        assert os.path.exists(self.temp('scale.fits.bak.1'))
+        assert os.path.exists(
+                os.path.expanduser(self.temp('scale.fits.bak')))
+        assert os.path.exists(
+                os.path.expanduser(self.temp('scale.fits.bak.1')))
 
     def test_replace_mmap_data(self):
         """Regression test for
@@ -891,9 +893,13 @@ class TestHDUListFunctions(FitsTestCase):
             assert hdulist[0] in hdulist
             assert fits.ImageHDU() not in hdulist
 
-    def test_overwrite(self):
+    def test_overwrite(self, home_is_temp):
         hdulist = fits.HDUList([fits.PrimaryHDU()])
         hdulist.writeto(self.temp('test_overwrite.fits'))
+
+        with pytest.raises(OSError, match=_NOT_OVERWRITING_MSG_MATCH):
+            hdulist.writeto(self.temp('test_overwrite.fits'), overwrite=False)
+
         hdulist.writeto(self.temp('test_overwrite.fits'), overwrite=True)
 
     def test_invalid_hdu_key_in_contains(self):

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -27,7 +27,7 @@ from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyUserWarni
 from astropy.io.fits.column import ColumnAttribute, Delayed, NUMPY2FITS
 from astropy.io.fits.util import decode_ascii
 from astropy.io.fits.verify import VerifyError
-from . import FitsTestCase
+from . import FitsTestCase, home_is_data
 
 
 def comparefloats(a, b):
@@ -146,7 +146,7 @@ class TestTableFunctions(FitsTestCase):
         # Original header should be unchanged
         assert thdr['FILENAME'] == 'labq01i3q_rawtag.fits'
 
-    def test_open(self):
+    def test_open(self, home_is_data):
         # open some existing FITS files:
         tt = fits.open(self.data('tb.fits'))
         fd = fits.open(self.data('test0.fits'))

--- a/astropy/io/fits/tests/test_tilde_path.py
+++ b/astropy/io/fits/tests/test_tilde_path.py
@@ -1,0 +1,144 @@
+# Licensed under a 3-clause BSD style license - see PYFITS.rst
+
+import numpy as np
+import os
+import pytest
+
+from astropy.io import fits
+from astropy.utils.misc import _NOT_OVERWRITING_MSG_MATCH
+from . import FitsTestCase, home_is_data, home_is_temp
+
+
+class TestTildePaths(FitsTestCase):
+    """
+    Exercises a few functions, just to ensure they run with tilde paths (i.e.
+    paths like '~/filename.fits'). Also exercises a few subclasses. Most of the
+    rest of the testing of tilde path handling is done by adding `home_is_data`
+    and `home_is_temp` fixtures (defined and explained in __init__.py) to
+    appropriate test cases, so that they are run both with and without tilde
+    paths.
+    """
+    def test_fits_info(self, home_is_data):
+        fits.info(self.data('tb.fits'), output=False)
+
+    def test_fits_printdiff(self, home_is_data):
+        fits.printdiff(self.data('test0.fits'), self.data('tb.fits'))
+
+    def test_fits_get_data(self, home_is_data):
+        fits.getdata(self.data('test0.fits'))
+        fits.getdata(self.data('test0.fits'), header=True)
+
+    def test_fits_get_header(self, home_is_data):
+        fits.getheader(self.data('test0.fits'))
+        fits.getheader(self.data('tb.fits'), ext=1)
+
+    def test_fits_get_set_del_val(self, home_is_temp):
+        self.copy_file('test0.fits')
+        filename = self.temp('test0.fits')
+        assert fits.getval(filename, 'shutter') == 'B'
+
+        fits.setval(filename, 'shutter', value='C')
+        assert fits.getval(filename, 'shutter') == 'C'
+
+        with pytest.raises(KeyError):
+            fits.getval(filename, 'missing')
+
+        fits.setval(filename, 'missing', value='C')
+        assert fits.getval(filename, 'missing') == 'C'
+
+        fits.delval(filename, 'missing')
+        with pytest.raises(KeyError):
+            fits.getval(filename, 'missing')
+
+    def test_header_formatter(self, home_is_data):
+        from astropy.io.fits.scripts import fitsheader
+        hf = fitsheader.HeaderFormatter(self.data('zerowidth.fits'))
+        hf.close()
+
+        thf = fitsheader.TableHeaderFormatter(self.data('zerowidth.fits'))
+        thf.close()
+
+    def test_BinTableHDU_dump_load(self, home_is_temp):
+        bright = np.rec.array(
+            [(1, 'Serius', -1.45, 'A1V'),
+             (2, 'Canopys', -0.73, 'F0Ib'),
+             (3, 'Rigil Kent', -0.1, 'G2V')],
+            formats='int16,a20,float32,a10',
+            names='order,name,mag,Sp')
+        hdu = fits.BinTableHDU(bright)
+
+        hdu.dump(self.temp('data.txt'), self.temp('cdfile.txt'),
+                self.temp('hfile.txt'))
+        with pytest.raises(OSError, match='already exists'):
+            hdu.dump(self.temp('data.txt'), self.temp('cdfile.txt'),
+                    self.temp('hfile.txt'), overwrite=False)
+        hdu.dump(self.temp('data.txt'), self.temp('cdfile.txt'),
+                self.temp('hfile.txt'), overwrite=True)
+
+        fits.BinTableHDU.load(self.temp('data.txt'), self.temp('cdfile.txt'),
+                self.temp('hfile.txt'))
+
+        self.copy_file('tb.fits')
+        with fits.open(self.temp('tb.fits')) as hdul:
+            hdu = hdul[1]
+            hdu.dump()
+        assert os.path.exists(os.path.expanduser(self.temp('tb.txt')))
+
+    def test_BinTableHDU_writeto(self, home_is_temp):
+        bright = np.rec.array(
+            [(1, 'Serius', -1.45, 'A1V'),
+             (2, 'Canopys', -0.73, 'F0Ib'),
+             (3, 'Rigil Kent', -0.1, 'G2V')],
+            formats='int16,a20,float32,a10',
+            names='order,name,mag,Sp')
+        hdu = fits.BinTableHDU(bright)
+
+        hdu.writeto(self.temp('table.fits'))
+        with pytest.raises(OSError, match=_NOT_OVERWRITING_MSG_MATCH):
+            hdu.writeto(self.temp('table.fits'), overwrite=False)
+        hdu.writeto(self.temp('table.fits'), overwrite=True)
+
+    def test_TableHDU_writeto(self, home_is_temp):
+        bright = np.rec.array(
+            [(1, 'Serius', -1.45, 'A1V'),
+             (2, 'Canopys', -0.73, 'F0Ib'),
+             (3, 'Rigil Kent', -0.1, 'G2V')],
+            formats='int16,a20,float32,a10',
+            names='order,name,mag,Sp')
+        hdu = fits.TableHDU.from_columns(bright, nrows=2)
+
+        hdu.writeto(self.temp('table.fits'))
+        with pytest.raises(OSError, match=_NOT_OVERWRITING_MSG_MATCH):
+            hdu.writeto(self.temp('table.fits'), overwrite=False)
+        hdu.writeto(self.temp('table.fits'), overwrite=True)
+
+    def fits_tabledump(self, home_is_temp):
+        self.copy_file('tb.fits')
+
+        fits.tabledump(self.temp('tb.fits'), self.temp('data.txt'),
+                self.temp('cdfile.txt'), self.temp('hfile.txt'))
+        with pytest.raises(OSError, match=_NOT_OVERWRITING_MSG_MATCH):
+            fits.tabledump(self.temp('tb.fits'), self.temp('data.txt'),
+                    self.temp('cdfile.txt'), self.temp('hfile.txt'),
+                    overwrite=False)
+        fits.tabledump(self.temp('tb.fits'), self.temp('data.txt'),
+                self.temp('cdfile.txt'), self.temp('hfile.txt'),
+                overwrite=True)
+
+        fits.tableload(self.temp('data.txt'), self.temp('cdfile.txt'),
+                self.temp('hfile.txt'))
+
+    def test_ImageHDU_writeto(self, home_is_temp):
+        hdu = fits.ImageHDU(np.arange(100).reshape((10, 10)))
+        hdu.writeto(self.temp('image.fits'))
+        with pytest.raises(OSError, match=_NOT_OVERWRITING_MSG_MATCH):
+            hdu.writeto(self.temp('image.fits'), overwrite=False)
+        hdu.writeto(self.temp('image.fits'), overwrite=True)
+
+    def test_CompImageHDU_writeto(self, home_is_temp):
+        hdu = fits.CompImageHDU(
+                np.arange(100).reshape((10, 10)).astype(np.int32))
+        hdu.writeto(self.temp('image.fits'))
+        with pytest.raises(OSError, match=_NOT_OVERWRITING_MSG_MATCH):
+            hdu.writeto(self.temp('image.fits'), overwrite=False)
+        hdu.writeto(self.temp('image.fits'), overwrite=True)

--- a/astropy/io/fits/util.py
+++ b/astropy/io/fits/util.py
@@ -23,7 +23,7 @@ from packaging.version import Version
 from astropy.utils import data
 from astropy.utils.exceptions import AstropyUserWarning
 
-path_like = (str, os.PathLike)
+path_like = (str, bytes, os.PathLike)
 
 cmp = lambda a, b: (a > b) - (a < b)
 

--- a/astropy/io/registry/core.py
+++ b/astropy/io/registry/core.py
@@ -167,6 +167,13 @@ class UnifiedInputRegistry(_UnifiedIORegistryBase):
         """
         ctx = None
         try:
+            # Conservatively attempt to apply expanduser to the first argument,
+            # which is only _probably_ a file path
+            if len(args) and isinstance(args[0], PATH_TYPES):
+                ex_user = os.path.expanduser(args[0])
+                if ex_user != args[0] and os.path.exists(ex_user):
+                    args = (ex_user,) + args[1:]
+
             if format is None:
                 path = None
                 fileobj = None
@@ -332,6 +339,12 @@ class UnifiedOutputRegistry(_UnifiedIORegistryBase):
 
             .. versionadded:: 4.3
         """
+        # Conservatively attempt to apply expanduser to the first argument,
+        # which is only _probably_ a file path
+        if len(args) and isinstance(args[0], PATH_TYPES):
+            ex_user = os.path.expanduser(args[0])
+            if ex_user != args[0] and os.path.exists(os.path.dirname(ex_user)):
+                args = (ex_user,) + args[1:]
 
         if format is None:
             path = None

--- a/astropy/io/votable/util.py
+++ b/astropy/io/votable/util.py
@@ -8,6 +8,7 @@ Various utilities and cookbook-like things.
 import codecs
 import contextlib
 import io
+import os
 import re
 import gzip
 
@@ -45,6 +46,7 @@ def convert_to_writable_filelike(fd, compressed=False):
     fd : writable file-like
     """
     if isinstance(fd, str):
+        fd = os.path.expanduser(fd)
         if fd.endswith('.gz') or compressed:
             with gzip.GzipFile(fd, 'wb') as real_fd:
                 encoded_fd = io.TextIOWrapper(real_fd, encoding='utf8')

--- a/astropy/io/votable/validator/main.py
+++ b/astropy/io/votable/validator/main.py
@@ -117,6 +117,7 @@ def make_validation_report(
             raise ValueError(
                 f'{stilts} does not exist.')
 
+    destdir = os.path.expanduser(destdir)
     destdir = os.path.abspath(destdir)
 
     if urls is None:

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -268,6 +268,8 @@ def get_readable_fileobj(name_or_obj, encoding=None, cache=False,
                 name_or_obj, cache=cache, show_progress=show_progress,
                 timeout=remote_timeout, sources=sources,
                 http_headers=http_headers)
+        else:
+            name_or_obj = os.path.expanduser(name_or_obj)
         fileobj = io.FileIO(name_or_obj, 'r')
         if is_url and not cache:
             delete_fds.append(fileobj)


### PR DESCRIPTION
### Description

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->


This PR is hopefully everything needed to close #12778 and allow paths to be given relative to the user's home directory as `~/dir/filename.fits`. I think this covers every part of the `io` module that should be covered (based on my scrolling through the docs---I could have missed something).

In most submodules within `io`, there's just some sort of read and write method, so it was pretty easy to add a call to `os.path.expanduser` to each and add a simple test. `io.fits` is by far the largest affected API. I tried adding the `expanduser` call at the bottom-most level in `fileobj_open` as discussed in #12778, but I found that there were other points in the call stack where the file path does get used (e.g. the `overwrite` flags supported by some of the output methods), and so instead I've added `expanduser` calls early in the call stack, so that the tilde is expanded before anything tries to use the file path.

At a few points in `io.fits`, functions can accept a file path or an open file object, and so the `os.path.expanduser` call comes after some sort of check to see if the input is a type that would represent a path. I noticed those checks weren't all consistent. Some use the `path_like = (str, os.PathLike)` tuple defined in `fits/utils.py`, others check for just a `str`, and a few check for a `str` or `bytes`. I didn't see a reason for this varied checking, so I added `bytes` to `path_like` and, wherever I was already making a change, I changed things to use `path_like`. In some places my change came after an existing check which I modified, but in others I had to add a new check and would have had to make a decision anyway on how to do this check. I won't claim to have harmonized this type checking over all of `io.fits`, and I can back out or separate this if it's too unrelated.

For testing tilde paths, I used pytest's `monkeypatch` to temporarily update the environment variables so that `~` resolves to either the test data directory or the temporary directory, as appropriate, and only for specific test cases. Then, depending on what I found in the existing tests, I either added a test case just for exercising `~` expansion, or I augmented an existing test to run both with data/temp paths given normally, and with data/temp paths given via `~` paths. In `io.fits` there's some existing infrastructure with a `FitsTestCase` class with methods to access the data and temp directories, and I've plugged into this to make it easy to sprinkle these tilde-path tests throughout the existing tests. I scrolled through the `io.fits` documentation to find everything that looked IO-related and end-user-facing. When I found a relatively simple test exercising those functions I added a fixture to run that test both with and without tilde paths, and otherwise I added a new test case specifically to exercise that function. There were a few utility functions that I don't think were being exercised at all in testing, so this PR might increase coverage a tad, though these new tests are more just about ensure a FileNotFound error isn't raised with tilde paths.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
