### PR TITLE
Bugfix for model evaluation with MagUnit parameters 

### DIFF
--- a/astropy/modeling/bounding_box.py
+++ b/astropy/modeling/bounding_box.py
@@ -520,7 +520,7 @@ class _BoundingDomain(abc.ABC):
         """
 
         if valid_outputs_unit is not None:
-            return Quantity(outputs, valid_outputs_unit, copy=False)
+            return Quantity(outputs, valid_outputs_unit, copy=False, subok=True)
 
         return outputs
 

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -2537,7 +2537,9 @@ class Model(metaclass=_ModelMeta):
             raise InputParameterError(
                 f"{self.__class__.__name__}.__init__() requires a Quantity for parameter "
                 f"{param_name!r}")
+
         param._unit = unit
+        param._set_unit(unit, force=True)
         param.internal_unit = None
         if param._setter is not None:
             if unit is not None:

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -418,7 +418,7 @@ class _ModelMeta(abc.ABCMeta):
                     # default is not a Quantity, attach the unit to the
                     # default.
                     if unit is not None:
-                        default = Quantity(default, unit, copy=False)
+                        default = Quantity(default, unit, copy=False, subok=True)
                     kwargs.append((param_name, default))
             else:
                 args = ('self',) + tuple(pdict.keys())
@@ -2689,7 +2689,7 @@ class Model(metaclass=_ModelMeta):
                 else:
                     unit = param.unit
                 if unit is not None:
-                    value = Quantity(value, unit)
+                    value = Quantity(value, unit, subok=True)
 
             values.append(value)
 

--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -1791,7 +1791,7 @@ class Const1D(Fittable1DModel):
         plt.show()
     """
 
-    amplitude = Parameter(default=1, description="Value of the constant function")
+    amplitude = Parameter(default=1, description="Value of the constant function", mag=True)
     linear = True
 
     @staticmethod
@@ -1846,7 +1846,7 @@ class Const2D(Fittable2DModel):
         .. math:: f(x, y) = A
     """
 
-    amplitude = Parameter(default=1, description="Value of the constant function")
+    amplitude = Parameter(default=1, description="Value of the constant function", mag=True)
     linear = True
 
     @staticmethod
@@ -1945,7 +1945,7 @@ class Ellipse2D(Fittable2DModel):
         plt.show()
     """
 
-    amplitude = Parameter(default=1, description="Value of the ellipse")
+    amplitude = Parameter(default=1, description="Value of the ellipse", mag=True)
     x_0 = Parameter(default=0, description="X position of the center of the disk.")
     y_0 = Parameter(default=0, description="Y position of the center of the disk.")
     a = Parameter(default=1, description="The length of the semimajor axis")
@@ -2041,7 +2041,7 @@ class Disk2D(Fittable2DModel):
                    \\right.
     """
 
-    amplitude = Parameter(default=1, description="Value of disk function")
+    amplitude = Parameter(default=1, description="Value of disk function", mag=True)
     x_0 = Parameter(default=0, description="X position of center of the disk")
     y_0 = Parameter(default=0, description="Y position of center of the disk")
     R_0 = Parameter(default=1, description="Radius of the disk")
@@ -2126,7 +2126,7 @@ class Ring2D(Fittable2DModel):
     Where :math:`r_{out} = r_{in} + r_{width}`.
     """
 
-    amplitude = Parameter(default=1, description="Value of the disk function")
+    amplitude = Parameter(default=1, description="Value of the disk function", mag=True)
     x_0 = Parameter(default=0, description="X position of center of disc")
     y_0 = Parameter(default=0, description="Y position of center of disc")
     r_in = Parameter(default=1, description="Inner radius of the ring")
@@ -2258,7 +2258,7 @@ class Box1D(Fittable1DModel):
         plt.show()
     """
 
-    amplitude = Parameter(default=1, description="Amplitude A")
+    amplitude = Parameter(default=1, description="Amplitude A", mag=True)
     x_0 = Parameter(default=0, description="Position of center of box function")
     width = Parameter(default=1, description="Width of the box")
 
@@ -2336,7 +2336,7 @@ class Box2D(Fittable2DModel):
 
     """
 
