### PR TITLE
run pyupgrade on timeseries

### DIFF
--- a/astropy/timeseries/periodograms/bls/core.py
+++ b/astropy/timeseries/periodograms/bls/core.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 __all__ = ["BoxLeastSquares", "BoxLeastSquaresResults"]
@@ -286,9 +285,8 @@ class BoxLeastSquares(BasePeriodogram):
             objective = "likelihood"
         allowed_objectives = ["snr", "likelihood"]
         if objective not in allowed_objectives:
-            raise ValueError(("Unrecognized method '{0}'\n"
-                              "allowed methods are: {1}")
-                             .format(objective, allowed_objectives))
+            raise ValueError(f"Unrecognized method '{objective}'\n"
+                             f"allowed methods are: {allowed_objectives}")
         use_likelihood = (objective == "likelihood")
 
         # Select the computational method
@@ -296,9 +294,8 @@ class BoxLeastSquares(BasePeriodogram):
             method = "fast"
         allowed_methods = ["fast", "slow"]
         if method not in allowed_methods:
-            raise ValueError(("Unrecognized method '{0}'\n"
-                              "allowed methods are: {1}")
-                             .format(method, allowed_methods))
+            raise ValueError(f"Unrecognized method '{method}'\n"
+                             f"allowed methods are: {allowed_methods}")
 
         # Format and check the input arrays
         t = np.ascontiguousarray(strip_units(self._trel), dtype=np.float64)

--- a/astropy/timeseries/periodograms/bls/methods.py
+++ b/astropy/timeseries/periodograms/bls/methods.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 __all__ = ["bls_fast", "bls_slow"]

--- a/astropy/timeseries/periodograms/bls/tests/test_bls.py
+++ b/astropy/timeseries/periodograms/bls/tests/test_bls.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import pytest

--- a/astropy/timeseries/periodograms/lombscargle/implementations/chi2_impl.py
+++ b/astropy/timeseries/periodograms/lombscargle/implementations/chi2_impl.py
@@ -1,4 +1,3 @@
-
 import numpy as np
 
 from .mle import design_matrix

--- a/astropy/timeseries/periodograms/lombscargle/implementations/fast_impl.py
+++ b/astropy/timeseries/periodograms/lombscargle/implementations/fast_impl.py
@@ -1,4 +1,3 @@
-
 import numpy as np
 from .utils import trig_sum
 

--- a/astropy/timeseries/periodograms/lombscargle/implementations/fastchi2_impl.py
+++ b/astropy/timeseries/periodograms/lombscargle/implementations/fastchi2_impl.py
@@ -1,4 +1,3 @@
-
 import numpy as np
 
 from .utils import trig_sum
@@ -100,8 +99,8 @@ def lombscargle_fastchi2(t, y, dy, f0, df, Nf, normalization='standard',
     # Now create an indexing scheme so we can quickly
     # build-up matrices at each frequency
     order = [('C', 0)] if fit_mean else []
-    order.extend(sum([[('S', i), ('C', i)]
-                      for i in range(1, nterms + 1)], []))
+    order.extend(sum(([('S', i), ('C', i)]
+                      for i in range(1, nterms + 1)), []))
 
     funcs = dict(S=lambda m, i: Syw[m][i],
                  C=lambda m, i: Cyw[m][i],

--- a/astropy/timeseries/periodograms/lombscargle/implementations/mle.py
+++ b/astropy/timeseries/periodograms/lombscargle/implementations/mle.py
@@ -1,4 +1,3 @@
-
 import numpy as np
 
 

--- a/astropy/timeseries/periodograms/lombscargle/implementations/scipy_impl.py
+++ b/astropy/timeseries/periodograms/lombscargle/implementations/scipy_impl.py
@@ -1,4 +1,3 @@
-
 import numpy as np
 
 

--- a/astropy/timeseries/periodograms/lombscargle/implementations/slow_impl.py
+++ b/astropy/timeseries/periodograms/lombscargle/implementations/slow_impl.py
@@ -1,4 +1,3 @@
-
 import numpy as np
 
 

--- a/astropy/timeseries/periodograms/lombscargle/implementations/tests/test_utils.py
+++ b/astropy/timeseries/periodograms/lombscargle/implementations/tests/test_utils.py
@@ -1,4 +1,3 @@
-
 import pytest
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal

--- a/astropy/timeseries/tests/test_sampled.py
+++ b/astropy/timeseries/tests/test_sampled.py
@@ -101,11 +101,11 @@ def test_initialization_with_time_in_data():
 
     ts1 = TimeSeries(data=data)
 
-    assert set(ts1.colnames) == set(['time', 'a', 'b', 'c'])
+    assert set(ts1.colnames) == {'time', 'a', 'b', 'c'}
     assert all(ts1.time == INPUT_TIME)
 
     ts2 = TimeSeries(data=[[10, 2, 3], INPUT_TIME], names=['a', 'time'])
-    assert set(ts2.colnames) == set(['time', 'a'])
+    assert set(ts2.colnames) == {'time', 'a'}
     assert all(ts2.time == INPUT_TIME)
 
     with pytest.raises(TypeError) as exc:


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

I ran ``pyupgrade —py38-plus`` on ``astropy/timeseries``.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
