### PR TITLE
Backport PR #13614 on branch v5.0.x (MNT: Compatibility with Python 3.11)

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -109,7 +109,7 @@ jobs:
       if: startsWith(matrix.os, 'ubuntu')
       run: |
         sudo apt-get update
-        sudo apt-get install language-pack-fr tzdata
+        sudo apt-get install language-pack-fr tzdata libopenblas-dev
     - name: Install tox
       run: python -m pip install --upgrade tox
     - name: Run tests
@@ -130,10 +130,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: (Allowed Failure) Python 3.8 with remote data and dev version of key dependencies
+          - name: (Allowed Failure) Python 3.11 with remote data and dev version of key dependencies
             os: ubuntu-latest
-            python: 3.8
-            toxenv: py38-test-devdeps
+            python: '3.11.0-rc.2'
+            toxenv: py311-test-devdeps
             toxposargs: --remote-data=any
 
     steps:

--- a/astropy/cosmology/io/tests/test_model.py
+++ b/astropy/cosmology/io/tests/test_model.py
@@ -6,17 +6,12 @@ import random
 
 # THIRD PARTY
 import pytest
-
 import numpy as np
 
 # LOCAL
-import astropy.units as u
-from astropy import cosmology
-from astropy.cosmology import Cosmology, Planck18, realizations
-from astropy.cosmology.core import _COSMOLOGY_CLASSES, Parameter
+from astropy.cosmology import realizations
 from astropy.cosmology.io.model import _CosmologyModel, from_model, to_model
 from astropy.cosmology.parameters import available
-from astropy.modeling import FittableModel
 from astropy.modeling.models import Gaussian1D
 from astropy.utils.compat.optional_deps import HAS_SCIPY
 
@@ -116,7 +111,7 @@ class ToFromModelTestMixin(IOTestMixinBase):
 
         got = model(*args)
         expected = getattr(cosmo, method_name)(*args)
-        assert np.all(got == expected)
+        np.testing.assert_allclose(got, expected)
 
         # vector result
         if "scalar" not in method_name:
@@ -129,7 +124,7 @@ class ToFromModelTestMixin(IOTestMixinBase):
 
             got = model(*args)
             expected = getattr(cosmo, method_name)(*args)
-            assert np.all(got == expected)
+            np.testing.assert_allclose(got, expected)
 
     def test_tofromformat_model_instance(self, cosmo_cls, cosmo, method_name,
                                          to_format, from_format):

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -1066,17 +1066,21 @@ class BaseOutputter:
                 try:
                     col.data = converter_func(col.str_vals)
                     col.type = converter_type
-                except (TypeError, ValueError) as err:
-                    col.converters.pop(0)
-                    last_err = err
-                except OverflowError as err:
+                except (OverflowError, TypeError, ValueError) as err:
                     # Overflow during conversion (most likely an int that
                     # doesn't fit in native C long). Put string at the top of
                     # the converters list for the next while iteration.
-                    warnings.warn(
-                        "OverflowError converting to {} in column {}, reverting to String."
-                        .format(converter_type.__name__, col.name), AstropyWarning)
-                    col.converters.insert(0, convert_numpy(numpy.str))
+                    # With python/cpython#95778 this has been supplemented with a
+                    # "ValueError: Exceeds the limit (4300) for integer string conversion"
+                    # so need to catch that as well.
+                    if isinstance(err, OverflowError) or (isinstance(err, ValueError) and
+                                                          str(err).startswith('Exceeds the limit')):
+                        warnings.warn(
+                            f'OverflowError converting to {converter_type.__name__} in column '
+                            f'{col.name}, reverting to String.', AstropyWarning)
+                        col.converters.insert(0, convert_numpy(numpy.str))
+                    else:
+                        col.converters.pop(0)
                     last_err = err
 
 

--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -418,7 +418,10 @@ def generic_recursive_equality_test(a, b, class_history):
     else:
         # NOTE: The call may need to be adapted if other objects implementing a __getstate__
         # with required argument(s) are passed to this function.
-        dict_a = a.__getstate__(a) if inspect.isclass(a) else a.__getstate__()
+        # For a class with `__slots__` the default state is not a `dict`;
+        # with neither `__dict__` nor `__slots__` it is `None`.
+        state = a.__getstate__(a) if inspect.isclass(a) else a.__getstate__()
+        dict_a = state if isinstance(state, dict) else getattr(a, '__dict__', dict())
     dict_b = b.__dict__
     for key in dict_a:
         assert key in dict_b, f"Did not pickle {key}"

--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -6,6 +6,7 @@ from the installed astropy.  It makes use of the `pytest`_ testing framework.
 import os
 import sys
 import pickle