-    amplitude = Parameter(default=1, description="Amplitude")
+    amplitude = Parameter(default=1, description="Amplitude", mag=True)
     x_0 = Parameter(default=0, description="X position of the center of the box function")
     y_0 = Parameter(default=0, description="Y position of the center of the box function")
     x_width = Parameter(default=1, description="Width in x direction of the box")

--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -1807,6 +1807,8 @@ class Const1D(Fittable1DModel):
             # parameter is given an array-like value
             x = amplitude * np.ones_like(x, subok=False)
 
+        if isinstance(amplitude, Quantity):
+            return Quantity(x, unit=amplitude.unit, copy=False, subok=True)
         return x
 
     @staticmethod
@@ -1860,6 +1862,8 @@ class Const2D(Fittable2DModel):
             # parameter is given an array-like value
             x = amplitude * np.ones_like(x, subok=False)
 
+        if isinstance(amplitude, Quantity):
+            return Quantity(x, unit=amplitude.unit, copy=False, subok=True)
         return x
 
     @property
@@ -1964,7 +1968,7 @@ class Ellipse2D(Fittable2DModel):
         result = np.select([in_ellipse], [amplitude])
 
         if isinstance(amplitude, Quantity):
-            return Quantity(result, unit=amplitude.unit, copy=False)
+            return Quantity(result, unit=amplitude.unit, copy=False, subok=True)
         return result
 
     @property
@@ -2050,7 +2054,7 @@ class Disk2D(Fittable2DModel):
         result = np.select([rr <= R_0 ** 2], [amplitude])
 
         if isinstance(amplitude, Quantity):
-            return Quantity(result, unit=amplitude.unit, copy=False)
+            return Quantity(result, unit=amplitude.unit, copy=False, subok=True)
         return result
 
     @property
@@ -2165,7 +2169,7 @@ class Ring2D(Fittable2DModel):
         result = np.select([r_range], [amplitude])
 
         if isinstance(amplitude, Quantity):
-            return Quantity(result, unit=amplitude.unit, copy=False)
+            return Quantity(result, unit=amplitude.unit, copy=False, subok=True)
         return result
 
     @property
@@ -2350,7 +2354,7 @@ class Box2D(Fittable2DModel):
         result = np.select([np.logical_and(x_range, y_range)], [amplitude], 0)
 
         if isinstance(amplitude, Quantity):
-            return Quantity(result, unit=amplitude.unit, copy=False)
+            return Quantity(result, unit=amplitude.unit, copy=False, subok=True)
         return result
 
     @property
@@ -2450,7 +2454,7 @@ class Trapezoid1D(Fittable1DModel):
         result = np.select([range_a, range_b, range_c], [val_a, val_b, val_c])
 
         if isinstance(amplitude, Quantity):
-            return Quantity(result, unit=amplitude.unit, copy=False)
+            return Quantity(result, unit=amplitude.unit, copy=False, subok=True)
         return result
 
     @property
@@ -2518,7 +2522,7 @@ class TrapezoidDisk2D(Fittable2DModel):
         result = np.select([range_1, range_2], [val_1, val_2])
 
         if isinstance(amplitude, Quantity):
-            return Quantity(result, unit=amplitude.unit, copy=False)
+            return Quantity(result, unit=amplitude.unit, copy=False, subok=True)
         return result
 
     @property
@@ -2791,7 +2795,7 @@ class AiryDisk2D(Fittable2DModel):
 
         if isinstance(amplitude, Quantity):
             # make z quantity too, otherwise in-place multiplication fails.
-            z = Quantity(z, u.dimensionless_unscaled, copy=False)
+            z = Quantity(z, u.dimensionless_unscaled, copy=False, subok=True)
 
         z *= amplitude
         return z

