### PR TITLE
rename private attr to make it a dunder attr

### DIFF
--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -408,7 +408,7 @@ class FlatCosmologyMixin(metaclass=abc.ABCMeta):
 
         # Determine the non-flat class.
         # This will raise a TypeError if the MRO is inconsistent.
-        cls._nonflat_cls_
+        cls.__nonflatclass__
 
     # ===============================================================
 
@@ -456,8 +456,8 @@ class FlatCosmologyMixin(metaclass=abc.ABCMeta):
 
         return nonflat.pop()
 
-    _nonflat_cls_ = classproperty(_get_nonflat_cls, lazy=True,
-                                  doc="Return the corresponding non-flat class.")
+    __nonflatclass__ = classproperty(_get_nonflat_cls, lazy=True,
+                                     doc="Return the corresponding non-flat class.")
 
     # ===============================================================
 
@@ -551,7 +551,7 @@ class FlatCosmologyMixin(metaclass=abc.ABCMeta):
         # check if `other` is the non-flat version of this class this makes the
         # assumption that any further subclass of a flat cosmo keeps the same
         # physics.
-        if not issubclass(other.__class__, self._nonflat_cls_):
+        if not issubclass(other.__class__, self.__nonflatclass__):
             return NotImplemented
 
         # Check if have equivalent parameters and all parameters in `other`

--- a/astropy/cosmology/flrw/base.py
+++ b/astropy/cosmology/flrw/base.py
@@ -1440,10 +1440,10 @@ class FlatFLRWMixin(FlatCosmologyMixin):
     def nonflat(self: _FlatFLRWMixinT) -> _FLRWT:
         # Create BoundArgument to handle args versus kwargs.
         # This also handles all errors from mismatched arguments
-        ba = self._nonflat_cls_._init_signature.bind_partial(**self._init_arguments,
+        ba = self.__nonflatclass__._init_signature.bind_partial(**self._init_arguments,
                                                              Ode0=self.Ode0)
         # Make new instance, respecting args vs kwargs
-        inst = self._nonflat_cls_(*ba.args, **ba.kwargs)
+        inst = self.__nonflatclass__(*ba.args, **ba.kwargs)
         # Because of machine precision, make sure parameters exactly match
         for n in inst.__all_parameters__ + ("Ok0", ):
             setattr(inst, "_" + n, getattr(self, n))

--- a/astropy/cosmology/flrw/tests/test_base.py
+++ b/astropy/cosmology/flrw/tests/test_base.py
@@ -928,7 +928,7 @@ class FlatFLRWMixinTest(FlatCosmologyMixinTest, ParameterFlatOde0TestMixin):
 
         # change to non-flat
         nc = cosmo.clone(to_nonflat=True, Ode0=cosmo.Ode0)
-        assert isinstance(nc, cosmo._nonflat_cls_)
+        assert isinstance(nc, cosmo.__nonflatclass__)
         assert nc == cosmo.nonflat
 
         nc = cosmo.clone(to_nonflat=True, Ode0=1)
@@ -946,7 +946,7 @@ class FlatFLRWMixinTest(FlatCosmologyMixinTest, ParameterFlatOde0TestMixin):
         assert not nonflatcosmo.is_equivalent(cosmo)
 
         # non-flat version of class
-        nonflat_cosmo_cls = cosmo._nonflat_cls_
+        nonflat_cosmo_cls = cosmo.__nonflatclass__
         # keys check in `test_is_equivalent_nonflat_class_different_params`
 
         # non-flat

--- a/astropy/cosmology/tests/test_core.py
+++ b/astropy/cosmology/tests/test_core.py
@@ -409,14 +409,14 @@ class FlatCosmologyMixinTest:
         """Test :attr:`astropy.cosmology.core.FlatCosmologyMixin.nonflat_cls`.
         """
         # Test it's a method on the class
-        assert issubclass(cosmo_cls, cosmo_cls._nonflat_cls_)
+        assert issubclass(cosmo_cls, cosmo_cls.__nonflatclass__)
 
         # It also works from the instance. # TODO! as a "metaclassmethod"
-        assert issubclass(cosmo_cls, cosmo._nonflat_cls_)
+        assert issubclass(cosmo_cls, cosmo.__nonflatclass__)
 
         # Maybe not the most robust test, but so far all Flat classes have the
         # name of their parent class.
-        assert cosmo._nonflat_cls_.__name__ in cosmo_cls.__name__
+        assert cosmo.__nonflatclass__.__name__ in cosmo_cls.__name__
 
     def test_is_flat(self, cosmo_cls, cosmo):
         """Test property ``is_flat``."""
@@ -438,7 +438,7 @@ class FlatCosmologyMixinTest:
         """Test method ``.clone()``to_nonflat argument."""
         # just converting the class
         nc = cosmo.clone(to_nonflat=True)
-        assert isinstance(nc, cosmo._nonflat_cls_)
+        assert isinstance(nc, cosmo.__nonflatclass__)
         assert nc == cosmo.nonflat
 
     @abc.abstractmethod
@@ -450,7 +450,7 @@ class FlatCosmologyMixinTest:
         """
         # send to non-flat
         nc = cosmo.clone(to_nonflat=True)
-        assert isinstance(nc, cosmo._nonflat_cls_)
+        assert isinstance(nc, cosmo.__nonflatclass__)
         assert nc == cosmo.nonflat
 
     # ------------------------------------------------
@@ -478,7 +478,7 @@ class FlatCosmologyMixinTest:
             pass
 
         # The classes have the same non-flat parent class
-        assert SubClass1._nonflat_cls_ is cosmo_cls._nonflat_cls_
+        assert SubClass1.__nonflatclass__ is cosmo_cls.__nonflatclass__
 
         # A more complex example is when Mixin classes are used.
         class Mixin:
@@ -488,19 +488,19 @@ class FlatCosmologyMixinTest:
             pass
 
         # The classes have the same non-flat parent class
-        assert SubClass2._nonflat_cls_ is cosmo_cls._nonflat_cls_
+        assert SubClass2.__nonflatclass__ is cosmo_cls.__nonflatclass__
 
         # The order of the Mixin should not matter
         class SubClass3(cosmo_cls, Mixin):
             pass
 
         # The classes have the same non-flat parent class
-        assert SubClass3._nonflat_cls_ is cosmo_cls._nonflat_cls_
+        assert SubClass3.__nonflatclass__ is cosmo_cls.__nonflatclass__
 
 
-def test_nonflat_cls_multiple_nonflat_inheritance():
+def test__nonflatclass__multiple_nonflat_inheritance():
     """
-    Test :meth:`astropy.cosmology.core.FlatCosmologyMixin._nonflat_cls_`
+    Test :meth:`astropy.cosmology.core.FlatCosmologyMixin.__nonflatclass__`
     when there's more than one non-flat class in the inheritance.
     """
     # Define a non-operable minimal subclass of Cosmology.


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

Dunder methods are properly inherited and this is modeled after ``classmethod`` and similar which have ``__func__`` and ``__wrapped__``, intending these to be more official and user-discoverable than obviously private methods like ``_<X>``.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
