### PR TITLE
Deprecate dms_to_degrees

### DIFF
--- a/astropy/coordinates/angle_formats.py
+++ b/astropy/coordinates/angle_formats.py
@@ -412,13 +412,22 @@ def degrees_to_dms(d):
 def dms_to_degrees(d, m, s=None):
     """
     Convert degrees, arcminute, arcsecond to a float degrees value.
-    """
-
+     """
     _check_minute_range(m)
     _check_second_range(s)
+    
+    # if d is a scaler
+    d = np.atleast_1d(d)
+    m = np.atleast_1d(m)
+    s = np.atleast_1d(s)
+    dmss = np.array([d,m,s]).T
+    sign = [1 for dms in dmss]
+    for k in range(0,dmss.size/3):
+        # looking for first non zero
+        for i in dmss[k]:
+            if i!=0:
+                sign[k] = np.copysign(1,i); break;
 
-    # determine sign
-    sign = np.copysign(1.0, d)
 
     try:
         d = np.floor(np.abs(d))

--- a/astropy/coordinates/angle_formats.py
+++ b/astropy/coordinates/angle_formats.py
@@ -27,6 +27,7 @@ from .errors import (IllegalHourWarning, IllegalHourError,
                      IllegalMinuteWarning, IllegalMinuteError,
                      IllegalSecondWarning, IllegalSecondError)
 from astropy.utils import format_exception, parsing
+from astropy.utils.decorators import deprecated
 from astropy import units as u
 
 
@@ -409,25 +410,19 @@ def degrees_to_dms(d):
     return np.floor(sign * d), sign * np.floor(m), sign * s
 
 
+@deprecated("dms_to_degrees (or creating an Angle with a tuple) has ambiguous "
+            "behavior when the degree value is 0",
+            alternative="another way of creating angles instead (e.g. a less "
+                         "ambiguous string like '-1d2m3.4s'")
 def dms_to_degrees(d, m, s=None):
     """
     Convert degrees, arcminute, arcsecond to a float degrees value.
-     """
+    """
     _check_minute_range(m)
     _check_second_range(s)
-    
-    # if d is a scaler
-    d = np.atleast_1d(d)
-    m = np.atleast_1d(m)
-    s = np.atleast_1d(s)
-    dmss = np.array([d,m,s]).T
-    sign = [1 for dms in dmss]
-    for k in range(0,dmss.size/3):
-        # looking for first non zero
-        for i in dmss[k]:
-            if i!=0:
-                sign[k] = np.copysign(1,i); break;
 
+    # determine sign
+    sign = np.copysign(1.0, d)
 
     try:
         d = np.floor(np.abs(d))

--- a/astropy/coordinates/angle_formats.py
+++ b/astropy/coordinates/angle_formats.py
@@ -413,7 +413,7 @@ def degrees_to_dms(d):
 @deprecated("dms_to_degrees (or creating an Angle with a tuple) has ambiguous "
             "behavior when the degree value is 0",
             alternative="another way of creating angles instead (e.g. a less "
-                         "ambiguous string like '-1d2m3.4s'")
+                         "ambiguous string like '-0d1m2.3s'")
 def dms_to_degrees(d, m, s=None):
     """
     Convert degrees, arcminute, arcsecond to a float degrees value.
@@ -440,6 +440,10 @@ def dms_to_degrees(d, m, s=None):
     return sign * (d + m / 60. + s / 3600.)
 
 
+@deprecated("hms_to_hours (or creating an Angle with a tuple) has ambiguous "
+            "behavior when the hour value is 0",
+            alternative="another way of creating angles instead (e.g. a less "
+                         "ambiguous string like '-0h1m2.3s'")
 def hms_to_hours(h, m, s=None):
     """
     Convert hour, minute, second to a float hour value.

--- a/astropy/coordinates/angles.py
+++ b/astropy/coordinates/angles.py
@@ -69,8 +69,6 @@ class Angle(u.SpecificTypeQuantity):
       <Angle 1.04166667 hourangle>
       >>> Angle('-1:2.5', unit=u.deg)
       <Angle -1.04166667 deg>
-      >>> Angle((10, 11, 12), unit='hourangle')  # (h, m, s)
-      <Angle 10.18666667 hourangle>
       >>> Angle(10.2345 * u.deg)
       <Angle 10.2345 deg>
       >>> Angle(Angle(10.2345 * u.deg))

--- a/astropy/coordinates/angles.py
+++ b/astropy/coordinates/angles.py
@@ -71,8 +71,6 @@ class Angle(u.SpecificTypeQuantity):
       <Angle -1.04166667 deg>
       >>> Angle((10, 11, 12), unit='hourangle')  # (h, m, s)
       <Angle 10.18666667 hourangle>
-      >>> Angle((-1, 2, 3), unit=u.deg)  # (d, m, s)
-      <Angle -1.03416667 deg>
       >>> Angle(10.2345 * u.deg)
       <Angle 10.2345 deg>
       >>> Angle(Angle(10.2345 * u.deg))

--- a/astropy/coordinates/angles.py
+++ b/astropy/coordinates/angles.py
@@ -122,7 +122,15 @@ class Angle(u.SpecificTypeQuantity):
                     angle_unit = unit
 
                 if isinstance(angle, tuple):
