### PR TITLE
Switch modeling over to using f-strings

### DIFF
--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -336,17 +336,17 @@ class _ModelMeta(abc.ABCMeta):
 
             if param.default is param.empty:
                 raise ModelDefinitionError(
-                    'The bounding_box method for {0} is not correctly '
-                    'defined: If defined as a method all arguments to that '
-                    'method (besides self) must be keyword arguments with '
-                    'default values that can be used to compute a default '
-                    'bounding box.'.format(cls.name))
+                    f"The bounding_box method for {cls.name} is not correctly "
+                    "defined: If defined as a method all arguments to that "
+                    "method (besides self) must be keyword arguments with "
+                    "default values that can be used to compute a default "
+                    "bounding box.")
 
             kwargs.append((param.name, param.default))
 
         __call__.__signature__ = sig
 
-        return type(f'{cls.name}ModelBoundingBox', (ModelBoundingBox,),
+        return type(f"{cls.name}ModelBoundingBox", (ModelBoundingBox,),
                     {'__call__': __call__})
 
     def _handle_special_methods(cls, members, pdict):
@@ -900,9 +900,8 @@ class Model(metaclass=_ModelMeta):
             if (np.size(value) != esize or
                     self._strip_ones(vshape) != self._strip_ones(eshape)):
                 raise InputParameterError(
-                    "Value for parameter {0} does not match shape or size\n"
-                    "expected by model ({1}, {2}) vs ({3}, {4})".format(
-                        attr, vshape, np.size(value), eshape, esize))
+                    f"Value for parameter {attr} does not match shape or size\n"
+                    f"expected by model ({vshape}, {np.size(value)}) vs ({eshape}, {esize})")
             if param.unit is None:
                 if isinstance(value, Quantity):
                     param._unit = value.unit
@@ -1216,7 +1215,7 @@ class Model(metaclass=_ModelMeta):
         except ValueError as e:
             raise InputParameterError(
                 "Input parameter values not compatible with the model "
-                "parameters array: {0}".format(e))
+                f"parameters array: {e}")
         self._array_to_parameters()
 
     @property
@@ -1535,7 +1534,7 @@ class Model(metaclass=_ModelMeta):
             return self._separable
         raise NotImplementedError(
             'The "separable" property is not defined for '
-            'model {}'.format(self.__class__.__name__))
+            f'model {self.__class__.__name__}')
 
     # *** Public methods ***
 
@@ -1885,10 +1884,9 @@ class Model(metaclass=_ModelMeta):
                         broadcast = input_shape
                 except IncompatibleShapeError:
                     raise ValueError(
-                        "self input argument {0!r} of shape {1!r} cannot be "
-                        "broadcast with parameter {2!r} of shape "
-                        "{3!r}.".format(self.inputs[idx], input_shape,
-                                        param.name, param.shape))
+                        f"self input argument {self.inputs[idx]!r} of shape {input_shape!r} "
+                        f"cannot be broadcast with parameter {param.name!r} of shape "
+                        f"{param.shape!r}.")
 
                 if len(broadcast) > len(max_broadcast):
                     max_broadcast = broadcast
