### PR TITLE
run pyupgrade on stats

### DIFF
--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -1536,7 +1536,7 @@ def fold_intervals(intervals):
     breaks.add(0.)
     breaks.add(1.)
     breaks = sorted(breaks)
-    breaks_map = dict([(f, i) for (i, f) in enumerate(breaks)])
+    breaks_map = {f: i for (i, f) in enumerate(breaks)}
     totals = np.zeros(len(breaks) - 1)
     totals += tot
     for (a, b, wt) in r:

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -489,7 +489,7 @@ class SigmaClip:
                     # points won't "grow" in that dimension:
                     if n not in axis:
                         dim[dim != cenidx] = size
-            kernel = (sum(((idx - cenidx)**2 for idx in indices))
+            kernel = (sum((idx - cenidx)**2 for idx in indices)
                       <= self.grow**2)
             del indices
 

--- a/astropy/stats/tests/test_circstats.py
+++ b/astropy/stats/tests/test_circstats.py
@@ -1,4 +1,3 @@
-
 import pytest
 import numpy as np
 

--- a/astropy/stats/tests/test_info_theory.py
+++ b/astropy/stats/tests/test_info_theory.py
@@ -1,4 +1,3 @@
-
 from numpy.testing import assert_allclose
 
 from astropy.stats.info_theory import bayesian_info_criterion, bayesian_info_criterion_lsq

--- a/astropy/stats/tests/test_spatial.py
+++ b/astropy/stats/tests/test_spatial.py
@@ -1,4 +1,3 @@
-
 import numpy as np
 import pytest
 


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

I ran ``pyupgrade —py38-plus`` on ``astropy/stats``.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
