### PR TITLE
Let get_frame_attr_names only return names, add get_frame_attr_defaults

### DIFF
--- a/astropy/coordinates/attributes.py
+++ b/astropy/coordinates/attributes.py
@@ -440,7 +440,7 @@ class CoordinateAttribute(Attribute):
         ValueError
             If the input is not valid for this attribute.
         """
-        from astropy.coordinates import SkyCoord
+        from .sky_coordinate import SkyCoord
 
         if value is None:
             return None, False

--- a/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
@@ -159,7 +159,7 @@ def gcrs_to_hcrs(gcrs_coo, hcrs_frame):
     if np.any(gcrs_coo.obstime != hcrs_frame.obstime):
         # if they GCRS obstime and HCRS obstime are not the same, we first
         # have to move to a GCRS where they are.
-        frameattrs = gcrs_coo.get_frame_attr_names()
+        frameattrs = gcrs_coo.get_frame_attr_defaults()
         frameattrs['obstime'] = hcrs_frame.obstime
         gcrs_coo = gcrs_coo.transform_to(GCRS(**frameattrs))
 

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -16,7 +16,6 @@ from astropy.utils.exceptions import AstropyUserWarning
 
 from .angles import Angle
 from .baseframe import BaseCoordinateFrame, GenericFrame, frame_transform_graph
-from .builtin_frames import ICRS, SkyOffsetFrame
 from .distances import Distance
 from .representation import (
     RadialDifferential, SphericalDifferential, SphericalRepresentation,
@@ -672,8 +671,7 @@ class SkyCoord(ShapedLikeNDArray):
 
         # Finally make the new SkyCoord object from the `new_coord` and
         # remaining frame_kwargs that are not frame_attributes in `new_coord`.
-        for attr in (set(new_coord.get_frame_attr_names()) &
-                     set(frame_kwargs.keys())):
+        for attr in (set(new_coord.frame_attributes) & set(frame_kwargs.keys())):
             frame_kwargs.pop(attr)
 
         # Always remove the origin frame attribute, as that attribute only makes
@@ -715,6 +713,7 @@ class SkyCoord(ShapedLikeNDArray):
             at the new time.  ``obstime`` will be set on this object to the new
             time only if ``self`` also has ``obstime``.
         """
+        from .builtin_frames.icrs import ICRS
 
         if (new_obstime is None and dt is None or
                 new_obstime is not None and dt is not None):
@@ -835,7 +834,7 @@ class SkyCoord(ShapedLikeNDArray):
             # here. If the attr is relevant for the current frame then delegate
             # to self.frame otherwise get it from self._<attr>.
             if attr in frame_transform_graph.frame_attributes:
-                if attr in self.frame.get_frame_attr_names():
+                if attr in self.frame.frame_attributes:
                     return getattr(self.frame, attr)
                 else:
                     return getattr(self, '_' + attr, None)
@@ -1272,6 +1271,7 @@ class SkyCoord(ShapedLikeNDArray):
         spherical_offsets_to : compute the angular offsets to another coordinate
         directional_offset_by : offset a coordinate by an angle in a direction
         """
+        from .builtin_frames.skyoffset import SkyOffsetFrame
         return self.__class__(
             SkyOffsetFrame(d_lon, d_lat, origin=self.frame).transform_to(self))
 
@@ -1626,6 +1626,7 @@ class SkyCoord(ShapedLikeNDArray):
             particular position angle in the un-rotated system will be sent to
             the positive latitude (z) direction in the final frame.
         """
+        from .builtin_frames.skyoffset import SkyOffsetFrame
         return SkyOffsetFrame(origin=self, rotation=rotation)
 
     def get_constellation(self, short_name=False, constellation_list='iau'):

