### PR TITLE
Change Table default to add structured array as Column not NdarrayMixin

### DIFF
--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -1239,13 +1239,6 @@ class Table:
                                 f'{fully_qualified_name} '
                                 'did not return a valid mixin column')
 
-        # Structured ndarray gets viewed as a mixin unless already a valid
-        # mixin class
-        if (not isinstance(data, Column) and not data_is_mixin
-                and isinstance(data, np.ndarray) and len(data.dtype) > 1):
-            data = data.view(NdarrayMixin)
-            data_is_mixin = True
-
         # Get the final column name using precedence.  Some objects may not
         # have an info attribute. Also avoid creating info as a side effect.
         if not name:

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -2916,6 +2916,21 @@ def test_data_to_col_convert_strategy():
     assert np.all(t['b'] == [2, 2])
 
 
+def test_structured_masked_column():
+    """Test that adding a masked ndarray with a structured dtype works"""
+    dtype = np.dtype([('z', 'f8'), ('x', 'f8'), ('y', 'i4')])
+    t = Table()
+    t['a'] = np.ma.array([(1, 2, 3),
+                          (4, 5, 6)],
+                         mask=[(False, False, True),
+                               (False, True, False)],
+                         dtype=dtype)
+    assert np.all(t['a']['z'].mask == [False, False])
+    assert np.all(t['a']['x'].mask == [False, True])
+    assert np.all(t['a']['y'].mask == [True, False])
+    assert isinstance(t['a'], MaskedColumn)
+
+
 def test_rows_with_mixins():
     """Test for #9165 to allow adding a list of mixin objects.
     Also test for fix to #9357 where group_by() failed due to

--- a/docs/changes/table/13236.api.rst
+++ b/docs/changes/table/13236.api.rst
@@ -1,0 +1,6 @@
+Changed behavior when a structured ``numpy.ndarray`` is added as a column to a
+``Table``. Previously this was converted to a ``NdarrayMixin`` subclass of
+``ndarray`` and added as a mixin column. This was because saving as a file (e.g.
+HDF5, FITS, ECSV) was not supported for structured array columns. Now a
+structured ``numpy.ndarray`` is added to the table as a native ``Column`` and
+saving to file is supported.

--- a/docs/changes/table/13236.bugfix.rst
+++ b/docs/changes/table/13236.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed a bug when adding a masked structured array to a table. Previously this
+was auto-converted to a ``NdarrayMixin`` which loses the mask. With this fix
+the data are added to the table as a ``MaskedColumn`` and the mask is preserved.

--- a/docs/table/construct_table.rst
+++ b/docs/table/construct_table.rst
@@ -361,7 +361,10 @@ including the simple structured array defined previously as a column::
 You can access or print a single field in the structured column as follows::
 
   >>> print(table['arr']['b'])
-  [2. 5.]
+  arr
+  ---
+  2.0
+  5.0
 
 **New column names**
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address the suggestion made in #13235, namely change the `Table` default to add a structured array as a `Column` not `NdarrayMixin`.

This also fixes a bug when trying to add a masked structured array to a table. The auto-conversion to `NdarrayMixin` loses the mask.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #13235.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
