### PR TITLE
Backport PR #12630 on branch v5.0.x (Calculate WCSAxes TickLabel pixel coords at draw time)

### DIFF
--- a/astropy/tests/figures/py39-test-image-mpl311.json
+++ b/astropy/tests/figures/py39-test-image-mpl311.json
@@ -18,7 +18,7 @@
   "astropy.visualization.wcsaxes.tests.test_images.TestBasic.test_plot_line": "0961332a596c87b6530a74f54c6dfccbcfbc994f443cbda926bded233a24fb98",
   "astropy.visualization.wcsaxes.tests.test_images.TestBasic.test_changed_axis_units": "d0ad181b8c9a2f19ec19ee014f4bfd0fcc792802f7f9ae1a9826c2868515db6f",
   "astropy.visualization.wcsaxes.tests.test_images.TestBasic.test_minor_ticks": "13d0d00d253a8ef745e7363bf340f2ba75ef1a0228cb6972c12a7d0255a03c08",
-  "astropy.visualization.wcsaxes.tests.test_images.TestBasic.test_ticks_labels": "608e440c8feeff5fb0d129c6fd15fb33b22f0a1fa553172b95a4f6ce5e025555",
+  "astropy.visualization.wcsaxes.tests.test_images.TestBasic.test_ticks_labels": "1688775dad979fd22a6cbbe22f2a5c0121d2b2353d5d6ca1b78609d01f63b747",
   "astropy.visualization.wcsaxes.tests.test_images.TestBasic.test_rcparams": "13aa853ceaa8d52aa7e8fedf708ae9555fd492de3ab5840a459241462ee4ad51",
   "astropy.visualization.wcsaxes.tests.test_images.TestBasic.test_tick_angles": "c249e6c4299472c8e4c9712e786ba8327f6a0bd8eaa6281982c2a67724322f48",
   "astropy.visualization.wcsaxes.tests.test_images.TestBasic.test_tick_angles_non_square_axes": "ee3801f0e974737f665b963ee3a8f6e3f16134a6c0660f1dd15805385549f14e",

--- a/astropy/tests/figures/py39-test-image-mpldev.json
+++ b/astropy/tests/figures/py39-test-image-mpldev.json
@@ -18,7 +18,7 @@
   "astropy.visualization.wcsaxes.tests.test_images.TestBasic.test_plot_line": "93f19f790da326940ced49147021fc9700c587bd9662eb156d10372faa156693",
   "astropy.visualization.wcsaxes.tests.test_images.TestBasic.test_changed_axis_units": "e1e2d787ac997ec3e1e27aedd7486f311d81a5cc88251a36e1fd4c0c3c5ee49f",
   "astropy.visualization.wcsaxes.tests.test_images.TestBasic.test_minor_ticks": "8498a992eb4d5e66a486fc5c59e195d5424e7ccfbc08a472ae7671b491a0be08",
-  "astropy.visualization.wcsaxes.tests.test_images.TestBasic.test_ticks_labels": "1af606bf4080c5c63549b02891322f9f9980833008792ebd2bf8b9e2cec2cbe3",
+  "astropy.visualization.wcsaxes.tests.test_images.TestBasic.test_ticks_labels": "093ad85f2e30d30bf2b56957ca6094b9c019e1409d1c3f14cd555e1b5263ebd1",
   "astropy.visualization.wcsaxes.tests.test_images.TestBasic.test_rcparams": "4d47fdf0616a87c85e729ae25ab89ddde39d88c6862e95827ef2bb73777f3fe7",
   "astropy.visualization.wcsaxes.tests.test_images.TestBasic.test_tick_angles": "edce883e1e89c3b4fc188c0d4aa81fffd63847d38782c798ba6f80df2b803c14",
   "astropy.visualization.wcsaxes.tests.test_images.TestBasic.test_tick_angles_non_square_axes": "b1b5349ebc0a1c206a09b0354d79c20cc0a672a884dab5390f8ab2d20cbc209e",