--- a/astropy/coordinates/sky_coordinate_parsers.py
+++ b/astropy/coordinates/sky_coordinate_parsers.py
@@ -10,7 +10,6 @@ from astropy import units as u
 from astropy.units import IrreducibleUnit, Unit
 
 from .baseframe import BaseCoordinateFrame, _get_diff_cls, _get_repr_cls, frame_transform_graph
-from .builtin_frames import ICRS
 from .representation import BaseRepresentation, SphericalRepresentation, UnitSphericalRepresentation
 
 """
@@ -105,7 +104,7 @@ def _get_frame_without_data(args, kwargs):
 
         if isinstance(frame, BaseCoordinateFrame):
             # Extract any frame attributes
-            for attr in frame.get_frame_attr_names():
+            for attr in frame.frame_attributes:
                 # If the frame was specified as an instance, we have to make
                 # sure that no frame attributes were specified as kwargs - this
                 # would require a potential three-way merge:
@@ -155,7 +154,7 @@ def _get_frame_without_data(args, kwargs):
                 # None still gets through if the user *requests* it
                 kwargs.setdefault('differential_type', frame_diff)
 
-            for attr in coord_frame_obj.get_frame_attr_names():
+            for attr in coord_frame_obj.frame_attributes:
                 if (attr in kwargs and
                         not coord_frame_obj.is_frame_attr_default(attr) and
                         np.any(kwargs[attr] != getattr(coord_frame_obj, attr))):
@@ -183,6 +182,7 @@ def _get_frame_without_data(args, kwargs):
                                          frame_cls.__name__))
 
     if frame_cls is None:
+        from .builtin_frames import ICRS
         frame_cls = ICRS
 
     # By now, frame_cls should be set - if it's not, something went wrong
@@ -431,7 +431,7 @@ def _parse_coordinate_arg(coords, frame, units, init_kwargs):
         for attr in frame_transform_graph.frame_attributes:
             value = getattr(coords, attr, None)
             use_value = (isinstance(coords, SkyCoord) or
-                         attr not in coords.get_frame_attr_names())
+                         attr not in coords.frame_attributes)
             if use_value and value is not None:
                 skycoord_kwargs[attr] = value
 

--- a/astropy/coordinates/tests/test_api_ape5.py
+++ b/astropy/coordinates/tests/test_api_ape5.py
@@ -171,9 +171,9 @@ def test_frame_api():
 
     # There is also a class-level attribute that lists the attributes needed to
     # identify the frame.  These include attributes like `equinox` shown above.
-    assert all(nm in ('equinox', 'obstime') for nm in fk5.get_frame_attr_names())
+    assert all(nm in ('equinox', 'obstime') for nm in fk5.frame_attributes)
 
-    # the result of `get_frame_attr_names` is called for particularly in  the
+    # the `frame_attributes` are called for particularly in  the
     # high-level class (discussed below) to allow round-tripping between various
     # frames.  It is also part of the public API for other similar developer /
     # advanced users' use.

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -19,7 +19,7 @@ from astropy.coordinates.representation import REPRESENTATION_CLASSES, Cartesian
 from astropy.tests.helper import assert_quantity_allclose as assert_allclose
 from astropy.time import Time
 from astropy.units import allclose
-from astropy.utils.exceptions import AstropyWarning
+from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyWarning
 
 from .test_representation import unitphysics  # this fixture is used below  # noqa: F401
 
@@ -88,7 +88,8 @@ def test_frame_subclass_attribute_descriptor():
     assert mfk4.obstime.value == 'B1980.000'
     assert mfk4.newattr == 'newattr'
 
-    assert set(mfk4.get_frame_attr_names()) == {'equinox', 'obstime', 'newattr'}
+    with pytest.warns(AstropyDeprecationWarning):
+        assert set(mfk4.get_frame_attr_names()) == {'equinox', 'obstime', 'newattr'}
 
     mfk4 = MyFK4(equinox='J1980.0', obstime='J1990.0', newattr='world')
     assert mfk4.equinox.value == 'J1980.000'
@@ -210,17 +211,17 @@ def test_create_orderered_data():
 def test_create_nodata_frames():
 
     i = ICRS()
-    assert len(i.get_frame_attr_names()) == 0
+    assert len(i.frame_attributes) == 0
 
     f5 = FK5()
-    assert f5.equinox == FK5.get_frame_attr_names()['equinox']
+    assert f5.equinox == FK5.get_frame_attr_defaults()['equinox']
 
     f4 = FK4()
-    assert f4.equinox == FK4.get_frame_attr_names()['equinox']
+    assert f4.equinox == FK4.get_frame_attr_defaults()['equinox']
 
     # obstime is special because it's a property that uses equinox if obstime is not set
-    assert f4.obstime in (FK4.get_frame_attr_names()['obstime'],
-                          FK4.get_frame_attr_names()['equinox'])
+    assert f4.obstime in (FK4.get_frame_attr_defaults()['obstime'],
+                          FK4.get_frame_attr_defaults()['equinox'])
 
 
 def test_no_data_nonscalar_frames():
@@ -406,7 +407,7 @@ def test_realizing():
     assert f2.has_data
 
     assert f2.equinox == f.equinox
-    assert f2.equinox != FK5.get_frame_attr_names()['equinox']
+    assert f2.equinox != FK5.get_frame_attr_defaults()['equinox']
 
     # Check that a nicer error message is returned:
     with pytest.raises(TypeError) as excinfo:
@@ -698,7 +699,7 @@ def test_is_frame_attr_default():
 
     """
     c1 = FK5(ra=1*u.deg, dec=1*u.deg)