@@ -1947,12 +1945,9 @@ class Model(metaclass=_ModelMeta):
                                                                  model_set_axis_param))
                 except IncompatibleShapeError:
                     raise ValueError(
-                        "Model input argument {0!r} of shape {1!r} cannot be "
-                        "broadcast with parameter {2!r} of shape "
-                        "{3!r}.".format(self.inputs[idx], input_shape,
-                                        param.name,
-                                        self._remove_axes_from_shape(param.shape,
-                                                                     model_set_axis_param)))
+                        f"Model input argument {self.inputs[idx]!r} of shape {input_shape!r} "
+                        f"cannot be broadcast with parameter {param.name!r} of shape "
+                        f"{self._remove_axes_from_shape(param.shape, model_set_axis_param)!r}.")
 
                 if len(param.shape) - 1 > len(max_param_shape):
                     max_param_shape = self._remove_axes_from_shape(param.shape,
@@ -2089,24 +2084,17 @@ class Model(metaclass=_ModelMeta):
                         # to be able to raise more appropriate/nicer exceptions
 
                         if input_unit is dimensionless_unscaled:
-                            raise UnitsError("{0}: Units of input '{1}', {2} ({3}),"
+                            raise UnitsError(f"{name}: Units of input '{self.inputs[i]}', "
+                                             f"{inputs[i].unit} ({inputs[i].unit.physical_type}),"
                                              "could not be converted to "
                                              "required dimensionless "
-                                             "input".format(name,
-                                                            self.inputs[i],
-                                                            inputs[i].unit,
-                                                            inputs[i].unit.physical_type))
+                                             "input")
                         else:
-                            raise UnitsError("{0}: Units of input '{1}', {2} ({3}),"
+                            raise UnitsError(f"{name}: Units of input '{self.inputs[i]}', "
+                                             f"{inputs[i].unit} ({inputs[i].unit.physical_type}),"
                                              " could not be "
                                              "converted to required input"
-                                             " units of {4} ({5})".format(
-                                                 name,
-                                                 self.inputs[i],
-                                                 inputs[i].unit,
-                                                 inputs[i].unit.physical_type,
-                                                 input_unit,
-                                                 input_unit.physical_type))
+                                             f" units of {input_unit} ({input_unit.physical_type})")
                 else:
 
                     # If we allow dimensionless input, we add the units to the
@@ -2398,7 +2386,7 @@ class Model(metaclass=_ModelMeta):
                 "n_models must be either None (in which case it is "
                 "determined from the model_set_axis of the parameter initial "
                 "values) or it must be a positive integer "
-                "(got {0!r})".format(n_models))
+                f"(got {n_models!r})")
 
         model_set_axis = kwargs.pop('model_set_axis', None)
         if model_set_axis is None:
@@ -2414,8 +2402,7 @@ class Model(metaclass=_ModelMeta):
                 raise ValueError(
                     "model_set_axis must be either False or an integer "
                     "specifying the parameter array axis to map to each "
-                    "model in a set of models (got {0!r}).".format(
-                        model_set_axis))
+                    f"model in a set of models (got {model_set_axis!r}).")
 
         # Process positional arguments by matching them up with the
         # corresponding parameters in self.param_names--if any also appear as
@@ -2423,9 +2410,8 @@ class Model(metaclass=_ModelMeta):
         params = set()
         if len(args) > len(self.param_names):
             raise TypeError(
-                "{0}.__init__() takes at most {1} positional arguments ({2} "
-                "given)".format(self.__class__.__name__, len(self.param_names),
-                                len(args)))
+                f"{self.__class__.__name__}.__init__() takes at most "
+                f"{len(self.param_names)} positional arguments ({len(args)} given)")
 
         self._model_set_axis = model_set_axis
         self._param_metrics = defaultdict(dict)
@@ -2451,8 +2437,8 @@ class Model(metaclass=_ModelMeta):
             if param_name in kwargs:
                 if param_name in params:
                     raise TypeError(
-                        "{0}.__init__() got multiple values for parameter "
-                        "{1!r}".format(self.__class__.__name__, param_name))
+                        f"{self.__class__.__name__}.__init__() got multiple values for parameter "
+                        f"{param_name!r}")
                 value = kwargs.pop(param_name)
                 if value is None:
                     continue
@@ -2474,8 +2460,8 @@ class Model(metaclass=_ModelMeta):
             for kwarg in kwargs:
                 # Just raise an error on the first unrecognized argument
                 raise TypeError(
-                    '{0}.__init__() got an unrecognized parameter '
-                    '{1!r}'.format(self.__class__.__name__, kwarg))
+                    f"{self.__class__.__name__}.__init__() got an unrecognized parameter "
+                    f"{kwarg!r}")
 
         # Determine the number of model sets: If the model_set_axis is
         # None then there is just one parameter set; otherwise it is determined
@@ -2495,9 +2481,8 @@ class Model(metaclass=_ModelMeta):
                 if param_ndim < min_ndim:
                     raise InputParameterError(
                         "All parameter values must be arrays of dimension "
-                        "at least {0} for model_set_axis={1} (the value "
-                        "given for {2!r} is only {3}-dimensional)".format(
-                            min_ndim, model_set_axis, name, param_ndim))
+                        f"at least {min_ndim} for model_set_axis={model_set_axis} (the value "
+                        f"given for {name!r} is only {param_ndim}-dimensional)")
 
                 max_ndim = max(max_ndim, param_ndim)
 
