### PR TITLE
Fix `aggregate_downsample` performance hit for plain ndarray columns

### DIFF
--- a/astropy/timeseries/downsample.py
+++ b/astropy/timeseries/downsample.py
@@ -33,8 +33,8 @@ def reduceat(array, indices, function):
             if indices[i + 1] <= indices[i] + 1:
                 result.append(function(array[indices[i]]))
             else:
-                result.append(function(array[indices[i]:indices[i+1]]))
-        result.append(function(array[indices[-1]:]))
+                result.append(function(array[indices[i] : indices[i + 1]]))
+        result.append(function(array[indices[-1] :]))
         return as_array(result)
 
 
@@ -45,7 +45,7 @@ def aggregate_downsample(
     time_bin_start=None,
     time_bin_end=None,
     n_bins=None,
-    aggregate_func=None
+    aggregate_func=None,
 ):
     """
     Downsample a time series by binning values into bins with a fixed size or
@@ -193,7 +193,7 @@ def aggregate_downsample(
     rel_bin_start = (bin_start - rel_base).to_value(format="sec", subfmt="long")
     rel_bin_end = (bin_end - rel_base).to_value(format="sec", subfmt="long")
     rel_ts_sorted_t = (ts_sorted.time - rel_base).to_value(format="sec", subfmt="long")
-    keep = ((rel_ts_sorted_t >= rel_bin_start[0]) & (rel_ts_sorted_t <= rel_bin_end[-1]))
+    keep = (rel_ts_sorted_t >= rel_bin_start[0]) & (rel_ts_sorted_t <= rel_bin_end[-1])
 
     # Find out indices to be removed because of noncontiguous bins
     #
@@ -247,7 +247,7 @@ def aggregate_downsample(
                 reduceat(values.value, groups, aggregate_func), values.unit, copy=False
             )
         elif isinstance(values, NdarrayMixin):
-            data = NdarrayMixin(np.repeat(np.nan,  n_bins))
+            data = NdarrayMixin(np.repeat(np.nan, n_bins))
             data[unique_indices] = reduceat(values, groups, aggregate_func)
         elif isinstance(values, np.ndarray):
             data = np.ma.zeros(n_bins, dtype=values.dtype)
@@ -256,8 +256,10 @@ def aggregate_downsample(
             data.mask[unique_indices] = 0
         # FIXME: figure out how to avoid the following, if possible (and if still happening)
         else:
-            warnings.warn(f"Skipping column '{colname}' since it has an unsupported mix-in type",
-                          AstropyUserWarning)
+            warnings.warn(
+                f"Skipping column '{colname}' since it has an unsupported mix-in type",
+                AstropyUserWarning,
+            )
             continue
 
         binned[colname] = data

--- a/astropy/timeseries/downsample.py
+++ b/astropy/timeseries/downsample.py
@@ -246,23 +246,20 @@ def aggregate_downsample(
 
         values = subset[colname]
 
-        # FIXME: figure out how to avoid the following, if possible
-        if not isinstance(values, (np.ndarray, u.Quantity)):
-            warnings.warn(
-                "Skipping column {0} since it has a mix-in type", AstropyUserWarning
-            )
-            continue
-
         if isinstance(values, u.Quantity):
             data = u.Quantity(np.repeat(np.nan, n_bins), unit=values.unit)
             data[unique_indices] = u.Quantity(
                 reduceat(values.value, groups, aggregate_func), values.unit, copy=False
             )
-        else:
+        elif isinstance(values, np.ndarray):
             data = np.ma.zeros(n_bins, dtype=values.dtype)
             data.mask = 1
-            data[unique_indices] = reduceat(values, groups, aggregate_func)
+            data[unique_indices] = reduceat(values.value, groups, aggregate_func)
             data.mask[unique_indices] = 0
+        # FIXME: figure out how to avoid the following, if possible
+        else:
+            warnings.warn("Skipping column {0} since it has a mix-in type", AstropyUserWarning)
+            continue
 
         binned[colname] = data
 

--- a/astropy/timeseries/tests/test_downsample.py
+++ b/astropy/timeseries/tests/test_downsample.py
@@ -305,14 +305,12 @@ def test_time_precision_limit(diff_from_base):
     """
     precision_limit = 500 * u.ns
 
