### PR TITLE
Deprecate `coordinates.matrix_utilities.matrix_product()`

### DIFF
--- a/astropy/coordinates/builtin_frames/ecliptic_transforms.py
+++ b/astropy/coordinates/builtin_frames/ecliptic_transforms.py
@@ -10,9 +10,7 @@ from astropy.coordinates.transformations import (
     FunctionTransformWithFiniteDifference, DynamicMatrixTransform,
     AffineTransform,
 )
-from astropy.coordinates.matrix_utilities import (rotation_matrix,
-                                                  matrix_product,
-                                                  matrix_transpose)
+from astropy.coordinates.matrix_utilities import matrix_transpose, rotation_matrix
 
 from .icrs import ICRS
 from .gcrs import GCRS
@@ -49,7 +47,7 @@ def _true_ecliptic_rotation_matrix(equinox):
     rnpb = erfa.fw2m(gamb, phib, psib+dpsi, epsa+deps)
     # calculate the true obliquity of the ecliptic
     obl = erfa.obl06(jd1, jd2)+deps
-    return matrix_product(rotation_matrix(obl << u.radian, 'x'), rnpb)
+    return rotation_matrix(obl << u.radian, 'x') @ rnpb
 
 
 def _obliquity_only_rotation_matrix(obl=erfa.obl80(EQUINOX_J2000.jd1, EQUINOX_J2000.jd2) * u.radian):

--- a/astropy/coordinates/builtin_frames/fk4_fk5_transforms.py
+++ b/astropy/coordinates/builtin_frames/fk4_fk5_transforms.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from astropy.coordinates.baseframe import frame_transform_graph
 from astropy.coordinates.transformations import DynamicMatrixTransform
-from astropy.coordinates.matrix_utilities import matrix_product, matrix_transpose
+from astropy.coordinates.matrix_utilities import matrix_transpose
 
 
 from .fk4 import FK4NoETerms
@@ -50,7 +50,7 @@ def fk4_no_e_to_fk5(fk4noecoord, fk5frame):
     pmat1 = fk4noecoord._precession_matrix(fk4noecoord.equinox, EQUINOX_B1950)
     pmat2 = fk5frame._precession_matrix(EQUINOX_J2000, fk5frame.equinox)
 
-    return matrix_product(pmat2, B, pmat1)
+    return pmat2 @ B @ pmat1
 
 
 # This transformation can't be static because the observation date is needed.
@@ -65,4 +65,4 @@ def fk5_to_fk4_no_e(fk5coord, fk4noeframe):
     pmat1 = fk5coord._precession_matrix(fk5coord.equinox, EQUINOX_J2000)
     pmat2 = fk4noeframe._precession_matrix(EQUINOX_B1950, fk4noeframe.equinox)
 
-    return matrix_product(pmat2, B, pmat1)
+    return pmat2 @ B @ pmat1

--- a/astropy/coordinates/builtin_frames/galactic_transforms.py
+++ b/astropy/coordinates/builtin_frames/galactic_transforms.py
@@ -1,8 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from astropy.coordinates.matrix_utilities import (rotation_matrix,
-                                                  matrix_product,
-                                                  matrix_transpose)
+from astropy.coordinates.matrix_utilities import matrix_transpose, rotation_matrix
 from astropy.coordinates.baseframe import frame_transform_graph
 from astropy.coordinates.transformations import DynamicMatrixTransform
 
@@ -17,12 +15,12 @@ from .galactic import Galactic
 @frame_transform_graph.transform(DynamicMatrixTransform, FK5, Galactic)
 def fk5_to_gal(fk5coord, galframe):
     # need precess to J2000 first
