### PR TITLE
register `numpy.lib.recfunctions.merge_arrays` for Quantity overload

### DIFF
--- a/astropy/units/quantity_helper/function_helpers.py
+++ b/astropy/units/quantity_helper/function_helpers.py
@@ -34,8 +34,6 @@ return a Quantity directly using ``quantity_result, None, None``.
 
 """
 
-from __future__ import annotations
-
 import functools
 import operator
 from functools import reduce
@@ -1124,8 +1122,8 @@ def _izip_units_flat(iterable):
     """
     from astropy.units import StructuredUnit
 
-    # Make Structured unit.
-    units = iterable if isinstance(iterable, StructuredUnit) else StructuredUnit(iterable)
+    # Make Structured unit (pass-through if it is already).
+    units = StructuredUnit(iterable)
 
     # Yield from structured unit.
     for v in units.values():
@@ -1158,21 +1156,18 @@ def merge_arrays(
         # TODO: use MaskedQuantity for this case
         raise ValueError("usemask=True is not supported.")
 
-    # Do we have a single ndarray as input ?
+    # Do we have a single Quantity as input?
     if isinstance(seqarrays, Quantity):
-        LEN1 = True
-        arrays = (seqarrays.value,)
-        units = (seqarrays.unit,)
-    else:
-        # Note: this also converts ndarray -> Quantity[dimensionless]
-        seqarrays = _as_quantities(*seqarrays)
-        arrays = tuple(q.value for q in seqarrays)
-        units = tuple(q.unit for q in seqarrays)
-        LEN1 = True if len(arrays) == 1 else False
+        seqarrays = (seqarrays,)
+
+    # Note: this also converts ndarray -> Quantity[dimensionless]
+    seqarrays = _as_quantities(*seqarrays)
+    arrays = tuple(q.value for q in seqarrays)
+    units = tuple(q.unit for q in seqarrays)
 
     if flatten:
         unit = StructuredUnit(tuple(_izip_units_flat(units)))
-    elif LEN1:
+    elif len(arrays) == 1:
         unit = StructuredUnit(units[0])
     else:
         unit = StructuredUnit(units)

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -2085,12 +2085,12 @@ class TestRecFunctions(metaclass=CoverageMeta):
         unstruct = [1, 2, 3] * u.m
         dtype=np.dtype([("f1", float), ("f2", float), ("f3", float)])
 
-        # it works
+        # It works.
         struct = rfn.unstructured_to_structured(unstruct, dtype=dtype)
         assert struct.unit == u.Unit("(m, m, m)")
         assert_array_equal(rfn.structured_to_unstructured(struct), unstruct)
 
-        # can't structure something that's already structured
+        # Can't structure something that's already structured.
         with pytest.raises(ValueError, match="arr must have at least one dimension"):
             rfn.unstructured_to_structured(struct, dtype=dtype)
 
@@ -2098,7 +2098,7 @@ class TestRecFunctions(metaclass=CoverageMeta):
         # ``test_structured.TestStructuredQuantityFunctions.test_unstructured_to_structured``
 
     def test_merge_arrays_repeat_dtypes(self):
-        # can't merge things with repeat dtypes
+        # Cannot merge things with repeat dtypes.
         q1 = u.Quantity([(1,)], dtype=[("f1", float)])
         q2 = u.Quantity([(1,)], dtype=[("f1", float)])
 
@@ -2108,45 +2108,42 @@ class TestRecFunctions(metaclass=CoverageMeta):
     @pytest.mark.parametrize("flatten", [True, False])
     def test_merge_arrays(self, flatten):
         """Test `numpy.lib.recfunctions.merge_arrays`."""
-        # merge 1 normal array
+        # Merge single normal array.
         arr = rfn.merge_arrays(self.q_pv["p"], flatten=flatten)
-        assert np.array_equal(arr.value["f0"], [1, 2, 3])
+        assert_array_equal(arr["f0"], self.q_pv["p"])
         assert arr.unit == (u.km,)
 
-        # merge 1 structured array
+        # Merge single structured array.
         arr = rfn.merge_arrays(self.q_pv, flatten=flatten)
-        assert np.array_equal(arr.value["p"], [1, 2, 3])
-        assert np.array_equal(arr.value["v"], [0.25, 0.5, 0.75])
+        assert_array_equal(arr, self.q_pv)
         assert arr.unit == (u.km, u.km/u.s)
 
-        # merge 1-elt tuple
+        # Merge 1-element tuple.
         arr = rfn.merge_arrays((self.q_pv,), flatten=flatten)
-        assert np.array_equal(arr.value["p"], [1, 2, 3])
-        assert np.array_equal(arr.value["v"], [0.25, 0.5, 0.75])
+        assert np.array_equal(arr, self.q_pv)
         assert arr.unit == (u.km, u.km/u.s)
 
     @pytest.mark.xfail
     @pytest.mark.parametrize("flatten", [True, False])
     def test_merge_arrays_nonquantities(self, flatten):
-        """Test `numpy.lib.recfunctions.merge_arrays`."""
+        # Fails because cannot create quantity from structured array.
         arr = rfn.merge_arrays((q_pv["p"], q_pv.value), flatten=flatten)
 
     def test_merge_array_nested_structure(self):
-        # merge 2-elt tuples
+        # Merge 2-element tuples without flattening.
         arr = rfn.merge_arrays((self.q_pv, self.q_pv_t))
-        assert np.array_equal(arr["f0"], self.q_pv)
-        assert np.array_equal(arr["f1"], self.q_pv_t)
+        assert_array_equal(arr["f0"], self.q_pv)
+        assert_array_equal(arr["f1"], self.q_pv_t)
         assert arr.unit == ((u.km, u.km/u.s), ((u.km, u.km/u.s), u.s))
 
     def test_merge_arrays_flatten_nested_structure(self):
-        """Test `numpy.lib.recfunctions.merge_arrays` with ``flatten=True``."""
-        # merge 2-elt tuple
+        # Merge 2-element tuple, flattening it.
         arr = rfn.merge_arrays((self.q_pv, self.q_pv_t), flatten=True)
-        assert np.array_equal(arr["p"].value, [1, 2, 3])
-        assert np.array_equal(arr["v"].value, [0.25, 0.5, 0.75])
-        assert np.array_equal(arr["pp"].value, [4, 5, 6])
-        assert np.array_equal(arr["vv"].value, [2.5, 5, 7.5])
-        assert np.array_equal(arr["t"].value, [0, 1, 2])
+        assert_array_equal(arr["p"], self.q_pv["p"])
+        assert_array_equal(arr["v"], self.q_pv["v"])
+        assert_array_equal(arr["pp"], self.q_pv_t["pv"]["pp"])
+        assert_array_equal(arr["vv"], self.q_pv_t["pv"]["vv"])
+        assert_array_equal(arr["t"], self.q_pv_t["t"])
         assert arr.unit == (u.km, u.km/u.s, u.km, u.km/u.s, u.s)
 
     def test_merge_arrays_asrecarray(self):

--- a/astropy/units/tests/test_structured.py
+++ b/astropy/units/tests/test_structured.py
@@ -625,6 +625,18 @@ class TestStructuredQuantityFunctions(StructuredTestBaseWithUnits):
         # For the other tests of ``structured_to_unstructured``, see
         # ``test_quantity_non_ufuncs.TestRecFunctions.test_unstructured_to_structured``
 
+    def test_merge_arrays(self):
+        """Test `numpy.lib.recfunctions.merge_arrays`."""
+        # can't merge things with repeat dtypes
+        q1 = u.Quantity([(1,)], dtype=[("f1", float)])
+        q2 = u.Quantity([(1,)], dtype=[("f1", float)])
+
+        with pytest.raises(ValueError, match="field 'f1' occurs more than once"):
+            rfn.merge_arrays((q1, q2))
+
+        # For the other tests of ``merge_arrays``, see
+        # ``test_quantity_non_ufuncs.TestRecFunctions.test_merge_arrays``
+
 
 class TestStructuredSpecificTypeQuantity(StructuredTestBaseWithUnits):
     def setup_class(self):

--- a/astropy/units/tests/test_structured.py
+++ b/astropy/units/tests/test_structured.py
@@ -625,18 +625,6 @@ class TestStructuredQuantityFunctions(StructuredTestBaseWithUnits):
         # For the other tests of ``structured_to_unstructured``, see
         # ``test_quantity_non_ufuncs.TestRecFunctions.test_unstructured_to_structured``
 
-    def test_merge_arrays(self):
-        """Test `numpy.lib.recfunctions.merge_arrays`."""
-        # can't merge things with repeat dtypes
-        q1 = u.Quantity([(1,)], dtype=[("f1", float)])
-        q2 = u.Quantity([(1,)], dtype=[("f1", float)])
-
-        with pytest.raises(ValueError, match="field 'f1' occurs more than once"):
-            rfn.merge_arrays((q1, q2))
-
-        # For the other tests of ``merge_arrays``, see
-        # ``test_quantity_non_ufuncs.TestRecFunctions.test_merge_arrays``
-
 
 class TestStructuredSpecificTypeQuantity(StructuredTestBaseWithUnits):
     def setup_class(self):

--- a/docs/changes/units/13669.feature.rst
+++ b/docs/changes/units/13669.feature.rst
@@ -1,0 +1,2 @@
+``numpy.lib.recfunctions.merge_arrays`` is registered with numpy overload for
+``astropy.Quantity``.

--- a/docs/changes/units/13669.feature.rst
+++ b/docs/changes/units/13669.feature.rst
@@ -1,2 +1,2 @@
-``numpy.lib.recfunctions.merge_arrays`` is registered with numpy overload for
-``astropy.Quantity``.
+``numpy.lib.recfunctions.merge_arrays()`` is registered with numpy overload for
+``Quantity``.


### PR DESCRIPTION


### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
