### PR TITLE
fix confusing cosmology ``__eq__``

### DIFF
--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -320,7 +320,7 @@ class Cosmology(metaclass=abc.ABCMeta):
         if other.__class__ is not self.__class__:
             return NotImplemented  # allows other.__equiv__
 
-        # check all parameters in 'other' match those in 'self' and 'other' has
+        # Check all parameters in 'other' match those in 'self' and 'other' has
         # no extra parameters (latter part should never happen b/c same class)
         params_eq = (set(self.__all_parameters__) == set(other.__all_parameters__)
                      and all(np.all(getattr(self, k) == getattr(other, k))
@@ -345,12 +345,18 @@ class Cosmology(metaclass=abc.ABCMeta):
         if other.__class__ is not self.__class__:
             return NotImplemented  # allows other.__eq__
 
-        # check all parameters in 'other' match those in 'self'
-        equivalent = self.__equiv__(other)
-        # non-Parameter checks: name
-        name_eq = (self.name == other.name)
+        eq = (
+            # non-Parameter checks: name
+            self.name == other.name
+            # check all parameters in 'other' match those in 'self' and 'other'
+            # has no extra parameters (latter part should never happen b/c same
+            # class) TODO! element-wise when there are array cosmologies
+            and set(self.__all_parameters__) == set(other.__all_parameters__)
+            and all(np.all(getattr(self, k) == getattr(other, k))
+                    for k in self.__all_parameters__)
+        )
 
-        return equivalent and name_eq
+        return eq
 
     # ---------------------------------------------------------------
 


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

### Description

``Cosmology.__eq__`` calls ``Cosmology.__equiv__``. It looks like there's a bug since ``FLRW.__equiv__`` allows for flat cosmologies to be considered equal to their non-flat counterparts. However, ``Cosmology.__eq__`` has a class check, so there's not actually a problem, the code is just confusing. This should clear it up a bit, at the price of some small duplication.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
