### PR TITLE
Limit tilde-path expansion in io.ascii to io.ascii itself

### DIFF
--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -268,8 +268,6 @@ def get_readable_fileobj(name_or_obj, encoding=None, cache=False,
                 name_or_obj, cache=cache, show_progress=show_progress,
                 timeout=remote_timeout, sources=sources,
                 http_headers=http_headers)
-        else:
-            name_or_obj = os.path.expanduser(name_or_obj)
         fileobj = io.FileIO(name_or_obj, 'r')
         if is_url and not cache:
             delete_fds.append(fileobj)


### PR DESCRIPTION
This addresses @taldcroft 's post-merge comments in #13130. The main change is moving the `expanduser` call in `utils/data.py` to the `read()` method in `io/ascii/ui.py` (and then refactoring to a helper function) to avoid accidental, partial support for tilde paths in other modules or packages. I've also rolled in the suggested check for newlines in the input data, as a clue that the string is not a filename.

I didn't see a way to add commits to #13130 after it was merged, thus the new PR.

There was also discussion in #13130 of adding a "What's new" entry. My inclination is to wait until this feature has landed throughout `io`, but I can add it now if that's the consensus.

cc: @pllim @hamogu 

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
