### PR TITLE
Document the pre-commit.ci bot

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -58,6 +58,7 @@ This checklist is meant to remind the package maintainer(s) who will review this
 
 - [ ] Do the proposed changes actually accomplish desired goals?
 - [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
+- [ ] Do the proposed changes need the code-style [fixed](https://docs.astropy.org/en/latest/development/workflow/maintainer_workflow.html#pre-commit_bot)?
 - [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
 - [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
 - [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -51,14 +51,7 @@ jobs:
       fail-fast: true
       matrix:
         include:
-
-          - name: Code style checks
-            os: ubuntu-latest
-            python: 3.x
-            toxenv: codestyle
-            toxposargs: --all-files -v
-
-          # NOTE: this 2nd coverage test is needed for tests and code that
+          # NOTE: this coverage test is needed for tests and code that
           #       run only with minimal dependencies.
           - name: Python 3.10 with minimal dependencies and full coverage
             os: ubuntu-latest

--- a/docs/development/workflow/maintainer_workflow.rst
+++ b/docs/development/workflow/maintainer_workflow.rst
@@ -108,7 +108,7 @@ Fixing coding style issues
 --------------------------
 
 Astropy now uses the `pre-commit.ci bot <https://pre-commit.ci/>`_ to assist
-maintainers with enforcing the astropy coding style and fixing the most code style
+with maintaining the astropy coding style and fixing code style
 issues. The bot makes use of the pre-commit hook described in detail in :ref:`pre-commit`.
 
 By default the bot will run a code-style check on every push to a pull request with the

--- a/docs/development/workflow/maintainer_workflow.rst
+++ b/docs/development/workflow/maintainer_workflow.rst
@@ -102,6 +102,33 @@ Push to trunk
 This pushes the ``my-new-feature`` branch in this repository to the ``main``
 branch in the ``upstream-rw`` repository.
 
+.. _pre-commit_bot:
+
+Fixing coding style issues
+--------------------------
+
+Astropy now uses the `pre-commit.ci bot <https://pre-commit.ci/>`_ to assist
+maintainers with enforcing the astropy coding style and fixing the most code style
+issues. The bot makes use of the pre-commit hook described in detail in :ref:`pre-commit`.
+
+By default the bot will run a code-style check on every push to a pull request with the
+results reported in the checks section of the pull request.  The bot will skip running
+its check if a commit message contains ``[skip ci]``, ``[ci skip]``, ``[skip pre-commit.ci]``,
+or ``[pre-commit.ci skip]``.
+
+One can control the bot by making comments on the pull request:
+
+* To trigger a re-run of the code-style check, comment on the PR with::
+
+    pre-commit.ci run
+
+* To have the pre-commit.ci bot push a commit to the PR fixing the code-style issues
+  (the ones that can be fixed by automated tools), comment on the PR with::
+
+    pre-commit.ci autofix
+
+.. note::
+  These comments must appear in the comment on a single line by themselves.
 
 .. _milestones-and-labels:
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request documents how to interact with and use the pre-commit.ci bot and removes the old codestyle action (this will be taken over by the bot).

NOTE: this PR should not be merged until #13552 is merged and the [pre-commit.ci](https://pre-commit.ci/) bot has been enabled in astropy.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #13320

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
