### PR TITLE
Fix mistakes in docs related to HDF5 I/O

### DIFF
--- a/astropy/io/misc/hdf5.py
+++ b/astropy/io/misc/hdf5.py
@@ -237,6 +237,10 @@ def write_table_hdf5(table, output, path=None, compression=False,
         Whether to overwrite any existing file without warning.
         If ``append=True`` and ``overwrite=True`` then only the dataset will be
         replaced; the file/group will not be overwritten.
+    serialize_meta : bool
+        Whether to serialize rich table meta-data when writing the HDF5 file, in
+        particular such data required to write and read back mixin columns like
+        ``Time``, ``SkyCoord``, or ``Quantity`` to the file.
     **create_dataset_kwargs
         Additional keyword arguments are passed to
         ``h5py.File.create_dataset()`` or ``h5py.Group.create_dataset()``.

--- a/docs/io/unified.rst
+++ b/docs/io/unified.rst
@@ -964,6 +964,43 @@ used to ensure that the data is compressed on disk::
 
 .. doctest-skip-all
 
+Metadata and Mixin Columns
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``astropy`` tables can contain metadata, both in the table ``meta`` attribute
+(which is an ordered dictionary of arbitrary key/value pairs), and within the
+columns, which each have attributes ``unit``, ``format``, ``description``,
+and ``meta``.
+
+By default, when writing a table to HDF5 the code will attempt to store each
+key/value pair within the table ``meta`` as HDF5 attributes of the table
+dataset. This will fail if the values within ``meta`` are not objects that can
+be stored as HDF5 attributes. In addition, if the table columns being stored
+have defined values for any of the above-listed column attributes, these
+metadata will *not* be stored and a warning will be issued.
+
+serialize_meta
+~~~~~~~~~~~~~~
+
+To enable storing all table and column metadata to the HDF5 file, call
+the ``write()`` method with ``serialize_meta=True``. This will store metadata
+in a separate HDF5 dataset, contained in the same file, which is named
+``<path>.__table_column_meta__``. Here ``path`` is the argument provided in
+the call to ``write()``::
+
+    >>> t.write('observations.hdf5', path='data', serialize_meta=True)
+
+The table metadata are stored as a dataset of strings by serializing the
+metadata in YAML following the `ECSV header format
+<https://github.com/astropy/astropy-APEs/blob/main/APE6.rst#header-details>`_
+definition. Since there are YAML parsers for most common languages, one can
+easily access and use the table metadata if reading the HDF5 in a non-astropy
+application.
+
+As of ``astropy`` 3.0, by specifying ``serialize_meta=True`` one can also store
+to HDF5 tables that contain :ref:`mixin_columns` such as `~astropy.time.Time` or
+`~astropy.coordinates.SkyCoord` columns.
+
 .. _table_io_parquet:
 
 Parquet
@@ -1014,43 +1051,6 @@ To read only a subset of the columns, use the ``include_names`` and/or ``exclude
 
 ..
   EXAMPLE END
-
-Metadata and Mixin Columns
-^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-``astropy`` tables can contain metadata, both in the table ``meta`` attribute
-(which is an ordered dictionary of arbitrary key/value pairs), and within the
-columns, which each have attributes ``unit``, ``format``, ``description``,
-and ``meta``.
-
-By default, when writing a table to HDF5 the code will attempt to store each
-key/value pair within the table ``meta`` as HDF5 attributes of the table
-dataset. This will fail if the values within ``meta`` are not objects that can
-be stored as HDF5 attributes. In addition, if the table columns being stored
-have defined values for any of the above-listed column attributes, these
-metadata will *not* be stored and a warning will be issued.
-
-serialize_meta
-~~~~~~~~~~~~~~
-
-To enable storing all table and column metadata to the HDF5 file, call
-the ``write()`` method with ``serialize_meta=True``. This will store metadata
-in a separate HDF5 dataset, contained in the same file, which is named
-``<path>.__table_column_meta__``. Here ``path`` is the argument provided in
-the call to ``write()``::
-
-    >>> t.write('observations.hdf5', path='data', serialize_meta=True)
-
-The table metadata are stored as a dataset of strings by serializing the
-metadata in YAML following the `ECSV header format
-<https://github.com/astropy/astropy-APEs/blob/main/APE6.rst#header-details>`_
-definition. Since there are YAML parsers for most common languages, one can
-easily access and use the table metadata if reading the HDF5 in a non-astropy
-application.
-
-As of ``astropy`` 3.0, by specifying ``serialize_meta=True`` one can also store
-to HDF5 tables that contain :ref:`mixin_columns` such as `~astropy.time.Time` or
-`~astropy.coordinates.SkyCoord` columns.
 
 .. _table_io_pandas:
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

The HDF5 `write_table_hdf5` docstring was missing the `serialize_meta` parameter description.

In addition, in the Unified I/O docs the subsections related to mixin columns and `serialize_meta` accidentally got separated from the HDF5 section and wound up after the Parquet I/O. This PR just moves it up into the right section.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
