### PR TITLE
move config into own file

### DIFF
--- a/astropy/time/__init__.py
+++ b/astropy/time/__init__.py
@@ -1,21 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from astropy import config as _config
 
-
-class Conf(_config.ConfigNamespace):  # noqa
-    """
-    Configuration parameters for `astropy.table`.
-    """
-
-    use_fast_parser = _config.ConfigItem(
-        ['True', 'False', 'force'],
-        "Use fast C parser for supported time strings formats, including ISO, "
-        "ISOT, and YearDayTime. Allowed values are the 'False' (use Python parser),"
-        "'True' (use C parser and fall through to Python parser if fails), and "
-        "'force' (use C parser and raise exception if it fails). Note that the"
-        "options are all strings.")
-
-conf = Conf()  # noqa
+from .config import Conf  # included for backwards compatibility
+from .config import conf
 
 # isort: off
 from .formats import *  # noqa

--- a/astropy/time/config.py
+++ b/astropy/time/config.py
@@ -1,0 +1,22 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+from astropy import config as _config
+
+__all__ = []  # not public API; import from `astropy.time` directly
+
+
+class Conf(_config.ConfigNamespace):
+    """
+    Configuration parameters for :mod:`astropy.time`.
+    """
+
+    use_fast_parser = _config.ConfigItem(
+        ['True', 'False', 'force'],
+        "Use fast C parser for supported time strings formats, including ISO, "
+        "ISOT, and YearDayTime. Allowed values are the 'False' (use Python parser),"
+        "'True' (use C parser and fall through to Python parser if fails), and "
+        "'force' (use C parser and raise exception if it fails). Note that the"
+        "options are all strings.")
+
+
+conf = Conf()

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -28,7 +28,7 @@ from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyWarning
 
 # Import TimeFromEpoch to avoid breaking code that followed the old example of
 # making a custom timescale in the documentation.
-from .formats import TimeFromEpoch  # noqa
+from .formats import TimeFromEpoch  # noqa: F401
 from .formats import (
     TIME_DELTA_FORMATS, TIME_FORMATS, TimeAstropyTime, TimeDatetime, TimeJD, TimeUnique)
 from .time_helper.function_helpers import CUSTOM_FUNCTIONS, UNSUPPORTED_FUNCTIONS

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -14,7 +14,8 @@ import astropy.units as u
 from astropy.utils.decorators import classproperty, lazyproperty
 from astropy.utils.exceptions import AstropyDeprecationWarning
 
-from . import _parse_times, conf, utils
+from . import _parse_times, utils
+from .config import conf
 from .utils import day_frac, quantity_day_frac, two_product, two_sum
 
 __all__ = ['TimeFormat', 'TimeJD', 'TimeMJD', 'TimeFromEpoch', 'TimeUnix',


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>


### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
