### PR TITLE
Add link to Header class in FITS header docs

### DIFF
--- a/docs/io/fits/index.rst
+++ b/docs/io/fits/index.rst
@@ -211,8 +211,8 @@ and comment must both be strings, whereas the value can be a string or an
 integer, floating point number, complex number, or ``True``/``False``. Keywords
 are usually unique within a header, except in a few special cases.
 
-The header attribute is a Header instance, another ``astropy`` object. To get
-the value associated with a header keyword, do (à la Python dicts)::
+The header attribute is a :class:`Header` instance, another ``astropy`` object.
+To get the value associated with a header keyword, do (à la Python dicts)::
 
     >>> hdul = fits.open(fits_image_filename)
     >>> hdul[0].header['DATE']


### PR DESCRIPTION
### Description

Just noticed that in the front page for the `io.fits` docs, the section on headers could use a direct link to the Header class docs.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
