### PR TITLE
Build Python 3.11 wheels

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,6 +48,7 @@ jobs:
         - cp38-manylinux_x86_64
         - cp39-manylinux_x86_64
         - cp310-manylinux_x86_64
+        - cp311-manylinux_x86_64
         # Note that following wheels are not currently tested:
         - cp38-manylinux_aarch64
         - cp39-manylinux_aarch64
@@ -62,9 +63,11 @@ jobs:
         - cp38*macosx_x86_64
         - cp39*macosx_x86_64
         - cp310*macosx_x86_64
+        - cp311*macosx_x86_64
         - cp38*macosx_arm64
         - cp39*macosx_arm64
         - cp310*macosx_arm64
+        - cp311*macosx_arm64
 
         # Windows wheels
         - cp38*win32
@@ -73,6 +76,8 @@ jobs:
         - cp39*win_amd64
         - cp310*win32
         - cp310*win_amd64
+        - cp311*win32
+        - cp311*win_amd64
 
     secrets:
       pypi_token: ${{ secrets.pypi_token }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,16 +19,24 @@ write_to = "astropy/_version.py"
         enabled = false
 
 [tool.cibuildwheel]
-manylinux-x86_64-image = "manylinux2010"
-manylinux-i686-image = "manylinux2010"
-# Numpy 1.22 doesn't have wheels for i386, so we pin Numpy to an older version
-# that does - this pin can be removed once we drop support for 32-bit wheels.
-test-requires = "numpy==1.21.*"
 # We disable testing for the following wheels:
 # - MacOS X ARM (no native hardware, tests are skipped anyway, this avoids a warning)
 # - Linux AArch64 (no native hardware, tests take too long)
 # - MuslLinux (tests hang non-deterministically)
 test-skip = "*-macosx_arm64 *-manylinux_aarch64 *-musllinux_x86_64"
+
+[[tool.cibuildwheel.overrides]]
+# Python 3.11 and later is not available in manylinux2010 so we only
+# set this for Python<=3.10.
+select = "cp3{8,9,10}-*"
+manylinux-x86_64-image = "manylinux2010"
+manylinux-i686-image = "manylinux2010"
+
+[[tool.cibuildwheel.overrides]]
+# Numpy 1.22 doesn't have wheels for i386, so we pin Numpy to an older version
+# that does - this pin can be removed once we drop support for 32-bit wheels.
+select = "cp3{8,9}-*"
+test-requires = "numpy==1.21.*"
 
 [tool.cibuildwheel.macos]
 archs = ["x86_64", "arm64"]


### PR DESCRIPTION
This adds 3.11 wheels to the build lists.

Note: This **should not** be backported until we want to build 3.11 wheels for releases, which means when a final release of 3.11 is out.