### PR TITLE
run pyupgrade on units

### DIFF
--- a/astropy/units/astrophys.py
+++ b/astropy/units/astrophys.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 """

--- a/astropy/units/cds.py
+++ b/astropy/units/cds.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 """

--- a/astropy/units/cgs.py
+++ b/astropy/units/cgs.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 This package defines the CGS units.  They are also available in the
@@ -114,7 +113,7 @@ def_unit(['Mx', 'Maxwell', 'maxwell'], 1e-8 * si.Wb, namespace=_ns,
 ###########################################################################
 # BASES
 
-bases = set([cm, g, s, rad, cd, K, mol])
+bases = {cm, g, s, rad, cd, K, mol}
 
 
 ###########################################################################

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -1201,7 +1201,7 @@ class UnitBase:
         # Store final results that reduce to a single unit or pair of
         # units
         if len(unit.bases) == 0:
-            final_results = [set([unit]), set()]
+            final_results = [{unit}, set()]
         else:
             final_results = [set(), set()]
 
@@ -1644,8 +1644,7 @@ class UnitBase:
         results = self.compose(
             equivalencies=equivalencies, units=units, max_depth=1,
             include_prefix_units=include_prefix_units)
-        results = set(
-            x.bases[0] for x in results if len(x.bases) == 1)
+        results = {x.bases[0] for x in results if len(x.bases) == 1}
         return self.EquivalentUnitsList(results)
 
     def is_unity(self):

--- a/astropy/units/decorators.py
+++ b/astropy/units/decorators.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 __all__ = ['quantity_input']

--- a/astropy/units/deprecated.py
+++ b/astropy/units/deprecated.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 This package defines deprecated units.

--- a/astropy/units/format/cds.py
+++ b/astropy/units/format/cds.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICNSE.rst
 
 # This module includes files automatically generated from ply (these end in

--- a/astropy/units/format/console.py
+++ b/astropy/units/format/console.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 """

--- a/astropy/units/format/ogip.py
+++ b/astropy/units/format/ogip.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICNSE.rst
 
 # This module includes files automatically generated from ply (these end in

--- a/astropy/units/format/unicode_format.py
+++ b/astropy/units/format/unicode_format.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 """

--- a/astropy/units/format/vounit.py
+++ b/astropy/units/format/vounit.py
@@ -55,10 +55,10 @@ class VOUnit(generic.Generic):
         binary_prefixes = [
             'Ki', 'Mi', 'Gi', 'Ti', 'Pi', 'Ei'
         ]
-        deprecated_units = set([
+        deprecated_units = {
             'a', 'angstrom', 'Angstrom', 'au', 'Ba', 'barn', 'ct',
             'erg', 'G', 'ph', 'pix'
-        ])
+        }
 
         def do_defines(bases, prefixes, skips=[]):
             for base in bases:

--- a/astropy/units/function/core.py
+++ b/astropy/units/function/core.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Function Units and Quantities."""
 
@@ -12,18 +11,18 @@ from astropy.units import (
 
 __all__ = ['FunctionUnitBase', 'FunctionQuantity']
 
-SUPPORTED_UFUNCS = set(getattr(np.core.umath, ufunc) for ufunc in (
+SUPPORTED_UFUNCS = {getattr(np.core.umath, ufunc) for ufunc in (
     'isfinite', 'isinf', 'isnan', 'sign', 'signbit',
     'rint', 'floor', 'ceil', 'trunc',
-    '_ones_like', 'ones_like', 'positive') if hasattr(np.core.umath, ufunc))
+    '_ones_like', 'ones_like', 'positive') if hasattr(np.core.umath, ufunc)}
 
 # TODO: the following could work if helper changed relative to Quantity:
 # - spacing should return dimensionless, not same unit
 # - negative should negate unit too,
 # - add, subtract, comparisons can work if units added/subtracted
 
-SUPPORTED_FUNCTIONS = set(getattr(np, function) for function in
-                          ('clip', 'trace', 'mean', 'min', 'max', 'round'))
+SUPPORTED_FUNCTIONS = {getattr(np, function) for function in
+                       ('clip', 'trace', 'mean', 'min', 'max', 'round')}
 
 
 # subclassing UnitBase or CompositeUnit was found to be problematic, requiring

--- a/astropy/units/function/logarithmic.py
+++ b/astropy/units/function/logarithmic.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import numbers
 
@@ -158,7 +157,7 @@ class DexUnit(LogUnit):
             else:
                 return f"[{self.physical_unit.to_string(format=format)}]"
         else:
-            return super(DexUnit, self).to_string()
+            return super().to_string()
 
 
 class DecibelUnit(LogUnit):
@@ -382,8 +381,8 @@ class LogQuantity(FunctionQuantity):
                                    unit=self.unit._copy(dimensionless_unscaled))
 
     _supported_functions = (FunctionQuantity._supported_functions |
-                            set(getattr(np, function) for function in
-                                ('var', 'std', 'ptp', 'diff', 'ediff1d')))
+                            {getattr(np, function) for function in
+                                ('var', 'std', 'ptp', 'diff', 'ediff1d')})
 
 
 class Dex(LogQuantity):

--- a/astropy/units/function/mixin.py
+++ b/astropy/units/function/mixin.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from astropy.units.core import IrreducibleUnit, Unit
 

--- a/astropy/units/function/units.py
+++ b/astropy/units/function/units.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 This package defines units that can also be used as functions of other units.

--- a/astropy/units/imperial.py
+++ b/astropy/units/imperial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 """

--- a/astropy/units/misc.py
+++ b/astropy/units/misc.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 """

--- a/astropy/units/photometric.py
+++ b/astropy/units/photometric.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 """

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 This module defines the `Quantity` object, which represents a number with some

--- a/astropy/units/quantity_helper/converters.py
+++ b/astropy/units/quantity_helper/converters.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Converters for Quantity."""
 

--- a/astropy/units/quantity_helper/erfa.py
+++ b/astropy/units/quantity_helper/erfa.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Quantity helpers for the ERFA ufuncs."""
 # Tests for these are in coordinates, not in units.

--- a/astropy/units/quantity_helper/function_helpers.py
+++ b/astropy/units/quantity_helper/function_helpers.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license. See LICENSE.rst except
 # for parts explicitly labelled as being (largely) copies of numpy
 # implementations; for those, see licenses/NUMPY_LICENSE.rst.

--- a/astropy/units/quantity_helper/helpers.py
+++ b/astropy/units/quantity_helper/helpers.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # The idea for this module (but no code) was borrowed from the
 # quantities (http://pythonhosted.org/quantities/) package.

--- a/astropy/units/quantity_helper/scipy_special.py
+++ b/astropy/units/quantity_helper/scipy_special.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Quantity helpers for the scipy.special ufuncs.
 

--- a/astropy/units/required_by_vounit.py
+++ b/astropy/units/required_by_vounit.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 This package defines SI prefixed units that are required by the VOUnit standard

--- a/astropy/units/si.py
+++ b/astropy/units/si.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 This package defines the SI units.  They are also available in the
@@ -220,7 +219,7 @@ def_unit(['Ci', 'curie'], Bq * 3.7e10, namespace=_ns, prefixes=False,
 ###########################################################################
 # BASES
 
-bases = set([m, s, kg, A, cd, rad, K, mol])
+bases = {m, s, kg, A, cd, rad, K, mol}
 
 
 ###########################################################################

--- a/astropy/units/structured.py
+++ b/astropy/units/structured.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 This module defines structured units and quantities.
@@ -223,7 +222,7 @@ class StructuredUnit:
             If given, should be a subclass of `~numpy.void`. By default,
             will return a new `~astropy.units.StructuredUnit` instance.
         """
-        results = np.array(tuple([func(part) for part in self.values()]),
+        results = np.array(tuple(func(part) for part in self.values()),
                            self._units.dtype)[()]
         if cls is not None:
             return results.view((cls, results.dtype))

--- a/astropy/units/tests/test_aliases.py
+++ b/astropy/units/tests/test_aliases.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Test setting and adding unit aliases."""
 import pytest

--- a/astropy/units/tests/test_deprecated.py
+++ b/astropy/units/tests/test_deprecated.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 

--- a/astropy/units/tests/test_equivalencies.py
+++ b/astropy/units/tests/test_equivalencies.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Separate tests specifically for equivalencies."""
 
@@ -532,10 +531,10 @@ def test_equivalent_units():
     with u.add_enabled_units(imperial):
         units = u.g.find_equivalent_units()
         units_set = set(units)
-        match = set(
-            [u.M_e, u.M_p, u.g, u.kg, u.solMass, u.t, u.u, u.M_earth,
+        match = {
+            u.M_e, u.M_p, u.g, u.kg, u.solMass, u.t, u.u, u.M_earth,
              u.M_jup, imperial.oz, imperial.lb, imperial.st, imperial.ton,
-             imperial.slug])
+             imperial.slug}
         assert units_set == match
 
     r = repr(units)
@@ -544,28 +543,28 @@ def test_equivalent_units():
 
 def test_equivalent_units2():
     units = set(u.Hz.find_equivalent_units(u.spectral()))
-    match = set(
-        [u.AU, u.Angstrom, u.Hz, u.J, u.Ry, u.cm, u.eV, u.erg, u.lyr, u.lsec,
-         u.m, u.micron, u.pc, u.solRad, u.Bq, u.Ci, u.k, u.earthRad,
-         u.jupiterRad])
+    match = {
+        u.AU, u.Angstrom, u.Hz, u.J, u.Ry, u.cm, u.eV, u.erg, u.lyr, u.lsec,
+        u.m, u.micron, u.pc, u.solRad, u.Bq, u.Ci, u.k, u.earthRad,
+        u.jupiterRad}
     assert units == match
 
     from astropy.units import imperial
     with u.add_enabled_units(imperial):
         units = set(u.Hz.find_equivalent_units(u.spectral()))
-        match = set(
-            [u.AU, u.Angstrom, imperial.BTU, u.Hz, u.J, u.Ry,
-             imperial.cal, u.cm, u.eV, u.erg, imperial.ft, imperial.fur,
-             imperial.inch, imperial.kcal, u.lyr, u.m, imperial.mi, u.lsec,
-             imperial.mil, u.micron, u.pc, u.solRad, imperial.yd, u.Bq, u.Ci,
-             imperial.nmi, u.k, u.earthRad, u.jupiterRad])
+        match = {
+            u.AU, u.Angstrom, imperial.BTU, u.Hz, u.J, u.Ry,
+            imperial.cal, u.cm, u.eV, u.erg, imperial.ft, imperial.fur,
+            imperial.inch, imperial.kcal, u.lyr, u.m, imperial.mi, u.lsec,
+            imperial.mil, u.micron, u.pc, u.solRad, imperial.yd, u.Bq, u.Ci,
+            imperial.nmi, u.k, u.earthRad, u.jupiterRad}
         assert units == match
 
     units = set(u.Hz.find_equivalent_units(u.spectral()))
-    match = set(
-        [u.AU, u.Angstrom, u.Hz, u.J, u.Ry, u.cm, u.eV, u.erg, u.lyr, u.lsec,
-         u.m, u.micron, u.pc, u.solRad, u.Bq, u.Ci, u.k, u.earthRad,
-         u.jupiterRad])
+    match = {
+        u.AU, u.Angstrom, u.Hz, u.J, u.Ry, u.cm, u.eV, u.erg, u.lyr, u.lsec,
+        u.m, u.micron, u.pc, u.solRad, u.Bq, u.Ci, u.k, u.earthRad,
+        u.jupiterRad}
     assert units == match
 
 

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 Regression tests for the units.format package

--- a/astropy/units/tests/test_logarithmic.py
+++ b/astropy/units/tests/test_logarithmic.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
     Test the Logarithmic Units and Quantities

--- a/astropy/units/tests/test_photometric.py
+++ b/astropy/units/tests/test_photometric.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 """

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Test the Quantity class and related."""
 

--- a/astropy/units/tests/test_quantity_annotations.py
+++ b/astropy/units/tests/test_quantity_annotations.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 # STDLIB

--- a/astropy/units/tests/test_quantity_decorator.py
+++ b/astropy/units/tests/test_quantity_decorator.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 # STDLIB

--- a/astropy/units/tests/test_quantity_typing.py
+++ b/astropy/units/tests/test_quantity_typing.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Test the Quantity class and related."""
 

--- a/astropy/units/tests/test_quantity_ufuncs.py
+++ b/astropy/units/tests/test_quantity_ufuncs.py
@@ -55,8 +55,8 @@ class TestUfuncHelpers:
     def test_coverage(self):
         """Test that we cover all ufunc's"""
 
-        all_np_ufuncs = set([ufunc for ufunc in np.core.umath.__dict__.values()
-                             if isinstance(ufunc, np.ufunc)])
+        all_np_ufuncs = {ufunc for ufunc in np.core.umath.__dict__.values()
+                         if isinstance(ufunc, np.ufunc)}
 
         all_q_ufuncs = (qh.UNSUPPORTED_UFUNCS |
                         set(qh.UFUNC_HELPERS.keys()))
@@ -65,8 +65,8 @@ class TestUfuncHelpers:
         # Check that all ufuncs we cover come from numpy or erfa.
         # (Since coverage for erfa is incomplete, we do not check
         # this the other way).
-        all_erfa_ufuncs = set([ufunc for ufunc in erfa_ufunc.__dict__.values()
-                               if isinstance(ufunc, np.ufunc)])
+        all_erfa_ufuncs = {ufunc for ufunc in erfa_ufunc.__dict__.values()
+                           if isinstance(ufunc, np.ufunc)}
         assert (all_q_ufuncs - all_np_ufuncs - all_erfa_ufuncs == set())
 
     def test_scipy_registered(self):

--- a/astropy/units/tests/test_structured.py
+++ b/astropy/units/tests/test_structured.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 Test Structured units and quantities.

--- a/astropy/units/tests/test_structured_erfa_ufuncs.py
+++ b/astropy/units/tests/test_structured_erfa_ufuncs.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 Test Structured units and quantities specifically with the ERFA ufuncs.

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Regression tests for the units package."""
 import pickle
@@ -269,7 +268,7 @@ def test_complex_compose():
     complex = u.cd * u.sr * u.Wb
     composed = complex.compose()
 
-    assert set(composed[0]._bases) == set([u.lm, u.Wb])
+    assert set(composed[0]._bases) == {u.lm, u.Wb}
 
 
 def test_equiv_compose():

--- a/astropy/units/tests/test_utils.py
+++ b/astropy/units/tests/test_utils.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
     Test utilities for `astropy.units`.


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

I ran ``pyupgrade —py38-plus`` on ``astropy/units``.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
