### PR TITLE
run pyupgrade on utils

### DIFF
--- a/astropy/utils/codegen.py
+++ b/astropy/utils/codegen.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Utilities for generating new Python code at runtime."""
 

--- a/astropy/utils/console.py
+++ b/astropy/utils/console.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 Utilities for console input and output.
@@ -458,7 +457,7 @@ def human_file_size(size):
     return f"{str_value:>3s}{suffix}"
 
 
-class _mapfunc(object):
+class _mapfunc:
     """
     A function wrapper to support ProgressBar.map().
     """

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -1043,7 +1043,7 @@ class _FTPTLSHandler(urllib.request.FTPHandler):
                               persistent=False)
 
 
-@functools.lru_cache()
+@functools.lru_cache
 def _build_urlopener(ftp_tls=False, ssl_context=None, allow_insecure=False):
     """
     Helper for building a `urllib.request.build_opener` which handles TLS/SSL.

--- a/astropy/utils/data_info.py
+++ b/astropy/utils/data_info.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 """This module contains functions and methods that relate to the DataInfo class
@@ -282,7 +281,7 @@ class DataInfo(metaclass=DataInfoMeta):
     """
     _stats = ['mean', 'std', 'min', 'max']
     attrs_from_parent = set()
-    attr_names = set(['name', 'unit', 'dtype', 'format', 'description', 'meta'])
+    attr_names = {'name', 'unit', 'dtype', 'format', 'description', 'meta'}
     _attr_defaults = {'dtype': np.dtype('O')}
     _attrs_no_copy = set()
     _info_summary_attrs = ('dtype', 'shape', 'unit', 'format', 'description', 'class')
@@ -523,7 +522,7 @@ class BaseColumnInfo(DataInfo):
     without importing the table package.
     """
     attr_names = DataInfo.attr_names | {'parent_table', 'indices'}
-    _attrs_no_copy = set(['parent_table', 'indices'])
+    _attrs_no_copy = {'parent_table', 'indices'}
 
     # Context for serialization.  This can be set temporarily via
     # ``serialize_context_as(context)`` context manager to allow downstream
@@ -578,8 +577,7 @@ class BaseColumnInfo(DataInfo):
             formatter = self.parent_table.formatter
 
         _pformat_col_iter = formatter._pformat_col_iter
-        for str_val in _pformat_col_iter(col, -1, False, False, {}):
-            yield str_val
+        yield from _pformat_col_iter(col, -1, False, False, {})
 
     @property
     def indices(self):
@@ -721,7 +719,7 @@ class BaseColumnInfo(DataInfo):
         out['dtype'] = metadata.common_dtype(cols)
 
         # Make sure all input shapes are the same
-        uniq_shapes = set(col.shape[1:] for col in cols)
+        uniq_shapes = {col.shape[1:] for col in cols}
         if len(uniq_shapes) != 1:
             raise TableMergeError('columns have different shapes')
         out['shape'] = uniq_shapes.pop()
@@ -776,4 +774,4 @@ class MixinInfo(BaseColumnInfo):
 class ParentDtypeInfo(MixinInfo):
     """Mixin that gets info.dtype from parent"""
 
-    attrs_from_parent = set(['dtype'])  # dtype and unit taken from parent
+    attrs_from_parent = {'dtype'}  # dtype and unit taken from parent

--- a/astropy/utils/decorators.py
+++ b/astropy/utils/decorators.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Sundry function and class decorators."""
 

--- a/astropy/utils/iers/__init__.py
+++ b/astropy/utils/iers/__init__.py
@@ -1,2 +1,1 @@
-
 from .iers import *

--- a/astropy/utils/introspection.py
+++ b/astropy/utils/introspection.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Functions related to Python runtime introspection."""
 

--- a/astropy/utils/masked/core.py
+++ b/astropy/utils/masked/core.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 Built-in mask mixin class.

--- a/astropy/utils/masked/function_helpers.py
+++ b/astropy/utils/masked/function_helpers.py
@@ -75,7 +75,7 @@ been lack of time.  Issues or PRs for support for functions are welcome.
 # Almost all from np.core.fromnumeric defer to methods so are OK.
 MASKED_SAFE_FUNCTIONS |= {
     getattr(np, name) for name in np.core.fromnumeric.__all__
-    if name not in ({'choose', 'put', 'resize', 'searchsorted', 'where', 'alen'})}
+    if name not in {'choose', 'put', 'resize', 'searchsorted', 'where', 'alen'}}
 
 MASKED_SAFE_FUNCTIONS |= {
     # built-in from multiarray

--- a/astropy/utils/masked/function_helpers.py
+++ b/astropy/utils/masked/function_helpers.py
@@ -73,9 +73,9 @@ been lack of time.  Issues or PRs for support for functions are welcome.
 """
 
 # Almost all from np.core.fromnumeric defer to methods so are OK.
