### PR TITLE
move coverage config to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,49 @@ write_to = "astropy/_version.py"
     group_by_package = true
     indented_import_headings = false
 
+[tool.coverage]
+
+    [tool.coverage.run]
+        omit = [
+            "astropy/__init__*",
+            "astropy/conftest.py",
+            "astropy/*setup*",
+            "astropy/*/tests/*",
+            "astropy/tests/test_*",
+            "astropy/extern/*",
+            "astropy/utils/compat/*",
+            "astropy/version*",
+            "astropy/wcs/docstrings*",
+            "astropy/_erfa/*",
+            "*/astropy/__init__*",
+            "*/astropy/conftest.py",
+            "*/astropy/*setup*",
+            "*/astropy/*/tests/*",
+            "*/astropy/tests/test_*",
+            "*/astropy/extern/*",
+            "*/astropy/utils/compat/*",
+            "*/astropy/version*",
+            "*/astropy/wcs/docstrings*",
+            "*/astropy/_erfa/*",
+        ]
+
+    [tool.coverage.report]
+        exclude_lines = [
+            # Have to re-enable the standard pragma
+            "pragma: no cover",
+            # Don't complain about packages we have installed
+            "except ImportError",
+            # Don't complain if tests don't hit defensive assertion code:
+            "raise AssertionError",
+            "raise NotImplementedError",
+            # Don't complain about script hooks
+            "'def main(.*):'",
+            # Ignore branches that don't pertain to this version of Python
+            "pragma: py{ignore_python_version}",
+            # Don't complain about IPython completion helper
+            "def _ipython_key_completions_",
+        ]
+
 [tool.towncrier]
     package = "astropy"
     filename = "CHANGES.rst"

--- a/setup.cfg
+++ b/setup.cfg
@@ -67,7 +67,7 @@ test_all =  # Required for testing, plus packages used by particular tests.
     pytest-xdist
     objgraph
     ipython>=4.2
-    coverage
+    coverage[toml]
     skyfield>=1.20
     sgp4>=2.3
 recommended =
@@ -168,42 +168,3 @@ exclude = extern,*parsetab.py,*lextab.py,astropy/_erfa/core.py
 [pycodestyle]
 max-line-length = 100
 exclude = extern,*parsetab.py,*lextab.py,astropy/_erfa/core.py
-
-[coverage:run]
-omit =
-  astropy/__init__*
-  astropy/conftest.py
-  astropy/*setup*
-  astropy/*/tests/*
-  astropy/tests/test_*
-  astropy/extern/*
-  astropy/utils/compat/*
-  astropy/version*
-  astropy/wcs/docstrings*
-  astropy/_erfa/*
-  */astropy/__init__*
-  */astropy/conftest.py
-  */astropy/*setup*
-  */astropy/*/tests/*
-  */astropy/tests/test_*
-  */astropy/extern/*
-  */astropy/utils/compat/*
-  */astropy/version*
-  */astropy/wcs/docstrings*
-  */astropy/_erfa/*
-
-[coverage:report]
-exclude_lines =
-  # Have to re-enable the standard pragma
-  pragma: no cover
-  # Don't complain about packages we have installed
-  except ImportError
-  # Don't complain if tests don't hit defensive assertion code:
-  raise AssertionError
-  raise NotImplementedError
-  # Don't complain about script hooks
-  def main\(.*\):
-  # Ignore branches that don't pertain to this version of Python
-  pragma: py{ignore_python_version}
-  # Don't complain about IPython completion helper
-  def _ipython_key_completions_


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

Moves coverage config from ``setup.cfg`` to ``pyproject.toml``.

One config to rule them all, one file in which to find them, one backend to bring them all and in the PyPI build them.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
