### PR TITLE
Minor updates to units documentation

### DIFF
--- a/docs/units/format.rst
+++ b/docs/units/format.rst
@@ -12,9 +12,9 @@ strings using the `Python Format String Syntax
 (demonstrated below using `f-strings
 <https://www.python.org/dev/peps/pep-0498/>`_).
 
-For quantities, format specifiers, like ``0.003f`` will be applied to
+For quantities, format specifiers, like ``.3f`` will be applied to
 the |Quantity| value, without affecting the unit. Specifiers like
-``20s``, which would only apply to a string, will be applied to the
+``^20s``, which would only apply to a string, will be applied to the
 whole string representation of the |Quantity|.
 
 Examples
@@ -31,23 +31,23 @@ To render |Quantity| or |Unit| objects as strings::
     <Quantity  10.5 km>
     >>> f"{q}"
     '10.5 km'
-    >>> f"{q:+0.03f}"
+    >>> f"{q:+.3f}"
     '+10.500 km'
-    >>> f"{q:20s}"
-    '10.5 km             '
+    >>> f"{q:^20s}"
+    '     10.5 km        '
 
 To format both the value and the unit separately, you can access the |Quantity|
-class attributes within format strings::
+attributes within format strings::
 
     >>> q = 10.5 * u.km
     >>> q
     <Quantity  10.5 km>
-    >>> f"{q.value:0.003f} in {q.unit:s}"
+    >>> f"{q.value:.3f} in {q.unit}"
     '10.500 in km'
 
-Because ``numpy`` arrays do not accept most format specifiers, using specifiers
-like ``0.003f`` will not work when applied to a ``numpy`` array or non-scalar
-|Quantity|. Use :func:`numpy.array_str` instead. For instance::
+Because |ndarray| does not accept most format specifiers, using specifiers like
+``.3f`` will not work when applied to a |ndarray| or non-scalar |Quantity|. Use
+:func:`numpy.array_str` instead. For instance::
 
     >>> q = np.linspace(0,1,10) * u.m
     >>> f"{np.array_str(q.value, precision=1)} {q.unit}"  # doctest: +FLOAT_CMP
@@ -72,15 +72,15 @@ parameter to select a different format, including ``"latex"``, ``"unicode"``,
     '10.000 in $\\mathrm{km}$'
     >>> fluxunit = u.erg / (u.cm ** 2 * u.s)
     >>> f"{fluxunit}"
-    u'erg / (cm2 s)'
+    'erg / (cm2 s)'
     >>> print(f"{fluxunit:console}")
      erg
     ------
     s cm^2
     >>> f"{fluxunit:latex}"
-    u'$\\mathrm{\\frac{erg}{s\\,cm^{2}}}$'
+    '$\\mathrm{\\frac{erg}{s\\,cm^{2}}}$'
     >>> f"{fluxunit:>20s}"
-    u'       erg / (cm2 s)'
+    '       erg / (cm2 s)'
 
 The :meth:`~astropy.units.core.UnitBase.to_string` method is an alternative way
 to format units as strings, and is the underlying implementation of the
@@ -88,7 +88,7 @@ to format units as strings, and is the underlying implementation of the
 
     >>> fluxunit = u.erg / (u.cm ** 2 * u.s)
     >>> fluxunit.to_string('latex')
-    u'$\\mathrm{\\frac{erg}{s\\,cm^{2}}}$'
+    '$\\mathrm{\\frac{erg}{s\\,cm^{2}}}$'
 
 Creating Units from Strings
 ===========================
@@ -110,7 +110,7 @@ formats using the `~astropy.units.Unit` class::
    Creating units from strings requires the use of a specialized
    parser for the unit language, which results in a performance
    penalty if units are created using strings. Thus, it is much
-   faster to use unit objects directly (e.g., ``unit = u.degree /
+   faster to use |Unit| objects directly (e.g., ``unit = u.degree /
    u.minute``) instead of via string parsing (``unit =
    u.Unit('deg/min')``). This parser is very useful, however, if your
    unit definitions are coming from a file format such as FITS or
@@ -151,7 +151,7 @@ following formats:
     `IAU Style Manual
     <https://www.iau.org/static/publications/stylemanual1989.pdf>`_
     recommendations for unit presentation. This format is
-    automatically used when printing a unit in the IPython notebook::
+    automatically used when printing a unit in the `IPython`_ notebook::
 
       >>> fluxunit  # doctest: +SKIP
 


### PR DESCRIPTION
### Description

~~The first commit in this pull request changes the `|Unit|` link defined in [`doc/common_links.txt`](https://github.com/astropy/astropy/blob/main/docs/common_links.txt) to point to the `Unit` class instead of the `UnitBase` class. This link was used in three places:~~
https://github.com/astropy/astropy/blob/497a9f84f60151ed46ff0ad4ab58e4ae1e5d2641/docs/units/format.rst#L9
https://github.com/astropy/astropy/blob/497a9f84f60151ed46ff0ad4ab58e4ae1e5d2641/docs/units/format.rst#L25
https://github.com/astropy/astropy/blob/497a9f84f60151ed46ff0ad4ab58e4ae1e5d2641/docs/units/structured_units.rst#L8

The second commit applies various small updates to [`docs/units/format.rst`](https://github.com/astropy/astropy/blob/main/docs/units/format.rst).

EDIT: The first commit has been removed to avoid making potentially controversial changes in a hurry.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
