### PR TITLE
possibly in-place upcast dtype in ilshift

### DIFF
--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -1096,7 +1096,7 @@ class Quantity(np.ndarray):
             self_as_array *= factor  # except output dtype
         # The real error is `numpy.core._exceptions._UFuncOutputCastingError`, which
         # inherits from `TypeError`.
-        except (UnitConversionError, TypeError):
+        except (UnitConversionError, TypeError, AttributeError):
             # Simple conversion failed. Integer dtype? Conversion via equivalency?
             # Given other.__rlshift__(self) a chance.
             return NotImplemented

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -699,6 +699,32 @@ def test_quantity_conversion():
         q1.to_value(u.zettastokes)
 
 
+def test_quantity_ilshift():  # in-place conversion
+    q = u.Quantity(10, unit=u.one)
+
+    # Incompatible units. This goes through ilshift and hits a
+    # UnitConversionError first in ilshift, then in the unit's rlshift.
+    with pytest.raises(u.UnitConversionError):
+        q <<= u.rad
+
+    # unless the equivalency is enabled
+    with u.add_enabled_equivalencies(u.dimensionless_angles()):
+        q <<= u.rad
+
+    assert np.isclose(q, 10 * u.rad)
+
+
+def test_regression_12964():
+    # This will fail if the fix to
+    # https://github.com/astropy/astropy/issues/12964 doesn't work.
+    x = u.Quantity(10, u.km, dtype=int)
+    x <<= u.pc
+
+    # We add a test that this worked.
+    assert x.unit is u.pc
+    assert x.dtype == np.float64
+
+
 def test_quantity_value_views():
     q1 = u.Quantity([1., 2.], unit=u.meter)
     # views if the unit is the same.

--- a/astropy/units/tests/test_structured.py
+++ b/astropy/units/tests/test_structured.py
@@ -520,11 +520,13 @@ class TestStructuredQuantity(StructuredTestBaseWithUnits):
         assert np.all(q2['t'] == q_pv_t['t'].to(u.Myr))
 
     def test_inplace_conversion(self):
+        # In principle, in-place might be possible, in which case this should be
+        # changed -- ie ``q1 is q_link``.
         q_pv = Quantity(self.pv, self.pv_unit)
         q1 = q_pv.copy()
         q_link = q1
         q1 <<= StructuredUnit(('AU', 'AU/day'))
-        assert q1 is q_link
+        assert q1 is not q_link
         assert q1['p'].unit == u.AU
         assert q1['v'].unit == u.AU / u.day
         assert np.all(q1['p'] == q_pv['p'].to(u.AU))
@@ -533,7 +535,7 @@ class TestStructuredQuantity(StructuredTestBaseWithUnits):
         q2 = q_pv_t.copy()
         q_link = q2
         q2 <<= '(kpc,kpc/Myr),Myr'
-        assert q2 is q_link
+        assert q2 is not q_link
         assert q2['pv']['p'].unit == u.kpc
         assert q2['pv']['v'].unit == u.kpc / u.Myr
         assert q2['t'].unit == u.Myr

--- a/docs/changes/units/13638.api.rst
+++ b/docs/changes/units/13638.api.rst
@@ -1,0 +1,5 @@
+In "in-place unit changes" of the form `quantity <<= new_unit`, the result will
+now share memory with the original only if the conversion could be done through
+a simple multiplication with a scale factor. Hence, memory will not be shared if
+the quantity has integer `dtype` or is structured, or when the conversion is
+through an equivalency.

--- a/docs/changes/units/13638.api.rst
+++ b/docs/changes/units/13638.api.rst
@@ -1,5 +1,5 @@
-In "in-place unit changes" of the form `quantity <<= new_unit`, the result will
-now share memory with the original only if the conversion could be done through
-a simple multiplication with a scale factor. Hence, memory will not be shared if
-the quantity has integer `dtype` or is structured, or when the conversion is
-through an equivalency.
+In "in-place unit changes" of the form ``quantity <<= new_unit``, the result
+will now share memory with the original only if the conversion could be done
+through a simple multiplication with a scale factor. Hence, memory will not be
+shared if the quantity has integer ```dtype``` or is structured, or when the
+conversion is through an equivalency.

--- a/docs/changes/units/13638.bugfix.rst
+++ b/docs/changes/units/13638.bugfix.rst
@@ -1,0 +1,4 @@
+Unit changes of the form ``quantity <<= new_unit`` will now ensure that the
+result is correct even if the quantity is integer by casting the quantity to
+float if the unit conversion requires it (e.g., meter to kilometer). This means
+that the result will not share memory with the original.

--- a/docs/changes/units/13638.bugfix.rst
+++ b/docs/changes/units/13638.bugfix.rst
@@ -1,4 +1,3 @@
-Unit changes of the form ``quantity <<= new_unit`` will now ensure that the
-result is correct even if the quantity is integer by casting the quantity to
-float if the unit conversion requires it (e.g., meter to kilometer). This means
-that the result will not share memory with the original.
+Unit changes of the form ``quantity <<= new_unit`` will now work also if the
+quantity is integer. The result will always be float. This means that the result
+will not share memory with the original.


### PR DESCRIPTION
Fixes #12964

Maybe backport?

Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>


### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Do the proposed changes need the code-style [fixed](https://docs.astropy.org/en/latest/development/workflow/maintainer_workflow.html#pre-commit_bot)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
