### PR TITLE
TST: Handle another test case for test_jd_add_subtract_round_trip

### DIFF
--- a/astropy/time/tests/test_precision.py
+++ b/astropy/time/tests/test_precision.py
@@ -510,6 +510,7 @@ def test_leap_stretch_mjd(d, f):
 @example(scale='utc', jds=(0.0, 5.787592627370942e-13), delta=0.0)
 @example(scale='utc', jds=(1.0, 0.25000000023283064), delta=-1.0)
 @example(scale='utc', jds=(0.0, 0.0), delta=2*2.220446049250313e-16)
+@example(scale='utc', jds=(2442778.5, 0.0), delta=-2.220446049250313e-16)
 def test_jd_add_subtract_round_trip(scale, jds, delta):
     jd1, jd2 = jds
     if scale == 'utc' and (jd1+jd2 < 1

--- a/astropy/time/tests/test_precision.py
+++ b/astropy/time/tests/test_precision.py
@@ -513,15 +513,18 @@ def test_leap_stretch_mjd(d, f):
 @example(scale='utc', jds=(2442778.5, 0.0), delta=-2.220446049250313e-16)
 def test_jd_add_subtract_round_trip(scale, jds, delta):
     jd1, jd2 = jds
-    if scale == 'utc' and (jd1+jd2 < 1
-                           or jd1+jd2+delta < 1):
-        # Near-zero UTC JDs degrade accuracy; not clear why,
-        # but also not so relevant, so ignoring.
-        minimum_for_change = 1e-9
-        thresh = minimum_for_change * u.day
-    else:
-        minimum_for_change = np.finfo(float).eps
-        thresh = 2*dt_tiny
+    minimum_for_change = np.finfo(float).eps
+    thresh = 2*dt_tiny
+    if scale == 'utc':
+        if jd1+jd2 < 1 or jd1+jd2+delta < 1:
+            # Near-zero UTC JDs degrade accuracy; not clear why,
+            # but also not so relevant, so ignoring.
+            minimum_for_change = 1e-9
+            thresh = minimum_for_change * u.day
+        else:
+            # UTC goes via TAI, so one can loose an extra bit.
+            minimum_for_change *= 2
+
     t = Time(jd1, jd2, scale=scale, format="jd")
     try:
         with quiet_erfa():


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to expose and then hopefully fix yet another failing test case from hypothesis for `test_jd_add_subtract_round_trip`. @mhvk et al., any idea?

Seen in https://github.com/astropy/astropy/runs/7850309130?check_suite_focus=true

```
                if abs(delta) >= minimum_for_change:
>                   assert t2 != t
E                   AssertionError: assert <Time object: scale='utc' format='jd' value=2442778.5> != <Time object: scale='utc' format='jd' value=2442778.5>
E                   Falsifying explicit example: test_jd_add_subtract_round_trip(
E                       scale='utc', jds=(2442778.5, 0.0), delta=-2.220446049250313e-16,
E                   )

.../astropy/time/tests/test_precision.py:530: AssertionError
```

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
