### PR TITLE
run pyupgrade on io

### DIFF
--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -1602,7 +1602,7 @@ def _get_reader(Reader, Inputter=None, Outputter=None, **kwargs):
         else:
             del kwargs['fast_reader']  # Otherwise ignore fast_reader parameter
 
-    reader_kwargs = dict([k, v] for k, v in kwargs.items() if k not in extra_reader_pars)
+    reader_kwargs = {k: v for k, v in kwargs.items() if k not in extra_reader_pars}
     reader = Reader(**reader_kwargs)
 
     if Inputter is not None:
@@ -1711,7 +1711,7 @@ def _get_writer(Writer, fast_writer, **kwargs):
         kwargs['fast_writer'] = fast_writer
         return FAST_CLASSES[f'fast_{Writer._format_name}'](**kwargs)
 
-    writer_kwargs = dict([k, v] for k, v in kwargs.items() if k not in extra_writer_pars)
+    writer_kwargs = {k: v for k, v in kwargs.items() if k not in extra_writer_pars}
     writer = Writer(**writer_kwargs)
 
     if 'delimiter' in kwargs:

--- a/astropy/io/ascii/daophot.py
+++ b/astropy/io/ascii/daophot.py
@@ -86,7 +86,7 @@ class DaophotHeader(core.BaseHeader):
         self.col_widths = col_widths
 
         # merge the multi-line header data into single line data
-        coldef_dict = dict((k, sum(v, [])) for (k, v) in coldef_dict.items())
+        coldef_dict = {k: sum(v, []) for (k, v) in coldef_dict.items()}
 
         return coldef_dict
 

--- a/astropy/io/ascii/fixedwidth.py
+++ b/astropy/io/ascii/fixedwidth.py
@@ -132,7 +132,7 @@ class FixedWidthHeader(basic.BasicHeader):
                 # slice col_ends but expects inclusive col_ends on input (for
                 # more intuitive user interface).
                 line = self.get_line(lines, position_line)
-                if len(set(line) - set([self.splitter.delimiter, ' '])) != 1:
+                if len(set(line) - {self.splitter.delimiter, ' '}) != 1:
                     raise InconsistentTableError(
                         'Position line should only contain delimiters and '
                         'one other character, e.g. "--- ------- ---".')
@@ -142,7 +142,7 @@ class FixedWidthHeader(basic.BasicHeader):
                     # spaces are so common everywhere that practicality beats
                     # purity here.
                 charset = self.set_of_position_line_characters.union(
-                    set([self.splitter.delimiter, ' ']))
+                    {self.splitter.delimiter, ' '})
                 if not set(line).issubset(charset):
                     raise InconsistentTableError(
                         f'Characters in position line must be part of {charset}')
@@ -245,7 +245,7 @@ class FixedWidthData(basic.BasicData):
             vals_list.append(vals)
 
         for i, col in enumerate(self.cols):
-            col.width = max([len(vals[i]) for vals in vals_list])
+            col.width = max(len(vals[i]) for vals in vals_list)
             if self.header.start_line is not None:
                 col.width = max(col.width, len(col.info.name))
 

--- a/astropy/io/ascii/ipac.py
+++ b/astropy/io/ascii/ipac.py
@@ -518,7 +518,7 @@ class Ipac(basic.Basic):
 
         # get header and data as strings to find width of each column
         for i, col in enumerate(table.columns.values()):
-            col.headwidth = max([len(vals[i]) for vals in self.header.str_vals()])
+            col.headwidth = max(len(vals[i]) for vals in self.header.str_vals())
         # keep data_str_vals because they take some time to make
         data_str_vals = []
         col_str_iters = self.data.str_vals()
@@ -529,7 +529,7 @@ class Ipac(basic.Basic):
             # FIXME: In Python 3.4, use max([], default=0).
             # See: https://docs.python.org/3/library/functions.html#max
             if data_str_vals:
-                col.width = max([len(vals[i]) for vals in data_str_vals])
+                col.width = max(len(vals[i]) for vals in data_str_vals)
             else:
                 col.width = 0
 

--- a/astropy/io/ascii/mrt.py
+++ b/astropy/io/ascii/mrt.py
@@ -13,6 +13,7 @@ import math
 import warnings
 import numpy as np
 from io import StringIO
+from math import floor, ceil
 
 from . import core
 from . import fixedwidth, cds
@@ -237,7 +238,7 @@ class MrtHeader(cds.CdsHeader):
             vals_list.append(vals)
 
         for i, col in enumerate(self.cols):
-            col.width = max([len(vals[i]) for vals in vals_list])
+            col.width = max(len(vals[i]) for vals in vals_list)
             if self.start_line is not None:
                 col.width = max(col.width, len(col.info.name))
         widths = [col.width for col in self.cols]
@@ -268,7 +269,7 @@ class MrtHeader(cds.CdsHeader):
             col.has_null = isinstance(col, MaskedColumn)
 
             if col.format is not None:
-                col.formatted_width = max([len(sval) for sval in col.str_vals])
+                col.formatted_width = max(len(sval) for sval in col.str_vals)
 
             # Set MRTColumn type, size and format.
             if np.issubdtype(col.dtype, np.integer):
@@ -340,15 +341,14 @@ class MrtHeader(cds.CdsHeader):
                 if col.fortran_format[0] == 'I':
                     if abs(col.min) < MAX_COL_INTLIMIT and abs(col.max) < MAX_COL_INTLIMIT:
                         if col.min == col.max:
-                            lim_vals = "[{0}]".format(col.min)
+                            lim_vals = f"[{col.min}]"
                         else:
-                            lim_vals = "[{0}/{1}]".format(col.min, col.max)
+                            lim_vals = f"[{col.min}/{col.max}]"
                 elif col.fortran_format[0] in ('E', 'F'):
