### PR TITLE
Remove / deprecate outdated code in `utils.compat`

### DIFF
--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -15,7 +15,6 @@ import warnings
 import numpy as np
 
 # Project
-from astropy.utils.compat.misc import override__dir__
 from astropy.utils.decorators import lazyproperty, format_doc
 from astropy.utils.exceptions import AstropyWarning, AstropyDeprecationWarning
 from astropy import units as u
@@ -1575,7 +1574,6 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
 
         self.cache.clear()
 
-    @override__dir__
     def __dir__(self):
         """
         Override the builtin `dir` behavior to include representation
@@ -1583,10 +1581,11 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
 
         TODO: dynamic representation transforms (i.e. include cylindrical et al.).
         """
-        dir_values = set(self.representation_component_names)
-        dir_values |= set(self.get_representation_component_names('s'))
-
-        return dir_values
+        return sorted(
+            set(super().__dir__())
+            | set(self.representation_component_names)
+            | set(self.get_representation_component_names('s'))
+        )
 
     def __getattr__(self, attr):
         """

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -6,7 +6,6 @@ import operator
 import numpy as np
 import erfa
 
-from astropy.utils.compat.misc import override__dir__
 from astropy import units as u
 from astropy.constants import c as speed_of_light
 from astropy.utils.data_info import MixinInfo
@@ -911,16 +910,15 @@ class SkyCoord(ShapedLikeNDArray):
             # Otherwise, do the standard Python attribute setting
             super().__delattr__(attr)
 
-    @override__dir__
     def __dir__(self):
         """
         Override the builtin `dir` behavior to include:
         - Transforms available by aliases
         - Attribute / methods of the underlying self.frame object
         """
+        dir_values = set(super().__dir__())
 
         # determine the aliases that this can be transformed to.
-        dir_values = set()
         for name in frame_transform_graph.get_names():
             frame_cls = frame_transform_graph.lookup_name(name)
             if self.frame.is_transformable_to(frame_cls):
@@ -932,7 +930,7 @@ class SkyCoord(ShapedLikeNDArray):
         # Add all possible frame attributes
         dir_values.update(frame_transform_graph.frame_attributes.keys())
 
-        return dir_values
+        return sorted(dir_values)
 
     def __repr__(self):
         clsnm = self.__class__.__name__

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -21,7 +21,6 @@ import erfa
 from astropy import units as u, constants as const
 from astropy.units import UnitConversionError
 from astropy.utils import ShapedLikeNDArray
-from astropy.utils.compat.misc import override__dir__
 from astropy.utils.data_info import MixinInfo, data_info_factory
 from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyWarning
 from .utils import day_frac
@@ -1401,11 +1400,8 @@ class TimeBase(ShapedLikeNDArray):
             # Should raise AttributeError
             return self.__getattribute__(attr)
 
-    @override__dir__
     def __dir__(self):
-        result = set(self.SCALES)
-        result.update(self.FORMATS)
-        return result
+        return sorted(set(super().__dir__()) | set(self.SCALES) | set(self.FORMATS))
 
     def _match_shape(self, val):
         """

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -18,7 +18,6 @@ import numpy as np
 # LOCAL
 from astropy import config as _config
 from astropy.utils.compat import NUMPY_LT_1_20, NUMPY_LT_1_22
-from astropy.utils.compat.misc import override__dir__
 from astropy.utils.data_info import ParentDtypeInfo
 from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyWarning
 from astropy.utils.misc import isiterable
@@ -1004,7 +1003,6 @@ class Quantity(np.ndarray):
     # Quantity, such as `astropy.coordinates.Angle`.
     _include_easy_conversion_members = False
 
-    @override__dir__
     def __dir__(self):
         """
         Quantities are able to directly convert to other units that
@@ -1012,13 +1010,13 @@ class Quantity(np.ndarray):
         order to make autocompletion still work correctly in IPython.
         """
         if not self._include_easy_conversion_members:
-            return []
-        extra_members = set()
+            return super().__dir__()
+
+        dir_values = set(super().__dir__())
         equivalencies = Unit._normalize_equivalencies(self.equivalencies)
