### PR TITLE
Add physical type to cosmological redshift unit

### DIFF
--- a/astropy/cosmology/tests/test_units.py
+++ b/astropy/cosmology/tests/test_units.py
@@ -72,6 +72,7 @@ def test_dimensionless_redshift():
     # show units not equal
     assert z.unit == cu.redshift
     assert z.unit != u.one
+    assert u.get_physical_type(z) == "redshift"
 
     # test equivalency enabled by default
     assert z == val
@@ -219,16 +220,19 @@ class Test_with_redshift:
     def test_temperature_off(self, cosmo):
         """Test ``with_redshift`` with the temperature off."""
         z = 15 * cu.redshift
+        err_msg = (
+            r"^'redshift' \(redshift\) and 'K' \(temperature\) are not convertible$"
+        )
 
         # 1) Default (without specifying the cosmology)
         with default_cosmology.set(cosmo):
             equivalency = cu.with_redshift(Tcmb=False)
-            with pytest.raises(u.UnitConversionError, match="'redshift' and 'K'"):
+            with pytest.raises(u.UnitConversionError, match=err_msg):
                 z.to(u.K, equivalency)
 
         # 2) Specifying the cosmology
         equivalency = cu.with_redshift(cosmo, Tcmb=False)
-        with pytest.raises(u.UnitConversionError, match="'redshift' and 'K'"):
+        with pytest.raises(u.UnitConversionError, match=err_msg):
             z.to(u.K, equivalency)
 
     def test_temperature(self, cosmo):
@@ -265,16 +269,20 @@ class Test_with_redshift:
         """Test ``with_redshift`` with Hubble off."""
         unit = u.km / u.s / u.Mpc
         z = 15 * cu.redshift
+        err_msg = (
+            r"^'redshift' \(redshift\) and 'km / \(Mpc s\)' \(frequency\) are not "
+            "convertible$"
+        )
 
         # 1) Default (without specifying the cosmology)
         with default_cosmology.set(cosmo):
             equivalency = cu.with_redshift(hubble=False)
-            with pytest.raises(u.UnitConversionError, match="'redshift' and 'km / "):
+            with pytest.raises(u.UnitConversionError, match=err_msg):
                 z.to(unit, equivalency)
 
         # 2) Specifying the cosmology
         equivalency = cu.with_redshift(cosmo, hubble=False)
-        with pytest.raises(u.UnitConversionError, match="'redshift' and 'km / "):
+        with pytest.raises(u.UnitConversionError, match=err_msg):
             z.to(unit, equivalency)
 
     def test_hubble(self, cosmo):
@@ -321,16 +329,17 @@ class Test_with_redshift:
     def test_distance_off(self, cosmo):
         """Test ``with_redshift`` with the distance off."""
         z = 15 * cu.redshift
+        err_msg = r"^'redshift' \(redshift\) and 'Mpc' \(length\) are not convertible$"
 
         # 1) Default (without specifying the cosmology)
         with default_cosmology.set(cosmo):
             equivalency = cu.with_redshift(distance=None)
-            with pytest.raises(u.UnitConversionError, match="'redshift' and 'Mpc'"):
+            with pytest.raises(u.UnitConversionError, match=err_msg):
                 z.to(u.Mpc, equivalency)
 
         # 2) Specifying the cosmology
         equivalency = cu.with_redshift(cosmo, distance=None)
-        with pytest.raises(u.UnitConversionError, match="'redshift' and 'Mpc'"):
+        with pytest.raises(u.UnitConversionError, match=err_msg):
             z.to(u.Mpc, equivalency)
 
     def test_distance_default(self):

--- a/astropy/cosmology/units.py
+++ b/astropy/cosmology/units.py
@@ -25,6 +25,7 @@ _ns = globals()
 # an appropriate equivalency is only possible if it's treated as a unit.
 redshift = u.def_unit(['redshift'], prefixes=False, namespace=_ns,
                       doc="Cosmological redshift.", format={'latex': r''})
+u.def_physical_type(redshift, "redshift")
 
 # This is not formally a unit, but is used in that way in many contexts, and
 # an appropriate equivalency is only possible if it's treated as a unit (see

--- a/docs/changes/cosmology/13561.feature.rst
+++ b/docs/changes/cosmology/13561.feature.rst
@@ -1,0 +1,1 @@
+The cosmological redshift unit now has a physical type of ``"redshift"``.


### PR DESCRIPTION
### Description

`astropy.cosmology` defines a unit for redshift, but currently its physical type is `"unknown"`. This pull request sets its physical type to `"redshift"`.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
