### PR TITLE
WCS: Add square pixel convenience function

### DIFF
--- a/astropy/wcs/utils.py
+++ b/astropy/wcs/utils.py
@@ -335,6 +335,40 @@ def proj_plane_pixel_scales(wcs):
     return np.sqrt((wcs.pixel_scale_matrix**2).sum(axis=0, dtype=float))
 
 
+def square_pixel_scale(wcs, maxerr=1e-5):
+    """
+    Return the one-dimensional pixel scale for square pixels.
+
+    Parameters
+    ----------
+    wcs : `~astropy.wcs.WCS`
+        A world coordinate system object.
+
+    Returns
+    -------
+    scale : float
+        The size of a pixel edge in degrees.
+
+    Raises
+    ------
+    ValueError if the pixels are not square
+
+    See Also
+    --------
+    astropy.wcs.utils.proj_plane_pixel_area,
+    astropy.wcs.utils.proj_plane_pixel_scales
+
+    """
+    pixel_scales = proj_plane_pixel_scales(wcs)
+
+    if pixel_scales[0] != pixel_scales[1]:
+        raise ValueError("Pixels are not square.")
+    if is_proj_plane_distorted(wcs, maxerr=maxerr):
+        raise ValueError("Projected plane is distorted; pixels are not square.")
+
+    return pixel_scales[0]
+
+
 def proj_plane_pixel_area(wcs):
     """
     For a **celestial** WCS (see `astropy.wcs.WCS.celestial`) returns pixel


### PR DESCRIPTION
A [very frequent](https://github.com/search?q=proj_plane_pixel_scales&type=code) use pattern is, e.g.:
```python
        pixscale = wcs.utils.proj_plane_pixel_scales(cube_hi.wcs.celestial)[0]
```
in which the user:
(1) assumes the pixels are square
(2) wants only the linear transformation from pixel edge size to degrees

This is a somewhat dangerous pattern because it will fail silently if the pixels are non-square or distorted.


The proposed convenience method does what I want - it gives you the one-dimensional pixel scale _without_ exposing you to the risk of misinterpreting rectangular or distorted pixels.

I can add tests for this, but I want to propose the change first.