### PR TITLE
isort wcs

### DIFF
--- a/astropy/wcs/__init__.py
+++ b/astropy/wcs/__init__.py
@@ -23,9 +23,9 @@ Each of these transformations can be used independently or together in
 a standard pipeline.
 """
 
+from . import utils
 from .wcs import *
 from .wcs import InvalidTabularParametersError  # just for docs
-from . import utils
 
 
 def get_include():

--- a/astropy/wcs/setup_package.py
+++ b/astropy/wcs/setup_package.py
@@ -2,18 +2,17 @@
 
 import io
 import os
-from os.path import join
 import os.path
 import shutil
 import sys
 from collections import defaultdict
+from os.path import join
 
+import numpy
 from setuptools import Extension
 from setuptools.dep_util import newer_group
 
-import numpy
-
-from extension_helpers import import_file, write_if_different, get_compiler, pkg_config
+from extension_helpers import get_compiler, import_file, pkg_config, write_if_different
 
 WCSROOT = os.path.relpath(os.path.dirname(__file__))
 WCSVERSION = "7.12"

--- a/astropy/wcs/tests/conftest.py
+++ b/astropy/wcs/tests/conftest.py
@@ -4,7 +4,7 @@ import pytest
 
 from astropy import wcs
 
-from . helper import SimModelTAB
+from .helper import SimModelTAB
 
 
 @pytest.fixture(scope='module')

--- a/astropy/wcs/tests/helper.py
+++ b/astropy/wcs/tests/helper.py
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-import pytest
-
 import numpy as np
+import pytest
 
 from astropy import wcs
 from astropy.io import fits

--- a/astropy/wcs/tests/test_auxprm.py
+++ b/astropy/wcs/tests/test_auxprm.py
@@ -7,7 +7,6 @@ from numpy.testing import assert_allclose
 from astropy.io import fits
 from astropy.wcs import WCS
 
-
 STR_EXPECTED_EMPTY = """
 rsun_ref:
 dsun_obs:

--- a/astropy/wcs/tests/test_celprm.py
+++ b/astropy/wcs/tests/test_celprm.py
@@ -1,12 +1,12 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from copy import copy, deepcopy
-import pytest
 
 import numpy as np
+import pytest
+
 from astropy import wcs
 
-from . helper import SimModelTAB
-
+from .helper import SimModelTAB
 
 _WCS_UNDEFINED = 987654321.0e99
 

--- a/astropy/wcs/tests/test_pickle.py
+++ b/astropy/wcs/tests/test_pickle.py
@@ -7,13 +7,12 @@ import numpy as np
 import pytest
 from numpy.testing import assert_array_almost_equal
 
-from astropy.utils.data import (get_pkg_data_contents, get_pkg_data_fileobj,
-                                get_pkg_data_filename)
-from astropy.utils.exceptions import AstropyDeprecationWarning
-from astropy.utils.misc import NumpyRNGContext
+from astropy import wcs
 from astropy.io import fits
 from astropy.io.fits.verify import VerifyWarning
-from astropy import wcs
+from astropy.utils.data import get_pkg_data_contents, get_pkg_data_filename, get_pkg_data_fileobj
+from astropy.utils.exceptions import AstropyDeprecationWarning
+from astropy.utils.misc import NumpyRNGContext
 from astropy.wcs.wcs import FITSFixedWarning
 
 

--- a/astropy/wcs/tests/test_prjprm.py
+++ b/astropy/wcs/tests/test_prjprm.py
@@ -1,11 +1,12 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from copy import copy, deepcopy
-import pytest
 
 import numpy as np
+import pytest
+
 from astropy import wcs
 
-from . helper import SimModelTAB
+from .helper import SimModelTAB
 
 
 def test_prjprm_init():

--- a/astropy/wcs/tests/test_profiling.py
+++ b/astropy/wcs/tests/test_profiling.py
@@ -2,13 +2,12 @@
 
 import os
 
-import pytest
 import numpy as np
-
-from astropy.utils.data import get_pkg_data_filenames, get_pkg_data_contents
-from astropy.utils.misc import NumpyRNGContext
+import pytest
 
 from astropy import wcs