--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -178,6 +178,8 @@ class Parameter:
     bounds : tuple
         specify min and max as a single tuple--bounds may not be specified
         simultaneously with min or max
+    mag : bool
+        Specify if the unit of the parameter can be a Magnitude unit or not
     """
 
     constraints = ('fixed', 'tied', 'bounds')
@@ -368,8 +370,8 @@ class Parameter:
     def _set_unit(self, unit, force=False):
         if force:
             if isinstance(unit, MagUnit) and not self._mag:
-                raise ParameterDefinitionError(
-                    f"This model does not support the magnitude units such as {unit}"
+                raise ValueError(
+                    f"This parameter does not support the magnitude units such as {unit}"
                 )
             self._unit = unit
         else:

--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -678,7 +678,7 @@ class Parameter:
         arr = np.asarray(self.value, dtype=dtype)
 
         if self.unit is not None:
-            arr = Quantity(arr, self.unit, copy=False)
+            arr = Quantity(arr, self.unit, copy=False, subok=True)
 
         return arr
 

--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -15,7 +15,7 @@ import operator
 
 import numpy as np
 
-from astropy.units import Quantity
+from astropy.units import MagUnit, Quantity
 from astropy.utils import isiterable
 
 from .utils import array_repr_oneline, get_inputs_and_params
@@ -191,7 +191,7 @@ class Parameter:
 
     def __init__(self, name='', description='', default=None, unit=None,
                  getter=None, setter=None, fixed=False, tied=False, min=None,
-                 max=None, bounds=None, prior=None, posterior=None):
+                 max=None, bounds=None, prior=None, posterior=None, mag=False):
         super().__init__()
 
         self._model = None
@@ -211,7 +211,9 @@ class Parameter:
             default = default.value
 
         self._default = default
-        self._unit = unit
+
+        self._mag = mag
+        self._set_unit(unit, force=True)
         # Internal units correspond to raw_units held by the model in the
         # previous implementation. The private _getter and _setter methods
         # use this to convert to and from the public unit defined for the
@@ -365,6 +367,10 @@ class Parameter:
 
     def _set_unit(self, unit, force=False):
         if force:
+            if isinstance(unit, MagUnit) and not self._mag:
+                raise ParameterDefinitionError(
+                    f"This model does not support the magnitude units such as {unit}"
+                )
             self._unit = unit
         else:
             self.unit = unit
@@ -399,7 +405,7 @@ class Parameter:
             raise TypeError("The .quantity attribute should be set "
                             "to a Quantity object")
         self.value = quantity.value
-        self._unit = quantity.unit
+        self._set_unit(quantity.unit, force=True)
 
     @property
     def shape(self):

--- a/astropy/modeling/powerlaws.py
+++ b/astropy/modeling/powerlaws.py
@@ -305,7 +305,7 @@ class SmoothlyBrokenPowerLaw1D(Fittable1DModel):
             f[i] = amplitude * xx[i] ** (-alpha_1) * r ** ((alpha_1 - alpha_2) * delta)
 
         if return_unit:
-            return Quantity(f, unit=return_unit, copy=False)
+            return Quantity(f, unit=return_unit, copy=False, subok=True)
         return f
 
     @staticmethod

--- a/astropy/modeling/powerlaws.py
+++ b/astropy/modeling/powerlaws.py
@@ -583,18 +583,19 @@ class Schechter1D(Fittable1DModel):
 
     phi_star = Parameter(default=1., description=('Normalization factor '
                                                   'in units of number density'))
-    m_star = Parameter(default=-20., description='Characteristic magnitude')
+    m_star = Parameter(default=-20., description='Characteristic magnitude', mag=True)
     alpha = Parameter(default=-1., description='Faint-end slope')
 
     @staticmethod
     def evaluate(mag, phi_star, m_star, alpha):
         """Schechter luminosity function model function."""
-        if isinstance(mag, Quantity) or isinstance(m_star, Quantity):
-            raise ValueError('mag and m_star must not have units')
-        factor = 10 ** (0.4 * (m_star - mag))
 
-        return (0.4 * np.log(10) * phi_star * factor**(alpha + 1)
-                * np.exp(-factor))
+        factor_exp = 0.4 * (m_star - mag)
+        if isinstance(factor_exp, Quantity):
+            factor_exp = factor_exp.value
+        factor = 10 ** factor_exp
+
+        return 0.4 * np.log(10) * phi_star * factor**(alpha + 1) * np.exp(-factor)
 
     @staticmethod
     def fit_deriv(mag, phi_star, m_star, alpha):
@@ -602,8 +603,6 @@ class Schechter1D(Fittable1DModel):
         Schechter luminosity function derivative with respect to
         parameters.
         """