-    c2 = FK5(ra=1*u.deg, dec=1*u.deg, equinox=FK5.get_frame_attr_names()['equinox'])
+    c2 = FK5(ra=1*u.deg, dec=1*u.deg, equinox=FK5.get_frame_attr_defaults()['equinox'])
     c3 = FK5(ra=1*u.deg, dec=1*u.deg, equinox=Time('J2001.5'))
 
     assert c1.equinox == c2.equinox
@@ -1394,7 +1395,7 @@ def test_galactocentric_defaults():
                           galcen_40.galcen_distance)
     assert not u.allclose(galcen_pre40.z_sun, galcen_40.z_sun)
 
-    for k in galcen_40.get_frame_attr_names():
+    for k in galcen_40.frame_attributes:
         if isinstance(getattr(galcen_40, k), BaseCoordinateFrame):
             continue  # skip coordinate comparison...
 
@@ -1431,7 +1432,7 @@ def test_galactocentric_references():
     with galactocentric_frame_defaults.set('pre-v4.0'):
         galcen_pre40 = Galactocentric()
 
-        for k in galcen_pre40.get_frame_attr_names():
+        for k in galcen_pre40.frame_attributes:
             if k == 'roll':  # no reference for this parameter
                 continue
 
@@ -1440,7 +1441,7 @@ def test_galactocentric_references():
     with galactocentric_frame_defaults.set('v4.0'):
         galcen_40 = Galactocentric()
 
-        for k in galcen_40.get_frame_attr_names():
+        for k in galcen_40.frame_attributes:
             if k == 'roll':  # no reference for this parameter
                 continue
 
@@ -1449,7 +1450,7 @@ def test_galactocentric_references():
     with galactocentric_frame_defaults.set('v4.0'):
         galcen_custom = Galactocentric(z_sun=15*u.pc)
 
-        for k in galcen_custom.get_frame_attr_names():
+        for k in galcen_custom.frame_attributes:
             if k == 'roll':  # no reference for this parameter
                 continue
 

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -116,20 +116,20 @@ def test_round_tripping(frame0, frame1, equinox0, equinox1, obstime0, obstime1):
 
     # Keep only frame attributes for frame1
     attrs1 = {attr: val for attr, val in attrs1.items()
-              if attr in frame1.get_frame_attr_names()}
+              if attr in frame1.frame_attributes}
     sc2 = sc.transform_to(frame1(**attrs1))
 
     # When coming back only keep frame0 attributes for transform_to
     attrs0 = {attr: val for attr, val in attrs0.items()
-              if attr in frame0.get_frame_attr_names()}
+              if attr in frame0.frame_attributes}
     # also, if any are None, fill in with defaults
