### PR TITLE
TST: Relax float comp for test_biweight_midvariance_masked

### DIFF
--- a/astropy/stats/tests/test_biweight.py
+++ b/astropy/stats/tests/test_biweight.py
@@ -334,10 +334,10 @@ def test_biweight_midvariance_masked():
     data1d_masked = np.ma.masked_invalid(data1d)
     data2d_masked = np.ma.masked_invalid(data2d)
 
-    assert_equal(biweight_midvariance(data1d, ignore_nan=True),
-                 biweight_midvariance(data1d_masked))
-    assert_equal(biweight_midvariance(data2d, ignore_nan=True),
-                 biweight_midvariance(data2d_masked))
+    assert_allclose(biweight_midvariance(data1d, ignore_nan=True),
+                    biweight_midvariance(data1d_masked))
+    assert_allclose(biweight_midvariance(data2d, ignore_nan=True),
+                    biweight_midvariance(data2d_masked))
 
     bw_scl = biweight_midvariance(data1d_masked)
     assert_allclose(bw_scl, 2.9238456)
@@ -347,11 +347,11 @@ def test_biweight_midvariance_masked():
     bw_loc_masked = biweight_midvariance(data2d_masked, axis=1)
     assert isinstance(bw_loc_masked, np.ma.MaskedArray)
     assert ~np.any(bw_loc_masked.mask)  # mask is all False
-    assert_equal(bw_loc, bw_loc_masked.data)
+    assert_allclose(bw_loc, bw_loc_masked.data)
 
     bw_loc = biweight_midvariance(data2d, ignore_nan=True, axis=0)
     bw_loc_masked = biweight_midvariance(data2d_masked, axis=0)
-    assert_equal(bw_loc_masked.data[:-1], bw_loc[:-1])
+    assert_allclose(bw_loc_masked.data[:-1], bw_loc[:-1])
     assert bw_loc_masked.mask[-1]  # last mask element is True
 
     data1d_masked.data[0] = np.nan  # unmasked NaN
@@ -359,8 +359,8 @@ def test_biweight_midvariance_masked():
     assert not isinstance(bw_scl, np.ma.MaskedArray)
     assert np.isscalar(bw_scl)
     assert np.isnan(bw_scl)
-    assert_equal(biweight_midvariance(data1d_masked, ignore_nan=True),
-                 biweight_midvariance(data1d[1:], ignore_nan=True))
+    assert_allclose(biweight_midvariance(data1d_masked, ignore_nan=True),
+                    biweight_midvariance(data1d[1:], ignore_nan=True))
 
     # ensure that input masked array is not modified
     assert np.isnan(data1d_masked[0])


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

I started seeing this failure in v5.1.x CI. Is there any reason why the float comparison is so strict? Can we relax it?

Example log: https://github.com/astropy/astropy/actions/runs/3060675514/jobs/4939480150

I reran the main branch CI devdeps job that was passing, just to be sure, and now it fails with the same error, so probably something changed in numpy: https://github.com/astropy/astropy/actions/runs/3056002494/jobs/4940841950

```
_______________________ test_biweight_midvariance_masked _______________________

    @pytest.mark.filterwarnings('ignore:All-NaN slice encountered')
    @pytest.mark.filterwarnings('ignore:Invalid value encountered in median')
    def test_biweight_midvariance_masked():
        data1d = np.array([1, 3, 5, 500, 2, np.nan])
        data2d = np.array([data1d, data1d])
    
        data1d_masked = np.ma.masked_invalid(data1d)
        data2d_masked = np.ma.masked_invalid(data2d)
    
>       assert_equal(biweight_midvariance(data1d, ignore_nan=True),
                     biweight_midvariance(data1d_masked))
E       AssertionError: 
E       Items are not equal:
E        ACTUAL: 2.923845628396891
E        DESIRED: 2.923845628396892

.../astropy/stats/tests/test_biweight.py:337: AssertionError
```


### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