@@ -2507,10 +2492,9 @@ class Model(metaclass=_ModelMeta):
                     n_models = value.shape[model_set_axis]
                 elif value.shape[model_set_axis] != n_models:
                     raise InputParameterError(
-                        "Inconsistent dimensions for parameter {0!r} for "
-                        "{1} model sets.  The length of axis {2} must be the "
-                        "same for all input parameter values".format(
-                            name, n_models, model_set_axis))
+                        f"Inconsistent dimensions for parameter {name!r} for "
+                        f"{n_models} model sets.  The length of axis {model_set_axis} must be the "
+                        "same for all input parameter values")
 
             self._check_param_broadcast(max_ndim)
         else:
@@ -2539,8 +2523,8 @@ class Model(metaclass=_ModelMeta):
                 # No value was supplied for the parameter and the
                 # parameter does not have a default, therefore the model
                 # is underspecified
-                raise TypeError("{0}.__init__() requires a value for parameter "
-                                "{1!r}".format(self.__class__.__name__, param_name))
+                raise TypeError(f"{self.__class__.__name__}.__init__() requires a value for "
+                                f"parameter {param_name!r}")
             value = default
             unit = param.unit
         else:
@@ -2551,8 +2535,8 @@ class Model(metaclass=_ModelMeta):
                 unit = None
         if unit is None and param.unit is not None:
             raise InputParameterError(
-                "{0}.__init__() requires a Quantity for parameter "
-                "{1!r}".format(self.__class__.__name__, param_name))
+                f"{self.__class__.__name__}.__init__() requires a Quantity for parameter "
+                f"{param_name!r}")
         param._unit = unit
         param.internal_unit = None
         if param._setter is not None:
@@ -2658,11 +2642,10 @@ class Model(metaclass=_ModelMeta):
             param_b = self.param_names[shape_b_idx]
 
             raise InputParameterError(
-                "Parameter {0!r} of shape {1!r} cannot be broadcast with "
-                "parameter {2!r} of shape {3!r}.  All parameter arrays "
+                f"Parameter {param_a!r} of shape {shape_a!r} cannot be broadcast with "
+                f"parameter {param_b!r} of shape {shape_b!r}.  All parameter arrays "
                 "must have shapes that are mutually compatible according "
-                "to the broadcasting rules.".format(param_a, shape_a,
-                                                    param_b, shape_b))
+                "to the broadcasting rules.")
 
     def _param_sets(self, raw=False, units=False):
         """
@@ -2944,12 +2927,11 @@ class CompoundModel(Model):
         elif op == '|':
             if left.n_outputs != right.n_inputs:
                 raise ModelDefinitionError(
-                    "Unsupported operands for |: {0} (n_inputs={1}, "
-                    "n_outputs={2}) and {3} (n_inputs={4}, n_outputs={5}); "
+                    f"Unsupported operands for |: {left.name} (n_inputs={left.n_inputs}, "
+                    f"n_outputs={left.n_outputs}) and {right.name} "
+                    f"(n_inputs={right.n_inputs}, n_outputs={right.n_outputs}); "
                     "n_outputs for the left-hand model must match n_inputs "
-                    "for the right-hand model.".format(
-                        left.name, left.n_inputs, left.n_outputs, right.name,
-                        right.n_inputs, right.n_outputs))
+                    "for the right-hand model.")
 
             self.n_inputs = left.n_inputs
             self.n_outputs = right.n_outputs
@@ -3373,8 +3355,8 @@ class CompoundModel(Model):
         if len(found) == 0:
             raise IndexError(f"No component with name '{str_index}' found")
         if len(found) > 1:
-            raise IndexError("Multiple components found using '{}' as name\n"
-                             "at indices {}".format(str_index, found))
+            raise IndexError(f"Multiple components found using '{str_index}' as name\n"
+                             f"at indices {found}")
         return found[0]
 
     @property
@@ -3465,7 +3447,7 @@ class CompoundModel(Model):
     def _format_components(self):
         if self._parameters_ is None:
             self._map_parameters()
-        return '\n\n'.join('[{0}]: {1!r}'.format(idx, m)
+        return "\n\n".join(f"[{idx}]: {m!r}"
                            for idx, m in enumerate(self._leaflist))
 
     def __str__(self):
@@ -4257,10 +4239,10 @@ def custom_model(*args, fit_deriv=None):
         return functools.partial(_custom_model_wrapper, fit_deriv=fit_deriv)
     else:
         raise TypeError(
-            "{0} takes at most one positional argument (the callable/"
+            f"{__name__} takes at most one positional argument (the callable/"
             "function to be turned into a model.  When used as a decorator "
             "it should be passed keyword arguments only (if "
-            "any).".format(__name__))
+            "any).")
 
 
 def _custom_model_inputs(func):

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -1215,7 +1215,7 @@ class Model(metaclass=_ModelMeta):
         except ValueError as e:
             raise InputParameterError(
                 "Input parameter values not compatible with the model "
-                f"parameters array: {e}")
+                f"parameters array: {e!r}")
         self._array_to_parameters()
 
     @property

--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -114,13 +114,11 @@ class StandardDeviations():
     def pprint(self, max_lines, round_val):
         longest_name = max([len(x) for x in self.param_names])
         ret_str = 'standard deviations\n'
-        fstring = '{0}{1}| {2}\n'
         for i, std in enumerate(self.stds):
             if i <= max_lines-1:
                 param = self.param_names[i]
-                ret_str += fstring.format(param,
-                                          ' ' * (longest_name - len(param)),
-                                          str(np.round(std, round_val)))
+                ret_str += (f"{param}{' ' * (longest_name - len(param))}| "
+                            f"{np.round(std, round_val)}\n")
             else:
                 ret_str += '...'
         return(ret_str.rstrip())
@@ -670,8 +668,8 @@ class LinearLSQFitter(metaclass=_FitterMeta):
         # failures below. Ultimately, np.linalg.lstsq can't handle >2D matrices,
         # so just raise a slightly more informative error when this happens:
         if np.asanyarray(lhs).ndim > 2:
-            raise ValueError('{} gives unsupported >2D derivative matrix for '
-                             'this x/y'.format(type(model_copy).__name__))
+            raise ValueError(f"{type(model_copy).__name__} gives unsupported >2D "
+                             "derivative matrix for this x/y")
 
         # Subtract any terms fixed by the user from (a copy of) the RHS, in
         # order to fit the remaining terms correctly:
@@ -843,19 +841,15 @@ class FittingWithOutlierRemoval:
         self.fit_info = {'niter': None}
 
     def __str__(self):
-        return ("Fitter: {0}\nOutlier function: {1}\nNum. of iterations: {2}" +
-                ("\nOutlier func. args.: {3}"))\
-                .format(self.fitter.__class__.__name__,
-                        self.outlier_func.__name__, self.niter,
-                        self.outlier_kwargs)
+        return (f"Fitter: {self.fitter.__class__.__name__}\n"
+                f"Outlier function: {self.outlier_func.__name__}\n"
+                f"Num. of iterations: {self.niter}\n"
+                f"Outlier func. args.: {self.outlier_kwargs}")
 
     def __repr__(self):
-        return ("{0}(fitter: {1}, outlier_func: {2}," +
-                " niter: {3}, outlier_kwargs: {4})")\
-                 .format(self.__class__.__name__,
-                         self.fitter.__class__.__name__,
-                         self.outlier_func.__name__, self.niter,
-                         self.outlier_kwargs)
+        return (f"{self.__class__.__name__}(fitter: {self.fitter.__class__.__name__}, "
+                f"outlier_func: {self.outlier_func.__name__},"
+                f" niter: {self.niter}, outlier_kwargs: {self.outlier_kwargs})")
 
     def __call__(self, model, x, y, z=None, weights=None, **kwargs):
         """
@@ -898,10 +892,10 @@ class FittingWithOutlierRemoval:
         if len(model) == 1:
             model_set_axis = None
         else:
-            if (not hasattr(self.fitter, 'supports_masked_input') or
-                    self.fitter.supports_masked_input is not True):
-                raise ValueError("{} cannot fit model sets with masked "
-                                 "values".format(type(self.fitter).__name__))
+            if not hasattr(self.fitter, 'supports_masked_input') or \
+               self.fitter.supports_masked_input is not True:
+                raise ValueError(f"{type(self.fitter).__name__} cannot fit model sets with masked "
+                                 "values")
 
             # Fitters use their input model's model_set_axis to determine how
             # their input data are stacked:
