### PR TITLE
Isort time

### DIFF
--- a/astropy/time/__init__.py
+++ b/astropy/time/__init__.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from astropy import config as _config
 
+
 class Conf(_config.ConfigNamespace):  # noqa
     """
     Configuration parameters for `astropy.table`.
@@ -16,5 +17,7 @@ class Conf(_config.ConfigNamespace):  # noqa
 
 conf = Conf()  # noqa
 
+# isort: off
 from .formats import *  # noqa
 from .core import *  # noqa
+# isort: on

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -6,32 +6,33 @@ UT1) and time representations (e.g. JD, MJD, ISO 8601) that are used in
 astronomy.
 """
 
-import os
 import copy
 import enum
 import operator
+import os
 import threading
-from datetime import datetime, date, timedelta
+from datetime import date, datetime, timedelta
 from time import strftime
 from warnings import warn
 
-import numpy as np
 import erfa
+import numpy as np
 
-from astropy import units as u, constants as const
+from astropy import constants as const
+from astropy import units as u
+from astropy.extern import _strptime
 from astropy.units import UnitConversionError
 from astropy.utils import ShapedLikeNDArray
 from astropy.utils.data_info import MixinInfo, data_info_factory
 from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyWarning
-from .utils import day_frac
-from .formats import (TIME_FORMATS, TIME_DELTA_FORMATS,
-                      TimeJD, TimeUnique, TimeAstropyTime, TimeDatetime)
+
 # Import TimeFromEpoch to avoid breaking code that followed the old example of
 # making a custom timescale in the documentation.
 from .formats import TimeFromEpoch  # noqa
+from .formats import (
+    TIME_DELTA_FORMATS, TIME_FORMATS, TimeAstropyTime, TimeDatetime, TimeJD, TimeUnique)
 from .time_helper.function_helpers import CUSTOM_FUNCTIONS, UNSUPPORTED_FUNCTIONS
-
-from astropy.extern import _strptime
+from .utils import day_frac
 
 __all__ = ['TimeBase', 'Time', 'TimeDelta', 'TimeInfo', 'TimeInfoBase', 'update_leap_seconds',
            'TIME_SCALES', 'STANDARD_TIME_SCALES', 'TIME_DELTA_SCALES',
@@ -1779,8 +1780,9 @@ class Time(TimeBase):
                                  'corrections')
             location = self.location
 
-        from astropy.coordinates import (UnitSphericalRepresentation, CartesianRepresentation,
-                                         HCRS, ICRS, GCRS, solar_system_ephemeris)
+        from astropy.coordinates import (
+            GCRS, HCRS, ICRS, CartesianRepresentation, UnitSphericalRepresentation,
+            solar_system_ephemeris)
 
         # ensure sky location is ICRS compatible
         if not skycoord.is_transformable_to(ICRS()):
