### PR TITLE
Backport PR #13462 on branch v5.0.x (TST: Unpin hypothesis)

### DIFF
--- a/astropy/time/tests/test_precision.py
+++ b/astropy/time/tests/test_precision.py
@@ -310,7 +310,12 @@ def test_two_sum(i, f):
         assert_almost_equal(a, b, atol=Decimal(tiny), rtol=Decimal(0))
 
 
-@given(floats(), floats())
+# The bounds are here since we want to be sure the sum does not go to infinity,
+# which does not have to be completely symmetric; e.g., this used to fail:
+#     @example(f1=-3.089785075544792e307, f2=1.7976931348623157e308)
+# See https://github.com/astropy/astropy/issues/12955#issuecomment-1186293703
+@given(floats(min_value=np.finfo(float).min/2, max_value=np.finfo(float).max/2),
+       floats(min_value=np.finfo(float).min/2, max_value=np.finfo(float).max/2))
 def test_two_sum_symmetric(f1, f2):
     np.testing.assert_equal(two_sum(f1, f2), two_sum(f2, f1))
 
@@ -339,6 +344,7 @@ def test_day_frac_harmless(i, f):
 
 @given(integers(-2**52+2, 2**52-2), floats(-0.5, 0.5))
 @example(i=65536, f=3.637978807091714e-12)
+@example(i=1, f=0.49999999999999994)
 def test_day_frac_exact(i, f):
     assume(abs(f) < 0.5 or i % 2 == 0)
     i_d, f_d = day_frac(i, f)
@@ -353,7 +359,7 @@ def test_day_frac_idempotent(i, f):
     assert (i_d, f_d) == day_frac(i_d, f_d)
 
 
-@given(integers(-2**52+2, 2**52-2), floats(-1, 1))
+@given(integers(-2**52+2, 2**52-int(erfa.DJM0)-3), floats(-1, 1))
 @example(i=65536, f=3.637978807091714e-12)
 def test_mjd_initialization_precise(i, f):
     t = Time(val=i, val2=f, format="mjd", scale="tai")
@@ -377,24 +383,32 @@ def test_day_frac_round_to_even(jd1, jd2):
     assert (abs(t_jd2) == 0.5) and (t_jd1 % 2 == 0)
 
 
-@given(scale=sampled_from(STANDARD_TIME_SCALES), jds=unreasonable_jd())
+@given(scale=sampled_from([sc for sc in STANDARD_TIME_SCALES if sc != 'utc']),
+       jds=unreasonable_jd())
 @example(scale="tai", jds=(0.0, 0.0))
 @example(scale="tai", jds=(0.0, -31738.500000000346))
 def test_resolution_never_decreases(scale, jds):
     jd1, jd2 = jds
-    assume(not scale == 'utc' or 2440000 < jd1 + jd2 < 2460000)
     t = Time(jd1, jd2, format="jd", scale=scale)
     with quiet_erfa():
         assert t != t + dt_tiny
 
 
 @given(reasonable_jd())
+@example(jds=(2442777.5, 0.9999999999999999))
 def test_resolution_never_decreases_utc(jds):
-    """UTC is very unhappy with unreasonable times"""
+    """UTC is very unhappy with unreasonable times,
+
+    Unlike for the other timescales, in which addition is done
+    directly, here the time is transformed to TAI before addition, and
+    then back to UTC.  Hence, some rounding errors can occur and only
+    a change of 2*dt_tiny is guaranteed to give a different time.
+
+    """
     jd1, jd2 = jds
     t = Time(jd1, jd2, format="jd", scale="utc")
     with quiet_erfa():
-        assert t != t + dt_tiny
+        assert t != t + 2*dt_tiny
 
 
 @given(scale1=sampled_from(STANDARD_TIME_SCALES),
@@ -422,6 +436,8 @@ def test_conversion_preserves_jd1_jd2_invariant(iers_b, scale1, scale2, jds):
        scale2=sampled_from(STANDARD_TIME_SCALES),
        jds=unreasonable_jd())
 @example(scale1='tai', scale2='utc', jds=(0.0, 0.0))
