### PR TITLE
Memoize UnitBase._get_physical_type_id

### DIFF
--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -672,10 +672,7 @@ class UnitBase:
         """
         if self._type_id is None:
             unit = self.decompose()
-            r = zip([x.name for x in unit.bases], unit.powers)
-            # bases and powers are already sorted in a unique way
-            # r.sort()
-            self._type_id = tuple(r)
+            self._type_id = tuple(zip((base.name for base in unit.bases), unit.powers))
 
         return self._type_id
 

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -631,6 +631,7 @@ class UnitBase:
     __array_priority__ = 1000
 
     _hash = None
+    _type_id = None
 
     def __deepcopy__(self, memo):
         # This may look odd, but the units conversion will be very
@@ -669,12 +670,14 @@ class UnitBase:
         this unit, without the scale.  Since it is hashable, it is
         useful as a dictionary key.
         """
-        unit = self.decompose()
-        r = zip([x.name for x in unit.bases], unit.powers)
-        # bases and powers are already sorted in a unique way
-        # r.sort()
-        r = tuple(r)
-        return r
+        if self._type_id is None:
+            unit = self.decompose()
+            r = zip([x.name for x in unit.bases], unit.powers)
+            # bases and powers are already sorted in a unique way
+            # r.sort()
+            self._type_id = tuple(r)
+
+        return self._type_id
 
     @property
     def names(self):
@@ -868,10 +871,11 @@ class UnitBase:
         return self._hash
 
     def __getstate__(self):
-        # If we get pickled, we should *not* store the memoized hash since
+        # If we get pickled, we should *not* store the memoized members since
         # hashes of strings vary between sessions.
         state = self.__dict__.copy()
         state.pop('_hash', None)
+        state.pop('_type_id', None)
         return state
 
     def __eq__(self, other):


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address ...

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Adds the same memoization strategy as for `_hash` for `_type_id` used in `_get_physical_type_id`

Fixes #13495 


Timings:

master:

```
Longitude
66.3 µs ± 1.06 µs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
Latitude
34.6 µs ± 479 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
Angle
7.44 µs ± 52.9 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
Quantity
1.75 µs ± 14.3 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
```

This branch:

```
Longitude
63.5 µs ± 1.47 µs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
Latitude
30.4 µs ± 225 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
Angle
5.21 µs ± 15.2 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
Quantity
1.79 µs ± 26.7 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
```

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
