### PR TITLE
Preserve order for structured columns on reading back from file

### DIFF
--- a/astropy/io/ascii/tests/test_ecsv.py
+++ b/astropy/io/ascii/tests/test_ecsv.py
@@ -269,7 +269,8 @@ def assert_objects_equal(obj1, obj2, attrs, compare_class=True):
 
     assert obj1.shape == obj2.shape
 
-    info_attrs = ['info.name', 'info.format', 'info.unit', 'info.description']
+    info_attrs = ['info.name', 'info.format', 'info.unit', 'info.description',
+                  'info.dtype']
     for attr in attrs + info_attrs:
         a1 = obj1
         a2 = obj2

--- a/astropy/io/misc/tests/test_hdf5.py
+++ b/astropy/io/misc/tests/test_hdf5.py
@@ -13,6 +13,7 @@ from astropy.utils.exceptions import AstropyUserWarning
 from astropy.utils.data import get_pkg_data_filename
 from astropy.utils.misc import _NOT_OVERWRITING_MSG_MATCH
 from astropy.io.misc.hdf5 import meta_path
+from astropy.utils.compat import NUMPY_LT_1_22
 from astropy.utils.compat.optional_deps import HAS_H5PY  # noqa
 if HAS_H5PY:
     import h5py
@@ -651,7 +652,8 @@ def assert_objects_equal(obj1, obj2, attrs, compare_class=True):
     if compare_class:
         assert obj1.__class__ is obj2.__class__
 
-    info_attrs = ['info.name', 'info.format', 'info.unit', 'info.description', 'info.meta']
+    info_attrs = ['info.name', 'info.format', 'info.unit', 'info.description', 'info.meta',
+                  'info.dtype']
     for attr in attrs + info_attrs:
         a1 = obj1
         a2 = obj2
@@ -673,6 +675,15 @@ def assert_objects_equal(obj1, obj2, attrs, compare_class=True):
 
         if isinstance(a1, np.ndarray) and a1.dtype.kind == 'f':
             assert quantity_allclose(a1, a2, rtol=1e-15)
+        elif isinstance(a1, np.dtype):
+            # HDF5 does not perfectly preserve dtype: byte order can change, and
+            # unicode gets stored as bytes.  So, we just check safe casting, to
+            # ensure we do not, e.g., accidentally change integer to float, etc.
+            if NUMPY_LT_1_22 and a1.names:
+                # For old numpy, can_cast does not deal well with structured dtype.
+                assert a1.names == a2.names
+            else:
+                assert np.can_cast(a2, a1, casting='safe')
         else:
             assert np.all(a1 == a2)
 

--- a/astropy/io/tests/mixin_columns.py
+++ b/astropy/io/tests/mixin_columns.py
@@ -45,7 +45,7 @@ su = table.Column([(1, (1.5, 1.6)),
                    (2, (2.5, 2.6))],
                   name='su',
                   dtype=[('i', np.int64),
-                         ('f', [('p0', np.float64), ('p1', np.float64)])])
+                         ('f', [('p1', np.float64), ('p0', np.float64)])])
 su2 = table.Column([(['snake', 'c'], [1.6, 1.5]),
                     (['eal', 'a'], [2.5, 2.6])],
                    dtype=[('name', 'U5', (2,)), ('f', 'f8', (2,))])
@@ -139,7 +139,7 @@ non_trivial_names = {
             'srd.differentials.s.d_lon_coslat',
             'srd.differentials.s.d_lat',
             'srd.differentials.s.d_distance'],
-    'su': ['su.i', 'su.f.p0', 'su.f.p1'],
+    'su': ['su.i', 'su.f.p1', 'su.f.p0'],
     'su2': ['su2.name', 'su2.f'],
     'tm': ['tm.jd1', 'tm.jd2'],
     'tm2': ['tm2.jd1', 'tm2.jd2'],

