### PR TITLE
Backport PR #13628 on branch v5.0.x (Bugfix for Error when fitting zero-degree polynomial #13617)

### DIFF
--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -1232,14 +1232,15 @@ class LevMarLSQFitter(metaclass=_FitterMeta):
             return [np.ravel(_) for _ in residues]
         else:
             if z is None:
+                fit_deriv = np.array(model.fit_deriv(x, *params))
                 try:
-                    return np.array([np.ravel(_) for _ in np.array(weights) *
-                                     np.array(model.fit_deriv(x, *params))])
+                    output = np.array([np.ravel(_) for _ in np.array(weights) * fit_deriv])
+                    if output.shape != fit_deriv.shape:
+                        output = np.array([np.ravel(_) for _ in np.atleast_2d(weights).T * fit_deriv])
+                    return output
                 except ValueError:
                     return np.array([np.ravel(_) for _ in np.array(weights) *
-                                     np.moveaxis(
-                                         np.array(model.fit_deriv(x, *params)),
-                                         -1, 0)]).transpose()
+                                    np.moveaxis(fit_deriv, -1, 0)]).transpose()
             else:
                 if not model.col_fit_deriv:
                     return [np.ravel(_) for _ in

--- a/astropy/modeling/tests/test_fitters.py
+++ b/astropy/modeling/tests/test_fitters.py
@@ -1246,3 +1246,29 @@ class TestFittingUncertanties:
 
         # test indexing for stds class.
         assert fit_mod.stds[1] == fit_mod.stds['intercept']
+
+
+@pytest.mark.skipif('not HAS_SCIPY')
+@pytest.mark.filterwarnings(r'ignore:Model is linear in parameters*')
+def test_non_linear_fit_zero_degree_polynomial_with_weights():
+    """
+    Regression test for issue #13617
+        Issue:
+            Weighted non-linear weighted fits of O-degree polynomials cause an error
+            to be raised by scipy.
+        Fix:
+            There should be no error raised in this circumstance
+    """
+
+    model = models.Polynomial1D(0, c0=0)
+    fitter = LevMarLSQFitter()
+
+    x = np.arange(10, dtype=float)
+    y = np.ones((10,))
+    weights = np.ones((10,))
+
+    fit = fitter(model, x, y)
+    assert_almost_equal(fit.c0, 1.0)
+
+    fit = fitter(model, x, y, weights=weights)
+    assert_almost_equal(fit.c0, 1.0)

--- a/docs/changes/modeling/13628.bugfix.rst
+++ b/docs/changes/modeling/13628.bugfix.rst
@@ -1,0 +1,1 @@
+Fix bug in using non-linear fitters to fit 0-degree polynomials using weights.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

Manual backport of #13628 to v5.0.x

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Do the proposed changes need the code-style [fixed](https://docs.astropy.org/en/latest/development/workflow/maintainer_workflow.html#pre-commit_bot)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
