### PR TITLE
Support opening file paths given relative to home directory with tildes in io.ascii

### DIFF
--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -23,6 +23,7 @@ from .common import (assert_equal, assert_almost_equal,
                      assert_true)
 from astropy.io.ascii import core
 from astropy.io.ascii.ui import _probably_html, get_read_trace
+from astropy.utils.data import get_pkg_data_path
 from astropy.utils.exceptions import AstropyWarning
 
 # NOTE: Python can be built without bz2.
@@ -34,6 +35,21 @@ from .common import setup_function, teardown_function  # noqa
 
 def asciiIO(x):
     return BytesIO(x.encode('ascii'))
+
+
+@pytest.fixture
+def home_is_data(monkeypatch, request):
+    """
+    Pytest fixture to run a test case with tilde-prefixed paths.
+
+    In the tilde-path case, environment variables are temporarily
+    modified so that '~' resolves to the data directory.
+    """
+    path = get_pkg_data_path('data')
+    # For Unix
+    monkeypatch.setenv('HOME', path)
+    # For Windows
+    monkeypatch.setenv('USERPROFILE', path)
 
 
 @pytest.mark.parametrize('fast_reader', [True, False, {'use_fast_converter': False},
@@ -184,11 +200,17 @@ def test_read_with_names_arg(fast_reader):
 
 
 @pytest.mark.parametrize('fast_reader', [True, False, 'force'])
-def test_read_all_files(fast_reader):
+@pytest.mark.parametrize('path_format', ['plain', 'tilde-str', 'tilde-pathlib'])
+def test_read_all_files(fast_reader, path_format, home_is_data):
     for testfile in get_testfiles():
         if testfile.get('skip'):
             print(f"\n\n******** SKIPPING {testfile['name']}")
             continue
+        if 'tilde' in path_format:
+            if 'str' in path_format:
+                testfile['name'] = '~/' + testfile['name'][5:]
+            else:
+                testfile['name'] = pathlib.Path('~/', testfile['name'][5:])
         print(f"\n\n******** READING {testfile['name']}")
         for guess in (True, False):
             test_opts = testfile['opts'].copy()
@@ -205,11 +227,17 @@ def test_read_all_files(fast_reader):
 
 
 @pytest.mark.parametrize('fast_reader', [True, False, 'force'])
-def test_read_all_files_via_table(fast_reader):
+@pytest.mark.parametrize('path_format', ['plain', 'tilde-str', 'tilde-pathlib'])
+def test_read_all_files_via_table(fast_reader, path_format, home_is_data):
     for testfile in get_testfiles():
         if testfile.get('skip'):
             print(f"\n\n******** SKIPPING {testfile['name']}")
             continue
+        if 'tilde' in path_format:
+            if 'str' in path_format:
+                testfile['name'] = '~/' + testfile['name'][5:]
+            else:
+                testfile['name'] = pathlib.Path('~/', testfile['name'][5:])
         print(f"\n\n******** READING {testfile['name']}")
         for guess in (True, False):
             test_opts = testfile['opts'].copy()
@@ -1179,11 +1207,12 @@ def test_commented_header_comments(fast):
     assert dat.colnames == ['a', 'b']
 
 
-def test_probably_html():
+def test_probably_html(home_is_data):
     """
     Test the routine for guessing if a table input to ascii.read is probably HTML
     """
     for tabl0 in ('data/html.html',
+                  '~/html.html',
                   'http://blah.com/table.html',
                   'https://blah.com/table.html',
                   'file://blah/table.htm',

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -80,7 +80,8 @@ def _probably_html(table, maxchars=100000):
             return True
 
         # Filename ending in .htm or .html which exists
-        if re.search(r'\.htm[l]?$', table[-5:], re.IGNORECASE) and os.path.exists(table):
+        if (re.search(r'\.htm[l]?$', table[-5:], re.IGNORECASE) and
+                os.path.exists(os.path.expanduser(table))):
             return True
 
         # Table starts with HTML document type declaration
@@ -346,6 +347,13 @@ def read(table, guess=None, **kwargs):
         if format is None:
             reader = get_reader(**new_kwargs)
             format = reader._format_name
+
+        if isinstance(table, (str, bytes, os.PathLike)):
+            # Conservatively attempt to expand `table`, which could be a file
+            # path or the actual data of a table.
+            ex_user = os.path.expanduser(table)
+            if os.path.exists(ex_user):
+                table = ex_user
 
         # Try the fast reader version of `format` first if applicable.  Note that
         # if user specified a fast format (e.g. format='fast_basic') this test
@@ -801,7 +809,8 @@ def write(table, output=None, format=None, Writer=None, fast_writer=True, *,
     _validate_read_write_kwargs('write', format=format, fast_writer=fast_writer,
                                 overwrite=overwrite, **kwargs)
 
-    if isinstance(output, str):
+    if isinstance(output, (str, bytes, os.PathLike)):
+        output = os.path.expanduser(output)
         if not overwrite and os.path.lexists(output):
             raise OSError(NOT_OVERWRITING_MSG.format(output))
 

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -268,6 +268,8 @@ def get_readable_fileobj(name_or_obj, encoding=None, cache=False,
                 name_or_obj, cache=cache, show_progress=show_progress,
                 timeout=remote_timeout, sources=sources,
                 http_headers=http_headers)
+        else:
+            name_or_obj = os.path.expanduser(name_or_obj)
         fileobj = io.FileIO(name_or_obj, 'r')
         if is_url and not cache:
             delete_fds.append(fileobj)

--- a/docs/changes/io.ascii/13130.feature.rst
+++ b/docs/changes/io.ascii/13130.feature.rst
@@ -1,0 +1,3 @@
+Added support in ``io.ascii`` for reading and writing file paths of the form
+``~/file.csv`` or ``~<username>/file.csv``, referring to the home directory of
+the current user or the specified user, respectively.


### PR DESCRIPTION
### Description
This PR is split from #13107 and addresses #12778 within `io.ascii`. The changes allow file paths to be given relative to the user's home directory as `~/dir/filename.fits` when doing file IO.

For testing, I used pytest's monkeypatch to temporarily update the environment variables so that `~` resolves to the test's temp or data directory, as appropriate and only for designated tests. Then I updated some of the existing IO tests to run twice, once with paths to temp or data files given normally, and once with those paths given with tildes.

Since some of the tests exercise `io.ascii` as wrapped by `Table`, I'll note that related changes to `Table` are in #13129, though those changes and tests seem to stand independently from these changes and tests.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
