### PR TITLE
Add keepdims argument to argmin, argmax for numpy >=1.22

### DIFF
--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -1639,11 +1639,18 @@ class Quantity(np.ndarray):
                                self._to_own_unit(v, check_precision=False),
                                *args, **kwargs)  # avoid numpy 1.6 problem
 
-    def argmax(self, axis=None, out=None):
-        return self.view(np.ndarray).argmax(axis, out=out)
+    if NUMPY_LT_1_22:
+        def argmax(self, axis=None, out=None):
+            return self.view(np.ndarray).argmax(axis, out=out)
 
-    def argmin(self, axis=None, out=None):
-        return self.view(np.ndarray).argmin(axis, out=out)
+        def argmin(self, axis=None, out=None):
+            return self.view(np.ndarray).argmin(axis, out=out)
+    else:
+        def argmax(self, axis=None, out=None, *, keepdims=False):
+            return self.view(np.ndarray).argmax(axis=axis, out=out, keepdims=keepdims)
+
+        def argmin(self, axis=None, out=None, *, keepdims=False):
+            return self.view(np.ndarray).argmin(axis=axis, out=out, keepdims=keepdims)
 
     def __array_function__(self, function, types, args, kwargs):
         """Wrap numpy functions, taking care of units.

--- a/astropy/units/tests/test_quantity_array_methods.py
+++ b/astropy/units/tests/test_quantity_array_methods.py
@@ -233,6 +233,12 @@ class TestQuantityStatsFuncs:
         q1 = np.array([6., 2., 4., 5., 6.]) * u.m
         assert np.argmin(q1) == 1
 
+    @pytest.mark.skipif(NUMPY_LT_1_22,
+                        reason='keepdims only introduced in numpy 1.22')
+    def test_argmin_keepdims(self):
+        q1 = np.array([[6., 2.], [4., 5.]]) * u.m
+        assert_array_equal(q1.argmin(axis=0, keepdims=True), np.array([[1, 0]]))
+
     def test_max(self):
         q1 = np.array([1., 2., 4., 5., 6.]) * u.m
         assert np.max(q1) == 6. * u.m
@@ -250,6 +256,12 @@ class TestQuantityStatsFuncs:
     def test_argmax(self):
         q1 = np.array([5., 2., 4., 5., 6.]) * u.m
         assert np.argmax(q1) == 4
+
+    @pytest.mark.skipif(NUMPY_LT_1_22,
+                        reason='keepdims only introduced in numpy 1.22')
+    def test_argmax_keepdims(self):
+        q1 = np.array([[6., 2.], [4., 5.]]) * u.m
+        assert_array_equal(q1.argmax(axis=0, keepdims=True), np.array([[0, 1]]))
 
     def test_clip(self):
         q1 = np.array([1., 2., 4., 5., 6.]) * u.km / u.m

--- a/astropy/utils/masked/core.py
+++ b/astropy/utils/masked/core.py
@@ -20,6 +20,7 @@ import builtins
 
 import numpy as np
 
+from astropy.utils.compat import NUMPY_LT_1_22
 from astropy.utils.shapes import NDArrayShapeMethods
 from astropy.utils.data_info import ParentDtypeInfo
 
@@ -936,15 +937,27 @@ class MaskedNDArray(Masked, np.ndarray, base_cls=np.ndarray, data_cls=np.ndarray
         # Let __array_function__ take care since choices can be masked too.
         return np.choose(self, choices, out=out, mode=mode)
 
-    def argmin(self, axis=None, out=None):
-        # Todo: should this return a masked integer array, with masks
-        # if all elements were masked?
-        at_min = self == self.min(axis=axis, keepdims=True)
-        return at_min.filled(False).argmax(axis=axis, out=out)
+    if NUMPY_LT_1_22:
+        def argmin(self, axis=None, out=None):
+            # Todo: should this return a masked integer array, with masks
+            # if all elements were masked?
+            at_min = self == self.min(axis=axis, keepdims=True)
+            return at_min.filled(False).argmax(axis=axis, out=out)
 
-    def argmax(self, axis=None, out=None):
-        at_max = self == self.max(axis=axis, keepdims=True)
-        return at_max.filled(False).argmax(axis=axis, out=out)
+        def argmax(self, axis=None, out=None):
+            at_max = self == self.max(axis=axis, keepdims=True)
+            return at_max.filled(False).argmax(axis=axis, out=out)
+
+    else:
+        def argmin(self, axis=None, out=None, *, keepdims=False):
+            # Todo: should this return a masked integer array, with masks
+            # if all elements were masked?
+            at_min = self == self.min(axis=axis, keepdims=True)
+            return at_min.filled(False).argmax(axis=axis, out=out, keepdims=keepdims)
+
+        def argmax(self, axis=None, out=None, *, keepdims=False):
+            at_max = self == self.max(axis=axis, keepdims=True)
+            return at_max.filled(False).argmax(axis=axis, out=out, keepdims=keepdims)
 
     def argsort(self, axis=-1, kind=None, order=None):
         """Returns the indices that would sort an array.