+from astropy.utils.data import get_pkg_data_contents, get_pkg_data_filenames
+from astropy.utils.misc import NumpyRNGContext
 from astropy.wcs.wcs import FITSFixedWarning
 
 # use the base name of the file, because everything we yield

--- a/astropy/wcs/tests/test_tab.py
+++ b/astropy/wcs/tests/test_tab.py
@@ -2,16 +2,15 @@
 from copy import deepcopy
 
 import numpy as np
-
 import pytest
 from packaging.version import Version
+
 from astropy import wcs
-from astropy.wcs import _wcs  # noqa
 from astropy.io import fits
 from astropy.utils.data import get_pkg_data_filename
+from astropy.wcs import _wcs  # noqa
 
-from . helper import SimModelTAB
-
+from .helper import SimModelTAB
 
 _WCSLIB_VER = Version(_wcs.__version__)
 

--- a/astropy/wcs/tests/test_tabprm.py
+++ b/astropy/wcs/tests/test_tabprm.py
@@ -2,13 +2,12 @@
 
 from copy import deepcopy
 
-import pytest
-
 import numpy as np
+import pytest
 
 from astropy import wcs
 
-from . helper import SimModelTAB
+from .helper import SimModelTAB
 
 
 def test_wcsprm_tab_basic(tab_wcs_2di):

--- a/astropy/wcs/tests/test_utils.py
+++ b/astropy/wcs/tests/test_utils.py
@@ -2,41 +2,29 @@
 import warnings
 from contextlib import nullcontext
 
-import pytest
-
-from packaging.version import Version
 import numpy as np
-from numpy.testing import assert_almost_equal, assert_equal, assert_allclose
+import pytest
+from numpy.testing import assert_allclose, assert_almost_equal, assert_equal
+from packaging.version import Version
 
+from astropy import units as u
+from astropy.coordinates import ITRS, EarthLocation, SkyCoord
+from astropy.io import fits
+from astropy.time import Time
+from astropy.units import Quantity
+from astropy.utils import unbroadcast
+from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa
 from astropy.utils.data import get_pkg_data_contents, get_pkg_data_filename
 from astropy.utils.exceptions import AstropyUserWarning
-from astropy.time import Time
-from astropy import units as u
-from astropy.utils import unbroadcast
-from astropy.coordinates import SkyCoord, EarthLocation, ITRS
-from astropy.units import Quantity
-from astropy.io import fits
-
 from astropy.wcs import _wcs  # noqa
-from astropy.wcs.wcs import (WCS, Sip, WCSSUB_LONGITUDE, WCSSUB_LATITUDE,
-                             FITSFixedWarning)
+from astropy.wcs.utils import (
+    _pixel_to_pixel_correlation_matrix, _pixel_to_world_correlation_matrix, _split_matrix,
+    add_stokes_axis_to_wcs, celestial_frame_to_wcs, custom_frame_to_wcs_mappings,
+    custom_wcs_to_frame_mappings, fit_wcs_from_points, is_proj_plane_distorted,
+    local_partial_pixel_derivatives, non_celestial_pixel_scales, obsgeo_to_frame, pixel_to_pixel,
+    pixel_to_skycoord, proj_plane_pixel_scales, skycoord_to_pixel, wcs_to_celestial_frame)
+from astropy.wcs.wcs import WCS, WCSSUB_LATITUDE, WCSSUB_LONGITUDE, FITSFixedWarning, Sip
 from astropy.wcs.wcsapi.fitswcs import SlicedFITSWCS
-from astropy.wcs.utils import (proj_plane_pixel_scales,
-                               is_proj_plane_distorted,
-                               non_celestial_pixel_scales,
-                               wcs_to_celestial_frame,
-                               celestial_frame_to_wcs, skycoord_to_pixel,
-                               pixel_to_skycoord, custom_wcs_to_frame_mappings,
-                               custom_frame_to_wcs_mappings,
-                               add_stokes_axis_to_wcs,
-                               pixel_to_pixel,
-                               _split_matrix,
-                               _pixel_to_pixel_correlation_matrix,
-                               _pixel_to_world_correlation_matrix,
-                               local_partial_pixel_derivatives,
-                               fit_wcs_from_points,
-                               obsgeo_to_frame)
-from astropy.utils.compat.optional_deps import HAS_SCIPY  # noqa
 
 
 def test_wcs_dropping():
