### PR TITLE
Fix for python 3.8 CI.

### DIFF
--- a/astropy/timeseries/tests/test_sampled.py
+++ b/astropy/timeseries/tests/test_sampled.py
@@ -11,7 +11,6 @@ from astropy.time import Time, TimeDelta
 from astropy import units as u
 from astropy.units import Quantity
 from astropy.utils.data import get_pkg_data_filename
-from astropy.utils.introspection import minversion
 from astropy.tests.helper import assert_quantity_allclose
 
 from astropy.timeseries.periodograms import BoxLeastSquares, LombScargle
@@ -272,14 +271,9 @@ def test_fold_invalid_options():
 def test_pandas():
     pandas = pytest.importorskip("pandas")
 
-    PANDAS_LT_1_5 = not minversion(pandas, '1.4.999')  # When this was written 1.5 was not released.
-
     df1 = pandas.DataFrame()
     df1['a'] = [1, 2, 3]
-    if PANDAS_LT_1_5:
-        df1.set_index(pandas.DatetimeIndex(INPUT_TIME.datetime64), inplace=True)
-    else:
-        df1 = df1.set_index(pandas.DatetimeIndex(INPUT_TIME.datetime64), copy=False)
+    df1.set_index(pandas.DatetimeIndex(INPUT_TIME.datetime64), inplace=True)
 
     ts = TimeSeries.from_pandas(df1)
     assert_equal(ts.time.isot, INPUT_TIME.isot)

--- a/docs/timeseries/pandas.rst
+++ b/docs/timeseries/pandas.rst
@@ -33,14 +33,10 @@ Consider a concise example starting from a :class:`~pandas.DataFrame`:
     >>> import pandas
     >>> import numpy as np
     >>> from astropy.utils.introspection import minversion
-    >>> PANDAS_LT_1_5 = not minversion(pandas, '1.4.999')
     >>> df = pandas.DataFrame()
     >>> df['a'] = [1, 2, 3]
     >>> times = np.array(['2015-07-04', '2015-07-05', '2015-07-06'], dtype=np.datetime64)
-    >>> if PANDAS_LT_1_5:
-    ...     df.set_index(pandas.DatetimeIndex(times), inplace=True)
-    ... else:
-    ...     df = df.set_index(pandas.DatetimeIndex(times), copy=False)
+    >>> df.set_index(pandas.DatetimeIndex(times), inplace=True)
     >>> df
         a
     2015-07-04  1

--- a/tox.ini
+++ b/tox.ini
@@ -79,6 +79,7 @@ deps =
     oldestdeps: scipy==1.3.*
     oldestdeps: pyyaml==3.13
     oldestdeps: ipython==4.2.*
+    oldestdeps: pandas==1.4.*
     # ipython did not pin traitlets, so we have to
     oldestdeps: traitlets<4.1
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

We are seeing the python 3.8 CI failing, e.g. https://github.com/astropy/astropy/actions/runs/3084051677/jobs/4985734475. This appears to be a result of the `pandas` 1.5 release, which requires `numpy` 1.20.3 or later. This messes up the `oldest-supported-numpy` requirement causing the latest `numpy` to be installed.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
