### PR TITLE
Faster string representation of Time-based objects

### DIFF
--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -610,6 +610,8 @@ class TimeBase(ShapedLikeNDArray):
             # Compress time object by allowing at most 2 * npo["edgeitems"] + 1
             # in each dimension. Then force numpy to use "summary mode" of
             # showing only the edge items by setting the size threshold to 0.
+            # TODO: use np.core.arrayprint._leading_trailing if we have support for 
+            # np.concatenate. See #8610.
             tm = _compress_array_dims(self)
             with np.printoptions(threshold=0):
                 out = str(tm.value)

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -610,7 +610,7 @@ class TimeBase(ShapedLikeNDArray):
             # Compress time object by allowing at most 2 * npo["edgeitems"] + 1
             # in each dimension. Then force numpy to use "summary mode" of
             # showing only the edge items by setting the size threshold to 0.
-            # TODO: use np.core.arrayprint._leading_trailing if we have support for 
+            # TODO: use np.core.arrayprint._leading_trailing if we have support for
             # np.concatenate. See #8610.
             tm = _compress_array_dims(self)
             with np.printoptions(threshold=0):

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -2476,3 +2476,33 @@ def test_linspace_fmts():
     assert all(ts[0].isclose(Time(['2020-01-01 00:00:00', '2020-01-02 00:00:00']), atol=atol))
     assert all(ts[1].isclose(Time(['2020-01-01 06:00:00', '2020-01-02 12:00:00']), atol=atol))
     assert all(ts[2].isclose(Time(['2020-01-01 12:00:00', '2020-01-03 00:00:00']), atol=atol))
+
+
+def test_to_string():
+    dims = [8, 2, 8]
+    dx = np.arange(np.prod(dims)).reshape(dims)
+    tm = Time('2020-01-01', out_subfmt='date') + dx * u.day
+    exp_lines = [
+        "[[['2020-01-01' '2020-01-02' ... '2020-01-07' '2020-01-08']",
+        "  ['2020-01-09' '2020-01-10' ... '2020-01-15' '2020-01-16']]",
+        "",
+        " [['2020-01-17' '2020-01-18' ... '2020-01-23' '2020-01-24']",
+        "  ['2020-01-25' '2020-01-26' ... '2020-01-31' '2020-02-01']]",
+        "",
+        " ...",
+        "",
+        " [['2020-04-06' '2020-04-07' ... '2020-04-12' '2020-04-13']",
+        "  ['2020-04-14' '2020-04-15' ... '2020-04-20' '2020-04-21']]",
+        "",
+        " [['2020-04-22' '2020-04-23' ... '2020-04-28' '2020-04-29']",
+        "  ['2020-04-30' '2020-05-01' ... '2020-05-06' '2020-05-07']]]",
+    ]
+    exp_str = "\n".join(exp_lines)
+
+    with np.printoptions(threshold=100, edgeitems=2, linewidth=75):
+        out_str = str(tm)
+        out_repr = repr(tm)
+    assert out_str == exp_str
+
+    exp_repr = f"<Time object: scale='utc' format='iso' value={exp_str}>"
+    assert out_repr == exp_repr

--- a/docs/changes/time/13555.feature.rst
+++ b/docs/changes/time/13555.feature.rst
@@ -1,0 +1,4 @@
+Improve the performance of getting the string representation of a large ``Time``
+or ``TimeDelta`` object. This is done via a new ``to_string()`` method that does
+the time string format conversion only for the outputted values. Previously the
+entire array was formatted in advance.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address the slow str / repr for Time objects highlighted in https://github.com/astropy/astropy/issues/5846 and https://github.com/astropy/astropy/issues/13549 (dup). It supercedes the initial attempt in #13551.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #5846

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