--- a/astropy/visualization/wcsaxes/coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/coordinate_helpers.py
@@ -785,8 +785,6 @@ class CoordinateHelper:
                     frac = (t - w1[imin]) / (w2[imin] - w1[imin])
                     x_data_i = spine.data[imin, 0] + frac * (spine.data[imax, 0] - spine.data[imin, 0])
                     y_data_i = spine.data[imin, 1] + frac * (spine.data[imax, 1] - spine.data[imin, 1])
-                    x_pix_i = spine.pixel[imin, 0] + frac * (spine.pixel[imax, 0] - spine.pixel[imin, 0])
-                    y_pix_i = spine.pixel[imin, 1] + frac * (spine.pixel[imax, 1] - spine.pixel[imin, 1])
                     delta_angle = tick_angle[imax] - tick_angle[imin]
                     if delta_angle > 180.:
                         delta_angle -= 360.
@@ -819,7 +817,7 @@ class CoordinateHelper:
                     # it's faster to format many ticklabels at once outside
                     # of the loop
                     self.lblinfo.append(dict(axis=axis,
-                                             pixel=(x_pix_i, y_pix_i),
+                                             data=(x_data_i, y_data_i),
                                              world=world,
                                              angle=spine.normal_angle[imin],
                                              axis_displacement=imin + frac))

--- a/astropy/visualization/wcsaxes/tests/test_frame.py
+++ b/astropy/visualization/wcsaxes/tests/test_frame.py
@@ -35,7 +35,7 @@ class HexagonalFrame(BaseFrame):
 
 class TestFrame(BaseImageTests):
 
-    @pytest.mark.remote_data(source='astropy')
+    @pytest.mark.remote_data
     @pytest.mark.mpl_image_compare(tolerance=0, style={})
     def test_custom_frame(self):
 
@@ -75,7 +75,7 @@ class TestFrame(BaseImageTests):
 
         return fig
 
-    @pytest.mark.remote_data(source='astropy')
+    @pytest.mark.remote_data
     @pytest.mark.mpl_image_compare(tolerance=0, style={})
     def test_update_clip_path_rectangular(self, tmpdir):
 
@@ -100,7 +100,7 @@ class TestFrame(BaseImageTests):
 
         return fig
 
-    @pytest.mark.remote_data(source='astropy')
+    @pytest.mark.remote_data
     @pytest.mark.mpl_image_compare(tolerance=0, style={})
     def test_update_clip_path_nonrectangular(self, tmpdir):
 
@@ -123,7 +123,7 @@ class TestFrame(BaseImageTests):
 
         return fig
 
-    @pytest.mark.remote_data(source='astropy')
+    @pytest.mark.remote_data
     @pytest.mark.mpl_image_compare(tolerance=0, style={})
     def test_update_clip_path_change_wcs(self, tmpdir):
 

--- a/astropy/visualization/wcsaxes/tests/test_images.py
+++ b/astropy/visualization/wcsaxes/tests/test_images.py
@@ -44,7 +44,7 @@ class BaseImageTests:
 
 class TestBasic(BaseImageTests):
 
-    @pytest.mark.remote_data(source='astropy')
+    @pytest.mark.remote_data
     @pytest.mark.mpl_image_compare(tolerance=0, style={})
     def test_image_plot(self):
         # Test for plotting image and also setting values of ticks
@@ -55,7 +55,7 @@ class TestBasic(BaseImageTests):
         ax.coords[0].set_ticks([-0.30, 0., 0.20] * u.degree, size=5, width=1)
         return fig
 
-    @pytest.mark.remote_data(source='astropy')
+    @pytest.mark.remote_data
     @pytest.mark.mpl_image_compare(tolerance=0, style={})
     def test_axes_off(self):
         # Test for turning the axes off
@@ -65,7 +65,7 @@ class TestBasic(BaseImageTests):
         ax.set_axis_off()
         return fig
 
