### PR TITLE
Use `numpy.int64` instead of `int` in ASCII table outputter

### DIFF
--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -1092,13 +1092,18 @@ class BaseOutputter:
                     col.converters.pop(0)
                     last_err = err
                 except OverflowError as err:
-                    # Overflow during conversion (most likely an int that
-                    # doesn't fit in native C long). Put string at the top of
-                    # the converters list for the next while iteration.
-                    warnings.warn(
-                        "OverflowError converting to {} in column {}, reverting to String."
-                        .format(converter_type.__name__, col.name), AstropyWarning)
-                    col.converters.insert(0, convert_numpy(numpy.str))
+                        # Overflow during conversion (most likely an int that
+                        # doesn't fit in native C long).
+                    if converter_type == IntType and not isinstance(last_err, OverflowError):
+                        # First attempt: use an int64, which may help on 32-bit platforms
+                        col.converters[0] = convert_numpy(numpy.int64)
+                    else:
+                        # Last resort: Put string at the top of the
+                        # converters list for the next while iteration.
+                        warnings.warn(
+                            "OverflowError converting to {} in column {}, reverting to String."
+                            .format(converter_type.__name__, col.name), AstropyWarning)
+                        col.converters[0] = convert_numpy(numpy.str)
                     last_err = err
 
 

--- a/astropy/io/ascii/tests/test_c_reader.py
+++ b/astropy/io/ascii/tests/test_c_reader.py
@@ -1287,7 +1287,7 @@ def test_int_out_of_order(guess):
     shows up first, it will produce a string column - with both readers.
     Broken with the parallel fast_reader.
     """
-    imax = np.iinfo(int).max - 1
+    imax = np.iinfo(np.int64).max - 1
     text = f'A B\n 12.3 {imax:d}0\n {imax:d}0 45.6e7'
     expected = Table([[12.3, 10. * imax], [f'{imax:d}0', '45.6e7']],
                      names=('A', 'B'))

--- a/docs/changes/io.ascii/13359.bugfix.rst
+++ b/docs/changes/io.ascii/13359.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ASCII table handling for large numbers on 32-bit platforms


### PR DESCRIPTION
### Description

The `int` type in numpy seems arch dependent and different on arch platforms. 
For example, on an 32-bit platform:
```python
>>> import numpy as np
>>> np.array(9048843364125, int)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
OverflowError: Python int too large to convert to C long
```
while on a common 64-bit platform:
```python
>>> import numpy as np
>>> np.array(9048843364125, int)
array(9048843364125)
```
This creates a failure on astroquery for 32-bit platforms, https://github.com/astropy/astroquery/issues/2435

However, I am not sure whether this may be a problem of numpy itself?

Fixes astropy/astroquery#2435

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
