### PR TITLE
MNT: Compatibility with Python 3.11

### DIFF
--- a/astropy/cosmology/tests/test_core.py
+++ b/astropy/cosmology/tests/test_core.py
@@ -17,10 +17,11 @@ import pytest
 # LOCAL
 import astropy.cosmology.units as cu
 import astropy.units as u
-from astropy.cosmology import Cosmology, CosmologyError, FlatCosmologyMixin
+from astropy.cosmology import Cosmology, FlatCosmologyMixin
 from astropy.cosmology.core import _COSMOLOGY_CLASSES
 from astropy.cosmology.parameter import Parameter
 from astropy.table import Column, QTable, Table
+from astropy.utils.compat import PYTHON_LT_3_11
 from astropy.utils.exceptions import AstropyDeprecationWarning
 from astropy.utils.metadata import MetaData
 
@@ -197,7 +198,9 @@ class TestCosmology(ParameterTestMixin, MetaTestMixin,
         assert cosmo.name == self.cls_kwargs["name"]  # test has expected value
 
         # immutable
-        with pytest.raises(AttributeError, match="can't set"):
+        match = ("can't set" if PYTHON_LT_3_11
+                 else f"property 'name' of {cosmo.__class__.__name__!r} object has no setter")
+        with pytest.raises(AttributeError, match=match):
             cosmo.name = None
 
     def test_is_flat(self, cosmo_cls, cosmo):

--- a/astropy/io/fits/tests/test_image.py
+++ b/astropy/io/fits/tests/test_image.py
@@ -1132,17 +1132,24 @@ class TestCompressedImage(FitsTestCase):
         Test that quantize_level is used.
 
         """
-        import scipy.misc
+        from astropy.utils import minversion
+
         np.random.seed(42)
-        data = scipy.misc.ascent() + np.random.randn(512, 512)*10
+
+        if minversion('scipy', '1.10'):
+            import scipy.datasets
+            scipy_data = scipy.datasets.ascent()
+        else:
+            import scipy.misc
+            scipy_data = scipy.misc.ascent()
+
+        data = scipy_data + np.random.randn(512, 512) * 10
 
         fits.ImageHDU(data).writeto(self.temp('im1.fits'))
         fits.CompImageHDU(data, compression_type='RICE_1', quantize_method=1,
-                          quantize_level=-1, dither_seed=5)\
-            .writeto(self.temp('im2.fits'))
+                          quantize_level=-1, dither_seed=5).writeto(self.temp('im2.fits'))
         fits.CompImageHDU(data, compression_type='RICE_1', quantize_method=1,
-                          quantize_level=-100, dither_seed=5)\
-            .writeto(self.temp('im3.fits'))
+                          quantize_level=-100, dither_seed=5).writeto(self.temp('im3.fits'))
 
         im1 = fits.getdata(self.temp('im1.fits'))
         im2 = fits.getdata(self.temp('im2.fits'))

--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -6,6 +6,7 @@ from the installed astropy.  It makes use of the `pytest`_ testing framework.
 import os
 import sys
 import pickle
+import inspect
 import warnings
 import functools
 
@@ -409,7 +410,10 @@ def generic_recursive_equality_test(a, b, class_history):
     Check if the attributes of a and b are equal. Then,
     check if the attributes of the attributes are equal.
     """
-    dict_a = a.__getstate__() if hasattr(a, '__getstate__') else a.__dict__
+    if hasattr(a, '__getstate__'):
+        dict_a = a.__getstate__(a) if inspect.isclass(a) else a.__getstate__()
+    else:
+        dict_a = a.__dict__
     dict_b = b.__dict__
     for key in dict_a:
         assert key in dict_b,\

--- a/astropy/time/tests/test_mask.py
+++ b/astropy/time/tests/test_mask.py
@@ -7,6 +7,7 @@ import pytest
 
 from astropy import units as u
 from astropy.utils import iers
+from astropy.utils.compat import PYTHON_LT_3_11
 from astropy.time import Time
 from astropy.table import Table
 from astropy.utils.compat.optional_deps import HAS_H5PY
@@ -14,6 +15,10 @@ from astropy.utils.compat.optional_deps import HAS_H5PY
 allclose_sec = functools.partial(np.allclose, rtol=2. ** -52,
                                  atol=2. ** -52 * 24 * 3600)  # 20 ps atol
 is_masked = np.ma.is_masked
+
+# This is r"can't set attribute '{0}'" for Python 3.10, but not 3.9.
+no_setter_err = (r"can't set attribute" if PYTHON_LT_3_11
+                 else r"property '{0}' of '{1}' object has no setter")
 
 
 def test_simple():
@@ -47,9 +52,8 @@ def test_scalar_init():
 
 def test_mask_not_writeable():
     t = Time('2000:001')
-    with pytest.raises(AttributeError) as err:
+    with pytest.raises(AttributeError, match=no_setter_err.format('mask', t.__class__.__name__)):
         t.mask = True
-    assert "can't set attribute" in str(err.value)
 
     t = Time(['2000:001'])
     with pytest.raises(ValueError) as err:

--- a/astropy/utils/compat/misc.py
+++ b/astropy/utils/compat/misc.py
@@ -11,7 +11,11 @@ import functools
 
 from astropy.utils.decorators import deprecated
 
-__all__ = ['override__dir__', 'possible_filename']
+__all__ = ["override__dir__", "possible_filename",
+           "PYTHON_LT_3_11"]
+
+
+PYTHON_LT_3_11 = sys.version_info < (3, 11)
 
 
 def possible_filename(filename):

--- a/docs/changes/13649.other.rst
+++ b/docs/changes/13649.other.rst
@@ -1,0 +1,1 @@
+Compatibility with Python 3.11.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request cherry-picked the actual fixes from #13614 so we can merge them before we can actually add Python 3.11 to the CI matrix, which is currently impossible because upstream has not caught up yet.

I might also put the scipy compat here just to get CI green again.

Fix #13644

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Do the proposed changes need the code-style [fixed](https://docs.astropy.org/en/latest/development/workflow/maintainer_workflow.html#pre-commit_bot)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
