### PR TITLE
run pyupgrade on constants

### DIFF
--- a/astropy/constants/constant.py
+++ b/astropy/constants/constant.py
@@ -46,7 +46,7 @@ class ConstantMeta(type):
 
                 if (not self.system and
                         name_lower in self._has_incompatible_units):
-                    systems = sorted([x for x in instances if x])
+                    systems = sorted(x for x in instances if x)
                     raise TypeError(
                         'Constant {!r} does not have physically compatible '
                         'units across all systems of units and cannot be '
@@ -60,11 +60,11 @@ class ConstantMeta(type):
 
         # The wrapper applies to so many of the __ methods that it's easier to
         # just exclude the ones it doesn't apply to
-        exclude = set(['__new__', '__array_finalize__', '__array_wrap__',
-                       '__dir__', '__getattr__', '__init__', '__str__',
-                       '__repr__', '__hash__', '__iter__', '__getitem__',
-                       '__len__', '__bool__', '__quantity_subclass__',
-                       '__setstate__'])
+        exclude = {'__new__', '__array_finalize__', '__array_wrap__',
+                   '__dir__', '__getattr__', '__init__', '__str__',
+                   '__repr__', '__hash__', '__iter__', '__getitem__',
+                   '__len__', '__bool__', '__quantity_subclass__',
+                   '__setstate__'}
         for attr, value in vars(Quantity).items():
             if (isinstance(value, types.FunctionType) and
                     attr.startswith('__') and attr.endswith('__') and


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

I ran ``pyupgrade --py38-plus`` on ``astropy/constants``

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