@@ -1706,11 +1700,11 @@ class JointFitter(metaclass=_FitterMeta):
             raise TypeError(f"Expected >1 models, {len(self.models)} is given")
         if len(self.jointparams.keys()) < 2:
             raise TypeError("At least two parameters are expected, "
-                            "{} is given".format(len(self.jointparams.keys())))
+                            f"{len(self.jointparams.keys())} is given")
         for j in self.jointparams.keys():
             if len(self.jointparams[j]) != len(self.initvals):
-                raise TypeError("{} parameter(s) provided but {} expected".format(
-                    len(self.jointparams[j]), len(self.initvals)))
+                raise TypeError(f"{len(self.jointparams[j])} parameter(s) "
+                                f"provided but {len(self.initvals)} expected")
 
     def __call__(self, *args):
         """
@@ -1721,9 +1715,8 @@ class JointFitter(metaclass=_FitterMeta):
         from scipy import optimize
 
         if len(args) != reduce(lambda x, y: x + 1 + y + 1, self.modeldims):
-            raise ValueError("Expected {} coordinates in args but {} provided"
-                             .format(reduce(lambda x, y: x + 1 + y + 1,
-                                            self.modeldims), len(args)))
+            raise ValueError(f"Expected {reduce(lambda x, y: x + 1 + y + 1, self.modeldims)} "
+                             f"coordinates in args but {len(args)} provided")
 
         self.fitparams[:], _ = optimize.leastsq(self.objective_function,
                                                 self.fitparams, args=args)
@@ -2023,8 +2016,8 @@ def populate_entry_points(entry_points):
                     __all__.append(name)
                 else:
                     warnings.warn(AstropyUserWarning(
-                        'Modeling entry point {} expected to extend '
-                        'astropy.modeling.Fitter' .format(name)))
+                        f"Modeling entry point {name} expected to extend "
+                        "astropy.modeling.Fitter"))
 
 
 def _populate_ep():

--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -892,8 +892,8 @@ class FittingWithOutlierRemoval:
         if len(model) == 1:
             model_set_axis = None
         else:
-            if not hasattr(self.fitter, 'supports_masked_input') or \
-               self.fitter.supports_masked_input is not True:
+            if (not hasattr(self.fitter, 'supports_masked_input') or
+                    self.fitter.supports_masked_input is not True):
                 raise ValueError(f"{type(self.fitter).__name__} cannot fit model sets with masked "
                                  "values")
 

--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -3176,7 +3176,7 @@ class KingProjectedAnalytic1D(Fittable1DModel):
             sig = mod(r)
 
 
-            plt.loglog(r, sig/sig[0], label='c ~ {:0.2f}'.format(mod.concentration))
+            plt.loglog(r, sig/sig[0], label=f"c ~ {mod.concentration:0.2f}")
 
         plt.xlabel("r")
         plt.ylabel(r"$\\sigma/\\sigma_0$")

--- a/astropy/modeling/mappings.py
+++ b/astropy/modeling/mappings.py
@@ -114,8 +114,8 @@ class Mapping(FittableModel):
                             for idx in range(self.n_inputs))
         except ValueError:
             raise NotImplementedError(
-                "Mappings such as {} that drop one or more of their inputs "
-                "are not invertible at this time.".format(self.mapping))
+                f"Mappings such as {self.mapping} that drop one or more of their inputs "
+                "are not invertible at this time.")
 
         inv = self.__class__(mapping)
         inv._inputs = self._outputs

--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -205,8 +205,8 @@ class Parameter:
         if isinstance(default, Quantity):
             if unit is not None and not unit.is_equivalent(default.unit):
                 raise ParameterDefinitionError(
-                    "parameter default {0} does not have units equivalent to "
-                    "the required unit {1}".format(default, unit))
+                    f"parameter default {default} does not have units equivalent to "
+                    f"the required unit {unit}")
             unit = default.unit
             default = default.value
 
@@ -229,8 +229,8 @@ class Parameter:
         if bounds is not None:
             if min is not None or max is not None:
                 raise ValueError(
-                    'bounds may not be specified simultaneously with min or '
-                    'max when instantiating Parameter {}'.format(name))
+                    "bounds may not be specified simultaneously with min or "
+                    f"max when instantiating Parameter {name}")
         else:
             bounds = (min, max)
 
@@ -271,7 +271,7 @@ class Parameter:
             if len(oldvalue[key]) == 0:
                 raise InputParameterError(
                     "Slice assignment outside the parameter dimensions for "
-                    "'{}'".format(self.name))
+                    f"'{self.name}'")
             for idx, val in zip(range(*key.indices(len(self))), value):
                 self.__setitem__(idx, val)
         else:
@@ -279,8 +279,8 @@ class Parameter:
                 oldvalue[key] = value
             except IndexError:
                 raise InputParameterError(
-                    "Input dimension {} invalid for {!r} parameter with "
-                    "dimension {}".format(key, self.name, value.shape[0]))  # likely wrong
+                    f"Input dimension {key} invalid for {self.name!r} parameter with "
+                    f"dimension {value.shape[0]}")  # likely wrong
 
     def __repr__(self):
         args = f"'{self._name}'"

--- a/astropy/modeling/polynomial.py
+++ b/astropy/modeling/polynomial.py
@@ -1633,8 +1633,8 @@ class SIP(Model):
         self._outputs = ("x", "y")
 
     def __repr__(self):
-        return '<{}({!r})>'.format(self.__class__.__name__,
-                                   [self.shift_a, self.shift_b, self.sip1d_a, self.sip1d_b])
+        return (f"<{self.__class__.__name__}"
+                f"({[self.shift_a, self.shift_b, self.sip1d_a, self.sip1d_b]!r})>")
 
     def __str__(self):
         parts = [f'Model: {self.__class__.__name__}']

--- a/astropy/modeling/projections.py
+++ b/astropy/modeling/projections.py
@@ -1510,8 +1510,8 @@ class AffineTransformation2D(Model):
 
         if det == 0:
             raise InputParameterError(
-                "Transformation matrix is singular; {} model does not "
-                "have an inverse".format(self.__class__.__name__))
+                f"Transformation matrix is singular; {self.__class__.__name__} model does not "
+                "have an inverse")
 
         matrix = np.linalg.inv(self.matrix.value)
         if self.matrix.unit is not None:

--- a/astropy/modeling/rotations.py
+++ b/astropy/modeling/rotations.py
@@ -236,7 +236,7 @@ class EulerAngleRotation(_EulerRotation, Model):
         unrecognized = set(axes_order).difference(self.axes)
         if unrecognized:
             raise ValueError(f"Unrecognized axis label {unrecognized}; "
-                             f"should be one of {self.axes} ")
+                             f"should be one of {self.axes}")
         self.axes_order = axes_order
         qs = [isinstance(par, u.Quantity) for par in [phi, theta, psi]]
         if any(qs) and not all(qs):

--- a/astropy/modeling/rotations.py
+++ b/astropy/modeling/rotations.py
@@ -92,13 +92,12 @@ class RotationSequence3D(Model):
         self.axes = ['x', 'y', 'z']
         unrecognized = set(axes_order).difference(self.axes)
         if unrecognized:
-            raise ValueError("Unrecognized axis label {0}; "
-                             "should be one of {1} ".format(unrecognized,
-                                                            self.axes))
+            raise ValueError(f"Unrecognized axis label {unrecognized}; "
+                             f"should be one of {self.axes} ")
         self.axes_order = axes_order
         if len(angles) != len(axes_order):
-            raise ValueError("The number of angles {0} should match the number of axes {1}."
-                             .format(len(angles), len(axes_order)))
+            raise ValueError(f"The number of angles {len(angles)} should match "
+                             f"the number of axes {len(axes_order)}.")
         super().__init__(angles, name=name)
         self._inputs = ('x', 'y', 'z')
         self._outputs = ('x', 'y', 'z')
@@ -233,11 +232,11 @@ class EulerAngleRotation(_EulerRotation, Model):
         if len(axes_order) != 3:
             raise TypeError(
                 "Expected axes_order to be a character sequence of length 3, "
-                "got {}".format(axes_order))
+                f"got {axes_order}")
         unrecognized = set(axes_order).difference(self.axes)
         if unrecognized:
-            raise ValueError("Unrecognized axis label {}; "
-                             "should be one of {} ".format(unrecognized, self.axes))
+            raise ValueError(f"Unrecognized axis label {unrecognized}; "
+                             f"should be one of {self.axes} ")
         self.axes_order = axes_order
         qs = [isinstance(par, u.Quantity) for par in [phi, theta, psi]]
         if any(qs) and not all(qs):

--- a/astropy/modeling/separable.py
+++ b/astropy/modeling/separable.py
@@ -157,11 +157,10 @@ def _arith_oper(left, right):
 
     if left_inputs != right_inputs or left_outputs != right_outputs:
         raise ModelDefinitionError(
-            "Unsupported operands for arithmetic operator: left (n_inputs={}, "
-            "n_outputs={}) and right (n_inputs={}, n_outputs={}); "
-            "models must have the same n_inputs and the same "
-            "n_outputs for this operator.".format(
-                left_inputs, left_outputs, right_inputs, right_outputs))
+            f"Unsupported operands for arithmetic operator: left (n_inputs={left_inputs}, "
+            f"n_outputs={left_outputs}) and right (n_inputs={right_inputs}, "
+            f"n_outputs={right_outputs}); models must have the same n_inputs and the same "
+            "n_outputs for this operator.")
 
     result = np.ones((left_outputs, left_inputs))
     return result
@@ -281,8 +280,7 @@ def _cdot(left, right):
     except ValueError:
         raise ModelDefinitionError(
             'Models cannot be combined with the "|" operator; '
-            'left coord_matrix is {}, right coord_matrix is {}'.format(
-                cright, cleft))
+            f'left coord_matrix is {cright}, right coord_matrix is {cleft}')
     return result
 
 

--- a/astropy/modeling/statistic.py
+++ b/astropy/modeling/statistic.py
@@ -51,10 +51,8 @@ def leastsquare(measured_vals, updated_model, weights, *x):
     model_vals = updated_model(*x)
 
     if np.shape(model_vals) != np.shape(measured_vals):
-        message = "Shape mismatch between model ({}) and measured ({})"
-        raise ValueError(
-            message.format(np.shape(model_vals), np.shape(measured_vals))
-        )
+        raise ValueError(f"Shape mismatch between model ({np.shape(model_vals)}) "
+                         f"and measured ({np.shape(measured_vals)})")
 
     if weights is None:
         weights = 1.0

--- a/astropy/modeling/tabular.py
+++ b/astropy/modeling/tabular.py
@@ -103,7 +103,7 @@ class _Tabular(Model):
 
         if self.lookup_table.ndim != lookup_table.ndim:
             raise ValueError("lookup_table should be an array with "
-                             "{} dimensions.".format(self.lookup_table.ndim))
+                             f"{self.lookup_table.ndim} dimensions.")
 
         if points is None:
             points = tuple(np.arange(x, dtype=float)
@@ -115,15 +115,15 @@ class _Tabular(Model):
             if npts != lookup_table.ndim:
                 raise ValueError(
                     "Expected grid points in "
-                    "{} directions, got {}.".format(lookup_table.ndim, npts))
+                    f"{lookup_table.ndim} directions, got {npts}.")
             if (npts > 1 and isinstance(points[0], u.Quantity) and
                     len(set([getattr(p, 'unit', None) for p in points])) > 1):
                 raise ValueError('points must all have the same unit.')
 
         if isinstance(fill_value, u.Quantity):
             if not isinstance(lookup_table, u.Quantity):
-                raise ValueError('fill value is in {} but expected to be '
-                                 'unitless.'.format(fill_value.unit))
+                raise ValueError(f"fill value is in {fill_value.unit} but expected to be "
+                                 "unitless.")
             fill_value = fill_value.to(lookup_table.unit).value
 
         self.points = points
@@ -133,8 +133,8 @@ class _Tabular(Model):
         self.fill_value = fill_value
 
     def __repr__(self):
-        return "<{}(points={}, lookup_table={})>".format(
-            self.__class__.__name__, self.points, self.lookup_table)
+        return (f"<{self.__class__.__name__}(points={self.points}, "
+                f"lookup_table={self.lookup_table})>")
 
     def __str__(self):
         default_keywords = [


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

f-strings are easier to read and maintain for building single use python strings. This PR switches modeling over to using f-strings whenever possible so that there is some consistency in its codebase.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
