### PR TITLE
Resolve ambiguity between empty variable-length arrays and non variable-legth arrays in tables

### DIFF
--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -1036,8 +1036,15 @@ class FITS_rec(np.recarray):
         base = self
         while hasattr(base, 'base') and base.base is not None:
             base = base.base
-            if hasattr(base, 'nbytes') and base.nbytes >= raw_data_bytes:
-                return base
+            # Variable-length-arrays: should take into account the case of
+            # empty arrays
+            if hasattr(base, '_heapoffset'):
+                if hasattr(base, 'nbytes') and base.nbytes > raw_data_bytes:
+                    return base
+            # non variable-length-arrays
+            else:
+                if hasattr(base, 'nbytes') and base.nbytes >= raw_data_bytes:
+                    return base
 
     def _get_scale_factors(self, column):
         """Get all the scaling flags and factors for one column."""

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -3072,6 +3072,22 @@ class TestVLATables(FitsTestCase):
                            match="Please consider using the 'Q' format for your file."):
             t.writeto(self.temp('matrix.fits'))
 
+    def test_empty_vla_raw_data(self):
+        """
+        Regression test for https://github.com/astropy/astropy/issues/12881
+
+        Check if empty vla are correctly read.
+        """
+
+        columns = [
+            fits.Column(name='integer', format='B', array=(1, 2)),
+            fits.Column(name='empty', format='PJ', array=([], [])),
+        ]
+        fits.BinTableHDU.from_columns(columns).writeto(self.temp('bug.fits'))
+        with fits.open(self.temp('bug.fits')) as hdu:
+            np.array_equal(hdu[1].data['empty'],
+                           [np.array([], dtype=np.int32), np.array([], dtype=np.int32)])
+
 
 # These are tests that solely test the Column and ColDefs interfaces and
 # related functionality without directly involving full tables; currently there

--- a/docs/changes/io.fits/13621.bugfix.rst
+++ b/docs/changes/io.fits/13621.bugfix.rst
@@ -1,0 +1,2 @@
+Empty variable-length arrays are now properly handled when pathological combinations of
+heapoffset and heapsize are encountered.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address the ambiguity in `_get_raw_data` between tables containing empty variable-length arrays and tables without variable-length arrays (having both `_heapsize` = 0).

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #12881

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Do the proposed changes need the code-style [fixed](https://docs.astropy.org/en/latest/development/workflow/maintainer_workflow.html#pre-commit_bot)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