@@ -253,7 +241,7 @@ def test_celestial():
 def test_wcs_to_celestial_frame():
 
     # Import astropy.coordinates here to avoid circular imports
-    from astropy.coordinates.builtin_frames import ICRS, ITRS, FK5, FK4, Galactic
+    from astropy.coordinates.builtin_frames import FK4, FK5, ICRS, ITRS, Galactic
 
     mywcs = WCS(naxis=2)
     mywcs.wcs.set()
@@ -377,7 +365,7 @@ def test_wcs_to_celestial_frame_extend():
 def test_celestial_frame_to_wcs():
 
     # Import astropy.coordinates here to avoid circular imports
-    from astropy.coordinates import ICRS, ITRS, FK5, FK4, FK4NoETerms, Galactic, BaseCoordinateFrame
+    from astropy.coordinates import FK4, FK5, ICRS, ITRS, BaseCoordinateFrame, FK4NoETerms, Galactic
 
     class FakeFrame(BaseCoordinateFrame):
         pass

--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -5,25 +5,22 @@ import os
 from contextlib import nullcontext
 from datetime import datetime
 
-from packaging.version import Version
-import pytest
 import numpy as np
+import pytest
 from numpy.testing import (
-    assert_allclose, assert_array_almost_equal, assert_array_almost_equal_nulp,
-    assert_array_equal)
+    assert_allclose, assert_array_almost_equal, assert_array_almost_equal_nulp, assert_array_equal)
+from packaging.version import Version
 
-from astropy import wcs
-from astropy.wcs import _wcs  # noqa
 from astropy import units as u
-from astropy.utils.data import (
-    get_pkg_data_filenames, get_pkg_data_contents, get_pkg_data_filename)
-from astropy.utils.misc import NumpyRNGContext
-from astropy.utils.exceptions import (
-    AstropyUserWarning, AstropyWarning, AstropyDeprecationWarning)
-from astropy.tests.helper import assert_quantity_allclose
-from astropy.io import fits
+from astropy import wcs
 from astropy.coordinates import SkyCoord
+from astropy.io import fits
 from astropy.nddata import Cutout2D
+from astropy.tests.helper import assert_quantity_allclose
+from astropy.utils.data import get_pkg_data_contents, get_pkg_data_filename, get_pkg_data_filenames
+from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyUserWarning, AstropyWarning
+from astropy.utils.misc import NumpyRNGContext
+from astropy.wcs import _wcs  # noqa
 
 _WCSLIB_VER = Version(_wcs.__version__)
 

--- a/astropy/wcs/tests/test_wcsprm.py
+++ b/astropy/wcs/tests/test_wcsprm.py
@@ -4,20 +4,18 @@ import gc
 import locale
 import re
 
-from packaging.version import Version
-import pytest
 import numpy as np
-from numpy.testing import assert_array_equal, assert_array_almost_equal
+import pytest
+from numpy.testing import assert_array_almost_equal, assert_array_equal
+from packaging.version import Version
 
-from astropy.io import fits
-from astropy.wcs import wcs
-from astropy.wcs import _wcs
-from astropy.wcs.wcs import FITSFixedWarning
-from astropy.utils.data import (
-    get_pkg_data_contents, get_pkg_data_fileobj, get_pkg_data_filename)
-from astropy.utils.misc import _set_locale
 from astropy import units as u
+from astropy.io import fits
 from astropy.units.core import UnitsWarning
+from astropy.utils.data import get_pkg_data_contents, get_pkg_data_filename, get_pkg_data_fileobj
+from astropy.utils.misc import _set_locale
+from astropy.wcs import _wcs, wcs
+from astropy.wcs.wcs import FITSFixedWarning
 
 ######################################################################
 

--- a/astropy/wcs/tests/test_wtbarr.py
+++ b/astropy/wcs/tests/test_wtbarr.py
@@ -1,8 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-import pytest
-
 import numpy as np
+import pytest
 
 from astropy import wcs
 

--- a/astropy/wcs/utils.py
+++ b/astropy/wcs/utils.py
@@ -5,7 +5,7 @@ import copy
 import numpy as np
 
 import astropy.units as u
