### PR TITLE
Add recording date of release to releasing documentation

### DIFF
--- a/docs/development/releasing.rst
+++ b/docs/development/releasing.rst
@@ -421,7 +421,7 @@ Post-Release procedures
       $ git push upstream stable --force
 
 #. If this is an LTS release (whether or not it is being supported alongside
-   a more recent version), update the "LTS" branch to ponit to the new LTS
+   a more recent version), update the "LTS" branch to point to the new LTS
    release::
 
       $ git checkout LTS

--- a/docs/development/releasing.rst
+++ b/docs/development/releasing.rst
@@ -106,6 +106,10 @@ The procedure for the feature freeze is as follows:
       $ git push upstream main:main
       $ git push upstream v<next_version>.dev:v<next_version>.dev
 
+#. Update the "Actual date" column of
+   https://github.com/astropy/astropy/wiki/Release-Calendar with the current
+   date for this version's feature freeze.
+
 #. Inform the Astropy developer community that the branching has occurred.
 
 #. Once the feature freeze has happened, you should go through the PRs labeled
@@ -314,6 +318,10 @@ as a template. You can now email the user and developer community advertising
 the release candidate and including a link to the wiki page to report any
 successes and failures.
 
+Additionally, you should update the release calendar by going to
+https://github.com/astropy/astropy/wiki/Release-Calendar and updating the
+"Actual date" column of this version's release candidate with the current date.
+
 Releasing subsequent release candidates
 =======================================
 
@@ -475,6 +483,11 @@ Post-Release procedures
    lists. For a bugfix release, use the previous announcement as a template.
    You should also coordinate with the rest of the Astropy release team and the
    community engagement coordinators.
+
+#. If this is a major release, update the release calendar by going to
+   https://github.com/astropy/astropy/wiki/Release-Calendar and updating the
+   "Actual date" column of this version's release with the date you performed
+   the release (probably the date of the tag and pypi upload).
 
 .. _release-procedure-bug-fix:
 

--- a/docs/development/releasing.rst
+++ b/docs/development/releasing.rst
@@ -487,7 +487,7 @@ Post-Release procedures
 #. If this is a major release, update the release calendar by going to
    https://github.com/astropy/astropy/wiki/Release-Calendar and updating the
    "Actual date" column of this version's release with the date you performed
-   the release (probably the date of the tag and pypi upload).
+   the release (probably the date of the tag and PyPI upload).
 
 .. _release-procedure-bug-fix:
 


### PR DESCRIPTION
This makes a few additions to the release instructions, motivated by me looking at https://github.com/astropy/astropy/wiki/Release-Calendar and seeing it hadn't been updated with release dates since 4.3.  I did my best to reconstruct the dates, but historically I did this as part of the releasing process, and on reflection it probably makes sense to leave this to whoever's actually doing that step, since they know the date best anyway.

cc @astrofrog

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