--- a/astropy/io/tests/mixin_columns.py
+++ b/astropy/io/tests/mixin_columns.py
@@ -46,9 +46,9 @@ su = table.Column([(1, (1.5, 1.6)),
                   name='su',
                   dtype=[('i', np.int64),
                          ('f', [('p0', np.float64), ('p1', np.float64)])])
-su2 = table.Column([(['d', 'c'], [1.6, 1.5]),
-                    (['b', 'a'], [2.5, 2.6])],
-                   dtype=[('s', 'U1', (2,)), ('f', 'f8', (2,))])
+su2 = table.Column([(['snake', 'c'], [1.6, 1.5]),
+                    (['eal', 'a'], [2.5, 2.6])],
+                   dtype=[('name', 'U5', (2,)), ('f', 'f8', (2,))])
 
 # NOTE: for testing, the name of the column "x" for the
 # Quantity is important since it tests the fix for #10215
@@ -113,7 +113,7 @@ compare_attrs = {
             'differentials.s.d_lat', 'differentials.s.d_distance'],
     'obj': [],
     'su': ['i', 'f.p0', 'f.p1'],
-    'su2': ['s', 'f'],
+    'su2': ['name', 'f'],
 }
 non_trivial_names = {
     'cr': ['cr.x', 'cr.y', 'cr.z'],
@@ -140,7 +140,7 @@ non_trivial_names = {
             'srd.differentials.s.d_lat',
             'srd.differentials.s.d_distance'],
     'su': ['su.i', 'su.f.p0', 'su.f.p1'],
-    'su2': ['su2.s', 'su2.f'],
+    'su2': ['su2.name', 'su2.f'],
     'tm': ['tm.jd1', 'tm.jd2'],
     'tm2': ['tm2.jd1', 'tm2.jd2'],
     'tm3': ['tm3.jd1', 'tm3.jd2',

--- a/astropy/table/serialize.py
+++ b/astropy/table/serialize.py
@@ -293,14 +293,19 @@ def _construct_mixin_from_obj_attrs_and_info(obj_attrs, info):
     # untrusted code by only importing known astropy classes.
     cls_full_name = obj_attrs.pop('__class__', None)
     if cls_full_name is None:
-        cls = SerializedColumn
-    elif cls_full_name not in __construct_mixin_classes:
-        raise ValueError(f'unsupported class for construct {cls_full_name}')
-    else:
-        mod_name, _, cls_name = cls_full_name.rpartition('.')
-        module = import_module(mod_name)
-        cls = getattr(module, cls_name)
+        # We're dealing with a SerializedColumn holding columns, stored in
+        # obj_attrs. For this case, info holds the name (and nothing else).
+        mixin = SerializedColumn(obj_attrs)
+        assert len(info) == 1, 'info for SerializedColumn should only hold name'
+        mixin.info.name = info['name']
+        return mixin
 
+    if cls_full_name not in __construct_mixin_classes:
+        raise ValueError(f'unsupported class for construct {cls_full_name}')
+
+    mod_name, _, cls_name = cls_full_name.rpartition('.')
+    module = import_module(mod_name)
+    cls = getattr(module, cls_name)
     for attr, value in info.items():
         if attr in cls.info.attrs_from_parent:
             obj_attrs[attr] = value
@@ -342,7 +347,11 @@ def _construct_mixin_from_columns(new_name, obj_attrs, out):
     data_attrs_map = {}
     for name, val in obj_attrs.items():
         if isinstance(val, SerializedColumn):
-            if 'name' in val:
+            # A SerializedColumn can just link to a serialized column using a name
+            # (e.g., time.jd1), or itself be a mixin (e.g., coord.obstime).  Note
+            # that in principle a mixin could have include a column called 'name',
+            # hence we check whether the value is actually a string (see gh-13232).
+            if 'name' in val and isinstance(val['name'], str):
                 data_attrs_map[val['name']] = name
             else:
                 out_name = f'{new_name}.{name}'

--- a/astropy/table/serialize.py
+++ b/astropy/table/serialize.py
@@ -296,7 +296,6 @@ def _construct_mixin_from_obj_attrs_and_info(obj_attrs, info):
         # We're dealing with a SerializedColumn holding columns, stored in
         # obj_attrs. For this case, info holds the name (and nothing else).
         mixin = SerializedColumn(obj_attrs)
-        assert len(info) == 1, 'info for SerializedColumn should only hold name'
         mixin.info.name = info['name']
         return mixin
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

Ensure that structured columns preserve their order when written to a file and read back.

So far, the test is done only for ECSV, as FITS and HDF5 get different failures if we explicitly test that the dtype of a column roundtrips (FITS has big-endian byteorder, while HDF5 has bytes instead of string). So, that needs a bit of thought. EDIT: went with just allowing those types of changes, since that used to be the case anyway. This is not perfect, since the unicode sandwich may not work as well.

Note that perhaps this is "affects-dev" 


<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #13231
Fixes #13232

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