-    @pytest.mark.remote_data(source='astropy')
+    @pytest.mark.remote_data
     @pytest.mark.mpl_image_compare(tolerance=1.5, style={})
     @pytest.mark.parametrize('axisbelow', [True, False, 'line'])
     def test_axisbelow(self, axisbelow):
@@ -93,7 +93,7 @@ class TestBasic(BaseImageTests):
 
         return fig
 
-    @pytest.mark.remote_data(source='astropy')
+    @pytest.mark.remote_data
     @pytest.mark.mpl_image_compare(tolerance=0, style={})
     def test_contour_overlay(self):
         # Test for overlaying contours on images
@@ -126,7 +126,7 @@ class TestBasic(BaseImageTests):
 
         return fig
 
-    @pytest.mark.remote_data(source='astropy')
+    @pytest.mark.remote_data
     @pytest.mark.mpl_image_compare(tolerance=0, style={})
     def test_contourf_overlay(self):
         # Test for overlaying contours on images
@@ -159,7 +159,7 @@ class TestBasic(BaseImageTests):
 
         return fig
 
-    @pytest.mark.remote_data(source='astropy')
+    @pytest.mark.remote_data
     @pytest.mark.mpl_image_compare(tolerance=0, style={})
     def test_overlay_features_image(self):
 
@@ -196,7 +196,7 @@ class TestBasic(BaseImageTests):
 
         return fig
 
-    @pytest.mark.remote_data(source='astropy')
+    @pytest.mark.remote_data
     @pytest.mark.mpl_image_compare(tolerance=0, style={})
     def test_curvilinear_grid_patches_image(self):
 
@@ -228,7 +228,7 @@ class TestBasic(BaseImageTests):
 
         return fig
 
-    @pytest.mark.remote_data(source='astropy')
+    @pytest.mark.remote_data
     @pytest.mark.mpl_image_compare(tolerance=0, style={})
     def test_cube_slice_image(self):
 
@@ -256,7 +256,7 @@ class TestBasic(BaseImageTests):
 
         return fig
 
-    @pytest.mark.remote_data(source='astropy')
+    @pytest.mark.remote_data
     @pytest.mark.mpl_image_compare(tolerance=0, style={})
     def test_cube_slice_image_lonlat(self):
 
@@ -282,7 +282,7 @@ class TestBasic(BaseImageTests):
 
         return fig
 
-    @pytest.mark.remote_data(source='astropy')
+    @pytest.mark.remote_data
     @pytest.mark.mpl_image_compare(tolerance=0, style={})
     def test_plot_coord(self):
         fig = plt.figure(figsize=(6, 6))
@@ -307,7 +307,7 @@ class TestBasic(BaseImageTests):
 
         return fig
 
-    @pytest.mark.remote_data(source='astropy')
+    @pytest.mark.remote_data
     @pytest.mark.mpl_image_compare(tolerance=0, style={})
     def test_plot_line(self):
         fig = plt.figure(figsize=(6, 6))
@@ -328,7 +328,7 @@ class TestBasic(BaseImageTests):
 
         return fig
 
-    @pytest.mark.remote_data(source='astropy')
+    @pytest.mark.remote_data
     @pytest.mark.mpl_image_compare(tolerance=0, style={})
     def test_changed_axis_units(self):
         # Test to see if changing the units of axis works
@@ -357,7 +357,7 @@ class TestBasic(BaseImageTests):
 
         return fig
 
-    @pytest.mark.remote_data(source='astropy')
+    @pytest.mark.remote_data
     @pytest.mark.mpl_image_compare(tolerance=0, style={})
     def test_minor_ticks(self):
         # Test for drawing minor ticks
@@ -385,7 +385,7 @@ class TestBasic(BaseImageTests):
 
         return fig
 
-    @pytest.mark.remote_data(source='astropy')
+    @pytest.mark.remote_data
     @pytest.mark.mpl_image_compare(tolerance=0, style={})
     def test_ticks_labels(self):
         fig = plt.figure(figsize=(6, 6))
