### PR TITLE
Fix bug of not being able format structured column

### DIFF
--- a/astropy/table/pprint.py
+++ b/astropy/table/pprint.py
@@ -42,6 +42,7 @@ def _possible_string_format_functions(format_):
     yield lambda format_, val: format(val, format_)
     yield lambda format_, val: format_.format(val)
     yield lambda format_, val: format_ % val
+    yield lambda format_, val: format_.format(**{k: val[k] for k in val.dtype.names})
 
 
 def get_auto_format_func(

--- a/astropy/table/tests/test_pprint.py
+++ b/astropy/table/tests/test_pprint.py
@@ -592,6 +592,22 @@ def test_pprint_structured():
         "        (2, (2.5, [2.6, 2.7]))"]
 
 
+def test_pprint_structured_with_format():
+    dtype = np.dtype([('par', 'f8'), ('min', 'f8'), ('id', 'i4'), ('name', 'U4')])
+    c = table.Column([(1.2345678, -20, 3, 'bar'),
+                      (12.345678, 4.5678, 33, 'foo')], dtype=dtype)
+    t = table.Table()
+    t['a'] = [1, 2]
+    t['c'] = c
+    t['c'].info.format = '{par:6.2f} {min:5.1f} {id:03d} {name:4s}'
+    exp = [
+        ' a  c [par, min, id, name]',
+        '--- ----------------------',
+        '  1    1.23 -20.0 003 bar ',
+        '  2   12.35   4.6 033 foo ']
+    assert t.pformat_all() == exp
+
+
 def test_pprint_nameless_col():
     """Regression test for #2213, making sure a nameless column can be printed
     using None as the name.

--- a/docs/changes/table/13233.bugfix.rst
+++ b/docs/changes/table/13233.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed a bug where it is not possible to set the `.info.format` property of a
+table structured column and get formatted output.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

Setting the format column to obtain formatted output for the column currently fails. This PR introduces a simple addition to the default list of format functions that accepts dict-style specification in the format string.

This relates to functionality added in #12644, but the problem was there before that for `NDArrayMixin` columns.

To do:
- [ ] Docs

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
