### PR TITLE
Support opening file paths given relative to home directory with tildes in io.fits

### DIFF
--- a/astropy/io/fits/convenience.py
+++ b/astropy/io/fits/convenience.py
@@ -69,7 +69,7 @@ from .hdu.hdulist import HDUList, fitsopen
 from .hdu.image import ImageHDU, PrimaryHDU
 from .hdu.table import BinTableHDU
 from .header import Header
-from .util import _is_dask_array, _is_int, fileobj_closed, fileobj_mode, fileobj_name
+from .util import _is_dask_array, _is_int, fileobj_closed, fileobj_mode, fileobj_name, path_like
 
 __all__ = ['getheader', 'getdata', 'getval', 'setval', 'delval', 'writeto',
            'append', 'update', 'info', 'tabledump', 'tableload',
@@ -657,6 +657,8 @@ def append(filename, data, header=None, checksum=False, verify=True, **kwargs):
         - Otherwise no additional arguments can be used.
 
     """
+    if isinstance(filename, path_like):
+        filename = os.path.expanduser(filename)
     name, closed, noexist_or_empty = _stat_filename_or_fileobj(filename)
 
     if noexist_or_empty:

--- a/astropy/io/fits/diff.py
+++ b/astropy/io/fits/diff.py
@@ -28,6 +28,7 @@ from .card import BLANK_CARD, Card
 from .hdu.hdulist import HDUList, fitsopen  # pylint: disable=W0611
 from .hdu.table import _TableLikeHDU
 from .header import Header
+from .util import path_like
 
 __all__ = ['FITSDiff', 'HDUDiff', 'HeaderDiff', 'ImageDataDiff', 'RawDataDiff',
            'TableDataDiff']
@@ -149,7 +150,8 @@ class _BaseDiff:
         return_string = False
         filepath = None
 
-        if isinstance(fileobj, str):
+        if isinstance(fileobj, path_like):
+            fileobj = os.path.expanduser(fileobj)
             if os.path.exists(fileobj) and not overwrite:
                 raise OSError(NOT_OVERWRITING_MSG.format(fileobj))
             else:

--- a/astropy/io/fits/file.py
+++ b/astropy/io/fits/file.py
@@ -25,7 +25,7 @@ from astropy.utils.misc import NOT_OVERWRITING_MSG
 
 from .util import (
     _array_from_file, _array_to_file, _write_string, fileobj_closed, fileobj_mode, fileobj_name,
-    isfile, isreadable, iswritable)
+    isfile, isreadable, iswritable, path_like)
 
 if HAS_BZ2:
     import bz2
@@ -166,6 +166,8 @@ class _File:
                     f"Mode {mode} not supported for HTTPResponse")
             fileobj = io.BytesIO(fileobj.read())
         else:
+            if isinstance(fileobj, path_like):
+                fileobj = os.path.expanduser(fileobj)
             self.name = fileobj_name(fileobj)
 
         self.mode = mode

--- a/astropy/io/fits/hdu/streaming.py
+++ b/astropy/io/fits/hdu/streaming.py
@@ -70,6 +70,8 @@ class StreamingHDU:
         # handle a file object instead of a file name
         filename = fileobj_name(name) or ''
 
+        filename = os.path.expanduser(filename)
+
         # Check if the file already exists.  If it does not, check to see
         # if we were provided with a Primary Header.  If not we will need
         # to prepend a default PrimaryHDU to the file before writing the

--- a/astropy/io/fits/hdu/table.py
+++ b/astropy/io/fits/hdu/table.py
@@ -23,7 +23,7 @@ from astropy.io.fits.column import (
     _scalar_to_format)
 from astropy.io.fits.fitsrec import FITS_rec, _get_recarray_field, _has_unicode_fields
 from astropy.io.fits.header import Header, _pad_length
-from astropy.io.fits.util import _is_int, _str_to_num
+from astropy.io.fits.util import _is_int, _str_to_num, path_like
 from astropy.utils import lazyproperty
 from astropy.utils.exceptions import AstropyDeprecationWarning
 
@@ -1084,12 +1084,18 @@ class BinTableHDU(_TableBaseHDU):
         plain text (ASCII) files.
         """
 
+        if isinstance(datafile, path_like):
+            datafile = os.path.expanduser(datafile)
+        if isinstance(cdfile, path_like):
+            cdfile = os.path.expanduser(cdfile)
+        if isinstance(hfile, path_like):
+            hfile = os.path.expanduser(hfile)
         # check if the output files already exist
         exist = []
         files = [datafile, cdfile, hfile]
 
         for f in files:
-            if isinstance(f, str):
+            if isinstance(f, path_like):
                 if os.path.exists(f) and os.path.getsize(f) != 0:
                     if overwrite:
                         os.remove(f)
@@ -1309,7 +1315,8 @@ class BinTableHDU(_TableBaseHDU):
 
         close_file = False
 
-        if isinstance(fileobj, str):
+        if isinstance(fileobj, path_like):
+            fileobj = os.path.expanduser(fileobj)
             fileobj = open(fileobj)
             close_file = True
 
@@ -1452,7 +1459,8 @@ class BinTableHDU(_TableBaseHDU):
 
         close_file = False
 
-        if isinstance(fileobj, str):
+        if isinstance(fileobj, path_like):
+            fileobj = os.path.expanduser(fileobj)
             fileobj = open(fileobj)
             close_file = True
 

--- a/astropy/io/fits/header.py
+++ b/astropy/io/fits/header.py
@@ -4,6 +4,7 @@ import collections
 import copy
 import itertools
 import numbers
+import os
 import re
 import warnings
 
@@ -498,6 +499,7 @@ class Header:
             #
             # Otherwise assume we are reading from an actual FITS file and open
             # in binary mode.
+            fileobj = os.path.expanduser(fileobj)
             if sep:
                 fileobj = open(fileobj, encoding='latin1')
             else:

--- a/astropy/io/fits/tests/__init__.py
+++ b/astropy/io/fits/tests/__init__.py
@@ -1,18 +1,68 @@
 # Licensed under a 3-clause BSD style license - see PYFITS.rst
 
 import os
+import pathlib
 import shutil
 import stat
 import tempfile
 import time
 
+import pytest
+
 from astropy.io import fits
+
+
+@pytest.fixture(
+        params=[False, 'str', 'pathlib'],
+        ids=['', 'home_is_data', 'home_is_data, pathlib'])
+def home_is_data(request, monkeypatch):
+    """
+    Pytest fixture to run a test case both with and without tilde paths.
+
+    In the tilde-path case, calls like self.data('filename.fits') will
+    produce '~/filename.fits', and environment variables will be temporarily
+    modified so that '~' resolves to the data directory.
+    """
+    # This checks the value specified in the fixture annotation
+    if request.param:
+        # `request.instance` refers to the test case that's using this fixture.
+        request.instance.monkeypatch = monkeypatch
+        request.instance.set_home_as_data()
+
+        request.instance.set_paths_via_pathlib(request.param == 'pathlib')
+
+
+@pytest.fixture(
+        params=[False, 'str', 'pathlib'],
+        ids=['', 'home_is_data', 'home_is_data, pathlib'])
+def home_is_temp(request, monkeypatch):
+    """
+    Pytest fixture to run a test case both with and without tilde paths.
+
+    In the tilde-path case, calls like self.temp('filename.fits') will
+    produce '~/filename.fits', and environment variables will be temporarily
+    modified so that '~' resolves to the temp directory. These files will also
+    be tracked so that, after the test case, we can verify no files were written
+    to a literal tilde path.
+    """
+    # This checks the value specified in the fixture annotation
+    if request.param:
+        # `request.instance` refers to the test case that's using this fixture.
+        request.instance.monkeypatch = monkeypatch
+        request.instance.set_home_as_temp()
+
+        request.instance.set_paths_via_pathlib(request.param == 'pathlib')
 
 
 class FitsTestCase:
     def setup(self):
         self.data_dir = os.path.join(os.path.dirname(__file__), 'data')
         self.temp_dir = tempfile.mkdtemp(prefix='fits-test-')
+
+        self.home_is_data = False
+        self.home_is_temp = False
+        self.temp_files_used = set()
+        self.use_pathlib = False
 
         # Restore global settings to defaults
         # TODO: Replace this when there's a better way to in the config API to
@@ -23,6 +73,12 @@ class FitsTestCase:
         fits.conf.use_memmap = True
 
     def teardown(self):
+        if self.home_is_temp:
+            # Verify that no files were written to a literal tilde path
+            for temp_file, temp_file_no_tilde in self.temp_files_used:
+                assert not os.path.exists(temp_file)
+                assert os.path.exists(temp_file_no_tilde)
+
         if hasattr(self, 'temp_dir') and os.path.exists(self.temp_dir):
             tries = 3
             while tries:
@@ -46,15 +102,63 @@ class FitsTestCase:
         mode to writeable.
         """
 
-        shutil.copy(self.data(filename), self.temp(filename))
-        os.chmod(self.temp(filename), stat.S_IREAD | stat.S_IWRITE)
+        shutil.copy(os.path.expanduser(self.data(filename)),
+                os.path.expanduser(self.temp(filename)))
+        os.chmod(os.path.expanduser(self.temp(filename)),
+                stat.S_IREAD | stat.S_IWRITE)
 
     def data(self, filename):
         """Returns the path to a test data file."""
+        if self.home_is_data:
+            prefix = '~'
+        else:
+            prefix = self.data_dir
 
-        return os.path.join(self.data_dir, filename)
+        if self.use_pathlib:
+            return pathlib.Path(prefix, filename)
+        return os.path.join(prefix, filename)
 
     def temp(self, filename):
         """ Returns the full path to a file in the test temp dir."""
+        real_target = os.path.join(self.temp_dir, filename)
+        if self.home_is_temp:
+            prefix = '~'
+            # Record the '~' path and the intended path, for use
+            # in `home_is_temp`
+            self.temp_files_used.add(
+                    (os.path.join(prefix, filename), real_target))
+        else:
+            prefix = self.temp_dir
 
-        return os.path.join(self.temp_dir, filename)
+        if self.use_pathlib:
+            return pathlib.Path(prefix, filename)
+        return os.path.join(prefix, filename)
+
+    def set_home_as_data(self):
+        """
+        This overrides the HOME environment variable, so that paths beginning
+        with '~/' expand to the data directory. Used by the `home_is_data`
+        fixture.
+        """
+        self.home_is_data = True
+        # For Unix
+        self.monkeypatch.setenv('HOME', self.data_dir)
+        # For Windows
+        self.monkeypatch.setenv('USERPROFILE', self.data_dir)
+
+    def set_home_as_temp(self):
+        """
+        This overrides the HOME environment variable, so that paths beginning
+        with '~/' expand to the temp directory. In conjunction with
+        self.temp(), temporary files are tracked as they are created, so we can
+        verify they end up in the temporary directory and not unexpected places
+        in the filesystem. Used by the `home_is_temp` fixture.
+        """
+        self.home_is_temp = True
+        # For Unix
+        self.monkeypatch.setenv('HOME', self.temp_dir)
+        # For Windows
+        self.monkeypatch.setenv('USERPROFILE', self.temp_dir)
+
+    def set_paths_via_pathlib(self, use_pathlib):
+        self.use_pathlib = use_pathlib

--- a/astropy/io/fits/tests/test_convenience.py
+++ b/astropy/io/fits/tests/test_convenience.py
@@ -18,7 +18,7 @@ from astropy.io.fits.tests.test_table import _assert_attr_col
 from astropy.table import Table
 from astropy.utils.exceptions import AstropyUserWarning
 
-from . import FitsTestCase
+from . import FitsTestCase, home_is_temp
 
 
 class TestConvenience(FitsTestCase):
@@ -190,7 +190,7 @@ class TestConvenience(FitsTestCase):
         h_out = fits.getheader(filename, ext=1)
         assert h_out['ANSWER'] == 42
 
-    def test_image_extension_update_header(self):
+    def test_image_extension_update_header(self, home_is_temp):
         """
         Test that _makehdu correctly includes the header. For example in the
         fits.update convenience function.
@@ -199,6 +199,13 @@ class TestConvenience(FitsTestCase):
 
         hdus = [fits.PrimaryHDU(np.zeros((10, 10))),
                 fits.ImageHDU(np.zeros((10, 10)))]
+
+        # Try to update a non-existant file
+        with pytest.raises(FileNotFoundError, match="No such file"):
+            fits.update(filename,
+                        np.zeros((10, 10)),
+                        header=fits.Header([('WHAT', 100)]),
+                        ext=1)
 
         fits.HDUList(hdus).writeto(filename)
 
@@ -302,7 +309,7 @@ class TestConvenience(FitsTestCase):
         with fits.open(self.temp(tablename)) as hdul:
             _assert_attr_col(new_tbhdu, hdul[1])
 
-    def test_append_filename(self):
+    def test_append_filename(self, home_is_temp):
         """
         Test fits.append with a filename argument.
         """

--- a/astropy/io/fits/tests/test_header.py
+++ b/astropy/io/fits/tests/test_header.py
@@ -14,8 +14,9 @@ from astropy.io.fits.header import _pad_length
 from astropy.io.fits.util import encode_ascii
 from astropy.io.fits.verify import VerifyError, VerifyWarning
 from astropy.utils.exceptions import AstropyUserWarning
+from astropy.utils.misc import _NOT_OVERWRITING_MSG_MATCH
 
-from . import FitsTestCase
+from . import FitsTestCase, home_is_temp
 
 
 def test_shallow_copy():
@@ -1617,13 +1618,18 @@ class TestHeaderFunctions(FitsTestCase):
         assert str(header.cards[1]) == 'HISTORY ' + longval[:72]
         assert str(header.cards[2]).rstrip() == 'HISTORY ' + longval[72:]
 
-    def test_totxtfile(self):
+    def test_totxtfile(self, home_is_temp):
+        header_filename = self.temp('header.txt')
         with fits.open(self.data('test0.fits')) as hdul:
-            hdul[0].header.totextfile(self.temp('header.txt'))
+            hdul[0].header.totextfile(header_filename)
+            # Check the `overwrite` flag
+            with pytest.raises(OSError, match=_NOT_OVERWRITING_MSG_MATCH):
+                hdul[0].header.totextfile(header_filename, overwrite=False)
+            hdul[0].header.totextfile(header_filename, overwrite=True)
 
         hdu = fits.ImageHDU()
         hdu.header.update({'MYKEY': 'FOO'})
-        hdu.header.extend(hdu.header.fromtextfile(self.temp('header.txt')),
+        hdu.header.extend(hdu.header.fromtextfile(header_filename),
                           update=True, update_first=True)
 
         # Write the hdu out and read it back in again--it should be recognized
@@ -1635,7 +1641,46 @@ class TestHeaderFunctions(FitsTestCase):
 
         hdu = fits.ImageHDU()
         hdu.header.update({'MYKEY': 'FOO'})
-        hdu.header.extend(hdu.header.fromtextfile(self.temp('header.txt')),
+        hdu.header.extend(hdu.header.fromtextfile(header_filename),
+                          update=True, update_first=True, strip=False)
+        assert 'MYKEY' in hdu.header
+        assert 'EXTENSION' not in hdu.header
+        assert 'SIMPLE' in hdu.header
+
+        hdu.writeto(self.temp('test.fits'), output_verify='ignore',
+                    overwrite=True)
+
+        with fits.open(self.temp('test.fits')) as hdul2:
+            assert len(hdul2) == 2
+            assert 'MYKEY' in hdul2[1].header
+
+    def test_tofile(self, home_is_temp):
+        """
+        Repeat test_totxtfile, but with tofile()
+        """
+        header_filename = self.temp('header.fits')
+        with fits.open(self.data('test0.fits')) as hdul:
+            hdul[0].header.tofile(header_filename)
+            # Check the `overwrite` flag
+            with pytest.raises(OSError, match=_NOT_OVERWRITING_MSG_MATCH):
+                hdul[0].header.tofile(header_filename, overwrite=False)
+            hdul[0].header.tofile(header_filename, overwrite=True)
+
+        hdu = fits.ImageHDU()
+        hdu.header.update({'MYKEY': 'FOO'})
+        hdu.header.extend(hdu.header.fromfile(header_filename),
+                          update=True, update_first=True)
+
+        # Write the hdu out and read it back in again--it should be recognized
+        # as a PrimaryHDU
+        hdu.writeto(self.temp('test.fits'), output_verify='ignore')
+
+        with fits.open(self.temp('test.fits')) as hdul:
+            assert isinstance(hdul[0], fits.PrimaryHDU)
+
+        hdu = fits.ImageHDU()
+        hdu.header.update({'MYKEY': 'FOO'})
+        hdu.header.extend(hdu.header.fromfile(header_filename),
                           update=True, update_first=True, strip=False)
         assert 'MYKEY' in hdu.header
         assert 'EXTENSION' not in hdu.header

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -27,7 +27,7 @@ from astropy.units import Unit, UnitsWarning, UnrecognizedUnit
 from astropy.utils.compat import NUMPY_LT_1_22, NUMPY_LT_1_22_1
 from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyUserWarning
 
-from . import FitsTestCase
+from . import FitsTestCase, home_is_data
 
 
 def comparefloats(a, b):
@@ -146,7 +146,7 @@ class TestTableFunctions(FitsTestCase):
         # Original header should be unchanged
         assert thdr['FILENAME'] == 'labq01i3q_rawtag.fits'
 
-    def test_open(self):
+    def test_open(self, home_is_data):
         # open some existing FITS files:
         tt = fits.open(self.data('tb.fits'))
         fd = fits.open(self.data('test0.fits'))

--- a/astropy/io/fits/tests/test_tilde_path.py
+++ b/astropy/io/fits/tests/test_tilde_path.py
@@ -1,0 +1,146 @@
+# Licensed under a 3-clause BSD style license - see PYFITS.rst
+
+import os
+
+import numpy as np
+import pytest
+
+from astropy.io import fits
+from astropy.utils.misc import _NOT_OVERWRITING_MSG_MATCH
+
+from . import FitsTestCase, home_is_data, home_is_temp
+
+
+class TestTildePaths(FitsTestCase):
+    """
+    Exercises a few functions, just to ensure they run with tilde paths (i.e.
+    paths like '~/filename.fits'). Also exercises a few subclasses. Most of the
+    rest of the testing of tilde path handling is done by adding `home_is_data`
+    and `home_is_temp` fixtures (defined and explained in __init__.py) to
+    appropriate test cases, so that they are run both with and without tilde
+    paths.
+    """
+    def test_fits_info(self, home_is_data):
+        fits.info(self.data('tb.fits'), output=False)
+
+    def test_fits_printdiff(self, home_is_data):
+        fits.printdiff(self.data('test0.fits'), self.data('tb.fits'))
+
+    def test_fits_get_data(self, home_is_data):
+        fits.getdata(self.data('test0.fits'))
+        fits.getdata(self.data('test0.fits'), header=True)
+
+    def test_fits_get_header(self, home_is_data):
+        fits.getheader(self.data('test0.fits'))
+        fits.getheader(self.data('tb.fits'), ext=1)
+
+    def test_fits_get_set_del_val(self, home_is_temp):
+        self.copy_file('test0.fits')
+        filename = self.temp('test0.fits')
+        assert fits.getval(filename, 'shutter') == 'B'
+
+        fits.setval(filename, 'shutter', value='C')
+        assert fits.getval(filename, 'shutter') == 'C'
+
+        with pytest.raises(KeyError):
+            fits.getval(filename, 'missing')
+
+        fits.setval(filename, 'missing', value='C')
+        assert fits.getval(filename, 'missing') == 'C'
+
+        fits.delval(filename, 'missing')
+        with pytest.raises(KeyError):
+            fits.getval(filename, 'missing')
+
+    def test_header_formatter(self, home_is_data):
+        from astropy.io.fits.scripts import fitsheader
+        hf = fitsheader.HeaderFormatter(self.data('zerowidth.fits'))
+        hf.close()
+
+        thf = fitsheader.TableHeaderFormatter(self.data('zerowidth.fits'))
+        thf.close()
+
+    def test_BinTableHDU_dump_load(self, home_is_temp):
+        bright = np.rec.array(
+            [(1, 'Serius', -1.45, 'A1V'),
+             (2, 'Canopys', -0.73, 'F0Ib'),
+             (3, 'Rigil Kent', -0.1, 'G2V')],
+            formats='int16,a20,float32,a10',
+            names='order,name,mag,Sp')
+        hdu = fits.BinTableHDU(bright)
+
+        hdu.dump(self.temp('data.txt'), self.temp('cdfile.txt'),
+                self.temp('hfile.txt'))
+        with pytest.raises(OSError, match='already exists'):
+            hdu.dump(self.temp('data.txt'), self.temp('cdfile.txt'),
+                    self.temp('hfile.txt'), overwrite=False)
+        hdu.dump(self.temp('data.txt'), self.temp('cdfile.txt'),
+                self.temp('hfile.txt'), overwrite=True)
+
+        fits.BinTableHDU.load(self.temp('data.txt'), self.temp('cdfile.txt'),
+                self.temp('hfile.txt'))
+
+        self.copy_file('tb.fits')
+        with fits.open(self.temp('tb.fits')) as hdul:
+            hdu = hdul[1]
+            hdu.dump()
+        assert os.path.exists(os.path.expanduser(self.temp('tb.txt')))
+
+    def test_BinTableHDU_writeto(self, home_is_temp):
+        bright = np.rec.array(
+            [(1, 'Serius', -1.45, 'A1V'),
+             (2, 'Canopys', -0.73, 'F0Ib'),
+             (3, 'Rigil Kent', -0.1, 'G2V')],
+            formats='int16,a20,float32,a10',
+            names='order,name,mag,Sp')
+        hdu = fits.BinTableHDU(bright)
+
+        hdu.writeto(self.temp('table.fits'))
+        with pytest.raises(OSError, match=_NOT_OVERWRITING_MSG_MATCH):
+            hdu.writeto(self.temp('table.fits'), overwrite=False)
+        hdu.writeto(self.temp('table.fits'), overwrite=True)
+
+    def test_TableHDU_writeto(self, home_is_temp):
+        bright = np.rec.array(
+            [(1, 'Serius', -1.45, 'A1V'),
+             (2, 'Canopys', -0.73, 'F0Ib'),
+             (3, 'Rigil Kent', -0.1, 'G2V')],
+            formats='int16,a20,float32,a10',
+            names='order,name,mag,Sp')
+        hdu = fits.TableHDU.from_columns(bright, nrows=2)
+
+        hdu.writeto(self.temp('table.fits'))
+        with pytest.raises(OSError, match=_NOT_OVERWRITING_MSG_MATCH):
+            hdu.writeto(self.temp('table.fits'), overwrite=False)
+        hdu.writeto(self.temp('table.fits'), overwrite=True)
+
+    def fits_tabledump(self, home_is_temp):
+        self.copy_file('tb.fits')
+
+        fits.tabledump(self.temp('tb.fits'), self.temp('data.txt'),
+                self.temp('cdfile.txt'), self.temp('hfile.txt'))
+        with pytest.raises(OSError, match=_NOT_OVERWRITING_MSG_MATCH):
+            fits.tabledump(self.temp('tb.fits'), self.temp('data.txt'),
+                    self.temp('cdfile.txt'), self.temp('hfile.txt'),
+                    overwrite=False)
+        fits.tabledump(self.temp('tb.fits'), self.temp('data.txt'),
+                self.temp('cdfile.txt'), self.temp('hfile.txt'),
+                overwrite=True)
+
+        fits.tableload(self.temp('data.txt'), self.temp('cdfile.txt'),
+                self.temp('hfile.txt'))
+
+    def test_ImageHDU_writeto(self, home_is_temp):
+        hdu = fits.ImageHDU(np.arange(100).reshape((10, 10)))
+        hdu.writeto(self.temp('image.fits'))
+        with pytest.raises(OSError, match=_NOT_OVERWRITING_MSG_MATCH):
+            hdu.writeto(self.temp('image.fits'), overwrite=False)
+        hdu.writeto(self.temp('image.fits'), overwrite=True)
+
+    def test_CompImageHDU_writeto(self, home_is_temp):
+        hdu = fits.CompImageHDU(
+                np.arange(100).reshape((10, 10)).astype(np.int32))
+        hdu.writeto(self.temp('image.fits'))
+        with pytest.raises(OSError, match=_NOT_OVERWRITING_MSG_MATCH):
+            hdu.writeto(self.temp('image.fits'), overwrite=False)
+        hdu.writeto(self.temp('image.fits'), overwrite=True)

--- a/astropy/io/fits/util.py
+++ b/astropy/io/fits/util.py
@@ -23,7 +23,7 @@ from packaging.version import Version
 from astropy.utils import data
 from astropy.utils.exceptions import AstropyUserWarning
 
-path_like = (str, os.PathLike)
+path_like = (str, bytes, os.PathLike)
 
 cmp = lambda a, b: (a > b) - (a < b)
 

--- a/docs/changes/io.fits/13131.feature.rst
+++ b/docs/changes/io.fits/13131.feature.rst
@@ -1,0 +1,3 @@
+Added support to the ``io.fits`` API for reading and writing file paths of the
+form ``~/file.fits`` or ``~<username>/file.fits``, referring to the home
+directory of the current user or the specified user, respectively.


### PR DESCRIPTION
### Description
This PR is split from #13107 and addresses #12778 within `io.fits`. The changes allow file paths to be given relative to the user's home directory as `~/dir/filename.fits` when doing file IO.

`io.fits` is by far the largest API in which I'm trying to add this feature. I tried adding the `expanduser` call at the bottom-most level in `fileobj_open` as discussed in #12778, but I found that there were other points in the call stack where the file path does get used (e.g. the `overwrite` flags supported by some of the output methods), and so instead I've added `expanduser` calls early in the call stack, so that the tilde is expanded before anything tries to use the file path.

For a few functions, users can provide a file path or an open file object, and so the `os.path.expanduser` call comes after some sort of (often pre-existing) check to see if the input is a type that would represent a path. I noticed those checks weren't all consistent. Some use the `path_like = (str, os.PathLike)` tuple defined in `io/fits/utils.py`, others check for just a `str`, and a few check for a `str` or `bytes`. I didn't see a reason for this varied checking, so I added `bytes` to `path_like` and, wherever I was already making a change, I changed things to use `path_like`. In some places my added `expanduser` call came after an existing check which I modified, but in others I had to add a new check and would have had to make a decision anyway on how to do this check. I won't claim to have harmonized this type checking over all of `io.fits`, and I can back out or separate this if it's too unrelated.

For testing tilde paths, I used pytest's `monkeypatch` to temporarily update the environment variables so that `~` resolves to either the test data directory or the temporary directory, as appropriate, and only for specific test cases. Then, depending on what I found in the existing tests, I either added a test case just for exercising `~` expansion, or I augmented an existing test to run both with data/temp paths given normally, and with data/temp paths given via `~` paths. In `io.fits` there's some existing infrastructure with a `FitsTestCase` class with methods to access the data and temp directories, and I've plugged into this to make it easy to sprinkle these tilde-path tests throughout the existing tests. I scrolled through the `io.fits` documentation to find everything that looked IO-related and end-user-facing. When I found a relatively simple test exercising those functions I added a fixture to run that test both with and without tilde paths, and otherwise I added a new test case specifically to exercise that function. There were a few utility functions that I don't think were being exercised at all in testing, so this PR might increase coverage a tad, though these new tests are more just about ensuring a FileNotFound error isn't raised with tilde paths.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
