### PR TITLE
Backport PR #13343 on branch v5.0.x (TST: Ignore RuntimeWarning when parsing regression.xml)

### DIFF
--- a/astropy/io/votable/tests/table_test.py
+++ b/astropy/io/votable/tests/table_test.py
@@ -23,7 +23,9 @@ from astropy.utils.misc import _NOT_OVERWRITING_MSG_MATCH
 
 def test_table(tmpdir):
     # Read the VOTABLE
-    votable = parse(get_pkg_data_filename('data/regression.xml'))
+    with np.errstate(over="ignore"):
+        # https://github.com/astropy/astropy/issues/13341
+        votable = parse(get_pkg_data_filename('data/regression.xml'))
     table = votable.get_first_table()
     astropy_table = table.to_table()
 
@@ -76,8 +78,10 @@ def test_table(tmpdir):
 
 
 def test_read_through_table_interface(tmpdir):
-    with get_pkg_data_fileobj('data/regression.xml', encoding='binary') as fd:
-        t = Table.read(fd, format='votable', table_id='main_table')
+    with np.errstate(over="ignore"):
+        # https://github.com/astropy/astropy/issues/13341
+        with get_pkg_data_fileobj('data/regression.xml', encoding='binary') as fd:
+            t = Table.read(fd, format='votable', table_id='main_table')
 
     assert len(t) == 5
 
@@ -97,8 +101,10 @@ def test_read_through_table_interface(tmpdir):
 
 
 def test_read_through_table_interface2():
-    with get_pkg_data_fileobj('data/regression.xml', encoding='binary') as fd:
-        t = Table.read(fd, format='votable', table_id='last_table')
+    with np.errstate(over="ignore"):
+        # https://github.com/astropy/astropy/issues/13341
+        with get_pkg_data_fileobj('data/regression.xml', encoding='binary') as fd:
+            t = Table.read(fd, format='votable', table_id='last_table')
 
     assert len(t) == 0
 

--- a/astropy/io/votable/tests/vo_test.py
+++ b/astropy/io/votable/tests/vo_test.py
@@ -44,14 +44,18 @@ def assert_validate_schema(filename, version):
 
 
 def test_parse_single_table():
-    table = parse_single_table(get_pkg_data_filename('data/regression.xml'))
+    with np.errstate(over="ignore"):
+        # https://github.com/astropy/astropy/issues/13341
+        table = parse_single_table(get_pkg_data_filename('data/regression.xml'))
     assert isinstance(table, tree.Table)
     assert len(table.array) == 5
 
 
 def test_parse_single_table2():
-    table2 = parse_single_table(get_pkg_data_filename('data/regression.xml'),
-                                table_number=1)
+    with np.errstate(over="ignore"):
+        # https://github.com/astropy/astropy/issues/13341
+        table2 = parse_single_table(get_pkg_data_filename('data/regression.xml'),
+                                    table_number=1)
     assert isinstance(table2, tree.Table)
     assert len(table2.array) == 1
     assert len(table2.array.dtype.names) == 28
@@ -189,8 +193,10 @@ def test_regression_binary2(tmpdir):
 
 class TestFixups:
     def setup_class(self):
-        self.table = parse(
-            get_pkg_data_filename('data/regression.xml')).get_first_table()
+        with np.errstate(over="ignore"):
+            # https://github.com/astropy/astropy/issues/13341
+            self.table = parse(
+                get_pkg_data_filename('data/regression.xml')).get_first_table()
         self.array = self.table.array
         self.mask = self.table.array.mask
 
@@ -201,7 +207,9 @@ class TestFixups:
 
 class TestReferences:
     def setup_class(self):
-        self.votable = parse(get_pkg_data_filename('data/regression.xml'))
+        with np.errstate(over="ignore"):
+            # https://github.com/astropy/astropy/issues/13341
+            self.votable = parse(get_pkg_data_filename('data/regression.xml'))
         self.table = self.votable.get_first_table()
         self.array = self.table.array
         self.mask = self.table.array.mask
