### PR TITLE
Partial revert on default_cosmology

### DIFF
--- a/astropy/cosmology/tests/test_realizations.py
+++ b/astropy/cosmology/tests/test_realizations.py
@@ -38,31 +38,13 @@ class Test_default_cosmology(object):
     # -----------------------------------------------------
     # Get
 
-    def test_get_fail(self):
-        """Test bad inputs to :meth:`astropy.cosmology.default_cosmology.get`."""
-        # a not-valid option, but still a str
-        with pytest.raises(ValueError, match="Unknown cosmology"):
-            default_cosmology.get("fail!")
-
-        # a not-valid type
-        with pytest.raises(TypeError, match="'key' must be must be"):
-            default_cosmology.get(object())
-
     def test_get_current(self):
         """Test :meth:`astropy.cosmology.default_cosmology.get` current value."""
-        cosmo = default_cosmology.get(None)
-        assert cosmo is default_cosmology.get(default_cosmology._value)
+        cosmo = default_cosmology.get()
+        assert cosmo is default_cosmology.validate(default_cosmology._value)
 
-    def test_get_none(self):
-        """Test :meth:`astropy.cosmology.default_cosmology.get` to `None`."""
-        cosmo = default_cosmology.get("no_default")
-        assert cosmo is None
-
-    @pytest.mark.parametrize("name", parameters.available)
-    def test_get_valid(self, name):
-        """Test :meth:`astropy.cosmology.default_cosmology.get` from str."""
-        cosmo = default_cosmology.get(name)
-        assert cosmo is getattr(realizations, name)
+    # -----------------------------------------------------
+    # get_cosmology_from_string (deprecated)
 
     def test_get_cosmology_from_string(self, recwarn):
         """Test method ``get_cosmology_from_string``."""
@@ -84,6 +66,14 @@ class Test_default_cosmology(object):
         with pytest.raises(TypeError, match="must be a string or Cosmology"):
             default_cosmology.validate(TypeError)
 
+        # a not-valid option, but still a str
+        with pytest.raises(ValueError, match="Unknown cosmology"):
+            default_cosmology.validate("fail!")
+
+        # a not-valid type
+        with pytest.raises(TypeError, match="cannot find a Cosmology"):
+            default_cosmology.validate("available")
+
     def test_validate_default(self):
         """Test method ``validate`` for specific values."""
         value = default_cosmology.validate(None)
@@ -101,6 +91,11 @@ class Test_default_cosmology(object):
         cosmo = getattr(realizations, name)
         value = default_cosmology.validate(cosmo)
         assert value is cosmo
+
+    def test_validate_no_default(self):
+        """Test :meth:`astropy.cosmology.default_cosmology.get` to `None`."""
+        cosmo = default_cosmology.validate("no_default")
+        assert cosmo is None
 
 
 @pytest.mark.parametrize("name", parameters.available)

--- a/docs/changes/cosmology/12375.api.rst
+++ b/docs/changes/cosmology/12375.api.rst
@@ -1,3 +1,3 @@
 ``default_cosmology.get_cosmology_from_string`` is deprecated and will be
 removed in two minor versions.
-Use ``default_cosmology.get(<str>)`` instead.
+Use ``getattr(astropy.cosmology, <str>)`` instead.


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

Before the feature freeze and a things gets baked in, I'd like to roll back some of the unnecessary bells and whistles I added in #12375. ``default_cosmology`` should be dead simple for getting and setting the default cosmology.
I pattern this refactor off ``galactocentric_defaults``, but make ``_get_from_registry`` private as there is not (yet) a registry.


### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