-                    lim_vals = "[{0}/{1}]".format(math.floor(col.min * 100) / 100.,
-                                                  math.ceil(col.max * 100) / 100.)
+                    lim_vals = f"[{floor(col.min * 100) / 100.}/{ceil(col.max * 100) / 100.}]"
 
             if lim_vals != '' or nullflag != '':
-                description = "{0}{1} {2}".format(lim_vals, nullflag, description)
+                description = f"{lim_vals}{nullflag} {description}"
 
             # Find the maximum label and description column widths.
             if len(col.name) > max_label_width:

--- a/astropy/io/ascii/tests/test_c_reader.py
+++ b/astropy/io/ascii/tests/test_c_reader.py
@@ -438,8 +438,8 @@ def test_quoted_fields(parallel, read_basic):
     ('data_start', -1),  # data_start negative
     ('quotechar', '##'),  # multi-char quote signifier
     ('header_start', -1),  # negative header_start
-    ('converters', dict((i + 1, ascii.convert_numpy(np.uint))
-                        for i in range(3))),  # passing converters
+    ('converters', {i + 1: ascii.convert_numpy(np.uint)
+                    for i in range(3)}),  # passing converters
     ('Inputter', ascii.ContinuationLinesInputter),  # passing Inputter
     ('header_Splitter', ascii.DefaultSplitter),  # passing Splitter
     ('data_Splitter', ascii.DefaultSplitter)])
@@ -1062,7 +1062,7 @@ def test_read_big_table(tmpdir):
     t = None
 
     print("Counting the number of lines in the csv, it should be {NB_ROWS} + 1 (header).")
-    with open(filename, 'r') as f:
+    with open(filename) as f:
         assert sum(1 for line in f) == NB_ROWS + 1
 
     print("Reading the file with astropy.")
@@ -1089,7 +1089,7 @@ def test_read_big_table2(tmpdir):
     t = None
 
     print("Counting the number of lines in the csv, it should be {NB_ROWS} + 1 (header).")
-    with open(filename, 'r') as f:
+    with open(filename) as f:
         assert sum(1 for line in f) == NB_ROWS + 1
 
     print("Reading the file with astropy.")

--- a/astropy/io/ascii/tests/test_c_reader.py
+++ b/astropy/io/ascii/tests/test_c_reader.py
@@ -438,8 +438,7 @@ def test_quoted_fields(parallel, read_basic):
     ('data_start', -1),  # data_start negative
     ('quotechar', '##'),  # multi-char quote signifier
     ('header_start', -1),  # negative header_start
-    ('converters', {i + 1: ascii.convert_numpy(np.uint)
-                    for i in range(3)}),  # passing converters
+    ('converters', {i + 1: ascii.convert_numpy(np.uint) for i in range(3)}),  # passing converters
     ('Inputter', ascii.ContinuationLinesInputter),  # passing Inputter
     ('header_Splitter', ascii.DefaultSplitter),  # passing Splitter
     ('data_Splitter', ascii.DefaultSplitter)])

--- a/astropy/io/ascii/tests/test_ecsv.py
+++ b/astropy/io/ascii/tests/test_ecsv.py
@@ -613,7 +613,7 @@ a
 
 def test_write_not_json_serializable():
     t = Table()
-    t['a'] = np.array([set([1, 2]), 1], dtype=object)
+    t['a'] = np.array([{1, 2}, 1], dtype=object)
     match = "could not convert column 'a' to string: Object of type set is not JSON serializable"
     out = StringIO()
     with pytest.raises(TypeError, match=match):