-    from astropy.timeseries.downsample import _to_relative_longdouble
-
     t_base = Time("1980-01-01T12:30:31.000", format="isot", scale="tdb")
     t2 = t_base + diff_from_base
     t3 = t2 + precision_limit
 
-    r_t2 = _to_relative_longdouble(t2, t_base)
-    r_t3 = _to_relative_longdouble(t3, t_base)
+    r_t2 = (t2 - t_base).to_value(format="sec", subfmt="long")
+    r_t3 = (t3 - t_base).to_value(format="sec", subfmt="long")
 
     # ensure in the converted relative time,
     # t2 and t3 can still be correctly compared

--- a/astropy/timeseries/tests/test_downsample.py
+++ b/astropy/timeseries/tests/test_downsample.py
@@ -131,9 +131,10 @@ def test_nbins():
         assert len(down_nbins) == n_times
 
 
-@pytest.mark.parametrize("data_type", [np.array, NdarrayMixin,
-                                       lambda x: x * u.ct,
-                                       lambda x: u.Quantity(x, unit='ct')])
+@pytest.mark.parametrize(
+    "data_type",
+    [np.array, NdarrayMixin, lambda x: x * u.ct, lambda x: u.Quantity(x, unit="ct")],
+)
 def test_downsample(data_type):
     ts = TimeSeries(time=INPUT_TIME, data=[data_type([1.0, 2, 3, 4, 5])], names=["a"])
     ts_units = TimeSeries(
@@ -207,7 +208,7 @@ def test_downsample(data_type):
     # Specific data type properties
     if isinstance(down_4["a"], u.Quantity):
         assert_equal(down_4["a"].value, np.array([2.5, 5]))
-        assert down_4["a"].unit.name == 'ct'
+        assert down_4["a"].unit.name == "ct"
     elif isinstance(down_4["a"], NdarrayMixin):
         assert_equal(np.array(down_4["a"]), np.array([2.5, 5]))
     else:

--- a/docs/changes/timeseries/13126.bugfix.rst
+++ b/docs/changes/timeseries/13126.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed a bug in ``timeseries.aggregate_downsample`` incorrectly converting
+mixin columns to ``np.array``.

--- a/docs/changes/timeseries/13126.feature.rst
+++ b/docs/changes/timeseries/13126.feature.rst
@@ -1,0 +1,2 @@
+Fixed another performance regression in ``timeseries.aggregate_downsample``
+when binning plain ``np.ndarray`` columns.

--- a/docs/timeseries/analysis.rst
+++ b/docs/timeseries/analysis.rst
@@ -112,13 +112,19 @@ Sorting time series in place can be done using the
 Resampling
 ==========
 
-We provide a :func:`~astropy.timeseries.aggregate_downsample` function
+We provide an :func:`~astropy.timeseries.aggregate_downsample` function
 that can be used to bin values from a time series into equal-size or uneven bins,
-and contiguous and non-contiguous bins, using a custom function (mean, median, etc.).
+and contiguous and non-contiguous bins, using a custom averaging function
+(mean, median, etc.) to evaluate the data values for each bin.
 This operation returns a |BinnedTimeSeries|. Note that this is a basic function in
 the sense that it does not, for example, know how to treat columns with uncertainties
 differently from other values, and it will blindly apply the custom function
 specified to all columns.
+Sorting and binning of the time points is done on relative offsets from the first
+point to allow efficient vectorization of these operations. In principle this
+involves some loss of precision compared to the |Time| objects, but the
+algorithm ensures an accuracy of ``< 1 µs`` on a baseline of over a century,
+and proportionately better for shorter time series.
 
 Example
 -------


### PR DESCRIPTION
### Description
Fixes #13093; the excess runtime found there seems to be due to `reduceat` being directly called on the column instance for the `isinstance(subset[colname], np.ndarray)` case as opposed to `subset[colname].value` for Quantity-type columns introducing additional overhead.
Alternatively this might be addressed directly inside `reduceat` by checking for a `Column` instance, e.g.
```python
if hasattr(array, 'value'):
    array = array.value
```
Will need #13069 to show any effect against the 100x larger performance hit fixed there.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
