### PR TITLE
Backport PR #13228 on branch v5.0.x (Fix bug with spectral WCS transformations when target is not available)

### DIFF
--- a/astropy/wcs/wcsapi/fitswcs.py
+++ b/astropy/wcs/wcsapi/fitswcs.py
@@ -497,9 +497,18 @@ class FITSWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
                                          unit=u.m, observer=observer, target=target)
 
                 def redshift_from_spectralcoord(spectralcoord):
-                    # TODO: check target is consistent
-                    if observer is None:
-                        warnings.warn('No observer defined on WCS, SpectralCoord '
+                    # TODO: check target is consistent between WCS and SpectralCoord,
+                    # if they are not the transformation doesn't make conceptual sense.
+                    if (observer is None
+                            or spectralcoord.observer is None
+                            or spectralcoord.target is None):
+                        if observer is None:
+                            msg = 'No observer defined on WCS'
+                        elif spectralcoord.observer is None:
+                            msg = 'No observer defined on SpectralCoord'
+                        else:
+                            msg = 'No target defined on SpectralCoord'
+                        warnings.warn(f'{msg}, SpectralCoord '
                                       'will be converted without any velocity '
                                       'frame change', AstropyUserWarning)
                         return spectralcoord.to_value(u.m) / self.wcs.restwav - 1.
@@ -521,10 +530,19 @@ class FITSWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
                                          observer=observer, target=target)
 
                 def beta_from_spectralcoord(spectralcoord):
-                    # TODO: check target is consistent
+                    # TODO: check target is consistent between WCS and SpectralCoord,
+                    # if they are not the transformation doesn't make conceptual sense.
                     doppler_equiv = u.doppler_relativistic(self.wcs.restwav * u.m)