+import inspect
 import warnings
 import functools
 
@@ -14,7 +15,7 @@ import pytest
 from astropy.units import allclose as quantity_allclose  # noqa
 from astropy.utils.exceptions import (AstropyDeprecationWarning,
                                       AstropyPendingDeprecationWarning)
-
+from astropy.utils.compat import PYTHON_LT_3_11
 
 # For backward-compatibility with affiliated packages
 from .runner import TestRunner  # pylint: disable=W0611  # noqa
@@ -412,11 +413,15 @@ def generic_recursive_equality_test(a, b, class_history):
     Check if the attributes of a and b are equal. Then,
     check if the attributes of the attributes are equal.
     """
-    dict_a = a.__getstate__() if hasattr(a, '__getstate__') else a.__dict__
+    if PYTHON_LT_3_11:
+        dict_a = a.__getstate__() if hasattr(a, '__getstate__') else a.__dict__
+    else:
+        # NOTE: The call may need to be adapted if other objects implementing a __getstate__
+        # with required argument(s) are passed to this function.
+        dict_a = a.__getstate__(a) if inspect.isclass(a) else a.__getstate__()
     dict_b = b.__dict__
     for key in dict_a:
-        assert key in dict_b,\
-          f"Did not pickle {key}"
+        assert key in dict_b, f"Did not pickle {key}"
 
         if dict_a[key].__class__.__eq__ is not object.__eq__:
             # Only compare if the class defines a proper equality test.

--- a/astropy/utils/compat/misc.py
+++ b/astropy/utils/compat/misc.py
@@ -12,7 +12,10 @@ from contextlib import suppress
 
 
 __all__ = ['override__dir__', 'suppress',
-           'possible_filename', 'namedtuple_asdict']
+           'possible_filename', 'namedtuple_asdict',
+           'PYTHON_LT_3_11']
+
+PYTHON_LT_3_11 = sys.version_info < (3, 11)
 
 
 def possible_filename(filename):

--- a/docs/changes/13614.other.rst
+++ b/docs/changes/13614.other.rst
@@ -1,0 +1,1 @@
+Compatibility with Python 3.11, 3.10.7, 3.9.14, 3.8.14

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = ["setuptools",
             "setuptools_scm>=6.2",
             "wheel",
-            "cython==0.29.22",
+            "cython==0.29.30",
             "markupsafe==2.0.1",  # jinja2 dependency
             "jinja2==3.0.3",
             "oldest-supported-numpy",

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{38,39,310,dev}-test{,-image,-recdeps,-alldeps,-oldestdeps,-devdeps,-numpy118,-numpy119,-numpy120,-numpy121,-mpl311}{,-cov}{,-clocale}
+    py{38,39,310,311,dev}-test{,-image,-recdeps,-alldeps,-oldestdeps,-devdeps,-numpy118,-numpy119,-numpy120,-numpy121,-mpl311}{,-cov}{,-clocale}
     build_docs
     linkcheck
     codestyle
@@ -28,6 +28,7 @@ setenv =
     !image: MPLFLAGS =
     clocale: LC_CTYPE = C.ascii
     clocale: LC_ALL = C
+    devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/scipy-wheels-nightly/simple
 
 # Run the tests in a temporary directory to make sure that we don't import
 # astropy from the source tree
@@ -85,7 +86,9 @@ deps =
 
     # The devdeps factor is intended to be used to install the latest developer version
     # or nightly wheel of key dependencies.
-    devdeps,mpldev: git+https://github.com/matplotlib/matplotlib.git#egg=matplotlib
+    devdeps: scipy>=0.0.dev0
+    devdeps: numpy>=0.0.dev0
+    devdeps,mpldev: matplotlib>=0.0.dev0
     devdeps: git+https://github.com/asdf-format/asdf.git#egg=asdf
     devdeps: git+https://github.com/liberfa/pyerfa.git#egg=pyerfa
 
@@ -99,7 +102,6 @@ extras =
     alldeps: test_all
 
 commands =
-    devdeps: pip install -U --pre --only-binary :all: -i https://pypi.anaconda.org/scipy-wheels-nightly/simple numpy
     pip freeze
     !cov-!double: pytest --pyargs astropy {toxinidir}/docs {env:MPLFLAGS} {posargs}
     cov-!double: pytest --pyargs astropy {toxinidir}/docs {env:MPLFLAGS} --cov astropy --cov-config={toxinidir}/setup.cfg {posargs}


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to manually backport #13614 to v5.0.x branch.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Do the proposed changes need the code-style [fixed](https://docs.astropy.org/en/latest/development/workflow/maintainer_workflow.html#pre-commit_bot)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
