### PR TITLE
Support remote and cloud-hosted FITS files

### DIFF
--- a/astropy/io/fits/__init__.py
+++ b/astropy/io/fits/__init__.py
@@ -50,13 +50,19 @@ class Conf(_config.ConfigNamespace):
         'If True, use lazy loading of HDUs when opening FITS files by '
         'default; that is fits.open() will only seek for and read HDUs on '
         'demand rather than reading all HDUs at once.  See the documentation '
-        'for fits.open() for more datails.')
+        'for fits.open() for more details.')
     enable_uint = _config.ConfigItem(
         True,
         'If True, default to recognizing the convention for representing '
         'unsigned integers in FITS--if an array has BITPIX > 0, BSCALE = 1, '
         'and BZERO = 2**BITPIX, represent the data as unsigned integers '
         'per this convention.')
+    use_fsspec = _config.ConfigItem(
+        False,
+        'Use the ``fsspec`` library to open FITS files? Defaults to `False` '
+        'unless the FITS file path starts with the Amazon S3 storage '
+        'prefix ``s3://`` or the Google Cloud Storage prefix ``gs://``. '
+        'See the documentation for fits.open() for more details.')
 
 
 conf = Conf()

--- a/astropy/io/fits/__init__.py
+++ b/astropy/io/fits/__init__.py
@@ -57,12 +57,6 @@ class Conf(_config.ConfigNamespace):
         'unsigned integers in FITS--if an array has BITPIX > 0, BSCALE = 1, '
         'and BZERO = 2**BITPIX, represent the data as unsigned integers '
         'per this convention.')
-    use_fsspec = _config.ConfigItem(
-        False,
-        'Use the ``fsspec`` library to open FITS files? Defaults to `False` '
-        'unless the FITS file path starts with the Amazon S3 storage '
-        'prefix ``s3://`` or the Google Cloud Storage prefix ``gs://``. '
-        'See the documentation for fits.open() for more details.')
 
 
 conf = Conf()

--- a/astropy/io/fits/file.py
+++ b/astropy/io/fits/file.py
@@ -18,7 +18,7 @@ import numpy as np
 
 # NOTE: Python can be built without bz2.
 from astropy.utils.compat.optional_deps import HAS_BZ2
-from astropy.utils.data import _is_url, download_file, _requires_fsspec, get_readable_fileobj
+from astropy.utils.data import _is_url, _requires_fsspec, download_file, get_readable_fileobj
 from astropy.utils.decorators import classproperty
 from astropy.utils.exceptions import AstropyUserWarning
 from astropy.utils.misc import NOT_OVERWRITING_MSG

--- a/astropy/io/fits/file.py
+++ b/astropy/io/fits/file.py
@@ -105,7 +105,7 @@ class _File:
     """
 
     def __init__(self, fileobj=None, mode=None, memmap=None, overwrite=False,
-                 cache=True, **kwargs):
+                 cache=True, *, use_fsspec=None, fsspec_kwargs=None):
         self.strict_memmap = bool(memmap)
         memmap = True if memmap is None else memmap
 
@@ -146,13 +146,13 @@ class _File:
             mode = 'readonly'
 
         # Handle cloud-hosted files using the optional ``fsspec`` dependency
-        if (kwargs.get('use_fsspec') or _requires_fsspec(fileobj)) and mode != "ostream":
+        if (use_fsspec or _requires_fsspec(fileobj)) and mode != "ostream":
             # Note: we don't use `get_readable_fileobj` as a context manager
             # because io.fits takes care of closing files itself
             fileobj = get_readable_fileobj(fileobj,
                                            encoding="binary",
-                                           use_fsspec=kwargs.get('use_fsspec'),
-                                           fsspec_kwargs=kwargs.get('fsspec_kwargs'),
+                                           use_fsspec=use_fsspec,
+                                           fsspec_kwargs=fsspec_kwargs,
                                            close_files=False).__enter__()
 
         # Handle raw URLs

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -37,7 +37,7 @@ FITS_SIGNATURE = b'SIMPLE  =                    T'
 
 def fitsopen(name, mode='readonly', memmap=None, save_backup=False,
              cache=True, lazy_load_hdus=None, ignore_missing_simple=False,
-             **kwargs):
+             use_fsspec=None, fsspec_kwargs=None, **kwargs):
     """Factory function to open a FITS file and return an `HDUList` object.
 
     Parameters
