### PR TITLE
Update `docs/units/format.rst`

### DIFF
--- a/docs/units/format.rst
+++ b/docs/units/format.rst
@@ -153,7 +153,10 @@ following formats:
     recommendations for unit presentation. This format is
     automatically used when printing a unit in the `IPython`_ notebook::
 
-      >>> fluxunit  # doctest: +SKIP
+        >>> f"{fluxunit:latex}"
+        '$\\mathrm{\\frac{erg}{s\\,cm^{2}}}$'
+
+    which renders as
 
     .. math::
 
@@ -167,7 +170,10 @@ following formats:
     <https://journals.aas.org/manuscript-preparation/>`_).
     Best suited for unit representation inline with text::
 
-      >>> fluxunit.to_string('latex_inline')  # doctest: +SKIP
+        >>> fluxunit.to_string('latex_inline')
+        '$\\mathrm{erg\\,s^{-1}\\,cm^{-2}}$'
+
+    which renders as
 
     .. math::
 

--- a/docs/units/format.rst
+++ b/docs/units/format.rst
@@ -45,6 +45,16 @@ attributes within format strings::
     >>> f"{q.value:.3f} in {q.unit}"
     '10.500 in km'
 
+This might not work well with LaTeX strings, in which case it would be better
+to use the `Quantity.to_string() <astropy.units.Quantity.to_string()>`
+method::
+
+    >>> q = 1.2478e12 * u.pc/u.Myr
+    >>> f"{q.value:.3e} {q.unit:latex}"  # The value is not in LaTeX
+    '1.248e+12 $\\mathrm{\\frac{pc}{Myr}}$'
+    >>> q.to_string(format="latex", precision=4)  # Right number of LaTeX digits
+    '$1.248 \\times 10^{12} \\; \\mathrm{\\frac{pc}{Myr}}$'
+
 Because |ndarray| does not accept most format specifiers, using specifiers like
 ``.3f`` will not work when applied to a |ndarray| or non-scalar |Quantity|. Use
 :func:`numpy.array_str` instead. For instance::
@@ -63,9 +73,8 @@ different styles. By default, the string format used is referred to as the
 <https://fits.gsfc.nasa.gov/fits_standard.html>`_ format for representing
 units, but supports all of the units defined within the :mod:`astropy.units`
 framework, including user-defined units. The format specifier (and
-:meth:`~astropy.units.core.UnitBase.to_string`) functions also take an optional
-parameter to select a different format, including ``"latex"``, ``"unicode"``,
-``"cds"``, and others, defined below::
+`UnitBase.to_string() <astropy.units.core.UnitBase.to_string>`) functions also
+take an optional parameter to select a different format::
 
     >>> q = 10 * u.km
     >>> f"{q.value:0.003f} in {q.unit:latex}"
@@ -82,9 +91,9 @@ parameter to select a different format, including ``"latex"``, ``"unicode"``,
     >>> f"{fluxunit:>20s}"
     '       erg / (cm2 s)'
 
-The :meth:`~astropy.units.core.UnitBase.to_string` method is an alternative way
-to format units as strings, and is the underlying implementation of the
-`format`-style usage::
+The `UnitBase.to_string() <astropy.units.core.UnitBase.to_string>` method is an
+alternative way to format units as strings, and is the underlying
+implementation of the `format`-style usage::
 
     >>> fluxunit = u.erg / (u.cm ** 2 * u.s)
     >>> fluxunit.to_string('latex')

--- a/docs/units/format.rst
+++ b/docs/units/format.rst
@@ -90,8 +90,8 @@ to format units as strings, and is the underlying implementation of the
     >>> fluxunit.to_string('latex')
     '$\\mathrm{\\frac{erg}{s\\,cm^{2}}}$'
 
-Creating Units from Strings
-===========================
+Converting from Strings
+=======================
 
 .. EXAMPLE START: Creating Units from Strings
 
@@ -105,16 +105,19 @@ formats using the `~astropy.units.Unit` class::
   >>> u.Unit("erg.s-1.cm-2", format="cds")
   Unit("erg / (cm2 s)")
 
+It is also possible to create a scalar |Quantity| from a string::
+
+    >>> u.Quantity("3m/s")
+    <Quantity 3. m / s>
+
 .. note::
 
-   Creating units from strings requires the use of a specialized
-   parser for the unit language, which results in a performance
-   penalty if units are created using strings. Thus, it is much
-   faster to use |Unit| objects directly (e.g., ``unit = u.degree /
-   u.minute``) instead of via string parsing (``unit =
-   u.Unit('deg/min')``). This parser is very useful, however, if your
-   unit definitions are coming from a file format such as FITS or
-   VOTable.
+   Converting from strings requires the use of a specialized parser for the
+   unit language, which results in a performance penalty. It is much faster to
+   use |Unit| objects directly (e.g., ``unit = u.degree / u.minute``) instead
+   of via string parsing (``unit = u.Unit('deg/min')``). This parser is very
+   useful, however, if your unit definitions are coming from a file format such
+   as FITS or VOTable.
 
 .. EXAMPLE END
 

--- a/docs/units/format.rst
+++ b/docs/units/format.rst
@@ -1,10 +1,10 @@
 .. _astropy-units-format:
 
-String Representations of Units
-*******************************
+String Representations of Units and Quantities
+**********************************************
 
-Converting Units to String Representations
-==========================================
+Converting to Strings
+=====================
 
 You can control the way that |Quantity| and |Unit| objects are rendered as
 strings using the `Python Format String Syntax
@@ -25,7 +25,6 @@ Examples
 To render |Quantity| or |Unit| objects as strings::
 
     >>> from astropy import units as u
-    >>> import numpy as np
     >>> q = 10.5 * u.km
     >>> q
     <Quantity  10.5 km>
@@ -33,6 +32,8 @@ To render |Quantity| or |Unit| objects as strings::
     '10.5 km'
     >>> f"{q:+.3f}"
     '+10.500 km'
+    >>> f"{q:^20}"
+    '        10.5         km'
     >>> f"{q:^20s}"
     '     10.5 km        '
 
@@ -59,6 +60,7 @@ Because |ndarray| does not accept most format specifiers, using specifiers like
 ``.3f`` will not work when applied to a |ndarray| or non-scalar |Quantity|. Use
 :func:`numpy.array_str` instead. For instance::
 
+    >>> import numpy as np
     >>> q = np.linspace(0,1,10) * u.m
     >>> f"{np.array_str(q.value, precision=1)} {q.unit}"  # doctest: +FLOAT_CMP
     '[0.  0.1 0.2 0.3 0.4 0.6 0.7 0.8 0.9 1. ] m'
@@ -67,9 +69,9 @@ Examine the NumPy documentation for more examples with :func:`numpy.array_str`.
 
 .. EXAMPLE END
 
-Units, or the unit part of a quantity, can also be formatted in a number of
-different styles. By default, the string format used is referred to as the
-"generic" format, which is based on syntax of the `FITS standard
+A |Unit|, or the unit part of a |Quantity|, can also be formatted in a number
+of different styles. By default, the string format used is the "generic"
+format, which is based on syntax of the `FITS standard
 <https://fits.gsfc.nasa.gov/fits_standard.html>`_ format for representing
 units, but supports all of the units defined within the :mod:`astropy.units`
 framework, including user-defined units. The format specifier (and


### PR DESCRIPTION
### Description

Minor updates to `UnitBase` and `Quantity` formatting documentation, see the commit messages for details. I see no reason why these changes shouldn't be backported.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
