### PR TITLE
Add 'Q' format documentation for VLA tables. Check size of the `heap`. 

### DIFF
--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -150,6 +150,7 @@ class FITS_rec(np.recarray):
 
     _record_type = FITS_record
     _character_as_bytes = False
+    _heaperror = ''
 
     def __new__(subtype, input):
         """
@@ -1112,8 +1113,14 @@ class FITS_rec(np.recarray):
                 # include the size of its constituent arrays in the heap size
                 # total
                 if heapsize >= 2**31:
-                    raise ValueError("The heapsize limit for 'P' format has been reached. "
-                                     "Please consider using the 'Q' format for your file.")
+                    try:
+                        raise ValueError("The heapsize limit for 'P' format "
+                                         "has been reached. "
+                                         "Please consider using the 'Q' format "
+                                         "for your file.")
+                    except ValueError as error:
+                        self._heaperror = error
+                        return
 
             if isinstance(recformat, _FormatX) and name in self._converted:
                 _wrapx(self._converted[name], raw_field, recformat.repeat)

--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -1166,6 +1166,12 @@ class FITS_rec(np.recarray):
                            np.array([ord('T')], dtype=np.int8)[0])
                 raw_field[:] = np.choose(field, choices)
 
+        if isinstance(recformat, _FormatP):
+            P_heap_limit = ((2**32) / 2) - 1
+            if recformat._format_code == 'P' and heapsize > P_heap_limit:
+                raise ValueError("The heapsize limit for 'P' format has been reached. "
+                                 "Please consider using the 'Q' format for your file.")
+
         # Store the updated heapsize
         self._heapsize = heapsize
 

--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -1111,6 +1111,9 @@ class FITS_rec(np.recarray):
                 # Even if this VLA has not been read or updated, we need to
                 # include the size of its constituent arrays in the heap size
                 # total
+                if heapsize >= 2**31:
+                    raise ValueError("The heapsize limit for 'P' format has been reached. "
+                                     "Please consider using the 'Q' format for your file.")
 
             if isinstance(recformat, _FormatX) and name in self._converted:
                 _wrapx(self._converted[name], raw_field, recformat.repeat)
@@ -1165,11 +1168,6 @@ class FITS_rec(np.recarray):
                 choices = (np.array([ord('F')], dtype=np.int8)[0],
                            np.array([ord('T')], dtype=np.int8)[0])
                 raw_field[:] = np.choose(field, choices)
-
-        if isinstance(recformat, _FormatP):
-            if recformat._format_code=='P' and heapsize >= 2**31:
-                raise ValueError("The heapsize limit for 'P' format has been reached. "
-                                 "Please consider using the 'Q' format for your file.")
 
         # Store the updated heapsize
         self._heapsize = heapsize

--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -150,7 +150,6 @@ class FITS_rec(np.recarray):
 
     _record_type = FITS_record
     _character_as_bytes = False
-    _heaperror = ''
 
     def __new__(subtype, input):
         """
@@ -1113,15 +1112,10 @@ class FITS_rec(np.recarray):
                 # include the size of its constituent arrays in the heap size
                 # total
                 if heapsize >= 2**31:
-                    try:
-                        raise ValueError("The heapsize limit for 'P' format "
-                                         "has been reached. "
-                                         "Please consider using the 'Q' format "
-                                         "for your file.")
-                    except ValueError as error:
-                        self._heaperror = error
-                        return
-
+                    raise ValueError("The heapsize limit for 'P' format "
+                                     "has been reached. "
+                                     "Please consider using the 'Q' format "
+                                     "for your file.")
             if isinstance(recformat, _FormatX) and name in self._converted:
                 _wrapx(self._converted[name], raw_field, recformat.repeat)
                 continue

--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -1167,8 +1167,7 @@ class FITS_rec(np.recarray):
                 raw_field[:] = np.choose(field, choices)
 
         if isinstance(recformat, _FormatP):
-            P_heap_limit = ((2**32) / 2) - 1
-            if recformat._format_code == 'P' and heapsize > P_heap_limit:
+            if recformat._format_code=='P' and heapsize >= 2**31:
                 raise ValueError("The heapsize limit for 'P' format has been reached. "
                                  "Please consider using the 'Q' format for your file.")
 

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -943,12 +943,14 @@ class HDUList(list, _Verify):
         except (AttributeError, TypeError):
             dirname = None
 