-                    angle = cls._tuple_to_float(angle, angle_unit)
+                    if angle_unit == u.hourangle:
+                        form._check_hour_range(angle[0])
+                    form._check_minute_range(angle[1])
+                    a = np.abs(angle[0]) + angle[1] / 60.
+                    if len(angle) == 3:
+                        form._check_second_range(angle[2])
+                        a += angle[2] / 3600.
+
+                    angle = np.copysign(a, angle[0])
 
                 if angle_unit is not unit:
                     # Possible conversion to `unit` will be done below.

--- a/astropy/coordinates/tests/test_angles.py
+++ b/astropy/coordinates/tests/test_angles.py
@@ -43,9 +43,11 @@ def test_create_angles():
 
     a10 = Angle(3.60827466667, unit=u.hour)
     a11 = Angle("3:36:29.7888000120", unit=u.hour)
-    a12 = Angle((3, 36, 29.7888000120), unit=u.hour)  # *must* be a tuple
-    # Regression test for #5001
-    a13 = Angle((3, 36, 29.7888000120), unit='hour')
+    with pytest.warns(AstropyDeprecationWarning, match='hms_to_hour'):
+        a12 = Angle((3, 36, 29.7888000120), unit=u.hour)  # *must* be a tuple
+    with pytest.warns(AstropyDeprecationWarning, match='hms_to_hour'):
+        # Regression test for #5001
+        a13 = Angle((3, 36, 29.7888000120), unit='hour')
 
     Angle(0.944644098745, unit=u.radian)
 
@@ -434,7 +436,8 @@ def test_radec():
         ra = Longitude((56, 14, 52.52))
     with pytest.raises(u.UnitsError):
         ra = Longitude((12, 14, 52))  # ambiguous w/o units
-    ra = Longitude((12, 14, 52), unit=u.hour)
+    with pytest.warns(AstropyDeprecationWarning, match='hms_to_hours'):
+        ra = Longitude((12, 14, 52), unit=u.hour)
 
     # Units can be specified
     ra = Longitude("4:08:15.162342", unit=u.hour)
