### PR TITLE
Ensure repr/str of structured subarrays works properly

### DIFF
--- a/astropy/utils/masked/function_helpers.py
+++ b/astropy/utils/masked/function_helpers.py
@@ -877,12 +877,18 @@ class MaskedFormat:
     """
     def __init__(self, format_function):
         self.format_function = format_function
-        # Special case for structured void: we need to make all the
+        # Special case for structured void and subarray: we need to make all the
         # format functions for the items masked as well.
         # TODO: maybe is a separate class is more logical?
         ffs = getattr(format_function, 'format_functions', None)
         if ffs:
+            # StructuredVoidFormat: multiple format functions to be changed.
             self.format_function.format_functions = [MaskedFormat(ff) for ff in ffs]
+
+        ff = getattr(format_function, 'format_function', None)
+        if ff:
+            # SubarrayFormat: change format function for the elements.
+            self.format_function.format_function = MaskedFormat(ff)
 
     def __call__(self, x):
         if x.dtype.names:
@@ -891,6 +897,13 @@ class MaskedFormat:
             # np.void but not an array scalar.
             return self.format_function([x[field] for field in x.dtype.names])
 
+        if x.shape:
+            # For a subarray pass on the data directly, since the
+            # items will be iterated on inside the function.
+            return self.format_function(x)
+
+        # Single element: first just typeset it normally, replace with masked
+        # string if needed.
         string = self.format_function(x.unmasked[()])
         if x.mask:
             # Strikethrough would be neat, but terminal needs a different

--- a/astropy/utils/masked/tests/test_masked.py
+++ b/astropy/utils/masked/tests/test_masked.py
@@ -50,6 +50,16 @@ class ArraySetup:
         self.sb = np.array([(1., 2.), (-3., 4.)], dtype=self.sdt)
         self.mask_sb = np.array([(True, False), (False, False)],
                                 dtype=self.mask_sdt)
+        self.scdt = np.dtype([('sa', '2f8'), ('sb', 'i8', (2, 2))])
+        self.sc = np.array([([1., 2.], [[1, 2], [3, 4]]),
+                            ([-1., -2.], [[-1, -2], [-3, -4]])],
+                           dtype=self.scdt)
+        self.mask_scdt = np.dtype([('sa', '2?'), ('sb', '?', (2, 2))])
+        self.mask_sc = np.array([([True, False], [[False, False],
+                                                  [True, True]]),
+                                 ([False, True], [[True, False],
+                                                  [False, True]])],
+                                dtype=self.mask_scdt)
 
 
 class QuantitySetup(ArraySetup):
@@ -385,6 +395,7 @@ class MaskedArraySetup(ArraySetup):
         self.mc = Masked(self.c, mask=self.mask_c)
         self.msa = Masked(self.sa, mask=self.mask_sa)
         self.msb = Masked(self.sb, mask=self.mask_sb)
+        self.msc = Masked(self.sc, mask=self.mask_sc)
 
 
 class TestViewing(MaskedArraySetup):
@@ -1237,12 +1248,15 @@ class TestMaskedArrayRepr(MaskedArraySetup):
         str(self.mc)
         str(self.msa)
         str(self.msb)
+        str(self.msc)
 
     def test_scalar_str(self):
         assert self.mb[0].shape == ()
         str(self.mb[0])
         assert self.msb[0].shape == ()
         str(self.msb[0])
+        assert self.msc[0].shape == ()
+        str(self.msc[0])
 
     def test_array_repr(self):
         repr(self.ma)
@@ -1250,10 +1264,12 @@ class TestMaskedArrayRepr(MaskedArraySetup):
         repr(self.mc)
         repr(self.msa)
         repr(self.msb)
+        repr(self.msc)
 
     def test_scalar_repr(self):
         repr(self.mb[0])
         repr(self.msb[0])
+        repr(self.msc[0])
 
 
 class TestMaskedQuantityRepr(TestMaskedArrayRepr, QuantitySetup):

--- a/docs/changes/utils/13404.bugfix.rst
+++ b/docs/changes/utils/13404.bugfix.rst
@@ -1,0 +1,2 @@
+Ensure ``str`` and ``repr`` work properly for ``Masked`` versions of
+structured subarrays.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description

<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

See title; this was not tested before.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #13401

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