-        with _free_space_check(self, dirname=dirname):
-            for hdu in self:
-                hdu._prewriteto(checksum=checksum)
-                hdu._writeto(hdulist._file)
-                hdu._postwriteto()
-        hdulist.close(output_verify=output_verify, closed=closed)
+        try:
+            with _free_space_check(self, dirname=dirname):
+                for hdu in self:
+                    hdu._prewriteto(checksum=checksum)
+                    hdu._writeto(hdulist._file)
+                    hdu._postwriteto()
+        finally:
+            hdulist.close(output_verify=output_verify, closed=closed)
 
     def close(self, output_verify='exception', verbose=False, closed=True):
         """

--- a/astropy/io/fits/hdu/table.py
+++ b/astropy/io/fits/hdu/table.py
@@ -504,6 +504,11 @@ class _TableBaseHDU(ExtensionHDU, _TableLikeHDU):
         if self._has_data:
             self.data._scale_back(
                 update_heap_pointers=not self._manages_own_heap)
+            if self.data._heaperror != '':
+                errormsg = self.data._heaperror
+                print(self)
+                self._close(closed=True)
+                raise ValueError(errormsg)
             # check TFIELDS and NAXIS2
             self._header['TFIELDS'] = len(self.data._coldefs)
             self._header['NAXIS2'] = self.data.shape[0]

--- a/astropy/io/fits/hdu/table.py
+++ b/astropy/io/fits/hdu/table.py
@@ -504,11 +504,6 @@ class _TableBaseHDU(ExtensionHDU, _TableLikeHDU):
         if self._has_data:
             self.data._scale_back(
                 update_heap_pointers=not self._manages_own_heap)
-            if self.data._heaperror != '':
-                errormsg = self.data._heaperror
-                print(self)
-                self._close(closed=True)
-                raise ValueError(errormsg)
             # check TFIELDS and NAXIS2
             self._header['TFIELDS'] = len(self.data._coldefs)
             self._header['NAXIS2'] = self.data.shape[0]

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -3046,16 +3046,15 @@ class TestVLATables(FitsTestCase):
         # a matrix with variable length array elements is created
         nrows = 30000
         matrix = np.zeros(nrows, dtype=np.object_)
-        xcol = np.ones(nrows)
         for i in range(0, nrows):
             matrix[i] = np.arange(0., float(i+1))
 
         col = fits.Column(name='MATRIX', format='PD('+str(nrows)+')',
                           unit='', array=matrix)
 
-        cols=fits.ColDefs([col])
+        cols = fits.ColDefs([col])
         t = fits.BinTableHDU.from_columns(cols)
-        t.name='MATRIX'
+        t.name = 'MATRIX'
 
         with pytest.raises(ValueError) as err:
             t.writeto(self.temp('matrix.fits'))

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -3035,7 +3035,8 @@ class TestVLATables(FitsTestCase):
             assert hdu.data.tolist() == [[[45, 56], [11, 3]], [[11, 12, 13], [12, 4]]]
             assert hdu.data['var'].tolist() == [[45, 56], [11, 12, 13]]
 
-    @pytest.mark.skipif('sys.maxsize < 2**32' or 'sys.platform == "win32"')
+    @pytest.mark.skipif('sys.maxsize < 2**32')
+    @pytest.mark.skipif('sys.platform == "win32"')
     #@pytest.mark.hugemem
     def test_heapsize_P_limit(self):
         """

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -3035,7 +3035,7 @@ class TestVLATables(FitsTestCase):
             assert hdu.data.tolist() == [[[45, 56], [11, 3]], [[11, 12, 13], [12, 4]]]
             assert hdu.data['var'].tolist() == [[45, 56], [11, 12, 13]]
 
-    @pytest.mark.skipif('sys.maxsize < 2**32' or 'sys.platform.startswith("win32")')
+    @pytest.mark.skipif(sys.maxsize < 2**32 or sys.platform == 'win32')
     #@pytest.mark.hugemem
     def test_heapsize_P_limit(self):
         """

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -3049,11 +3049,10 @@ class TestVLATables(FitsTestCase):
         for i in range(0, nrows):
             matrix[i] = np.arange(0., float(i+1))
 
-        col = fits.Column(name='MATRIX', format='PD('+str(nrows)+')',
+        col = fits.Column(name='MATRIX', format=f'PD({nrows})',
                           unit='', array=matrix)
 
-        cols = fits.ColDefs([col])
-        t = fits.BinTableHDU.from_columns(cols)
+        t = fits.BinTableHDU.from_columns([cols])
         t.name = 'MATRIX'
 
         with pytest.raises(ValueError) as err:

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -3035,6 +3035,7 @@ class TestVLATables(FitsTestCase):
             assert hdu.data.tolist() == [[[45, 56], [11, 3]], [[11, 12, 13], [12, 4]]]
             assert hdu.data['var'].tolist() == [[45, 56], [11, 12, 13]]
 
+    #@pytest.mark.hugemem
     def test_heapsize_P_limit(self):
         """
         Regression test for https://github.com/astropy/astropy/issues/10812