-    pmat = fk5coord._precession_matrix(fk5coord.equinox, EQUINOX_J2000)
-    mat1 = rotation_matrix(180 - Galactic._lon0_J2000.degree, 'z')
-    mat2 = rotation_matrix(90 - Galactic._ngp_J2000.dec.degree, 'y')
-    mat3 = rotation_matrix(Galactic._ngp_J2000.ra.degree, 'z')
-
-    return matrix_product(mat1, mat2, mat3, pmat)
+    return (
+        rotation_matrix(180 - Galactic._lon0_J2000.degree, 'z')
+        @ rotation_matrix(90 - Galactic._ngp_J2000.dec.degree, 'y')
+        @ rotation_matrix(Galactic._ngp_J2000.ra.degree, 'z')
+        @ fk5coord._precession_matrix(fk5coord.equinox, EQUINOX_J2000)
+    )
 
 
 @frame_transform_graph.transform(DynamicMatrixTransform, Galactic, FK5)
@@ -32,12 +30,12 @@ def _gal_to_fk5(galcoord, fk5frame):
 
 @frame_transform_graph.transform(DynamicMatrixTransform, FK4NoETerms, Galactic)
 def fk4_to_gal(fk4coords, galframe):
-    mat1 = rotation_matrix(180 - Galactic._lon0_B1950.degree, 'z')
-    mat2 = rotation_matrix(90 - Galactic._ngp_B1950.dec.degree, 'y')
-    mat3 = rotation_matrix(Galactic._ngp_B1950.ra.degree, 'z')
-    matprec = fk4coords._precession_matrix(fk4coords.equinox, EQUINOX_B1950)
-
-    return matrix_product(mat1, mat2, mat3, matprec)
+    return (
+        rotation_matrix(180 - Galactic._lon0_B1950.degree, 'z')
+        @ rotation_matrix(90 - Galactic._ngp_B1950.dec.degree, 'y')
+        @ rotation_matrix(Galactic._ngp_B1950.ra.degree, 'z')
+        @ fk4coords._precession_matrix(fk4coords.equinox, EQUINOX_B1950)
+    )
 
 
 @frame_transform_graph.transform(DynamicMatrixTransform, Galactic, FK4NoETerms)

--- a/astropy/coordinates/builtin_frames/galactocentric.py
+++ b/astropy/coordinates/builtin_frames/galactocentric.py
@@ -10,7 +10,7 @@ from astropy import units as u
 from astropy.utils.state import ScienceState
 from astropy.utils.decorators import format_doc, classproperty, deprecated
 from astropy.coordinates.angles import Angle