--- a/astropy/io/ascii/tests/test_html.py
+++ b/astropy/io/ascii/tests/test_html.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 """

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -1,9 +1,8 @@
-# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 from astropy.io.ascii.core import convert_numpy
 import re
-from io import BytesIO, open
+from io import BytesIO
 from collections import OrderedDict
 import locale
 import platform
@@ -266,8 +265,8 @@ def test_guess_all_files():
         print(f"\n\n******** READING {testfile['name']}")
         for filter_read_opts in (['Reader', 'delimiter', 'quotechar'], []):
             # Copy read options except for those in filter_read_opts
-            guess_opts = dict((k, v) for k, v in testfile['opts'].items()
-                              if k not in filter_read_opts)
+            guess_opts = {k: v for k, v in testfile['opts'].items()
+                          if k not in filter_read_opts}
             table = ascii.read(testfile['name'], guess=True, **guess_opts)
             assert_equal(table.dtype.names, testfile['cols'])
             for colname in table.dtype.names:
@@ -1478,7 +1477,7 @@ def test_read_chunks_input_types():
     fpath = 'data/test5.dat'
     t1 = ascii.read(fpath, header_start=1, data_start=3, )
 
-    with open(fpath, 'r') as fd1, open(fpath, 'r') as fd2:
+    with open(fpath) as fd1, open(fpath) as fd2:
         for fp in (fpath, fd1, fd2.read()):
             t_gen = ascii.read(fp, header_start=1, data_start=3,
                                guess=False, format='fast_basic',
@@ -1493,7 +1492,7 @@ def test_read_chunks_input_types():
             t2 = table.vstack(ts)
             assert np.all(t1 == t2)
 
-    with open(fpath, 'r') as fd1, open(fpath, 'r') as fd2:
+    with open(fpath) as fd1, open(fpath) as fd2:
         for fp in (fpath, fd1, fd2.read()):
             # Now read the full table in chunks
             t3 = ascii.read(fp, header_start=1, data_start=3,

--- a/astropy/io/ascii/tests/test_write.py
+++ b/astropy/io/ascii/tests/test_write.py
@@ -842,7 +842,7 @@ def test_write_newlines(fast_writer, tmpdir):
     t = table.Table([['a', 'b', 'c']], names=['col'])
     ascii.write(t, filename, fast_writer=fast_writer)
 
-    with open(filename, 'r', newline='') as f:
+    with open(filename, newline='') as f:
         content = f.read()
 
     assert content == os.linesep.join(['col', 'a', 'b', 'c']) + os.linesep

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -552,8 +552,7 @@ def _guess(table, read_kwargs, format, fast_reader):
             failed_kwargs.append(read_kwargs)
             lines = ['\nERROR: Unable to guess table format with the guesses listed below:']
             for kwargs in failed_kwargs:
-                sorted_keys = sorted([x for x in sorted(kwargs)
-                                      if x not in ('Reader', 'Outputter')])
+                sorted_keys = sorted(x for x in sorted(kwargs) if x not in ('Reader', 'Outputter'))
                 reader_repr = repr(kwargs.get('Reader', basic.Basic))
                 keys_vals = ['Reader:' + re.search(r"\.(\w+)'>", reader_repr).group(1)]
                 kwargs_sorted = ((key, kwargs[key]) for key in sorted_keys)

--- a/astropy/io/fits/diff.py
+++ b/astropy/io/fits/diff.py
@@ -285,10 +285,10 @@ class FITSDiff(_BaseDiff):
             close_b = False
 
         # Normalize keywords/fields to ignore to upper case
-        self.ignore_hdus = set(k.upper() for k in ignore_hdus)
-        self.ignore_keywords = set(k.upper() for k in ignore_keywords)
-        self.ignore_comments = set(k.upper() for k in ignore_comments)
-        self.ignore_fields = set(k.upper() for k in ignore_fields)
+        self.ignore_hdus = {k.upper() for k in ignore_hdus}
+        self.ignore_keywords = {k.upper() for k in ignore_keywords}
+        self.ignore_comments = {k.upper() for k in ignore_comments}
+        self.ignore_fields = {k.upper() for k in ignore_fields}
 
         self.numdiffs = numdiffs
         self.rtol = rtol

--- a/astropy/io/fits/hdu/table.py
+++ b/astropy/io/fits/hdu/table.py
@@ -1311,7 +1311,7 @@ class BinTableHDU(_TableBaseHDU):
         close_file = False
 
         if isinstance(fileobj, str):
-            fileobj = open(fileobj, 'r')
+            fileobj = open(fileobj)
             close_file = True
 
         initialpos = fileobj.tell()  # We'll be returning here later
@@ -1454,7 +1454,7 @@ class BinTableHDU(_TableBaseHDU):
         close_file = False
 
         if isinstance(fileobj, str):
-            fileobj = open(fileobj, 'r')
+            fileobj = open(fileobj)
             close_file = True
 
         columns = []

--- a/astropy/io/fits/header.py
+++ b/astropy/io/fits/header.py
@@ -501,7 +501,7 @@ class Header:
             # Otherwise assume we are reading from an actual FITS file and open
             # in binary mode.
             if sep:
-                fileobj = open(fileobj, 'r', encoding='latin1')
+                fileobj = open(fileobj, encoding='latin1')
             else:
                 fileobj = open(fileobj, 'rb')
 
@@ -820,7 +820,7 @@ class Header:
             A new :class:`Header` instance.
         """
 
-        tmp = self.__class__((copy.copy(card) for card in self._cards))
+        tmp = self.__class__(copy.copy(card) for card in self._cards)
         if strip:
             tmp.strip()
         return tmp

--- a/astropy/io/fits/scripts/fitsdiff.py
+++ b/astropy/io/fits/scripts/fitsdiff.py
@@ -78,7 +78,7 @@ class StoreListAction(argparse.Action):
                 log.warning(f'{self.dest} argument {value} does not exist')
                 return
             try:
-                values = [v.strip() for v in open(value, 'r').readlines()]
+                values = [v.strip() for v in open(value).readlines()]
                 setattr(namespace, self.dest, values)
             except OSError as exc:
                 log.warning('reading {} for {} failed: {}; ignoring this '

--- a/astropy/io/fits/tests/test_division.py
+++ b/astropy/io/fits/tests/test_division.py
@@ -24,7 +24,7 @@ class TestDivisionFunctions(FitsTestCase):
 
     def test_valid_hdu_size(self):
         with fits.open(self.data('tb.fits')) as t1:
-            assert type(t1[1].size) is type(1)  # noqa
+            assert type(t1[1].size) is int  # noqa
 
     def test_hdu_get_size(self):
         with fits.open(self.data('tb.fits')) as _:

--- a/astropy/io/fits/tests/test_hdulist.py
+++ b/astropy/io/fits/tests/test_hdulist.py
@@ -604,7 +604,7 @@ class TestHDUListFunctions(FitsTestCase):
         padding_len = 2880 - padding_start
         with open(self.temp('temp.fits'), 'r+b') as f:
             f.seek(padding_start)
-            f.write('\0'.encode('ascii') * padding_len)
+            f.write(b'\0' * padding_len)
 
         with pytest.warns(AstropyUserWarning, match='contains null bytes instead of spaces') as w:
             with fits.open(self.temp('temp.fits')) as hdul:

--- a/astropy/io/fits/tests/test_header.py
+++ b/astropy/io/fits/tests/test_header.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see PYFITS.rst
 
 import copy

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -978,8 +978,8 @@ class TestTableFunctions(FitsTestCase):
         """
 
         dtype = [
-            (str('x'), (str, 5)),        # 1D column of 5-character strings
-            (str('y'), (str, 3), (4,)),  # 2D column; each row is four 3-char strings
+            ('x', (str, 5)),        # 1D column of 5-character strings
+            ('y', (str, 3), (4,)),  # 2D column; each row is four 3-char strings
         ]
         data = np.zeros(2, dtype=dtype)
         data['x'] = ['abcde', 'xyz']

--- a/astropy/io/fits/verify.py
+++ b/astropy/io/fits/verify.py
@@ -165,7 +165,6 @@ class _ErrList(list):
                                            shift=shift)
                     yield first_line
 
-                for line in next_lines:
-                    yield line
+                yield from next_lines
 
                 element += 1

--- a/astropy/io/misc/asdf/connect.py
+++ b/astropy/io/misc/asdf/connect.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# -*- coding: utf-8 -*-
 # This file connects ASDF to the astropy.table.Table class
 import warnings
 

--- a/astropy/io/misc/asdf/extension.py
+++ b/astropy/io/misc/asdf/extension.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# -*- coding: utf-8 -*-
 
 import os
 

--- a/astropy/io/misc/asdf/tags/__init__.py
+++ b/astropy/io/misc/asdf/tags/__init__.py
@@ -1,2 +1,1 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# -*- coding: utf-8 -*-

--- a/astropy/io/misc/asdf/tags/coordinates/__init__.py
+++ b/astropy/io/misc/asdf/tags/coordinates/__init__.py
@@ -1,2 +1,1 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# -*- coding: utf-8 -*-

--- a/astropy/io/misc/asdf/tags/coordinates/angle.py
+++ b/astropy/io/misc/asdf/tags/coordinates/angle.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# -*- coding: utf-8 -*-
 from astropy.coordinates import Angle, Latitude, Longitude
 
 from astropy.io.misc.asdf.tags.unit.quantity import QuantityType

--- a/astropy/io/misc/asdf/tags/coordinates/earthlocation.py
+++ b/astropy/io/misc/asdf/tags/coordinates/earthlocation.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# -*- coding: utf-8 -*-
 from astropy.coordinates import EarthLocation
 from astropy.io.misc.asdf.types import AstropyType
 

--- a/astropy/io/misc/asdf/tags/coordinates/frames.py
+++ b/astropy/io/misc/asdf/tags/coordinates/frames.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# -*- coding: utf-8 -*-
 import os
 import glob
 import warnings

--- a/astropy/io/misc/asdf/tags/coordinates/skycoord.py
+++ b/astropy/io/misc/asdf/tags/coordinates/skycoord.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# -*- coding: utf-8 -*-
 from astropy.coordinates import SkyCoord
 from astropy.coordinates.tests.helper import skycoord_equal
 from astropy.io.misc.asdf.types import AstropyType

--- a/astropy/io/misc/asdf/tags/coordinates/spectralcoord.py
+++ b/astropy/io/misc/asdf/tags/coordinates/spectralcoord.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# -*- coding: utf-8 -*-
 from asdf.tags.core import NDArrayType
 
 from astropy.coordinates.spectral_coordinate import SpectralCoord

--- a/astropy/io/misc/asdf/tags/coordinates/tests/test_angle.py
+++ b/astropy/io/misc/asdf/tags/coordinates/tests/test_angle.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# -*- coding: utf-8 -*-
 
 import pytest
 

--- a/astropy/io/misc/asdf/tags/coordinates/tests/test_earthlocation.py
+++ b/astropy/io/misc/asdf/tags/coordinates/tests/test_earthlocation.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# -*- coding: utf-8 -*-
 
 import pytest
 

--- a/astropy/io/misc/asdf/tags/coordinates/tests/test_frames.py
+++ b/astropy/io/misc/asdf/tags/coordinates/tests/test_frames.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# -*- coding: utf-8 -*-
 
 import pytest
 

--- a/astropy/io/misc/asdf/tags/coordinates/tests/test_representation.py
+++ b/astropy/io/misc/asdf/tags/coordinates/tests/test_representation.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# -*- coding: utf-8 -*-
 import pytest
 
 asdf = pytest.importorskip('asdf')

--- a/astropy/io/misc/asdf/tags/coordinates/tests/test_skycoord.py
+++ b/astropy/io/misc/asdf/tags/coordinates/tests/test_skycoord.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# -*- coding: utf-8 -*-
 
 import numpy as np
 

--- a/astropy/io/misc/asdf/tags/coordinates/tests/test_spectralcoord.py
+++ b/astropy/io/misc/asdf/tags/coordinates/tests/test_spectralcoord.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# -*- coding: utf-8 -*-
 
 import pytest
 

--- a/astropy/io/misc/asdf/tags/fits/__init__.py
+++ b/astropy/io/misc/asdf/tags/fits/__init__.py
@@ -1,2 +1,1 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# -*- coding: utf-8 -*-

--- a/astropy/io/misc/asdf/tags/fits/fits.py
+++ b/astropy/io/misc/asdf/tags/fits/fits.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# -*- coding: utf-8 -*-
 from numpy.testing import assert_array_equal
 
 from astropy import table

--- a/astropy/io/misc/asdf/tags/fits/tests/test_fits.py
+++ b/astropy/io/misc/asdf/tags/fits/tests/test_fits.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# -*- coding: utf-8 -*-
 
 import pytest
 

--- a/astropy/io/misc/asdf/tags/helpers.py
+++ b/astropy/io/misc/asdf/tags/helpers.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# -*- coding: utf-8 -*-
 from astropy.coordinates.tests.helper import skycoord_equal as _skycoord_equal
 from astropy.utils.decorators import deprecated
 

--- a/astropy/io/misc/asdf/tags/table/__init__.py
+++ b/astropy/io/misc/asdf/tags/table/__init__.py
@@ -1,2 +1,1 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# -*- coding: utf-8 -*-

--- a/astropy/io/misc/asdf/tags/table/table.py
+++ b/astropy/io/misc/asdf/tags/table/table.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# -*- coding: utf-8 -*-
 import numpy as np
 
 from asdf.tags.core.ndarray import NDArrayType

--- a/astropy/io/misc/asdf/tags/table/tests/test_table.py
+++ b/astropy/io/misc/asdf/tags/table/tests/test_table.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# -*- coding: utf-8 -*-
 
 import pytest
 

--- a/astropy/io/misc/asdf/tags/tests/__init__.py
+++ b/astropy/io/misc/asdf/tags/tests/__init__.py
@@ -1,2 +1,1 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# -*- coding: utf-8 -*-

--- a/astropy/io/misc/asdf/tags/tests/helpers.py
+++ b/astropy/io/misc/asdf/tags/tests/helpers.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# -*- coding: utf-8 -*-
 import numpy as np
 
 

--- a/astropy/io/misc/asdf/tags/time/__init__.py
+++ b/astropy/io/misc/asdf/tags/time/__init__.py
@@ -1,2 +1,1 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# -*- coding: utf-8 -*-

--- a/astropy/io/misc/asdf/tags/time/tests/test_time.py
+++ b/astropy/io/misc/asdf/tags/time/tests/test_time.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# -*- coding: utf-8 -*-
 
 import pytest
 

--- a/astropy/io/misc/asdf/tags/time/tests/test_timedelta.py
+++ b/astropy/io/misc/asdf/tags/time/tests/test_timedelta.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# -*- coding: utf-8 -*-
 
 import pytest
 

--- a/astropy/io/misc/asdf/tags/time/time.py
+++ b/astropy/io/misc/asdf/tags/time/time.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# -*- coding: utf-8 -*-
 import numpy as np
 from numpy.testing import assert_array_equal
 
@@ -13,7 +12,7 @@ from astropy.io.misc.asdf.types import AstropyAsdfType
 
 __all__ = ['TimeType']
 
-_guessable_formats = set(['iso', 'byear', 'jyear', 'yday'])
+_guessable_formats = {'iso', 'byear', 'jyear', 'yday'}
 
 _astropy_format_to_asdf_format = {
     'isot': 'iso',

--- a/astropy/io/misc/asdf/tags/time/timedelta.py
+++ b/astropy/io/misc/asdf/tags/time/timedelta.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# -*- coding: utf-8 -*-
 import functools
 
 import numpy as np

--- a/astropy/io/misc/asdf/tags/transform/__init__.py
+++ b/astropy/io/misc/asdf/tags/transform/__init__.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# -*- coding: utf-8 -*-
 
 import astropy.units as u
 

--- a/astropy/io/misc/asdf/tags/transform/basic.py
+++ b/astropy/io/misc/asdf/tags/transform/basic.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# -*- coding: utf-8 -*-
 import numpy as np
 
 from asdf.versioning import AsdfVersion

--- a/astropy/io/misc/asdf/tags/transform/compound.py
+++ b/astropy/io/misc/asdf/tags/transform/compound.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# -*- coding: utf-8 -*-
 import warnings
 
 from asdf import tagged
@@ -113,8 +112,7 @@ class RemapAxesType(TransformType):
             return Mapping(tuple(mapping), n_inputs)
 
         if n_inputs is None:
-            n_inputs = max([x for x in mapping
-                            if isinstance(x, int)]) + 1
+            n_inputs = max(x for x in mapping if isinstance(x, int)) + 1
 
         transform = Identity(n_inputs)
         new_mapping = []

--- a/astropy/io/misc/asdf/tags/transform/functional_models.py
+++ b/astropy/io/misc/asdf/tags/transform/functional_models.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# -*- coding: utf-8 -*-
 from numpy.testing import assert_array_equal
 
 from astropy.modeling import functional_models

--- a/astropy/io/misc/asdf/tags/transform/math.py
+++ b/astropy/io/misc/asdf/tags/transform/math.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# -*- coding: utf-8 -*-
 from astropy.modeling.math_functions import __all__ as math_classes
 from astropy.modeling.math_functions import *
 from astropy.modeling import math_functions

--- a/astropy/io/misc/asdf/tags/transform/physical_models.py
+++ b/astropy/io/misc/asdf/tags/transform/physical_models.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# -*- coding: utf-8 -*-
 from numpy.testing import assert_array_equal
 
 from astropy.modeling import physical_models

--- a/astropy/io/misc/asdf/tags/transform/polynomial.py
+++ b/astropy/io/misc/asdf/tags/transform/polynomial.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# -*- coding: utf-8 -*-
 import numpy as np
 from numpy.testing import assert_array_equal
 
@@ -217,7 +216,7 @@ class OrthoPolynomialType(TransformType):
         'hermite': 4,
     }
 
-    invtypemap = dict([[v, k] for k, v in typemap.items()])
+    invtypemap = {v: k for k, v in typemap.items()}
 
     version = "1.0.0"
 

--- a/astropy/io/misc/asdf/tags/transform/powerlaws.py
+++ b/astropy/io/misc/asdf/tags/transform/powerlaws.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# -*- coding: utf-8 -*-
 from numpy.testing import assert_array_equal
 
 from astropy.modeling import powerlaws

--- a/astropy/io/misc/asdf/tags/transform/projections.py
+++ b/astropy/io/misc/asdf/tags/transform/projections.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# -*- coding: utf-8 -*-
 from numpy.testing import assert_array_equal
 
 from astropy import modeling

--- a/astropy/io/misc/asdf/tags/transform/tabular.py
+++ b/astropy/io/misc/asdf/tags/transform/tabular.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# -*- coding: utf-8 -*-
 import numpy as np
 from numpy.testing import assert_array_equal
 
@@ -30,14 +29,14 @@ class TabularType(TransformType):
                                               method=node['method'], bounds_error=node['bounds_error'],
                                               fill_value=fill_value)
         elif dim == 2:
-            points = tuple([p[:] for p in node['points']])
+            points = tuple(p[:] for p in node['points'])
             model = modeling.models.Tabular2D(points=points, lookup_table=lookup_table,
                                               method=node['method'], bounds_error=node['bounds_error'],
                                               fill_value=fill_value)
 
         else:
             tabular_class = modeling.models.tabular_model(dim, name)
-            points = tuple([p[:] for p in node['points']])
+            points = tuple(p[:] for p in node['points'])
             model = tabular_class(points=points, lookup_table=lookup_table,
                                   method=node['method'], bounds_error=node['bounds_error'],
                                   fill_value=fill_value)

--- a/astropy/io/misc/asdf/tags/transform/tests/test_transform.py
+++ b/astropy/io/misc/asdf/tags/transform/tests/test_transform.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# -*- coding: utf-8 -*-
 
 import pytest
 

--- a/astropy/io/misc/asdf/tags/unit/__init__.py
+++ b/astropy/io/misc/asdf/tags/unit/__init__.py
@@ -1,2 +1,1 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# -*- coding: utf-8 -*-

--- a/astropy/io/misc/asdf/tags/unit/equivalency.py
+++ b/astropy/io/misc/asdf/tags/unit/equivalency.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# -*- coding: utf-8 -*-
 from astropy.units.equivalencies import Equivalency
 from astropy.units import equivalencies
 from astropy.io.misc.asdf.types import AstropyType

--- a/astropy/io/misc/asdf/tags/unit/quantity.py
+++ b/astropy/io/misc/asdf/tags/unit/quantity.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# -*- coding: utf-8 -*-
 from asdf.tags.core import NDArrayType
 
 from astropy.units import Quantity

--- a/astropy/io/misc/asdf/tags/unit/tests/test_equivalency.py
+++ b/astropy/io/misc/asdf/tags/unit/tests/test_equivalency.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# -*- coding: utf-8 -*-
 
 import pytest
 

--- a/astropy/io/misc/asdf/tags/unit/tests/test_quantity.py
+++ b/astropy/io/misc/asdf/tags/unit/tests/test_quantity.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# -*- coding: utf-8 -*-
 
 import pytest
 

--- a/astropy/io/misc/asdf/tags/unit/tests/test_unit.py
+++ b/astropy/io/misc/asdf/tags/unit/tests/test_unit.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# -*- coding: utf-8 -*-
 
 import pytest
 

--- a/astropy/io/misc/asdf/tags/unit/unit.py
+++ b/astropy/io/misc/asdf/tags/unit/unit.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# -*- coding: utf-8 -*-
 from astropy.units import Unit, UnitBase
 from astropy.io.misc.asdf.types import AstropyAsdfType
 

--- a/astropy/io/misc/asdf/tests/__init__.py
+++ b/astropy/io/misc/asdf/tests/__init__.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# -*- coding: utf-8 -*-
 
 # Define a constant to know if the entry points are installed, since this impacts
 # whether we can run the tests.

--- a/astropy/io/misc/asdf/tests/test_io.py
+++ b/astropy/io/misc/asdf/tests/test_io.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# -*- coding: utf-8 -*-
 
 import pytest
 

--- a/astropy/io/misc/asdf/types.py
+++ b/astropy/io/misc/asdf/types.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# -*- coding: utf-8 -*-
 import warnings
 
 from asdf.types import CustomType, ExtensionTypeMeta

--- a/astropy/io/misc/hdf5.py
+++ b/astropy/io/misc/hdf5.py
@@ -170,7 +170,7 @@ def read_table_hdf5(input, path=None, character_as_bytes=True):
         if 'meta' in list(header.keys()):
             table.meta = header['meta']
 
-        header_cols = dict((x['name'], x) for x in header['datatype'])
+        header_cols = {x['name']: x for x in header['datatype']}
         for col in table.columns.values():
             for attr in ('description', 'format', 'unit', 'meta'):
                 if attr in header_cols[col.name]:

--- a/astropy/io/misc/parquet.py
+++ b/astropy/io/misc/parquet.py
@@ -212,7 +212,7 @@ def read_table_parquet(input, include_names=None, exclude_names=None,
                           f"Guessing {{strlen}} for schema.",
                           AstropyUserWarning)
         else:
-            strlen = max([len(row.as_py()) for row in pa_table[name]])
+            strlen = max(len(row.as_py()) for row in pa_table[name])
             warnings.warn(f"No {md_name} found in metadata. "
                           f"Using longest string ({{strlen}} characters).",
                           AstropyUserWarning)
@@ -231,7 +231,7 @@ def read_table_parquet(input, include_names=None, exclude_names=None,
     if meta_hdr is not None:
         # Set description, format, unit, meta from the column
         # metadata that was serialized with the table.
-        header_cols = dict((x['name'], x) for x in meta_hdr['datatype'])
+        header_cols = {x['name']: x for x in meta_hdr['datatype']}
         for col in table.columns.values():
             for attr in ('description', 'format', 'unit', 'meta'):
                 if attr in header_cols[col.name]:

--- a/astropy/io/registry/tests/test_registries.py
+++ b/astropy/io/registry/tests/test_registries.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 """

--- a/astropy/io/votable/exceptions.py
+++ b/astropy/io/votable/exceptions.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# -*- coding: utf-8 -*-
 """
 .. _warnings:
 

--- a/astropy/io/votable/tests/vo_test.py
+++ b/astropy/io/votable/tests/vo_test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 This is a set of regression tests for vo.
@@ -142,11 +141,9 @@ def _test_regression(tmpdir, _python_based=False, binary_mode=1):
 
     with open(
         get_pkg_data_filename(
-            f'data/regression.bin.tabledata.truth.{votable.version}.xml'),
-            'rt', encoding='utf-8') as fd:
+            f'data/regression.bin.tabledata.truth.{votable.version}.xml'), encoding='utf-8') as fd:
         truth = fd.readlines()
-    with open(str(tmpdir.join("regression.bin.tabledata.xml")),
-              'rt', encoding='utf-8') as fd:
+    with open(str(tmpdir.join("regression.bin.tabledata.xml")), encoding='utf-8') as fd:
         output = fd.readlines()
 
     # If the lines happen to be different, print a diff
@@ -806,8 +803,7 @@ def test_validate(test_path_object=False):
     #    fd.write(u''.join(output))
 
     with open(
-        get_pkg_data_filename('data/validation.txt'),
-            'rt', encoding='utf-8') as fd:
+        get_pkg_data_filename('data/validation.txt'), encoding='utf-8') as fd:
         truth = fd.readlines()
 
     truth = truth[1:]
@@ -978,8 +974,7 @@ def test_no_resource_check():
     #     fd.write(u''.join(output))
 
     with open(
-        get_pkg_data_filename('data/no_resource.txt'),
-            'rt', encoding='utf-8') as fd:
+        get_pkg_data_filename('data/no_resource.txt'), encoding='utf-8') as fd:
         truth = fd.readlines()
 
     truth = truth[1:]

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -2113,8 +2113,7 @@ class Group(Element, _IDProperty, _NameProperty, _UtypeProperty,
             if isinstance(entry, Param):
                 yield entry
             elif isinstance(entry, Group):
-                for field in entry.iter_fields_and_params():
-                    yield field
+                yield from entry.iter_fields_and_params()
 
     def iter_groups(self):
         """
@@ -2124,8 +2123,7 @@ class Group(Element, _IDProperty, _NameProperty, _UtypeProperty,
         for entry in self.entries:
             if isinstance(entry, Group):
                 yield entry
-                for group in entry.iter_groups():
-                    yield group
+                yield from entry.iter_groups()
 
 
 class Table(Element, _IDProperty, _NameProperty, _UcdProperty,
@@ -3041,13 +3039,10 @@ class Table(Element, _IDProperty, _NameProperty, _UcdProperty,
         Recursively iterate over all FIELD and PARAM elements in the
         TABLE.
         """
-        for param in self.params:
-            yield param
-        for field in self.fields:
-            yield field
+        yield from self.params
+        yield from self.fields
         for group in self.groups:
-            for field in group.iter_fields_and_params():
-                yield field
+            yield from group.iter_fields_and_params()
 
     get_field_by_id = _lookup_by_attr_factory(
         'ID', True, 'iter_fields_and_params', 'FIELD or PARAM',
@@ -3074,8 +3069,7 @@ class Table(Element, _IDProperty, _NameProperty, _UcdProperty,
         """
         for group in self.groups:
             yield group
-            for g in group.iter_groups():
-                yield g
+            yield from group.iter_groups()
 
     get_group_by_id = _lookup_by_attr_factory(
         'ID', True, 'iter_groups', 'GROUP',
@@ -3092,8 +3086,7 @@ class Table(Element, _IDProperty, _NameProperty, _UcdProperty,
         """)
 
     def iter_info(self):
-        for info in self.infos:
-            yield info
+        yield from self.infos
 
 
 class Resource(Element, _IDProperty, _NameProperty, _UtypeProperty,
@@ -3319,61 +3312,49 @@ class Resource(Element, _IDProperty, _NameProperty, _UtypeProperty,
         Recursively iterates over all tables in the resource and
         nested resources.
         """
-        for table in self.tables:
-            yield table
+        yield from self.tables
         for resource in self.resources:
-            for table in resource.iter_tables():
-                yield table
+            yield from resource.iter_tables()
 
     def iter_fields_and_params(self):
         """
         Recursively iterates over all FIELD_ and PARAM_ elements in
         the resource, its tables and nested resources.
         """
-        for param in self.params:
-            yield param
+        yield from self.params
         for table in self.tables:
-            for param in table.iter_fields_and_params():
-                yield param
+            yield from table.iter_fields_and_params()
         for resource in self.resources:
-            for param in resource.iter_fields_and_params():
-                yield param
+            yield from resource.iter_fields_and_params()
 
     def iter_coosys(self):
         """
         Recursively iterates over all the COOSYS_ elements in the
         resource and nested resources.
         """
-        for coosys in self.coordinate_systems:
-            yield coosys
+        yield from self.coordinate_systems
         for resource in self.resources:
-            for coosys in resource.iter_coosys():
-                yield coosys
+            yield from resource.iter_coosys()
 
     def iter_timesys(self):
         """
         Recursively iterates over all the TIMESYS_ elements in the
         resource and nested resources.
         """
-        for timesys in self.time_systems:
-            yield timesys
+        yield from self.time_systems
         for resource in self.resources:
-            for timesys in resource.iter_timesys():
-                yield timesys
+            yield from resource.iter_timesys()
 
     def iter_info(self):
         """
         Recursively iterates over all the INFO_ elements in the
         resource and nested resources.
         """
-        for info in self.infos:
-            yield info
+        yield from self.infos
         for table in self.tables:
-            for info in table.iter_info():
-                yield info
+            yield from table.iter_info()
         for resource in self.resources:
-            for info in resource.iter_info():
-                yield info
+            yield from resource.iter_info()
 
 
 class VOTableFile(Element, _IDProperty, _DescriptionProperty):
@@ -3704,8 +3685,7 @@ class VOTableFile(Element, _IDProperty, _DescriptionProperty):
         ignoring the nesting of resources etc.
         """
         for resource in self.resources:
-            for table in resource.iter_tables():
-                yield table
+            yield from resource.iter_tables()
 
     def get_first_table(self):
         """
@@ -3747,8 +3727,7 @@ class VOTableFile(Element, _IDProperty, _DescriptionProperty):
         VOTABLE_ file.
         """
         for resource in self.resources:
-            for field in resource.iter_fields_and_params():
-                yield field
+            yield from resource.iter_fields_and_params()
 
     get_field_by_id = _lookup_by_attr_factory(
         'ID', True, 'iter_fields_and_params', 'FIELD',
@@ -3791,8 +3770,7 @@ class VOTableFile(Element, _IDProperty, _DescriptionProperty):
         file.
         """
         for table in self.iter_tables():
-            for group in table.iter_groups():
-                yield group
+            yield from table.iter_groups()
 
     get_group_by_id = _lookup_by_attr_factory(
         'ID', True, 'iter_groups', 'GROUP',
@@ -3813,11 +3791,9 @@ class VOTableFile(Element, _IDProperty, _DescriptionProperty):
         Recursively iterate over all COOSYS_ elements in the VOTABLE_
         file.
         """
-        for coosys in self.coordinate_systems:
-            yield coosys
+        yield from self.coordinate_systems
         for resource in self.resources:
-            for coosys in resource.iter_coosys():
-                yield coosys
+            yield from resource.iter_coosys()
 
     get_coosys_by_id = _lookup_by_attr_factory(
         'ID', True, 'iter_coosys', 'COOSYS',
@@ -3828,11 +3804,9 @@ class VOTableFile(Element, _IDProperty, _DescriptionProperty):
         Recursively iterate over all TIMESYS_ elements in the VOTABLE_
         file.
         """
-        for timesys in self.time_systems:
-            yield timesys
+        yield from self.time_systems
         for resource in self.resources:
-            for timesys in resource.iter_timesys():
-                yield timesys
+            yield from resource.iter_timesys()
 
     get_timesys_by_id = _lookup_by_attr_factory(
         'ID', True, 'iter_timesys', 'TIMESYS',
@@ -3843,11 +3817,9 @@ class VOTableFile(Element, _IDProperty, _DescriptionProperty):
         Recursively iterate over all INFO_ elements in the VOTABLE_
         file.
         """
-        for info in self.infos:
-            yield info
+        yield from self.infos
         for resource in self.resources:
-            for info in resource.iter_info():
-                yield info
+            yield from resource.iter_info()
 
     get_info_by_id = _lookup_by_attr_factory(
         'ID', True, 'iter_info', 'INFO',

--- a/astropy/io/votable/ucd.py
+++ b/astropy/io/votable/ucd.py
@@ -30,8 +30,7 @@ class UCDWords:
         with data.get_pkg_data_fileobj(
                 "data/ucd1p-words.txt", encoding='ascii') as fd:
             for line in fd.readlines():
-                type, name, descr = [
-                    x.strip() for x in line.split('|')]
+                type, name, descr = (x.strip() for x in line.split('|'))
                 name_lower = name.lower()
                 if type in 'QPEVC':
                     self._primary.add(name_lower)

--- a/astropy/io/votable/util.py
+++ b/astropy/io/votable/util.py
@@ -86,14 +86,14 @@ def convert_to_writable_filelike(fd, compressed=False):
 
 
 # <http://www.ivoa.net/documents/REC/DM/STC-20071030.html>
-stc_reference_frames = set([
+stc_reference_frames = {
     'FK4', 'FK5', 'ECLIPTIC', 'ICRS', 'GALACTIC', 'GALACTIC_I', 'GALACTIC_II',
     'SUPER_GALACTIC', 'AZ_EL', 'BODY', 'GEO_C', 'GEO_D', 'MAG', 'GSE', 'GSM',
     'SM', 'HGC', 'HGS', 'HEEQ', 'HRTN', 'HPC', 'HPR', 'HCC', 'HGI',
     'MERCURY_C', 'VENUS_C', 'LUNA_C', 'MARS_C', 'JUPITER_C_III',
     'SATURN_C_III', 'URANUS_C_III', 'NEPTUNE_C_III', 'PLUTO_C', 'MERCURY_G',
     'VENUS_G', 'LUNA_G', 'MARS_G', 'JUPITER_G_III', 'SATURN_G_III',
-    'URANUS_G_III', 'NEPTUNE_G_III', 'PLUTO_G', 'UNKNOWNFrame'])
+    'URANUS_G_III', 'NEPTUNE_G_III', 'PLUTO_G', 'UNKNOWNFrame'}
 
 
 def coerce_range_list_param(p, frames=None, numeric=True):

--- a/astropy/io/votable/validator/result.py
+++ b/astropy/io/votable/validator/result.py
@@ -99,7 +99,7 @@ class Result:
         def fail(reason):
             reason = str(reason)
             with open(path, 'wb') as fd:
-                fd.write(f'FAILED: {reason}\n'.encode('utf-8'))
+                fd.write(f'FAILED: {reason}\n'.encode())
             self['network_error'] = reason
 
         r = None
@@ -116,7 +116,7 @@ class Result:
         except http.client.HTTPException as e:
             fail(f"HTTPException: {str(e)}")
             return
-        except (socket.timeout, socket.error) as e:
+        except (socket.timeout, OSError) as e:
             fail("Timeout")
             return
 


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

I ran ``pyupgrade —py38-plus`` on ``astropy/io``.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
