### PR TITLE
Fix bug with spectral WCS transformations when target is not available

### DIFF
--- a/astropy/wcs/wcsapi/fitswcs.py
+++ b/astropy/wcs/wcsapi/fitswcs.py
@@ -507,7 +507,8 @@ class FITSWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
                                          unit=u.m, observer=observer, target=target)
 
                 def redshift_from_spectralcoord(spectralcoord):
-                    # TODO: check target is consistent
+                    # TODO: check target is consistent between WCS and SpectralCoord,
+                    # if they are not the transformation doesn't make conceptual sense.
                     if (observer is None
                             or spectralcoord.observer is None
                             or spectralcoord.target is None):
@@ -539,7 +540,8 @@ class FITSWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
                                          observer=observer, target=target)
 
                 def beta_from_spectralcoord(spectralcoord):
-                    # TODO: check target is consistent
+                    # TODO: check target is consistent between WCS and SpectralCoord,
+                    # if they are not the transformation doesn't make conceptual sense.
                     doppler_equiv = u.doppler_relativistic(self.wcs.restwav * u.m)
                     if (observer is None
                             or spectralcoord.observer is None
@@ -581,7 +583,8 @@ class FITSWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
                     return SpectralCoord(value, observer=observer, target=target, **kwargs)
 
                 def value_from_spectralcoord(spectralcoord):
-                    # TODO: check target is consistent
+                    # TODO: check target is consistent between WCS and SpectralCoord,
+                    # if they are not the transformation doesn't make conceptual sense.
                     if (observer is None
                             or spectralcoord.observer is None
                             or spectralcoord.target is None):

--- a/astropy/wcs/wcsapi/fitswcs.py
+++ b/astropy/wcs/wcsapi/fitswcs.py
@@ -508,8 +508,16 @@ class FITSWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
 
                 def redshift_from_spectralcoord(spectralcoord):
                     # TODO: check target is consistent
-                    if observer is None:
-                        warnings.warn('No observer defined on WCS, SpectralCoord '
+                    if (observer is None
+                            or spectralcoord.observer is None
+                            or spectralcoord.target is None):
+                        if observer is None:
+                            msg = 'No observer defined on WCS'
+                        elif spectralcoord.observer is None:
+                            msg = 'No observer defined on SpectralCoord'
+                        else:
+                            msg = 'No target defined on SpectralCoord'
+                        warnings.warn(f'{msg}, SpectralCoord '
                                       'will be converted without any velocity '
                                       'frame change', AstropyUserWarning)
                         return spectralcoord.to_value(u.m) / self.wcs.restwav - 1.
@@ -533,8 +541,16 @@ class FITSWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
                 def beta_from_spectralcoord(spectralcoord):
                     # TODO: check target is consistent
                     doppler_equiv = u.doppler_relativistic(self.wcs.restwav * u.m)
-                    if observer is None:
-                        warnings.warn('No observer defined on WCS, SpectralCoord '
+                    if (observer is None
+                            or spectralcoord.observer is None
+                            or spectralcoord.target is None):
+                        if observer is None:
+                            msg = 'No observer defined on WCS'
+                        elif spectralcoord.observer is None:
+                            msg = 'No observer defined on SpectralCoord'
+                        else:
+                            msg = 'No target defined on SpectralCoord'
+                        warnings.warn(f'{msg}, SpectralCoord '
                                       'will be converted without any velocity '
                                       'frame change', AstropyUserWarning)
                         return spectralcoord.to_value(u.m / u.s, doppler_equiv) / C_SI
@@ -560,12 +576,22 @@ class FITSWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
                         kwargs['doppler_rest'] = self.wcs.restwav * u.m
 
                 def spectralcoord_from_value(value):
+                    if isinstance(value, SpectralCoord):
+                        return value
                     return SpectralCoord(value, observer=observer, target=target, **kwargs)
 
                 def value_from_spectralcoord(spectralcoord):
                     # TODO: check target is consistent
-                    if observer is None:
-                        warnings.warn('No observer defined on WCS, SpectralCoord '
+                    if (observer is None
+                            or spectralcoord.observer is None
+                            or spectralcoord.target is None):
+                        if observer is None:
+                            msg = 'No observer defined on WCS'
+                        elif spectralcoord.observer is None:
+                            msg = 'No observer defined on SpectralCoord'
+                        else:
+                            msg = 'No target defined on SpectralCoord'
+                        warnings.warn(f'{msg}, SpectralCoord '
                                       'will be converted without any velocity '
                                       'frame change', AstropyUserWarning)
                         return spectralcoord.to_value(**kwargs)

--- a/astropy/wcs/wcsapi/tests/test_fitswcs.py
+++ b/astropy/wcs/wcsapi/tests/test_fitswcs.py
@@ -1109,6 +1109,7 @@ RESTFRQ =      1.420405752E+09 / [Hz]
 RADESYS = 'FK5'
 """
 
+
 @pytest.fixture
 def header_spectral_1d():
     return Header.fromstring(HEADER_SPECTRAL_1D, sep='\n')

--- a/docs/changes/wcs/13228.bugfix.rst
+++ b/docs/changes/wcs/13228.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed error that occured in ``WCS.world_to_pixel`` for ``WCS`` objects with a
+spectral axis and observer location information when passing a ``SpectralCoord``
+that had missing observer or target information.


### PR DESCRIPTION
### Description

This PR aims to fix a bug I tracked down in the APE 14 FITS WCS implementation for spectral WCSes which is causing failures seen e.g. in https://github.com/spacetelescope/jdaviz/issues/1288. The failures in question happen when one calls ``WCS.world_to_pixel`` with a ``SpectralCoord`` on which a target or observer is not defined, or a plain ``Quantity``, if ``WCS`` has an observer defined. So in fact, it will even fail when trying to round-trip coordinates with a ``WCS`` in which the observer but not the target is defined (since going from pixel to world will create a ``SpectralCoord`` with an observer but no target, and plugging that back in to the world to pixel transformation will crash). The error users see in these cases is:

```
ValueError: This method can only be used if both observer and target are defined on the SpectralCoord.
```

The fix will be that in these cases we should emit a warning and ignore the observer/target (we already emit such a warning if the ``WCS`` has no observer).

<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

Fix spacetelescope/jdaviz#1288

Close spacetelescope/jdaviz#1296

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
