### PR TITLE
run pyupgrade on time

### DIFF
--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 The astropy.time package provides functionality for manipulating times and
@@ -42,8 +41,7 @@ __all__ = ['TimeBase', 'Time', 'TimeDelta', 'TimeInfo', 'TimeInfoBase', 'update_
 
 STANDARD_TIME_SCALES = ('tai', 'tcb', 'tcg', 'tdb', 'tt', 'ut1', 'utc')
 LOCAL_SCALES = ('local',)
-TIME_TYPES = dict((scale, scales) for scales in (STANDARD_TIME_SCALES, LOCAL_SCALES)
-                  for scale in scales)
+TIME_TYPES = {scale: scales for scales in (STANDARD_TIME_SCALES, LOCAL_SCALES) for scale in scales}
 TIME_SCALES = STANDARD_TIME_SCALES + LOCAL_SCALES
 MULTI_HOPS = {('tai', 'tcb'): ('tt', 'tdb'),
               ('tai', 'tcg'): ('tt',),
@@ -64,9 +62,9 @@ MULTI_HOPS = {('tai', 'tcb'): ('tt', 'tdb'),
 GEOCENTRIC_SCALES = ('tai', 'tt', 'tcg')
 BARYCENTRIC_SCALES = ('tcb', 'tdb')
 ROTATIONAL_SCALES = ('ut1',)
-TIME_DELTA_TYPES = dict((scale, scales)
-                        for scales in (GEOCENTRIC_SCALES, BARYCENTRIC_SCALES,
-                                       ROTATIONAL_SCALES, LOCAL_SCALES) for scale in scales)
+TIME_DELTA_TYPES = {scale: scales
+                    for scales in (GEOCENTRIC_SCALES, BARYCENTRIC_SCALES,
+                                   ROTATIONAL_SCALES, LOCAL_SCALES) for scale in scales}
 TIME_DELTA_SCALES = GEOCENTRIC_SCALES + BARYCENTRIC_SCALES + ROTATIONAL_SCALES + LOCAL_SCALES
 # For time scale changes, we need L_G and L_B, which are stored in erfam.h as
 #   /* L_G = 1 - d(TT)/d(TCG) */

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import fnmatch
 import time

--- a/astropy/time/tests/test_delta.py
+++ b/astropy/time/tests/test_delta.py
@@ -298,10 +298,10 @@ class TestTimeDeltaScales:
         # pick a date that includes a leap second for better testing
         self.iso_times = ['2012-06-30 12:00:00', '2012-06-30 23:59:59',
                           '2012-07-01 00:00:00', '2012-07-01 12:00:00']
-        self.t = dict((scale, Time(self.iso_times, scale=scale, precision=9))
-                      for scale in TIME_SCALES)
-        self.dt = dict((scale, self.t[scale] - self.t[scale][0])
-                       for scale in TIME_SCALES)
+        self.t = {scale: Time(self.iso_times, scale=scale, precision=9)
+                  for scale in TIME_SCALES}
+        self.dt = {scale: self.t[scale] - self.t[scale][0]
+                   for scale in TIME_SCALES}
 
     def test_delta_scales_definition(self):
         for scale in list(TIME_DELTA_SCALES) + [None]:

--- a/astropy/time/tests/test_sidereal.py
+++ b/astropy/time/tests/test_sidereal.py
@@ -123,7 +123,7 @@ class TestST:
         # And with it, one should reach full precision.
         sp = erfa.sp00(t.tt.jd1, t.tt.jd2)
         iers_table = iers.earth_orientation_table.get()
-        xp, yp = [c.to_value(u.rad) for c in iers_table.pm_xy(t)]
+        xp, yp = (c.to_value(u.rad) for c in iers_table.pm_xy(t))
         r = erfa.rx(-yp, erfa.ry(-xp, erfa.rz(sp, np.eye(3))))
         expected1 = expected + (np.arctan2(r[0, 1], r[0, 0]) << u.radian)
         assert np.abs(era - expected1) < 1e-12 * u.radian

--- a/astropy/time/utils.py
+++ b/astropy/time/utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Time utilities.
 


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

I ran ``pyupgrade —py38-plus`` on ``astropy/time``.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
