### PR TITLE
Fix translation of compressed keywords from primary hdu.

### DIFF
--- a/astropy/io/fits/hdu/compressed.py
+++ b/astropy/io/fits/hdu/compressed.py
@@ -1519,6 +1519,7 @@ class CompImageHDU(BinTableHDU):
         if 'ZSIMPLE' in self._header:
             image_header.set('SIMPLE', self._header['ZSIMPLE'],
                              self._header.comments['ZSIMPLE'], before=0)
+            del image_header['XTENSION']
         elif 'ZTENSION' in self._header:
             if self._header['ZTENSION'] != 'IMAGE':
                 warnings.warn("ZTENSION keyword in compressed "

--- a/astropy/io/fits/tests/test_header.py
+++ b/astropy/io/fits/tests/test_header.py
@@ -2961,6 +2961,15 @@ class TestRecordValuedKeywordCards(FitsTestCase):
                                                  compressed=True)
         hf.close()
 
+    def test_fitsheader_compressed_from_primary_image_ext(self):
+        """Regression test for issue https://github.com/astropy/astropy/issues/7312"""
+        data = np.arange(2*2, dtype=np.int8).reshape((2, 2))
+        phdu = fits.PrimaryHDU(data=data)
+        chdu = fits.CompImageHDU(data=phdu.data, header=phdu.header)
+        chdu.writeto(self.temp('tmp2.fits'), overwrite=True)
+        with fits.open(self.temp('tmp2.fits')) as hdul:
+            assert 'XTENSION' not in hdul[1].header
+
     def test_fitsheader_table_feature(self):
         """Tests the `--table` feature of the `fitsheader` script."""
         from astropy.io import fits

--- a/docs/changes/io.fits/13557.bugfix.rst
+++ b/docs/changes/io.fits/13557.bugfix.rst
@@ -1,0 +1,2 @@
+A compressed image HDU created from the header of a PRIMARY HDU, now correctly updates
+'XTENSION' and 'SIMPLE' keywords.


### PR DESCRIPTION
### Description

This pull request addresses the consistency between compressed and uncompressed keywords when a compressed image HDU is created  from the header of a PRIMARY HDU.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #7312

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
