### PR TITLE
move pytest config to `tox.ini`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -112,56 +112,6 @@ astropy.tests.figures = *.json
 astropy.wcs = include/*/*.h
 astropy.wcs.tests = extension/*.c
 
-[tool:pytest]
-minversion = 7.0
-testpaths = "astropy" "docs"
-norecursedirs =
-    "docs[\/]_build"
-    "docs[\/]generated"
-    "astropy[\/]extern"
-    "astropy[\/]_dev"
-astropy_header = true
-doctest_plus = enabled
-text_file_format = rst
-open_files_ignore = "astropy.log" "/etc/hosts" "*.ttf"
-remote_data_strict = true
-addopts = --color=yes --doctest-rst
-xfail_strict = true
-qt_no_exception_capture = 1
-filterwarnings =
-    error
-    ignore:unclosed <socket:ResourceWarning
-    ignore:unclosed <ssl.SSLSocket:ResourceWarning
-    ignore:numpy\.ufunc size changed:RuntimeWarning
-    ignore:numpy\.ndarray size changed:RuntimeWarning
-    ignore:Importing from numpy:DeprecationWarning:scipy
-    ignore:Conversion of the second argument:FutureWarning:scipy
-    ignore:Using a non-tuple sequence:FutureWarning:scipy
-    ignore:Using or importing the ABCs from 'collections':DeprecationWarning
-    ignore:Unknown pytest\.mark\.mpl_image_compare:pytest.PytestUnknownMarkWarning
-    ignore:Unknown config option:pytest.PytestConfigWarning
-    ignore:matplotlibrc text\.usetex:UserWarning:matplotlib
-    ignore:The 'text' argument to find\(\)-type methods is deprecated:DeprecationWarning
-    # Triggered by ProgressBar > ipykernel.iostream
-    ignore:the imp module is deprecated:DeprecationWarning
-    # toolz internal deprecation warning https://github.com/pytoolz/toolz/issues/500
-    ignore:The toolz\.compatibility module is no longer needed:DeprecationWarning
-    # Ignore a warning we emit about not supporting the parallel
-    # reading option for now, can be removed once the issue is fixed
-    ignore:parallel reading does not currently work, so falling back to serial
-    # numpy configurable allocator now wants memory policy set
-    ignore:Trying to dealloc data, but a memory policy is not set.
-    # Ignore deprecation warning for asdf in astropy
-    ignore:ASDF functionality for astropy is being moved.*:astropy.utils.exceptions.AstropyDeprecationWarning:astropy.io.misc.asdf.types
-    ignore:ASDF functionality for astropy is being moved.*:astropy.utils.exceptions.AstropyDeprecationWarning:astropy.io.misc.asdf.tags.coordinates.frames
-    ignore:ASDF functionality for astropy is being moved.*:astropy.utils.exceptions.AstropyDeprecationWarning:astropy.io.misc.asdf.tags.transform.compound
-    ignore:ASDF functionality for astropy is being moved.*:astropy.utils.exceptions.AstropyDeprecationWarning:astropy.io.misc.asdf.connect
-doctest_norecursedirs =
-    */setup_package.py
-doctest_subpackage_requires =
-    astropy/io/misc/asdf/* = asdf
-    astropy/table/mixins/dask.py = dask
-
 [flake8]
 max-line-length = 100
 exclude = extern,*parsetab.py,*lextab.py

--- a/tox.ini
+++ b/tox.ini
@@ -178,3 +178,58 @@ commands =
                 --hidden-import pytest_doctestplus.plugin \
                 --hidden-import pytest_mpl.plugin
     ./run_astropy_tests --astropy-root {toxinidir}
+
+
+[pytest]
+# Pytest configuration. Eventually this will be moved to `pyproject.toml`, but 2
+# things need to happen first:
+# 1. pytest should finalize their TOML syntax (not done in v<6.0)
+# 2. doctest-plus needs to support pyproject configuration.
+minversion = 7.0
+testpaths = "astropy" "docs"
+norecursedirs =
+    "docs[\/]_build"
+    "docs[\/]generated"
+    "astropy[\/]extern"
+    "astropy[\/]_dev"
+astropy_header = true
+doctest_plus = enabled
+text_file_format = rst
+open_files_ignore = "astropy.log" "/etc/hosts" "*.ttf"
+remote_data_strict = true
+addopts = --color=yes --doctest-rst
+xfail_strict = true
+qt_no_exception_capture = 1
+filterwarnings =
+    error
+    ignore:unclosed <socket:ResourceWarning
+    ignore:unclosed <ssl.SSLSocket:ResourceWarning
+    ignore:numpy\.ufunc size changed:RuntimeWarning
+    ignore:numpy\.ndarray size changed:RuntimeWarning
+    ignore:Importing from numpy:DeprecationWarning:scipy
+    ignore:Conversion of the second argument:FutureWarning:scipy
+    ignore:Using a non-tuple sequence:FutureWarning:scipy
+    ignore:Using or importing the ABCs from 'collections':DeprecationWarning
+    ignore:Unknown pytest\.mark\.mpl_image_compare:pytest.PytestUnknownMarkWarning
+    ignore:Unknown config option:pytest.PytestConfigWarning
+    ignore:matplotlibrc text\.usetex:UserWarning:matplotlib
+    ignore:The 'text' argument to find\(\)-type methods is deprecated:DeprecationWarning
+    # Triggered by ProgressBar > ipykernel.iostream
+    ignore:the imp module is deprecated:DeprecationWarning
+    # toolz internal deprecation warning https://github.com/pytoolz/toolz/issues/500
+    ignore:The toolz\.compatibility module is no longer needed:DeprecationWarning
+    # Ignore a warning we emit about not supporting the parallel
+    # reading option for now, can be removed once the issue is fixed
+    ignore:parallel reading does not currently work, so falling back to serial
+    # numpy configurable allocator now wants memory policy set
+    ignore:Trying to dealloc data, but a memory policy is not set.
+    # Ignore deprecation warning for asdf in astropy
+    ignore:ASDF functionality for astropy is being moved.*:astropy.utils.exceptions.AstropyDeprecationWarning:astropy.io.misc.asdf.types
+    ignore:ASDF functionality for astropy is being moved.*:astropy.utils.exceptions.AstropyDeprecationWarning:astropy.io.misc.asdf.tags.coordinates.frames
+    ignore:ASDF functionality for astropy is being moved.*:astropy.utils.exceptions.AstropyDeprecationWarning:astropy.io.misc.asdf.tags.transform.compound
+    ignore:ASDF functionality for astropy is being moved.*:astropy.utils.exceptions.AstropyDeprecationWarning:astropy.io.misc.asdf.connect
+doctest_norecursedirs =
+    */setup_package.py
+doctest_subpackage_requires =
+    astropy/io/misc/asdf/* = asdf
+    astropy/table/mixins/dask.py = dask


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

One more step on the roadmap to deprecating `setup.cfg`. Eventually `pytest` will support ``pyproject.toml`` (support is currently in beta), but until then I've moved the configuration to ``tox.ini``. While this sounds like a weird place to put the configuration, ``pytest`` actually prefers ``tox.ini`` to ``setup.cfg`` (https://docs.pytest.org/en/7.1.x/reference/customize.html#setup-cfg)!


### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
