### PR TITLE
Validate frame attributes when setting them, not when getting them

### DIFF
--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -873,9 +873,9 @@ class SkyCoord(ShapedLikeNDArray):
             # variable.  See __getattr__ above.
             super().__setattr__('_' + attr, val)
             # Validate it
-            frame_transform_graph.frame_attributes[attr].__get__(self)
+            frame_transform_graph.frame_attributes[attr].validate(self)
             # And add to set of extra attributes
-            self._extra_frameattr_names |= {attr}
+            self._extra_frameattr_names.add(attr)
 
         else:
             # Otherwise, do the standard Python attribute setting


### PR DESCRIPTION
### Description

This pull request adds methods `validate` and `broadcast` to `FrameAttribute` and removes all expensive checks from `__get__`.

`BaseCoordinateFrame` and `SkyCoord` now call `validate` / `convert_input` and `broadcast` where appropriate, so that these operations only happen once, not on each get.

Timings:

This branch:
```
296 ns ± 9.44 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
location
305 ns ± 4.76 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
temperature
319 ns ± 6.95 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
```

main:
```
❯ ipython time_frame_attr.py
obstime
1.61 µs ± 27.3 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
location
675 ns ± 11.6 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
temperature
1.81 µs ± 14.2 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
```


Script:

```
from astropy.coordinates import EarthLocation, AltAz
from astropy.time import Time

loc = EarthLocation.of_site("Roque de los Muchachos")
time = Time.now()
frame = AltAz(location=loc, obstime=time)

for attr in ('obstime', 'location', 'temperature'):
    print(attr)
    get_ipython().run_line_magic('timeit', f'frame.{attr}')
```

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
