### PR TITLE
Adjust expected error for illegal Angle input.

### DIFF
--- a/astropy/coordinates/tests/test_arrays.py
+++ b/astropy/coordinates/tests/test_arrays.py
@@ -8,12 +8,11 @@ from numpy import testing as npt
 from astropy import units as u
 from astropy.time import Time
 from astropy.tests.helper import assert_quantity_allclose as assert_allclose
-from astropy.utils.compat import NUMPY_LT_1_19
+from astropy.utils.compat import NUMPY_LT_1_19, NUMPY_LT_1_24
 from astropy.utils.exceptions import AstropyDeprecationWarning
 
 from astropy.coordinates import (Angle, ICRS, FK4, FK5, Galactic, SkyCoord,
                                  CartesianRepresentation)
-from astropy.coordinates.angle_formats import dms_to_degrees, hms_to_hours
 
 
 def test_angle_arrays():
@@ -43,14 +42,17 @@ def test_angle_arrays():
     assert a6.unit is u.degree
 
     with ExitStack() as stack:
-        stack.enter_context(pytest.raises(TypeError))
-        # Arrays where the elements are Angle objects are not supported -- it's
-        # really tricky to do correctly, if at all, due to the possibility of
-        # nesting.
-        if not NUMPY_LT_1_19:
-            stack.enter_context(
-                pytest.warns(DeprecationWarning,
-                             match='automatic object dtype is deprecated'))
+        if NUMPY_LT_1_24:
+            stack.enter_context(pytest.raises(TypeError))
+            # Arrays where the elements are Angle objects are not supported -- it's
+            # really tricky to do correctly, if at all, due to the possibility of
+            # nesting.
+            if not NUMPY_LT_1_19:
+                stack.enter_context(
+                    pytest.warns(DeprecationWarning,
+                                 match='automatic object dtype is deprecated'))
+        else:
+            stack.enter_context(pytest.raises(ValueError))
 
         a7 = Angle([a1, a2, a3], unit=u.degree)
 

--- a/astropy/utils/compat/numpycompat.py
+++ b/astropy/utils/compat/numpycompat.py
@@ -9,7 +9,7 @@ from astropy.utils import minversion
 
 __all__ = ['NUMPY_LT_1_19', 'NUMPY_LT_1_19_1', 'NUMPY_LT_1_20',
            'NUMPY_LT_1_21_1', 'NUMPY_LT_1_22', 'NUMPY_LT_1_22_1',
-           'NUMPY_LT_1_23']
+           'NUMPY_LT_1_23', 'NUMPY_LT_1_24']
 
 # TODO: It might also be nice to have aliases to these named for specific
 # features/bugs we're checking for (ex:
@@ -20,4 +20,5 @@ NUMPY_LT_1_20 = not minversion(np, '1.20')
 NUMPY_LT_1_21_1 = not minversion(np, '1.21.1')
 NUMPY_LT_1_22 = not minversion(np, '1.22')
 NUMPY_LT_1_22_1 = not minversion(np, '1.22.1')
-NUMPY_LT_1_23 = not minversion(np, '1.23dev0')
+NUMPY_LT_1_23 = not minversion(np, '1.23')
+NUMPY_LT_1_24 = not minversion(np, '1.24dev0')


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

Looks like numpy changed its deprecation warning to a proper error, which is a `ValueError` rather than the `TypeError` we looked for before.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #13489

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
