### PR TITLE
Remove last mentions of `OrderedDict` from `coordinates` documentation

### DIFF
--- a/docs/coordinates/representations.rst
+++ b/docs/coordinates/representations.rst
@@ -586,7 +586,7 @@ provides default properties for the components so that they can be accessed
 using ``<instance>.<component>``. For the machinery to work, the following
 must be defined:
 
-* ``attr_classes`` class attribute (``OrderedDict``):
+* ``attr_classes`` class attribute (:class:`dict`):
 
   Defines through its keys the names of the components (as well as the default
   order), and through its values defines the class of which they should be
@@ -650,9 +650,11 @@ In pseudo-code, this means that a class will look like::
 
     class MyRepresentation(BaseRepresentation):
 
-        attr_classes = OrderedDict([('comp1', ComponentClass1),
-                                     ('comp2', ComponentClass2),
-                                     ('comp3', ComponentClass3)])
+        attr_classes = {
+            "comp1": ComponentClass1,
+            "comp2": ComponentClass2,
+            "comp3": ComponentClass3,
+        }
 
 	# __init__ is optional
         def __init__(self, comp1, comp2, comp3, copy=True):


### PR DESCRIPTION
### Description

All uses of `OrderedDict` in `astropy.coordinates` were removed by #10990, but a couple of mentions in documentation have persisted until now.

This should have been done already in v4.3, so I'd like to see this backported.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
