### PR TITLE
Ensure that np.concatenate with dtype argument works on quantities and masked data

### DIFF
--- a/astropy/units/quantity_helper/function_helpers.py
+++ b/astropy/units/quantity_helper/function_helpers.py
@@ -377,10 +377,10 @@ def _iterable_helper(*args, out=None, **kwargs):
 
 
 @function_helper
-def concatenate(arrays, axis=0, out=None):
+def concatenate(arrays, axis=0, out=None, **kwargs):
     # TODO: make this smarter by creating an appropriately shaped
     # empty output array and just filling it.
-    arrays, kwargs, unit, out = _iterable_helper(*arrays, out=out, axis=axis)
+    arrays, kwargs, unit, out = _iterable_helper(*arrays, out=out, axis=axis, **kwargs)
     return (arrays,), kwargs, unit, out
 
 

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -460,6 +460,10 @@ class TestConcatenate(metaclass=CoverageMeta):
     def test_concatenate(self):
         self.check(np.concatenate)
         self.check(np.concatenate, axis=1)
+        if not NUMPY_LT_1_20:
+            # dtype argument only introduced in numpy 1.20
+            # regression test for gh-13322.
+            self.check(np.concatenate, dtype='f4')
 
         self.check(np.concatenate, q_list=[np.zeros(self.q1.shape), self.q1, self.q2],
                    q_ref=self.q1)

--- a/astropy/utils/masked/tests/test_function_helpers.py
+++ b/astropy/utils/masked/tests/test_function_helpers.py
@@ -472,6 +472,9 @@ class TestConcatenate(MaskedArraySetup):
         self.check(np.concatenate)
         self.check(np.concatenate, axis=1)
         self.check(np.concatenate, ma_list=[self.a, self.ma])
+        if not NUMPY_LT_1_20:
+            # Check that we can accept a dtype argument (introduced in numpy 1.20)
+            self.check(np.concatenate, dtype='f4')
 
         out = Masked(np.empty((4, 3)))
         result = np.concatenate([self.ma, self.ma], out=out)

--- a/docs/changes/units/13323.bugfix.rst
+++ b/docs/changes/units/13323.bugfix.rst
@@ -1,0 +1,1 @@
+Ensure that ``np.concatenate`` on quantities can take a ``dtype`` argument (added in numpy 1.20).

--- a/docs/changes/utils/13323.bugfix.rst
+++ b/docs/changes/utils/13323.bugfix.rst
@@ -1,0 +1,1 @@
+Ensure that ``np.concatenate`` on masked data can take a ``dtype`` argument (added in numpy 1.20).


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request ensures `np.concatenate` will work on `Quantity` and `Masked` also with the `dtype` argument (new since numpy 1.20); see discussion in #13322 (but relevant not just for numpy-dev). 

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
