### PR TITLE
DOC: Add back wcslint section

### DIFF
--- a/docs/wcs/index.rst
+++ b/docs/wcs/index.rst
@@ -114,10 +114,6 @@ Examples creating a WCS programmatically
    Example of Cube WCS <example_cube_wcs.rst>
    Loading From a FITS File <loading_from_fits.rst>
 
-.. _wcslint:
-
-
-
 WCS Tools
 =========
 

--- a/docs/wcs/validation.rst
+++ b/docs/wcs/validation.rst
@@ -3,6 +3,38 @@
 Validation and Bounds checking
 ******************************
 
+.. _wcslint:
+
+Validating the WCS keywords in a FITS file
+------------------------------------------
+
+``astropy`` includes a command-line tool, ``wcslint``, to check the WCS
+keywords in a FITS file. The example below shows it reporting back
+results for a problematic file named ``invalid.fits``::
+
+    > wcslint invalid.fits
+    HDU 1:
+      WCS key ' ':
+        - RADECSYS= 'ICRS ' / Astrometric system
+          RADECSYS is non-standard, use RADESYSa.
+        - The WCS transformation has more axes (2) than the image it is
+          associated with (0)
+        - 'celfix' made the change 'PV1_5 : Unrecognized coordinate
+          transformation parameter'.
+
+    HDU 2:
+      WCS key ' ':
+        - The WCS transformation has more axes (3) than the image it is
+          associated with (0)
+        - 'celfix' made the change 'In CUNIT2 : Mismatched units type
+          'length': have 'Hz', want 'm''.
+        - 'unitfix' made the change 'Changed units: 'HZ      ' -> 'Hz''.
+
+.. _wcs-bounds-check:
+
+Bounds checking
+---------------
+
 Bounds checking is enabled by default, and any computed world
 coordinates outside of [-180°, 180°] for longitude and [-90°, 90°] in
 latitude are marked as invalid.  To disable this behavior, use


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

Not sure why wcslint was completely removed back in #10058 . Perhaps it was an oversight. This PR adds it back.

Rendered PR doc: https://astropy--13656.org.readthedocs.build/en/13656/wcs/validation.html#wcslint

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #13203

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Do the proposed changes need the code-style [fixed](https://docs.astropy.org/en/latest/development/workflow/maintainer_workflow.html#pre-commit_bot)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