--- a/astropy/utils/masked/tests/test_masked.py
+++ b/astropy/utils/masked/tests/test_masked.py
@@ -13,7 +13,7 @@ from astropy import units as u
 from astropy.units import Quantity
 from astropy.coordinates import Longitude
 from astropy.utils.masked import Masked, MaskedNDArray
-from astropy.utils.compat import NUMPY_LT_1_20
+from astropy.utils.compat import NUMPY_LT_1_20, NUMPY_LT_1_22
 
 
 def assert_masked_equal(a, b):
@@ -990,6 +990,12 @@ class TestMaskedArrayMethods(MaskedArraySetup):
         ma = Masked(data=[1, 2], mask=[True, False])
         assert ma.argmin() == 1
 
+    if not NUMPY_LT_1_22:
+        def test_argmin_keepdims(self):
+            ma = Masked(data=[[1, 2], [3, 4]], mask=[[True, False], [False, False]])
+            assert_array_equal(ma.argmin(axis=0, keepdims=True),
+                               np.array([[1, 0]]))
+
     @pytest.mark.parametrize('axis', (0, 1, None))
     def test_argmax(self, axis):
         ma_argmax = self.ma.argmax(axis)
@@ -997,6 +1003,12 @@ class TestMaskedArrayMethods(MaskedArraySetup):
         filled[self.mask_a] = self.a.min()
         expected_data = filled.argmax(axis)
         assert_array_equal(ma_argmax, expected_data)
+
+    if not NUMPY_LT_1_22:
+        def test_argmax_keepdims(self):
+            ma = Masked(data=[[1, 2], [3, 4]], mask=[[True, False], [False, False]])
+            assert_array_equal(ma.argmax(axis=1, keepdims=True),
+                               np.array([[1], [1]]))
 
     @pytest.mark.parametrize('axis', (0, 1, None))
     def test_argsort(self, axis):

--- a/docs/changes/units/13329.feature.rst
+++ b/docs/changes/units/13329.feature.rst
@@ -1,0 +1,2 @@
+Ensure that the ``argmin`` and ``argmax`` methods of ``Quantity`` support the
+``keepdims`` argument when numpy does (numpy version 1.22 and later).

--- a/docs/changes/utils/13329.feature.rst
+++ b/docs/changes/utils/13329.feature.rst
@@ -1,0 +1,3 @@
+Ensure that the ``argmin`` and ``argmax`` methods of ``Masked`` instances
+support the ``keepdims`` argument when numpy does (numpy version 1.22 and
+later).


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request adds support for `keepdims` for `Quantity.argmin` and `.argmax` and `Masked.argmin` and `.argmax` for numpy versions that support it (>=1.22).

(Not quite sure whether to call this a feature or a bug, but since no existing code is breaking, feature seems more appropriate.)
<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