@@ -106,6 +106,26 @@ def fitsopen(name, mode='readonly', memmap=None, save_backup=False,
 
         .. versionadded:: 4.2
 
+    use_fsspec : bool, optional
+        Use the ``fsspec`` library to open the file? Defaults to `False` unless
+        the ``name`` parameter starts with the Amazon S3 storage prefix ``s3://``
+        or the Google Cloud Storage prefix ``gs://``.  Can also be used for paths
+        with other prefixes (e.g. ``http://``) but in this case you must
+        explicitely pass ``use_fsspec=True``.
+        Use of this feature requires the optional ``fsspec`` package.
+        A ``ModuleNotFoundError`` will be raised if the dependency is missing.
+
+        .. versionadded:: 5.2
+
+    fsspec_kwargs : dict, optional
+        Keyword arguments passed on to `fsspec.open`. This can be used to
+        configure cloud storage credentials and caching behavior.
+        Defaults to ``{"anon": True}`` for paths with prefix ``s3://``
+        which is required for reading data from Amazon S3 open data buckets.
+        See ``fsspec``'s documentation for available parameters.
+
+        .. versionadded:: 5.2
+
     checksum : bool, str, optional
         If `True`, verifies that both ``DATASUM`` and ``CHECKSUM`` card values
         (when present in the HDU header) match the header and data of all HDU's
@@ -167,6 +187,24 @@ def fitsopen(name, mode='readonly', memmap=None, save_backup=False,
     else:
         lazy_load_hdus = bool(lazy_load_hdus)
 
+    if use_fsspec is None:
+        if isinstance(name, str) and name.startswith(("s3://", "gs://")):
+            use_fsspec = True
+        else:
+            use_fsspec = conf.use_fsspec
+    else:
+        use_fsspec = bool(use_fsspec)
+
+    if use_fsspec:
+        if not isinstance(name, str):
+            raise TypeError("`name` must be a string when `use_fsspec=True`")
+        # For s3:// paths, it is useful to have fsspec default to `anon=True`
+        # because Hubble's data archive is available via a public S3 buckets.
+        # Accessing a public bucket without credentials raises a
+        # `NoCredentialsError` unless `anon=True` is passed explicitely.
+        if fsspec_kwargs is None and name.startswith("s3://"):
+            fsspec_kwargs = {'anon': True}
+
     if 'uint' not in kwargs:
         kwargs['uint'] = conf.enable_uint
 
@@ -174,7 +212,9 @@ def fitsopen(name, mode='readonly', memmap=None, save_backup=False,
         raise ValueError(f'Empty filename: {name!r}')
 
     return HDUList.fromfile(name, mode, memmap, save_backup, cache,
-                            lazy_load_hdus, ignore_missing_simple, **kwargs)
+                            lazy_load_hdus, ignore_missing_simple,
+                            use_fsspec=use_fsspec, fsspec_kwargs=fsspec_kwargs,
+                            **kwargs)
 
 
 class HDUList(list, _Verify):
@@ -253,6 +293,12 @@ class HDUList(list, _Verify):
         return super().__len__()
 
     def __repr__(self):
+        # Special case: if the FITS file is located on a remote file system
+        # and has not been fully read yet, we return a simplified repr to
+        # avoid downloading the entire file
+        if not self._read_all and self._file and self._file.use_fsspec:
+            return f"{type(self)} (partially read)"
+
         # In order to correctly repr an HDUList we need to load all the
         # HDUs as well
         self.readall()
@@ -399,7 +445,8 @@ class HDUList(list, _Verify):
     @classmethod
     def fromfile(cls, fileobj, mode=None, memmap=None,
                  save_backup=False, cache=True, lazy_load_hdus=True,
-                 ignore_missing_simple=False, **kwargs):
+                 ignore_missing_simple=False, use_fsspec=None,
+                 fsspec_kwargs=None, **kwargs):
         """
         Creates an `HDUList` instance from a file-like object.
 
@@ -411,7 +458,8 @@ class HDUList(list, _Verify):
         return cls._readfrom(fileobj=fileobj, mode=mode, memmap=memmap,
                              save_backup=save_backup, cache=cache,
                              ignore_missing_simple=ignore_missing_simple,
-                             lazy_load_hdus=lazy_load_hdus, **kwargs)
+                             lazy_load_hdus=lazy_load_hdus, use_fsspec=use_fsspec,
+                             fsspec_kwargs=fsspec_kwargs, **kwargs)
 
     @classmethod
     def fromstring(cls, data, **kwargs):
@@ -1050,7 +1098,7 @@ class HDUList(list, _Verify):
     @classmethod
     def _readfrom(cls, fileobj=None, data=None, mode=None, memmap=None,
                   cache=True, lazy_load_hdus=True, ignore_missing_simple=False,
-                  **kwargs):
+                  use_fsspec=None, fsspec_kwargs=None, **kwargs):
         """
         Provides the implementations from HDUList.fromfile and
         HDUList.fromstring, both of which wrap this method, as their
@@ -1060,7 +1108,8 @@ class HDUList(list, _Verify):
         if fileobj is not None:
             if not isinstance(fileobj, _File):
                 # instantiate a FITS file object (ffo)
-                fileobj = _File(fileobj, mode=mode, memmap=memmap, cache=cache)
+                fileobj = _File(fileobj, mode=mode, memmap=memmap, cache=cache,
+                                use_fsspec=use_fsspec, fsspec_kwargs=fsspec_kwargs)
             # The Astropy mode is determined by the _File initializer if the
             # supplied mode was None
             mode = fileobj.mode

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -150,7 +150,7 @@ def fitsopen(name, mode='readonly', memmap=None, save_backup=False,
         Use `fsspec.open` to open the file? Defaults to `False` unless
         ``name`` starts with the Amazon S3 storage prefix ``s3://`` or the
         Google Cloud Storage prefix ``gs://``.  Can also be used for paths
-        with other prefixes (e.g. ``http://``) but in this case you must
+        with other prefixes (e.g., ``http://``) but in this case you must
         explicitely pass ``use_fsspec=True``.
         Use of this feature requires the optional ``fsspec`` package.
         A ``ModuleNotFoundError`` will be raised if the dependency is missing.

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -148,8 +148,8 @@ def fitsopen(name, mode='readonly', memmap=None, save_backup=False,
 
     use_fsspec : bool, optional
         Use `fsspec.open` to open the file? Defaults to `False` unless
-        ``name`` starts with the Amazon S3 storage prefix ``s3://``
-        or the Google Cloud Storage prefix ``gs://``.  Can also be used for paths
+        ``name`` starts with the Amazon S3 storage prefix ``s3://`` or the
+        Google Cloud Storage prefix ``gs://``.  Can also be used for paths
         with other prefixes (e.g. ``http://``) but in this case you must
         explicitely pass ``use_fsspec=True``.
         Use of this feature requires the optional ``fsspec`` package.
@@ -160,8 +160,8 @@ def fitsopen(name, mode='readonly', memmap=None, save_backup=False,
     fsspec_kwargs : dict, optional
         Keyword arguments passed on to `fsspec.open`. This can be used to
         configure cloud storage credentials and caching behavior.
-        Defaults to ``{"anon": True}`` for paths with prefix ``s3://``
-        which is required for reading data from Amazon S3 open data buckets.
+        For example, pass ``fsspec_kwargs={"anon": True}`` to enable
+        anonymous access to Amazon S3 open data buckets.
         See ``fsspec``'s documentation for available parameters.
 
         .. versionadded:: 5.2

--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -196,8 +196,8 @@ class _ImageBaseHDU(_ValidHDU):
         should still be used to deal with very large scaled images.
 
         Note that sections cannot currently be written to.  Moreover, any
-        in-memory updates to the image's `.data` property may not be
-        reflected in the slices obtained via `.section`. See the
+        in-memory updates to the image's ``.data`` property may not be
+        reflected in the slices obtained via ``.section``. See the
         :ref:`astropy:data-sections` section of the documentation for
         more details.
         """

--- a/astropy/io/fits/tests/test_fsspec.py
+++ b/astropy/io/fits/tests/test_fsspec.py
@@ -85,8 +85,8 @@ class TestFsspecRemote:
         # listed above to a local path and and executing:
         # with fits.open(local_path) as hdul:
         #     expected_cutout = hdul[1].data[31:33, 27:30]
-        self.expected_cutout = np.array([[ 24,  88, 228],
-                                         [ 35, 132, 305]], dtype=np.int32)
+        self.expected_cutout = np.array([[24,  88, 228],
+                                         [35, 132, 305]], dtype=np.int32)
 
     @pytest.mark.skipif("not HAS_FSSPEC")
     def test_fsspec_http(self):
@@ -105,7 +105,6 @@ class TestFsspecRemote:
                 assert_array_equal(hdul2[1].section[self.slice], self.expected_cutout)
                 assert "partially read" in repr(hdul)
                 assert "partially read" in str(hdul)
-
 
     @pytest.mark.skipif("not HAS_S3FS")
     def test_fsspec_s3(self):

--- a/astropy/io/fits/tests/test_fsspec.py
+++ b/astropy/io/fits/tests/test_fsspec.py
@@ -64,9 +64,8 @@ def test_fsspec_compressed():
         # The .data attribute should work as normal
         assert hdul[1].data[0,0] == 7
         # However the .section attribute does not support compressed data
-        with pytest.raises(AttributeError) as excinfo:
+        with pytest.raises(AttributeError, match="'CompImageHDU' object has no attribute 'section'") as excinfo:
             hdul[1].section[1,2]
-        assert "'CompImageHDU' object has no attribute 'section'" in str(excinfo.value)
 
 
 @pytest.mark.remote_data

--- a/astropy/io/fits/tests/test_fsspec.py
+++ b/astropy/io/fits/tests/test_fsspec.py
@@ -44,12 +44,6 @@ def test_fsspec_local_write(tmpdir):
     with fits.open(fn_tmp) as hdul:
         assert hdul[1].data[2,3] == -999
 
-    # Does fsspec support `mode="update"` for local files?
-    with fits.open(str(fn_tmp), use_fsspec=True, mode="update") as hdul:
-        hdul[1].data[2,3] = 42
-    with fits.open(fn_tmp) as hdul:
-        assert hdul[1].data[2,3] == 42
-
 
 @pytest.mark.remote_data
 @pytest.mark.skipif("not HAS_FSSPEC")

--- a/astropy/io/fits/tests/test_fsspec.py
+++ b/astropy/io/fits/tests/test_fsspec.py
@@ -109,7 +109,7 @@ class TestFsspecRemote:
     @pytest.mark.skipif("not HAS_S3FS")
     def test_fsspec_s3(self):
         """Can we use fsspec to open a FITS file in a public Amazon S3 bucket?"""
-        with fits.open(self.s3_uri) as hdul:  # s3:// paths should default to use_fsspec=True
+        with fits.open(self.s3_uri, fsspec_kwargs={"anon": True}) as hdul:  # s3:// paths should default to use_fsspec=True
             # Do we retrieve the expected array?
             assert_array_equal(hdul[1].section[self.slice], self.expected_cutout)
             # The file has multiple extensions which are not yet downloaded;

--- a/astropy/io/fits/tests/test_fsspec.py
+++ b/astropy/io/fits/tests/test_fsspec.py
@@ -1,14 +1,14 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Can `astropy.io.fits.open` access (remote) data using the fsspec package?
 """
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose, assert_array_equal
+
 from astropy.io import fits
 from astropy.nddata import Cutout2D
 from astropy.utils.compat.optional_deps import HAS_FSSPEC, HAS_S3FS  # noqa
-from astropy.utils.data import get_pkg_data_filename, conf
-
-import numpy as np
-from numpy.testing import assert_array_equal, assert_allclose
-import pytest
+from astropy.utils.data import conf, get_pkg_data_filename
 
 if HAS_FSSPEC:
     import fsspec

--- a/astropy/io/fits/tests/test_fsspec.py
+++ b/astropy/io/fits/tests/test_fsspec.py
@@ -10,6 +10,9 @@ import numpy as np
 from numpy.testing import assert_array_equal, assert_allclose
 import pytest
 
+if HAS_FSSPEC:
+    import fsspec
+
 
 @pytest.mark.skipif("not HAS_FSSPEC")
 def test_fsspec_local():
@@ -67,7 +70,6 @@ def test_fsspec_http():
         assert "partially read" in str(hdul)
 
     # Can the user also pass an fsspec file object directly to fits open?
-    import fsspec
     with fsspec.open(uri) as fileobj:
         with fits.open(fileobj) as hdul2:
             assert_allclose(hdul2[1].section[1000:1002, 2000:2003], expected, atol=1e-7)
@@ -94,7 +96,6 @@ def test_fsspec_s3():
         assert "partially read" in str(hdul)
 
     # Can the user also pass an fsspec file object directly to fits open?
-    import fsspec
     with fsspec.open(uri, anon=True) as fileobj:
         with fits.open(fileobj) as hdul2:
             assert_allclose(hdul2[1].section[1000:1002, 2000:2003], expected, atol=1e-7)

--- a/astropy/io/fits/tests/test_fsspec.py
+++ b/astropy/io/fits/tests/test_fsspec.py
@@ -1,0 +1,114 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""Can `astropy.io.fits.open` access (remote) data using the fsspec package?
+"""
+from astropy.io import fits
+from astropy.nddata import Cutout2D
+from astropy.utils.compat.optional_deps import HAS_FSSPEC, HAS_S3FS  # noqa
+from astropy.utils.data import get_pkg_data_filename
+
+import numpy as np
+from numpy.testing import assert_array_equal, assert_allclose
+import pytest
+
+
+@pytest.mark.skipif("not HAS_FSSPEC")
+def test_fsspec_local():
+    """Can we use fsspec to read a local file?"""
+    fn = get_pkg_data_filename('data/test0.fits')
+    hdulist_classic = fits.open(fn, use_fsspec=False)
+    hdulist_fsspec = fits.open(fn, use_fsspec=True)
+    assert_array_equal(hdulist_classic[2].data, hdulist_fsspec[2].data)
+    assert_array_equal(hdulist_classic[2].section[3:5], hdulist_fsspec[2].section[3:5])
+    assert "partially read" not in repr(hdulist_classic)
+    assert "partially read" in repr(hdulist_fsspec)
+    hdulist_classic.close()
+    hdulist_fsspec.close()
+
+
+@pytest.mark.skipif("not HAS_FSSPEC")
+def test_fsspec_local_write(tmpdir):
+    """Can we write to a local file that was opened using fsspec?"""
+    fn = get_pkg_data_filename('data/test0.fits')
+    fn_tmp = tmpdir / "tmp.fits"
+    with fits.open(fn, use_fsspec=True) as hdul:
+        # writing to a section is never allowed
+        with pytest.raises(TypeError):
+            hdul[1].section[0, 0] = -999
+        # however writing to .data should work
+        hdul[1].data[2, 3] = -999
+        assert hdul[1].data[2,3] == -999
+        hdul.writeto(fn_tmp)
+
+    # Is the new value present when we re-open the file?
+    with fits.open(fn_tmp) as hdul:
+        assert hdul[1].data[2,3] == -999
+
+    # Does fsspec support `mode="update"`?
+    with fits.open(str(fn_tmp), use_fsspec=True, mode="update") as hdul:
+        hdul[1].data[2,3] = 42
+    with fits.open(fn_tmp) as hdul:
+        assert hdul[1].data[2,3] == 42
+
+
+@pytest.mark.remote_data
+@pytest.mark.skipif("not HAS_FSSPEC")
+def test_fsspec_http():
+    """Can we use fsspec to open a remote FITS file via http?"""
+    uri = "https://mast.stsci.edu/api/v0.1/Download/file/?uri=mast:HST/product/j8pu0y010_drc.fits"
+    # Expected array was obtained by downloading the file locally and executing:
+    # with fits.open(local_path) as hdul:
+    #     hdul[1].data[1000:1002, 2000:2003]
+    expected = np.array([[0.00545289, 0.0051066, -0.00034149],
+                         [0.00120684, 0.00782754, 0.00546404]])
+    with fits.open(uri, use_fsspec=True) as hdul:
+        # Do we retrieve the expected array?
+        assert_allclose(hdul[1].section[1000:1002, 2000:2003], expected, atol=1e-7)
+        # The file has multiple extensions which are not yet downloaded;
+        # the repr and string representation should reflect this.
+        assert "partially read" in repr(hdul)
+        assert "partially read" in str(hdul)
+
+
+@pytest.mark.remote_data
+@pytest.mark.skipif("not HAS_S3FS")
+def test_fsspec_s3():
+    """Can we use fsspec to open a FITS file in a public Amazon S3 bucket?"""
+    uri = f"s3://stpubdata/hst/public/j8pu/j8pu0y010/j8pu0y010_drc.fits"
+    # Expected array was obtained by downloading the file locally and executing:
+    # with fits.open(local_path) as hdul:
+    #     hdul[1].data[1000:1002, 2000:2003]
+    expected = np.array([[0.00545289, 0.0051066, -0.00034149],
+                         [0.00120684, 0.00782754, 0.00546404]])
+    with fits.open(uri) as hdul:  # s3:// paths should default to use_fsspec=True
+        # Do we retrieve the expected array?
+        assert_allclose(hdul[1].section[1000:1002, 2000:2003], expected, atol=1e-7)
+        # The file has multiple extensions which are not yet downloaded;
+        # the repr and string representation should reflect this.
+        assert "partially read" in repr(hdul)
+        assert "partially read" in str(hdul)
+
+
+@pytest.mark.skipif("not HAS_FSSPEC")
+def test_fsspec_cutout2d():
+    """Does Cutout2D work with data loaded lazily using fsspec and .section?"""
+    fn = get_pkg_data_filename('data/test0.fits')
+    with fits.open(fn, use_fsspec=True) as hdul:
+        position = (10, 20)
+        size = (2, 3)
+        cutout1 = Cutout2D(hdul[1].data, position, size)
+        cutout2 = Cutout2D(hdul[1].section, position, size)
+        assert_allclose(cutout1.data, cutout2.data)
+
+
+@pytest.mark.skipif("not HAS_FSSPEC")
+def test_fsspec_compressed():
+    """Does fsspec support compressed data correctly?"""
+    # comp.fits[1] is a compressed image with shape (440, 300)
+    fn = get_pkg_data_filename('data/comp.fits')
+    with fits.open(fn, use_fsspec=True) as hdul:
+        # The .data attribute should work as normal
+        assert hdul[1].data[0,0] == 7
+        # However the .section attribute does not support compressed data
+        with pytest.raises(AttributeError) as excinfo:
+            hdul[1].section[1,2]
+        assert "'CompImageHDU' object has no attribute 'section'" in str(excinfo.value)

--- a/astropy/io/fits/tests/test_image.py
+++ b/astropy/io/fits/tests/test_image.py
@@ -454,6 +454,11 @@ class TestImageFunctions(FitsTestCase):
         assert np.array_equal(fs[0].section[..., ::2], dat[..., ::2])
         assert np.array_equal(fs[0].section[..., [1, 2, 4], 3],
                               dat[..., [1, 2, 4], 3])
+
+        # Can we use negative indices?
+        assert np.array_equal(fs[0].section[-1], dat[-1])
+        assert np.array_equal(fs[0].section[-9:-7], dat[-9:-7])
+        assert np.array_equal(fs[0].section[-4, -6:-3, -1], dat[-4, -6:-3, -1])
         fs.close()
 
     def test_section_data_single(self):

--- a/astropy/io/fits/tests/test_image.py
+++ b/astropy/io/fits/tests/test_image.py
@@ -895,6 +895,9 @@ class TestImageFunctions(FitsTestCase):
         with fits.open(self.temp('test0.fits')) as hdul:
             assert (orig_data == hdul[1].data).all()
 
+    # The test below raised a `ResourceWarning: unclosed transport` exception
+    # due to a bug in Python <=3.10 (cf. cpython#90476)
+    @pytest.mark.filterwarnings("ignore:unclosed transport <asyncio.sslproto")
     def test_open_scaled_in_update_mode(self):
         """
         Regression test for https://aeon.stsci.edu/ssb/trac/pyfits/ticket/119

--- a/astropy/io/fits/tests/test_image.py
+++ b/astropy/io/fits/tests/test_image.py
@@ -3,6 +3,7 @@
 import math
 import os
 import re
+import sys
 import time
 
 import numpy as np
@@ -894,6 +895,9 @@ class TestImageFunctions(FitsTestCase):
         with fits.open(self.temp('test0.fits')) as hdul:
             assert (orig_data == hdul[1].data).all()
 
+    # The test below raised a `ResourceWarning: unclosed transport` exception
+    # due to a bug in Python <=3.10 (cf. cpython#90476)
+    @pytest.mark.skipif(sys.version_info < (3, 11), reason="failure due to cpython#90476")
     def test_open_scaled_in_update_mode(self):
         """
         Regression test for https://aeon.stsci.edu/ssb/trac/pyfits/ticket/119

--- a/astropy/io/fits/tests/test_image.py
+++ b/astropy/io/fits/tests/test_image.py
@@ -895,9 +895,6 @@ class TestImageFunctions(FitsTestCase):
         with fits.open(self.temp('test0.fits')) as hdul:
             assert (orig_data == hdul[1].data).all()
 
-    # The test below raised a `ResourceWarning: unclosed transport` exception
-    # due to a bug in Python <=3.10 (cf. cpython#90476)
-    @pytest.mark.skipif(sys.version_info < (3, 11), reason="failure due to cpython#90476")
     def test_open_scaled_in_update_mode(self):
         """
         Regression test for https://aeon.stsci.edu/ssb/trac/pyfits/ticket/119

--- a/astropy/nddata/utils.py
+++ b/astropy/nddata/utils.py
@@ -12,6 +12,7 @@ from astropy.coordinates import SkyCoord
 from astropy.utils import lazyproperty
 from astropy.wcs import Sip
 from astropy.wcs.utils import proj_plane_pixel_scales, skycoord_to_pixel
+from astropy.io.fits.hdu.image import Section
 
 __all__ = ['extract_array', 'add_array', 'subpixel_indices',
            'overlap_slices', 'NoOverlapError', 'PartialOverlapError',
@@ -563,7 +564,8 @@ class Cutout2D:
                     raise ValueError('shape can contain Quantities with only '
                                      'pixel or angular units')
 
-        data = np.asanyarray(data)
+        if not isinstance(data, Section):  # Accept lazy-loaded image sections
+            data = np.asanyarray(data)
         # reverse position because extract_array and overlap_slices
         # use (y, x), but keep the input position
         pos_yx = position[::-1]

--- a/astropy/nddata/utils.py
+++ b/astropy/nddata/utils.py
@@ -9,10 +9,10 @@ import numpy as np
 
 from astropy import units as u
 from astropy.coordinates import SkyCoord
+from astropy.io.fits.hdu.image import Section
 from astropy.utils import lazyproperty
 from astropy.wcs import Sip
 from astropy.wcs.utils import proj_plane_pixel_scales, skycoord_to_pixel
-from astropy.io.fits.hdu.image import Section
 
 __all__ = ['extract_array', 'add_array', 'subpixel_indices',
            'overlap_slices', 'NoOverlapError', 'PartialOverlapError',

--- a/astropy/utils/compat/optional_deps.py
+++ b/astropy/utils/compat/optional_deps.py
@@ -10,7 +10,7 @@ import warnings
 # some of the package names are different from the pip-install name (e.g.,
 # beautifulsoup4 -> bs4).
 _optional_deps = ['asdf', 'asdf_astropy', 'bleach', 'bottleneck', 'bs4', 'bz2',
-                  'fsspec', 'gcsfs', 'h5py', 'html5lib', 'IPython', 'jplephem',
+                  'fsspec', 'h5py', 'html5lib', 'IPython', 'jplephem',
                   'lxml', 'matplotlib', 'mpmath', 'pandas', 'PIL', 'pytz',
                   's3fs', 'scipy', 'skyfield', 'sortedcontainers', 'lzma',
                   'pyarrow']

--- a/astropy/utils/compat/optional_deps.py
+++ b/astropy/utils/compat/optional_deps.py
@@ -9,10 +9,11 @@ import warnings
 # TODO: This list is a duplicate of the dependencies in setup.cfg "all", but
 # some of the package names are different from the pip-install name (e.g.,
 # beautifulsoup4 -> bs4).
-_optional_deps = ['asdf', 'asdf_astropy', 'bleach', 'bottleneck', 'bs4', 'bz2', 'h5py',
-                  'html5lib', 'IPython', 'jplephem', 'lxml', 'matplotlib',
-                  'mpmath', 'pandas', 'PIL', 'pytz', 'scipy', 'skyfield',
-                  'sortedcontainers', 'lzma', 'pyarrow']
+_optional_deps = ['asdf', 'asdf_astropy', 'bleach', 'bottleneck', 'bs4', 'bz2',
+                  'fsspec', 'gcsfs', 'h5py', 'html5lib', 'IPython', 'jplephem',
+                  'lxml', 'matplotlib', 'mpmath', 'pandas', 'PIL', 'pytz',
+                  's3fs', 'scipy', 'skyfield', 'sortedcontainers', 'lzma',
+                  'pyarrow']
 _formerly_optional_deps = ['yaml']  # for backward compatibility
 _deps = {k.upper(): k for k in _optional_deps + _formerly_optional_deps}
 

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -310,7 +310,9 @@ def get_readable_fileobj(name_or_obj, encoding=None, cache=False,
             if not HAS_FSSPEC:
                 raise ModuleNotFoundError("please install `fsspec` to open this file")
             import fsspec  # local import because it is a niche dependency
-            fileobj = fsspec.open(name_or_obj, **fsspec_kwargs).open()
+            openfileobj = fsspec.open(name_or_obj, **fsspec_kwargs)
+            close_fds.append(openfileobj)
+            fileobj = openfileobj.open()
             close_fds.append(fileobj)
         else:
             is_url = _is_url(name_or_obj)

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -170,7 +170,7 @@ def _is_inside(path, parent_path):
 @contextlib.contextmanager
 def get_readable_fileobj(name_or_obj, encoding=None, cache=False,
                          show_progress=True, remote_timeout=None,
-                         sources=None, http_headers=None,
+                         sources=None, http_headers=None, *,
                          use_fsspec=None, fsspec_kwargs=None,
                          close_files=True):
     """Yield a readable, seekable file-like object from a file or URL.
@@ -244,7 +244,7 @@ def get_readable_fileobj(name_or_obj, encoding=None, cache=False,
         is set by ``astropy.utils.data.conf.default_http_user_agent``.
 
     use_fsspec : bool, optional
-        Use the ``fsspec`` library to open the file? Defaults to `False` unless
+        Use `fsspec.open` to open the file? Defaults to `False` unless
         ``name_or_obj`` starts with the Amazon S3 storage prefix ``s3://``
         or the Google Cloud Storage prefix ``gs://``.  Can also be used for paths
         with other prefixes (e.g. ``http://``) but in this case you must
@@ -313,7 +313,7 @@ def get_readable_fileobj(name_or_obj, encoding=None, cache=False,
     # Get a file object to the content
     if isinstance(name_or_obj, str):
         # Use fsspec to open certain cloud-hosted files (e.g., AWS S3, Google Cloud Storage)
-        if use_fsspec or _requires_fsspec(name_or_obj):
+        if use_fsspec:
             if not HAS_FSSPEC:
                 raise ModuleNotFoundError("please install `fsspec` to open this file")
             import fsspec  # local import because it is a niche dependency

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -257,8 +257,8 @@ def get_readable_fileobj(name_or_obj, encoding=None, cache=False,
     fsspec_kwargs : dict, optional
         Keyword arguments passed on to `fsspec.open`. This can be used to
         configure cloud storage credentials and caching behavior.
-        Defaults to ``{"anon": True}`` for paths with prefix ``s3://``
-        which is required for reading data from Amazon S3 open data buckets.
+        For example, pass ``fsspec_kwargs={"anon": True}`` to enable
+        anonymous access to Amazon S3 open data buckets.
         See ``fsspec``'s documentation for available parameters.
 
         .. versionadded:: 5.2
@@ -296,15 +296,8 @@ def get_readable_fileobj(name_or_obj, encoding=None, cache=False,
     if use_fsspec:
         if not isinstance(name_or_obj, str):
             raise TypeError("`name_or_obj` must be a string when `use_fsspec=True`")
-        # For s3:// paths, it is useful to have fsspec default to `anon=True`
-        # because Hubble/JWST's data archive is available via a public S3 buckets.
-        # Accessing a public bucket without credentials raises a
-        # `NoCredentialsError` unless `anon=True` is passed explicitely.
         if fsspec_kwargs is None:
-            if name_or_obj.startswith("s3://"):
-                fsspec_kwargs = {'anon': True}
-            else:
-                fsspec_kwargs = {}
+            fsspec_kwargs = {}
 
     # name_or_obj could be an os.PathLike object
     if isinstance(name_or_obj, os.PathLike):

--- a/docs/changes/io.fits/13238.feature.rst
+++ b/docs/changes/io.fits/13238.feature.rst
@@ -1,2 +1,2 @@
 Add options ``use_fsspec`` and ``fsspec_kwargs`` to ``astropy.io.fits.open``
-to enable cloud-hosted FITS files to be opened seamlessly.
+to enable remote and cloud-hosted FITS files to be opened seamlessly.

--- a/docs/changes/io.fits/13238.feature.rst
+++ b/docs/changes/io.fits/13238.feature.rst
@@ -1,2 +1,2 @@
-Add options ``use_fsspec`` and ``fsspec_kwargs`` to ``astropy.io.fits.open``
-to enable remote and cloud-hosted FITS files to be opened seamlessly.
+Added support for opening remote and cloud-hosted FITS files using the
+``fsspec`` package, which has been added as an optional dependency.

--- a/docs/changes/io.fits/TBD.feature.rst
+++ b/docs/changes/io.fits/TBD.feature.rst
@@ -1,0 +1,2 @@
+Add options ``use_fsspec`` and ``fsspec_kwargs`` to ``astropy.io.fits.open``
+to enable cloud-hosted FITS files to be opened seamlessly.

--- a/docs/changes/nddata/13238.feature.rst
+++ b/docs/changes/nddata/13238.feature.rst
@@ -1,0 +1,2 @@
+Modified ``Cutout2D`` to allow objects of type ``astropy.io.fits.Section``
+to be passed to the ``data`` parameter.

--- a/docs/changes/utils/13238.feature.rst
+++ b/docs/changes/utils/13238.feature.rst
@@ -1,0 +1,2 @@
+Added the ``use_fsspec``, ``fsspec_kwargs``, and ``close_files`` arguments
+to ``utils.data.get_readable_fileobj``.

--- a/docs/common_links.txt
+++ b/docs/common_links.txt
@@ -148,3 +148,11 @@
 .. _pytest-doctestplus: https://github.com/astropy/pytest-doctestplus
 .. _pytest-openfiles: https://github.com/astropy/pytest-openfiles
 .. _pytest-remotedata: https://github.com/astropy/pytest-remotedata
+
+.. fsspec
+.. _fsspec: https://filesystem-spec.readthedocs.io
+.. |minimum_fsspec_version| replace:: {fsspec}
+
+.. s3fs
+.. _s3fs: https://s3fs.readthedocs.io
+.. |minimum_s3fs_version| replace:: {s3fs}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -99,6 +99,7 @@ intersphinx_mapping['sphinx_automodapi'] = ('https://sphinx-automodapi.readthedo
 intersphinx_mapping['packagetemplate'] = ('https://docs.astropy.org/projects/package-template/en/latest/', None)  # noqa: F405, E501
 intersphinx_mapping['h5py'] = ('https://docs.h5py.org/en/stable/', None)  # noqa: F405
 intersphinx_mapping['asdf-astropy'] = ('https://asdf-astropy.readthedocs.io/en/latest/', None)  # noqa: F405
+intersphinx_mapping['fsspec'] = ('https://filesystem-spec.readthedocs.io/en/latest/', None)  # noqa: F405
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -2,6 +2,8 @@
 Installation
 ************
 
+.. _installing-astropy:
+
 Installing ``astropy``
 ======================
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -210,6 +210,12 @@ The further dependencies provide more specific features:
 - `pyarrow <https://arrow.apache.org/docs/python/>`_ |minimum_pyarrow_version| or later:
   To read/write :class:`~astropy.table.Table` objects from/to Parquet files.
 
+- `fsspec`_ |minimum_fsspec_version| or later: Enables access to :ref:`subsets
+  of remote FITS files <fits_io_cloud>` without having to download the entire file.
+
+- `s3fs`_ |minimum_s3fs_version| or later: Enables access to files hosted in
+  Amazon AWS S3 cloud storage.
+
 However, note that these packages require installation only if those particular
 features are needed. ``astropy`` will import even if these dependencies are not
 installed.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -214,7 +214,7 @@ The further dependencies provide more specific features:
   of remote FITS files <fits_io_cloud>` without having to download the entire file.
 
 - `s3fs`_ |minimum_s3fs_version| or later: Enables access to files hosted in
-  Amazon AWS S3 cloud storage.
+  AWS S3 cloud storage.
 
 However, note that these packages require installation only if those particular
 features are needed. ``astropy`` will import even if these dependencies are not

--- a/docs/io/fits/index.rst
+++ b/docs/io/fits/index.rst
@@ -146,12 +146,13 @@ backends such as Amazon and Google Cloud Storage. For example, you can access a
 Hubble Space Telescope image located in the Hubble's public
 Amazon S3 bucket as follows:
 
-.. doctest-remote-data::
+.. doctest-requires:: fsspec
+
     >>> # Location of a large Hubble archive image in Amazon S3 (213 MB)
     >>> uri = "s3://stpubdata/hst/public/j8pu/j8pu0y010/j8pu0y010_drc.fits"
     ...
     >>> # Extract a 10-by-20 pixel cutout image
-    >>> with fits.open(uri, use_fsspec=True, fsspec_kwargs={"anon": True}) as hdul:
+    >>> with fits.open(uri, use_fsspec=True, fsspec_kwargs={"anon": True}) as hdul:  # doctest: +REMOTE_DATA
     ...    cutout = hdul[1].section[10:20, 30:50]
 
 Note that the example above obtains a cutout image using the `ImageHDU.section`

--- a/docs/io/fits/index.rst
+++ b/docs/io/fits/index.rst
@@ -140,7 +140,7 @@ Working with remote and cloud-hosted files
 """"""""""""""""""""""""""""""""""""""""""
 
 The :func:`open` function supports a ``use_fsspec`` argument which allows file
-paths to be opened using `fsspec <https://filesystem-spec.readthedocs.io>`__.
+paths to be opened using `fsspec`_.
 The ``fsspec`` package supports a range of remote and distributed storage
 backends such as Amazon and Google Cloud Storage. For example, you can access a
 Hubble Space Telescope image located in the Hubble's public

--- a/docs/io/fits/index.rst
+++ b/docs/io/fits/index.rst
@@ -134,6 +134,38 @@ because by that point you are likely to run out of physical memory anyways), but
     ``del hdul[0].data``. (This works so long as there are no other references
     held to the data array.)
 
+.. _fits-cloud-files:
+
+Working with remote and cloud-hosted files
+""""""""""""""""""""""""""""""""""""""""""
+
+The :func:`open` function supports a ``use_fsspec`` argument which allows file
+paths to be opened using `fsspec <https://filesystem-spec.readthedocs.io>`__.
+The ``fsspec`` package supports a range of remote and distributed storage
+backends such as Amazon and Google Cloud Storage. For example, you can access a
+Hubble Space Telescope image located in the Hubble's public
+Amazon S3 bucket as follows:
+
+.. doctest-remote-data::
+    >>> # Location of a large Hubble archive image in Amazon S3 (213 MB)
+    >>> uri = "s3://stpubdata/hst/public/j8pu/j8pu0y010/j8pu0y010_drc.fits"
+    ...
+    >>> # Extract a 10-by-20 pixel cutout image
+    >>> with fits.open(uri, use_fsspec=True, fsspec_kwargs={"anon": True}) as hdul:
+    ...    cutout = hdul[1].section[10:20, 30:50]
+
+Note that the example above obtains a cutout image using the `ImageHDU.section`
+attribute rather than the traditional `ImageHDU.data` attribute.
+The use of ``.section`` ensures that only the necessary parts of the FITS
+image are transferred from the server, rather than downloading the entire data
+array. This trick can significantly speed up your code if you require small
+subsets of large FITS files located on slow (remote) storage systems.
+See :ref:`fits_io_cloud` for additional information on working with remote FITS
+files in this way.
+
+.. seealso:: :ref:`fits_io_cloud`.
+
+
 Unsigned integers
 """""""""""""""""
 
@@ -959,6 +991,7 @@ Using `astropy.io.fits`
    usage/unfamiliar
    usage/scripts
    usage/misc
+   usage/cloud
 
 Command-Line Utilities
 ======================

--- a/docs/io/fits/usage/cloud.rst
+++ b/docs/io/fits/usage/cloud.rst
@@ -8,8 +8,7 @@ Obtaining subsets from cloud-hosted FITS files
 Astropy offers support for extracting data from FITS files stored in the cloud.
 Specifically, the `astropy.io.fits.open` function accepts the ``use_fsspec``
 and ``fsspec_kwargs`` parameters, which allow remote files to be accessed in an
-efficient way using the `fsspec <https://filesystem-spec.readthedocs.io>`__
-package.
+efficient way using the `fsspec`_ package.
 
 ``fsspec`` is an optional dependency of Astropy which supports reading
 files from a range of remote and distributed storage backends, such as Amazon
@@ -117,7 +116,7 @@ your code is running on a server in the same Amazon cloud region as the data.
 .. note::
 
     To open paths with prefix ``s3://``, fsspec requires an optional dependency called
-    ``s3fs``.  A ``ModuleNotFoundError`` will be raised if this dependency is
+    `s3fs`_.  A ``ModuleNotFoundError`` will be raised if this dependency is
     missing. See :ref:`installing-astropy` for details on installing optional
     dependencies.
 
@@ -143,7 +142,7 @@ as follows:
     Including secret access keys inside Python code is dangerous because you
     may accidentally end up revealing your keys when you share your code with
     others. A better practice is to store your access keys via a configuration
-    file or environment variables. See the ``s3fs`` documentation for guidance.
+    file or environment variables. See the `s3fs`_ documentation for guidance.
 
 .. note::
 
@@ -272,5 +271,4 @@ For example, we can configure fsspec to make buffered reads with a minimum
 The ideal configuration will depend on the latency and throughput of the
 network, as well as the exact shape and volume of the data you seek to obtain.
 
-See the `fsspec documentation <https://filesystem-spec.readthedocs.io>`__
-for more information on its options.
+See the `fsspec documentation <fsspec_>`_ for more information on its options.

--- a/docs/io/fits/usage/cloud.rst
+++ b/docs/io/fits/usage/cloud.rst
@@ -1,0 +1,265 @@
+.. currentmodule:: astropy.io.fits
+
+..  _fits_io_cloud:
+
+Obtaining subsets from cloud-hosted FITS files
+**********************************************
+
+Astropy offers support for extracting data from FITS files stored in the cloud.
+Specifically, the `astropy.io.fits.open` function accepts the ``use_fsspec``
+and ``fsspec_kwargs`` parameters, which allow remote files to be accessed in an
+efficient way using the `fsspec <https://filesystem-spec.readthedocs.io>`__
+package.
+
+``fsspec`` is an optional dependency of Astropy which supports reading
+files from a range of remote and distributed storage backends, such as Amazon
+and Google Cloud Storage.  This chapter explains its use.
+
+.. note::
+
+    The examples in this chapter require ``fsspec`` which is an optional
+    dependency of Astropy.  See :ref:`installing-astropy` for details on
+    installing optional dependencies.
+
+
+Subsetting FITS files hosted on an HTTP web server
+==================================================
+
+A common use case for ``fsspec`` is to read subsets of FITS data from a web
+server which supports serving partial files via the
+`Range Requests <https://en.wikipedia.org/wiki/Byte_serving>`__ feature of the
+HTTP protocol.  Most web servers support serving portions of files in this way.
+
+For example, let's assume you want to retrieve data from a large image obtained
+by the Hubble Space Telescope available at the following url::
+
+    >>> # Download link for a large Hubble archive image (213 MB)
+    >>> url = "https://mast.stsci.edu/api/v0.1/Download/file/?uri=mast:HST/product/j8pu0y010_drc.fits"
+
+This file can be opened by passing the url to `astropy.io.fits.open`.
+By default, Astropy will download the entire file to local disc before opening
+it.  This works fine for small files but tends to require a lot of time and
+memory for large files.
+
+You can improve the performance for large files by passing the parameters
+``use_fsspec=True`` and ``lazy_load_hdus=True`` to `open`.  This will make
+Astropy use ``fsspec`` to download only the necessary parts of the FITS file.
+For example:
+
+.. doctest-remote-data::
+
+    >>> from astropy.io import fits
+    ...
+    >>> # `fits.open` will download the primary header
+    >>> with fits.open(url, use_fsspec=True, lazy_load_hdus=True) as hdul:
+    ...
+    ...     # Download a single header
+    ...     header = hdul[1].header
+    ...
+    ...     # Download a single data array
+    ...     image = hdul[1].data
+    ...
+    ...     # Download a 10-by-20 pixel cutout by using .section
+    ...     cutout = hdul[2].section[10:20, 30:50]
+
+The example above requires less time and memory than would be required to
+download the entire file. This is because ``fsspec`` is able to leverage
+two *lazy data loading* features available in Astropy:
+
+1. The ``lazy_load_hdus`` parameter takes care of loading HDU header and data
+   attributes on demand rather than reading all HDUs at once.  This parameter
+   is set to ``True`` by default. You do not need to pass it explicitely,
+   unless you changed its default value in the :ref:`astropy:astropy_config`.
+2. The `ImageHDU.section` property enables a subset of a data array to be
+   read into memory without downloading the entire image or cube. See the
+   :ref:`astropy:data-sections` part of the documentation for more details.
+
+Additional tips for achieving good performance when working with remote files
+are provided in the :ref:`astropy:optimizing_fsspec` section further down
+this page.
+
+.. note::
+
+    The `ImageHDU.section` feature is only available for uncompressed FITS
+    image extensions.  This includes file-level compression like gzip as
+    well as compression internal to the FITS format, like tile compression.
+    Attempting to use ``.section`` on a compressed image will yield an
+    `AttributeError`.
+
+
+Subsetting FITS files hosted in Amazon S3 cloud storage
+======================================================
+
+The FITS file used in the example above also happens to be available via
+Amazon cloud storage, where it is stored in a
+`public S3 bucket <https://registry.opendata.aws/hst/>`__ at the following
+location::
+
+    >>> s3_uri = "s3://stpubdata/hst/public/j8pu/j8pu0y010/j8pu0y010_drc.fits"
+
+With ``use_fsspec`` enabled, you can obtain a small cutout from a file stored
+in Amazon S3 cloud storage in the same way as above.  For example:
+
+.. doctest-remote-data::
+    >>> # Download a small 10-by-20 pixel cutout from a FITS file stored in Amazon S3
+    >>> with fits.open(s3_uri, use_fsspec=True, fsspec_kwargs={"anon": True}) as hdul:
+    ...     cutout = hdul[1].section[10:20, 30:50]
+
+
+Obtaining cutouts from Amazon S3 in this way may be particularly performant if
+your code is running on a server in the same Amazon cloud region as the data.
+
+.. note::
+
+    To open paths with prefix ``s3://``, fsspec requires an optional dependency called
+    ``s3fs``.  A ``ModuleNotFoundError`` will be raised if this dependency is
+    missing. See :ref:`installing-astropy` for details on installing optional
+    dependencies.
+
+Working with Amazon S3 access credentials
+-----------------------------------------
+
+Note that we used the ``fsspec_kwargs`` parameter in the example above to pass
+extra arguments to the `fsspec.open` function.  Specifically, we passed the
+``anon=True`` parameter to indicate that we want to retrieve data in an
+anonymous way without providing Amazon cloud access credentials.
+For convenience, Astropy will pass ``anon=True`` by default if a path starts
+with ``s3://`` and ``fsspec_kwargs`` is unspecified.
+
+In some cases you may want to access data stored in an Amazon S3 data bucket
+that is private or uses the "Requester Pays" feature. You will have to provide
+a secret access key in this case. You can use the ``fsspec_kwargs`` parameter
+to provide your key as follows:
+
+.. doctest-skip::
+
+    >>> fsspec_kwargs = {"key": "YOUR-SECRET-KEY-ID",
+    ...                  "secret": "YOUR-SECRET-KEY"}
+    >>> with fits.open(s3_uri, use_fsspec=True, fsspec_kwargs=fsspec_kwargs) as hdul:
+    ...     cutout = hdul[2].section[10:20, 30:50]
+
+.. warning::
+
+    Including secret access keys inside Python code is dangerous because you
+    may accidentally end up revealing your keys when you share your code with
+    others. A better practice is to store your access keys via a configuration
+    file or environment variables. See the ``s3fs`` documentation for guidance.
+
+
+Using :class:`~astropy.nddata.Cutout2D` with cloud-hosted FITS files
+====================================================================
+
+The examples above used the `ImageHDU.section` feature to download
+small cutouts given a set of pixel coordinates. For astronomical images it is
+often more convenient to obtain cutouts based on a sky position and angular
+size rather than array coordinates. For this reason, Astropy provides the
+`astropy.nddata.Cutout2D` tool which makes it easy to obtain cutouts informed
+by an image's World Coordinate System (`~astropy.wcs.WCS`).
+
+This cutout tool can be used in combination with ``fsspec`` and ``.section``.
+For example, assume you happen to know that the image we opened above contains
+a nice edge-on galaxy at the following position::
+
+    >>> # Approximate location of an edge-on galaxy
+    >>> from astropy.coordinates import SkyCoord
+    >>> position = SkyCoord('10h01m41.13s 02d25m20.58s')
+
+We also know that the radius of the galaxy is approximately 5 arcseconds::
+
+    >>> # Approximate size of the galaxy
+    >>> from astropy import units as u
+    >>> size = 5*u.arcsec
+
+Given this sky position and radius, we can use `~astropy.nddata.Cutout2D`
+in combination with ``use_fsspec=True`` and ``.section`` as follows:
+
+.. doctest-remote-data::
+    >>> from astropy.nddata import Cutout2D
+    >>> from astropy.wcs import WCS
+    ...
+    >>> with fits.open(s3_uri, use_fsspec=True) as hdul:
+    ...     wcs = WCS(hdul[1].header)
+    ...     cutout = Cutout2D(hdul[1].section,  # use `.section` rather than `.data`!
+    ...                       position=position,
+    ...                       size=size,
+    ...                       wcs=wcs)
+
+As a final step, you can plot the cutout using Matplotlib as follows:
+
+.. doctest-remote-data::
+    >>> import matplotlib.pyplot as plt
+    >>> from astropy.visualization import astropy_mpl_style
+    ...
+    >>> plt.style.use(astropy_mpl_style)
+    >>> plt.figure()
+    >>> plt.imshow(cutout.data, cmap='gray')
+    >>> plt.colorbar()
+
+See :ref:`cutout_images` for more details on this feature.
+
+
+..  _optimizing_fsspec:
+
+Performance improvement tips for subsetting remote FITS files
+=============================================================
+
+In the examples above we explained that it is important to use the
+``use_fsspec=True`` feature in combination with the ``lazy_load_hdus=True``
+parameter and the ``ImageHDU.section`` feature to obtain good performance.
+
+There are two additional factors which significantly impact the performance
+you will encounter, namely: (i) the structure of the FITS file, and (ii) the caching
+and block size configuration of ``fsspec``.  The remainder of this section
+briefly explains these two factors.
+
+Matching the FITS file structure to the data slicing patterns
+-------------------------------------------------------------
+
+The order in which multi-dimensional data is organized inside FITS files plays
+a major role in the subsetting performance.
+
+Astropy uses the row-major order for indexing FITS data. This means that the
+right-most axis is the one that varies the fastest inside the file.
+Put differently, the data for the right-most dimension tends to be located in
+contiguous regions of the file and is therefore the easiest to extract.
+
+For example, in the case of a 2D image, the slice ``.section[0, :]`` can be
+obtained by downloading one contiguous region of bytes from the file.
+In contrast, the slice ``.section[:, 0]`` requires accessing bytes spread
+across the entire image array. The same is true for higher dimensions,
+for example, obtaining the slice ``.section[0, :, :]`` from a 3D cube
+will tend to be much faster than requesting ``.section[:, :, 0]``.
+
+Obtaining slices of data that are well matched to the internal layout of
+the FITS file generally yields the best performance.
+If subsetting performance is important to you, you may have to consider
+modifying your FITS files to ensure that the ordering of the dimensions
+is well-matched to your data slicing patterns.
+
+Configuring the ``fsspec`` block size and download strategy
+-----------------------------------------------------------
+
+The ``fsspec`` package supports different data reading and caching strategies
+which aim to find a balance between the number of network requests on one hand
+and the total amount of data transferred on the other hand.  By default, fsspec
+will attempt to download data in large contiguous blocks using a buffered
+*read ahead* strategy, similar to the strategy that is employed when operating
+systems load local files into memory.
+
+You can tune the performance of fsspec's buffering strategy by passing custom
+``block_size`` and ``cache_type`` parameters to `fsspec.open`.  You can pass
+these parameters via the ``fsspec_kwargs`` argument of `astropy.io.fits.open`.
+For example, we can configure fsspec to make buffered reads with a minimum
+``block_size`` of 1 MB as follows:
+
+.. doctest-remote-data::
+
+    >>> fsspec_kwargs = {"block_size": 1_000_000, "cache_type": "bytes"}
+    >>> with fits.open(url, use_fsspec=True, fsspec_kwargs=fsspec_kwargs) as hdul:
+    ...     cutout = hdul[1].section[10:20, 30:50]
+
+The ideal configuration will depend on the latency and throughput of the
+network, as well as the exact shape and volume of the data you seek to obtain.
+
+See the `fsspec documentation <https://filesystem-spec.readthedocs.io>`__
+for more information on its options.

--- a/docs/io/fits/usage/cloud.rst
+++ b/docs/io/fits/usage/cloud.rst
@@ -203,7 +203,6 @@ As a final step, you can plot the cutout using Matplotlib as follows:
     >>> plt.style.use(astropy_mpl_style)  # doctest: +REMOTE_DATA
     >>> plt.figure()  # doctest: +REMOTE_DATA +IGNORE_OUTPUT
     >>> plt.imshow(cutout.data, cmap='gray')  # doctest: +REMOTE_DATA +IGNORE_OUTPUT
-    >>> plt.colorbar()  # doctest: +REMOTE_DATA +IGNORE_OUTPUT
 
 See :ref:`cutout_images` for more details on this feature.
 

--- a/docs/io/fits/usage/cloud.rst
+++ b/docs/io/fits/usage/cloud.rst
@@ -91,9 +91,8 @@ Subsetting FITS files hosted in Amazon S3 cloud storage
 =======================================================
 
 The FITS file used in the example above also happens to be available via
-Amazon cloud storage, where it is stored in a
-`public S3 bucket <https://registry.opendata.aws/hst/>`__ at the following
-location::
+Amazon cloud storage, where it is stored in a `public S3 bucket
+<https://registry.opendata.aws/hst/>`__ at the following location::
 
     >>> s3_uri = "s3://stpubdata/hst/public/j8pu/j8pu0y010/j8pu0y010_drc.fits"
 
@@ -106,29 +105,33 @@ For example:
 .. doctest-requires:: fsspec
 
     >>> # Download a small 10-by-20 pixel cutout from a FITS file stored in Amazon S3
-    >>> with fits.open(s3_uri) as hdul:  # doctest: +REMOTE_DATA
+    >>> with fits.open(s3_uri, fsspec_kwargs={"anon": True}) as hdul:  # doctest: +REMOTE_DATA
     ...     cutout = hdul[1].section[10:20, 30:50]
-
 
 Obtaining cutouts from Amazon S3 in this way may be particularly performant if
 your code is running on a server in the same Amazon cloud region as the data.
 
 .. note::
 
-    To open paths with prefix ``s3://``, fsspec requires an optional dependency called
-    `s3fs`_.  A ``ModuleNotFoundError`` will be raised if this dependency is
-    missing. See :ref:`installing-astropy` for details on installing optional
+    To open paths with prefix ``s3://``, fsspec requires an optional dependency
+    called `s3fs`_.  A ``ModuleNotFoundError`` will be raised if this dependency
+    is missing. See :ref:`installing-astropy` for details on installing optional
     dependencies.
 
 
 Working with Amazon S3 access credentials
 -----------------------------------------
 
+In the example above, we passed ``fsspec_kwargs={"anon": True}`` to enable the
+data to be retrieved in an anonymous way without providing Amazon cloud access
+credentials.  This is possible because the data is located in a public S3
+bucket which has been configured to allow anonymous access.
+
 In some cases you may want to access data stored in an Amazon S3 data bucket
 that is private or uses the "Requester Pays" feature. You will have to provide
-a secret access key in this case.  You can use the ``fsspec_kwargs`` parameter
-to pass extra arguments, such as access keys, to the `fsspec.open` function
-as follows:
+a secret access key in this case to avoid encountering a ``NoCredentialsError``.
+You can use the ``fsspec_kwargs`` parameter to pass extra arguments, such as
+access keys, to the `fsspec.open` function as follows:
 
 .. doctest-skip::
 
@@ -143,15 +146,6 @@ as follows:
     may accidentally end up revealing your keys when you share your code with
     others. A better practice is to store your access keys via a configuration
     file or environment variables. See the `s3fs`_ documentation for guidance.
-
-.. note::
-
-   For convenience, Astropy defaults to ``fsspec_kwargs={"anon": True}``
-   if a path starts with ``s3://`` and ``fsspec_kwargs`` is unspecified.
-   This setting enables data to be retrieved in an anonymous way without
-   providing Amazon cloud access credentials.  Note that anonymous access
-   will yield an error message if the bucket is private or uses the
-   "Requester Pays" feature.
 
 
 Using :class:`~astropy.nddata.Cutout2D` with cloud-hosted FITS files
@@ -186,7 +180,7 @@ in combination with ``use_fsspec=True`` and ``.section`` as follows:
     >>> from astropy.nddata import Cutout2D
     >>> from astropy.wcs import WCS
     ...
-    >>> with fits.open(s3_uri, use_fsspec=True) as hdul:  # doctest: +REMOTE_DATA
+    >>> with fits.open(s3_uri, use_fsspec=True, fsspec_kwargs={"anon": True}) as hdul:  # doctest: +REMOTE_DATA
     ...     wcs = WCS(hdul[1].header)
     ...     cutout = Cutout2D(hdul[1].section,  # use `.section` rather than `.data`!
     ...                       position=position,

--- a/docs/io/fits/usage/cloud.rst
+++ b/docs/io/fits/usage/cloud.rst
@@ -46,12 +46,12 @@ You can improve the performance for large files by passing the parameters
 Astropy use ``fsspec`` to download only the necessary parts of the FITS file.
 For example:
 
-.. doctest-remote-data::
+.. doctest-requires:: fsspec
 
     >>> from astropy.io import fits
     ...
     >>> # `fits.open` will download the primary header
-    >>> with fits.open(url, use_fsspec=True, lazy_load_hdus=True) as hdul:
+    >>> with fits.open(url, use_fsspec=True, lazy_load_hdus=True) as hdul:  # doctest: +REMOTE_DATA
     ...
     ...     # Download a single header
     ...     header = hdul[1].header
@@ -88,7 +88,7 @@ this page.
 
 
 Subsetting FITS files hosted in Amazon S3 cloud storage
-======================================================
+=======================================================
 
 The FITS file used in the example above also happens to be available via
 Amazon cloud storage, where it is stored in a
@@ -100,9 +100,10 @@ location::
 With ``use_fsspec`` enabled, you can obtain a small cutout from a file stored
 in Amazon S3 cloud storage in the same way as above.  For example:
 
-.. doctest-remote-data::
+.. doctest-requires:: fsspec
+
     >>> # Download a small 10-by-20 pixel cutout from a FITS file stored in Amazon S3
-    >>> with fits.open(s3_uri, use_fsspec=True, fsspec_kwargs={"anon": True}) as hdul:
+    >>> with fits.open(s3_uri, use_fsspec=True, fsspec_kwargs={"anon": True}) as hdul:  # doctest: +REMOTE_DATA
     ...     cutout = hdul[1].section[10:20, 30:50]
 
 
@@ -173,11 +174,12 @@ We also know that the radius of the galaxy is approximately 5 arcseconds::
 Given this sky position and radius, we can use `~astropy.nddata.Cutout2D`
 in combination with ``use_fsspec=True`` and ``.section`` as follows:
 
-.. doctest-remote-data::
+.. doctest-requires:: fsspec
+
     >>> from astropy.nddata import Cutout2D
     >>> from astropy.wcs import WCS
     ...
-    >>> with fits.open(s3_uri, use_fsspec=True) as hdul:
+    >>> with fits.open(s3_uri, use_fsspec=True) as hdul:  # doctest: +REMOTE_DATA
     ...     wcs = WCS(hdul[1].header)
     ...     cutout = Cutout2D(hdul[1].section,  # use `.section` rather than `.data`!
     ...                       position=position,
@@ -186,14 +188,15 @@ in combination with ``use_fsspec=True`` and ``.section`` as follows:
 
 As a final step, you can plot the cutout using Matplotlib as follows:
 
-.. doctest-remote-data::
+.. doctest-requires:: fsspec
+
     >>> import matplotlib.pyplot as plt
     >>> from astropy.visualization import astropy_mpl_style
     ...
-    >>> plt.style.use(astropy_mpl_style)
-    >>> plt.figure()
-    >>> plt.imshow(cutout.data, cmap='gray')
-    >>> plt.colorbar()
+    >>> plt.style.use(astropy_mpl_style)  # doctest: +REMOTE_DATA
+    >>> plt.figure()  # doctest: +REMOTE_DATA +IGNORE_OUTPUT
+    >>> plt.imshow(cutout.data, cmap='gray')  # doctest: +REMOTE_DATA +IGNORE_OUTPUT
+    >>> plt.colorbar()  # doctest: +REMOTE_DATA +IGNORE_OUTPUT
 
 See :ref:`cutout_images` for more details on this feature.
 
@@ -252,10 +255,10 @@ these parameters via the ``fsspec_kwargs`` argument of `astropy.io.fits.open`.
 For example, we can configure fsspec to make buffered reads with a minimum
 ``block_size`` of 1 MB as follows:
 
-.. doctest-remote-data::
+.. doctest-requires:: fsspec
 
     >>> fsspec_kwargs = {"block_size": 1_000_000, "cache_type": "bytes"}
-    >>> with fits.open(url, use_fsspec=True, fsspec_kwargs=fsspec_kwargs) as hdul:
+    >>> with fits.open(url, use_fsspec=True, fsspec_kwargs=fsspec_kwargs) as hdul:  # doctest: +REMOTE_DATA
     ...     cutout = hdul[1].section[10:20, 30:50]
 
 The ideal configuration will depend on the latency and throughput of the

--- a/docs/io/fits/usage/image.rst
+++ b/docs/io/fits/usage/image.rst
@@ -234,11 +234,15 @@ the images(s) ten rows at a time), the :attr:`~ImageHDU.section` attribute of an
 HDU can be used to alleviate such memory problems.
 
 With ``astropy``'s improved support for memory-mapping, the sections feature is
-not as necessary as it used to be for handling very large images. However, if
-the image's data is scaled with non-trivial BSCALE/BZERO values, accessing the
-data in sections may still be necessary under the current implementation.
-Memmap is also insufficient for loading images larger than 2 to 4 GB on a 32-bit
-system — in such cases it may be necessary to use sections.
+not as necessary as it used to be for handling large images stored in local files.
+However, it remains very useful in the following circumstances:
+
+* If the image's data is scaled with non-trivial BSCALE/BZERO values, accessing the
+  data in sections may still be necessary under the current implementation.
+* Memory mapping is insufficient for loading images larger than 2 to 4 GB on a 32-bit
+  system — in such cases it may be necessary to use sections.
+* Memory mapping does not work for accessing remote FITS files.
+  In this case sections may be your only option. See :ref:`astropy:fits_io_cloud`.
 
 Example
 -------

--- a/docs/whatsnew/5.2.rst
+++ b/docs/whatsnew/5.2.rst
@@ -131,7 +131,7 @@ Hubble's public Amazon S3 bucket as follows:
 
     >>> from astropy.io import fits
     >>> uri = "s3://stpubdata/hst/public/j8pu/j8pu0y010/j8pu0y010_drc.fits"
-    >>> with fits.open(uri) as hdul:  # doctest: +REMOTE_DATA
+    >>> with fits.open(uri, fsspec_kwargs={"anon": True}) as hdul:  # doctest: +REMOTE_DATA
     ...
     ...     # Download a single header
     ...     header = hdul[1].header

--- a/docs/whatsnew/5.2.rst
+++ b/docs/whatsnew/5.2.rst
@@ -15,7 +15,11 @@ In particular, this release includes:
 * :ref:`whatsnew-5.2-quantity-dtype`
 * :ref:`whatsnew-5.2-cosmology`
 * :ref:`whatsnew-5.2-coordinates`
+<<<<<<< HEAD
 * :ref:`whatsnew-5.2-io-ascii-fixed-width`
+=======
+* :ref:`whatsnew-5.2-fits`
+>>>>>>> 968660722 (Add "What's New" entry)
 
 
 .. _whatsnew-5.2-quantity-dtype:
@@ -108,6 +112,48 @@ additional header rows specifying any or all of the column ``dtype``, ``unit``,
     1 1.00 c     4
     2 2.00 d     5
     3 3.00 e     6
+
+
+.. _whatsnew-5.2-fits:
+
+Accessing cloud-hosted FITS files
+=================================
+
+A ``use_fsspec`` argument has been added to `astropy.io.fits.open` which
+enables users to seamlessly extract data from FITS files stored on a web server
+or in the cloud without downloading the entire file to local storage.
+This feature uses a new optional dependency, `fsspec`_, which supports a range
+of remote and distributed storage backends including Amazon and Google Cloud Storage.
+For example, you can now access a Hubble Space Telescope image located in
+Hubble's public Amazon S3 bucket as follows::
+
+
+    >>> from astropy.io import fits
+
+    >>> # Location of a large Hubble archive image in Amazon S3 (213 MB)
+    >>> uri = "s3://stpubdata/hst/public/j8pu/j8pu0y010/j8pu0y010_drc.fits"
+
+    >>> # Download the primary header
+    >>> with fits.open(uri) as hdul:
+    ...
+    ...     # Download a single header
+    ...     header = hdul[1].header
+    ...
+    ...     # Download a single image
+    ...     mydata = hdul[1].data
+    ...
+    ...     # Download a small cutout
+    ...     cutout = hdul[1].section[10:20, 30:50]
+
+Note that the example above obtains a cutout image using the `~astropy.io.fits.ImageHDU.section`
+attribute rather than the traditional `~astropy.io.fits.ImageHDU.data` attribute.
+The use of ``.section`` ensures that only the necessary parts of the FITS
+image are transferred from the server, rather than downloading the entire data
+array. This trick can significantly speed up your code if you require small
+subsets of large FITS files located on slow (remote) storage systems.
+See :ref:`fits_io_cloud` for additional information on working with
+FITS files in this way.
+
 
 Full change log
 ===============

--- a/docs/whatsnew/5.2.rst
+++ b/docs/whatsnew/5.2.rst
@@ -125,16 +125,13 @@ or in the cloud without downloading the entire file to local storage.
 This feature uses a new optional dependency, `fsspec`_, which supports a range
 of remote and distributed storage backends including Amazon and Google Cloud Storage.
 For example, you can now access a Hubble Space Telescope image located in
-Hubble's public Amazon S3 bucket as follows::
+Hubble's public Amazon S3 bucket as follows:
 
+.. doctest-requires:: fsspec
 
     >>> from astropy.io import fits
-
-    >>> # Location of a large Hubble archive image in Amazon S3 (213 MB)
     >>> uri = "s3://stpubdata/hst/public/j8pu/j8pu0y010/j8pu0y010_drc.fits"
-
-    >>> # Download the primary header
-    >>> with fits.open(uri) as hdul:
+    >>> with fits.open(uri) as hdul:  # doctest: +REMOTE_DATA
     ...
     ...     # Download a single header
     ...     header = hdul[1].header

--- a/docs/whatsnew/5.2.rst
+++ b/docs/whatsnew/5.2.rst
@@ -15,11 +15,8 @@ In particular, this release includes:
 * :ref:`whatsnew-5.2-quantity-dtype`
 * :ref:`whatsnew-5.2-cosmology`
 * :ref:`whatsnew-5.2-coordinates`
-<<<<<<< HEAD
 * :ref:`whatsnew-5.2-io-ascii-fixed-width`
-=======
 * :ref:`whatsnew-5.2-fits`
->>>>>>> 968660722 (Add "What's New" entry)
 
 
 .. _whatsnew-5.2-quantity-dtype:

--- a/setup.cfg
+++ b/setup.cfg
@@ -94,8 +94,7 @@ all =
     ipython>=4.2
     pytest>=7.0
     typing_extensions>=3.10.0.1
-    fsspec>=2022.1.0,!=2022.7.1
-    aiohttp!=4.0.0a0,!=4.0.0a1  # dependency of fsspec with broken alpha releases
+    fsspec[http] @ git+https://git@github.com/fsspec/filesystem_spec
     s3fs>=2022.1.0
 docs =
     sphinx<4

--- a/setup.cfg
+++ b/setup.cfg
@@ -94,8 +94,8 @@ all =
     ipython>=4.2
     pytest>=7.0
     typing_extensions>=3.10.0.1
-    fsspec[http] @ git+https://git@github.com/fsspec/filesystem_spec
-    s3fs>=2022.1.0
+    fsspec[http]>=2022.8.1
+    s3fs>=2022.8.1
 docs =
     sphinx<4
     sphinx-astropy>=1.6

--- a/setup.cfg
+++ b/setup.cfg
@@ -95,6 +95,7 @@ all =
     pytest>=7.0
     typing_extensions>=3.10.0.1
     fsspec>=2022.1.0,!=2022.7.1
+    aiohttp!=4.0.0a0,!=4.0.0a1  # dependency of fsspec with broken alpha releases
     s3fs>=2022.1.0
 docs =
     sphinx<4

--- a/setup.cfg
+++ b/setup.cfg
@@ -94,6 +94,9 @@ all =
     ipython>=4.2
     pytest>=7.0
     typing_extensions>=3.10.0.1
+    fsspec
+    s3fs
+    gcsfs
 docs =
     sphinx<4
     sphinx-astropy>=1.6

--- a/setup.cfg
+++ b/setup.cfg
@@ -94,8 +94,8 @@ all =
     ipython>=4.2
     pytest>=7.0
     typing_extensions>=3.10.0.1
-    fsspec
-    s3fs
+    fsspec>=2022.1.0,!=2022.7.1
+    s3fs>=2022.1.0
 docs =
     sphinx<4
     sphinx-astropy>=1.6

--- a/setup.cfg
+++ b/setup.cfg
@@ -94,8 +94,8 @@ all =
     ipython>=4.2
     pytest>=7.0
     typing_extensions>=3.10.0.1
-    fsspec[http]>=2022.8.1
-    s3fs>=2022.8.1
+    fsspec[http]>=2022.8.2
+    s3fs>=2022.8.2
 docs =
     sphinx<4
     sphinx-astropy>=1.6

--- a/setup.cfg
+++ b/setup.cfg
@@ -134,7 +134,6 @@ filterwarnings =
     error
     ignore:unclosed <socket:ResourceWarning
     ignore:unclosed <ssl.SSLSocket:ResourceWarning
-    ignore:unclosed transport <asyncio.sslproto
     ignore:numpy\.ufunc size changed:RuntimeWarning
     ignore:numpy\.ndarray size changed:RuntimeWarning
     ignore:Importing from numpy:DeprecationWarning:scipy

--- a/setup.cfg
+++ b/setup.cfg
@@ -96,7 +96,6 @@ all =
     typing_extensions>=3.10.0.1
     fsspec
     s3fs
-    gcsfs
 docs =
     sphinx<4
     sphinx-astropy>=1.6

--- a/setup.cfg
+++ b/setup.cfg
@@ -134,6 +134,7 @@ filterwarnings =
     error
     ignore:unclosed <socket:ResourceWarning
     ignore:unclosed <ssl.SSLSocket:ResourceWarning
+    ignore:unclosed transport <asyncio.sslproto
     ignore:numpy\.ufunc size changed:RuntimeWarning
     ignore:numpy\.ndarray size changed:RuntimeWarning
     ignore:Importing from numpy:DeprecationWarning:scipy


### PR DESCRIPTION
## Summary

This PR would enable users to seamlessly extract data from FITS files stored on a web server or in the cloud without downloading the entire file to local storage.  Specifically, this PR proposes adding the [fsspec package](https://filesystem-spec.readthedocs.io/) as an optional astropy dependency to enable remote FITS files to be accessed using the following usage pattern:

```python
from astropy.io import fits

# URI of a 213 MB FITS file hosted in a free Amazon S3 cloud storage bucket
uri = "s3://stpubdata/hst/public/j8pu/j8pu0y010/j8pu0y010_drc.fits"

# Download the primary header
with fits.open(uri, fsspec_kwargs={"anon": True}) as hdul:

    # Download a single header
    header = hdul[1].header

    # Download a single image
    mydata = hdul[1].data

    # Download a small cutout
    myslice = hdul[2].section[10:12, 20:22]
```

**A key feature is that the example above does not download the entire 213 MB file. Instead, only the necessary chunks of the FITS file are transferred on demand.**

## How does this work?

The efficient behavior is achieved by using the well-established [fsspec package](https://filesystem-spec.readthedocs.io) to open remote files.  Fsspec provides seamless access to cloud data by providing a `file`-like interface to a range of remote file systems.  In the case of files hosted on web servers or in cloud storage, fsspec translates random access `file.read()` operations into buffered [HTTP Range Requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests).

Once a remote FITS file has been opened with fsspec, `astropy.io.fits` can use it in nearly the same way as a local file (with the exception of memory mapping). As a result, we can leverage two existing "lazy data loading" features which have been part of Astropy for many years:
1. The `lazy_load_hdus=True` parameter takes care of reading HDU header and data sections on demand rather than loading all HDUs at once.
2. The `ImageHDU.section` property enables a subset of a data array to be read into memory without downloading the entire image or cube.

Fsspec is already a dependency of major packages such as `dask` and `pandas`, so we can reasonably expect it to be maintained long term.  For example, pandas uses fsspec to enable users to open data from S3 seamlessly using `pandas.read_csv("s3://...")`, similar to what is being proposed here.

## Which changes does this PR make?

The changes required to Astropy are fairly modest.  In summary, this PR:
* Adds `fsspec` as an optional dependency, alongside the fsspec-affiliated package `s3fs` (for Amazon S3 support, which is the cloud vendor used by the Hubble/JWST data archive at MAST).
* Adds the  `use_fsspec` parameter to `astropy.utils.data.get_readable_fileobj`, which triggers file paths to be opened with `fsspec.open()` rather than `io.FileIO()`.
* Adds the `fsspec_kwargs` parameter to `astropy.utils.data.get_readable_fileobj`, which enables buffering options and cloud credentials to be configured.
* Adds a new docs chapter titled "[Obtaining subsets from cloud-hosted FITS files](https://astropy--13238.org.readthedocs.build/en/13238/io/fits/usage/cloud.html)" (`docs/io/fits/usage/cloud.rst`).
* Adds unit tests (`io/fits/tests/test_fsspec.py`).
* Makes minor edits to the docs and the implementation of `.section`.

## How can we verify it really works?

I wrote a lightweight tool called [fsspec-monitor](https://github.com/barentsen/fsspec-monitor) which enables the exact network traffic to be explored when opening a FITS file with astropy+fsspec.  For example, we can use this tool to monitor what happens when we request a 10-by-20 pixel cutout from a 213 MB FITS file as follows:
```python
from fsspecmonitor import FsspecMonitor  # requires `barentsen/fsspec-monitor`
from astropy.io import fits

# URL of a 213 MB Hubble image
url = "https://mast.stsci.edu/api/v0.1/Download/file/?uri=mast:HST/product/j8pu0y010_drc.fits"

with FsspecMonitor() as monitor:
    with fits.open(url, use_fsspec=True, fsspec_kwargs={"block_size": 500_000}) as hdul:
        cutout = hdul[2].section[10:20, 30:40]
    monitor.summary()
```

The above example triggers the following diagnostic log to be printed to stdout:
```
Reading https://mast.stsci.edu/api/v0.1/Download/file/?uri=mast:HST/product/j8pu0y010_drc.fits (213.82 MB)
Fetch bytes 0-500080 (0.91 MB/s)
Fetch bytes 74759040-75261920 (2.71 MB/s)
Summary: fetched 1002960 bytes (0.96 MB) in 0.70 s (1.36 MB/s) using 2 requests.
```

These diagnostics confirm that it took just 2 HTTP requests and less than 1 MB of data to extract a cutout from a 213 MB FITS file. 🎉 

(Disclosure: the example above was optimized by using `fsspec_kwargs` to set the minimum `block_size` to 500KB.  The block size refers to the fact that fsspec uses a buffered readahead strategy to minimize the number of requests. The minimum block size is 5MB by default which would have caused 10MB of data transfer, which is probably a good default for many use cases.)