-        if isinstance(mag, Quantity) or isinstance(m_star, Quantity):
-            raise ValueError('mag and m_star must not have units')
         factor = 10 ** (0.4 * (m_star - mag))
 
         d_phi_star = 0.4 * np.log(10) * factor**(alpha + 1) * np.exp(-factor)

--- a/astropy/modeling/powerlaws.py
+++ b/astropy/modeling/powerlaws.py
@@ -5,7 +5,7 @@ Power law model variants
 # pylint: disable=invalid-name
 import numpy as np
 
-from astropy.units import Quantity, dimensionless_unscaled
+from astropy.units import Magnitude, Quantity, UnitsError, dimensionless_unscaled, mag
 
 from .core import Fittable1DModel
 from .parameters import InputParameterError, Parameter
@@ -589,8 +589,14 @@ class Schechter1D(Fittable1DModel):
     @staticmethod
     def _factor(magnitude, m_star):
         factor_exp = (magnitude - m_star)
+
         if isinstance(factor_exp, Quantity):
-            return factor_exp.to(dimensionless_unscaled)
+            if factor_exp.unit == mag:
+                factor_exp = Magnitude(factor_exp.value, unit=mag)
+
+                return factor_exp.to(dimensionless_unscaled)
+            else:
+                raise UnitsError("The units of magnitude and m_star must be a magnitude")
         else:
             return 10 ** (-0.4 * factor_exp)
 

--- a/astropy/modeling/powerlaws.py
+++ b/astropy/modeling/powerlaws.py
@@ -588,11 +588,11 @@ class Schechter1D(Fittable1DModel):
 
     @staticmethod
     def _factor(magnitude, m_star):
-        factor_exp = (m_star - magnitude)
+        factor_exp = (magnitude - m_star)
         if isinstance(factor_exp, Quantity):
-            return (-1 * factor_exp).to(dimensionless_unscaled)
+            return factor_exp.to(dimensionless_unscaled)
         else:
-            return 10 ** (0.4 * factor_exp)
+            return 10 ** (-0.4 * factor_exp)
 
     def evaluate(self, mag, phi_star, m_star, alpha):
         """Schechter luminosity function model function."""

