### PR TITLE
MNT: Handle pandas deprecation warning

### DIFF
--- a/astropy/timeseries/tests/test_sampled.py
+++ b/astropy/timeseries/tests/test_sampled.py
@@ -11,6 +11,7 @@ from astropy.time import Time, TimeDelta
 from astropy import units as u
 from astropy.units import Quantity
 from astropy.utils.data import get_pkg_data_filename
+from astropy.utils.introspection import minversion
 from astropy.tests.helper import assert_quantity_allclose
 
 from astropy.timeseries.periodograms import BoxLeastSquares, LombScargle
@@ -271,9 +272,14 @@ def test_fold_invalid_options():
 def test_pandas():
     pandas = pytest.importorskip("pandas")
 
+    PANDAS_LT_1_5 = not minversion(pandas, '1.4.999')  # When this was written 1.5 was not released.
+
     df1 = pandas.DataFrame()
     df1['a'] = [1, 2, 3]
-    df1.set_index(pandas.DatetimeIndex(INPUT_TIME.datetime64), inplace=True)
+    if PANDAS_LT_1_5:
+        df1.set_index(pandas.DatetimeIndex(INPUT_TIME.datetime64), inplace=True)
+    else:
+        df1 = df1.set_index(pandas.DatetimeIndex(INPUT_TIME.datetime64), copy=False)
 
     ts = TimeSeries.from_pandas(df1)
     assert_equal(ts.time.isot, INPUT_TIME.isot)
@@ -304,7 +310,7 @@ def test_pandas():
 def test_read_time_missing():
     with pytest.raises(ValueError) as exc:
         TimeSeries.read(CSV_FILE, format='csv')
-    assert exc.value.args[0] == '``time_column`` should be provided since the default Table readers are being used.'
+    assert exc.value.args[0] == '``time_column`` should be provided since the default Table readers are being used.'  # noqa: E501
 
 
 def test_read_time_wrong():
@@ -339,7 +345,7 @@ def test_kepler_astropy():
 
 @pytest.mark.remote_data(source='astropy')
 def test_tess_astropy():
-    filename = get_pkg_data_filename('timeseries/hlsp_tess-data-alerts_tess_phot_00025155310-s01_tess_v1_lc.fits')
+    filename = get_pkg_data_filename('timeseries/hlsp_tess-data-alerts_tess_phot_00025155310-s01_tess_v1_lc.fits')  # noqa: E501
     with pytest.warns(UserWarning, match='Ignoring 815 rows with NaN times'):
         timeseries = TimeSeries.read(filename, format='tess.fits')
     assert timeseries["time"].format == 'isot'

--- a/docs/timeseries/pandas.rst
+++ b/docs/timeseries/pandas.rst
@@ -32,10 +32,15 @@ Consider a concise example starting from a :class:`~pandas.DataFrame`:
 
     >>> import pandas
     >>> import numpy as np
+    >>> from astropy.utils.introspection import minversion
+    >>> PANDAS_LT_1_5 = not minversion(pandas, '1.4.999')
     >>> df = pandas.DataFrame()
     >>> df['a'] = [1, 2, 3]
     >>> times = np.array(['2015-07-04', '2015-07-05', '2015-07-06'], dtype=np.datetime64)
-    >>> df.set_index(pandas.DatetimeIndex(times), inplace=True)
+    >>> if PANDAS_LT_1_5:
+    ...     df.set_index(pandas.DatetimeIndex(times), inplace=True)
+    ... else:
+    ...     df = df.set_index(pandas.DatetimeIndex(times), copy=False)
     >>> df
         a
     2015-07-04  1


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to use new API for pandas in timeseries test and doc to avoid deprecation warning like this:

```
FutureWarning: The 'inplace' keyword in DataFrame.set_index is deprecated and will be removed in a future version.
Use `df = df.set_index(..., copy=False)` instead.
```

Example failing log: https://github.com/astropy/astropy/runs/8008366554?check_suite_focus=true#step:6:1671

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
