### PR TITLE
Improve documentation of handing non-finite fitting data

### DIFF
--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -1075,7 +1075,8 @@ class _NonLinearLSQFitter(metaclass=_FitterMeta):
 
         if not np.all(np.isfinite(value)):
             raise NonFiniteValueError("Objective function has encountered a non-finite value, "
-                                      "this will cause the fit to fail!")
+                                      "this will cause the fit to fail!\n"
+                                      "Please remove non-finite values from your input data before fitting to avoid this error.")
 
         return value
 

--- a/docs/modeling/fitting.rst
+++ b/docs/modeling/fitting.rst
@@ -36,21 +36,19 @@ The rules for passing input to fitters are:
     any non-finite value is present in the data to be fitted. To avoid this error
     users should "filter" the non-finite values from their data, for example
     when fitting a ``model``, with a ``fitter`` using ``data`` containing non-finite
-    values one can "filter" these problems via::
+    values one can "filter" these problems as follow for the 1D case::
 
           # Filter non-finite values from data
           mask = np.isfinite(data)
           # Fit model to filtered data
           model = fitter(model, x[mask], data[mask])
 
-    in the 1D case or::
+    or for the 2D case::
 
           # Filter non-finite values from data
           mask = np.isfinite(data)
           # Fit model to filtered data
           model = fitter(model, x[mask], y[mask], data[mask])
-
-    in the 2D case.
 
 .. _modeling-getting-started-nonlinear-notes:
 

--- a/docs/modeling/fitting.rst
+++ b/docs/modeling/fitting.rst
@@ -33,7 +33,7 @@ The rules for passing input to fitters are:
     In general, non-linear fitters do not support fitting to data which contains
     non-finite values: ``NaN``, ``Inf``, or ``-Inf``. This is a limitation of the
     underlying scipy library. As a consequence, an error will be raised whenever
-    an non-finite value is present in the data to be fitted. To avoid this error
+    any non-finite value is present in the data to be fitted. To avoid this error
     users should "filter" the non-finite values from their data, for example
     when fitting a ``model``, with a ``fitter`` using ``data`` containing non-finite
     values one can "filter" these problems via::

--- a/docs/modeling/fitting.rst
+++ b/docs/modeling/fitting.rst
@@ -29,6 +29,29 @@ The rules for passing input to fitters are:
   `~astropy.modeling.polynomial.Chebyshev2D` but not compound models that map
   ``x, y -> x', y'``).
 
+.. note::
+    In general, non-linear fitters do not support fitting to data which contains
+    non-finite values: ``NaN``, ``Inf``, or ``-Inf``. This is a limitation of the
+    underlying scipy library. As a consequence, an error will be raised whenever
+    an non-finite value is present in the data to be fitted. To avoid this error
+    users should "filter" the non-finite values from their data, for example
+    when fitting a ``model``, with a ``fitter`` using ``data`` containing non-finite
+    values one can "filter" these problems via::
+
+          # Filter non-finite values from data
+          mask = np.isfinite(data)
+          # Fit model to filtered data
+          model = fitter(model, x[mask], data[mask])
+
+    in the 1D case or::
+
+          # Filter non-finite values from data
+          mask = np.isfinite(data)
+          # Fit model to filtered data
+          model = fitter(model, x[mask], y[mask], data[mask])
+
+    in the 2D case.
+
 .. _modeling-getting-started-nonlinear-notes:
 
 Notes on non-linear fitting

--- a/docs/modeling/fitting.rst
+++ b/docs/modeling/fitting.rst
@@ -36,7 +36,7 @@ The rules for passing input to fitters are:
     any non-finite value is present in the data to be fitted. To avoid this error
     users should "filter" the non-finite values from their data, for example
     when fitting a ``model``, with a ``fitter`` using ``data`` containing non-finite
-    values one can "filter" these problems as follow for the 1D case::
+    values one can "filter" these problems as follows for the 1D case::
 
           # Filter non-finite values from data
           mask = np.isfinite(data)


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This PR addresses the changes decided upon for astropy during an offline discussion of astropy/photutils#1345, which amount to adding documentation how to resolve the error and an improved error message.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
