### PR TITLE
run pyupgrade on modeling

### DIFF
--- a/astropy/modeling/bounding_box.py
+++ b/astropy/modeling/bounding_box.py
@@ -658,7 +658,7 @@ class ModelBoundingBox(_BoundingDomain):
             if order == 'C':
                 inputs = inputs[::-1]
 
-            bbox = tuple([tuple(self[input_name]) for input_name in inputs])
+            bbox = tuple(tuple(self[input_name]) for input_name in inputs)
             if len(bbox) == 1:
                 bbox = bbox[0]
 
@@ -1152,7 +1152,7 @@ class _SelectorArguments(tuple):
         *inputs :
             All the processed model evaluation inputs.
         """
-        return tuple([argument.get_selector(*inputs) for argument in self])
+        return tuple(argument.get_selector(*inputs) for argument in self)
 
     def is_selector(self, _selector):
         """
@@ -1177,7 +1177,7 @@ class _SelectorArguments(tuple):
         values : dict
             Dictionary of fixed inputs.
         """
-        return tuple([argument.get_fixed_value(model, values) for argument in self])
+        return tuple(argument.get_fixed_value(model, values) for argument in self)
 
     def is_argument(self, model, argument) -> bool:
         """
@@ -1265,7 +1265,7 @@ class _SelectorArguments(tuple):
         model : `~astropy.modeling.Model`
             The Model these selector arguments are for.
         """
-        return tuple([selector_arg.named_tuple(model) for selector_arg in self])
+        return tuple(selector_arg.named_tuple(model) for selector_arg in self)
 
 
 class CompoundBoundingBox(_BoundingDomain):

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -127,7 +127,7 @@ class _ModelMeta(abc.ABCMeta):
         return cls
 
     def __init__(cls, name, bases, members, **kwds):
-        super(_ModelMeta, cls).__init__(name, bases, members, **kwds)
+        super().__init__(name, bases, members, **kwds)
         cls._create_inverse_property(members)
         cls._create_bounding_box_property(members)
         pdict = {}
@@ -1835,7 +1835,7 @@ class Model(metaclass=_ModelMeta):
             annotations.pop('return', None)
             if annotations:
                 # If there are not annotations for all inputs this will error.
-                return dict((name, annotations[name]) for name in self.inputs)
+                return {name: annotations[name] for name in self.inputs}
         else:
             # None means any unit is accepted
             return None
@@ -2120,8 +2120,8 @@ class Model(metaclass=_ModelMeta):
             else:
                 return_units = self.return_units
 
-            outputs = tuple([Quantity(out, return_units.get(out_name, None), subok=True)
-                             for out, out_name in zip(outputs, self.outputs)])
+            outputs = tuple(Quantity(out, return_units.get(out_name, None), subok=True)
+                             for out, out_name in zip(outputs, self.outputs))
         return outputs
 
     @staticmethod
@@ -3534,7 +3534,7 @@ class CompoundModel(Model):
                     param_map[new_param_name] = (lindex, param_name)
         self._param_metrics = {}
         self._param_map = param_map
-        self._param_map_inverse = dict((v, k) for k, v in param_map.items())
+        self._param_map_inverse = {v: k for k, v in param_map.items()}
         self._initialize_slices()
         self._param_names = tuple(self._param_names)
 
@@ -4014,8 +4014,8 @@ def binary_operation(binoperator, left, right):
     Perform binary operation. Operands may be matching tuples of operands.
     '''
     if isinstance(left, tuple) and isinstance(right, tuple):
-        return tuple([binoperator(item[0], item[1])
-                      for item in zip(left, right)])
+        return tuple(binoperator(item[0], item[1])
+                      for item in zip(left, right))
     return binoperator(left, right)
 
 
@@ -4088,7 +4088,7 @@ def fix_inputs(modelinstance, values, bounding_boxes=None, selector_args=None):
     model = CompoundModel('fix_inputs', modelinstance, values)
     if bounding_boxes is not None:
         if selector_args is None:
-            selector_args = tuple([(key, True) for key in values.keys()])
+            selector_args = tuple((key, True) for key in values.keys())
         bbox = CompoundBoundingBox.validate(modelinstance, bounding_boxes, selector_args)
         _selector = bbox.selector_args.get_fixed_values(modelinstance, values)
 

--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -70,7 +70,7 @@ class Covariance():
     def pprint(self, max_lines, round_val):
         # Print and label lower triangle of covariance matrix
         # Print rows for params up to `max_lines`, round floats to 'round_val'
-        longest_name = max([len(x) for x in self.param_names])
+        longest_name = max(len(x) for x in self.param_names)
         ret_str = 'parameter variances / covariances \n'
         fstring = f'{"": <{longest_name}}| {{0}}\n'
         for i, row in enumerate(self.cov_matrix):
@@ -112,7 +112,7 @@ class StandardDeviations():
         return stds
 
     def pprint(self, max_lines, round_val):
-        longest_name = max([len(x) for x in self.param_names])
+        longest_name = max(len(x) for x in self.param_names)
         ret_str = 'standard deviations\n'
         for i, std in enumerate(self.stds):
             if i <= max_lines-1:

--- a/astropy/modeling/polynomial.py
+++ b/astropy/modeling/polynomial.py
@@ -1693,10 +1693,8 @@ class InverseSIP(Model):
         ap_coeff.setdefault('AP_0_0', 0)
         bp_coeff.setdefault('BP_0_0', 0)
 
-        ap_coeff_params = dict((k.replace('AP_', 'c'), v)
-                               for k, v in ap_coeff.items())
-        bp_coeff_params = dict((k.replace('BP_', 'c'), v)
-                               for k, v in bp_coeff.items())
+        ap_coeff_params = {k.replace('AP_', 'c'): v for k, v in ap_coeff.items()}
+        bp_coeff_params = {k.replace('BP_', 'c'): v for k, v in bp_coeff.items()}
 
         self.sip1d_ap = Polynomial2D(degree=ap_order,
                                      model_set_axis=model_set_axis,

--- a/astropy/modeling/projections.py
+++ b/astropy/modeling/projections.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# -*- coding: utf-8 -*-
 # pylint: disable=invalid-name
 """
 Implements projections--particularly sky projections defined in WCS Paper II
