### PR TITLE
Test that swapped -TAB axes return same world coordinates in swapped order

### DIFF
--- a/astropy/wcs/tests/test_tab.py
+++ b/astropy/wcs/tests/test_tab.py
@@ -69,3 +69,21 @@ def test_wcstab_swapaxes():
         w = wcs.WCS(hdul[0].header, hdul)
     wswp = w.swapaxes(2, 0)
     deepcopy(wswp)
+
+
+@pytest.mark.skipif(
+    _WCSLIB_VER < Version('7.8'),
+    reason="Requires WCSLIB >= 7.8 for swapping -TAB axes to work."
+)
+def test_wcstab_swapaxes_same_val():
+    filename = get_pkg_data_filename('data/tab-time-last-axis.fits')
+    with fits.open(filename) as hdul:
+        w = wcs.WCS(hdul[0].header, hdul)
+        w.wcs.ctype[-1] = 'FREQ-TAB'
+        w.wcs.set()
+        ws = w.sub([3, 2, 1])
+
+    val_ref = w.wcs_pix2world([[3, 5, 7]], 0)[0]
+    val_swapped = ws.wcs_pix2world([[7, 5, 3]], 0)[0]
+
+    assert np.allclose(val_ref, val_swapped[([2, 1, 0], )])

--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -1555,3 +1555,18 @@ def test_temporal():
     assert w.sub([wcs.WCSSUB_TIME]).is_temporal
     assert (w.wcs_pix2world([[1, 2, 3]], 0)[0, 2] ==
             w.temporal.wcs_pix2world([[3]], 0)[0, 0])
+
+
+def test_swapaxes_same_val():
+    w = wcs.WCS(naxis=3)
+    w.wcs.ctype = ["RA---TAN", "DEC--TAN", "FREQ"]
+    w.wcs.crpix = [32.5, 16.5, 1.]
+    w.wcs.crval = [5.63, -72.05, 1.]
+    w.wcs.pc = [[5.9e-06, 1.3e-05, 0.0], [-1.2e-05, 5.0e-06, 0.0], [0.0, 0.0, 1.0]]
+    w.wcs.cdelt = [1.0, 1.0, 1.0]
+    w.wcs.set()
+    ws = w.sub([3, 2, 1])
+    val_ref = w.wcs_pix2world([[3, 5, 7]], 0)[0]
+    val_swapped = ws.wcs_pix2world([[7, 5, 3]], 0)[0]
+
+    assert np.allclose(val_ref, val_swapped[([2, 1, 0], )])


### PR DESCRIPTION
### Description

Unit test to test that world coordinates corresponding pixel coordinates in a swapped-tab-axis WCS are similar to the world coordinates of the original WCS when order of axes is taken into account.

### Checklist for package maintainer(s)

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