-MASKED_SAFE_FUNCTIONS |= set(
+MASKED_SAFE_FUNCTIONS |= {
     getattr(np, name) for name in np.core.fromnumeric.__all__
-    if name not in ({'choose', 'put', 'resize', 'searchsorted', 'where', 'alen'}))
+    if name not in ({'choose', 'put', 'resize', 'searchsorted', 'where', 'alen'})}
 
 MASKED_SAFE_FUNCTIONS |= {
     # built-in from multiarray
@@ -136,8 +136,7 @@ IGNORED_FUNCTIONS |= {
 }
 
 # Really should do these...
-IGNORED_FUNCTIONS |= set(getattr(np, setopsname)
-                         for setopsname in np.lib.arraysetops.__all__)
+IGNORED_FUNCTIONS |= {getattr(np, setopsname) for setopsname in np.lib.arraysetops.__all__}
 
 
 if NUMPY_LT_1_23:

--- a/astropy/utils/masked/tests/test_containers.py
+++ b/astropy/utils/masked/tests/test_containers.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import numpy as np

--- a/astropy/utils/masked/tests/test_table.py
+++ b/astropy/utils/masked/tests/test_table.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import numpy as np

--- a/astropy/utils/metadata.py
+++ b/astropy/utils/metadata.py
@@ -54,8 +54,8 @@ def common_dtype(arrs):
         return getattr(arr, 'dtype', np.dtype('O'))
 
     np_types = (np.bool_, np.object_, np.number, np.character, np.void)
-    uniq_types = set(tuple(issubclass(dtype(arr).type, np_type) for np_type in np_types)
-                     for arr in arrs)
+    uniq_types = {tuple(issubclass(dtype(arr).type, np_type) for np_type in np_types)
+                  for arr in arrs}
     if len(uniq_types) > 1:
         # Embed into the exception the actual list of incompatible types.
         incompat_types = [dtype(arr).name for arr in arrs]

--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 A "grab bag" of relatively small general-purpose utilities that don't have
@@ -293,8 +292,8 @@ def signal_number_to_name(signum):
     # Since these numbers and names are platform specific, we use the
     # builtin signal module and build a reverse mapping.
 
-    signal_to_name_map = dict((k, v) for v, k in signal.__dict__.items()
-                              if v.startswith('SIG'))
+    signal_to_name_map = {k: v for v, k in signal.__dict__.items()
+                          if v.startswith('SIG')}
 
     return signal_to_name_map.get(signum, 'UNKNOWN')
 
@@ -791,8 +790,7 @@ class OrderedDescriptorContainer(type):
             instances = OrderedDict((key, value) for value, key in instances)
             setattr(cls, descriptor_cls._class_attribute_, instances)
 
-        super(OrderedDescriptorContainer, cls).__init__(cls_name, bases,
-                                                        members)
+        super().__init__(cls_name, bases, members)
 
 
 LOCALE_LOCK = threading.Lock()

--- a/astropy/utils/parsing.py
+++ b/astropy/utils/parsing.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 Wrappers for PLY to provide thread safety.
@@ -30,7 +29,7 @@ _LOCK = threading.RLock()
 
 
 def _add_tab_header(filename, package):
-    with open(filename, 'r') as f:
+    with open(filename) as f:
         contents = f.read()
 
     with open(filename, 'w') as f:

--- a/astropy/utils/tests/test_console.py
+++ b/astropy/utils/tests/test_console.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# -*- coding: utf-8 -*-
 
 
 import io

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import io
@@ -89,7 +88,7 @@ def can_rename_directory_in_use():
         with open(f1, "wt") as f:
             f.write("some contents\n")
         try:
-            with open(f1, "rt"):
+            with open(f1):
                 os.rename(d1, d2)
         except PermissionError:
             return False
@@ -173,7 +172,7 @@ def readonly_cache(tmpdir, valid_urls):
         # to make into the cache
         d = pathlib.Path(d)
         with paths.set_temp_cache(d):
-            us = set(u for u, c in islice(valid_urls, FEW))
+            us = {u for u, c in islice(valid_urls, FEW)}
             urls = {u: download_file(u, cache=True) for u in us}
             files = set(d.iterdir())
             with readonly_dir(d):
@@ -206,7 +205,7 @@ def fake_readonly_cache(tmpdir, valid_urls, monkeypatch):
         # to make into the cache
         d = pathlib.Path(d)
         with paths.set_temp_cache(d):
-            us = set(u for u, c in islice(valid_urls, FEW))
+            us = {u for u, c in islice(valid_urls, FEW)}
             urls = {u: download_file(u, cache=True) for u in us}
             files = set(d.iterdir())
             monkeypatch.setattr(os, "mkdir", no_mkdir)
@@ -700,7 +699,7 @@ def test_download_parallel_fills_cache(tmpdir, valid_urls, method):
             [u for (u, c) in urls], multiprocessing_start_method=method
         )
         assert len(rs) == len(urls)
