### PR TITLE
isort nddata

### DIFF
--- a/astropy/nddata/__init__.py
+++ b/astropy/nddata/__init__.py
@@ -8,25 +8,22 @@ just `numpy.ndarray` objects, because it provides metadata that cannot
 be easily provided by a single array.
 """
 
+from astropy import config as _config
+
+from .bitmask import *
+from .blocks import *
+from .ccddata import *
+from .compat import *
+from .decorators import *
+from .flag_collection import *
+from .mixins.ndarithmetic import *
+from .mixins.ndio import *
+from .mixins.ndslicing import *
 from .nddata import *
 from .nddata_base import *
 from .nddata_withmixins import *
 from .nduncertainty import *
-from .flag_collection import *
-
-from .decorators import *
-
-from .mixins.ndarithmetic import *
-from .mixins.ndslicing import *
-from .mixins.ndio import *
-
-from .blocks import *
-from .compat import *
 from .utils import *
-from .ccddata import *
-from .bitmask import *
-
-from astropy import config as _config
 
 
 class Conf(_config.ConfigNamespace):

--- a/astropy/nddata/bitmask.py
+++ b/astropy/nddata/bitmask.py
@@ -3,11 +3,11 @@ A module that provides functions for manipulating bit masks and data quality
 (DQ) arrays.
 
 """
-import warnings
 import numbers
+import warnings
 from collections import OrderedDict
-import numpy as np
 
+import numpy as np
 
 __all__ = ['bitfield_to_boolean_mask', 'interpret_bit_flags',
            'BitFlagNameMap', 'extend_bit_flag_map', 'InvalidBitFlag']

--- a/astropy/nddata/ccddata.py
+++ b/astropy/nddata/ccddata.py
@@ -5,15 +5,14 @@ import itertools
 
 import numpy as np
 
-from .compat import NDDataArray
-from .nduncertainty import (
-    StdDevUncertainty, NDUncertainty, VarianceUncertainty, InverseVariance)
-from astropy.io import fits, registry
-from astropy import units as u
 from astropy import log
-from astropy.wcs import WCS
+from astropy import units as u
+from astropy.io import fits, registry
 from astropy.utils.decorators import sharedmethod
+from astropy.wcs import WCS
 
+from .compat import NDDataArray
+from .nduncertainty import InverseVariance, NDUncertainty, StdDevUncertainty, VarianceUncertainty
 
 __all__ = ['CCDData', 'fits_ccddata_reader', 'fits_ccddata_writer']
 

--- a/astropy/nddata/compat.py
+++ b/astropy/nddata/compat.py
@@ -4,17 +4,15 @@
 
 import numpy as np
 
-from astropy.units import UnitsError, UnitConversionError, Unit
 from astropy import log
-
-from .nddata import NDData
-from .nduncertainty import NDUncertainty
-
-from .mixins.ndslicing import NDSlicingMixin
-from .mixins.ndarithmetic import NDArithmeticMixin
-from .mixins.ndio import NDIOMixin
+from astropy.units import Unit, UnitConversionError, UnitsError
 
 from .flag_collection import FlagCollection
+from .mixins.ndarithmetic import NDArithmeticMixin
+from .mixins.ndio import NDIOMixin
+from .mixins.ndslicing import NDSlicingMixin
+from .nddata import NDData
+from .nduncertainty import NDUncertainty
 
 __all__ = ['NDDataArray']
 

--- a/astropy/nddata/decorators.py
+++ b/astropy/nddata/decorators.py
@@ -1,11 +1,11 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 
+import warnings
 from copy import deepcopy
+from functools import wraps
 from inspect import signature
 from itertools import islice
-import warnings
-from functools import wraps
 
 from astropy.utils.exceptions import AstropyUserWarning
 

--- a/astropy/nddata/mixins/ndslicing.py
+++ b/astropy/nddata/mixins/ndslicing.py
@@ -3,8 +3,8 @@
 
 
 from astropy import log
-from astropy.wcs.wcsapi import (BaseLowLevelWCS, BaseHighLevelWCS,
-                                SlicedLowLevelWCS, HighLevelWCSWrapper)
+from astropy.wcs.wcsapi import (
+    BaseHighLevelWCS, BaseLowLevelWCS, HighLevelWCSWrapper, SlicedLowLevelWCS)
 
 __all__ = ['NDSlicingMixin']
 

--- a/astropy/nddata/mixins/tests/test_ndarithmetic.py
+++ b/astropy/nddata/mixins/tests/test_ndarithmetic.py
@@ -1,21 +1,17 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-import pytest
 import numpy as np
