### PR TITLE
run pyupgrade on coordinates

### DIFF
--- a/astropy/coordinates/angle_lextab.py
+++ b/astropy/coordinates/angle_lextab.py
@@ -11,7 +11,7 @@
 
 # angle_lextab.py. This file automatically created by PLY (version 3.11). Don't edit!
 _tabversion   = '3.10'
-_lextokens    = set(('COLON', 'DEGREE', 'EASTWEST', 'HOUR', 'MINUTE', 'NORTHSOUTH', 'SECOND', 'SIGN', 'SIMPLE_UNIT', 'UFLOAT', 'UINT'))
+_lextokens    = {'COLON', 'DEGREE', 'EASTWEST', 'HOUR', 'MINUTE', 'NORTHSOUTH', 'SECOND', 'SIGN', 'SIMPLE_UNIT', 'UFLOAT', 'UINT'}
 _lexreflags   = 64
 _lexliterals  = ''
 _lexstateinfo = {'INITIAL': 'inclusive'}

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -784,7 +784,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
                 # to update as needed for this frame.
                 nms = repr_attrs[repr_diff_cls]['names']
                 uns = repr_attrs[repr_diff_cls]['units']
-                comptomap = dict([(m.reprname, m) for m in mappings])
+                comptomap = {m.reprname: m for m in mappings}
                 for i, c in enumerate(repr_diff_cls.attr_classes.keys()):
                     if c in comptomap:
                         mapp = comptomap[c]
@@ -1081,8 +1081,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
             # set of names and units, then use that.
             new_attrs = self.representation_info.get(representation_cls)
             if new_attrs and in_frame_units:
-                datakwargs = dict((comp, getattr(data, comp))
-                                  for comp in data.components)
+                datakwargs = {comp: getattr(data, comp) for comp in data.components}
                 for comp, new_attr_unit in zip(data.components, new_attrs['units']):
                     if new_attr_unit:
                         datakwargs[comp] = datakwargs[comp].to(new_attr_unit)
@@ -1096,8 +1095,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
                 # defined set of names and units, then use that.
                 new_attrs = self.representation_info.get(differential_cls)
                 if new_attrs and in_frame_units:
-                    diffkwargs = dict((comp, getattr(diff, comp))
-                                      for comp in diff.components)
+                    diffkwargs = {comp: getattr(diff, comp) for comp in diff.components}
                     for comp, new_attr_unit in zip(diff.components,
                                                    new_attrs['units']):
                         # Some special-casing to treat a situation where the
@@ -1408,8 +1406,8 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
                 comp_str, _, part2 = remainder.partition(')')
                 comp_names = comp_str.split(', ')
                 # Swap in frame-specific component names
-                invnames = dict([(nmrepr, nmpref) for nmpref, nmrepr
-                                 in self.representation_component_names.items()])
+                invnames = {nmrepr: nmpref
+                            for nmpref, nmrepr in self.representation_component_names.items()}
                 for i, name in enumerate(comp_names):
                     comp_names[i] = invnames.get(name, name)
                 # Reassemble the repr string

--- a/astropy/coordinates/funcs.py
+++ b/astropy/coordinates/funcs.py
@@ -209,9 +209,8 @@ def get_constellation(coord, short_name=False, constellation_list='iau'):
         cdata = data.get_pkg_data_contents('data/constellation_data_roman87.dat')
         ctable = ascii.read(cdata, names=['ral', 'rau', 'decl', 'name'])
         cnames = data.get_pkg_data_contents('data/constellation_names.dat', encoding='UTF8')
-        cnames_short_to_long = dict([(l[:3], l[4:])
-                                     for l in cnames.split('\n')
-                                     if not l.startswith('#')])
+        cnames_short_to_long = {l[:3]: l[4:] for l in cnames.split('\n')
+                                if not l.startswith('#')}
         cnames_long = np.array([cnames_short_to_long[nm] for nm in ctable['name']])
 
         _constellation_data['ctable'] = ctable

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -501,8 +501,7 @@ class BaseRepresentationOrDifferential(ShapedLikeNDArray):
     @property
     def _units(self):
         """Return a dictionary with the units of the coordinate components."""
-        return dict([(component, getattr(self, component).unit)
-                     for component in self.components])
+        return {cmpnt: getattr(self, cmpnt).unit for cmpnt in self.components}
 
     @property
     def _unitstr(self):
@@ -817,8 +816,7 @@ class BaseRepresentation(BaseRepresentationOrDifferential):
                              "as a dictionary with keys equal to a string "
                              "representation of the unit of the derivative "
                              "for each differential stored with this "
-                             "representation object ({0})"
-                             .format(self.differentials))
+                             f"representation object ({self.differentials})")
 
         new_diffs = dict()
         for k in self.differentials:
@@ -1010,9 +1008,8 @@ class BaseRepresentation(BaseRepresentationOrDifferential):
         """
         rep = super()._apply(method, *args, **kwargs)
 
-        rep._differentials = dict(
-            [(k, diff._apply(method, *args, **kwargs))
-             for k, diff in self._differentials.items()])
+        rep._differentials = {k: diff._apply(method, *args, **kwargs)
+                              for k, diff in self._differentials.items()}
         return rep
 
     def __setitem__(self, item, value):
@@ -1400,8 +1397,8 @@ class CartesianRepresentation(BaseRepresentation):
         # transformed representation
         rep = self.__class__(p, xyz_axis=-1, copy=False)
         # Handle differentials attached to this representation
-        new_diffs = dict((k, d.transform(matrix, self, rep))
-                         for k, d in self.differentials.items())
+        new_diffs = {k: d.transform(matrix, self, rep)
+                     for k, d in self.differentials.items()}
         return rep.with_differentials(new_diffs)
 
     def _combine_operation(self, op, other, reverse=False):
@@ -1654,8 +1651,8 @@ class UnitSphericalRepresentation(BaseRepresentation):
             lon, lat = erfa_ufunc.c2s(p)
             rep = self.__class__(lon=lon, lat=lat)
             # handle differentials
-            new_diffs = dict((k, d.transform(matrix, self, rep))
-                             for k, d in self.differentials.items())
+            new_diffs = {k: d.transform(matrix, self, rep)
+                         for k, d in self.differentials.items()}
             rep = rep.with_differentials(new_diffs)
 
         else:  # switch to dimensional representation
@@ -2050,8 +2047,8 @@ class SphericalRepresentation(BaseRepresentation):
         rep = self.__class__(lon=lon, lat=lat, distance=self.distance * ur)
 
         # handle differentials
-        new_diffs = dict((k, d.transform(matrix, self, rep))
-                         for k, d in self.differentials.items())
+        new_diffs = {k: d.transform(matrix, self, rep)
+                     for k, d in self.differentials.items()}
         return rep.with_differentials(new_diffs)
 
     def norm(self):
@@ -2255,8 +2252,8 @@ class PhysicsSphericalRepresentation(BaseRepresentation):
         # reapplying the distance scaling
         rep = self.__class__(phi=lon, theta=90*u.deg-lat, r=self.r * ur)
 
-        new_diffs = dict((k, d.transform(matrix, self, rep))
-                         for k, d in self.differentials.items())
+        new_diffs = {k: d.transform(matrix, self, rep)
+                     for k, d in self.differentials.items()}
         return rep.with_differentials(new_diffs)
 
     def norm(self):

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -37,7 +37,7 @@ class SkyCoordInfo(MixinInfo):
     required when the object is used as a mixin column within a table, but can
     be used as a general way to store meta information.
     """
-    attrs_from_parent = set(['unit'])  # Unit is read-only
+    attrs_from_parent = {'unit'}  # Unit is read-only
     _supports_indexing = False
 
     @staticmethod
@@ -927,7 +927,7 @@ class SkyCoord(ShapedLikeNDArray):
                 dir_values.add(name)
 
         # Add public attributes of self.frame
-        dir_values.update(set(attr for attr in dir(self.frame) if not attr.startswith('_')))
+        dir_values.update({attr for attr in dir(self.frame) if not attr.startswith('_')})
 
         # Add all possible frame attributes
         dir_values.update(frame_transform_graph.frame_attributes.keys())

--- a/astropy/coordinates/sky_coordinate_parsers.py
+++ b/astropy/coordinates/sky_coordinate_parsers.py
@@ -521,7 +521,7 @@ def _parse_coordinate_arg(coords, frame, units, init_kwargs):
             # Do some basic validation of the list elements: all have a length and all
             # lengths the same
             try:
-                n_coords = sorted(set(len(x) for x in vals))
+                n_coords = sorted({len(x) for x in vals})
             except Exception as err:
                 raise ValueError('One or more elements of input sequence '
                                  'does not have a length.') from err