-        url_set = set(u for (u, c) in urls)
+        url_set = {u for (u, c) in urls}
         assert url_set <= set(get_cached_urls())
         for r, (u, c) in zip(rs, urls):
             assert get_file_contents(r) == c
@@ -1340,7 +1339,7 @@ def test_export_import_roundtrip_different_location(tmpdir, valid_urls):
     zip_file_name = tmpdir / "the.zip"
 
     urls = list(islice(valid_urls, FEW))
-    initial_urls_in_cache = set(u for (u, c) in urls)
+    initial_urls_in_cache = {u for (u, c) in urls}
     with paths.set_temp_cache(original_cache):
         for u, c in urls:
             download_file(u, cache=True)
@@ -1488,7 +1487,7 @@ def test_check_download_cache_cleanup(temp_cache, valid_urls):
 
     with pytest.raises(CacheDamaged) as e:
         check_download_cache()
-    assert set(e.value.bad_files) == set([bf1, bf2, bf3, bf4])
+    assert set(e.value.bad_files) == {bf1, bf2, bf3, bf4}
     for bf in e.value.bad_files:
         clear_download_cache(bf)
     # download cache will be checked on exit
@@ -1618,7 +1617,7 @@ def test_get_fileobj_binary(a_binary_file):
 
 def test_get_fileobj_already_open_text(a_file):
     fn, c = a_file
-    with open(fn, "r") as f:
+    with open(fn) as f:
         with get_readable_fileobj(f) as rf:
             with pytest.raises(TypeError):
                 rf.read()

--- a/astropy/utils/tests/test_data_info.py
+++ b/astropy/utils/tests/test_data_info.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import pytest

--- a/astropy/utils/tests/test_misc.py
+++ b/astropy/utils/tests/test_misc.py
@@ -66,7 +66,7 @@ def test_JsonCustomEncoder():
     from astropy import units as u
     assert json.dumps(np.arange(3), cls=misc.JsonCustomEncoder) == '[0, 1, 2]'
     assert json.dumps(1+2j, cls=misc.JsonCustomEncoder) == '[1.0, 2.0]'
-    assert json.dumps(set([1, 2, 1]), cls=misc.JsonCustomEncoder) == '[1, 2]'
+    assert json.dumps({1, 2, 1}, cls=misc.JsonCustomEncoder) == '[1, 2]'
     assert json.dumps(b'hello world \xc3\x85',
                       cls=misc.JsonCustomEncoder) == '"hello world \\u00c5"'
     assert json.dumps({1: 2},

--- a/astropy/utils/xml/iterparser.py
+++ b/astropy/utils/xml/iterparser.py
@@ -100,14 +100,12 @@ def _fast_iterparse(fd, buffersize=2 ** 10):
     data = read(buffersize)
     while data:
         Parse(data, False)
-        for elem in queue:
-            yield elem
+        yield from queue
         del queue[:]
         data = read(buffersize)
 
     Parse('', True)
-    for elem in queue:
-        yield elem
+    yield from queue
 
 
 # Try to import the C version of the iterparser, otherwise fall back


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

I ran ``pyupgrade —py38-plus`` on ``astropy/utils``.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
