### PR TITLE
Test docs build with Sphinx fork that fixes the inheritance-diagram links

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,6 +6,9 @@ build:
     - graphviz
   tools:
     python: "3.9"
+  jobs:
+    post_install:
+      - pip install -U git+https://github.com/ayshih/sphinx@svg_urls_3.5.4
 
 sphinx:
   builder: html


### PR DESCRIPTION
This is a test PR to confirm that the pending Sphinx PR (~sphinx-doc/sphinx#10576~) to fix the bug with links in inheritance diagrams does in fact fix the issue in Astropy's docs (#4935).  Do not merge this PR.

Edit: The relevant Sphinx PR is now sphinx-doc/sphinx#10614