-        for equivalent in self.unit._get_units_with_same_physical_type(
-                equivalencies):
-            extra_members.update(equivalent.names)
-        return extra_members
+        for equivalent in self.unit._get_units_with_same_physical_type(equivalencies):
+            dir_values.update(equivalent.names)
+        return sorted(dir_values)
 
     def __getattr__(self, attr):
         """

--- a/astropy/utils/compat/misc.py
+++ b/astropy/utils/compat/misc.py
@@ -8,11 +8,9 @@ be accessed from there.
 
 import sys
 import functools
-from contextlib import suppress
 
 
-__all__ = ['override__dir__', 'suppress',
-           'possible_filename', 'namedtuple_asdict']
+__all__ = ['override__dir__', 'possible_filename']
 
 
 def possible_filename(filename):
@@ -61,15 +59,3 @@ def override__dir__(f):
         return sorted(members)
 
     return override__dir__wrapper
-
-
-def namedtuple_asdict(namedtuple):
-    """
-    The same as ``namedtuple._adict()``.
-
-    Parameters
-    ----------
-    namedtuple : collections.namedtuple
-    The named tuple to get the dict of
-    """
-    return namedtuple._asdict()

--- a/astropy/utils/compat/misc.py
+++ b/astropy/utils/compat/misc.py
@@ -9,6 +9,7 @@ be accessed from there.
 import sys
 import functools
 
+from astropy.utils.decorators import deprecated
 
 __all__ = ['override__dir__', 'possible_filename']
 
@@ -33,13 +34,19 @@ def possible_filename(filename):
     return False
 
 
+@deprecated(
+    since="v5.2",
+    message="http://bugs.python.org/issue12166 is resolved. See docstring for alternatives."
+)
 def override__dir__(f):
     """
-    When overriding a __dir__ method on an object, you often want to
-    include the "standard" members on the object as well.  This
-    decorator takes care of that automatically, and all the wrapped
-    function needs to do is return a list of the "special" members
-    that wouldn't be found by the normal Python means.
+    When overriding a __dir__ method on an object, you often want to include the
+    "standard" members on the object as well.  This decorator takes care of that
+    automatically, and all the wrapped function needs to do is return a list of
+    the "special" members that wouldn't be found by the normal Python means.
+
+    .. deprecated:: v5.2
+        Use ``sorted(super().__dir__() + ...)`` instead.
 
     Example
     -------
@@ -49,6 +56,18 @@ def override__dir__(f):
         @override__dir__
         def __dir__(self):
             return ['special_method1', 'special_method2']
+
+    Notes
+    -----
+    This function was introduced because of http://bugs.python.org/issue12166,
+    which has since been resolved by
+    http://hg.python.org/cpython/rev/8f403199f999. Now, the best way to
+    customize ``__dir__`` is to use ``super``.
+    ::
+
+        def __dir__(self):
+            added = {'special_method1', 'special_method2'}
+            return sorted(set(super().__dir__()) | added)
     """
     # http://bugs.python.org/issue12166
 

--- a/docs/changes/utils/13636.api.rst
+++ b/docs/changes/utils/13636.api.rst
@@ -1,0 +1,3 @@
+``astropy.utils.misc.suppress`` has been removed, use ``contextlib.suppress``
+instead. ``astropy.utils.namedtuple_asdict`` has been removed, instead use
+method ``._asdict`` on a ``namedtuple``.

--- a/docs/changes/utils/13636.api.rst
+++ b/docs/changes/utils/13636.api.rst
@@ -1,3 +1,5 @@
 ``astropy.utils.misc.suppress`` has been removed, use ``contextlib.suppress``
 instead. ``astropy.utils.namedtuple_asdict`` has been removed, instead use
-method ``._asdict`` on a ``namedtuple``.
+method ``._asdict`` on a ``namedtuple``. ``override__dir__`` has been deprecated
+and will be removed in a future version, see the docstring for the better
+alternative.


### PR DESCRIPTION
### Description

- ``suppress`` is part of core python and should be imported as such.
- ``namedtuple_asdict`` was for python 3.3 and is not used in the core package.
- ``override__dir__`` is deprecated. It was necessary because of http://bugs.python.org/issue12166, which has been resolved for a long time.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Do the proposed changes need the code-style [fixed](https://docs.astropy.org/en/latest/development/workflow/maintainer_workflow.html#pre-commit_bot)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
