### PR TITLE
Do not load SIP when no celestial axes present

### DIFF
--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -551,6 +551,15 @@ reduce these to 2 dimensions using the naxis kwarg.
         for fd in close_fds:
             fd.close()
 
+        try:
+            # disable SIP for non-celestial axes - see #13105
+            if not (self.wcs.lng >= 0 and self.wcs.lat >= 0):
+                self.sip = None
+        except (InconsistentAxisTypesError, InvalidTransformError,
+                InvalidPrjParametersError, InvalidSubimageSpecificationError,
+                NonseparableSubimageCoordinateSystemError):
+            self.sip = None
+
         self._pixel_bounds = None
 
     def __copy__(self):

--- a/docs/changes/wcs/13159.bugfix.rst
+++ b/docs/changes/wcs/13159.bugfix.rst
@@ -1,0 +1,1 @@
+Do not load SIP coefficients when celestial axes are not present.


### PR DESCRIPTION
### Description
This PR turns off loading SIP distortion model when there are no celestial axes present.
Looking into #13105 I noticed that SIP coefficients are loaded even for spectral WCS (as long as it is a 2D WCS). I consider this a bug (but others may disagree).

This pull request is to partially address #13105.

### Checklist for package maintainer(s)
This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