--- a/astropy/modeling/powerlaws.py
+++ b/astropy/modeling/powerlaws.py
@@ -238,7 +238,7 @@ class SmoothlyBrokenPowerLaw1D(Fittable1DModel):
 
     """
 
-    amplitude = Parameter(default=1, min=0, description="Peak value at break point")
+    amplitude = Parameter(default=1, min=0, description="Peak value at break point", mag=True)
     x_break = Parameter(default=1, description="Break point")
     alpha_1 = Parameter(default=-2, description="Power law index before break point")
     alpha_2 = Parameter(default=2, description="Power law index after break point")

--- a/astropy/modeling/rotations.py
+++ b/astropy/modeling/rotations.py
@@ -509,7 +509,7 @@ class Rotation2D(Model):
         x, y = result[0], result[1]
         x.shape = y.shape = orig_shape
         if has_units:
-            return u.Quantity(x, unit=x_unit), u.Quantity(y, unit=y_unit)
+            return u.Quantity(x, unit=x_unit, subok=True), u.Quantity(y, unit=y_unit, subok=True)
         return x, y
 
     @staticmethod

--- a/astropy/modeling/tests/test_models_quantities.py
+++ b/astropy/modeling/tests/test_models_quantities.py
@@ -660,3 +660,72 @@ def test_input_unit_mismatch_error(model):
         with pytest.raises(u.UnitsError) as err:
             m.without_units_for_data(**kwargs)
         assert str(err.value) == message
+
+
+mag_models = [
+    {
+        'class': Const1D,
+        'parameters': {'amplitude': 3 * u.ABmag},
+        'evaluation': [(0.6 * u.ABmag, 3 * u.ABmag)],
+    },
+    {
+        'class': Const1D,
+        'parameters': {'amplitude': 3 * u.ABmag},
+        'evaluation': [(0.6 * u.mag, 3 * u.ABmag)],
+    },
+    {
+        'class': Const1D,
+        'parameters': {'amplitude': 3 * u.mag},
+        'evaluation': [(0.6 * u.ABmag, 3 * u.mag)],
+    },
+    {
+        'class': Const1D,
+        'parameters': {'amplitude': 3 * u.mag},
+        'evaluation': [(0.6 * u.mag, 3 * u.mag)],
+    },
+    {
+        'class': Const2D,
+        'parameters': {'amplitude': 3 * u.ABmag},
+        'evaluation': [(0.6 * u.micron, 0.2 * u.m, 3 * u.ABmag)],
+    },
+    {
+        'class': Ellipse2D,
+        'parameters': {'amplitude': 3 * u.ABmag, 'x_0': 3 * u.m, 'y_0': 2 * u.m,
+                       'a': 300 * u.cm, 'b': 200 * u.cm, 'theta': 45 * u.deg},
+        'evaluation': [(4 * u.m, 300 * u.cm, 3 * u.ABmag)],
+    },
+    {
+        'class': Disk2D,
+        'parameters': {'amplitude': 3 * u.ABmag, 'x_0': 3 * u.m, 'y_0': 2 * u.m,
+                       'R_0': 300 * u.cm},
+        'evaluation': [(5.8 * u.m, 201 * u.cm, 3 * u.ABmag)],
+    },
+    {
+        'class': Ring2D,
+        'parameters': {'amplitude': 3 * u.ABmag, 'x_0': 3 * u.m, 'y_0': 2 * u.m,
+                       'r_in': 2 * u.cm, 'r_out': 2.1 * u.cm},
+        'evaluation': [(302.05 * u.cm, 2 * u.m + 10 * u.um, 3 * u.ABmag)],
+    },
+    {
+        'class': Box2D,
+        'parameters': {'amplitude': 3 * u.ABmag, 'x_0': 3 * u.m, 'y_0': 2 * u.s,
+                       'x_width': 4 * u.cm, 'y_width': 3 * u.s},
+        'evaluation': [(301 * u.cm, 3 * u.s, 3 * u.ABmag)],
+    },
+    {
+        'class': SmoothlyBrokenPowerLaw1D,
+        'parameters': {'amplitude': 5 * u.ABmag, 'x_break': 10 * u.cm,
+                       'alpha_1': 1, 'alpha_2': -1, 'delta': 1},
+        'evaluation': [(1 * u.cm, 15.125 * u.ABmag), (1 * u.m, 15.125 * u.ABmag)],
+    },
+]
+
+
+@pytest.mark.parametrize('model', mag_models)
+def test_models_evaluate_magunits(model):
+    if not HAS_SCIPY and model['class'] in SCIPY_MODELS:
+        pytest.skip()
+
+    m = model['class'](**model['parameters'])
+    for args in model['evaluation']:
+        assert_quantity_allclose(m(*args[:-1]), args[-1])

--- a/astropy/modeling/tests/test_models_quantities.py
+++ b/astropy/modeling/tests/test_models_quantities.py
@@ -768,3 +768,8 @@ def test_Schechter1D_errors():
     model = Schechter1D(phi_star=1.e-4 * (u.Mpc ** -3), m_star=-20. * u.ABmag, alpha=-1.9)
     with pytest.raises(u.UnitsError):
         model(-23 * u.STmag)
+
+    # Differing magnitude systems are bad
+    model = Schechter1D(phi_star=1.e-4 * (u.Mpc ** -3), m_star=-20. * u.ABmag, alpha=-1.9)
+    with pytest.raises(u.UnitsError):
+        model(-23 * u.mag)

--- a/astropy/modeling/tests/test_models_quantities.py
+++ b/astropy/modeling/tests/test_models_quantities.py
@@ -750,3 +750,15 @@ def test_models_evaluate_magunits(model):
     m = model['class'](**model['parameters'])
     for args in model['evaluation']:
         assert_quantity_allclose(m(*args[:-1]), args[-1])
+
+
+def test_Schechter1D_errors():
+    # Non magnitude units are bad
+    model = Schechter1D(phi_star=1.e-4 * (u.Mpc ** -3), m_star=-20. * u.km, alpha=-1.9)
+    with pytest.raises(u.UnitConversionError):
+        model(-23 * u.km)
+
+    # Differing magnitude systems are bad
+    model = Schechter1D(phi_star=1.e-4 * (u.Mpc ** -3), m_star=-20. * u.ABmag, alpha=-1.9)
+    with pytest.raises(u.UnitsError):
+        model(-23 * u.STmag)

--- a/astropy/modeling/tests/test_models_quantities.py
+++ b/astropy/modeling/tests/test_models_quantities.py
@@ -718,6 +718,12 @@ mag_models = [
                        'alpha_1': 1, 'alpha_2': -1, 'delta': 1},
         'evaluation': [(1 * u.cm, 15.125 * u.ABmag), (1 * u.m, 15.125 * u.ABmag)],
     },
+    {
+        'class': Box1D,
+        'parameters': {'amplitude': 3 * u.ABmag, 'x_0': 4.4 * u.um, 'width': 1 * u.um},
+        'evaluation': [(4200 * u.nm, 3 * u.ABmag), (1 * u.m, 0 * u.ABmag)],
+        'bounding_box': [3.9, 4.9] * u.um
+    },
 ]
 
 

--- a/astropy/modeling/tests/test_models_quantities.py
+++ b/astropy/modeling/tests/test_models_quantities.py
@@ -18,7 +18,7 @@ from astropy.modeling.parameters import InputParameterError
 from astropy.modeling.physical_models import Drude1D, Plummer1D
 from astropy.modeling.polynomial import Polynomial1D, Polynomial2D
 from astropy.modeling.powerlaws import (
-    BrokenPowerLaw1D, ExponentialCutoffPowerLaw1D, LogParabola1D, PowerLaw1D,
+    BrokenPowerLaw1D, ExponentialCutoffPowerLaw1D, LogParabola1D, PowerLaw1D, Schechter1D,
     SmoothlyBrokenPowerLaw1D)
 from astropy.tests.helper import assert_quantity_allclose
 from astropy.utils.compat.optional_deps import HAS_SCIPY
@@ -294,6 +294,13 @@ POWERLAW_MODELS = [
         'evaluation': [(1 * u.cm, 5 * 0.1 ** (-1 - 2 * np.log(0.1)) * u.kg)],
         'bounding_box': False
     },
+    {
+        'class': Schechter1D,
+        'parameters': {'phi_star': 1.e-4 * (u.Mpc ** -3), 'm_star': -20. * u.ABmag,
+                       'alpha': -1.9},
+        'evaluation': [(-23 * u.ABmag, 1.002702276867279e-12 * (u.Mpc ** -3))],
+        'bounding_box': False
+    },
 ]
 
 POLY_MODELS = [
@@ -355,7 +362,8 @@ NON_FINITE_LevMar_MODELS = [
     PowerLaw1D,
     ExponentialCutoffPowerLaw1D,
     BrokenPowerLaw1D,
-    LogParabola1D
+    LogParabola1D,
+    Schechter1D
 ]
 
 # These models will fail the TRFLSQFitter fitting test due to non-finite
@@ -376,6 +384,7 @@ NON_FINITE_LM_MODELS = [
     ArcCosine1D,
     PowerLaw1D,
     LogParabola1D,
+    Schechter1D,
     ExponentialCutoffPowerLaw1D,
     BrokenPowerLaw1D
 ]
@@ -429,9 +438,9 @@ def test_models_evaluate_with_units_x_array(model):
     for args in model['evaluation']:
         if len(args) == 2:
             x, y = args
-            x_arr = u.Quantity([x, x])
+            x_arr = u.Quantity([x, x], subok=True)
             result = m(x_arr)
-            assert_quantity_allclose(result, u.Quantity([y, y]))
+            assert_quantity_allclose(result, u.Quantity([y, y], subok=True))
         else:
             x, y, z = args
             x_arr = u.Quantity([x, x])
@@ -460,9 +469,9 @@ def test_models_evaluate_with_units_param_array(model):
     for args in model['evaluation']:
         if len(args) == 2:
             x, y = args
-            x_arr = u.Quantity([x, x])
+            x_arr = u.Quantity([x, x], subok=True)
             result = m(x_arr)
-            assert_quantity_allclose(result, u.Quantity([y, y]))
+            assert_quantity_allclose(result, u.Quantity([y, y], subok=True))
         else:
             x, y, z = args
             x_arr = u.Quantity([x, x])
@@ -723,6 +732,12 @@ mag_models = [
         'parameters': {'amplitude': 3 * u.ABmag, 'x_0': 4.4 * u.um, 'width': 1 * u.um},
         'evaluation': [(4200 * u.nm, 3 * u.ABmag), (1 * u.m, 0 * u.ABmag)],
         'bounding_box': [3.9, 4.9] * u.um
+    },
+    {
+        'class': Schechter1D,
+        'parameters': {'phi_star': 1.e-4 * (u.Mpc ** -3), 'm_star': -20. * u.ABmag,
+                       'alpha': -1.9},
+        'evaluation': [(-23 * u.ABmag, 1.002702276867279e-12 * (u.Mpc ** -3))],
     },
 ]
 

--- a/astropy/modeling/tests/test_models_quantities.py
+++ b/astropy/modeling/tests/test_models_quantities.py
@@ -739,6 +739,12 @@ mag_models = [
                        'alpha': -1.9},
         'evaluation': [(-23 * u.ABmag, 1.002702276867279e-12 * (u.Mpc ** -3))],
     },
+    {
+        'class': Schechter1D,
+        'parameters': {'phi_star': 1.e-4 * (u.Mpc ** -3), 'm_star': -20. * u.mag,
+                       'alpha': -1.9},
+        'evaluation': [(-23 * u.mag, 1.002702276867279e-12 * (u.Mpc ** -3))],
+    },
 ]
 
 
@@ -755,7 +761,7 @@ def test_models_evaluate_magunits(model):
 def test_Schechter1D_errors():
     # Non magnitude units are bad
     model = Schechter1D(phi_star=1.e-4 * (u.Mpc ** -3), m_star=-20. * u.km, alpha=-1.9)
-    with pytest.raises(u.UnitConversionError):
+    with pytest.raises(u.UnitsError):
         model(-23 * u.km)
 
     # Differing magnitude systems are bad

--- a/astropy/modeling/tests/test_parameters.py
+++ b/astropy/modeling/tests/test_parameters.py
@@ -459,6 +459,17 @@ class TestParameters:
         param._set_unit(u.m, True)
         assert param.unit == u.m
 
+        # Force magnitude unit (mag=False)
+        with pytest.raises(ValueError) as err:
+            param._set_unit(u.ABmag, True)
+        assert str(err.value) == (
+            "This parameter does not support the magnitude units such as mag(AB)"
+        )
+        # Force magnitude unit (mag=True)
+        param._mag = True
+        param._set_unit(u.ABmag, True)
+        assert param._unit == u.ABmag
+
         # No force Error (existing unit)
         with pytest.raises(ValueError) as err:
             param._set_unit(u.K)

--- a/astropy/modeling/tests/test_parameters.py
+++ b/astropy/modeling/tests/test_parameters.py
@@ -460,11 +460,10 @@ class TestParameters:
         assert param.unit == u.m
 
         # Force magnitude unit (mag=False)
-        with pytest.raises(ValueError) as err:
+        with pytest.raises(ValueError,
+                           match=r"This parameter does not support the magnitude units such as .*"):
             param._set_unit(u.ABmag, True)
-        assert str(err.value) == (
-            "This parameter does not support the magnitude units such as mag(AB)"
-        )
+
         # Force magnitude unit (mag=True)
         param._mag = True
         param._set_unit(u.ABmag, True)

--- a/astropy/modeling/tests/test_quantities_parameters.py
+++ b/astropy/modeling/tests/test_quantities_parameters.py
@@ -11,7 +11,8 @@ import pytest
 from astropy import coordinates as coord
 from astropy import units as u
 from astropy.modeling.core import Fittable1DModel, InputParameterError
-from astropy.modeling.models import Gaussian1D, Pix2Sky_TAN, RotateNative2Celestial, Rotation2D
+from astropy.modeling.models import (
+    Const1D, Gaussian1D, Pix2Sky_TAN, RotateNative2Celestial, Rotation2D)
 from astropy.modeling.parameters import Parameter, ParameterDefinitionError
 from astropy.tests.helper import assert_quantity_allclose
 from astropy.units import UnitsError
@@ -339,3 +340,13 @@ def test_parameters_compound_models():
     n2c = RotateNative2Celestial(sky_coords.ra, sky_coords.dec, lon_pole)
     rot = Rotation2D(23)
     rot | n2c
+
+
+def test_magunit_parameter():
+    """Regression test for bug reproducer in issue #13133"""
+
+    unit = u.ABmag
+    c = -20.0 * unit
+    model = Const1D(c)
+
+    assert model(-23.0 * unit) == c