@@ -162,7 +161,7 @@ class Pix2SkyProjection(Projection):
     def __new__(cls, *args, **kwargs):
         long_name = cls.name.split('_')[1]
         cls.prj_code = _PROJ_NAME_CODE_MAP[long_name]
-        return super(Pix2SkyProjection, cls).__new__(cls)
+        return super().__new__(cls)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -209,7 +208,7 @@ class Sky2PixProjection(Projection):
     def __new__(cls, *args, **kwargs):
         long_name = cls.name.split('_')[1]
         cls.prj_code = _PROJ_NAME_CODE_MAP[long_name]
-        return super(Sky2PixProjection, cls).__new__(cls)
+        return super().__new__(cls)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/astropy/modeling/tabular.py
+++ b/astropy/modeling/tabular.py
@@ -117,7 +117,7 @@ class _Tabular(Model):
                     "Expected grid points in "
                     f"{lookup_table.ndim} directions, got {npts}.")
             if (npts > 1 and isinstance(points[0], u.Quantity) and
-                    len(set([getattr(p, 'unit', None) for p in points])) > 1):
+                    len({getattr(p, 'unit', None) for p in points}) > 1):
                 raise ValueError('points must all have the same unit.')
 
         if isinstance(fill_value, u.Quantity):
@@ -161,7 +161,7 @@ class _Tabular(Model):
         pts = self.points[0]
         if not isinstance(pts, u.Quantity):
             return None
-        return dict([(x, pts.unit) for x in self.inputs])
+        return {x: pts.unit for x in self.inputs}
 
     @property
     def return_units(self):