-from numpy.testing import assert_array_equal, assert_array_almost_equal
+import pytest
+from numpy.testing import assert_array_almost_equal, assert_array_equal
 
-from astropy.nddata.nduncertainty import (
-    StdDevUncertainty, VarianceUncertainty,
-    InverseVariance,
-    UnknownUncertainty,
-    IncompatibleUncertaintiesException)
+from astropy import units as u
 from astropy.nddata import NDDataRef
 from astropy.nddata import _testing as nd_testing
-
-from astropy.units import UnitsError, Quantity
-from astropy import units as u
+from astropy.nddata.nduncertainty import (
+    IncompatibleUncertaintiesException, InverseVariance, StdDevUncertainty, UnknownUncertainty,
+    VarianceUncertainty)
+from astropy.units import Quantity, UnitsError
 from astropy.wcs import WCS
-
 
 # Alias NDDataAllMixins in case this will be renamed ... :-)
 NDDataArithmetic = NDDataRef

--- a/astropy/nddata/mixins/tests/test_ndio.py
+++ b/astropy/nddata/mixins/tests/test_ndio.py
@@ -1,5 +1,4 @@
-from astropy.nddata import NDData, NDIOMixin, NDDataRef
-
+from astropy.nddata import NDData, NDDataRef, NDIOMixin
 
 # Alias NDDataAllMixins in case this will be renamed ... :-)
 NDDataIO = NDDataRef

--- a/astropy/nddata/mixins/tests/test_ndslicing.py
+++ b/astropy/nddata/mixins/tests/test_ndslicing.py
@@ -1,14 +1,14 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 
-import pytest
 import numpy as np
+import pytest
 from numpy.testing import assert_array_equal
 
+from astropy import units as u
 from astropy.nddata import NDData, NDSlicingMixin
 from astropy.nddata import _testing as nd_testing
 from astropy.nddata.nduncertainty import NDUncertainty, StdDevUncertainty
-from astropy import units as u
 
 
 # Just add the Mixin to NDData

--- a/astropy/nddata/nddata.py
+++ b/astropy/nddata/nddata.py
@@ -2,16 +2,18 @@
 # This module implements the base NDData class.
 
 
-import numpy as np
 from copy import deepcopy
+
+import numpy as np
+
+from astropy import log
+from astropy.units import Quantity, Unit
+from astropy.utils.metadata import MetaData
+from astropy.wcs.wcsapi import (
+    BaseHighLevelWCS, BaseLowLevelWCS, HighLevelWCSWrapper, SlicedLowLevelWCS)
 
 from .nddata_base import NDDataBase
 from .nduncertainty import NDUncertainty, UnknownUncertainty
-from astropy import log
-from astropy.units import Unit, Quantity
-from astropy.utils.metadata import MetaData
-from astropy.wcs.wcsapi import (BaseLowLevelWCS, BaseHighLevelWCS,
-                                SlicedLowLevelWCS, HighLevelWCSWrapper)
 
 __all__ = ['NDData']
 

--- a/astropy/nddata/nddata_base.py
+++ b/astropy/nddata/nddata_base.py
@@ -4,7 +4,6 @@
 
 from abc import ABCMeta, abstractmethod
 
-
 __all__ = ['NDDataBase']
 
 

--- a/astropy/nddata/nddata_withmixins.py
+++ b/astropy/nddata/nddata_withmixins.py
@@ -5,11 +5,10 @@ This module implements a class based on NDData with all Mixins.
 """
 
 
-from .nddata import NDData
-
-from .mixins.ndslicing import NDSlicingMixin
 from .mixins.ndarithmetic import NDArithmeticMixin
 from .mixins.ndio import NDIOMixin
+from .mixins.ndslicing import NDSlicingMixin
+from .nddata import NDData
 
 __all__ = ['NDDataRef']
 

--- a/astropy/nddata/nduncertainty.py
+++ b/astropy/nddata/nduncertainty.py
@@ -1,14 +1,14 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-import numpy as np
+import weakref
 from abc import ABCMeta, abstractmethod
 from copy import deepcopy
-import weakref
 
+import numpy as np
 
 # from astropy.utils.compat import ignored
 from astropy import log
-from astropy.units import Unit, Quantity, UnitConversionError
+from astropy.units import Quantity, Unit, UnitConversionError
 
 __all__ = ['MissingDataAssociationException',
            'IncompatibleUncertaintiesException', 'NDUncertainty',

--- a/astropy/nddata/tests/test_bitmask.py
+++ b/astropy/nddata/tests/test_bitmask.py
@@ -5,11 +5,11 @@ Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 """
 import warnings
+
 import numpy as np
 import pytest
 
 from astropy.nddata import bitmask