@@ -413,7 +413,7 @@ class TestBasic(BaseImageTests):
 
         return fig
 
-    @pytest.mark.remote_data(source='astropy')
+    @pytest.mark.remote_data
     @pytest.mark.mpl_image_compare(tolerance=0, style={})
     def test_rcparams(self):
 
@@ -457,7 +457,7 @@ class TestBasic(BaseImageTests):
             ax.coords[1].set_ticklabel(exclude_overlapping=True)
             return fig
 
-    @pytest.mark.remote_data(source='astropy')
+    @pytest.mark.remote_data
     @pytest.mark.mpl_image_compare(tolerance=0, style={})
     def test_tick_angles(self):
         # Test that tick marks point in the correct direction, even when the
@@ -483,7 +483,7 @@ class TestBasic(BaseImageTests):
         ax.coords[0].set_format_unit(u.degree)
         return fig
 
-    @pytest.mark.remote_data(source='astropy')
+    @pytest.mark.remote_data
     @pytest.mark.mpl_image_compare(tolerance=0, style={})
     def test_tick_angles_non_square_axes(self):
         # Test that tick marks point in the correct direction, even when the
@@ -510,7 +510,7 @@ class TestBasic(BaseImageTests):
         ax.coords[0].set_format_unit(u.degree)
         return fig
 
-    @pytest.mark.remote_data(source='astropy')
+    @pytest.mark.remote_data
     @pytest.mark.mpl_image_compare(tolerance=0, style={})
     def test_set_coord_type(self):
         # Test for setting coord_type
@@ -528,7 +528,7 @@ class TestBasic(BaseImageTests):
         ax.coords[1].set_ticklabel(exclude_overlapping=True)
         return fig
 
-    @pytest.mark.remote_data(source='astropy')
+    @pytest.mark.remote_data
     @pytest.mark.mpl_image_compare(tolerance=0, style={})
     def test_ticks_regression(self):
         # Regression test for a bug that caused ticks aligned exactly with a
@@ -551,7 +551,7 @@ class TestBasic(BaseImageTests):
         ax.coords[1].set_ticklabel_position('all')
         return fig
 
-    @pytest.mark.remote_data(source='astropy')
+    @pytest.mark.remote_data
     @pytest.mark.mpl_image_compare(savefig_kwargs={'bbox_inches': 'tight'},
                                    tolerance=0, style={})
     def test_axislabels_regression(self):
@@ -568,7 +568,7 @@ class TestBasic(BaseImageTests):
         ax.coords[1].ticklabels.set_visible(False)
         return fig
 
-    @pytest.mark.remote_data(source='astropy')
+    @pytest.mark.remote_data
     @pytest.mark.mpl_image_compare(savefig_kwargs={'bbox_inches': 'tight'},
                                    tolerance=0, style={})
     def test_noncelestial_angular(self, tmpdir):
@@ -606,7 +606,7 @@ class TestBasic(BaseImageTests):
 
         return fig
 
-    @pytest.mark.remote_data(source='astropy')
+    @pytest.mark.remote_data
     @pytest.mark.mpl_image_compare(savefig_kwargs={'bbox_inches': 'tight'},
                                    tolerance=0, style={})
     def test_patches_distortion(self, tmpdir):
@@ -668,7 +668,7 @@ class TestBasic(BaseImageTests):
 
         return fig
 
-    @pytest.mark.remote_data(source='astropy')
+    @pytest.mark.remote_data
     @pytest.mark.mpl_image_compare(tolerance=0, style={})
     def test_quadrangle(self, tmpdir):
         # Test that Quadrangle can have curved edges while Rectangle does not
@@ -695,7 +695,7 @@ class TestBasic(BaseImageTests):
 
         return fig
 
-    @pytest.mark.remote_data(source='astropy')
+    @pytest.mark.remote_data
     @pytest.mark.mpl_image_compare(tolerance=0, style={})
     def test_elliptical_frame(self):
 