-from astropy.coordinates import CartesianRepresentation, SphericalRepresentation, ITRS
+from astropy.coordinates import ITRS, CartesianRepresentation, SphericalRepresentation
 from astropy.utils import unbroadcast
 
 from .wcs import WCS, WCSSUB_LATITUDE, WCSSUB_LONGITUDE
@@ -52,8 +52,8 @@ def add_stokes_axis_to_wcs(wcs, add_before_ind):
 def _wcs_to_celestial_frame_builtin(wcs):
 
     # Import astropy.coordinates here to avoid circular imports
-    from astropy.coordinates import (FK4, FK5, ICRS, ITRS, FK4NoETerms,
-                                     Galactic, SphericalRepresentation)
+    from astropy.coordinates import (
+        FK4, FK5, ICRS, ITRS, FK4NoETerms, Galactic, SphericalRepresentation)
     # Import astropy.time here otherwise setup.py fails before extensions are compiled
     from astropy.time import Time
 

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -28,30 +28,28 @@
 #    - `wcslib`_ WCS transformation (by a `~astropy.wcs.Wcsprm` object)
 
 # STDLIB
+import builtins
 import copy
-import uuid
 import io
 import itertools
 import os
 import re
 import textwrap
+import uuid
 import warnings
-import builtins
 
-# THIRD-
-from packaging.version import Version
+# THIRD-PARTY
 import numpy as np
+from packaging.version import Version
 
 # LOCAL
 from astropy import log
-from astropy.io import fits
-from . import docstrings
-from . import _wcs
-
 from astropy import units as u
-from astropy.utils.exceptions import AstropyWarning, AstropyUserWarning, AstropyDeprecationWarning
+from astropy.io import fits
 from astropy.utils.decorators import deprecated_renamed_argument
+from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyUserWarning, AstropyWarning
 
+from . import _wcs, docstrings
 # Mix-in class that provides the APE 14 API
 from .wcsapi.fitswcs import FITSWCSAPIMixin, SlicedFITSWCS
 

--- a/astropy/wcs/wcsapi/__init__.py
+++ b/astropy/wcs/wcsapi/__init__.py
@@ -1,5 +1,5 @@
-from .low_level_api import *  # noqa
 from .high_level_api import *  # noqa
 from .high_level_wcs_wrapper import *  # noqa
+from .low_level_api import *  # noqa
 from .utils import *  # noqa
 from .wrappers import *  # noqa

--- a/astropy/wcs/wcsapi/conftest.py
+++ b/astropy/wcs/wcsapi/conftest.py
@@ -1,5 +1,5 @@
-import pytest
 import numpy as np
+import pytest
 
 from astropy.coordinates import SkyCoord
 from astropy.units import Quantity

--- a/astropy/wcs/wcsapi/fitswcs.py
+++ b/astropy/wcs/wcsapi/fitswcs.py
@@ -8,13 +8,14 @@ import warnings
 import numpy as np
 
 from astropy import units as u
-from astropy.coordinates import SpectralCoord, Galactic, ICRS
-from astropy.coordinates.spectral_coordinate import update_differentials_to_match, attach_zero_velocities
-from astropy.utils.exceptions import AstropyUserWarning
 from astropy.constants import c
+from astropy.coordinates import ICRS, Galactic, SpectralCoord
+from astropy.coordinates.spectral_coordinate import (
+    attach_zero_velocities, update_differentials_to_match)
+from astropy.utils.exceptions import AstropyUserWarning
 
-from .low_level_api import BaseLowLevelWCS
 from .high_level_api import HighLevelWCSMixin
+from .low_level_api import BaseLowLevelWCS
 from .wrappers import SlicedLowLevelWCS
 
 __all__ = ['custom_ctype_to_ucd_mapping', 'SlicedFITSWCS', 'FITSWCSAPIMixin']
@@ -378,10 +379,10 @@ class FITSWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
                 self._components_and_classes_cache = None
 
         # Avoid circular imports by importing here
-        from astropy.wcs.utils import wcs_to_celestial_frame
-        from astropy.coordinates import SkyCoord, EarthLocation
-        from astropy.time.formats import FITS_DEPRECATED_SCALES
+        from astropy.coordinates import EarthLocation, SkyCoord
         from astropy.time import Time, TimeDelta