-
 
 MAX_INT_TYPE = np.maximum_sctype(np.int_)
 MAX_UINT_TYPE = np.maximum_sctype(np.uint)

--- a/astropy/nddata/tests/test_blocks.py
+++ b/astropy/nddata/tests/test_blocks.py
@@ -3,7 +3,7 @@
 import numpy as np
 import pytest
 
-from astropy.nddata import reshape_as_blocks, block_reduce, block_replicate
+from astropy.nddata import block_reduce, block_replicate, reshape_as_blocks
 
 
 class TestReshapeAsBlocks:

--- a/astropy/nddata/tests/test_ccddata.py
+++ b/astropy/nddata/tests/test_ccddata.py
@@ -5,21 +5,18 @@ import textwrap
 import numpy as np
 import pytest
 
-from astropy.io import fits
-from astropy.nddata.nduncertainty import (
-    StdDevUncertainty, MissingDataAssociationException, VarianceUncertainty,
-    InverseVariance)
-from astropy import units as u
 from astropy import log
-from astropy.wcs import WCS, FITSFixedWarning
-from astropy.utils import NumpyRNGContext
-from astropy.utils.data import (get_pkg_data_filename, get_pkg_data_filenames,
-                                get_pkg_data_contents)
-from astropy.utils.exceptions import AstropyWarning
-
-from astropy.nddata.ccddata import CCDData
+from astropy import units as u
+from astropy.io import fits
 from astropy.nddata import _testing as nd_testing
+from astropy.nddata.ccddata import CCDData
+from astropy.nddata.nduncertainty import (
+    InverseVariance, MissingDataAssociationException, StdDevUncertainty, VarianceUncertainty)
 from astropy.table import Table
+from astropy.utils import NumpyRNGContext
+from astropy.utils.data import get_pkg_data_contents, get_pkg_data_filename, get_pkg_data_filenames
+from astropy.utils.exceptions import AstropyWarning
+from astropy.wcs import WCS, FITSFixedWarning
 
 DEFAULT_DATA_SIZE = 100
 
