### PR TITLE
run pyupgrade on Samp

### DIFF
--- a/astropy/samp/client.py
+++ b/astropy/samp/client.py
@@ -95,7 +95,7 @@ class SAMPClient:
             try:
                 self._host_name = socket.getfqdn()
                 socket.getaddrinfo(self._addr or self._host_name, self._port or 0)
-            except socket.error:
+            except OSError:
                 self._host_name = "127.0.0.1"
 
         self.hub = hub

--- a/astropy/samp/hub.py
+++ b/astropy/samp/hub.py
@@ -132,7 +132,7 @@ class SAMPHubServer:
                 self._host_name = socket.getfqdn()
                 socket.getaddrinfo(self._addr or self._host_name,
                                    self._port or 0)
-            except socket.error:
+            except OSError:
                 self._host_name = "127.0.0.1"
 
         # Threading stuff
@@ -266,7 +266,7 @@ class SAMPHubServer:
             self._web_profile_server.register_introspection_functions()
             self._register_web_profile_api(self._web_profile_server)
             log.info("Hub set to run with Web Profile support enabled.")
-        except socket.error:
+        except OSError:
             log.warning("Port {} already in use. Impossible to run the "
                         "Hub with Web Profile support.".format(self._web_port),
                         SAMPWarning)

--- a/astropy/samp/lockfile_helpers.py
+++ b/astropy/samp/lockfile_helpers.py
@@ -230,7 +230,7 @@ def check_running_hub(lockfilename):
             # There is a protocol error (e.g. for authentication required),
             # but the server is alive
             is_running = True
-        except socket.error:
+        except OSError:
             pass
 
     return is_running, lockfiledict


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

I ran ``pyupgrade —py38-plus`` on ``astropy/samp``.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
