### PR TITLE
Update fitsheader.py

### DIFF
--- a/astropy/io/fits/tests/test_fitsheader.py
+++ b/astropy/io/fits/tests/test_fitsheader.py
@@ -91,42 +91,58 @@ class TestFITSheader_script(FitsTestCase):
                          self.data('test0.fits'), self.data('test1.fits')])
         out, err = capsys.readouterr()
         out = out.splitlines()
-        assert len(out) == 4
-        assert out[2].endswith('test0.fits 49491.65366175    0.23')
-        assert out[3].endswith('test1.fits 49492.65366175    0.22')
+        assert len(out) == 3
+        assert out[1].endswith('test0.fits | 49491.65366175 |    0.23 |')
+        assert out[2].endswith('test1.fits | 49492.65366175 |    0.22 |')
+        # assert len(out) == 4
+        # assert out[2].endswith('test0.fits 49491.65366175    0.23')
+        # assert out[3].endswith('test1.fits 49492.65366175    0.22')
 
         fitsheader.main(['-e', '0', '-f', '-k', 'EXPSTART', '-k', 'EXPTIME',
                          self.data('test0.fits')])
         out, err = capsys.readouterr()
         out = out.splitlines()
-        assert len(out) == 3
-        assert out[2].endswith('test0.fits 49491.65366175    0.23')
+        assert len(out) == 2
+        assert out[1].endswith('test0.fits | 49491.65366175 |    0.23 |')
+        # assert len(out) == 3
+        # assert out[2].endswith('test0.fits 49491.65366175    0.23')
 
         fitsheader.main(['-f', '-k', 'NAXIS',
                          self.data('tdim.fits'), self.data('test1.fits')])
         out, err = capsys.readouterr()
         out = out.splitlines()
-        assert len(out) == 4
-        assert out[0].endswith('0:NAXIS 1:NAXIS 2:NAXIS 3:NAXIS 4:NAXIS')
-        assert out[2].endswith('tdim.fits       0       2      --      --      --')
-        assert out[3].endswith('test1.fits       0       2       2       2       2')
+        assert len(out) == 3
+        assert out[0].endswith(' 0:NAXIS | 1:NAXIS | 2:NAXIS | 3:NAXIS | 4:NAXIS |')
+        assert out[1].endswith('tdim.fits |       0 |       2 |         |         |         |')
+        assert out[2].endswith('test1.fits |       0 |       2 |       2 |       2 |       2 |')
+        # assert len(out) == 4
+        # assert out[0].endswith('0:NAXIS 1:NAXIS 2:NAXIS 3:NAXIS 4:NAXIS')
+        # assert out[2].endswith('tdim.fits       0       2      --      --      --')
+        # assert out[3].endswith('test1.fits       0       2       2       2       2')
 
         # check that files without required keyword are present
         fitsheader.main(['-f', '-k', 'DATE-OBS',
                          self.data('table.fits'), self.data('test0.fits')])
         out, err = capsys.readouterr()
         out = out.splitlines()
-        assert len(out) == 4
-        assert out[2].endswith('table.fits       --')
-        assert out[3].endswith('test0.fits 19/05/94')
+        assert len(out) == 3
+        assert out[1].endswith('table.fits |          |')
+        assert out[2].endswith('test0.fits | 19/05/94 |')
+        # assert len(out) == 4
+        # assert out[2].endswith('table.fits       --')
+        # assert out[3].endswith('test0.fits 19/05/94')
 
         # check that COMMENT and HISTORY are excluded
-        fitsheader.main(['-e', '0', '-f', self.data('tb.fits')])
+        # fitsheader.main(['-e', '0', '-f', self.data('tb.fits')])
+        fitsheader.main([self.data('tb.fits'), '-e', '0', '-f'])
         out, err = capsys.readouterr()
         out = out.splitlines()
-        assert len(out) == 3
-        assert out[2].endswith('tb.fits   True     16     0   True '
-                               'STScI-STSDAS/TABLES  tb.fits       1')
+        assert len(out) == 2
+        assert out[1].endswith('tb.fits |   True |     16 |     0 |   True | STScI-STSDAS/TABLES |'
+                               '  tb.fits |       1 |')
+        # assert len(out) == 3
+        # assert out[2].endswith('tb.fits   True     16     0   True '
+        #                        'STScI-STSDAS/TABLES  tb.fits       1')
 
     def test_fitsort_sorting_keyword_fitsort(self, capsys):
         """check that sorting by keyword works"""
@@ -140,13 +156,20 @@ class TestFITSheader_script(FitsTestCase):
         out_sorted, err_sorted = capsys.readouterr()
         out_sorted = out_sorted.splitlines()
 
-        assert len(out_unsorted) == 4
-        assert out_unsorted[2].endswith('group.fits     5')
-        assert out_unsorted[3].endswith('test0.fits     0')
+        assert len(out_unsorted) == 3
+        assert out_unsorted[1].endswith('group.fits |     5 |')
+        assert out_unsorted[2].endswith('test0.fits |     0 |')
+        # assert len(out_unsorted) == 4
+        # assert out_unsorted[2].endswith('group.fits     5')
+        # assert out_unsorted[3].endswith('test0.fits     0')
 
-        assert len(out_sorted) == 4
-        assert out_sorted[2].endswith('test0.fits     0')
-        assert out_sorted[3].endswith('group.fits     5')
+        assert len(out_sorted) == 3
+        assert out_sorted[1].endswith('test0.fits |     0 |')
+        assert out_sorted[2].endswith('group.fits |     5 |')
+        # assert len(out_sorted) == 4
+        # assert out_sorted[2].endswith('test0.fits     0')
+        # assert out_sorted[3].endswith('group.fits     5')
+        
 
     def test_fitsort_sorting_keyword_complains(self, capsys):
         with pytest.raises(SystemExit):
@@ -174,3 +197,4 @@ class TestFITSheader_script(FitsTestCase):
         out = out.splitlines()
         assert len(out) == 2
         assert out[1].strip().endswith("HIERARCH ESO DET ID = 'DV13' / Detector system Id")
+        


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

Add a command-line argument (-r/--replace_spaces) to replaces spaces in keyword values. The new functionality only applies to output in tabular format, i.e. f/--fitsort or -t/--table. The scope of the change is to make the output easier to handle as space-separated ascii columns.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