@@ -728,9 +725,8 @@ def test_wcs_keyword_removal_for_wcs_test_files():
 
     Includes regression test for #8597
     """
-    from astropy.nddata.ccddata import _generate_wcs_and_update_header
-    from astropy.nddata.ccddata import (_KEEP_THESE_KEYWORDS_IN_HEADER,
-                                        _CDs, _PCs)
+    from astropy.nddata.ccddata import (
+        _KEEP_THESE_KEYWORDS_IN_HEADER, _CDs, _generate_wcs_and_update_header, _PCs)
 
     keepers = set(_KEEP_THESE_KEYWORDS_IN_HEADER)
     wcs_headers = get_pkg_data_filenames('../../wcs/tests/data',

--- a/astropy/nddata/tests/test_compat.py
+++ b/astropy/nddata/tests/test_compat.py
@@ -2,15 +2,14 @@
 # This module contains tests of a class equivalent to pre-1.0 NDData.
 
 
-import pytest
 import numpy as np
+import pytest
 
-from astropy.nddata.nddata import NDData
+from astropy import units as u
 from astropy.nddata.compat import NDDataArray
+from astropy.nddata.nddata import NDData
 from astropy.nddata.nduncertainty import StdDevUncertainty
 from astropy.wcs import WCS
-from astropy import units as u
-
 
 NDDATA_ATTRIBUTES = ['mask', 'flags', 'uncertainty', 'unit', 'shape', 'size',
                      'dtype', 'ndim', 'wcs', 'convert_unit_to']

--- a/astropy/nddata/tests/test_decorators.py
+++ b/astropy/nddata/tests/test_decorators.py
@@ -2,15 +2,14 @@
 
 import inspect
 
-import pytest
 import numpy as np
+import pytest
 
-from astropy.utils.exceptions import AstropyUserWarning
 from astropy import units as u
-from astropy.wcs import WCS
-
-from astropy.nddata.nddata import NDData
 from astropy.nddata.decorators import support_nddata
+from astropy.nddata.nddata import NDData
+from astropy.utils.exceptions import AstropyUserWarning
+from astropy.wcs import WCS
 
 
 class CCDData(NDData):

--- a/astropy/nddata/tests/test_flag_collection.py
+++ b/astropy/nddata/tests/test_flag_collection.py
@@ -1,8 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 
-import pytest
 import numpy as np
+import pytest
 
 from astropy.nddata import FlagCollection
 

--- a/astropy/nddata/tests/test_nddata.py
+++ b/astropy/nddata/tests/test_nddata.py
@@ -5,20 +5,19 @@ import pickle
 import textwrap
 from collections import OrderedDict
 
-import pytest
 import numpy as np
+import pytest
 from numpy.testing import assert_array_equal
 
+from astropy import units as u
+from astropy.nddata import _testing as nd_testing
 from astropy.nddata.nddata import NDData
 from astropy.nddata.nduncertainty import StdDevUncertainty
-from astropy import units as u
 from astropy.utils import NumpyRNGContext
 from astropy.wcs import WCS
-from astropy.wcs.wcsapi import HighLevelWCSWrapper, SlicedLowLevelWCS, \
-                               BaseHighLevelWCS
+from astropy.wcs.wcsapi import BaseHighLevelWCS, HighLevelWCSWrapper, SlicedLowLevelWCS
 
 from .test_nduncertainty import FakeUncertainty
-from astropy.nddata import _testing as nd_testing
 
 
 class FakeNumpyArray:

--- a/astropy/nddata/tests/test_nduncertainty.py
+++ b/astropy/nddata/tests/test_nduncertainty.py
@@ -2,21 +2,17 @@
 
 import pickle
 
-import pytest
 import numpy as np
-from numpy.testing import assert_array_equal, assert_allclose
+import pytest
+from numpy.testing import assert_allclose, assert_array_equal
 
-from astropy.nddata.nduncertainty import (StdDevUncertainty,
-                             VarianceUncertainty,
-                             InverseVariance,
-                             NDUncertainty,
-                             IncompatibleUncertaintiesException,
-                             MissingDataAssociationException,
-                             UnknownUncertainty)
-from astropy.nddata.nddata import NDData
-from astropy.nddata.compat import NDDataArray
-from astropy.nddata.ccddata import CCDData
 from astropy import units as u
+from astropy.nddata.ccddata import CCDData
+from astropy.nddata.compat import NDDataArray
+from astropy.nddata.nddata import NDData
+from astropy.nddata.nduncertainty import (
+    IncompatibleUncertaintiesException, InverseVariance, MissingDataAssociationException,
+    NDUncertainty, StdDevUncertainty, UnknownUncertainty, VarianceUncertainty)
 
 # Regarding setter tests:
 # No need to test setters since the uncertainty is considered immutable after

--- a/astropy/nddata/tests/test_utils.py
+++ b/astropy/nddata/tests/test_utils.py
@@ -1,21 +1,18 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from packaging.version import Version
-import pytest
 import numpy as np
+import pytest
 from numpy.testing import assert_allclose, assert_array_equal
+from packaging.version import Version
 
+from astropy import units as u
+from astropy.coordinates import SkyCoord
+from astropy.nddata import (
+    CCDData, Cutout2D, NoOverlapError, PartialOverlapError, add_array, extract_array,
+    overlap_slices, subpixel_indices)
 from astropy.tests.helper import assert_quantity_allclose
-from astropy.nddata import (extract_array, add_array, subpixel_indices,
-                            overlap_slices, NoOverlapError,
-                            PartialOverlapError, Cutout2D)
 from astropy.wcs import WCS, Sip
 from astropy.wcs.utils import proj_plane_pixel_area
-from astropy.coordinates import SkyCoord
-from astropy import units as u
-
-from astropy.nddata import CCDData
-
 
 test_positions = [(10.52, 3.12), (5.62, 12.97), (31.33, 31.77),
                   (0.46, 0.94), (20.45, 12.12), (42.24, 24.42)]

--- a/astropy/nddata/utils.py
+++ b/astropy/nddata/utils.py
@@ -10,8 +10,8 @@ import numpy as np
 from astropy import units as u
 from astropy.coordinates import SkyCoord
 from astropy.utils import lazyproperty
-from astropy.wcs.utils import skycoord_to_pixel, proj_plane_pixel_scales
 from astropy.wcs import Sip
+from astropy.wcs.utils import proj_plane_pixel_scales, skycoord_to_pixel
 
 __all__ = ['extract_array', 'add_array', 'subpixel_indices',
            'overlap_slices', 'NoOverlapError', 'PartialOverlapError',
@@ -672,8 +672,8 @@ class Cutout2D:
             input ``ax``.
         """
 
-        import matplotlib.pyplot as plt
         import matplotlib.patches as mpatches
+        import matplotlib.pyplot as plt
 
         kwargs['fill'] = fill
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,6 @@ archs = ["auto", "aarch64"]
         "docs/*",
         "examples/*",
         "astropy/extern/*",
-        "astropy/nddata/*",
         "astropy/timeseries/*",
         "astropy/uncertainty/*",
         "astropy/utils/*",


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
