### PR TITLE
Update and document the pre-commit configuration.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,6 @@
+ci:
+  autofix_prs: false
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.2.0

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 Astropy
 =======
 
-|Actions Status| |CircleCI Status| |Coverage Status| |PyPI Status| |Documentation Status| |Zenodo|
+|Actions Status| |CircleCI Status| |Coverage Status| |PyPI Status| |Documentation Status| |Pre-Commit| |Zenodo|
 
 The Astropy Project (http://astropy.org/) is a community effort to develop a
 single core package for Astronomy in Python and foster interoperability between
@@ -71,6 +71,10 @@ Astropy is licensed under a 3-clause BSD style license - see the
 .. |Documentation Status| image:: https://img.shields.io/readthedocs/astropy/latest.svg?logo=read%20the%20docs&logoColor=white&label=Docs&version=stable
     :target: https://docs.astropy.org/en/stable/?badge=stable
     :alt: Documentation Status
+
+.. |Pre-Commit| image:: https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white
+   :target: https://github.com/pre-commit/pre-commit
+   :alt: pre-commit
 
 .. |NumFOCUS| image:: https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A
     :target: http://numfocus.org

--- a/docs/development/codeguide.rst
+++ b/docs/development/codeguide.rst
@@ -126,6 +126,8 @@ module. The logger can be imported using::
 
     from astropy import log
 
+.. _code-style:
+
 Coding Style/Conventions
 ========================
 
@@ -135,21 +137,34 @@ Coding Style/Conventions
 
 * Our testing infrastructure currently enforces a subset of the PEP8 style
   guide, and some packages enforce stronger styling checks such as using
-  `isort <https://pycqa.github.io/isort/>`_ to sort the module imports. We
-  provide a `pre-commit <https://pre-commit.com/>`_ hook that checks and enforces
-  all of these styling checks on each commit. We strongly suggest that you setup
-  and use the pre-commit hook, by running::
+  `isort <https://pycqa.github.io/isort/>`_ to sort the module imports.
 
-    pip install pre-commit
-    pre-commit install
+  * We provide a `pre-commit <https://pre-commit.com/>`_ based git ``pre-commit``
+    hook, which enforces all of these styling checks on each commit and automatically
+    fixes styling issues whenever possible. Note that ``pre-commit``
+    `hooks <https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks#_git_hooks>`_
+    in git are essentially scripts that get run automatically by git before the
+    commit message can be entered; meaning, if the ``pre-commit`` hook fails you
+    will be unable to commit your code without overriding (which should be avoided
+    whenever possible) the hook, which can be done by running::
 
-  in your clone of astropy, see pre-commit `install guide <https://pre-commit.com/#install>`_
-  for details.
+      git commit --no-verify
 
-  Alternately, you can manually check whether your changes have followed these by
-  running the following `tox <https://tox.readthedocs.io/>`__ command::
+    We strongly suggest that you setup and use the pre-commit hook, by running::
 
-    tox -e codestyle
+      pip install pre-commit
+      pre-commit install
+
+    in your clone of astropy, see pre-commit `install guide <https://pre-commit.com/#install>`_
+    for details. This will ensure that every commit you make will follow the astropy
+    code style guide.
+
+  * Alternately, you can manually check and fix your changes by running the
+    following `tox <https://tox.readthedocs.io/>`__ command::
+
+      tox -e codestyle
+
+    which sets up and runs the pre-commit hook in an isolated environment.
 
 * *Follow the existing coding style* within a subpackage and avoid making
   changes that are purely stylistic.  In particular, there is variation in the

--- a/docs/development/codeguide.rst
+++ b/docs/development/codeguide.rst
@@ -134,7 +134,19 @@ Coding Style/Conventions
   using only 4 spaces for indentation, and never tabs.
 
 * Our testing infrastructure currently enforces a subset of the PEP8 style
-  guide. You can check locally whether your changes have followed these by
+  guide, and some packages enforce stronger styling checks such as using
+  `isort <https://pycqa.github.io/isort/>_` to sort the module imports. We
+  provide a `pre-commit <https://pre-commit.com/>`_ hook that checks and enforces
+  all of these styling checks on each commit. We strongly suggest that you setup
+  and use the pre-commit hook, by running::
+
+    pip install pre-commit
+    pre-commit install
+
+  in your clone of astropy, see pre-commit `install guide<https://pre-commit.com/#install>`_
+  for details.
+
+  Alternately, you can manually check whether your changes have followed these by
   running the following `tox <https://tox.readthedocs.io/>`__ command::
 
     tox -e codestyle

--- a/docs/development/codeguide.rst
+++ b/docs/development/codeguide.rst
@@ -140,11 +140,11 @@ Coding Style/Conventions
   `isort <https://pycqa.github.io/isort/>`_ to sort the module imports.
 
   * We provide a `pre-commit <https://pre-commit.com/>`_ based git ``pre-commit``
-    hook, which enforces all of these styling checks on each commit and automatically
+    hook which enforces all of these styling checks on each commit and automatically
     fixes styling issues whenever possible. Note that ``pre-commit``
     `hooks <https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks#_git_hooks>`_
     in git are essentially scripts that get run automatically by git before the
-    commit message can be entered; meaning, if the ``pre-commit`` hook fails you
+    commit message can be entered. If the ``pre-commit`` hook fails you
     will be unable to commit your code without overriding (which should be avoided
     whenever possible) the hook, which can be done by running::
 

--- a/docs/development/codeguide.rst
+++ b/docs/development/codeguide.rst
@@ -135,7 +135,7 @@ Coding Style/Conventions
 
 * Our testing infrastructure currently enforces a subset of the PEP8 style
   guide, and some packages enforce stronger styling checks such as using
-  `isort <https://pycqa.github.io/isort/>_` to sort the module imports. We
+  `isort <https://pycqa.github.io/isort/>`_ to sort the module imports. We
   provide a `pre-commit <https://pre-commit.com/>`_ hook that checks and enforces
   all of these styling checks on each commit. We strongly suggest that you setup
   and use the pre-commit hook, by running::
@@ -143,7 +143,7 @@ Coding Style/Conventions
     pip install pre-commit
     pre-commit install
 
-  in your clone of astropy, see pre-commit `install guide<https://pre-commit.com/#install>`_
+  in your clone of astropy, see pre-commit `install guide <https://pre-commit.com/#install>`_
   for details.
 
   Alternately, you can manually check whether your changes have followed these by

--- a/docs/development/codeguide.rst
+++ b/docs/development/codeguide.rst
@@ -136,35 +136,17 @@ Coding Style/Conventions
   using only 4 spaces for indentation, and never tabs.
 
 * Our testing infrastructure currently enforces a subset of the PEP8 style
-  guide, and some packages enforce stronger styling checks such as using
+  guide, and some sub-packages enforce stronger styling checks such as using
   `isort <https://pycqa.github.io/isort/>`_ to sort the module imports.
 
-  * We provide a `pre-commit <https://pre-commit.com/>`_ based git ``pre-commit``
-    hook which enforces all of these styling checks on each commit and automatically
-    fixes styling issues whenever possible. Note that ``pre-commit``
-    `hooks <https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks#_git_hooks>`_
-    in git are essentially scripts that get run automatically by git before the
-    commit message can be entered. If the ``pre-commit`` hook fails you
-    will be unable to commit your code without overriding (which should be avoided
-    whenever possible) the hook, which can be done by running::
-
-      git commit --no-verify
-
-    We strongly suggest that you setup and use the pre-commit hook, by running::
-
-      pip install pre-commit
-      pre-commit install
-
-    in your clone of astropy, see pre-commit `install guide <https://pre-commit.com/#install>`_
-    for details. This will ensure that every commit you make will follow the astropy
-    code style guide.
+  * We provide a ``pre-commit`` hook which automatically enforces and fixes
+    (whenever possible) the coding style, see :ref:`pre-commit` for details on
+    how to setup and use this.
 
   * Alternately, you can manually check and fix your changes by running the
     following `tox <https://tox.readthedocs.io/>`__ command::
 
       tox -e codestyle
-
-    which sets up and runs the pre-commit hook in an isolated environment.
 
 * *Follow the existing coding style* within a subpackage and avoid making
   changes that are purely stylistic.  In particular, there is variation in the

--- a/docs/development/testguide.rst
+++ b/docs/development/testguide.rst
@@ -99,7 +99,7 @@ will run checks using the flake8 tool.
 
 .. note::
     It is suggested that you automate the code-style checks using the provided
-    pre-commit hook, as described in the :ref:`code-style` section.
+    pre-commit hook, as described in the :ref:`pre-commit` section.
 
 Is is possible to pass options to pytest when running tox - to do this, add a
 ``--`` after the regular tox command, and anything after this will be passed to

--- a/docs/development/testguide.rst
+++ b/docs/development/testguide.rst
@@ -97,6 +97,10 @@ You can also run checks or commands not directly related to tests - for instance
 
 will run checks using the flake8 tool.
 
+.. note::
+    It is suggested that you automate the code-style checks using the provided
+    pre-commit hook, as described in the :ref:`code-style` section.
+
 Is is possible to pass options to pytest when running tox - to do this, add a
 ``--`` after the regular tox command, and anything after this will be passed to
 pytest, e.g.::

--- a/docs/development/workflow/development_workflow.rst
+++ b/docs/development/workflow/development_workflow.rst
@@ -129,7 +129,7 @@ Astropy Guidelines for `git`_
 
 .. note::
     It is strongly suggested that you automate the code-style checks using the
-    provided pre-commit hook, see :ref:`code-style` for details.
+    provided pre-commit hook, see :ref:`pre-commit` below for details.
 
 * Don't use your ``main`` branch for anything. Consider :ref:`delete-main`.
 * Make a new branch, called a *feature branch*, for each separable set of
@@ -152,6 +152,45 @@ document:
 * Name the remote that is the primary Astropy repository
   ``astropy``; in prior versions of this documentation it was referred to as
   ``upstream``.
+
+
+.. _pre-commit:
+
+Pre-commit
+**********
+
+All of the coding style checks described in :ref:`code-style` can be performed automatically
+when you make a git commit using our provided `pre-commit hook <https://pre-commit.com/>`_
+for git, for more information see
+`git hooks <https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks#_git_hooks>`_.
+We encourage you to setup and use these hooks to ensure that your code always meets
+our coding style standards. This can be done by installing ``pre-commit`` in the root
+of your astropy repository by running::
+
+    pip install pre-commit
+    pre-commit install
+
+For more detailed instructions on installing ``pre-commit``, see the
+`install guide <https://pre-commit.com/#install>`_. Once this installation is
+complete, all the coding style checks will be run each time you commit and the
+necessary changes will automatically be applied to your code if possible.
+
+.. note::
+  The changes made by ``pre-commit`` will not be automatically staged, so you
+  will need to review and re-stage any files that ``pre-commit`` has changed.
+
+In general, git will not allow you to commit until the ``pre-commit`` hook has
+run successfully. If you need to make a commit which fails the ``pre-commit`` checks,
+you can skip these checks by running::
+
+  git commit --no-verify
+
+If you do not want to use ``pre-commit`` as part of your git workflow, you can
+still run the checks manually (see, :ref:`code-style`) using::
+
+  tox -e codestyle
+
+Again, this will automatically apply the necessary changes to your code if possible.
 
 Workflow
 ********

--- a/docs/development/workflow/development_workflow.rst
+++ b/docs/development/workflow/development_workflow.rst
@@ -127,6 +127,10 @@ walks you through recovering from `git`_ mistakes is the
 Astropy Guidelines for `git`_
 *****************************
 
+.. note::
+    It is strongly suggested that you automate the code-style checks using the
+    provided pre-commit hook, see :ref:`code-style` for details.
+
 * Don't use your ``main`` branch for anything. Consider :ref:`delete-main`.
 * Make a new branch, called a *feature branch*, for each separable set of
   changes: "one task, one branch" (`ipython git workflow`_).


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request documents our use of pre-commit.ci in the docs and modifies the pre-commit configuration to include the agreed upon configuration changes for pre-commit.ci for astropy, see #13320 for details. Note that the addition of the pre-commit.ci configuration will not effect astropy in any way until pre-commit.ci is installed; moreover, it will protect astropy's development from any disruptions caused by pre-commit.ci if/when it is installed (even if accidentally). 

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
