### PR TITLE
Implement a `help()` method for the configuration system

### DIFF
--- a/astropy/config/configuration.py
+++ b/astropy/config/configuration.py
@@ -135,6 +135,37 @@ class ConfigNamespace(metaclass=_ConfigNamespaceMeta):
             if isinstance(val, ConfigItem):
                 yield key, val
 
+    def help(self, name=None):
+        """Print info about configuration items.
+
+        Parameters
+        ----------
+        name : `str`, optional
+            Name of the configuration item to be described. If no name is
+            provided then info about all the configuration items will be
+            printed.
+
+        Examples
+        --------
+        >>> from astropy import conf
+        >>> conf.help("unicode_output")
+        ConfigItem: unicode_output
+          cfgtype='boolean'
+          defaultvalue=False
+          description='When True, use Unicode characters when outputting values, and displaying widgets at the console.'
+          module=astropy
+          value=False
+        """
+        if name is None:
+            print(self)
+        else:
+            try:
+                print(type(self).__dict__[name])
+            except KeyError:
+                raise KeyError(
+                    f"'{name}' is not among configuration items {tuple(self)}"
+                ) from None
+
     def set_temp(self, attr, value):
         """
         Temporarily set a configuration value.

--- a/astropy/config/configuration.py
+++ b/astropy/config/configuration.py
@@ -112,6 +112,14 @@ class ConfigNamespace(metaclass=_ConfigNamespaceMeta):
             if isinstance(val, ConfigItem):
                 yield key
 
+    def __str__(self):
+        try:
+            header = f"{self.__doc__.strip()}\n\n"
+        except AttributeError:
+            current_module = str(find_current_module(2)).split("'")[1]
+            header = f"Configuration parameters for `{current_module}`\n\n"
+        return header + "\n\n".join(map(str, self.values()))
+
     keys = __iter__
     """Iterate over configuration item names."""
 

--- a/astropy/config/tests/test_configs.py
+++ b/astropy/config/tests/test_configs.py
@@ -4,6 +4,7 @@ import io
 import os
 import subprocess
 import sys
+from inspect import cleandoc
 
 import pytest
 
@@ -242,6 +243,19 @@ def test_configitem():
     assert ci.description == "this is a Description"
 
     assert conf.tstnm == 34
+
+    assert str(conf) == cleandoc(
+        """
+        Configuration parameters for `astropy.config.tests.test_configs`
+
+        ConfigItem: tstnm
+          cfgtype='integer'
+          defaultvalue=34
+          description='this is a Description'
+          module=astropy.config.tests.test_configs
+          value=34
+        """
+    )
 
     sec = get_config(ci.module)
     assert sec["tstnm"] == 34

--- a/astropy/config/tests/test_configs.py
+++ b/astropy/config/tests/test_configs.py
@@ -358,6 +358,43 @@ def test_configitem_options(tmp_path):
     assert "tstnmo = op2" in lns
 
 
+def test_help(capsys):
+    from astropy import conf
+
+    use_color_msg = cleandoc(
+        """
+        ConfigItem: use_color
+          cfgtype='boolean'
+          defaultvalue={is_not_windows}
+          description='When True, use ANSI color escape sequences when writing to the console.'
+          module=astropy
+          value={is_not_windows}
+        """
+    ).format(is_not_windows=sys.platform != "win32")
+    conf.help("use_color")
+    assert capsys.readouterr().out == use_color_msg + "\n"
+
+    conf.help()
+    help_text = capsys.readouterr().out
+    assert help_text.startswith(
+        "Configuration parameters for `astropy`.\n\nConfigItem: unicode_output"
+    )
+    assert use_color_msg in help_text
+
+
+def test_help_invalid_config_item():
+    from astropy import conf
+
+    with pytest.raises(
+        KeyError,
+        match=(
+            "'bad_name' is not among configuration items "
+            r"\('unicode_output', 'use_color', 'max_lines', 'max_width'\)"
+        ),
+    ):
+        conf.help("bad_name")
+
+
 def test_config_noastropy_fallback(monkeypatch):
     """
     Tests to make sure configuration items fall back to their defaults when

--- a/docs/changes/config/13499.feature.rst
+++ b/docs/changes/config/13499.feature.rst
@@ -1,0 +1,2 @@
+The new ``ConfigNamespace.help()`` method provides a convenient way to get
+information about configuration items.

--- a/docs/config/index.rst
+++ b/docs/config/index.rst
@@ -220,22 +220,35 @@ To see what configuration parameters are defined for a given ``conf``::
      'auto_max_age',
      ...,
      'ietf_leap_second_auto_url']
-    >>> conf.auto_max_age
-    30.0
+
+You can see more detailed information about a configuration parameter by
+calling the :meth:`~astropy.config.ConfigNamespace.help` method::
+
+    >>> conf.help("auto_max_age")
+    ConfigItem: auto_max_age
+      cfgtype='float'
+      defaultvalue=30.0
+      description='Maximum age (days) of predictive data before auto-downloading. See "Auto refresh behavior" in astropy.utils.iers documentation for details. Default is 30.'
+      module=astropy.utils.iers.iers
+      value=30.0
+
+You can see information about all the configuration parameters by calling
+:meth:`~astropy.config.ConfigNamespace.help` without arguments::
+
+    >>> conf.help()
+    Configuration parameters for `astropy.utils.iers`.
+    <BLANKLINE>
+    ConfigItem: auto_download
+      cfgtype='boolean'
+      ...
 
 You can also iterate through ``conf`` in a dictionary-like fashion::
 
-    >>> list(conf.values())
-    [<ConfigItem: name='auto_download' value=True at ...>,
-     <ConfigItem: name='auto_max_age' value=30.0 at ...>,
-     ...,
-     <ConfigItem: name='ietf_leap_second_auto_url' value=...>]
     >>> for (key, cfgitem) in conf.items():
-    ...     if key == 'auto_max_age':
-    ...         print(f'{cfgitem.description} Value is {cfgitem()}')
-    Maximum age (days) of predictive data before auto-downloading. See "Auto
-    refresh behavior" in astropy.utils.iers documentation for details. Default
-    is 30. Value is 30.0
+    ...     print(f'{key} default value is {cfgitem.defaultvalue}')
+    auto_download default value is True
+    auto_max_age default value is 30.0
+      ...
 
 Upgrading ``astropy``
 ---------------------


### PR DESCRIPTION
`ConfigItem` instances have a `description` attribute, the contents of which are written to the configuration file as comments. However, there is currently no convenient way of accessing the `description` strings through the configuration system at runtime (see the awkward code examples in the documentation that this pull request replaces). The new `ConfigNamespace.help()` method provides a user-friendly way of seeing the name, current value, type and description of one or more configuration items.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
