### PR TITLE
run pyupgrade on tests

### DIFF
--- a/astropy/tests/command.py
+++ b/astropy/tests/command.py
@@ -333,7 +333,7 @@ class AstropyTest(Command, metaclass=FixRemoteDataOption):
             self.testing_path, self.package_name.replace('.', '/'),
             'tests', 'coveragerc')
 
-        with open(coveragerc, 'r') as fd:
+        with open(coveragerc) as fd:
             coveragerc_content = fd.read()
 
         coveragerc_content = coveragerc_content.replace(

--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -106,16 +106,16 @@ class raises:
 # TODO: Remove these when deprecation period of things deprecated in PR 12633 are removed.
 _deprecations_as_exceptions = False
 _include_astropy_deprecations = True
-_modules_to_ignore_on_import = set([
+_modules_to_ignore_on_import = {
     r'compiler',  # A deprecated stdlib module used by pytest
     r'scipy',
     r'pygments',
     r'ipykernel',
     r'IPython',   # deprecation warnings for async and await
-    r'setuptools'])
-_warnings_to_ignore_entire_module = set([])
+    r'setuptools'}
+_warnings_to_ignore_entire_module = set()
 _warnings_to_ignore_by_pyver = {
-    None: set([  # Python version agnostic
+    None: {  # Python version agnostic
         # https://github.com/astropy/astropy/pull/7372
         (r"Importing from numpy\.testing\.decorators is deprecated, "
          r"import from numpy\.testing instead\.", DeprecationWarning),
@@ -128,12 +128,12 @@ _warnings_to_ignore_by_pyver = {
         (r"split\(\) requires a non-empty pattern match", FutureWarning),
         # Package resolution warning that we can do nothing about
         (r"can't resolve package from __spec__ or __package__, "
-         r"falling back on __name__ and __path__", ImportWarning)]),
-    (3, 7): set([
+         r"falling back on __name__ and __path__", ImportWarning)},
+    (3, 7): {
         # Deprecation warning for collections.abc, fixed in Astropy but still
         # used in lxml, and maybe others
         (r"Using or importing the ABCs from 'collections'",
-         DeprecationWarning)])
+         DeprecationWarning)}
 }
 
 

--- a/astropy/tests/tests/test_run_tests.py
+++ b/astropy/tests/tests/test_run_tests.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import pytest
 


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

I ran ``pyupgrade —py38-plus`` on ``astropy/tests``.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
