### PR TITLE
TST: Use mpl callbacks.process to test key events

### DIFF
--- a/astropy/visualization/wcsaxes/tests/test_display_world_coordinates.py
+++ b/astropy/visualization/wcsaxes/tests/test_display_world_coordinates.py
@@ -1,15 +1,12 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import matplotlib.pyplot as plt
-import pytest
 from matplotlib.backend_bases import KeyEvent
 
 import numpy as np
 
 import astropy.units as u
 from astropy.coordinates import FK5, SkyCoord
-from astropy.io import fits
 from astropy.time import Time
-from astropy.utils.data import get_pkg_data_filename
 from astropy.visualization.wcsaxes.core import WCSAxes
 from astropy.wcs import WCS
 from astropy.coordinates import galactocentric_frame_defaults
@@ -41,12 +38,12 @@ class TestDisplayWorldCoordinate(BaseImageTests):
 
         # Test pixel coordinates
         event1 = KeyEvent('test_pixel_coords', canvas, 'w')
-        fig.canvas.key_press_event(event1.key, guiEvent=event1)
+        fig.canvas.callbacks.process('key_press_event', event1)
         string_pixel = ax._display_world_coords(0.523412, 0.523412)
         assert string_pixel == "0.523412 0.523412 (pixel)"
 
         event3 = KeyEvent('test_pixel_coords', canvas, 'w')
-        fig.canvas.key_press_event(event3.key, guiEvent=event3)
+        fig.canvas.callbacks.process('key_press_event', event3)
         # Test that it still displays world coords when there are no overlay coords
         string_world2 = ax._display_world_coords(0.523412, 0.518311)
         assert string_world2 == '0\xb029\'45" -0\xb029\'20" (world)'
@@ -62,7 +59,7 @@ class TestDisplayWorldCoordinate(BaseImageTests):
         fig.savefig(tmpdir.join('test2.png').strpath)
 
         event4 = KeyEvent('test_pixel_coords', canvas, 'w')
-        fig.canvas.key_press_event(event4.key, guiEvent=event4)
+        fig.canvas.callbacks.process('key_press_event', event4)
         # Test that it displays the overlay world coordinates
         string_world3 = ax._display_world_coords(0.523412, 0.518311)
 
@@ -79,7 +76,7 @@ class TestDisplayWorldCoordinate(BaseImageTests):
         fig.savefig(tmpdir.join('test3.png').strpath)
 
         event5 = KeyEvent('test_pixel_coords', canvas, 'w')
-        fig.canvas.key_press_event(event4.key, guiEvent=event4)
+        fig.canvas.callbacks.process('key_press_event', event5)
         # Test that it displays the overlay world coordinates
         string_world4 = ax._display_world_coords(0.523412, 0.518311)
 
@@ -96,7 +93,7 @@ class TestDisplayWorldCoordinate(BaseImageTests):
         fig.savefig(tmpdir.join('test4.png').strpath)
 
         event6 = KeyEvent('test_pixel_coords', canvas, 'w')
-        fig.canvas.key_press_event(event5.key, guiEvent=event6)
+        fig.canvas.callbacks.process('key_press_event', event6)
         # Test that it displays the overlay world coordinates
         string_world5 = ax._display_world_coords(0.523412, 0.518311)
 
@@ -121,7 +118,7 @@ class TestDisplayWorldCoordinate(BaseImageTests):
 
         # Test pixel coordinates
         event1 = KeyEvent('test_pixel_coords', canvas, 'w')
-        fig.canvas.key_press_event(event1.key, guiEvent=event1)
+        fig.canvas.callbacks.process('key_press_event', event1)
         string_pixel = ax._display_world_coords(0.523412, 0.523412)
         assert string_pixel == "0.523412 0.523412 (pixel)"
 
@@ -148,7 +145,7 @@ class TestDisplayWorldCoordinate(BaseImageTests):
 
         # Test pixel coordinates
         event1 = KeyEvent('test_pixel_coords', canvas, 'w')
-        fig.canvas.key_press_event(event1.key, guiEvent=event1)
+        fig.canvas.callbacks.process('key_press_event', event1)
         string_pixel = ax._display_world_coords(0.523412, 0.523412)
         assert string_pixel == "0.523412 0.523412 (pixel)"
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to get rid of this warning in a test module: *matplotlib._api.deprecation.MatplotlibDeprecationWarning: The key_press_event function was deprecated in Matplotlib 3.6 and will be removed two minor releases later. Use callbacks.process('key_press_event', KeyEvent(...)) instead.*

https://github.com/matplotlib/matplotlib/blob/f3593aed059b0caad44a1a536e340ab18ba026b7/lib/matplotlib/backend_bases.py#L1782-L1792

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #13490

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