+        from astropy.time.formats import FITS_DEPRECATED_SCALES
+        from astropy.wcs.utils import wcs_to_celestial_frame
 
         components = [None] * self.naxis
         classes = {}

--- a/astropy/wcs/wcsapi/high_level_api.py
+++ b/astropy/wcs/wcsapi/high_level_api.py
@@ -1,5 +1,5 @@
 import abc
-from collections import defaultdict, OrderedDict
+from collections import OrderedDict, defaultdict
 
 import numpy as np
 

--- a/astropy/wcs/wcsapi/low_level_api.py
+++ b/astropy/wcs/wcsapi/low_level_api.py
@@ -1,5 +1,5 @@
-import os
 import abc
+import os
 
 import numpy as np
 

--- a/astropy/wcs/wcsapi/sliced_low_level_wcs.py
+++ b/astropy/wcs/wcsapi/sliced_low_level_wcs.py
@@ -1,7 +1,8 @@
 import warnings
 
-from .wrappers.sliced_wcs import SlicedLowLevelWCS, sanitize_slices
 from astropy.utils.exceptions import AstropyDeprecationWarning
+
+from .wrappers.sliced_wcs import SlicedLowLevelWCS, sanitize_slices
 
 warnings.warn(
     "SlicedLowLevelWCS has been moved to"

--- a/astropy/wcs/wcsapi/tests/test_fitswcs.py
+++ b/astropy/wcs/wcsapi/tests/test_fitswcs.py
@@ -3,27 +3,27 @@
 # a mix-in)
 
 import warnings
-
-from packaging.version import Version
-import numpy as np
-import pytest
-from numpy.testing import assert_equal, assert_allclose
 from itertools import product
 
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose, assert_equal
+from packaging.version import Version
+
 from astropy import units as u
-from astropy.time import Time
-from astropy.tests.helper import assert_quantity_allclose
-from astropy.units import Quantity
-from astropy.coordinates import ICRS, FK5, Galactic, SkyCoord, SpectralCoord, ITRS, EarthLocation
+from astropy.coordinates import FK5, ICRS, ITRS, EarthLocation, Galactic, SkyCoord, SpectralCoord
 from astropy.io.fits import Header
 from astropy.io.fits.verify import VerifyWarning
+from astropy.tests.helper import assert_quantity_allclose
+from astropy.time import Time
+from astropy.units import Quantity
 from astropy.units.core import UnitsWarning
-from astropy.utils.data import get_pkg_data_filename
-from astropy.wcs.wcs import WCS, FITSFixedWarning, Sip, NoConvergence
-from astropy.wcs.wcsapi.fitswcs import custom_ctype_to_ucd_mapping, VELOCITY_FRAMES
-from astropy.wcs._wcs import __version__ as wcsver
 from astropy.utils import iers
+from astropy.utils.data import get_pkg_data_filename
 from astropy.utils.exceptions import AstropyUserWarning
+from astropy.wcs._wcs import __version__ as wcsver
+from astropy.wcs.wcs import WCS, FITSFixedWarning, NoConvergence, Sip
+from astropy.wcs.wcsapi.fitswcs import VELOCITY_FRAMES, custom_ctype_to_ucd_mapping
 
 ###############################################################################
 # The following example is the simplest WCS with default values

--- a/astropy/wcs/wcsapi/tests/test_high_level_api.py
+++ b/astropy/wcs/wcsapi/tests/test_high_level_api.py
@@ -1,11 +1,11 @@
 import numpy as np
 from numpy.testing import assert_allclose
 
-from astropy.units import Quantity
 from astropy.coordinates import SkyCoord
-
+from astropy.units import Quantity
+from astropy.wcs.wcsapi.high_level_api import (
+    HighLevelWCSMixin, high_level_objects_to_values, values_to_high_level_objects)
 from astropy.wcs.wcsapi.low_level_api import BaseLowLevelWCS
-from astropy.wcs.wcsapi.high_level_api import HighLevelWCSMixin, high_level_objects_to_values, values_to_high_level_objects
 
 
 class DoubleLowLevelWCS(BaseLowLevelWCS):

--- a/astropy/wcs/wcsapi/tests/test_high_level_wcs_wrapper.py
+++ b/astropy/wcs/wcsapi/tests/test_high_level_wcs_wrapper.py
@@ -1,11 +1,10 @@
-import pytest
 import numpy as np
+import pytest
 from numpy.testing import assert_allclose
 
 from astropy.coordinates import SkyCoord
-
-from astropy.wcs.wcsapi.low_level_api import BaseLowLevelWCS
 from astropy.wcs.wcsapi.high_level_wcs_wrapper import HighLevelWCSWrapper
+from astropy.wcs.wcsapi.low_level_api import BaseLowLevelWCS
 
 
 class CustomLowLevelWCS(BaseLowLevelWCS):

--- a/astropy/wcs/wcsapi/tests/test_utils.py
+++ b/astropy/wcs/wcsapi/tests/test_utils.py
@@ -1,13 +1,11 @@
 import numpy as np
-from numpy.testing import assert_allclose
-
 import pytest
+from numpy.testing import assert_allclose
 from pytest import raises
 
 from astropy import units as u
-
-from astropy.wcs import WCS
 from astropy.tests.helper import assert_quantity_allclose
+from astropy.wcs import WCS
 from astropy.wcs.wcsapi.utils import deserialize_class, wcs_info_str
 
 

--- a/astropy/wcs/wcsapi/utils.py
+++ b/astropy/wcs/wcsapi/utils.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import importlib
+
 import numpy as np
 
 __all__ = ['deserialize_class', 'wcs_info_str']

--- a/astropy/wcs/wcsapi/wrappers/__init__.py
+++ b/astropy/wcs/wcsapi/wrappers/__init__.py
@@ -1,2 +1,2 @@
-from .sliced_wcs import *  # noqa
 from .base import BaseWCSWrapper
+from .sliced_wcs import *  # noqa

--- a/astropy/wcs/wcsapi/wrappers/tests/test_sliced_wcs.py
+++ b/astropy/wcs/wcsapi/wrappers/tests/test_sliced_wcs.py
@@ -1,21 +1,21 @@
 import warnings
 
-import pytest
-
 import numpy as np
-from numpy.testing import assert_equal, assert_allclose
-from astropy.wcs.wcs import WCS, FITSFixedWarning
-from astropy.time import Time
-from astropy.wcs import WCS
+import pytest
+from numpy.testing import assert_allclose, assert_equal
+
+import astropy.units as u
+from astropy.coordinates import ICRS, Galactic, SkyCoord
+from astropy.coordinates.spectral_coordinate import SpectralCoord
 from astropy.io.fits import Header
 from astropy.io.fits.verify import VerifyWarning
-from astropy.coordinates import SkyCoord, Galactic, ICRS
+from astropy.time import Time
 from astropy.units import Quantity
-from astropy.wcs.wcsapi.wrappers.sliced_wcs import SlicedLowLevelWCS, sanitize_slices, combine_slices
+from astropy.wcs import WCS
+from astropy.wcs.wcs import WCS, FITSFixedWarning
 from astropy.wcs.wcsapi.utils import wcs_info_str
-import astropy.units as u
-
-from astropy.coordinates.spectral_coordinate import SpectralCoord
+from astropy.wcs.wcsapi.wrappers.sliced_wcs import (
+    SlicedLowLevelWCS, combine_slices, sanitize_slices)
 
 # To test the slicing we start off from standard FITS WCS
 # objects since those implement the low-level API. We create

--- a/astropy/wcs/wcslint.py
+++ b/astropy/wcs/wcslint.py
@@ -5,8 +5,9 @@ Script support for validating the WCS keywords in a FITS file.
 
 
 def main(args=None):
-    from . import wcs
     import argparse
+
+    from . import wcs
 
     parser = argparse.ArgumentParser(
         description=("Check the WCS keywords in a FITS file for "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,6 @@ archs = ["auto", "aarch64"]
         "docs/*",
         "examples/*",
         "astropy/extern/*",
-        "astropy/wcs/*"
     ]
     line_length = 100
     known_third_party = ["erfa", "PyYAML", "packaging", "pytest", "scipy", "matplotlib"]


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
