### PR TITLE
run pyupgrade on nddata

### DIFF
--- a/astropy/nddata/ccddata.py
+++ b/astropy/nddata/ccddata.py
@@ -458,8 +458,8 @@ _KEEP_THESE_KEYWORDS_IN_HEADER = [
     'MJD-OBS',
     'DATE-OBS'
 ]
-_PCs = set(['PC1_1', 'PC1_2', 'PC2_1', 'PC2_2'])
-_CDs = set(['CD1_1', 'CD1_2', 'CD2_1', 'CD2_2'])
+_PCs = {'PC1_1', 'PC1_2', 'PC2_1', 'PC2_2'}
+_CDs = {'CD1_1', 'CD1_2', 'CD2_1', 'CD2_2'}
 
 
 def _generate_wcs_and_update_header(hdr):

--- a/astropy/nddata/mixins/tests/test_ndio.py
+++ b/astropy/nddata/mixins/tests/test_ndio.py
@@ -1,4 +1,3 @@
-
 from astropy.nddata import NDData, NDIOMixin, NDDataRef
 
 


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

I ran ``pyupgrade —py38-plus`` on ``astropy/nddata``.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