@@ -3044,15 +3045,14 @@ class TestVLATables(FitsTestCase):
         """
 
         # a matrix with variable length array elements is created
-        nrows = 30000
-        matrix = np.zeros(nrows, dtype=np.object_)
-        for i in range(0, nrows):
-            matrix[i] = np.arange(0., float(i+1))
+        nelem = 2**28
+        matrix = np.zeros(1, dtype=np.object_)
+        matrix[0] = np.arange(0., float(nelem+1))
 
-        col = fits.Column(name='MATRIX', format=f'PD({nrows})',
+        col = fits.Column(name='MATRIX', format=f'PD({nelem})',
                           unit='', array=matrix)
 
-        t = fits.BinTableHDU.from_columns([cols])
+        t = fits.BinTableHDU.from_columns([col])
         t.name = 'MATRIX'
 
         with pytest.raises(ValueError) as err:

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -3061,6 +3061,7 @@ class TestVLATables(FitsTestCase):
 
         assert "Please consider using the 'Q' format for your file." in str(err.value)
 
+
 # These are tests that solely test the Column and ColDefs interfaces and
 # related functionality without directly involving full tables; currently there
 # are few of these but I expect there to be more as I improve the test coverage

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -3035,6 +3035,7 @@ class TestVLATables(FitsTestCase):
             assert hdu.data.tolist() == [[[45, 56], [11, 3]], [[11, 12, 13], [12, 4]]]
             assert hdu.data['var'].tolist() == [[45, 56], [11, 12, 13]]
 
+    @pytest.mark.skipif('sys.maxsize < 2**32')
     #@pytest.mark.hugemem
     def test_heapsize_P_limit(self):
         """

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -3035,7 +3035,7 @@ class TestVLATables(FitsTestCase):
             assert hdu.data.tolist() == [[[45, 56], [11, 3]], [[11, 12, 13], [12, 4]]]
             assert hdu.data['var'].tolist() == [[45, 56], [11, 12, 13]]
 
-    @pytest.mark.skipif(sys.maxsize < 2**32 or sys.platform == 'win32')
+    @pytest.mark.skipif('sys.maxsize < 2**32' or 'sys.platform == "win32"')
     #@pytest.mark.hugemem
     def test_heapsize_P_limit(self):
         """

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -3037,7 +3037,7 @@ class TestVLATables(FitsTestCase):
 
     @pytest.mark.skipif('sys.maxsize < 2**32')
     @pytest.mark.skipif('sys.platform == "win32"')
-    #@pytest.mark.hugemem
+    @pytest.mark.hugemem
     def test_heapsize_P_limit(self):
         """
         Regression test for https://github.com/astropy/astropy/issues/10812
@@ -3057,10 +3057,9 @@ class TestVLATables(FitsTestCase):
         t = fits.BinTableHDU.from_columns([col])
         t.name = 'MATRIX'
 
-        with pytest.raises(ValueError) as err:
+        with pytest.raises(ValueError,
+                           match="Please consider using the 'Q' format for your file."):
             t.writeto(self.temp('matrix.fits'))
-
-        assert "Please consider using the 'Q' format for your file." in str(err.value)
 
 
 # These are tests that solely test the Column and ColDefs interfaces and

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -3035,7 +3035,7 @@ class TestVLATables(FitsTestCase):
             assert hdu.data.tolist() == [[[45, 56], [11, 3]], [[11, 12, 13], [12, 4]]]
             assert hdu.data['var'].tolist() == [[45, 56], [11, 12, 13]]
 
