### PR TITLE
Fix compiler errors with older externally installed WCSLIB

### DIFF
--- a/astropy/wcs/docstrings.py
+++ b/astropy/wcs/docstrings.py
@@ -2312,7 +2312,7 @@ axes : int or a sequence.
 
     - ``'stokes'`` / ``WCSSUB_STOKES``: Stokes axis
 
-    - ``'temporal'`` / WCSSUB_TIME: Time axis
+    - ``'temporal'`` / ``WCSSUB_TIME``: Time axis (requires ``WCSLIB`` version 7.8 or greater)
 
     - ``'celestial'`` / ``WCSSUB_CELESTIAL``: An alias for the
       combination of ``'longitude'``, ``'latitude'`` and ``'cubeface'``.

--- a/astropy/wcs/tests/test_tab.py
+++ b/astropy/wcs/tests/test_tab.py
@@ -61,11 +61,17 @@ def test_mixed_celest_and_1d_tab_roundtrip():
     assert np.allclose(pts, w.wcs_world2pix(w.wcs_pix2world(pts, 0), 0))
 
 
+@pytest.mark.skipif(
+    _WCSLIB_VER < Version('7.8'),
+    reason="Requires WCSLIB >= 7.8 for swapping -TAB axes to work."
+)
 def test_wcstab_swapaxes():
     # Crash on deepcopy of swapped -TAB axes reported in #13036.
     # Fixed in #13063.
     filename = get_pkg_data_filename('data/tab-time-last-axis.fits')
     with fits.open(filename) as hdul:
         w = wcs.WCS(hdul[0].header, hdul)
+        w.wcs.ctype[-1] = 'FREQ-TAB'
+        w.wcs.set()
     wswp = w.swapaxes(2, 0)
     deepcopy(wswp)


### PR DESCRIPTION
### Description

This pull request is to address compiler errors when compiling WCSLIB wrapper with externally installed WCSLIB of version less than 7.8.

- [x] ~Rebase after #13120 is merged.~ Fix for test backported directly in #13123

Fixes #13109

### Checklist for package maintainer(s)

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
