### PR TITLE
isort tests

### DIFF
--- a/astropy/tests/command.py
+++ b/astropy/tests/command.py
@@ -5,14 +5,15 @@ once astropy-helpers has reached end-of-life.
 
 """
 import os
-import stat
 import shutil
+import stat
 import subprocess
 import sys
 import tempfile
 from contextlib import contextmanager
 
 from setuptools import Command
+
 from astropy.logger import log
 
 
@@ -240,6 +241,7 @@ class AstropyTest(Command, metaclass=FixRemoteDataOption):
             retcode = testproc.wait()
         except KeyboardInterrupt:
             import signal
+
             # If a keyboard interrupt is handled, pass it to the test
             # subprocess to prompt pytest to initiate its teardown
             testproc.send_signal(signal.SIGINT)

--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -3,20 +3,19 @@
 This module provides the tools used to internally run the astropy test suite
 from the installed astropy.  It makes use of the `pytest`_ testing framework.
 """
-import os
-import sys
-import pickle
-import inspect
-import warnings
 import functools
+import inspect
+import os
+import pickle
+import sys
+import warnings
 
 import pytest
 
 from astropy.units import allclose as quantity_allclose  # noqa: F401
-from astropy.utils.decorators import deprecated
-from astropy.utils.exceptions import (AstropyDeprecationWarning,
-                                      AstropyPendingDeprecationWarning)
 from astropy.utils.compat import PYTHON_LT_3_11
+from astropy.utils.decorators import deprecated
+from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyPendingDeprecationWarning
 
 # For backward-compatibility with affiliated packages
 from .runner import TestRunner  # pylint: disable=W0611  # noqa
@@ -467,6 +466,7 @@ def assert_quantity_allclose(actual, desired, rtol=1.e-7, atol=None,
     :func:`numpy.testing.assert_allclose`.
     """
     import numpy as np
+
     from astropy.units.quantity import _unquantify_allclose_arguments
     np.testing.assert_allclose(*_unquantify_allclose_arguments(
         actual, desired, rtol, atol), **kwargs)

--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -1,20 +1,20 @@
 """Implements the Astropy TestRunner which is a thin wrapper around pytest."""
 
+import copy
+import glob
 import inspect
 import os
-import glob
-import copy
 import shlex
 import sys
 import tempfile
 import warnings
 from collections import OrderedDict
-from importlib.util import find_spec
 from functools import wraps
+from importlib.util import find_spec
 
-from astropy.config.paths import set_temp_config, set_temp_cache
+from astropy.config.paths import set_temp_cache, set_temp_config
 from astropy.utils import find_current_module
-from astropy.utils.exceptions import AstropyWarning, AstropyDeprecationWarning
+from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyWarning
 
 __all__ = ['TestRunner', 'TestRunnerBase', 'keyword']
 
@@ -541,7 +541,7 @@ class TestRunner(TestRunnerBase):
         """
         if parallel != 0:
             try:
-                from xdist import plugin # noqa
+                from xdist import plugin  # noqa
             except ImportError:
                 raise SystemError(
                     "running tests in parallel requires the pytest-xdist package")

--- a/astropy/tests/test_logger.py
+++ b/astropy/tests/test_logger.py
@@ -1,16 +1,16 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import importlib
+import locale
+import logging
 import sys
 import warnings
-import logging
-import locale
 
 import pytest
 
 from astropy import log
 from astropy.logger import LoggingError, conf
-from astropy.utils.exceptions import AstropyWarning, AstropyUserWarning
+from astropy.utils.exceptions import AstropyUserWarning, AstropyWarning
 
 # Save original values of hooks. These are not the system values, but the
 # already overwritten values since the logger already gets imported before

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,6 @@ archs = ["auto", "aarch64"]
         "examples/*",
         "astropy/extern/*",
         "astropy/nddata/*",
-        "astropy/tests/*",
         "astropy/timeseries/*",
         "astropy/uncertainty/*",
         "astropy/utils/*",


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