--- a/astropy/modeling/utils.py
+++ b/astropy/modeling/utils.py
@@ -324,7 +324,7 @@ def ellipse_extent(a, b, theta):
     dy = b * np.sin(t) * np.cos(theta) + a * np.cos(t) * np.sin(theta)
 
     if isinstance(dx, u.Quantity) or isinstance(dy, u.Quantity):
-        return np.abs(u.Quantity([dx, dy]))
+        return np.abs(u.Quantity([dx, dy], subok=True))
     return np.abs([dx, dy])
 
 

--- a/docs/changes/modeling/13158.bugfix.rst
+++ b/docs/changes/modeling/13158.bugfix.rst
@@ -1,0 +1,1 @@
+Bugfix for using `MagUnit` units on model parameters.

--- a/docs/changes/modeling/13158.bugfix.rst
+++ b/docs/changes/modeling/13158.bugfix.rst
@@ -1,1 +1,1 @@
-Bugfix for using `MagUnit` units on model parameters.
+Bugfix for using ``MagUnit`` units on model parameters.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This is a bug fix for #13133, which reports that models cannot be evaluated with `MagUnit` parameters. This has been solved by enabling general use of `MagUnit` but with protections in the `Parameter` type.

Namely, when `mag=True` is passed to a model parameter, this parameter can take on `MagUnit` values as needed. This has been done because `MagUnit` quantities do not support multiplication and division generally, so `MagUnit` units cannot be supported in general by models. Thus if a model can operate with `MagUnit` as a parameter, it should specify `mag=True` when specifying the parameter.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #13133

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
