### PR TITLE
Support tilde-prefixed paths in io.votable

### DIFF
--- a/astropy/io/votable/table.py
+++ b/astropy/io/votable/table.py
@@ -150,6 +150,9 @@ def parse(source, columns=None, invalid='exception', verify=None,
         'datatype_mapping': datatype_mapping
     }
 
+    if isinstance(source, str):
+        source = os.path.expanduser(source)
+
     if filename is None and isinstance(source, str):
         config['filename'] = source
 
@@ -253,6 +256,9 @@ def validate(source, output=sys.stdout, xmllint=False, filename=None):
     votable = None
 
     reset_vo_warnings()
+
+    if isinstance(source, str):
+        source = os.path.expanduser(source)
 
     with data.get_readable_fileobj(source, encoding='binary') as fd:
         content = fd.read()
@@ -372,6 +378,8 @@ def is_votable(source):
     is_votable : bool
         Returns `True` if the given file is a VOTable file.
     """
+    if isinstance(source, str):
+        source = os.path.expanduser(source)
     try:
         with iterparser.get_xml_iterator(source) as iterator:
             for start, tag, d, pos in iterator:

--- a/astropy/io/votable/util.py
+++ b/astropy/io/votable/util.py
@@ -9,6 +9,7 @@ import codecs
 import contextlib
 import gzip
 import io
+import os
 import re
 
 from packaging.version import Version
@@ -44,6 +45,7 @@ def convert_to_writable_filelike(fd, compressed=False):
     fd : writable file-like
     """
     if isinstance(fd, str):
+        fd = os.path.expanduser(fd)
         if fd.endswith('.gz') or compressed:
             with gzip.GzipFile(fd, 'wb') as real_fd:
                 encoded_fd = io.TextIOWrapper(real_fd, encoding='utf8')

--- a/astropy/io/votable/validator/main.py
+++ b/astropy/io/votable/validator/main.py
@@ -116,6 +116,7 @@ def make_validation_report(
             raise ValueError(
                 f'{stilts} does not exist.')
 
+    destdir = os.path.expanduser(destdir)
     destdir = os.path.abspath(destdir)
 
     if urls is None:

--- a/docs/changes/io.votable/13149.feature.rst
+++ b/docs/changes/io.votable/13149.feature.rst
@@ -1,0 +1,3 @@
+Added support in ``io.votable`` for reading and writing file paths of the form
+``~/file.xml`` or ``~<username>/file.xml``, referring to the home directory of
+the current user or the specified user, respectively.


### PR DESCRIPTION
### Description
This PR is split from #13107 and addresses #12778 within `io.votable`. The changes allow file paths to be given relative to the user's home directory as `~/dir/filename.xml` when doing file IO.

For testing, I used pytest's monkeypatch to temporarily update the environment variables so that `~` resolves to the test's temp or data directory, as appropriate and only for designated tests. Then I wrote some basic tests to exercise the IO functions with tilde-prefixed paths.

I've updated this PR post-#13161 to not rely on changing `astropy/utils/data.py`, and instead contain all the changes in `io.votable`.

@pllim If the `home_is_data` and `home_is_temp` fixtures get factored out (which seems like the right call), these tests will be part of that.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