-    @pytest.mark.skipif('sys.maxsize < 2**32')
+    @pytest.mark.skipif('sys.maxsize < 2**32' or 'sys.platform.startswith("win32")')
     #@pytest.mark.hugemem
     def test_heapsize_P_limit(self):
         """

--- a/docs/changes/io.fits/13429.bugfix.rst
+++ b/docs/changes/io.fits/13429.bugfix.rst
@@ -1,0 +1,2 @@
+``heapsize`` is now checked for VLA tables. An error is thrown whether P format is used
+but the heap size is bigger than what can be indexed with a 32 bit signed int.

--- a/docs/io/fits/usage/unfamiliar.rst
+++ b/docs/io/fits/usage/unfamiliar.rst
@@ -125,10 +125,14 @@ different cells.
 
 A variable length array table can have one or more fields (columns) which are
 variable length. The rest of the fields (columns) in the same table can still
-be regular, fixed-length ones. ``astropy`` will automatically detect what kind
+be regular, fixed-length ones.
+The data for the variable-length arrays in a table are not
+stored in the main data table; they are stored in a supplemental
+data area, the heap, following the main data table.
+``astropy`` will automatically detect what kind
 of field it is during reading; no special action is needed from the user. The
 data type specification (i.e., the value of the TFORM keyword) uses an extra
-letter 'P' and the format is:
+letter 'P' (or 'Q') and the format is:
 
 .. parsed-literal::
 
@@ -140,6 +144,19 @@ variable length arrays), ``t`` is one of the letter codes for basic data types
 array field in ``astropy``), and ``max`` is the maximum number of elements of
 any array in the column. So, for a variable length field of int16, the
 corresponding format spec is, for example, 'PJ(100)'.
+What is stored in the main data table field is an array descriptor.
+This consists of two 32-bit signed integer values in the case of ’P’ format,
+(or two 64-bit signed integer values in the case of ’Q’ format):
+the number of elements (array length) of the stored array,
+followed by the zero-indexed byte offset of the first
+element of the array, measured from the start of the heap area.
+
+.. note::
+    While P format uses 32-bit signed integers, the FITS standard does not define
+    the meaning for negative values. P format indexes from byte 0 to $2^{32} - 1$.
+    Depending of the format of the variable arrays (int or float or double) and 
+    the number of rows it might be necessary to use the Q format to allocate enough
+    heap space.
 
 Example
 -------

--- a/docs/io/fits/usage/unfamiliar.rst
+++ b/docs/io/fits/usage/unfamiliar.rst
@@ -154,7 +154,7 @@ element of the array, measured from the start of the heap area.
 .. note::
     While P format uses 32-bit signed integers, the FITS standard does not define
     the meaning for negative values. P format indexes from byte 0 to
-    :math:`frac{2^{32}}{2} - 1`.
+    :math:`2^{31} - 1`.
     Depending on the format of the variable arrays (int or float or double) and
     the number of rows it might be necessary to use the Q format to allocate enough
     heap space.

--- a/docs/io/fits/usage/unfamiliar.rst
+++ b/docs/io/fits/usage/unfamiliar.rst
@@ -155,7 +155,7 @@ element of the array, measured from the start of the heap area.
     While P format uses 32-bit signed integers, the FITS standard does not define
     the meaning for negative values. P format indexes from byte 0 to
     $frac{2^{32}}{2} - 1$.
-    Depending of the format of the variable arrays (int or float or double) and 
+    Depending of the format of the variable arrays (int or float or double) and
     the number of rows it might be necessary to use the Q format to allocate enough
     heap space.
 

--- a/docs/io/fits/usage/unfamiliar.rst
+++ b/docs/io/fits/usage/unfamiliar.rst
@@ -153,7 +153,8 @@ element of the array, measured from the start of the heap area.
 
 .. note::
     While P format uses 32-bit signed integers, the FITS standard does not define
-    the meaning for negative values. P format indexes from byte 0 to $2^{32} - 1$.
+    the meaning for negative values. P format indexes from byte 0 to
+    $frac{2^{32}}{2} - 1$.
     Depending of the format of the variable arrays (int or float or double) and 
     the number of rows it might be necessary to use the Q format to allocate enough
     heap space.

--- a/docs/io/fits/usage/unfamiliar.rst
+++ b/docs/io/fits/usage/unfamiliar.rst
@@ -154,8 +154,8 @@ element of the array, measured from the start of the heap area.
 .. note::
     While P format uses 32-bit signed integers, the FITS standard does not define
     the meaning for negative values. P format indexes from byte 0 to
-    $frac{2^{32}}{2} - 1$.
-    Depending of the format of the variable arrays (int or float or double) and
+    :math:`frac{2^{32}}{2} - 1`.
+    Depending on the format of the variable arrays (int or float or double) and
     the number of rows it might be necessary to use the Q format to allocate enough
     heap space.
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request add documentation about 'Q' format for variable length arrays and add check whether the heap size is bigger than what can be indexed with a 32 bit signed int.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #10812.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