-    for attrnm in frame0.get_frame_attr_names():
+    for attrnm in frame0.frame_attributes:
         if attrs0.get(attrnm, None) is None:
-            if attrnm == 'obstime' and frame0.get_frame_attr_names()[attrnm] is None:
+            if attrnm == 'obstime' and frame0.get_frame_attr_defaults()[attrnm] is None:
                 if 'equinox' in attrs0:
                     attrs0[attrnm] = attrs0['equinox']
             else:
-                attrs0[attrnm] = frame0.get_frame_attr_names()[attrnm]
+                attrs0[attrnm] = frame0.get_frame_attr_defaults()[attrnm]
     sc_rt = sc2.transform_to(frame0(**attrs0))
 
     if frame0 is Galactic:

--- a/astropy/coordinates/transformations.py
+++ b/astropy/coordinates/transformations.py
@@ -798,12 +798,12 @@ class CoordinateTransform(metaclass=ABCMeta):
                 raise TypeError('fromsys and tosys must be classes')
 
         self.overlapping_frame_attr_names = overlap = []
-        if (hasattr(fromsys, 'get_frame_attr_names') and
-                hasattr(tosys, 'get_frame_attr_names')):
+        if (hasattr(fromsys, 'frame_attributes') and
+                hasattr(tosys, 'frame_attributes')):
             # the if statement is there so that non-frame things might be usable
             # if it makes sense
-            for from_nm in fromsys.frame_attributes.keys():
-                if from_nm in tosys.frame_attributes.keys():
+            for from_nm in fromsys.frame_attributes:
+                if from_nm in tosys.frame_attributes:
                     overlap.append(from_nm)
 
     def register(self, graph):
@@ -848,8 +848,8 @@ class CoordinateTransform(metaclass=ABCMeta):
         toframe : object
             An object that has the attributes necessary to fully specify the
             frame.  That is, it must have attributes with names that match the
-            keys of the dictionary that ``tosys.get_frame_attr_names()``
-            returns. Typically this is of class ``tosys``, but it *might* be
+            keys of the dictionary ``tosys.frame_attributes``.
+            Typically this is of class ``tosys``, but it *might* be
             some other class as long as it has the appropriate attributes.
 
         Returns
@@ -1461,7 +1461,7 @@ class CompositeTransform(CoordinateTransform):
             # TODO: caching this information when creating the transform may
             # speed things up a lot
             frattrs = {}
-            for inter_frame_attr_nm in t.tosys.get_frame_attr_names():
+            for inter_frame_attr_nm in t.tosys.frame_attributes:
                 if hasattr(toframe, inter_frame_attr_nm):
                     attr = getattr(toframe, inter_frame_attr_nm)
                     frattrs[inter_frame_attr_nm] = attr

--- a/astropy/io/misc/tests/test_yaml.py
+++ b/astropy/io/misc/tests/test_yaml.py
@@ -100,8 +100,8 @@ def compare_coord(c, cy):
     assert c.shape == cy.shape
     assert c.frame.name == cy.frame.name
 
