### PR TITLE
Finalize set-up of GitHub actions for building wheels

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,12 +29,8 @@ jobs:
     if: (github.repository == 'astropy/astropy' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'Build all wheels')))
     with:
 
-      # TODO: currently this will publish wheels to PyPI for any tag starting with
-      # 'v' but we need to exclude '.dev' tags.
-
-      # For now, we upload all successful builds to anaconda.org, and we don't
-      # ever upload to PyPI. Once the Azure pipelines configuration is removed,
-      # we can enable PyPI uploads here.
+      # We upload to PyPI for all tags starting with v but not ones ending in .dev
+      upload_to_pypi: ${{ startsWith(github.ref, 'refs/tags/v') && !endsWith(github.ref, '.dev') && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
       upload_to_anaconda: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
       anaconda_user: astropy
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,7 +35,6 @@ jobs:
       # For now, we upload all successful builds to anaconda.org, and we don't
       # ever upload to PyPI. Once the Azure pipelines configuration is removed,
       # we can enable PyPI uploads here.
-      upload_to_pypi: false
       upload_to_anaconda: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
       anaconda_user: astropy
 

--- a/docs/changes/13431.other.rst
+++ b/docs/changes/13431.other.rst
@@ -1,0 +1,3 @@
+Development wheels of astropy should now be installed from
+https://pypi.anaconda.org/astropy/simple instead of from
+https://pkgs.dev.azure.com/astropy-project/astropy/_packaging/nightly/pypi/simple.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -413,16 +413,16 @@ Installing pre-built Development Versions of ``astropy``
 Most nights a development snapshot of ``astropy`` will be compiled.
 This is useful if you want to test against a development version of astropy but
 do not want to have to build it yourselves. You can see the
-`available astropy dev snapshots page <https://dev.azure.com/astropy-project/astropy/_packaging?_a=package&feed=nightly&package=astropy&protocolType=PyPI&view=versions>`_
+`available astropy dev snapshots page <https://anaconda.org/astropy/astropy/files?type=pypi>`_
 to find out what is currently being offered.
 
 Installing these "nightlies" of ``astropy`` can be achieved by using ``pip``::
 
-  $ pip install --extra-index-url=https://pkgs.dev.azure.com/astropy-project/astropy/_packaging/nightly/pypi/simple/ --pre astropy
+  $ pip install -i https://pypi.anaconda.org/astropy/simple astropy --pre
 
-The extra index URL tells ``pip`` to check the ``pip`` index on Azure Pipelines, where the
-nightlies are built, and the ``--pre`` command tells ``pip`` to install pre-release
-versions (in this case ``.dev`` releases).
+The extra index URL tells ``pip`` to check the ``pip`` index on
+pypi.anaconda.org, where the nightlies are stored, and the ``--pre`` command
+tells ``pip`` to install pre-release versions (in this case ``.dev`` releases).
 
 .. _builddocs:
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -418,7 +418,7 @@ to find out what is currently being offered.
 
 Installing these "nightlies" of ``astropy`` can be achieved by using ``pip``::
 
-  $ pip install -i https://pypi.anaconda.org/astropy/simple astropy --pre
+  $ pip install -U -i https://pypi.anaconda.org/astropy/simple astropy --pre
 
 The extra index URL tells ``pip`` to check the ``pip`` index on
 pypi.anaconda.org, where the nightlies are stored, and the ``--pre`` command


### PR DESCRIPTION
### Description

Companion to https://github.com/astropy/astropy/pull/13298 (the present PR should be merged first I believe)

Also fixes https://github.com/astropy/astropy/issues/13194 by not uploading .dev tags (thanks @ConorMacBride!)

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
