### PR TITLE
MAINT Fix some -Wincompatible-function-pointer-types errors

### DIFF
--- a/astropy/stats/src/fast_sigma_clip.c
+++ b/astropy/stats/src/fast_sigma_clip.c
@@ -11,7 +11,7 @@ static char _sigma_clip_fast_docstring[] = "Compute sigma clipping";
 
 /* Declare the C functions here. */
 static void _sigma_clip_fast(
-    char **args, npy_intp const *dimensions, npy_intp const* steps, void* data);
+    char **args, npy_intp const* dimensions, npy_intp const* steps, void* data);
 
 /* Define the methods that will be available on the module. */
 static PyMethodDef module_methods[] = {{NULL, NULL, 0, NULL}};
@@ -72,7 +72,7 @@ MOD_INIT(_fast_sigma_clip) {
 
 
 static void _sigma_clip_fast(
-    char **args, npy_intp const *dimensions, npy_intp const* steps, void* data)
+    char **args, npy_intp const* dimensions, npy_intp const* steps, void* data)
 {
     npy_intp i_o, i;
     int count;

--- a/astropy/stats/src/fast_sigma_clip.c
+++ b/astropy/stats/src/fast_sigma_clip.c
@@ -11,7 +11,7 @@ static char _sigma_clip_fast_docstring[] = "Compute sigma clipping";
 
 /* Declare the C functions here. */
 static void _sigma_clip_fast(
-    char **args, npy_intp *dimensions, npy_intp* steps, void* data);
+    char **args, npy_intp const *dimensions, npy_intp const* steps, void* data);
 
 /* Define the methods that will be available on the module. */
 static PyMethodDef module_methods[] = {{NULL, NULL, 0, NULL}};
@@ -72,7 +72,7 @@ MOD_INIT(_fast_sigma_clip) {
 
 
 static void _sigma_clip_fast(
-    char **args, npy_intp *dimensions, npy_intp* steps, void* data)
+    char **args, npy_intp const *dimensions, npy_intp const* steps, void* data)
 {
     npy_intp i_o, i;
     int count;

--- a/astropy/wcs/src/wcslib_wtbarr_wrap.c
+++ b/astropy/wcs/src/wcslib_wtbarr_wrap.c
@@ -205,8 +205,8 @@ PyTypeObject PyWtbarrType = {
   0,                            /*tp_as_buffer*/
   Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /*tp_flags*/
   doc_Wtbarr,                   /* tp_doc */
-  PyWtbarr_traverse,            /* tp_traverse */
-  PyWtbarr_clear,               /* tp_clear */
+  (traverseproc)PyWtbarr_traverse, /* tp_traverse */
+  (inquiry)PyWtbarr_clear,      /* tp_clear */
   0,                            /* tp_richcompare */
   0,                            /* tp_weaklistoffset */
   0,                            /* tp_iter */


### PR DESCRIPTION
<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

### Description

In the newest version of LLVM `-Wincompatible-function-pointer-types` has gotten a bit more strict. It is unhappy that the first argument of `PyWtbarr_traverse` and `PyWtbarr_clear` is `PyWtbarr*` and not `PyObject*`. It is also unhappy that the `dimensions` and `steps` arguments are not declared as `const`. This fixes these errors.

### Checklist for package maintainer(s)

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