-    assert list(c.get_frame_attr_names()) == list(cy.get_frame_attr_names())
-    for attr in c.get_frame_attr_names():
+    assert list(c.frame_attributes) == list(cy.frame_attributes)
+    for attr in c.frame_attributes:
         assert getattr(c, attr) == getattr(cy, attr)
 
     assert (list(c.representation_component_names) ==

--- a/docs/changes/coordinates/13484.bugfix.rst
+++ b/docs/changes/coordinates/13484.bugfix.rst
@@ -1,0 +1,4 @@
+``BaseCoordinateFrame.get_frame_attr_names()`` had a misleading name,
+because it actually provided a ``dict`` of attribute names and
+their default values. It is now deprecated and replaced by ``BaseCoordinateFrame.get_frame_attr_defaults()``.
+The fastest way to obtain the attribute names is ``BaseFrame.frame_attributes.keys()``.

--- a/docs/coordinates/frames.rst
+++ b/docs/coordinates/frames.rst
@@ -42,11 +42,16 @@ is first created::
     >>> FK5()  # uses default equinox
     <FK5 Frame (equinox=J2000.000)>
 
-The specific names of attributes available for a particular frame (and
-their default values) are available as the class method
-``get_frame_attr_names``::
+The specific names of attributes available for a particular frame are available
+as the keys of the ``frame_attributes`` dictionary::
 
-    >>> FK5.get_frame_attr_names()
+    >>> FK5.frame_attributes.keys()
+    dict_keys(['equinox'])
+
+The defaults of the frame attributes are available as:
+:meth:`~astropy.coordinates.BaseCoordinateFrame.get_frame_attr_defaults`::
+
+    >>> FK5.get_frame_attr_defaults()
     {'equinox': <Time object: scale='tt' format='jyear_str' value=J2000.000>}
 
 You can access any of the attributes on a frame by using standard Python

--- a/docs/coordinates/skycoord.rst
+++ b/docs/coordinates/skycoord.rst
@@ -542,15 +542,14 @@ a spherical-type coordinate (and not, for example, a Cartesian coordinate).
 Furthermore, the frame's ``representation_component_names`` attribute defines
 the coordinate keyword arguments that |SkyCoord| will accept.
 
-Another important attribute is ``frame_attr_names``, which defines the
+Another important attribute is ``frame_attributes``, which defines the
 additional attributes that are required to fully define the frame::
 
   >>> sc_fk4 = SkyCoord(1, 2, frame='fk4', unit='deg')
-  >>> sc_fk4.get_frame_attr_names()
-  {'equinox': <Time object: scale='tt' format='byear_str' value=B1950.000>, 'obstime': None}
+  >>> sc_fk4.frame_attributes   # doctest: +ELLIPSIS
+  {'equinox': <...TimeAttribute ...>, 'obstime': <...TimeAttribute ...>}
 
-The key values correspond to the defaults if no explicit value is provided by
-the user. This example shows that the `~astropy.coordinates.FK4` frame has two
+This example shows that the `~astropy.coordinates.FK4` frame has two
 attributes, ``equinox`` and ``obstime``, that are required to fully define the
 frame.
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

I let `get_frame_attr_names` really only return the names, not build a dict.

At the few places where really the dict is used, i added the (basically renamed) `get_frame_attr_defaults`) function.

Fixes #13483 

I had to add a call to `get_frame_attr_defaults()` to `BaseCoordinateFrame.__init__subclass__` as this was previously relied on to initialize the values.

Benchmark script:

```
import astropy.units as u
from astropy.coordinates import EarthLocation, AltAz, SkyCoord
from astropy.time import Time

loc = EarthLocation.of_site("Roque de los Muchachos")
time = Time.now()
frame = AltAz(location=loc, obstime=time)
coord = SkyCoord(0 * u.deg, 0 * u.deg, frame=frame)

for attr in ('obstime', 'location', 'temperature'):
    print(attr)
    get_ipython().run_line_magic('timeit', f'coord.{attr}')
```

Results on main:

```
obstime
8.28 µs ± 15.1 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
location
8.61 µs ± 342 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
temperature
8.76 µs ± 186 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
```

Results here:

```
obstime
3.24 µs ± 15.1 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
location
2.32 µs ± 30.8 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
temperature
3.56 µs ± 44.5 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
```
```


### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