-                    if observer is None:
-                        warnings.warn('No observer defined on WCS, SpectralCoord '
+                    if (observer is None
+                            or spectralcoord.observer is None
+                            or spectralcoord.target is None):
+                        if observer is None:
+                            msg = 'No observer defined on WCS'
+                        elif spectralcoord.observer is None:
+                            msg = 'No observer defined on SpectralCoord'
+                        else:
+                            msg = 'No target defined on SpectralCoord'
+                        warnings.warn(f'{msg}, SpectralCoord '
                                       'will be converted without any velocity '
                                       'frame change', AstropyUserWarning)
                         return spectralcoord.to_value(u.m / u.s, doppler_equiv) / C_SI
@@ -550,12 +568,23 @@ class FITSWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
                         kwargs['doppler_rest'] = self.wcs.restwav * u.m
 
                 def spectralcoord_from_value(value):
+                    if isinstance(value, SpectralCoord):
+                        return value
                     return SpectralCoord(value, observer=observer, target=target, **kwargs)
 
                 def value_from_spectralcoord(spectralcoord):
-                    # TODO: check target is consistent
-                    if observer is None:
-                        warnings.warn('No observer defined on WCS, SpectralCoord '
+                    # TODO: check target is consistent between WCS and SpectralCoord,
+                    # if they are not the transformation doesn't make conceptual sense.
+                    if (observer is None
+                            or spectralcoord.observer is None
+                            or spectralcoord.target is None):
+                        if observer is None:
+                            msg = 'No observer defined on WCS'
+                        elif spectralcoord.observer is None:
+                            msg = 'No observer defined on SpectralCoord'
+                        else:
+                            msg = 'No target defined on SpectralCoord'
+                        warnings.warn(f'{msg}, SpectralCoord '
                                       'will be converted without any velocity '
                                       'frame change', AstropyUserWarning)
                         return spectralcoord.to_value(**kwargs)

--- a/astropy/wcs/wcsapi/tests/test_fitswcs.py
+++ b/astropy/wcs/wcsapi/tests/test_fitswcs.py
@@ -1067,3 +1067,104 @@ def test_different_ctypes(header_spectral_frames, ctype3, observer):
             pix = wcs.world_to_pixel(skycoord, spectralcoord)
 
     assert_allclose(pix, [0, 0, 31], rtol=1e-6)
+
+
+HEADER_SPECTRAL_1D = """
+CTYPE1  = 'FREQ'
+CRVAL1  =    1.37835117405E+09
+CDELT1  =      9.765625000E+04
+CRPIX1  =                 32.0
+CUNIT1  = 'Hz'
+SPECSYS = 'TOPOCENT'
+RESTFRQ =      1.420405752E+09 / [Hz]
+RADESYS = 'FK5'
+"""
+
+
+@pytest.fixture
+def header_spectral_1d():
+    return Header.fromstring(HEADER_SPECTRAL_1D, sep='\n')
+
+
+@pytest.mark.parametrize(('ctype1', 'observer'), product(['ZOPT', 'BETA', 'VELO', 'VRAD', 'VOPT'], [False, True]))
+def test_spectral_1d(header_spectral_1d, ctype1, observer):
+
+    # This is a regression test for issues that happened with 1-d WCS
+    # where the target is not defined but observer is.
+
+    header = header_spectral_1d.copy()
+    header['CTYPE1'] = ctype1
+    header['CRVAL1'] = 0.1
+    header['CDELT1'] = 0.001
+
+    if ctype1[0] == 'V':
+        header['CUNIT1'] = 'm s-1'
+    else:
+        header['CUNIT1'] = ''
+
+    header['RESTWAV'] = 1.420405752E+09
+    header['MJD-OBS'] = 55197
+
+    if observer:
+        header['OBSGEO-L'] = 144.2
+        header['OBSGEO-B'] = -20.2
+        header['OBSGEO-H'] = 0.
+        header['SPECSYS'] = 'BARYCENT'
+
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', FITSFixedWarning)
+        wcs = WCS(header)
+
+    # First ensure that transformations round-trip
+
+    spectralcoord = wcs.pixel_to_world(31)
+
+    assert isinstance(spectralcoord, SpectralCoord)
+    assert spectralcoord.target is None
+    assert (spectralcoord.observer is not None) is observer
+
+    if observer:
+        expected_message = 'No target defined on SpectralCoord'
+    else:
+        expected_message = 'No observer defined on WCS'
+
+    with pytest.warns(AstropyUserWarning, match=expected_message):
+        pix = wcs.world_to_pixel(spectralcoord)
+
+    assert_allclose(pix, [31], rtol=1e-6)
+
+    # Also make sure that we can convert a SpectralCoord on which the observer
+    # is not defined but the target is.
+
+    with pytest.warns(AstropyUserWarning, match='No velocity defined on frame'):
+        spectralcoord_no_obs = SpectralCoord(spectralcoord.quantity,
+                                             doppler_rest=spectralcoord.doppler_rest,
+                                             doppler_convention=spectralcoord.doppler_convention,
+                                             target=ICRS(10 * u.deg, 20 * u.deg, distance=1 * u.kpc))
+
+    if observer:
+        expected_message = 'No observer defined on SpectralCoord'
+    else:
+        expected_message = 'No observer defined on WCS'
+
+    with pytest.warns(AstropyUserWarning, match=expected_message):
+        pix2 = wcs.world_to_pixel(spectralcoord_no_obs)
+    assert_allclose(pix2, [31], rtol=1e-6)
+
+    # And finally check case when both observer and target are defined on the
+    # SpectralCoord
+
+    with pytest.warns(AstropyUserWarning, match='No velocity defined on frame'):
+        spectralcoord_no_obs = SpectralCoord(spectralcoord.quantity,
+                                             doppler_rest=spectralcoord.doppler_rest,
+                                             doppler_convention=spectralcoord.doppler_convention,
+                                             observer=ICRS(10 * u.deg, 20 * u.deg, distance=0 * u.kpc),
+                                             target=ICRS(10 * u.deg, 20 * u.deg, distance=1 * u.kpc))
+
+    if observer:
+        pix3 = wcs.world_to_pixel(spectralcoord_no_obs)
+    else:
+        with pytest.warns(AstropyUserWarning, match='No observer defined on WCS'):
+            pix3 = wcs.world_to_pixel(spectralcoord_no_obs)
+
+    assert_allclose(pix3, [31], rtol=1e-6)

--- a/docs/changes/wcs/13228.bugfix.rst
+++ b/docs/changes/wcs/13228.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed error that occured in ``WCS.world_to_pixel`` for ``WCS`` objects with a
+spectral axis and observer location information when passing a ``SpectralCoord``
+that had missing observer or target information.


### PR DESCRIPTION
### Description

Manual backport of https://github.com/astropy/astropy/pull/13228 to LTS

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