@@ -1970,7 +1972,7 @@ class Time(TimeBase):
             Local sidereal time or Earth rotation angle, with units of hourangle.
 
         """  # noqa
-        from astropy.coordinates import Longitude, EarthLocation
+        from astropy.coordinates import EarthLocation, Longitude
         from astropy.coordinates.builtin_frames.utils import get_polar_motion
         from astropy.coordinates.matrix_utilities import rotation_matrix
 

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -1,23 +1,21 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-import fnmatch
-import time
-import re
 import datetime
+import fnmatch
+import re
+import time
 import warnings
-from decimal import Decimal
 from collections import OrderedDict, defaultdict
+from decimal import Decimal
 
-import numpy as np
 import erfa
+import numpy as np
 
-from astropy.utils.decorators import lazyproperty, classproperty
-from astropy.utils.exceptions import AstropyDeprecationWarning
 import astropy.units as u
+from astropy.utils.decorators import classproperty, lazyproperty
+from astropy.utils.exceptions import AstropyDeprecationWarning
 
-from . import _parse_times
-from . import utils
-from .utils import day_frac, quantity_day_frac, two_sum, two_product
-from . import conf
+from . import _parse_times, conf, utils
+from .utils import day_frac, quantity_day_frac, two_product, two_sum
 
 __all__ = ['TimeFormat', 'TimeJD', 'TimeMJD', 'TimeFromEpoch', 'TimeUnix',
            'TimeUnixTai', 'TimeCxcSec', 'TimeGPS', 'TimeDecimalYear',
@@ -1956,4 +1954,4 @@ def _broadcast_writeable(jd1, jd2):
 
 # Import symbols from core.py that are used in this module. This succeeds
 # because __init__.py imports format.py just before core.py.
-from .core import Time, TIME_SCALES, TIME_DELTA_SCALES, ScaleValueError  # noqa
+from .core import TIME_DELTA_SCALES, TIME_SCALES, ScaleValueError, Time  # noqa

--- a/astropy/time/setup_package.py
+++ b/astropy/time/setup_package.py
@@ -3,9 +3,9 @@
 # Copied from astropy/convolution/setup_package.py
 
 import os
-from setuptools import Extension
 
 import numpy
+from setuptools import Extension
 
 C_TIME_PKGDIR = os.path.relpath(os.path.dirname(__file__))
 

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -1,28 +1,27 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-import os
 import copy
-import functools
 import datetime
+import functools
+import os
 from copy import deepcopy
 from decimal import Decimal, localcontext
 from io import StringIO
 
+import erfa
 import numpy as np
 import pytest
-from numpy.testing import assert_allclose
-import erfa
 from erfa import ErfaWarning
+from numpy.testing import assert_allclose
 
-from astropy.utils.exceptions import AstropyDeprecationWarning
-from astropy.utils import isiterable, iers
-from astropy.time import (Time, TimeDelta, ScaleValueError, STANDARD_TIME_SCALES,
-                          TimeString, TimezoneInfo, TIME_FORMATS)
-from astropy.coordinates import EarthLocation
 from astropy import units as u
+from astropy.coordinates import EarthLocation
 from astropy.table import Column, Table
-from astropy.utils.compat.optional_deps import HAS_PYTZ, HAS_H5PY  # noqa
-
+from astropy.time import (
+    STANDARD_TIME_SCALES, TIME_FORMATS, ScaleValueError, Time, TimeDelta, TimeString, TimezoneInfo)
+from astropy.utils import iers, isiterable
+from astropy.utils.compat.optional_deps import HAS_H5PY, HAS_PYTZ  # noqa
+from astropy.utils.exceptions import AstropyDeprecationWarning
 
 allclose_jd = functools.partial(np.allclose, rtol=np.finfo(float).eps, atol=0)
 allclose_jd2 = functools.partial(np.allclose, rtol=np.finfo(float).eps,

--- a/astropy/time/tests/test_comparisons.py
+++ b/astropy/time/tests/test_comparisons.py
@@ -2,11 +2,11 @@
 
 import operator
 
-import pytest
 import numpy as np
+import pytest
 
-from astropy.time import Time, TimeDelta
 import astropy.units as u
+from astropy.time import Time, TimeDelta
 
 
 class TestTimeComparisons:

--- a/astropy/time/tests/test_custom_formats.py
+++ b/astropy/time/tests/test_custom_formats.py
@@ -3,9 +3,8 @@
 from datetime import date
 from itertools import count
 
-import pytest
-
 import numpy as np
+import pytest
 from erfa import DJM0
 
 from astropy.time import Time, TimeFormat

--- a/astropy/time/tests/test_delta.py
+++ b/astropy/time/tests/test_delta.py
@@ -2,19 +2,18 @@
 import functools
 import itertools
 import operator
-from decimal import Decimal
 from datetime import timedelta
+from decimal import Decimal
 
-import pytest
 import numpy as np
+import pytest
 
-from astropy.time import (
-    Time, TimeDelta, OperandTypeError, ScaleValueError, TIME_SCALES,
-    STANDARD_TIME_SCALES, TIME_DELTA_SCALES, TimeDeltaMissingUnitWarning,
-)
-from astropy.utils import iers
 from astropy import units as u
 from astropy.table import Table
+from astropy.time import (
+    STANDARD_TIME_SCALES, TIME_DELTA_SCALES, TIME_SCALES, OperandTypeError, ScaleValueError, Time,
+    TimeDelta, TimeDeltaMissingUnitWarning)
+from astropy.utils import iers
 
 allclose_jd = functools.partial(np.allclose, rtol=2. ** -52, atol=0)
 allclose_jd2 = functools.partial(np.allclose, rtol=2. ** -52,

--- a/astropy/time/tests/test_fast_parser.py
+++ b/astropy/time/tests/test_fast_parser.py
@@ -5,7 +5,7 @@ import re
 import numpy as np
 import pytest
 
-from astropy.time import Time, conf, TimeYearDayTime
+from astropy.time import Time, TimeYearDayTime, conf
 
 iso_times = ['2000-02-29', '1981-12-31 12:13', '1981-12-31 12:13:14', '2020-12-31 12:13:14.56']
 isot_times = [re.sub(' ', 'T', tm) for tm in iso_times]

--- a/astropy/time/tests/test_functions.py
+++ b/astropy/time/tests/test_functions.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-import pytest
 import numpy as np
+import pytest
 
 from astropy.time import Time, TimeDelta
 from astropy.units.quantity_helper.function_helpers import ARRAY_FUNCTION_ENABLED

--- a/astropy/time/tests/test_mask.py
+++ b/astropy/time/tests/test_mask.py
@@ -6,10 +6,10 @@ import numpy as np
 import pytest
 
 from astropy import units as u
+from astropy.table import Table
+from astropy.time import Time
 from astropy.utils import iers
 from astropy.utils.compat import PYTHON_LT_3_11
-from astropy.time import Time
-from astropy.table import Table
 from astropy.utils.compat.optional_deps import HAS_H5PY
 
 allclose_sec = functools.partial(np.allclose, rtol=2. ** -52,

--- a/astropy/time/tests/test_methods.py
+++ b/astropy/time/tests/test_methods.py
@@ -1,16 +1,15 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-import warnings
-import itertools
 import copy
+import itertools
+import warnings
 
-import pytest
 import numpy as np
+import pytest
 
 from astropy.time import Time
-from astropy.utils import iers
 from astropy.units.quantity_helper.function_helpers import ARRAY_FUNCTION_ENABLED
-
+from astropy.utils import iers
 
 needs_array_function = pytest.mark.xfail(
     not ARRAY_FUNCTION_ENABLED,

--- a/astropy/time/tests/test_pickle.py
+++ b/astropy/time/tests/test_pickle.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import pickle
+
 import numpy as np
 
 from astropy.time import Time

--- a/astropy/time/tests/test_precision.py
+++ b/astropy/time/tests/test_precision.py
@@ -1,26 +1,24 @@
-import decimal
-import warnings
-import functools
 import contextlib
-from decimal import Decimal
+import decimal
+import functools
+import warnings
 from datetime import datetime, timedelta
+from decimal import Decimal
 
+import erfa
+import numpy as np
 import pytest
+from erfa import ErfaError, ErfaWarning
 from hypothesis import assume, example, given, target
 from hypothesis.extra.numpy import array_shapes, arrays
-from hypothesis.strategies import (composite, datetimes, floats, integers,
-                                   one_of, sampled_from, timedeltas, tuples)
-
-import numpy as np
-import erfa
-from erfa import ErfaError, ErfaWarning
+from hypothesis.strategies import (
+    composite, datetimes, floats, integers, one_of, sampled_from, timedeltas, tuples)
 
 import astropy.units as u
 from astropy.tests.helper import assert_quantity_allclose
 from astropy.time import STANDARD_TIME_SCALES, Time, TimeDelta
 from astropy.time.utils import day_frac, two_sum
 from astropy.utils import iers
-
 
 allclose_jd = functools.partial(np.allclose, rtol=np.finfo(float).eps, atol=0)
 allclose_jd2 = functools.partial(np.allclose, rtol=np.finfo(float).eps,

--- a/astropy/time/tests/test_quantity_interaction.py
+++ b/astropy/time/tests/test_quantity_interaction.py
@@ -1,12 +1,12 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import functools
 
-import pytest
 import numpy as np
+import pytest
 
-from astropy.time import Time, TimeDelta
 from astropy import units as u
 from astropy.table import Column
+from astropy.time import Time, TimeDelta
 
 allclose_sec = functools.partial(np.allclose, rtol=2. ** -52,
                                  atol=2. ** -52 * 24 * 3600)  # 20 ps atol

--- a/astropy/time/tests/test_sidereal.py
+++ b/astropy/time/tests/test_sidereal.py
@@ -2,9 +2,9 @@
 import functools
 import itertools
 
-import pytest
-import numpy as np
 import erfa
+import numpy as np
+import pytest
 
 from astropy import units as u
 from astropy.time import Time

--- a/astropy/time/tests/test_update_leap_seconds.py
+++ b/astropy/time/tests/test_update_leap_seconds.py
@@ -2,14 +2,13 @@
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta
 
-import pytest
 import erfa
-
-from astropy.utils import iers
-from astropy.utils.exceptions import AstropyWarning
+import pytest
 
 import astropy.time.core
-from astropy.time import update_leap_seconds, Time
+from astropy.time import Time, update_leap_seconds
+from astropy.utils import iers
+from astropy.utils.exceptions import AstropyWarning
 
 
 class TestUpdateLeapSeconds:

--- a/astropy/time/tests/test_ut1.py
+++ b/astropy/time/tests/test_ut1.py
@@ -1,8 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import functools
 
-import pytest
 import numpy as np
+import pytest
 
 from astropy.time import Time
 from astropy.utils.iers import conf as iers_conf

--- a/astropy/time/utils.py
+++ b/astropy/time/utils.py
@@ -11,6 +11,7 @@ objects into two values, and vice versa.
 import decimal
 
 import numpy as np
+
 import astropy.units as u
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,6 @@ archs = ["auto", "aarch64"]
         "astropy/samp/*",
         "astropy/stats/*",
         "astropy/tests/*",
-        "astropy/time/*",
         "astropy/timeseries/*",
         "astropy/uncertainty/*",
         "astropy/utils/*",


### PR DESCRIPTION

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
