### PR TITLE
Update docs git:// to https:// as unencrypted Git protocol unavailable [ci skip]

### DIFF
--- a/docs/development/workflow/get_devel_version.rst
+++ b/docs/development/workflow/get_devel_version.rst
@@ -152,14 +152,14 @@ Change into the ``astropy`` directory you created in the previous step and
 let `git`_ know about about the astropy remote::
 
     cd astropy
-    git remote add astropy git://github.com/astropy/astropy.git
+    git remote add astropy https://github.com/astropy/astropy.git
 
 You can check that everything is set up properly so far by asking `git`_ to
 show you all of the remotes it knows about for your local repository of
 `Astropy`_ with ``git remote -v``, which should display something like::
 
-    astropy   git://github.com/astropy/astropy.git (fetch)
-    astropy   git://github.com/astropy/astropy.git (push)
+    astropy   https://github.com/astropy/astropy.git (fetch)
+    astropy   https://github.com/astropy/astropy.git (push)
     origin     git@github.com:your-user-name/astropy.git (fetch)
     origin     git@github.com:your-user-name/astropy.git (push)
 

--- a/docs/development/workflow/maintainer_workflow.rst
+++ b/docs/development/workflow/maintainer_workflow.rst
@@ -37,7 +37,7 @@ Let's say you have some changes that need to go into trunk
 The changes are in some branch that you are currently on. For example, you are
 looking at someone's changes like this::
 
-    git remote add someone git://github.com/someone/astropy.git
+    git remote add someone https://github.com/someone/astropy.git
     git fetch someone
     git branch cool-feature --track someone/cool-feature
     git checkout cool-feature

--- a/docs/development/workflow/patches.rst
+++ b/docs/development/workflow/patches.rst
@@ -17,7 +17,7 @@ If you haven't already configured git::
 Then, the workflow is the following::
 
    # Get the repository if you don't have it
-   git clone --recursive git://github.com/astropy/astropy.git
+   git clone --recursive https://github.com/astropy/astropy.git
 
    # Make a branch for your patching
    cd astropy
@@ -58,7 +58,7 @@ In detail
 #. If you don't already have one, clone a copy of the
    Astropy_ repository::
 
-      git clone --recursive git://github.com/astropy/astropy.git
+      git clone --recursive https://github.com/astropy/astropy.git
       cd astropy
 
 #. Make a 'feature branch'. This will be where you work on your bug fix. It's

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -304,7 +304,7 @@ Development Repository
 The latest development version of ``astropy`` can be cloned from GitHub
 using this command::
 
-   git clone git://github.com/astropy/astropy.git
+   git clone https://github.com/astropy/astropy.git
 
 If you wish to participate in the development of ``astropy``, see the
 :ref:`developer-docs`. The present document covers only the basics necessary to


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address the removal of unprotected Git protocol. The use of git:// is no longer supported, so this pull request is to change the documentation links using git:// to https://. 
[There is a GitHub blog entry describing the changes here](https://github.blog/2021-09-01-improving-git-protocol-security-github/#no-more-unauthenticated-git)

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
