### PR TITLE
Adjust Column to work with numpy-dev, simplifying it somewhat

### DIFF
--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -1531,10 +1531,11 @@ class MaskedColumn(Column, _MaskedColumnGetitemShim, ma.MaskedArray):
 
         # Note: do not set fill_value in the MaskedArray constructor because this does not
         # go through the fill_value workarounds.
-        if fill_value is None and getattr(data, 'fill_value', None) is not None:
-            # Coerce the fill_value to the correct type since `data` may be a
-            # different dtype than self.
-            fill_value = np.array(data.fill_value, self.dtype)[()]
+        if fill_value is None:
+            data_fill_value = getattr(data, 'fill_value', None)
+            if (data_fill_value is not None
+                    and data_fill_value != np.ma.default_fill_value(data.dtype)):
+                fill_value = np.array(data_fill_value, self.dtype)[()]
         self.fill_value = fill_value
 
         self.parent_table = None

--- a/astropy/table/tests/test_column.py
+++ b/astropy/table/tests/test_column.py
@@ -2,6 +2,7 @@
 
 from astropy.utils.tests.test_metadata import MetaBaseTest
 import operator
+import warnings
 
 import pytest
 import numpy as np
@@ -752,7 +753,6 @@ def test_col_unicode_sandwich_bytes(Column):
         assert np.all(ok == [True, False])
 
 
-@pytest.mark.filterwarnings("ignore:.*elementwise comparison failed.*")
 def test_col_unicode_sandwich_unicode():
     """
     Sanity check that Unicode Column behaves normally.
@@ -774,9 +774,10 @@ def test_col_unicode_sandwich_unicode():
     assert ok.dtype.char == '?'
     assert np.all(ok)
 
-    # The following emits a FutureWarning in numpy >=1.24, which is OK,
-    # so filtered out above.
-    assert np.all(c != [uba8, b'def'])
+    with warnings.catch_warnings():
+        # Ignore the FutureWarning in numpy >=1.24 (it is OK).
+        warnings.filterwarnings('ignore', message='.*elementwise comparison failed.*')
+        assert np.all(c != [uba8, b'def'])
 
 
 def test_masked_col_unicode_sandwich():

--- a/astropy/table/tests/test_column.py
+++ b/astropy/table/tests/test_column.py
@@ -752,6 +752,7 @@ def test_col_unicode_sandwich_bytes(Column):
         assert np.all(ok == [True, False])
 
 
+@pytest.mark.filterwarnings("ignore:.*elementwise comparison failed.*")
 def test_col_unicode_sandwich_unicode():
     """
     Sanity check that Unicode Column behaves normally.
@@ -773,6 +774,8 @@ def test_col_unicode_sandwich_unicode():
     assert ok.dtype.char == '?'
     assert np.all(ok)
 
+    # The following emits a FutureWarning in numpy >=1.24, which is OK,
+    # so filtered out above.
     assert np.all(c != [uba8, b'def'])
 
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address failures with `astropy.table` on numpy-dev. There are two commits. One avoids a runtime error in casting `fill_value` from float to int, by only using the `fill_value` from input data if it is not the default for the data type. That seems more logical in general (I considered trying to push this upstream, and can pursue that if wished, but since we already fiddle with `fill_value` more, it seems OK to just do it here). In principle, one could also just filter out the warning.

The second commit addresses failures in comparisons. These were partially due to string comparisons being moved to a ufunc, and partially due to MaskedArray now overriding some comparisons (which is done in part to alleviate other astropy problems; see https://github.com/numpy/numpy/pull/21812). In both cases, the solution turns out to be to not be too eager to do the comparison oneself, but rather defer to the other.  For the unicode sandwich, this nicely simplifies the code.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #13332

(Note that some modelling errors remain.)

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
