### PR TITLE
In astropy/utils/data.py, update `_rmtree` to use `shutil.move` instead of `os.rename`.

### DIFF
--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -2046,6 +2046,13 @@ def _rmtree(path, replace=None):
                 )
             )
             raise
+        except OSError as e:
+            if e.errno == errno.EXDEV:
+                warn(e.strerror, AstropyWarning)
+                shutil.move(path, os.path.join(d, "to-zap"))
+            else:
+                raise
+
         if replace is not None:
             try:
                 os.rename(replace, path)
@@ -2056,6 +2063,9 @@ def _rmtree(path, replace=None):
                 if e.errno == errno.ENOTEMPTY:
                     # already there, fine
                     pass
+                elif e.errno == errno.EXDEV:
+                    warn(e.strerror, AstropyWarning)
+                    shutil.move(replace, path)
                 else:
                     raise
 

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -1825,6 +1825,26 @@ def test_import_file_cache_readonly(readonly_cache, tmp_path):
     assert not is_url_in_cache(url)
 
 
+def test_import_file_cache_invalid_cross_device_link(tmp_path, monkeypatch):
+    def no_rename(path, mode=None):
+        if os.path.exists(path):
+            raise OSError(errno.EXDEV, "os.rename monkeypatched out")
+        else:
+            raise FileNotFoundError(f"File {path} does not exist.")
+
+    monkeypatch.setattr(os, "rename", no_rename)
+
+    filename = tmp_path / "test-file"
+    content = "Some text or other"
+    url = "http://example.com/"
+    with open(filename, "w") as f:
+        f.write(content)
+
+    with pytest.warns(AstropyWarning, match="os.rename monkeypatched out"):
+        import_file_to_cache(url, filename, remove_original=True, replace=True)
+    assert is_url_in_cache(url)
+
+
 def test_download_file_cache_readonly_cache_miss(readonly_cache, valid_urls):
     u, c = next(valid_urls)
     with pytest.warns(CacheMissingWarning):
@@ -2136,6 +2156,37 @@ def test_clear_download_cache_variants(temp_cache, valid_urls):
     h = compute_hash(f)
     clear_download_cache(h)
     assert not is_url_in_cache(u)
+
+
+def test_clear_download_cache_invalid_cross_device_link(
+    temp_cache, valid_urls, monkeypatch
+):
+    def no_rename(path, mode=None):
+        raise OSError(errno.EXDEV, "os.rename monkeypatched out")
+
+    u, c = next(valid_urls)
+    download_file(u, cache=True)
+
+    monkeypatch.setattr(os, "rename", no_rename)
+
+    assert is_url_in_cache(u)
+    with pytest.warns(AstropyWarning, match="os.rename monkeypatched out"):
+        clear_download_cache(u)
+    assert not is_url_in_cache(u)
+
+
+def test_clear_download_cache_raises_os_error(temp_cache, valid_urls, monkeypatch):
+    def no_rename(path, mode=None):
+        raise OSError(errno.EBUSY, "os.rename monkeypatched out")
+
+    u, c = next(valid_urls)
+    download_file(u, cache=True)
+
+    monkeypatch.setattr(os, "rename", no_rename)
+
+    assert is_url_in_cache(u)
+    with pytest.warns(CacheMissingWarning, match="os.rename monkeypatched out"):
+        clear_download_cache(u)
 
 
 @pytest.mark.skipif(

--- a/docs/changes/utils/13730.bugfix.rst
+++ b/docs/changes/utils/13730.bugfix.rst
@@ -1,0 +1,3 @@
+When using astropy in environments with sparse file systems (e.g., where the temporary directory and astropy data directory resides in different volumes), ``os.rename`` may fail with ``OSError: [Errno 18] Invalid cross-device link``.
+This may affect some clean-up operations executed by the ``data`` module, causing them to fail.
+This patch is to catch ``OSError`` with ``errno == EXDEV`` (i.e., Errno 18) when performing these operations and try to use ``shutil.move`` instead to relocate the data.


### PR DESCRIPTION
Using `os.rename` may raise an 

```
OSError: [Errno 18] Invalid cross-device link
```

exception when running on a containairized environments deployed on kubernetes.

<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address an error we get when using astropy in a containerized environment deployed using Kubernetes. For some reason using `os.rename` on these environments raises an `OSError` exception even when the file is in the same directory. Replacing `os.rename` with `shuttle.move` solves this issue.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