@@ -707,7 +707,7 @@ class TestBasic(BaseImageTests):
         fig.add_axes([0.2, 0.2, 0.6, 0.6], projection=wcs, frame_class=EllipticalFrame)
         return fig
 
-    @pytest.mark.remote_data(source='astropy')
+    @pytest.mark.remote_data
     @pytest.mark.mpl_image_compare(tolerance=0, style={})
     def test_hms_labels(self):
         # This tests the apparance of the hms superscripts in tick labels
@@ -720,7 +720,7 @@ class TestBasic(BaseImageTests):
         ax.coords[0].set_ticks(spacing=0.2 * 15 * u.arcsec)
         return fig
 
-    @pytest.mark.remote_data(source='astropy')
+    @pytest.mark.remote_data
     @pytest.mark.mpl_image_compare(tolerance=0, style={'text.usetex': True})
     def test_latex_labels(self):
         fig = plt.figure(figsize=(3, 3))
@@ -732,7 +732,7 @@ class TestBasic(BaseImageTests):
         ax.coords[0].set_ticks(spacing=0.2 * 15 * u.arcsec)
         return fig
 
-    @pytest.mark.remote_data(source='astropy')
+    @pytest.mark.remote_data
     @pytest.mark.mpl_image_compare(tolerance=0, style={})
     def test_tick_params(self):
 
@@ -816,7 +816,7 @@ def wave_wcs_1d():
     return wcs
 
 
-@pytest.mark.remote_data(source='astropy')
+@pytest.mark.remote_data
 @pytest.mark.mpl_image_compare(tolerance=0, style={})
 def test_1d_plot_1d_wcs(wave_wcs_1d):
     fig = plt.figure()
@@ -829,7 +829,7 @@ def test_1d_plot_1d_wcs(wave_wcs_1d):
     return fig
 
 
-@pytest.mark.remote_data(source='astropy')
+@pytest.mark.remote_data
 @pytest.mark.mpl_image_compare(tolerance=0, style={})
 def test_1d_plot_1d_wcs_format_unit(wave_wcs_1d):
     """
@@ -856,7 +856,7 @@ def spatial_wcs_2d():
     return wcs
 
 
-@pytest.mark.remote_data(source='astropy')
+@pytest.mark.remote_data
 @pytest.mark.mpl_image_compare(tolerance=0, style={})
 def test_1d_plot_2d_wcs_correlated(spatial_wcs_2d):
     fig = plt.figure()
@@ -893,7 +893,7 @@ def spatial_wcs_2d_small_angle():
     # Remember SLLWCS takes slices in array order
     (np.s_[0, :], 'custom:pos.helioprojective.lon'),
     (np.s_[:, 0], 'custom:pos.helioprojective.lat')])
-@pytest.mark.remote_data(source='astropy')
+@pytest.mark.remote_data
 @pytest.mark.mpl_image_compare(tolerance=0, style={})
 def test_1d_plot_1d_sliced_low_level_wcs(spatial_wcs_2d_small_angle, slices, bottom_axis):
     """
