### PR TITLE
Improve performance of Angle.wrap_at

### DIFF
--- a/astropy/coordinates/angles.py
+++ b/astropy/coordinates/angles.py
@@ -396,9 +396,9 @@ class Angle(u.SpecificTypeQuantity):
         # any more for >= 1.19 (NUMPY_LT_1_19), but former is).
         with np.errstate(invalid='ignore'):
             wraps = (self_angle - wrap_angle_floor) // a360
-            np.nan_to_num(wraps, copy=False)
-            if np.any(wraps != 0):
-                self_angle -= wraps*a360
+            valid = np.isfinite(wraps) & (wraps != 0)
+            if np.any(valid):
+                self_angle -= wraps * a360
                 # Rounding errors can cause problems.
                 self_angle[self_angle >= wrap_angle] -= a360
                 self_angle[self_angle < wrap_angle_floor] += a360


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
This is an already nice performance improvement to `Angle.wraps` that does not need numba (see #13480) but still helps a bit:

Benchmark:
```
import astropy.units as u
from astropy.units import Quantity
import numpy as np
from astropy.coordinates.angles import Longitude, Latitude, Angle


print("Does not wrap")
values = np.random.uniform(0, 359, 100)
get_ipython().run_line_magic('timeit', f'Longitude(values, u.deg)')


print("Wraps")
values = np.random.uniform(-180, 180, 100)
get_ipython().run_line_magic('timeit', f'Longitude(values, u.deg)')
```



main:

```
Does not wrap
62.4 µs ± 1.17 µs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
Wraps
71.8 µs ± 602 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
```

Here:

```
Does not wrap
39.6 µs ± 367 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
Wraps
52.7 µs ± 675 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)

```



### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
