### PR TITLE
Switch to OpenAstronomy GitHub Actions workflow to build and publish wheels

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,15 +1,44 @@
-name: CI
+name: Wheel building
 
 on:
+  schedule:
+    # run every day at 4am UTC
+    - cron: '0 4 * * *'
+  workflow_dispatch:
   push:
   pull_request:
 
 jobs:
-  publish:
-    # TODO: currently this will publish wheels to PyPI for any tag starting with
-    # 'v' but we need to exclude '.dev' tags.
+
+  test_wheel_building:
+    # This ensures that a couple of targets work fine in pull requests and pushes
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish.yml@v1
+    if: (github.event_name == 'push' || github.event_name == 'pull_request')
     with:
+      upload_to_pypi: false
+      upload_to_anaconda: false
+      test_extras: test
+      test_command: pytest -p no:warnings --astropy-header -m "not hypothesis" -k "not test_data_out_of_range and not test_wcsapi_extension and not test_set_locale" --pyargs astropy
+      targets: |
+        - cp39-manylinux_x86_64
+
+  build_and_publish:
+    # This does the actual wheel building and publishing as part of the cron job
+    # or if triggered manually via the workflow dispatch.
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish.yml@v1
+    if: (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+    with:
+
+      # TODO: currently this will publish wheels to PyPI for any tag starting with
+      # 'v' but we need to exclude '.dev' tags.
+
+      # For now, we upload all successful builds to anaconda.org, and we don't
+      # ever upload to PyPI. Once the Azure pipelines configuration is removed,
+      # we can enable PyPI uploads here.
+      upload_to_pypi: false
+      upload_to_anaconda: true
+      anaconda_user: astropy
+
       test_extras: test
       # FIXME: we exclude the test_data_out_of_range test since it
       # currently fails, see https://github.com/astropy/astropy/issues/10409
@@ -55,3 +84,4 @@ jobs:
 
     secrets:
       pypi_token: ${{ secrets.pypi_token }}
+      anaconda_token: ${{ secrets.anaconda_token }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,55 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  publish:
+    # TODO: currently this will publish wheels to PyPI for any tag starting with
+    # 'v' but we need to exclude '.dev' tags.
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish.yml@v1
+    with:
+      test_extras: test
+      # FIXME: we exclude the test_data_out_of_range test since it
+      # currently fails, see https://github.com/astropy/astropy/issues/10409
+      test_command: pytest -p no:warnings --astropy-header -m "not hypothesis" -k "not test_data_out_of_range and not test_wcsapi_extension" --pyargs astropy
+      targets: |
+        # Linux wheels
+        - cp38-manylinux_i686
+        - cp39-manylinux_i686
+        # - cp310*linux_i686  # We can't build this as PyYAML doesn't have i686 wheels for 3.10 yet so the build takes too long
+        - cp38-manylinux_x86_64
+        - cp39-manylinux_x86_64
+        - cp310-manylinux_x86_64
+
+        # MacOS X wheels - as noted in https://github.com/astropy/astropy/pull/12379 we deliberately
+        # do not build universal2 wheels. Note that the arm64 wheels are not actually tested so we
+        # rely on local manual testing of these to make sure they are ok.
+        - cp38*macosx_x86_64
+        - cp39*macosx_x86_64
+        - cp310*macosx_x86_64
+        - cp38*macosx_arm64
+        - cp39*macosx_arm64
+        - cp310*macosx_arm64
+
+        # Windows wheels
+        - cp38*win32
+        - cp38*win_amd64
+        - cp39*win32
+        - cp39*win_amd64
+        - cp310*win32
+        - cp310*win_amd64
+
+        # TODO: Add support for musllinux here (which seems to be new in cibuildwheel 2.2)
+        # This seems to introduce real numerical issues
+        # - cp38-musllinux_x86_64
+        # - cp39-musllinux_x86_64
+        # - cp310-musllinux_x86_64
+        # TODO: The aarch64 builds take longer than an hour to complete so get killed
+        # - cp38-manylinux_aarch64
+        # - cp39-manylinux_aarch64
+        # - cp310-manylinux_aarch64
+
+    secrets:
+      pypi_token: ${{ secrets.pypi_token }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,7 @@ jobs:
     # This does the actual wheel building and publishing as part of the cron job
     # or if triggered manually via the workflow dispatch.
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish.yml@v1
-    if: (github.repository == 'astropy/astropy' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'))
+    if: ((github.repository == 'astropy/astropy' && github.event_name == 'schedule') || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'Build all wheels'))
     with:
 
       # TODO: currently this will publish wheels to PyPI for any tag starting with
@@ -36,7 +36,7 @@ jobs:
       # ever upload to PyPI. Once the Azure pipelines configuration is removed,
       # we can enable PyPI uploads here.
       upload_to_pypi: false
-      upload_to_anaconda: true
+      upload_to_anaconda: ${{ ((github.repository == 'astropy/astropy' && github.event_name == 'schedule') || github.event_name == 'workflow_dispatch') }}
       anaconda_user: astropy
 
       test_extras: test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,7 @@ jobs:
       # ever upload to PyPI. Once the Azure pipelines configuration is removed,
       # we can enable PyPI uploads here.
       upload_to_pypi: false
-      upload_to_anaconda: ${{ ((github.repository == 'astropy/astropy' && github.event_name == 'schedule') || github.event_name == 'workflow_dispatch') }}
+      upload_to_anaconda: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
       anaconda_user: astropy
 
       test_extras: test
@@ -53,6 +53,9 @@ jobs:
         - cp38-manylinux_x86_64
         - cp39-manylinux_x86_64
         - cp310-manylinux_x86_64
+        - cp38-musllinux_x86_64
+        - cp39-musllinux_x86_64
+        - cp310-musllinux_x86_64
 
         # MacOS X wheels - as noted in https://github.com/astropy/astropy/pull/12379 we deliberately
         # do not build universal2 wheels. Note that the arm64 wheels are not actually tested so we
@@ -72,11 +75,6 @@ jobs:
         - cp310*win32
         - cp310*win_amd64
 
-        # TODO: Add support for musllinux here (which seems to be new in cibuildwheel 2.2)
-        # This seems to introduce real numerical issues
-        - cp38-musllinux_x86_64
-        - cp39-musllinux_x86_64
-        - cp310-musllinux_x86_64
         # TODO: The aarch64 builds take longer than an hour to complete so get killed
         # - cp38-manylinux_aarch64
         # - cp39-manylinux_aarch64

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,9 @@ jobs:
       test_extras: test
       # FIXME: we exclude the test_data_out_of_range test since it
       # currently fails, see https://github.com/astropy/astropy/issues/10409
-      test_command: pytest -p no:warnings --astropy-header -m "not hypothesis" -k "not test_data_out_of_range and not test_wcsapi_extension" --pyargs astropy
+      # We also exclude test_set_locale as it sometimes relies on the correct locale
+      # packages being installed, which it isn't always.
+      test_command: pytest -p no:warnings --astropy-header -m "not hypothesis" -k "not test_data_out_of_range and not test_wcsapi_extension and not test_set_locale" --pyargs astropy
       targets: |
         # Linux wheels
         - cp38-manylinux_i686
@@ -43,9 +45,9 @@ jobs:
 
         # TODO: Add support for musllinux here (which seems to be new in cibuildwheel 2.2)
         # This seems to introduce real numerical issues
-        # - cp38-musllinux_x86_64
-        # - cp39-musllinux_x86_64
-        # - cp310-musllinux_x86_64
+        - cp38-musllinux_x86_64
+        - cp39-musllinux_x86_64
+        - cp310-musllinux_x86_64
         # TODO: The aarch64 builds take longer than an hour to complete so get killed
         # - cp38-manylinux_aarch64
         # - cp39-manylinux_aarch64

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,7 @@ jobs:
     # This does the actual wheel building and publishing as part of the cron job
     # or if triggered manually via the workflow dispatch.
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish.yml@v1
-    if: (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+    if: (github.repository == 'astropy/astropy' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'))
     with:
 
       # TODO: currently this will publish wheels to PyPI for any tag starting with

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,7 @@ jobs:
     # This does the actual wheel building and publishing as part of the cron job
     # or if triggered manually via the workflow dispatch.
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish.yml@v1
-    if: ((github.repository == 'astropy/astropy' && github.event_name == 'schedule') || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'Build all wheels'))
+    if: (github.repository == 'astropy/astropy' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'Build all wheels')))
     with:
 
       # TODO: currently this will publish wheels to PyPI for any tag starting with

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -2099,7 +2099,7 @@ def test_unitphysics(unitphysics):
 
     assph = obj.represent_as(SphericalRepresentation)
     assert assph.lon == obj.phi
-    assert assph.lat == 80*u.deg
+    assert_allclose_quantity(assph.lat, 80*u.deg)
     assert_allclose_quantity(assph.distance, 1*u.dimensionless_unscaled)
 
     with pytest.raises(TypeError, match='got multiple values'):

--- a/astropy/wcs/wcsapi/tests/test_fitswcs.py
+++ b/astropy/wcs/wcsapi/tests/test_fitswcs.py
@@ -1066,7 +1066,7 @@ def test_different_ctypes(header_spectral_frames, ctype3, observer):
         with pytest.warns(AstropyUserWarning, match='No observer defined on WCS'):
             pix = wcs.world_to_pixel(skycoord, spectralcoord)
 
-    assert_allclose(pix, [0, 0, 31], rtol=1e-6)
+    assert_allclose(pix, [0, 0, 31], rtol=1e-6, atol=1e-9)
 
 
 def test_non_convergence_warning():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,19 @@ write_to = "astropy/_version.py"
     [tool.astropy-bot.changelog_checker]
         enabled = false
 
+[tool.cibuildwheel]
+manylinux-x86_64-image = "manylinux2010"
+manylinux-i686-image = "manylinux2010"
+# Numpy 1.22 doesn't have wheels for i386, so we pin Numpy to an older version
+# that does - this pin can be removed once we drop support for 32-bit wheels.
+test-requires = "numpy==1.21.*"
+
+[tool.cibuildwheel.macos]
+archs = ["x86_64", "arm64"]
+
+[tool.cibuildwheel.linux]
+archs = ["auto", "aarch64"]
+
 [tool.isort]
     extend_skip_glob = [
         "docs/*",


### PR DESCRIPTION
### Description

This switches the wheel building and publishing machinery from Azure to GitHub Actions, making use of the OpenAstronomy workflow (https://github.com/OpenAstronomy/github-actions-workflows).

To start with, I am copying over the configuration as-is, and we can then see if any improvements can be made. Remaining things to do:

* [ ] <s>Check if we can enable the musllinux wheels</s> - still some issues, will investigate after this PR
* [x] Set up nightly build machinery, which will require changing the URL for development wheels to a different URL (assuming we do this, we should clearly warn people in advance - nothing will break since the old dev wheels will still be available at the old URL but no new dev wheels will be added there)
* [x] Consider whether to drop 32-bit wheels for Linux - I think for now we should actually leave it in this PR so that we can backport it to 5.0.x and 5.1.x and then remove 32-bit Linux support in ``main`` (if we decide to)
* [x] Don't build all the wheels for all PRs - build only a couple for regular PRs, and all on release branches and tags.
* [x] Add back all the regular CI builds (remove the TMP commit)

<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->



### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