@@ -914,7 +914,7 @@ def test_1d_plot_1d_sliced_low_level_wcs(spatial_wcs_2d_small_angle, slices, bot
 @pytest.mark.parametrize("slices, bottom_axis", [
     (('x', 0), 'hpln'),
     ((0, 'x'), 'hplt')])
-@pytest.mark.remote_data(source='astropy')
+@pytest.mark.remote_data
 @pytest.mark.mpl_image_compare(tolerance=0, style={})
 def test_1d_plot_put_varying_axis_on_bottom_lon(spatial_wcs_2d_small_angle, slices, bottom_axis):
     """
@@ -938,7 +938,7 @@ def test_1d_plot_put_varying_axis_on_bottom_lon(spatial_wcs_2d_small_angle, slic
     return fig
 
 
-@pytest.mark.remote_data(source='astropy')
+@pytest.mark.remote_data
 @pytest.mark.mpl_image_compare(tolerance=0, style={})
 def test_allsky_labels_wrap():
 

--- a/astropy/visualization/wcsaxes/tests/test_transform_coord_meta.py
+++ b/astropy/visualization/wcsaxes/tests/test_transform_coord_meta.py
@@ -56,7 +56,7 @@ class LonLatToDistance(CurvedTransform):
 
 class TestTransformCoordMeta(BaseImageTests):
 
-    @pytest.mark.remote_data(source='astropy')
+    @pytest.mark.remote_data
     @pytest.mark.mpl_image_compare(tolerance=0, style={})
     def test_coords_overlay(self):
 
@@ -104,7 +104,7 @@ class TestTransformCoordMeta(BaseImageTests):
 
         return fig
 
-    @pytest.mark.remote_data(source='astropy')
+    @pytest.mark.remote_data
     @pytest.mark.mpl_image_compare(tolerance=0, style={})
     def test_coords_overlay_auto_coord_meta(self):
 
@@ -127,7 +127,7 @@ class TestTransformCoordMeta(BaseImageTests):
 
         return fig
 
-    @pytest.mark.remote_data(source='astropy')
+    @pytest.mark.remote_data
     @pytest.mark.mpl_image_compare(tolerance=0, style={})
     def test_direct_init(self):
 

--- a/astropy/visualization/wcsaxes/tests/test_wcsapi.py
+++ b/astropy/visualization/wcsaxes/tests/test_wcsapi.py
@@ -460,7 +460,7 @@ def test_coord_meta_wcsapi():
     assert coord_meta['default_axis_label'] == ['Frequency', 'time', 'RA', 'DEC', 'phys.polarization.stokes']
 
 
-@pytest.mark.remote_data(source='astropy')
+@pytest.mark.remote_data
 @pytest.mark.mpl_image_compare(tolerance=0, style={})
 def test_wcsapi_5d_with_names(plt_close):
     # Test for plotting image and also setting values of ticks

--- a/astropy/visualization/wcsaxes/ticklabels.py
+++ b/astropy/visualization/wcsaxes/ticklabels.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+from collections import defaultdict
 
 import numpy as np
 
@@ -37,25 +38,55 @@ class TickLabels(Text):
             self.set_size(rcParams['xtick.labelsize'])
 
     def clear(self):
-        self.world = {}
-        self.pixel = {}
-        self.angle = {}
-        self.text = {}
-        self.disp = {}
+        self.world = defaultdict(list)
+        self.data = defaultdict(list)
+        self.angle = defaultdict(list)
+        self.text = defaultdict(list)
+        self.disp = defaultdict(list)
 
-    def add(self, axis, world, pixel, angle, text, axis_displacement):
-        if axis not in self.world:
-            self.world[axis] = [world]
-            self.pixel[axis] = [pixel]
-            self.angle[axis] = [angle]
-            self.text[axis] = [text]
-            self.disp[axis] = [axis_displacement]
-        else:
-            self.world[axis].append(world)
-            self.pixel[axis].append(pixel)
-            self.angle[axis].append(angle)
-            self.text[axis].append(text)
-            self.disp[axis].append(axis_displacement)
+    def add(self, axis=None, world=None, pixel=None, angle=None, text=None,
+            axis_displacement=None, data=None):
+        """
+        Add a label.
+
+        Parameters
+        ----------
+        axis : str
+            Axis to add label to.
+        world : Quantity
+            Coordinate value along this axis.
+        pixel : [float, float]
+            Pixel coordinates of the label. Deprecated and no longer used.
+        angle : float
+            Angle of the label.
+        text : str
+            Label text.
+        axis_displacement : float
+            Displacement from axis.
+        data : [float, float]
+            Data coordinates of the label.
+        """
+        required_args = ['axis', 'world', 'angle', 'text', 'axis_displacement', 'data']
+        if pixel is not None:
+            warnings.warn('Setting the pixel coordinates of a label does nothing and is deprecated, '
+                          'as these can only be accurately calculated when Matplotlib '
+                          'is drawing a figure. To prevent this warning pass the following '
+                          f'arguments as keyword arguments: {required_args}',
+                          AstropyDeprecationWarning)
+        if (axis is None or
+                world is None or
+                angle is None or
+                text is None or
+                axis_displacement is None or
+                data is None):
+            raise TypeError(f'All of the following arguments must be provided: {required_args}')
+
+        self.world[axis].append(world)
+        self.data[axis].append(data)
+        self.angle[axis].append(angle)
+        self.text[axis].append(text)
+        self.disp[axis].append(axis_displacement)
+
         self._stale = True
 
     def sort(self):
@@ -65,7 +96,7 @@ class TickLabels(Text):
         """
         for axis in self.world:
             self.world[axis] = sort_using(self.world[axis], self.disp[axis])
-            self.pixel[axis] = sort_using(self.pixel[axis], self.disp[axis])
+            self.data[axis] = sort_using(self.data[axis], self.disp[axis])
             self.angle[axis] = sort_using(self.angle[axis], self.disp[axis])
             self.text[axis] = sort_using(self.text[axis], self.disp[axis])
             self.disp[axis] = sort_using(self.disp[axis], self.disp[axis])
@@ -149,7 +180,7 @@ class TickLabels(Text):
                 if self.text[axis][i] == '':
                     continue
 
-                x, y = self.pixel[axis][i]
+                x, y = self._frame.parent_axes.transData.transform(self.data[axis][i])
                 pad = renderer.points_to_pixels(self.get_pad() + tick_out_size)
 
                 if isinstance(self._frame, RectangularFrame):

--- a/docs/changes/wcs/12630.api.rst
+++ b/docs/changes/wcs/12630.api.rst
@@ -1,0 +1,7 @@
+The ``pixel`` argument to ``astropy.visualization.wcsaxes.ticklabels.TickLabels.add``
+no longer does anything, is deprecated, and will be removed in a future
+astropy version. It has been replaced by a new required ``data`` argument, which
+should be used to specify the data coordinates of the tick label being added.
+
+This changes has been made because it is (in general) not possible to correctly
+calculate pixel coordinates before Matplotlib is drawing a figure.

--- a/docs/changes/wcs/12630.bugfix.rst
+++ b/docs/changes/wcs/12630.bugfix.rst
@@ -1,0 +1,3 @@
+The locations of ``WCSAxes`` ticks and tick-labels are now correctly calculated
+when the DPI of a figure changes between a WCSAxes being created and the figure
+being drawn, or when a rasterized artist is added to the WCSAxes.

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ passenv = HOME WINDIR LC_ALL LC_CTYPE CC CI IS_CRON ARCH_ON_CI TEST_READ_HUGE_FI
 setenv =
     # For coverage, we need to pass extra options to the C compiler
     cov: CFLAGS = --coverage -fno-inline-functions -O0
-    image: MPLFLAGS = -m "mpl_image_compare" --mpl --mpl-generate-summary=html --mpl-results-path={toxinidir}/results --mpl-hash-library={toxinidir}/astropy/tests/figures/{envname}.json --mpl-baseline-path=https://raw.githubusercontent.com/astropy/astropy-figure-tests/astropy-main/figures/{envname}/ --remote-data=astropy -W ignore::DeprecationWarning
+    image: MPLFLAGS = -m "mpl_image_compare" --mpl --mpl-generate-summary=html --mpl-results-path={toxinidir}/results --mpl-hash-library={toxinidir}/astropy/tests/figures/{envname}.json --mpl-baseline-path=https://raw.githubusercontent.com/astropy/astropy-figure-tests/astropy-main/figures/{envname}/ --remote-data -W ignore::DeprecationWarning
     !image: MPLFLAGS =
     clocale: LC_CTYPE = C.ascii
     clocale: LC_ALL = C


### PR DESCRIPTION
Backport PR https://github.com/astropy/astropy/pull/12630: Calculate WCSAxes TickLabel pixel coords at draw time