### PR TITLE
Fix for asdf-astropy downstream

### DIFF
--- a/astropy/io/misc/asdf/tags/time/tests/test_time.py
+++ b/astropy/io/misc/asdf/tags/time/tests/test_time.py
@@ -81,15 +81,23 @@ def test_time_with_location_1_0_0(tmpdir):
 
 
 def test_isot(tmpdir):
+    isot = time.Time('2000-01-01T00:00:00.000')
+
     tree = {
-        'time': time.Time('2000-01-01T00:00:00.000')
+        'time': isot
     }
 
     helpers.assert_roundtrip_tree(tree, tmpdir)
 
     ff = asdf.AsdfFile(tree)
     tree = yamlutil.custom_tree_to_tagged_tree(ff.tree, ff)
-    assert isinstance(tree['time'], str)
+    if isinstance(tree['time'], str):
+        assert str(tree['time']) == isot.value
+    elif isinstance(tree['time'], dict):
+        assert str(tree['time']['value']) == isot.value
+        assert str(tree['time']['base_format']) == "isot"
+    else:
+        assert False
 
 
 def test_isot_array(tmpdir):


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

`asdf-astropy` is showing downstream testing failures with `astropy` develop: https://github.com/astropy/asdf-astropy/runs/6961361487?check_suite_focus=true. This testing is to ensure that `asdf-astropy` satisfies the same tests that the depreciated `astropy.io.misc.asdf` code does. The test that is causing the failure is poorly written as it makes assumptions about the nature of what the asdf tree should be, which are invalid. This PR corrects this issue, by testing against a more general asdf tree.

Note that astropy should not install `asdf-astropy` during its normal testing because `asdf-astropy` will override all of the `astropy.io.misc.asdf` provided asdf extensions meaning that no code within `astropy.io.misc.asdf` will actually be functionally tested by the astropy unit tests. This is why `asdf-astropy` has elected to perform downstream testing that uncovered this poorly designed test.

I have personally ran the equivalent of the downstream test for `asdf-astropy` using this branch of `astropy` and have shown that it successfully passes now.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
