### PR TITLE
pre-commit comments layout

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -72,43 +72,43 @@ repos:
         args: ["--py38-plus"]
         exclude: ".*(extern.*|_parsetab.py|_lextab.py)$"
 
-  # We list the warnings/errors to check for here rather than in setup.cfg because
-  # we don't want these options to apply whenever anyone calls flake8 from the
-  # command-line or their code editor - in this case all warnings/errors should be
-  # checked for. The warnings/errors we check for here are:
-  # E101 - mix of tabs and spaces
-  # W191 - use of tabs
-  # E201 - whitespace after '('
-  # E202 - whitespace before ')'
-  # W291 - trailing whitespace
-  # W292 - no newline at end of file
-  # W293 - trailing whitespace
-  # W391 - blank line at end of file
-  # E111 - 4 spaces per indentation level
-  # E112 - 4 spaces per indentation level
-  # E113 - 4 spaces per indentation level
-  # E301 - expected 1 blank line, found 0
-  # E302 - expected 2 blank lines, found 0
-  # E303 - too many blank lines (3)
-  # E304 - blank lines found after function decorator
-  # E305 - expected 2 blank lines after class or function definition
-  # E306 - expected 1 blank line before a nested definition
-  # E502 - the backslash is redundant between brackets
-  # E722 - do not use bare except
-  # E901 - SyntaxError or IndentationError
-  # E902 - IOError
-  # E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree
-  # F822: undefined name in __all__
-  # F823: local variable name referenced before assignment
+
   - repo: https://github.com/PyCQA/flake8
     rev: 5.0.4
     hooks:
       - id: flake8
+        # We list the warnings/errors to check for here rather than in setup.cfg because
+        # we don't want these options to apply whenever anyone calls flake8 from the
+        # command-line or their code editor - in this case all warnings/errors should be
+        # checked for. The warnings/errors we check for here are:
         args:
           [
             "--count",
             "--select",
-            "E101,W191,E201,E202,W291,W292,W293,W391,E111,E112,E113,E30,E502,E722,E901,E902,E999,F822,F823",
+            "E101,",  # mix of tabs and spaces
+            "W191,",  # use of tabs
+            "E201,",  # whitespace after '('
+            "E202,",  # whitespace before ')'
+            "W291,",  # trailing whitespace
+            "W292,",  # no newline at end of file
+            "W293,",  # trailing whitespace
+            "W391,",  # blank line at end of file
+            "E111,",  # 4 spaces per indentation level
+            "E112,",  # 4 spaces per indentation level
+            "E113,",  # 4 spaces per indentation level
+            "E301,",  # expected 1 blank line, found 0
+            "E302,",  # expected 2 blank lines, found 0
+            "E303,",  # too many blank lines (3)
+            "E304,",  # blank lines found after function decorator
+            "E305,",  # expected 2 blank lines after class or function definition
+            "E306,",  # expected 1 blank line before a nested definition
+            "E502,",  # the backslash is redundant between brackets
+            "E722,",  # do not use bare except
+            "E901,",  # SyntaxError or IndentationError
+            "E902,",  # IOError
+            "E999,",  # SyntaxError -- failed to compile a file into an Abstract Syntax Tree
+            "F822,",  # undefined name in __all__
+            "F823,",  # local variable name referenced before assignment
           ]
         exclude: ".*(data.*|extern.*|cextern)$"
 


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

Followup to #13703.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
