### PR TITLE
isort config

### DIFF
--- a/astropy/config/__init__.py
+++ b/astropy/config/__init__.py
@@ -6,6 +6,6 @@ Astropy project. This includes all functionality related to the
 affiliated package index.
 """
 
-from .paths import *
-from .configuration import *
 from .affiliated import *
+from .configuration import *
+from .paths import *

--- a/astropy/config/configuration.py
+++ b/astropy/config/configuration.py
@@ -9,16 +9,16 @@ configuration files for Astropy and affiliated packages.
     found at https://configobj.readthedocs.io .
 """
 
+import contextlib
+import importlib
 import io
+import os
 import pkgutil
 import warnings
-import importlib
-import contextlib
-import os
+from contextlib import contextmanager, nullcontext
 from os import path
 from textwrap import TextWrapper
 from warnings import warn
-from contextlib import contextmanager, nullcontext
 
 from astropy.extern.configobj import configobj, validate
 from astropy.utils import find_current_module, silence

--- a/astropy/config/paths.py
+++ b/astropy/config/paths.py
@@ -3,12 +3,10 @@
 data/cache files used by Astropy should be placed.
 """
 
-from functools import wraps
-
 import os
 import shutil
 import sys
-
+from functools import wraps
 
 __all__ = ['get_config_dir', 'get_cache_dir', 'set_temp_config',
            'set_temp_cache']

--- a/astropy/config/tests/test_configs.py
+++ b/astropy/config/tests/test_configs.py
@@ -2,16 +2,14 @@
 
 import io
 import os
-import sys
 import subprocess
+import sys
 
 import pytest
 
-from astropy.config import (configuration, set_temp_config, paths,
-                            create_config_file)
+from astropy.config import configuration, create_config_file, paths, set_temp_config
 from astropy.utils.data import get_pkg_data_filename
 from astropy.utils.exceptions import AstropyDeprecationWarning
-
 
 OLD_CONFIG = {}
 
@@ -226,7 +224,7 @@ def test_create_config_file(tmp_path, caplog):
 
 def test_configitem():
 
-    from astropy.config.configuration import ConfigNamespace, ConfigItem, get_config
+    from astropy.config.configuration import ConfigItem, ConfigNamespace, get_config
 
     ci = ConfigItem(34, 'this is a Description')
 
@@ -267,7 +265,7 @@ def test_configitem():
 
 def test_configitem_types():
 
-    from astropy.config.configuration import ConfigNamespace, ConfigItem
+    from astropy.config.configuration import ConfigItem, ConfigNamespace
 
     ci1 = ConfigItem(34)
     ci2 = ConfigItem(34.3)
@@ -308,7 +306,7 @@ def test_configitem_types():
 
 def test_configitem_options(tmpdir):
 
-    from astropy.config.configuration import ConfigNamespace, ConfigItem, get_config
+    from astropy.config.configuration import ConfigItem, ConfigNamespace, get_config
 
     cio = ConfigItem(['op1', 'op2', 'op3'])
 
@@ -372,7 +370,7 @@ def test_config_noastropy_fallback(monkeypatch):
 
 def test_configitem_setters():
 
-    from astropy.config.configuration import ConfigNamespace, ConfigItem
+    from astropy.config.configuration import ConfigItem, ConfigNamespace
 
     class Conf(ConfigNamespace):
         tstnm12 = ConfigItem(42, 'this is another Description')
@@ -440,7 +438,7 @@ class TestAliasRead:
 
 def test_configitem_unicode(tmpdir):
 
-    from astropy.config.configuration import ConfigNamespace, ConfigItem, get_config
+    from astropy.config.configuration import ConfigItem, ConfigNamespace, get_config
 
     cio = ConfigItem('ასტრონომიის')
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,6 @@ archs = ["auto", "aarch64"]
         "docs/*",
         "examples/*",
         "astropy/_dev/*",
-        "astropy/config/*",
         "astropy/constants/*",
         "astropy/convolution/*",
         "astropy/extern/*",


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