+@example(scale1='utc', scale2='ut1', jds=(2441316.5, 0.9999999999999991))
+@example(scale1='ut1', scale2='tai', jds=(2441498.5, 0.9999999999999999))
 def test_conversion_never_loses_precision(iers_b, scale1, scale2, jds):
     """Check that time ordering remains if we convert to another scale.
 
@@ -440,7 +456,9 @@ def test_conversion_never_loses_precision(iers_b, scale1, scale2, jds):
     try:
         with quiet_erfa():
             t2 = t + tiny
-            assert getattr(t, scale2) < getattr(t2, scale2)
+            t_scale2 = getattr(t, scale2)
+            t2_scale2 = getattr(t2, scale2)
+            assert t_scale2 < t2_scale2
     except iers.IERSRangeError:  # UT1 conversion needs IERS data
         assume(scale1 != 'ut1' or 2440000 < jd1 + jd2 < 2458000)
         assume(scale2 != 'ut1' or 2440000 < jd1 + jd2 < 2458000)
@@ -453,6 +471,19 @@ def test_conversion_never_loses_precision(iers_b, scale1, scale2, jds):
         barycentric = {scale1, scale2}.issubset({'tcb', 'tdb'})
         geocentric = {scale1, scale2}.issubset({'tai', 'tt', 'tcg'})
         assume(jd1 + jd2 >= -31738.5 or geocentric or barycentric)
+        raise
+    except AssertionError:
+        # Before 1972, TAI-UTC changed smoothly but not always very
+        # consistently; this can cause trouble on day boundaries for UTC to
+        # UT1; it is not clear whether this will ever be resolved (and is
+        # unlikely ever to matter).
+        # Furthermore, exactly at leap-second boundaries, it is possible to
+        # get the wrong leap-second correction due to rounding errors.
+        # The latter is xfail'd for now, but should be fixed; see gh-13517.
+        if 'ut1' in (scale1, scale2):
+            if abs(t_scale2 - t2_scale2 - 1 * u.s) < 1*u.ms:
+                pytest.xfail()
+            assume(t.jd > 2441317.5 or t.jd2 < 0.4999999)
         raise
 
 
@@ -477,9 +508,11 @@ def test_leap_stretch_mjd(d, f):
          jds=(2441682.5, 2.2204460492503136e-16),
          delta=7.327471962526035e-12)
 @example(scale='utc', jds=(0.0, 5.787592627370942e-13), delta=0.0)
+@example(scale='utc', jds=(1.0, 0.25000000023283064), delta=-1.0)
 def test_jd_add_subtract_round_trip(scale, jds, delta):
     jd1, jd2 = jds
-    if scale == 'utc' and abs(jd1+jd2) < 1:
+    if scale == 'utc' and (jd1+jd2 < 1
+                           or jd1+jd2+delta < 1):
         # Near-zero UTC JDs degrade accuracy; not clear why,
         # but also not so relevant, so ignoring.
         thresh = 100*u.us
@@ -498,17 +531,25 @@ def test_jd_add_subtract_round_trip(scale, jds, delta):
         raise
 
 
-@given(scale=sampled_from(STANDARD_TIME_SCALES),
+@given(scale=sampled_from(TimeDelta.SCALES),
        jds=reasonable_jd(),
        delta=floats(-3*tiny, 3*tiny))
 @example(scale='tai', jds=(0.0, 3.5762786865234384), delta=2.220446049250313e-16)
+@example(scale='tai', jds=(2441316.5, 0.0), delta=6.938893903907228e-17)
+@example(scale='tai', jds=(2441317.5, 0.0), delta=-6.938893903907228e-17)
+@example(scale='tai', jds=(2440001.0, 0.49999999999999994), delta=5.551115123125783e-17)
 def test_time_argminmaxsort(scale, jds, delta):
     jd1, jd2 = jds
-    t = Time(jd1, jd2+np.array([0, delta]), scale=scale, format="jd")
+    t = (Time(jd1, jd2, scale=scale, format="jd")
+         + TimeDelta([0, delta], scale=scale, format='jd'))
     imin = t.argmin()
     imax = t.argmax()
     isort = t.argsort()
-    diff = (t.jd1[1]-t.jd1[0]) + (t.jd2[1]-t.jd2[0])
+    # Be careful in constructing diff, for case that abs(jd2[1]-jd2[0]) ~ 1.
+    # and that is compensated by jd1[1]-jd1[0] (see example above).
+    diff, extra = two_sum(t.jd2[1], -t.jd2[0])
+    diff += t.jd1[1]-t.jd1[0]
+    diff += extra
     if diff < 0:  # item 1 smaller
         assert delta < 0
         assert imin == 1 and imax == 0 and np.all(isort == [1, 0])

--- a/astropy/time/utils.py
+++ b/astropy/time/utils.py
@@ -61,14 +61,16 @@ def day_frac(val1, val2, factor=None, divisor=None):
 
     # get integer fraction
     day = np.round(sum12)
-    extra, frac = two_sum(sum12, -day)
-    frac += extra + err12
-    # Our fraction can now have gotten >0.5 or <-0.5, which means we would
-    # loose one bit of precision. So, correct for that.
-    excess = np.round(frac)
+    # Calculate remaining fraction. This can have gotten >0.5 or <-0.5, which means
+    # we would lose one bit of precision. So, correct for that.  Here, we need
+    # particular care for the case that frac=0.5 and check>0 or frac=-0.5 and check<0,
+    # since in that case if check is large enough, rounding was done the wrong way.
+    frac, check = two_sum(sum12 - day, err12)
+    excess = np.where(frac * np.sign(check) != 0.5, np.round(frac),
+                      np.round(frac+2*check))
     day += excess
-    extra, frac = two_sum(sum12, -day)
-    frac += extra + err12
+    frac = sum12 - day
+    frac += err12
     return day, frac
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,14 +55,12 @@ asdf_extensions =
 [options.extras_require]
 test =  # Required to run the astropy test suite.
     pytest>=7.0
-    hypothesis==6.46.7
     pytest-doctestplus>=0.12
     pytest-astropy-header>=0.2.1
     pytest-astropy>=0.9
     pytest-xdist
 test_all =  # Required for testing, plus packages used by particular tests.
     pytest>=7.0
-    hypothesis==6.46.7
     pytest-doctestplus>=0.12
     pytest-astropy-header>=0.2.1
     pytest-astropy>=0.9


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to manually backport #13462 into v5.0.x (LTS) branch.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
