### PR TITLE
Fix access of one field in structured column

### DIFF
--- a/astropy/table/_column_mixins.pyx
+++ b/astropy/table/_column_mixins.pyx
@@ -28,6 +28,7 @@ import numpy as np
 
 
 cdef tuple INTEGER_TYPES = (int, np.integer)
+cdef tuple STRING_TYPES = (str, np.str_)
 
 
 # Annoying boilerplate that we shouldn't have to write; Cython should
@@ -56,10 +57,14 @@ cdef inline object base_getitem(object self, object item, item_getter getitem):
     if (<ndarray>self).ndim > 1 and isinstance(item, INTEGER_TYPES):
         return self.data[item]
 
+    dtype_kind = (<ndarray>self).dtype.kind
+    if dtype_kind == 'V' and isinstance(item, STRING_TYPES):
+        return self.data[item]
+
     value = getitem(self, item)
 
     try:
-        if value.dtype.char == 'S' and not value.shape:
+        if dtype_kind == 'S' and not value.shape:
             value = value.decode('utf-8', errors='replace')
     except AttributeError:
         pass

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -366,7 +366,7 @@ class ColumnInfo(BaseColumnInfo):
         else:
             units = [None] * len(names)
         for name, part_unit in zip(names, units):
-            part = self._parent[name]
+            part = Column(self._parent[name])
             part.unit = part_unit
             part.description = None
             part.meta = {}

--- a/docs/changes/table/13269.bugfix.rst
+++ b/docs/changes/table/13269.bugfix.rst
@@ -1,3 +1,3 @@
 Fix a problem where accessing one field of a structured column returned a Column
-with the same info as the original column. This resulted in uninuitive behavior
+with the same info as the original column. This resulted in unintuitive behavior
 in general and an exception if the format for the column was set.

--- a/docs/changes/table/13269.bugfix.rst
+++ b/docs/changes/table/13269.bugfix.rst
@@ -1,0 +1,3 @@
+Fix a problem where accessing one field of a structured column returned a Column
+with the same info as the original column. This resulted in uninuitive behavior
+in general and an exception if the format for the column was set.

--- a/docs/table/construct_table.rst
+++ b/docs/table/construct_table.rst
@@ -361,10 +361,7 @@ including the simple structured array defined previously as a column::
 You can access or print a single field in the structured column as follows::
 
   >>> print(table['arr']['b'])
-  arr
-  ---
-  2.0
-  5.0
+  [2. 5.]
 
 **New column names**
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to fix a problem where accessing one field of a structured column returns a `Column` with the same `info` set. This can be unintuitive as follows:
```
t = Table()
a = np.array([(1, 2), (3, 4)], dtype=[('a', int), ('b', int)])
t['sc'] = a
print(repr(t['sc']['a']))
<Column name='sc' dtype='int64' length=2>  # this is not really column "sc" any more
1
3
```
Worse, if `info.format` is set to something the correctly formats the structured column then an exception occurs as shown in #13267.

This PR follows the precedent of turning item access for a multi-dimensional column into a pure `ndarray`. For the table example above you get the following with this PR:
```
print(repr(t['sc']['a']))
array([1, 3])
```

Unfortunately there is an associated performance penalty and default column access for a single item is about 12% slower.
```
c = Column([1, 2])
%timeit c[0]
# Patch: 155 ns 
# main: 138 ns
```

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #13267

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
