### PR TITLE
remove private function `possible_filename`

### DIFF
--- a/astropy/utils/compat/misc.py
+++ b/astropy/utils/compat/misc.py
@@ -11,30 +11,9 @@ import functools
 
 from astropy.utils.decorators import deprecated
 
-__all__ = ["override__dir__", "possible_filename",
-           "PYTHON_LT_3_11"]
+__all__ = ["override__dir__", "PYTHON_LT_3_11"]
 
 PYTHON_LT_3_11 = sys.version_info < (3, 11)
-
-
-def possible_filename(filename):
-    """
-    Determine if the ``filename`` argument is an allowable type for a filename.
-
-    In Python 3.3 use of non-unicode filenames on system calls such as
-    `os.stat` and others that accept a filename argument was deprecated (and
-    may be removed outright in the future).
-
-    Therefore this returns `True` in all cases except for `bytes` strings in
-    Windows.
-    """
-
-    if isinstance(filename, str):
-        return True
-    elif isinstance(filename, bytes):
-        return not (sys.platform == 'win32')
-
-    return False
 
 
 @deprecated(

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -49,7 +49,6 @@ from . import docstrings
 from . import _wcs
 
 from astropy import units as u
-from astropy.utils.compat import possible_filename
 from astropy.utils.exceptions import AstropyWarning, AstropyUserWarning, AstropyDeprecationWarning
 from astropy.utils.decorators import deprecated_renamed_argument
 
@@ -411,8 +410,7 @@ class WCS(FITSWCSAPIMixin, WCSBase):
 
             if isinstance(header, (str, bytes)):
                 try:
-                    is_path = (possible_filename(header) and
-                               os.path.exists(header))
+                    is_path = os.path.exists(header)
                 except (OSError, ValueError):
                     is_path = False
 

--- a/docs/changes/utils/13661.api.rst
+++ b/docs/changes/utils/13661.api.rst
@@ -1,0 +1,1 @@
+``astropy.utils.misc.possible_filename`` has been removed.


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Do the proposed changes need the code-style [fixed](https://docs.astropy.org/en/latest/development/workflow/maintainer_workflow.html#pre-commit_bot)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
