### PR TITLE
Enable aarch64 wheels and turn off testing of aarch64 and musllinux wheels

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,6 +48,10 @@ jobs:
         - cp38-manylinux_x86_64
         - cp39-manylinux_x86_64
         - cp310-manylinux_x86_64
+        # Note that following wheels are not currently tested:
+        - cp38-manylinux_aarch64
+        - cp39-manylinux_aarch64
+        - cp310-manylinux_aarch64
         - cp38-musllinux_x86_64
         - cp39-musllinux_x86_64
         - cp310-musllinux_x86_64
@@ -69,11 +73,6 @@ jobs:
         - cp39*win_amd64
         - cp310*win32
         - cp310*win_amd64
-
-        # TODO: The aarch64 builds take longer than an hour to complete so get killed
-        # - cp38-manylinux_aarch64
-        # - cp39-manylinux_aarch64
-        # - cp310-manylinux_aarch64
 
     secrets:
       pypi_token: ${{ secrets.pypi_token }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,11 @@ manylinux-i686-image = "manylinux2010"
 # Numpy 1.22 doesn't have wheels for i386, so we pin Numpy to an older version
 # that does - this pin can be removed once we drop support for 32-bit wheels.
 test-requires = "numpy==1.21.*"
+# We disable testing for the following wheels:
+# - MacOS X ARM (no native hardware, tests are skipped anyway, this avoids a warning)
+# - Linux AArch64 (no native hardware, tests take too long)
+# - MuslLinux (tests hang non-deterministically)
+test-skip = "*-macosx_arm64 *-manylinux_aarch64 *-musllinux_x86_64"
 
 [tool.cibuildwheel.macos]
 archs = ["x86_64", "arm64"]


### PR DESCRIPTION
### Description

Tests on Linux aarch64 take much too long to run as they are run using qemu (this can be hundreds of times slower than running natively). In addition, the musllinux wheels hang non-deterministically.

For now, I think it is safe to disable testing of these wheels - after all we already can't test the Mac ARM64 wheels so there is precedent for this. We've never had an issue come up so far that was specific to any of these platforms and not on other platforms, and our release candidates and releases go through extensive multi-platform testing (thanks @olebole!). Of course if we can re-enable testing here in future that would be great, but for now I think this should be fine.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Do the proposed changes need the code-style [fixed](https://docs.astropy.org/en/latest/development/workflow/maintainer_workflow.html#pre-commit_bot)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
