### PR TITLE
Merge pull request #13340 from mhvk/quantity-unit-of-initial-argument-for-reductions

### DIFF
--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -603,6 +603,15 @@ class Quantity(np.ndarray):
             # Ensure output argument remains a tuple.
             kwargs['out'] = (out_array,) if function.nout == 1 else out_array
 
+        if method == 'reduce' and 'initial' in kwargs and unit is not None:
+            # Special-case for initial argument for reductions like
+            # np.add.reduce.  This should be converted to the output unit as
+            # well, which is typically the same as the input unit (but can
+            # in principle be different: unitless for np.equal, radian
+            # for np.arctan2, though those are not necessarily useful!)
+            kwargs['initial'] = self._to_own_unit(kwargs['initial'],
+                                                  check_precision=False, unit=unit)
+
         # Same for inputs, but here also convert if necessary.
         arrays = []
         for input_, converter in zip(inputs, converters):
@@ -1522,9 +1531,32 @@ class Quantity(np.ndarray):
         raise NotImplementedError("cannot make a list of Quantities.  Get "
                                   "list of values with q.value.tolist()")
 
-    def _to_own_unit(self, value, check_precision=True):
+    def _to_own_unit(self, value, check_precision=True, *, unit=None):
+        """Convert value to one's own unit (or that given).
+
+        Here, non-quantities are treated as dimensionless, and care is taken
+        for values of 0, infinity or nan, which are allowed to have any unit.
+
+        Parameters
+        ----------
+        value : anything convertible to `~astropy.units.Quantity`
+            The value to be converted to the requested unit.
+        check_precision : bool
+            Whether to forbit conversion of float to integer if that changes
+            the input number.  Default: `True`.
+        unit : `~astropy.units.Unit` or None
+            The unit to convert to.  By default, the unit of ``self``.
+
+        Returns
+        -------
+        value : number or `~numpy.ndarray`
+            In the requested units.
+
+        """
+        if unit is None:
+            unit = self.unit
         try:
-            _value = value.to_value(self.unit)
+            _value = value.to_value(unit)
         except AttributeError:
             # We're not a Quantity.
             # First remove two special cases (with a fast test):
@@ -1540,7 +1572,7 @@ class Quantity(np.ndarray):
             # but anything with a unit attribute will use that.
             try:
                 as_quantity = Quantity(value)
-                _value = as_quantity.to_value(self.unit)
+                _value = as_quantity.to_value(unit)
             except UnitsError:
                 # last chance: if this was not something with a unit
                 # and is all 0, inf, or nan, we treat it as arbitrary unit.
@@ -1841,9 +1873,18 @@ class Quantity(np.ndarray):
     def ediff1d(self, to_end=None, to_begin=None):
         return self._wrap_function(np.ediff1d, to_end, to_begin)
 
-    def nansum(self, axis=None, out=None, keepdims=False):
-        return self._wrap_function(np.nansum, axis,
-                                   out=out, keepdims=keepdims)
+    if NUMPY_LT_1_22:
+        def nansum(self, axis=None, out=None, keepdims=False):
+            return self._wrap_function(np.nansum, axis,
+                                       out=out, keepdims=keepdims)
+    else:
+        # TODO: deprecate this method? It is not on ndarray, and we do not
+        # support nanmean, etc., so why this one?
+        def nansum(self, axis=None, out=None, keepdims=False, *, initial=None, where=True):
+            if initial is not None:
+                initial = self._to_own_unit(initial)
+            return self._wrap_function(np.nansum, axis,
+                                       out=out, keepdims=keepdims, initial=initial, where=where)
 
     def insert(self, obj, values, axis=None):
         """

--- a/astropy/units/tests/test_quantity_array_methods.py
+++ b/astropy/units/tests/test_quantity_array_methods.py
@@ -270,7 +270,6 @@ class TestQuantityStatsFuncs:
         assert np.all(q1.round(decimals=2) == qi)
 
     def test_sum(self):
-
         q1 = np.array([1., 2., 6.]) * u.m
         assert np.all(q1.sum() == 9. * u.m)
         assert np.all(np.sum(q1) == 9. * u.m)
@@ -284,6 +283,30 @@ class TestQuantityStatsFuncs:
         qi = 1.5 * u.s
         np.sum(q1, out=qi)
         assert qi == 9. * u.m
+
+    def test_sum_where(self):
+
+        q1 = np.array([1., 2., 6., 7.]) * u.m
+        where = q1 < 7 * u.m
+        assert np.all(q1.sum(where=where) == 9. * u.m)
+        assert np.all(np.sum(q1, where=where) == 9. * u.m)
+
+    @pytest.mark.parametrize('initial', [0, 0*u.m, 1*u.km])
+    def test_sum_initial(self, initial):
+        q1 = np.array([1., 2., 6., 7.]) * u.m
+        expected = 16*u.m + initial
+        assert q1.sum(initial=initial) == expected
+        assert np.sum(q1, initial=initial) == expected
+
+    def test_sum_dimensionless_initial(self):
+        q1 = np.array([1., 2., 6., 7.]) * u.one
+        assert q1.sum(initial=1000) == 1016*u.one
+
+    @pytest.mark.parametrize('initial', [10, 1*u.s])
+    def test_sum_initial_exception(self, initial):
+        q1 = np.array([1., 2., 6., 7.]) * u.m
+        with pytest.raises(u.UnitsError):
+            q1.sum(initial=initial)
 
     def test_cumsum(self):
 

--- a/docs/changes/units/13340.bugfix.rst
+++ b/docs/changes/units/13340.bugfix.rst
@@ -1,0 +1,2 @@
+Ensure that the units of any ``initial`` argument to reductions such as
+``np.add.reduce`` (which underlies ``np.sum``) are properly taken into account.


### PR DESCRIPTION
Take into account units of `initial` argument to reductions

(cherry picked from commit 23e209a60afaadc19aab222eabcd0457012a16d0)

Note that it looks like another small PR was not backported to 5.0 when logically it might as well have been. That effectively is now corrected...

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
