### PR TITLE
structured unit / quantity stuff

### DIFF
--- a/astropy/units/tests/test_structured.py
+++ b/astropy/units/tests/test_structured.py
@@ -12,6 +12,7 @@ from numpy.testing import assert_array_equal
 from astropy import units as u
 from astropy.tests.helper import check_pickling_recovery, pickle_protocol
 from astropy.units import Quantity, StructuredUnit, Unit, UnitBase
+from astropy.units.quantity import _structured_unit_like_dtype
 from astropy.utils.compat import NUMPY_LT_1_21_1
 from astropy.utils.masked import Masked
 
@@ -432,6 +433,17 @@ class TestStructuredQuantity(StructuredTestBaseWithUnits):
         assert q_pv_t.unit is self.pv_t_unit
         assert np.all(q_pv_t.value == self.pv_t)
         assert np.may_share_memory(q_pv_t, self.pv_t)
+
+    def test_initialization_without_unit(self):
+        q_pv_t = u.Quantity(self.pv_t, unit=None)
+
+        assert np.all(q_pv_t.value == self.pv_t)
+
+        # Test that unit is a structured unit like the dtype
+        expected_unit = _structured_unit_like_dtype(u.Quantity._default_unit, self.pv_t.dtype)
+        assert q_pv_t.unit == expected_unit
+        # A more explicit test
+        assert q_pv_t.unit == u.StructuredUnit(((u.one, u.one), u.one))
 
     def test_getitem(self):
         q_pv_t = Quantity(self.pv_t, self.pv_t_unit)

--- a/docs/changes/units/13676.api.rst
+++ b/docs/changes/units/13676.api.rst
@@ -1,0 +1,2 @@
+When ``Quantity`` is constructed from a structured array and ``unit`` is
+``None``, the default unit is now structured like the input data.


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

Necessary for https://github.com/astropy/astropy/pull/13669

- Quantity now builds a structured unit if ``unit=None`` in the constructor and the value is structured.

TODO:
- [x] changelog
- [x] tests

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
