### PR TITLE
Take into account units of `initial` argument to reductions

### DIFF
--- a/astropy/units/tests/test_quantity_array_methods.py
+++ b/astropy/units/tests/test_quantity_array_methods.py
@@ -323,10 +323,26 @@ class TestQuantityStatsFuncs:
     def test_sum_where(self):
 
         q1 = np.array([1., 2., 6., 7.]) * u.m
-        initial = 0 * u.m
         where = q1 < 7 * u.m
-        assert np.all(q1.sum(initial=initial, where=where) == 9. * u.m)
-        assert np.all(np.sum(q1, initial=initial, where=where) == 9. * u.m)
+        assert np.all(q1.sum(where=where) == 9. * u.m)
+        assert np.all(np.sum(q1, where=where) == 9. * u.m)
+
+    @pytest.mark.parametrize('initial', [0, 0*u.m, 1*u.km])
+    def test_sum_initial(self, initial):
+        q1 = np.array([1., 2., 6., 7.]) * u.m
+        expected = 16*u.m + initial
+        assert q1.sum(initial=initial) == expected
+        assert np.sum(q1, initial=initial) == expected
+
+    def test_sum_dimensionless_initial(self):
+        q1 = np.array([1., 2., 6., 7.]) * u.one
+        assert q1.sum(initial=1000) == 1016*u.one
+
+    @pytest.mark.parametrize('initial', [10, 1*u.s])
+    def test_sum_initial_exception(self, initial):
+        q1 = np.array([1., 2., 6., 7.]) * u.m
+        with pytest.raises(u.UnitsError):
+            q1.sum(initial=initial)
 
     def test_cumsum(self):
 

--- a/docs/changes/units/13340.bugfix.rst
+++ b/docs/changes/units/13340.bugfix.rst
@@ -1,0 +1,2 @@
+Ensure that the units of any ``initial`` argument to reductions such as
+``np.add.reduce`` (which underlies ``np.sum``) are properly taken into account.


### PR DESCRIPTION
This is needed for `np.add.reduce` (and thus `np.sum`) and others.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

This partially addresses the numerous failures with `numpy-dev`, but while those are the reason the bug was found, the bug is present for all numpy versions (most new tests under `test_sum_initial` fail on current master). Hence, the `numpy-dev` job should be ignored for this PR.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
