### PR TITLE
Fix 12229 (Can't convert a list of Astropy tables to a NumPy array of tables)

### DIFF
--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -1069,7 +1069,11 @@ class Table:
         Coercion to a different dtype via np.array(table, dtype) is not
         supported and will raise a ValueError.
         """
-        if dtype is not None:
+        if np.dtype(dtype).kind == 'O':
+            out = np.array(None, dtype=object)
+            out[()] = self
+            return out
+        elif dtype is not None:
             raise ValueError('Datatype coercion is not allowed')
 
         # This limitation is because of the following unexpected result that

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -1069,12 +1069,13 @@ class Table:
         Coercion to a different dtype via np.array(table, dtype) is not
         supported and will raise a ValueError.
         """
-        if np.dtype(dtype).kind == 'O':
+        if dtype is not None:
+            if np.dtype(dtype) != object:
+                raise ValueError('Datatype coercion is not allowed')
+
             out = np.array(None, dtype=object)
             out[()] = self
             return out
-        elif dtype is not None:
-            raise ValueError('Datatype coercion is not allowed')
 
         # This limitation is because of the following unexpected result that
         # should have made a table copy while changing the column names.

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -28,6 +28,7 @@ from astropy.time import Time, TimeDelta
 from .conftest import MaskedTable, MIXIN_COLS
 
 from astropy.utils.compat.optional_deps import HAS_PANDAS  # noqa
+from astropy.utils.compat.numpycompat import NUMPY_LT_1_20
 
 
 @pytest.fixture
@@ -1407,11 +1408,19 @@ class TestConvertNumpyArray():
 
     def test_convert_numpy_object_array(self, table_types):
         d = table_types.Table([[1, 2], [3, 4]], names=('a', 'b'))
-        ds = [d, d, d]
 
+        # Single table
+        np_d = np.array(d, dtype=object)
+        assert isinstance(np_d, np.ndarray)
+        assert np_d[()] is d
+
+    @pytest.mark.xfail(NUMPY_LT_1_20, reason="numpy array introspection changed")
+    def test_convert_list_numpy_object_array(self, table_types):
+        d = table_types.Table([[1, 2], [3, 4]], names=('a', 'b'))
+        ds = [d, d, d]
         np_ds = np.array(ds, dtype=object)
-        assert all(isinstance(t, table_types.Table) for t in np_ds)
-        assert all(np.array_equal(t, d) for t in np_ds)
+        assert all([isinstance(t, table_types.Table) for t in np_ds])
+        assert all([np.array_equal(t, d) for t in np_ds])
 
 
 def _assert_copies(t, t2, deep=True):

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -1405,6 +1405,14 @@ class TestConvertNumpyArray():
                 assert (data[colname].dtype.byteorder
                         == arr2[colname].dtype.byteorder)
 
+    def test_convert_numpy_object_array(self, table_types):
+        d = table_types.Table([[1, 2], [3, 4]], names=('a', 'b'))
+        ds = [d, d, d]
+
+        np_ds = np.array(ds, dtype=object)
+        assert all(isinstance(t, table_types.Table) for t in np_ds)
+        assert all(np.array_equal(t, d) for t in np_ds)
+
 
 def _assert_copies(t, t2, deep=True):
     assert t.colnames == t2.colnames

--- a/docs/changes/table/13469.feature.rst
+++ b/docs/changes/table/13469.feature.rst
@@ -1,2 +1,3 @@
-A list of Astropy tables can now be converted to an NumPy object array of
+An Astropy table can now be converted to a scalar NumPy object array. For NumPy
+>= 1.20, a list of Astropy tables can be converted to an NumPy object array of
 tables.

--- a/docs/changes/table/13469.feature.rst
+++ b/docs/changes/table/13469.feature.rst
@@ -1,0 +1,2 @@
+A list of Astropy tables can now be converted to an NumPy object array of
+tables.

--- a/setup.cfg
+++ b/setup.cfg
@@ -100,7 +100,7 @@ docs =
     scipy>=1.3
     matplotlib>=3.1,!=3.4.0,!=3.5.2
     sphinx-changelog>=1.2.0
-    Jinja2<3.1
+    Jinja2>=3.0,<3.1
 
 [options.package_data]
 * = data/*, data/*/*, data/*/*/*, data/*/*/*/*, data/*/*/*/*/*, data/*/*/*/*/*/*


### PR DESCRIPTION
I had some trouble taking over the PR at #12743, so this is just re-pushing it from my branch.
I kept @YashNandwana's commits, just squashed them down.

Fixes #12229

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