--- a/astropy/coordinates/tests/accuracy/__init__.py
+++ b/astropy/coordinates/tests/accuracy/__init__.py
@@ -1,4 +1,3 @@
-
 """
 The modules in the accuracy testing subpackage are primarily intended for
 comparison with "known-good" (or at least "known-familiar") datasets. More

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -114,7 +114,7 @@ def test_frame_subclass_attribute_descriptor():
     assert mfk4.obstime.value == 'B1980.000'
     assert mfk4.newattr == 'newattr'
 
-    assert set(mfk4.get_frame_attr_names()) == set(['equinox', 'obstime', 'newattr'])
+    assert set(mfk4.get_frame_attr_names()) == {'equinox', 'obstime', 'newattr'}
 
     mfk4 = MyFK4(equinox='J1980.0', obstime='J1990.0', newattr='world')
     assert mfk4.equinox.value == 'J1980.000'

--- a/astropy/coordinates/tests/test_sites.py
+++ b/astropy/coordinates/tests/test_sites.py
@@ -1,4 +1,3 @@
-
 import pytest
 
 from astropy.tests.helper import assert_quantity_allclose

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -111,20 +111,20 @@ def test_round_tripping(frame0, frame1, equinox0, equinox1, obstime0, obstime1):
     attrs1 = {'equinox': equinox1, 'obstime': obstime1}
 
     # Remove None values
-    attrs0 = dict((k, v) for k, v in attrs0.items() if v is not None)
-    attrs1 = dict((k, v) for k, v in attrs1.items() if v is not None)
+    attrs0 = {k: v for k, v in attrs0.items() if v is not None}
+    attrs1 = {k: v for k, v in attrs1.items() if v is not None}
 
     # Go out and back
     sc = SkyCoord(RA, DEC, frame=frame0, **attrs0)
 
     # Keep only frame attributes for frame1
-    attrs1 = dict((attr, val) for attr, val in attrs1.items()
-                  if attr in frame1.get_frame_attr_names())
+    attrs1 = {attr: val for attr, val in attrs1.items()
+              if attr in frame1.get_frame_attr_names()}
     sc2 = sc.transform_to(frame1(**attrs1))
 
     # When coming back only keep frame0 attributes for transform_to
-    attrs0 = dict((attr, val) for attr, val in attrs0.items()
-                  if attr in frame0.get_frame_attr_names())
+    attrs0 = {attr: val for attr, val in attrs0.items()
+              if attr in frame0.get_frame_attr_names()}
     # also, if any are None, fill in with defaults
     for attrnm in frame0.get_frame_attr_names():
         if attrs0.get(attrnm, None) is None:

--- a/astropy/coordinates/tests/test_transformations.py
+++ b/astropy/coordinates/tests/test_transformations.py
@@ -271,8 +271,8 @@ def test_affine_transform_succeed(transfunc, rep):
     M, offset = transfunc(c, TCoo2)
 
     _rep = rep.to_cartesian()
-    diffs = dict([(k, diff.represent_as(r.CartesianDifferential, rep))
-                  for k, diff in rep.differentials.items()])
+    diffs = {k: diff.represent_as(r.CartesianDifferential, rep)
+             for k, diff in rep.differentials.items()}
     expected_rep = _rep.with_differentials(diffs)
 
     if M is not None:

--- a/astropy/coordinates/tests/test_velocity_corrs.py
+++ b/astropy/coordinates/tests/test_velocity_corrs.py
@@ -1,4 +1,3 @@
-
 import pytest
 
 import numpy as np

--- a/astropy/coordinates/transformations.py
+++ b/astropy/coordinates/transformations.py
@@ -511,8 +511,8 @@ class TransformGraph:
             if node not in nodes:
                 nodes.append(node)
         nodenames = []
-        invclsaliases = dict([(f, [k for k, v in self._cached_names.items() if v == f])
-                              for f in self.frame_set])
+        invclsaliases = {f: [k for k, v in self._cached_names.items() if v == f]
+                         for f in self.frame_set}
         for n in nodes:
             if n in invclsaliases:
                 aliases = '`\\n`'.join(invclsaliases[n])
@@ -1163,8 +1163,8 @@ class BaseAffineTransform(CoordinateTransform):
         # Convert the representation and differentials to cartesian without
         # having them attached to a frame
         rep = data.to_cartesian()
-        diffs = dict([(k, diff.represent_as(CartesianDifferential, data))
-                      for k, diff in data.differentials.items()])
+        diffs = {k: diff.represent_as(CartesianDifferential, data)
+                 for k, diff in data.differentials.items()}
         rep = rep.with_differentials(diffs)
 
         # Only do transform if matrix is specified. This is for speed in
@@ -1204,8 +1204,7 @@ class BaseAffineTransform(CoordinateTransform):
                 _unit_cls = fromcoord.data.differentials['s']._unit_differential
                 newdiff = newdiff.represent_as(_unit_cls, newrep)
 
-                kwargs = dict([(comp, getattr(newdiff, comp))
-                               for comp in newdiff.components])
+                kwargs = {comp: getattr(newdiff, comp) for comp in newdiff.components}
                 kwargs['d_distance'] = fromcoord.data.differentials['s'].d_distance
                 diffs = {'s': fromcoord.data.differentials['s'].__class__(
                     copy=False, **kwargs)}


### PR DESCRIPTION
I ran ``pyupgrade —py38-plus`` on ``astropy/coordinates``.
+ a few style corrections

Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
