### PR TITLE
Enabled `np.mean()` function for instances of `astropy.time.Time`.

### DIFF
--- a/astropy/table/tests/test_info.py
+++ b/astropy/table/tests/test_info.py
@@ -67,7 +67,7 @@ def test_table_info_stats(table_types):
     a = np.array([1, 2, 1, 2], dtype='int32')
     b = np.array([1, 2, 1, 2], dtype='float32')
     c = np.array(['a', 'c', 'e', 'f'], dtype='|S1')
-    d = time.Time([1, 2, 1, 2], format='mjd')
+    d = time.Time([1, 2, 1, 2], format='mjd', scale='tai')
     t = table_types.Table([a, b, c, d], names=['a', 'b', 'c', 'd'])
 
     # option = 'stats'
@@ -81,14 +81,14 @@ def test_table_info_stats(table_types):
            '   a  1.5 0.5   1   2',
            '   b  1.5 0.5   1   2',
            '   c   --  --  --  --',
-           '   d   --  -- 1.0 2.0']
+           '   d  1.5  -- 1.0 2.0']
     assert out.getvalue().splitlines() == exp
 
     # option = ['attributes', 'stats']
     tinfo = t.info(['attributes', 'stats'], out=None)
     assert tinfo.colnames == ['name', 'dtype', 'shape', 'unit', 'format', 'description',
                               'class', 'mean', 'std', 'min', 'max', 'n_bad', 'length']
-    assert np.all(tinfo['mean'] == ['1.5', '1.5', '--', '--'])
+    assert np.all(tinfo['mean'] == ['1.5', '1.5', '--', '1.5'])
     assert np.all(tinfo['std'] == ['0.5', '0.5', '--', '--'])
     assert np.all(tinfo['min'] == ['1', '1', '--', '1.0'])
     assert np.all(tinfo['max'] == ['2', '2', '--', '2.0'])
@@ -101,7 +101,7 @@ def test_table_info_stats(table_types):
            '   a  1.5 0.5   1   2',
            '   b  1.5 0.5   1   2',
            '   c   --  --  --  --',
-           '   d   --  -- 1.0 2.0']
+           '   d  1.5  -- 1.0 2.0']
     assert out.getvalue().splitlines() == exp
 
     # option = ['attributes', custom]

--- a/astropy/time/tests/test_delta.py
+++ b/astropy/time/tests/test_delta.py
@@ -209,6 +209,16 @@ class TestTimeDelta:
         with pytest.raises(TypeError):
             self.dt * object()
 
+    def test_mean(self):
+
+        def is_consistent(time_delta: TimeDelta):
+            mean_expected = (np.sum(time_delta.jd1) + np.sum(time_delta.jd2)) / time_delta.size
+            mean_test = time_delta.mean().jd1 + time_delta.mean().jd2
+            return mean_test == mean_expected
+
+        assert is_consistent(self.dt)
+        assert is_consistent(self.dt_array)
+
     def test_keep_properties(self):
         # closes #1924 (partially)
         dt = TimeDelta(1000., format='sec')

--- a/docs/changes/time/13508.feature.rst
+++ b/docs/changes/time/13508.feature.rst
@@ -1,0 +1,1 @@
+Added the ``astropy.time.Time.mean()`` method which also enables the ``numpy.mean()`` function to be used on instances of ``astropy.time.Time``.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address enabling the `numpy.mean()` array function to instances of `astropy.time.Time`

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #13507 

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