@@ -898,7 +901,8 @@ def test_create_tuple():
 
     (d, m, s) tuples are not tested because of sign ambiguity issues (#13162)
     """
-    a1 = Angle((1, 30, 0), unit=u.hourangle)
+    with pytest.warns(AstropyDeprecationWarning, match='hms_to_hours'):
+        a1 = Angle((1, 30, 0), unit=u.hourangle)
     assert a1.value == 1.5
 
 

--- a/astropy/coordinates/tests/test_angles.py
+++ b/astropy/coordinates/tests/test_angles.py
@@ -36,10 +36,7 @@ def test_create_angles():
     a4 = Angle("54.12412 deg")
     a5 = Angle("54.12412 degrees")
     a6 = Angle("54.12412°")  # because we like Unicode
-    a7 = Angle((54, 7, 26.832), unit=u.degree)
     a8 = Angle("54°07'26.832\"")
-    # (deg,min,sec) *tuples* are acceptable, but lists/arrays are *not*
-    # because of the need to eventually support arrays of coordinates
     a9 = Angle([54, 7, 26.832], unit=u.degree)
     assert_allclose(a9.value, [54, 7, 26.832])
     assert a9.unit is u.degree
@@ -82,13 +79,12 @@ def test_create_angles():
     a24 = Angle("+ 3h", unit=u.hour)
 
     # ensure the above angles that should match do
-    assert a1 == a2 == a3 == a4 == a5 == a6 == a7 == a8 == a18 == a19 == a20
+    assert a1 == a2 == a3 == a4 == a5 == a6 == a8 == a18 == a19 == a20
     assert_allclose(a1.radian, a2.radian)
     assert_allclose(a2.degree, a3.degree)
     assert_allclose(a3.radian, a4.radian)
     assert_allclose(a4.radian, a5.radian)
     assert_allclose(a5.radian, a6.radian)
-    assert_allclose(a6.radian, a7.radian)
 
     assert_allclose(a10.degree, a11.degree)
     assert a11 == a12 == a13 == a14
@@ -432,7 +428,6 @@ def test_radec():
     ra = Longitude("12h43m23s")
     assert_allclose(ra.hour, 12.7230555556)
 
-    ra = Longitude((56, 14, 52.52), unit=u.degree)      # can accept tuples
     # TODO: again, fix based on >24 behavior
     # ra = Longitude((56,14,52.52))
     with pytest.raises(u.UnitsError):
@@ -440,8 +435,6 @@ def test_radec():
     with pytest.raises(u.UnitsError):
         ra = Longitude((12, 14, 52))  # ambiguous w/o units
     ra = Longitude((12, 14, 52), unit=u.hour)
-
-    ra = Longitude([56, 64, 52.2], unit=u.degree)  # ...but not arrays (yet)
 
     # Units can be specified
     ra = Longitude("4:08:15.162342", unit=u.hour)
@@ -901,11 +894,10 @@ def test_empty_sep():
 
 def test_create_tuple():
     """
-    Tests creation of an angle with a (d,m,s) or (h,m,s) tuple
-    """
-    a1 = Angle((1, 30, 0), unit=u.degree)
-    assert a1.value == 1.5
+    Tests creation of an angle with an (h,m,s) tuple
 
+    (d, m, s) tuples are not tested because of sign ambiguity issues (#13162)
+    """
     a1 = Angle((1, 30, 0), unit=u.hourangle)
     assert a1.value == 1.5
 

--- a/astropy/coordinates/tests/test_arrays.py
+++ b/astropy/coordinates/tests/test_arrays.py
@@ -71,14 +71,6 @@ def test_dms():
     npt.assert_almost_equal(m, [0, 30, -30])
     npt.assert_almost_equal(s, [0, 0, -0])
 
-    dms = a1.dms
-    degrees = dms_to_degrees(*dms)
-    npt.assert_almost_equal(a1.degree, degrees)
-
-    a2 = Angle(dms, unit=u.degree)
-
-    npt.assert_almost_equal(a2.radian, a1.radian)
-
 
 def test_hms():
     a1 = Angle([0, 11.5, -11.5], unit=u.hour)

--- a/astropy/coordinates/tests/test_arrays.py
+++ b/astropy/coordinates/tests/test_arrays.py
@@ -10,6 +10,7 @@ from astropy import units as u
 from astropy.time import Time
 from astropy.tests.helper import assert_quantity_allclose as assert_allclose
 from astropy.utils.compat import NUMPY_LT_1_19
+from astropy.utils.exceptions import AstropyDeprecationWarning
 
 from astropy.coordinates import (Angle, ICRS, FK4, FK5, Galactic, SkyCoord,
                                  CartesianRepresentation)
@@ -80,10 +81,11 @@ def test_hms():
     npt.assert_almost_equal(s, [0, 0, -0])
 
     hms = a1.hms
-    hours = hms_to_hours(*hms)
+    hours = hms[0] + hms[1] / 60. + hms[2] / 3600.
     npt.assert_almost_equal(a1.hour, hours)
 
-    a2 = Angle(hms, unit=u.hour)
+    with pytest.warns(AstropyDeprecationWarning, match='hms_to_hours'):
+        a2 = Angle(hms, unit=u.hour)
 
     npt.assert_almost_equal(a2.radian, a1.radian)
 

--- a/docs/changes/coordinates/13162.api.rst
+++ b/docs/changes/coordinates/13162.api.rst
@@ -1,0 +1,1 @@
+The dms_to_degrees function (and implicitly tuple-based initialization of ``Angle``) is now deprecated, as it was difficult to be sure about the intent of the user for signed values of the degrees, minutes, and seconds.

--- a/docs/changes/coordinates/13162.api.rst
+++ b/docs/changes/coordinates/13162.api.rst
@@ -1,1 +1,4 @@
-The dms_to_degrees function (and implicitly tuple-based initialization of ``Angle``) is now deprecated, as it was difficult to be sure about the intent of the user for signed values of the degrees, minutes, and seconds.
+The ``dms_to_degrees`` and ``hms_to_hours`` functions (and implicitly
+tuple-based initialization of ``Angle``) is now deprecated, as it was
+difficult to be sure about the intent of the user for signed values of
+the degrees/hours, minutes, and seconds.

--- a/docs/coordinates/angles.rst
+++ b/docs/coordinates/angles.rst
@@ -54,8 +54,6 @@ There are a number of ways to create an |Angle|::
     <Angle -1.03416667 hourangle>
     >>> Angle('-1h2m3sW')               # Hour, minute, second, direction  # doctest: +FLOAT_CMP
     <Angle 1.03416667 hourangle>
-    >>> Angle((-1, 2, 3), unit=u.deg)  # (degree, arcmin, arcsec)  # doctest: +FLOAT_CMP
-    <Angle -1.03416667 deg>
     >>> Angle(10.2345 * u.deg)         # From a Quantity object in degrees  # doctest: +FLOAT_CMP
     <Angle 10.2345 deg>
     >>> Angle(Angle(10.2345 * u.deg))  # From another Angle object  # doctest: +FLOAT_CMP


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This PR is essentially a replacement for #12443 and fixes #12239 - in its current state it simply adds a deprecation warning for ``dms_to_degrees`` a la https://github.com/astropy/astropy/issues/12239#issuecomment-964345806, - I agree with @mhvk's point that this is more trouble than it's worth to really try to work out the user's intent. The deprecation warning now specifically says essentially "convert to degrees yourself, or use the string input where there's not sign ambiguity".

I did explore a few other options, though, and so there's a few extraneous commits.  That is *intentional*, so I do not want to squash it out, as it shows how a follow-on PR might address this use case if we wanted to.  Right now I just want to make sure we get the deprecation warning in for 5.1 since deprecating sooner is always better.

(Note this also contains the commits #12443 - that is also intentional because I don't think we should merge #12443 but @webbdays deserves some credit for sleuthing out some of these corner cases - if someone wants I am fine squashing all that down to one commit but :shrug: to me it didn't seem worth the effort).

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

EDIT: Close #12443

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
