### PR TITLE
run pyupgrade on wcs

### DIFF
--- a/astropy/wcs/setup_package.py
+++ b/astropy/wcs/setup_package.py
@@ -303,7 +303,7 @@ def get_extensions():
     cfg['sources'].extend(join(WCSROOT, 'src', x) for x in astropy_wcs_files)
 
     cfg['sources'] = [str(x) for x in cfg['sources']]
-    cfg = dict((str(key), val) for key, val in cfg.items())
+    cfg = {str(key): val for key, val in cfg.items()}
 
     # Copy over header files from WCSLIB into the installed version of Astropy
     # so that other Python packages can write extensions that link to it. We

--- a/astropy/wcs/tests/test_auxprm.py
+++ b/astropy/wcs/tests/test_auxprm.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 # Tests for the auxiliary parameters contained in wcsaux

--- a/astropy/wcs/tests/test_utils.py
+++ b/astropy/wcs/tests/test_utils.py
@@ -860,7 +860,7 @@ def test_pixel_to_pixel_correlation_matrix_nonsquare():
     # coordinates - the idea is to make sure that things work fine in cases
     # where the number of input and output pixel coordinates do not match.
 
-    class FakeWCS(object):
+    class FakeWCS:
         pass
 
     wcs_in = FakeWCS()
@@ -1233,7 +1233,7 @@ RADESYS = 'ICRS'               / Equatorial coordinate system
     y, x = (10, 200)
 
     center_coord = SkyCoord(ffi_wcs.all_pix2world([[xi+x//2, yi+y//2]], 0), unit='deg')[0]
-    ypix, xpix = [arr.flatten() for arr in np.mgrid[xi : xi + x, yi : yi + y]]
+    ypix, xpix = (arr.flatten() for arr in np.mgrid[xi : xi + x, yi : yi + y])
     world_pix = SkyCoord(*ffi_wcs.all_pix2world(xpix, ypix, 0), unit='deg')
 
     fit_wcs = fit_wcs_from_points((ypix, xpix), world_pix, proj_point='center')

--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -453,7 +453,7 @@ def test_find_all_wcs_crash():
 @pytest.mark.filterwarnings("ignore")
 def test_validate():
     results = wcs.validate(get_pkg_data_filename("data/validate.fits"))
-    results_txt = sorted(set([x.strip() for x in repr(results).splitlines()]))
+    results_txt = sorted({x.strip() for x in repr(results).splitlines()})
     if _WCSLIB_VER >= Version('7.6'):
         filename = 'data/validate.7.6.txt'
     elif _WCSLIB_VER >= Version('7.4'):
@@ -466,9 +466,9 @@ def test_validate():
         filename = 'data/validate.5.0.txt'
     else:
         filename = 'data/validate.txt'
-    with open(get_pkg_data_filename(filename), "r") as fd:
+    with open(get_pkg_data_filename(filename)) as fd:
         lines = fd.readlines()
-    assert sorted(set([x.strip() for x in lines])) == results_txt
+    assert sorted({x.strip() for x in lines}) == results_txt
 
 
 def test_validate_with_2_wcses():
@@ -666,7 +666,7 @@ def test_footprint_to_file(tmpdir):
     testfile = str(tmpdir.join('test.txt'))
     w.footprint_to_file(testfile)
 
-    with open(testfile, 'r') as f:
+    with open(testfile) as f:
         lines = f.readlines()
 
     assert len(lines) == 4
@@ -675,7 +675,7 @@ def test_footprint_to_file(tmpdir):
 
     w.footprint_to_file(testfile, coordsys='FK5', color='red')
 
-    with open(testfile, 'r') as f:
+    with open(testfile) as f:
         lines = f.readlines()
 
     assert len(lines) == 4

--- a/astropy/wcs/tests/test_wcsprm.py
+++ b/astropy/wcs/tests/test_wcsprm.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import gc

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -624,7 +624,7 @@ reduce these to 2 dimensions using the naxis kwarg.
 
         # Subset pixel_shape and pixel_bounds
         if self.pixel_shape:
-            copy.pixel_shape = tuple([None if i is None else self.pixel_shape[i] for i in keep])
+            copy.pixel_shape = tuple(None if i is None else self.pixel_shape[i] for i in keep)
         if self.pixel_bounds:
             copy.pixel_bounds = [None if i is None else self.pixel_bounds[i] for i in keep]
 
@@ -1071,8 +1071,8 @@ reduce these to 2 dimensions using the naxis kwarg.
         """
         # Never pass SIP coefficients to wcslib
         # CTYPE must be passed with -SIP to wcslib
-        for key in set(m.group() for m in map(SIP_KW.match, list(header))
-                       if m is not None):
+        for key in {m.group() for m in map(SIP_KW.match, list(header))
+                    if m is not None}:
             del header[key]
 
     def _read_sip_kw(self, header, wcskey=""):

--- a/astropy/wcs/wcsapi/low_level_api.py
+++ b/astropy/wcs/wcsapi/low_level_api.py
@@ -343,7 +343,7 @@ class BaseLowLevelWCS(metaclass=abc.ABCMeta):
 
 UCDS_FILE = os.path.join(os.path.dirname(__file__), 'data', 'ucds.txt')
 with open(UCDS_FILE) as f:
-    VALID_UCDS = set([x.strip() for x in f.read().splitlines()[1:]])
+    VALID_UCDS = {x.strip() for x in f.read().splitlines()[1:]}
 
 
 def validate_physical_types(physical_types):

--- a/astropy/wcs/wcsapi/utils.py
+++ b/astropy/wcs/wcsapi/utils.py
@@ -18,7 +18,7 @@ def deserialize_class(tpl, construct=True):
     module = importlib.import_module(module)
     klass = getattr(module, klass)
 
-    args = tuple([deserialize_class(arg) if isinstance(arg, tuple) else arg for arg in tpl[1]])
+    args = tuple(deserialize_class(arg) if isinstance(arg, tuple) else arg for arg in tpl[1])
 
     kwargs = dict((key, deserialize_class(val)) if isinstance(val, tuple) else (key, val) for (key, val) in tpl[2].items())
 

--- a/astropy/wcs/wcsapi/wrappers/sliced_wcs.py
+++ b/astropy/wcs/wcsapi/wrappers/sliced_wcs.py
@@ -27,7 +27,7 @@ def sanitize_slices(slices, ndim):
             f"The dimensionality of the specified slice {slices} can not be greater "
             f"than the dimensionality ({ndim}) of the wcs.")
 
-    if any((isiterable(s) for s in slices)):
+    if any(isiterable(s) for s in slices):
         raise IndexError("This slice is invalid, only integer or range slices are supported.")
 
     slices = list(slices)


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

I ran ``pyupgrade —py38-plus`` on ``astropy/wcs``.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
