### PR TITLE
Ensure tables with structured columns can be stacked

### DIFF
--- a/astropy/table/tests/test_operations.py
+++ b/astropy/table/tests/test_operations.py
@@ -789,6 +789,21 @@ class TestJoin():
         with pytest.raises(ValueError, match=msg):
             table.join(t1, t2, keys_left=['a'], keys_right=['a'], join_funcs={})
 
+    def test_join_structured_column(self):
+        """Regression tests for gh-13271."""
+        # Two tables with matching names, including a structured column.
+        t1 = Table([np.array([(1., 1), (2., 2)], dtype=[('f', 'f8'), ('i', 'i8')]),
+                    ['one', 'two']], names=['structured', 'string'])
+        t2 = Table([np.array([(2., 2), (4., 4)], dtype=[('f', 'f8'), ('i', 'i8')]),
+                    ['three', 'four']], names=['structured', 'string'])
+        t12 = table.join(t1, t2, ['structured'], join_type='outer')
+        assert t12.pformat() == [
+            'structured [f, i] string_1 string_2',
+            '----------------- -------- --------',
+            '          (1., 1)      one       --',
+            '          (2., 2)      two    three',
+            '          (4., 4)       --     four']
+
 
 class TestSetdiff():
 
@@ -1260,6 +1275,33 @@ class TestVStack():
         with pytest.raises(ValueError, match='representations are inconsistent'):
             table.vstack([t1, t3])
 
+    def test_vstack_structured_column(self):
+        """Regression tests for gh-13271."""
+        # Two tables with matching names, including a structured column.
+        t1 = Table([np.array([(1., 1), (2., 2)], dtype=[('f', 'f8'), ('i', 'i8')]),
+                    ['one', 'two']], names=['structured', 'string'])
+        t2 = Table([np.array([(3., 3), (4., 4)], dtype=[('f', 'f8'), ('i', 'i8')]),
+                    ['three', 'four']], names=['structured', 'string'])
+        t12 = table.vstack([t1, t2])
+        assert t12.pformat() == [
+            'structured [f, i] string',
+            '----------------- ------',
+            '          (1., 1)    one',
+            '          (2., 2)    two',
+            '          (3., 3)  three',
+            '          (4., 4)   four']
+
+        # One table without the structured column.
+        t3 = t2[('string',)]
+        t13 = table.vstack([t1, t3])
+        assert t13.pformat() == [
+            'structured [f, i] string',
+            '----------------- ------',
+            '         (1.0, 1)    one',
+            '         (2.0, 2)    two',
+            '               --  three',
+            '               --   four']
+
 
 class TestDStack():
 
@@ -1399,6 +1441,29 @@ class TestDStack():
         t12 = table.dstack([t1, t2])
         assert skycoord_equal(sc1, t12['col0'][:, 0])
         assert skycoord_equal(sc2, t12['col0'][:, 1])
+
+    def test_dstack_structured_column(self):
+        """Regression tests for gh-13271."""
+        # Two tables with matching names, including a structured column.
+        t1 = Table([np.array([(1., 1), (2., 2)], dtype=[('f', 'f8'), ('i', 'i8')]),
+                    ['one', 'two']], names=['structured', 'string'])
+        t2 = Table([np.array([(3., 3), (4., 4)], dtype=[('f', 'f8'), ('i', 'i8')]),
+                    ['three', 'four']], names=['structured', 'string'])
+        t12 = table.dstack([t1, t2])
+        assert t12.pformat() == [
+            'structured [f, i]     string   ',
+            '------------------ ------------',
+            '(1., 1) .. (3., 3) one .. three',
+            '(2., 2) .. (4., 4)  two .. four']
+
+        # One table without the structured column.
+        t3 = t2[('string',)]
+        t13 = table.dstack([t1, t3])
+        assert t13.pformat() == [
+            'structured [f, i]    string   ',
+            '----------------- ------------',
+            '   (1.0, 1) .. -- one .. three',
+            '   (2.0, 2) .. --  two .. four']
 
 
 class TestHStack():

--- a/astropy/utils/metadata.py
+++ b/astropy/utils/metadata.py
@@ -73,7 +73,7 @@ def common_dtype(arrs):
                        dtype_bytes_or_chars(arr.dtype)]
 
     arr_common = np.array([arr[0] for arr in arrs])
-    return arr_common.dtype.str
+    return arr_common.dtype.str if arr_common.dtype.names is None else arr_common.dtype.descr
 
 
 class MergeStrategyMeta(type):

--- a/docs/changes/table/13306.bugfix.rst
+++ b/docs/changes/table/13306.bugfix.rst
@@ -1,0 +1,1 @@
+Tables with columns with structured data can now be properly stacked and joined.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

Allow stacking of tables with structured columns. In current master, the problem is that the dtype of such columns is changed to plain `void`, losing the description of the elements in the dtype. A simple change in `common_dtype` corrects this. EDIT: no longer an API change ~But since this is an API change, it means the fix cannot be backported. (In principle, it may be possible to make a backward-compatible version of this, which returns `dtype.descr` for structured dtype.)~

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #13271

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
