### PR TITLE
Update release docs

### DIFF
--- a/docs/development/releasing.rst
+++ b/docs/development/releasing.rst
@@ -108,6 +108,10 @@ The procedure for the feature freeze is as follows:
 
 #. Inform the Astropy developer community that the branching has occurred.
 
+#. Once the feature freeze has happened, you should go through the PRs labeled
+   with ``backport-v<prev_version>.x`` to see if they must also be labeled with
+   the new version backport label.
+
 .. _release-procedure-first-rc:
 
 Releasing the first major release candidate
@@ -141,7 +145,7 @@ To find the statistics and contributors, use the `generate_releaserst.xsh`_
 script. This requires `xonsh <https://xon.sh/>`_ and `docopt
 <http://docopt.org/>`_ which you can install with::
 
-   pip install xonsh docopt
+   pip install xonsh docopt requests
 
 You should then run the script in the root of the astropy repository as follows::
 
@@ -217,6 +221,21 @@ the release branch.
 
 Ensure continuous integration and intensive tests pass
 ------------------------------------------------------
+
+Update ``.github/workflows/ci_workflows.yml`` so that pushes on the release
+branch trigger a build with Github Actions, e.g.::
+
+  on:
+    push:
+      branches:
+      - v5.1.x
+    pull_request:
+      branches:
+      - v5.1.x
+
+You also need to activate builds on the release branch for ReadTheDocs. Go to
+`RTD's Settings <https://readthedocs.org/projects/astropy/versions/>`_ and check
+"Activate" and "Hidden" for the new release branch.
 
 Make sure that the continuous integration services (e.g., GitHub Actions or CircleCI) are passing
 for the `astropy core repository`_ branch you are going to release. Also check that
@@ -448,13 +467,15 @@ Post-Release procedures
    https://doi.org/10.5281/zenodo.4670728 . If you encounter problems during this
    step, please contact the Astropy Coordination Committee.
 
-#. Once the release(s) are available on the default ``conda`` channels,
-   prepare the public announcement. Use the previous announcement as a template,
-   but link to the release tag instead of ``stable``. For a new major release,
-   you should coordinate with the rest of the Astropy release team and the
-   community engagement coordinators. Meanwhile, for a bugfix release, you can
+#. Once the release(s) are available on the default ``conda`` channels, prepare
+   the public announcement. For a new major release, copy the `latest
+   announcement
+   <https://github.com/astropy/astropy.github.com/tree/main/announcements>`_ and
+   edit it to update the version number and links. Once it is merged, you can
    proceed to send out an email to the ``astropy-dev`` and Astropy mailing
-   lists.
+   lists. For a bugfix release, use the previous announcement as a template.
+   You should also coordinate with the rest of the Astropy release team and the
+   community engagement coordinators.
 
 .. _release-procedure-bug-fix:
 
@@ -569,7 +590,7 @@ Backporting fixes from main
     freeze but before its release.
 
 Most pull requests will be backported automatically by a backport bot, which
-opens pull requests with the backports aganist the release branch. Make sure
+opens pull requests with the backports against the release branch. Make sure
 that any such pull requests are merged in before starting the release process
 for a new bugfix release.
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address ...

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
