### PR TITLE
Backport PR #13614 on branch v5.1.x (MNT: Compatibility with Python 3.11)

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -99,7 +99,7 @@ jobs:
       if: startsWith(matrix.os, 'ubuntu')
       run: |
         sudo apt-get update
-        sudo apt-get install language-pack-fr tzdata
+        sudo apt-get install language-pack-fr tzdata libopenblas-dev
     - name: Install tox
       run: python -m pip install --upgrade tox
     - name: Run tests
@@ -120,10 +120,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: (Allowed Failure) Python 3.8 with remote data and dev version of key dependencies
+          - name: (Allowed Failure) Python 3.11 with remote data and dev version of key dependencies
             os: ubuntu-latest
-            python: 3.8
-            toxenv: py38-test-devdeps
+            python: '3.11.0-rc.2'
+            toxenv: py311-test-devdeps
             toxposargs: --remote-data=any
 
     steps:

--- a/astropy/cosmology/tests/test_core.py
+++ b/astropy/cosmology/tests/test_core.py
@@ -17,10 +17,11 @@ import pytest
 # LOCAL
 import astropy.cosmology.units as cu
 import astropy.units as u
-from astropy.cosmology import Cosmology, CosmologyError, FlatCosmologyMixin
+from astropy.cosmology import Cosmology, FlatCosmologyMixin
 from astropy.cosmology.core import _COSMOLOGY_CLASSES
 from astropy.cosmology.parameter import Parameter
 from astropy.table import Column, QTable, Table
+from astropy.utils.compat import PYTHON_LT_3_11
 from astropy.utils.exceptions import AstropyDeprecationWarning
 from astropy.utils.metadata import MetaData
 
@@ -197,7 +198,9 @@ class TestCosmology(ParameterTestMixin, MetaTestMixin,
         assert cosmo.name == self.cls_kwargs["name"]  # test has expected value
 
         # immutable
-        with pytest.raises(AttributeError, match="can't set"):
+        match = ("can't set" if PYTHON_LT_3_11
+                 else f"property 'name' of {cosmo.__class__.__name__!r} object has no setter")
+        with pytest.raises(AttributeError, match=match):
             cosmo.name = None
 
     def test_is_flat(self, cosmo_cls, cosmo):

--- a/astropy/utils/compat/misc.py
+++ b/astropy/utils/compat/misc.py
@@ -10,9 +10,11 @@ import sys
 import functools
 from contextlib import suppress
 
-
 __all__ = ['override__dir__', 'suppress',
-           'possible_filename', 'namedtuple_asdict']
+           'possible_filename', 'namedtuple_asdict',
+           'PYTHON_LT_3_11']
+
+PYTHON_LT_3_11 = sys.version_info < (3, 11)
 
 
 def possible_filename(filename):

--- a/docs/changes/13614.other.rst
+++ b/docs/changes/13614.other.rst
@@ -1,0 +1,1 @@
+Compatibility with Python 3.11, 3.10.7, 3.9.14, 3.8.14

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{38,39,310,dev}-test{,-image,-recdeps,-alldeps,-oldestdeps,-devdeps,-numpy118,-numpy119,-numpy120,-numpy121,-mpl311}{,-cov}{,-clocale}
+    py{38,39,310,311,dev}-test{,-image,-recdeps,-alldeps,-oldestdeps,-devdeps,-numpy118,-numpy119,-numpy120,-numpy121,-mpl311}{,-cov}{,-clocale}
     build_docs
     linkcheck
     codestyle
@@ -28,6 +28,7 @@ setenv =
     !image: MPLFLAGS =
     clocale: LC_CTYPE = C.ascii
     clocale: LC_ALL = C
+    devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/scipy-wheels-nightly/simple
 
 # Run the tests in a temporary directory to make sure that we don't import
 # astropy from the source tree
@@ -86,7 +87,9 @@ deps =
     # The devdeps factor is intended to be used to install the latest developer version
     # or nightly wheel of key dependencies.
     # Do not install asdf-astropy so we can test astropy.io.misc.asdf until we remove it.
-    devdeps,mpldev: git+https://github.com/matplotlib/matplotlib.git#egg=matplotlib
+    devdeps: scipy>=0.0.dev0
+    devdeps: numpy>=0.0.dev0
+    devdeps,mpldev: matplotlib>=0.0.dev0
     devdeps: git+https://github.com/asdf-format/asdf.git#egg=asdf
     devdeps: git+https://github.com/liberfa/pyerfa.git#egg=pyerfa
 
@@ -100,7 +103,6 @@ extras =
     alldeps: test_all
 
 commands =
-    devdeps: pip install -U --pre --only-binary :all: -i https://pypi.anaconda.org/scipy-wheels-nightly/simple numpy
     pip freeze
     !cov-!double: pytest --pyargs astropy {toxinidir}/docs {env:MPLFLAGS} {posargs}
     cov-!double: pytest --pyargs astropy {toxinidir}/docs {env:MPLFLAGS} --cov astropy --cov-config={toxinidir}/setup.cfg {posargs}


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to manually backport #13614 into v5.1.x branch.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Do the proposed changes need the code-style [fixed](https://docs.astropy.org/en/latest/development/workflow/maintainer_workflow.html#pre-commit_bot)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