--- a/astropy/modeling/tests/test_bounding_box.py
+++ b/astropy/modeling/tests/test_bounding_box.py
@@ -377,7 +377,7 @@ class Test_BoundingDomain:
     def test___call__(self):
         bounding_box = self.BoundingDomain(mk.MagicMock())
 
-        args = tuple([mk.MagicMock() for _ in range(3)])
+        args = tuple(mk.MagicMock() for _ in range(3))
         kwargs = {f"test{idx}": mk.MagicMock() for idx in range(3)}
 
         with pytest.raises(RuntimeError) as err:

--- a/astropy/modeling/tests/test_models_quantities.py
+++ b/astropy/modeling/tests/test_models_quantities.py
@@ -344,7 +344,7 @@ POLY_MODELS = [
 MODELS = (FUNC_MODELS_1D + SCALE_MODELS + FUNC_MODELS_2D + POWERLAW_MODELS +
           PHYS_MODELS_1D + POLY_MODELS)
 
-SCIPY_MODELS = set([Sersic1D, Sersic2D, AiryDisk2D])
+SCIPY_MODELS = {Sersic1D, Sersic2D, AiryDisk2D}
 
 # These models will fail fitting test, because built in fitting data
 #   will produce non-finite values

--- a/astropy/modeling/tests/test_parameters.py
+++ b/astropy/modeling/tests/test_parameters.py
@@ -126,7 +126,7 @@ def test__tofloat():
     assert str(err.value) == message
 
     # other
-    class Value(object):
+    class Value:
         pass
     with pytest.raises(InputParameterError) as err:
         _tofloat(Value)

--- a/astropy/modeling/tests/test_spline.py
+++ b/astropy/modeling/tests/test_spline.py
@@ -85,11 +85,11 @@ class TestSpline:
         spl = self.Spline()
         assert spl.param_names == ()
 
-        knot_names = tuple([mk.MagicMock() for _ in range(3)])
+        knot_names = tuple(mk.MagicMock() for _ in range(3))
         spl._knot_names = knot_names
         assert spl.param_names == knot_names
 
-        coeff_names = tuple([mk.MagicMock() for _ in range(3)])
+        coeff_names = tuple(mk.MagicMock() for _ in range(3))
         spl._coeff_names = coeff_names
         assert spl.param_names == knot_names + coeff_names
 
@@ -186,7 +186,7 @@ class TestSpline:
     def test___call__(self):
         spl = self.Spline()
 
-        args = tuple([mk.MagicMock() for _ in range(3)])
+        args = tuple(mk.MagicMock() for _ in range(3))
         kwargs = {f"test{idx}": mk.MagicMock() for idx in range(3)}
         new_kwargs = {f"new_test{idx}": mk.MagicMock() for idx in range(3)}
         with mk.patch.object(_Spline, "_intercept_optional_inputs",
@@ -267,7 +267,7 @@ class TestSpline:
         with mk.patch.object(_Spline, '_create_parameter',
                              autospec=True) as mkCreate:
             params = spl._create_parameters("test_param", "test", fixed)
-            assert params == tuple([f"test_param{idx}" for idx in range(20)])
+            assert params == tuple(f"test_param{idx}" for idx in range(20))
             assert mkCreate.call_args_list == [
                 mk.call(spl, f"test_param{idx}", idx, 'test', fixed) for idx in range(20)
             ]
@@ -1048,7 +1048,7 @@ class TestSpline1D:
     def test_evaluate(self):
         spl = Spline1D()
 
-        args = tuple([mk.MagicMock() for _ in range(3)])
+        args = tuple(mk.MagicMock() for _ in range(3))
         kwargs = {f"test{idx}": mk.MagicMock() for idx in range(3)}
         new_kwargs = {f"new_test{idx}": mk.MagicMock() for idx in range(3)}
 


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

I ran ``pyupgrade —py38-plus`` on ``astropy/modeling``.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
