### PR TITLE
Add `rtol` and `atol` to `report_diff_values` in `FITSDiff`

### DIFF
--- a/astropy/io/fits/diff.py
+++ b/astropy/io/fits/diff.py
@@ -1051,7 +1051,8 @@ class ImageDataDiff(_BaseDiff):
             index = [x + 1 for x in reversed(index)]
             self._writeln(f' Data differs at {index}:')
             report_diff_values(values[0], values[1], fileobj=self._fileobj,
-                               indent_width=self._indent + 1)
+                               indent_width=self._indent + 1, rtol=self.rtol,
+                               atol=self.atol)
 
         if self.diff_total > self.numdiffs:
             self._writeln(' ...')
@@ -1130,7 +1131,8 @@ class RawDataDiff(ImageDataDiff):
         for index, values in self.diff_bytes:
             self._writeln(f' Data differs at byte {index}:')
             report_diff_values(values[0], values[1], fileobj=self._fileobj,
-                               indent_width=self._indent + 1)
+                               indent_width=self._indent + 1, rtol=self.rtol,
+                               atol=self.atol)
 
         self._writeln(' ...')
         self._writeln(' {} different bytes found ({:.2%} different).'
@@ -1417,7 +1419,8 @@ class TableDataDiff(_BaseDiff):
             name, attr = col_attr
             self._writeln(f' Column {name} has different {col_attrs[attr]}:')
             report_diff_values(vals[0], vals[1], fileobj=self._fileobj,
-                               indent_width=self._indent + 1)
+                               indent_width=self._indent + 1, rtol=self.rtol,
+                               atol=self.atol)
 
         if self.diff_rows:
             self._writeln(' Table rows differ:')
@@ -1433,7 +1436,8 @@ class TableDataDiff(_BaseDiff):
         for indx, values in self.diff_values:
             self._writeln(' Column {} data differs in row {}:'.format(*indx))
             report_diff_values(values[0], values[1], fileobj=self._fileobj,
-                               indent_width=self._indent + 1)
+                               indent_width=self._indent + 1, rtol=self.rtol,
+                               atol=self.atol)
 
         if self.diff_values and self.numdiffs < self.diff_total:
             self._writeln(' ...{} additional difference(s) found.'.format(

--- a/astropy/io/fits/tests/test_diff.py
+++ b/astropy/io/fits/tests/test_diff.py
@@ -893,3 +893,35 @@ def test_fitsdiff_with_names(tmpdir):
 
     diff = FITSDiff(path1, path2)
     assert "Extension HDU 1:" in diff.report()
+
+
+def test_rawdatadiff_diff_with_rtol(tmpdir):
+    """Regression test for https://github.com/astropy/astropy/issues/13330"""
+    path1 = str(tmpdir.join("test1.fits"))
+    path2 = str(tmpdir.join("test2.fits"))
+    a = np.zeros((10, 2), dtype='float32')
+    a[:, 0] = np.arange(10, dtype='float32') + 10
+    a[:, 1] = np.arange(10, dtype='float32') + 20
+    b = a.copy()
+    changes = [(3, 13.1, 23.1), (8, 20.5, 30.5)]
+    for i, v, w in changes:
+        b[i, 0] = v
+        b[i, 1] = w
+
+    ca = Column('A', format='20E', array=[a])
+    cb = Column('A', format='20E', array=[b])
+    hdu_a = BinTableHDU.from_columns([ca])
+    hdu_a.writeto(path1, overwrite=True)
+    hdu_b = BinTableHDU.from_columns([cb])
+    hdu_b.writeto(path2, overwrite=True)
+    with fits.open(path1) as fits1:
+        with fits.open(path2) as fits2:
+
+            diff = FITSDiff(fits1, fits2, atol=0, rtol=0.001)
+            str1 = diff.report(fileobj=None, indent=0)
+
+            diff = FITSDiff(fits1, fits2, atol=0, rtol=0.01)
+            str2 = diff.report(fileobj=None, indent=0)
+
+    assert "...and at 1 more indices." in str1
+    assert "...and at 1 more indices." not in str2

--- a/docs/changes/io.fits/13465.bugfix.rst
+++ b/docs/changes/io.fits/13465.bugfix.rst
@@ -1,0 +1,3 @@
+``report_diff_values()`` have now two new parameters ``rtol`` and ``atol`` to make the
+report consistent with ``numpy.allclose`` results.
+This fixes ``FITSDiff`` with multi-dimensional columns.


### PR DESCRIPTION
### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to adds to `report_diff_values` the parameters `rtol` and `atol` in order to report only values to be considered different with respect to tolerances.

Thanks for considering it.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #13330.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