-from astropy.coordinates.matrix_utilities import rotation_matrix, matrix_product, matrix_transpose
+from astropy.coordinates.matrix_utilities import matrix_transpose, rotation_matrix
 from astropy.coordinates import representation as r
 from astropy.coordinates.baseframe import (BaseCoordinateFrame,
                                            frame_transform_graph,
@@ -528,7 +528,7 @@ def get_matrix_vectors(galactocentric_frame, inverse=False):
     mat0 = rotation_matrix(gcf.get_roll0() - gcf.roll, 'x')
 
     # construct transformation matrix and use it
-    R = matrix_product(mat0, mat1, mat2)
+    R = mat0 @ mat1 @ mat2
 
     # Now need to translate by Sun-Galactic center distance around x' and
     # rotate about y' to account for tilt due to Sun's height above the plane
@@ -537,7 +537,7 @@ def get_matrix_vectors(galactocentric_frame, inverse=False):
     H = rotation_matrix(-np.arcsin(z_d), 'y')
 
     # compute total matrices
-    A = matrix_product(H, R)
+    A = H @ R
 
     # Now we re-align the translation vector to account for the Sun's height
     # above the midplane

--- a/astropy/coordinates/builtin_frames/icrs_fk5_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_fk5_transforms.py
@@ -1,8 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from astropy.coordinates.matrix_utilities import (rotation_matrix,
-                                                  matrix_product,
-                                                  matrix_transpose)
+from astropy.coordinates.matrix_utilities import matrix_transpose, rotation_matrix
 from astropy.coordinates.baseframe import frame_transform_graph
 from astropy.coordinates.transformations import DynamicMatrixTransform
 
@@ -21,11 +19,11 @@ def _icrs_to_fk5_matrix():
     xi0 = 9.1 / 3600000.
     da0 = -22.9 / 3600000.
 
-    m1 = rotation_matrix(-eta0, 'x')
-    m2 = rotation_matrix(xi0, 'y')
-    m3 = rotation_matrix(da0, 'z')
-
-    return matrix_product(m1, m2, m3)
+    return (
+        rotation_matrix(-eta0, 'x')
+        @ rotation_matrix(xi0, 'y')
+        @ rotation_matrix(da0, 'z')
+    )
 
 
 # define this here because it only needs to be computed once
@@ -36,7 +34,7 @@ _ICRS_TO_FK5_J2000_MAT = _icrs_to_fk5_matrix()
 def icrs_to_fk5(icrscoord, fk5frame):
     # ICRS is by design very close to J2000 equinox
     pmat = fk5frame._precession_matrix(EQUINOX_J2000, fk5frame.equinox)
-    return matrix_product(pmat, _ICRS_TO_FK5_J2000_MAT)
+    return pmat @ _ICRS_TO_FK5_J2000_MAT
 
 
 # can't be static because the equinox is needed
@@ -44,4 +42,4 @@ def icrs_to_fk5(icrscoord, fk5frame):
 def fk5_to_icrs(fk5coord, icrsframe):
     # ICRS is by design very close to J2000 equinox
     pmat = fk5coord._precession_matrix(fk5coord.equinox, EQUINOX_J2000)
-    return matrix_product(matrix_transpose(_ICRS_TO_FK5_J2000_MAT), pmat)
+    return matrix_transpose(_ICRS_TO_FK5_J2000_MAT) @ pmat

--- a/astropy/coordinates/builtin_frames/skyoffset.py
+++ b/astropy/coordinates/builtin_frames/skyoffset.py
@@ -4,9 +4,7 @@ from astropy.coordinates.transformations import DynamicMatrixTransform, Function
 from astropy.coordinates.baseframe import (frame_transform_graph,
                                            BaseCoordinateFrame)
 from astropy.coordinates.attributes import CoordinateAttribute, QuantityAttribute
-from astropy.coordinates.matrix_utilities import (rotation_matrix,
-                                                  matrix_product,
-                                                  matrix_transpose)
+from astropy.coordinates.matrix_utilities import matrix_transpose, rotation_matrix
 
 _skyoffset_cache = {}
 
@@ -71,10 +69,11 @@ def make_skyoffset_cls(framecls):
         # Define rotation matrices along the position angle vector, and
         # relative to the origin.
         origin = skyoffset_frame.origin.spherical
-        mat1 = rotation_matrix(-skyoffset_frame.rotation, 'x')
-        mat2 = rotation_matrix(-origin.lat, 'y')
-        mat3 = rotation_matrix(origin.lon, 'z')
-        return matrix_product(mat1, mat2, mat3)
+        return (
+            rotation_matrix(-skyoffset_frame.rotation, 'x')
+            @ rotation_matrix(-origin.lat, 'y')
+            @ rotation_matrix(origin.lon, 'z')
+        )
 
     @frame_transform_graph.transform(DynamicMatrixTransform, _SkyOffsetFramecls, framecls)
     def skyoffset_to_reference(skyoffset_coord, reference_frame):

--- a/astropy/coordinates/builtin_frames/supergalactic_transforms.py
+++ b/astropy/coordinates/builtin_frames/supergalactic_transforms.py
@@ -1,8 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from astropy.coordinates.matrix_utilities import (rotation_matrix,
-                                                  matrix_product,
-                                                  matrix_transpose)
+from astropy.coordinates.matrix_utilities import matrix_transpose, rotation_matrix
 from astropy.coordinates.baseframe import frame_transform_graph
 from astropy.coordinates.transformations import StaticMatrixTransform
 
@@ -12,10 +10,11 @@ from .supergalactic import Supergalactic
 
 @frame_transform_graph.transform(StaticMatrixTransform, Galactic, Supergalactic)
 def gal_to_supergal():
-    mat1 = rotation_matrix(90, 'z')
-    mat2 = rotation_matrix(90 - Supergalactic._nsgp_gal.b.degree, 'y')
-    mat3 = rotation_matrix(Supergalactic._nsgp_gal.l.degree, 'z')
-    return matrix_product(mat1, mat2, mat3)
+    return (
+        rotation_matrix(90, 'z')
+        @ rotation_matrix(90 - Supergalactic._nsgp_gal.b.degree, 'y')
+        @ rotation_matrix(Supergalactic._nsgp_gal.l.degree, 'z')
+    )
 
 
 @frame_transform_graph.transform(StaticMatrixTransform, Supergalactic, Galactic)

--- a/astropy/coordinates/earth_orientation.py
+++ b/astropy/coordinates/earth_orientation.py
@@ -14,7 +14,7 @@ import erfa
 
 from astropy.time import Time
 from .builtin_frames.utils import get_jd12
-from .matrix_utilities import rotation_matrix, matrix_product, matrix_transpose
+from .matrix_utilities import matrix_transpose, rotation_matrix
 
 
 jd1950 = Time('B1950').jd
@@ -168,9 +168,11 @@ def _precession_matrix_besselian(epoch1, epoch2):
     ptheta = (theta3, theta2, theta1, 0)
     theta = np.polyval(ptheta, dt) / 3600
 
-    return matrix_product(rotation_matrix(-z, 'z'),
-                          rotation_matrix(theta, 'y'),
-                          rotation_matrix(-zeta, 'z'))
+    return (
+        rotation_matrix(-z, 'z')
+        @ rotation_matrix(theta, 'y')
+        @ rotation_matrix(-zeta, 'z')
+    )
 
 
 def nutation_components2000B(jd):

--- a/astropy/coordinates/matrix_utilities.py
+++ b/astropy/coordinates/matrix_utilities.py
@@ -7,9 +7,11 @@ from functools import reduce
 import numpy as np
 
 from astropy import units as u
+from astropy.utils import deprecated
 from .angles import Angle
 
 
+@deprecated("5.2", alternative="@")
 def matrix_product(*matrices):
     """Matrix multiply all arguments together.
 

--- a/astropy/coordinates/tests/test_matrix_utilities.py
+++ b/astropy/coordinates/tests/test_matrix_utilities.py
@@ -1,10 +1,13 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import numpy as np
+import pytest
 from numpy.testing import assert_allclose, assert_array_equal
 
 from astropy import units as u
-from astropy.coordinates.matrix_utilities import (rotation_matrix, angle_axis,
-                                                  is_O3, is_rotation)
+from astropy.coordinates.matrix_utilities import (
+    angle_axis, is_O3, is_rotation, matrix_product, rotation_matrix
+)
+from astropy.utils.exceptions import AstropyDeprecationWarning
 
 
 def test_rotation_matrix():
@@ -98,3 +101,8 @@ def test_is_rotation():
     # and (M, 3, 3)
     n3 = np.stack((m1, m3))
     assert tuple(is_rotation(n3)) == (True, False)  # (show the broadcasting)
+
+
+def test_matrix_product_deprecation():
+    with pytest.warns(AstropyDeprecationWarning, match=r"Use @ instead\.$"):
+        matrix_product(np.eye(2))

--- a/astropy/coordinates/transformations.py
+++ b/astropy/coordinates/transformations.py
@@ -30,8 +30,6 @@ import numpy as np
 from astropy import units as u
 from astropy.utils.exceptions import AstropyWarning
 
-from .matrix_utilities import matrix_product
-
 __all__ = ['TransformGraph', 'CoordinateTransform', 'FunctionTransform',
            'BaseAffineTransform', 'AffineTransform',
            'StaticMatrixTransform', 'DynamicMatrixTransform',
@@ -1449,10 +1447,11 @@ class CompositeTransform(CoordinateTransform):
 
             if (isinstance(lasttrans, StaticMatrixTransform) and
                     isinstance(currtrans, StaticMatrixTransform)):
-                combinedmat = matrix_product(currtrans.matrix, lasttrans.matrix)
-                newtrans[-1] = StaticMatrixTransform(combinedmat,
-                                                     lasttrans.fromsys,
-                                                     currtrans.tosys)
+                newtrans[-1] = StaticMatrixTransform(
+                    currtrans.matrix @ lasttrans.matrix,
+                    lasttrans.fromsys,
+                    currtrans.tosys,
+                )
             else:
                 newtrans.append(currtrans)
         return newtrans

--- a/astropy/modeling/rotations.py
+++ b/astropy/modeling/rotations.py
@@ -21,11 +21,12 @@ References
 # pylint: disable=invalid-name, too-many-arguments, no-member
 
 import math
+from functools import reduce
 
 import numpy as np
 
 from astropy import units as u
-from astropy.coordinates.matrix_utilities import matrix_product, rotation_matrix
+from astropy.coordinates.matrix_utilities import rotation_matrix
 
 from .core import Model
 from .parameters import Parameter
@@ -42,8 +43,7 @@ def _create_matrix(angles, axes_order):
             angle = angle.value
         angle = angle.item()
         matrices.append(rotation_matrix(angle, axis, unit=u.rad))
-    result = matrix_product(*matrices[::-1])
-    return result
+    return reduce(np.matmul, matrices[::-1])
 
 
 def spherical2cartesian(alpha, delta):

--- a/astropy/visualization/wcsaxes/patches.py
+++ b/astropy/visualization/wcsaxes/patches.py
@@ -8,7 +8,7 @@ from matplotlib.patches import Polygon
 from astropy import units as u
 from astropy.coordinates import SkyCoord
 from astropy.coordinates.representation import UnitSphericalRepresentation, SphericalRepresentation
-from astropy.coordinates.matrix_utilities import rotation_matrix, matrix_product
+from astropy.coordinates.matrix_utilities import rotation_matrix
 from astropy.utils.exceptions import AstropyUserWarning
 
 
@@ -39,9 +39,10 @@ def _rotate_polygon(lon, lat, lon0, lat0):
 
     # Determine rotation matrix to make it so that the circle is centered
     # on the correct longitude/latitude.
-    m1 = rotation_matrix(-(0.5 * np.pi * u.radian - lat0), axis='y')
-    m2 = rotation_matrix(-lon0, axis='z')
-    transform_matrix = matrix_product(m2, m1)
+    transform_matrix = (
+        rotation_matrix(-lon0, axis='z')
+        @ rotation_matrix(-(0.5 * np.pi * u.radian - lat0), axis='y')
+    )
 
     # Apply 3D rotation
     polygon = polygon.to_cartesian()

--- a/examples/coordinates/plot_sgr-coordinate-frame.py
+++ b/examples/coordinates/plot_sgr-coordinate-frame.py
@@ -53,7 +53,7 @@ plt.style.use(astropy_mpl_style)
 # Import the packages necessary for coordinates
 
 from astropy.coordinates import frame_transform_graph
-from astropy.coordinates.matrix_utilities import rotation_matrix, matrix_product, matrix_transpose
+from astropy.coordinates.matrix_utilities import matrix_transpose, rotation_matrix
 import astropy.coordinates as coord
 import astropy.units as u
 
@@ -128,11 +128,12 @@ SGR_THETA = (90 - 13.46) * u.degree
 SGR_PSI = (180 + 14.111534) * u.degree
 
 # Generate the rotation matrix using the x-convention (see Goldstein)
-D = rotation_matrix(SGR_PHI, "z")
-C = rotation_matrix(SGR_THETA, "x")
-B = rotation_matrix(SGR_PSI, "z")
-A = np.diag([1.,1.,-1.])
-SGR_MATRIX = matrix_product(A, B, C, D)
+SGR_MATRIX = (
+    np.diag([1.,1.,-1.])
+    @ rotation_matrix(SGR_PSI, "z")
+    @ rotation_matrix(SGR_THETA, "x")
+    @ rotation_matrix(SGR_PHI, "z")
+)
 
 
 ##############################################################################


### PR DESCRIPTION
### Description

`matrix_product()` was meant to improve readability of long matrix products, but is not needed anymore because Python 3.5 implemented [PEP 465](https://peps.python.org/pep-0465/). See also the docstring of the deprecated function.

~~`coordinates.matrix_utilities` is not a part of the public API, so the function can be removed immediately without deprecating it first.~~
EDIT: It looks like it is better to deprecate the function before removing it.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