@@ -265,7 +273,9 @@ def test_select_columns_by_name():
 
 class TestParse:
     def setup_class(self):
-        self.votable = parse(get_pkg_data_filename('data/regression.xml'))
+        with np.errstate(over="ignore"):
+            # https://github.com/astropy/astropy/issues/13341
+            self.votable = parse(get_pkg_data_filename('data/regression.xml'))
         self.table = self.votable.get_first_table()
         self.array = self.table.array
         self.mask = self.table.array.mask
@@ -594,7 +604,9 @@ class TestParse:
 
 class TestThroughTableData(TestParse):
     def setup_class(self):
-        votable = parse(get_pkg_data_filename('data/regression.xml'))
+        with np.errstate(over="ignore"):
+            # https://github.com/astropy/astropy/issues/13341
+            votable = parse(get_pkg_data_filename('data/regression.xml'))
 
         self.xmlout = bio = io.BytesIO()
         # W39: Bit values can not be masked
@@ -627,7 +639,9 @@ class TestThroughTableData(TestParse):
 
 class TestThroughBinary(TestParse):
     def setup_class(self):
-        votable = parse(get_pkg_data_filename('data/regression.xml'))
+        with np.errstate(over="ignore"):
+            # https://github.com/astropy/astropy/issues/13341
+            votable = parse(get_pkg_data_filename('data/regression.xml'))
         votable.get_first_table().format = 'binary'
 
         self.xmlout = bio = io.BytesIO()
@@ -656,7 +670,9 @@ class TestThroughBinary(TestParse):
 
 class TestThroughBinary2(TestParse):
     def setup_class(self):
-        votable = parse(get_pkg_data_filename('data/regression.xml'))
+        with np.errstate(over="ignore"):
+            # https://github.com/astropy/astropy/issues/13341
+            votable = parse(get_pkg_data_filename('data/regression.xml'))
         votable.version = '1.3'
         votable.get_first_table()._config['version_1_3_or_later'] = True
         votable.get_first_table().format = 'binary2'
@@ -710,6 +726,8 @@ def table_from_scratch():
     votable.to_xml(out)
 
 
+# https://github.com/astropy/astropy/issues/13341
+@np.errstate(over="ignore")
 def test_open_files():
     for filename in get_pkg_data_filenames('data', pattern='*.xml'):
         if (filename.endswith('custom_datatype.xml') or
@@ -821,7 +839,9 @@ def test_validate_path_object():
 
 
 def test_gzip_filehandles(tmpdir):
-    votable = parse(get_pkg_data_filename('data/regression.xml'))
+    with np.errstate(over="ignore"):
+        # https://github.com/astropy/astropy/issues/13341
+        votable = parse(get_pkg_data_filename('data/regression.xml'))
 
     # W39: Bit values can not be masked
     with pytest.warns(W39):

--- a/astropy/table/tests/test_showtable.py
+++ b/astropy/table/tests/test_showtable.py
@@ -1,6 +1,8 @@
 import os
 import re
 
+import numpy as np
+
 from astropy.table.scripts import showtable
 
 ROOT = os.path.abspath(os.path.dirname(__file__))
@@ -96,8 +98,10 @@ def test_ascii_delimiter(capsys):
 
 
 def test_votable(capsys):
-    showtable.main([os.path.join(VOTABLE_ROOT, 'data/regression.xml'),
-                    '--table-id', 'main_table', '--max-width', '50'])
+    with np.errstate(over="ignore"):
+        # https://github.com/astropy/astropy/issues/13341
+        showtable.main([os.path.join(VOTABLE_ROOT, 'data/regression.xml'),
+                        '--table-id', 'main_table', '--max-width', '50'])
     out, err = capsys.readouterr()
     assert out.splitlines() == [
         '   string_test    string_test_2 ... bitarray2 [16]',


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to manually backport #13343 onto branch `v5.0.x`.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
