### PR TITLE
Avoid changing `EarthLocation` site registry in tests

### DIFF
--- a/astropy/coordinates/tests/test_spectral_coordinate.py
+++ b/astropy/coordinates/tests/test_spectral_coordinate.py
@@ -54,13 +54,14 @@ def assert_frame_allclose(frame1, frame2,
         assert_quantity_allclose(d1.norm(d1), d1.norm(d2), rtol=vel_rtol, atol=vel_atol)
 
 
-def get_greenwich_earthlocation():
-    """
-    A helper function to get an EarthLocation for greenwich (without trying to
-    do a download)
-    """
-    site_registry = EarthLocation._get_site_registry(force_builtin=True)
-    return site_registry.get('greenwich')
+@pytest.fixture(scope="module")
+def greenwich_earthlocation(request):
+    if (
+        not hasattr(EarthLocation, '_site_registry')
+        and request.config.getoption("remote_data") == "none"
+    ):
+        EarthLocation._get_site_registry(force_builtin=True)
+    return EarthLocation.of_site("Greenwich")
 
 
 # GENERAL TESTS
@@ -573,12 +574,12 @@ def test_relativistic_radial_velocity():
 # SCIENCE USE CASE TESTS
 
 
-def test_spectral_coord_jupiter():
+def test_spectral_coord_jupiter(greenwich_earthlocation):
     """
     Checks radial velocity between Earth and Jupiter
     """
     obstime = time.Time('2018-12-13 9:00')
-    obs = get_greenwich_earthlocation().get_gcrs(obstime)
+    obs = greenwich_earthlocation.get_gcrs(obstime)
 
     pos, vel = get_body_barycentric_posvel('jupiter', obstime)
     jupiter = SkyCoord(pos.with_differentials(CartesianDifferential(vel.xyz)), obstime=obstime)
@@ -592,12 +593,12 @@ def test_spectral_coord_jupiter():
     assert_quantity_allclose(spc.radial_velocity, -7.35219854 * u.km / u.s)
 
 
-def test_spectral_coord_alphacen():
+def test_spectral_coord_alphacen(greenwich_earthlocation):
     """
     Checks radial velocity between Earth and Alpha Centauri
     """
     obstime = time.Time('2018-12-13 9:00')
-    obs = get_greenwich_earthlocation().get_gcrs(obstime)
+    obs = greenwich_earthlocation.get_gcrs(obstime)
 
     # Coordinates were obtained from the following then hard-coded to avoid download
     # acen = SkyCoord.from_name('alpha cen')
@@ -613,12 +614,12 @@ def test_spectral_coord_alphacen():
     assert_quantity_allclose(spc.radial_velocity, -26.328301 * u.km / u.s)
 
 
-def test_spectral_coord_m31():
+def test_spectral_coord_m31(greenwich_earthlocation):
     """
     Checks radial velocity between Earth and M31
     """
     obstime = time.Time('2018-12-13 9:00')
-    obs = get_greenwich_earthlocation().get_gcrs(obstime)
+    obs = greenwich_earthlocation.get_gcrs(obstime)
 
     # Coordinates were obtained from the following then hard-coded to avoid download
     # m31 = SkyCoord.from_name('M31')
@@ -658,12 +659,12 @@ def test_shift_to_rest_galaxy():
         assert_frame_allclose(rest_spc.observer, rest_spc.target)
 
 
-def test_shift_to_rest_star_withobserver():
+def test_shift_to_rest_star_withobserver(greenwich_earthlocation):
     rv = -8.3283011*u.km/u.s
     rest_line_wls = [5007, 6563]*u.AA
 
     obstime = time.Time('2018-12-13 9:00')
-    eloc = get_greenwich_earthlocation()
+    eloc = greenwich_earthlocation
     obs = eloc.get_gcrs(obstime)
     acen = SkyCoord(ra=219.90085*u.deg, dec=-60.83562*u.deg, frame='icrs',
                     distance=4.37*u.lightyear)


### PR DESCRIPTION
### Description

`EarthLocation.of_site()` provides access to coordinates of several observatories by name, but most of them are only available from online data. A helper function in the tests forced `astropy` to use the smaller built-in registry, which allowed tests to run without remote data, but this caused problems for following remote data tests. For example, the test setup in [`docs/coordinates/index.rst`](https://github.com/astropy/astropy/blob/f4615bfafafa4bf75dd4a6b52de1695c1b9f8ea2/docs/coordinates/index.rst) explicitly changes the registry again for remote-data tests, but it does so in the `main` and `v5.1.x` branches and not in the `v5.0.x` branch because #12721 was not backported.  This caused the remote-data tests for the `v5.0.x` branch to start failing when #13487 was backported.

This pull request replaces the problematic helper function with a fixture that does not cause a permanent change in the `EarthLocation` site registry. This allows the remote-data tests to succeed in the `v5.0.x` branch even without backporting #12721, although that pull request is labelled as a bugfix and therefore could be backported.

Fixes #13529

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
