### PR TITLE
Fix flake8 issues for modeling

### DIFF
--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -2121,7 +2121,7 @@ class Model(metaclass=_ModelMeta):
                 return_units = self.return_units
 
             outputs = tuple(Quantity(out, return_units.get(out_name, None), subok=True)
-                             for out, out_name in zip(outputs, self.outputs))
+                            for out, out_name in zip(outputs, self.outputs))
         return outputs
 
     @staticmethod
@@ -4017,7 +4017,7 @@ def binary_operation(binoperator, left, right):
     '''
     if isinstance(left, tuple) and isinstance(right, tuple):
         return tuple(binoperator(item[0], item[1])
-                      for item in zip(left, right))
+                     for item in zip(left, right))
     return binoperator(left, right)
 
 

--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -80,10 +80,10 @@ class Covariance():
                             .format(repr(np.round(row[:i+1], round_val))[7:-2]))
             else:
                 ret_str += '...'
-        return(ret_str.rstrip())
+        return ret_str.rstrip()
 
     def __repr__(self):
-        return(self.pprint(max_lines=10, round_val=3))
+        return self.pprint(max_lines=10, round_val=3)
 
     def __getitem__(self, params):
         # index covariance matrix by parameter names or indices
@@ -95,7 +95,7 @@ class Covariance():
             i1, i2 = params
         else:
             raise TypeError('Covariance can be indexed by two parameter names or integer indices.')
-        return(self.cov_matrix[i1][i2])
+        return self.cov_matrix[i1][i2]
 
 
 class StandardDeviations():
@@ -121,10 +121,10 @@ class StandardDeviations():
                             f"{np.round(std, round_val)}\n")
             else:
                 ret_str += '...'
-        return(ret_str.rstrip())
+        return ret_str.rstrip()
 
     def __repr__(self):
-        return(self.pprint(max_lines=10, round_val=3))
+        return self.pprint(max_lines=10, round_val=3)
 
     def __getitem__(self, param):
         if isinstance(param, str):
@@ -133,7 +133,7 @@ class StandardDeviations():
             i = param
         else:
             raise TypeError('Standard deviation can be indexed by parameter name or integer.')
-        return(self.stds[i])
+        return self.stds[i]
 
 
 class ModelsError(Exception):
@@ -393,7 +393,7 @@ class LinearLSQFitter(metaclass=_FitterMeta):
 
         # check if invertible. if not, can't calc covariance.
         if not self._is_invertible(x_dot_x_prime):
-            return(model)
+            return model
         inv_x_dot_x_prime = np.linalg.inv(x_dot_x_prime)
 
         if z is None:  # 1D models
@@ -1076,7 +1076,8 @@ class _NonLinearLSQFitter(metaclass=_FitterMeta):
         if not np.all(np.isfinite(value)):
             raise NonFiniteValueError("Objective function has encountered a non-finite value, "
                                       "this will cause the fit to fail!\n"
-                                      "Please remove non-finite values from your input data before fitting to avoid this error.")
+                                      "Please remove non-finite values from your input data before "
+                                      "fitting to avoid this error.")
 
         return value
 
@@ -1143,7 +1144,8 @@ class _NonLinearLSQFitter(metaclass=_FitterMeta):
                 try:
                     output = np.array([np.ravel(_) for _ in np.array(weights) * fit_deriv])
                     if output.shape != fit_deriv.shape:
-                        output = np.array([np.ravel(_) for _ in np.atleast_2d(weights).T * fit_deriv])
+                        output = np.array([np.ravel(_)
+                                           for _ in np.atleast_2d(weights).T * fit_deriv])
                     return output
                 except ValueError:
                     return np.array([np.ravel(_) for _ in np.array(weights) *

--- a/astropy/modeling/tests/test_fitters.py
+++ b/astropy/modeling/tests/test_fitters.py
@@ -836,15 +836,15 @@ class TestWeightedFittingWithOutlierRemoval:
         fitter = FittingWithOutlierRemoval(LinearLSQFitter(), sigma_clip,
                                            niter=3, sigma=3.)
         fit, mask = fitter(model, self.x1d, self.z1d)
-        assert((~mask).sum() == self.z1d.size - 2)
-        assert(mask[0] and mask[1])
+        assert (~mask).sum() == self.z1d.size - 2
+        assert mask[0] and mask[1]
         assert_allclose(fit.parameters[0], 0.0, atol=10**(-2))  # with removed outliers mean is 0.0
 
     def test_1d_with_weights_without_sigma_clip(self):
         model = models.Polynomial1D(0)
         fitter = LinearLSQFitter()
         fit = fitter(model, self.x1d, self.z1d, weights=self.weights1d)
-        assert(fit.parameters[0] > 1.0)     # outliers pulled it high
+        assert fit.parameters[0] > 1.0      # outliers pulled it high
 
     def test_1d_with_weights_with_sigma_clip(self):
         """
@@ -855,9 +855,9 @@ class TestWeightedFittingWithOutlierRemoval:
         fitter = FittingWithOutlierRemoval(LinearLSQFitter(), sigma_clip,
                                            niter=3, sigma=3.)
         fit, filtered = fitter(model, self.x1d, self.z1d, weights=self.weights1d)
-        assert(fit.parameters[0] > 10**(-2))  # weights pulled it > 0
+        assert fit.parameters[0] > 10**(-2)  # weights pulled it > 0
         # outliers didn't pull it out of [-1:1] because they had been removed
-        assert(fit.parameters[0] < 1.0)
+        assert fit.parameters[0] < 1.0
 
     def test_1d_set_with_common_weights_with_sigma_clip(self):
         """added for #6819 (1D model set with weights in common)"""
@@ -891,8 +891,8 @@ class TestWeightedFittingWithOutlierRemoval:
         fitter = FittingWithOutlierRemoval(LinearLSQFitter(), sigma_clip,
                                            niter=3, sigma=3.)
         fit, mask = fitter(model, self.x, self.y, self.z)
-        assert((~mask).sum() == self.z.size - 2)
-        assert(mask[0, 0] and mask[0, 1])
+        assert (~mask).sum() == self.z.size - 2
+        assert mask[0, 0] and mask[0, 1]
         assert_allclose(fit.parameters[0], 0.0, atol=10**(-2))
 
     @pytest.mark.parametrize('fitter', non_linear_fitters)
@@ -903,13 +903,13 @@ class TestWeightedFittingWithOutlierRemoval:
         with pytest.warns(AstropyUserWarning,
                           match=r'Model is linear in parameters'):
             fit = fitter(model, self.x, self.y, self.z, weights=self.weights)
-        assert(fit.parameters[0] > 1.0)     # outliers pulled it high
+        assert fit.parameters[0] > 1.0      # outliers pulled it high
 
     def test_2d_linear_with_weights_without_sigma_clip(self):
         model = models.Polynomial2D(0)
         fitter = LinearLSQFitter()  # LinearLSQFitter doesn't handle weights properly in 2D
         fit = fitter(model, self.x, self.y, self.z, weights=self.weights)
-        assert(fit.parameters[0] > 1.0)     # outliers pulled it high
+        assert fit.parameters[0] > 1.0     # outliers pulled it high
 
     @pytest.mark.parametrize('base_fitter', non_linear_fitters)
     def test_2d_with_weights_with_sigma_clip(self, base_fitter):
@@ -923,9 +923,9 @@ class TestWeightedFittingWithOutlierRemoval:
         with pytest.warns(AstropyUserWarning,
                           match=r'Model is linear in parameters'):
             fit, _ = fitter(model, self.x, self.y, self.z, weights=self.weights)
-        assert(fit.parameters[0] > 10**(-2))  # weights pulled it > 0
+        assert fit.parameters[0] > 10**(-2)  # weights pulled it > 0
         # outliers didn't pull it out of [-1:1] because they had been removed
-        assert(fit.parameters[0] < 1.0)
+        assert fit.parameters[0] < 1.0
 
     def test_2d_linear_with_weights_with_sigma_clip(self):
         """same as test above with a linear fitter."""
@@ -933,9 +933,9 @@ class TestWeightedFittingWithOutlierRemoval:
         fitter = FittingWithOutlierRemoval(LinearLSQFitter(), sigma_clip,
                                            niter=3, sigma=3.)
         fit, _ = fitter(model, self.x, self.y, self.z, weights=self.weights)
-        assert(fit.parameters[0] > 10**(-2))  # weights pulled it > 0
+        assert fit.parameters[0] > 10**(-2)  # weights pulled it > 0
         # outliers didn't pull it out of [-1:1] because they had been removed
-        assert(fit.parameters[0] < 1.0)
+        assert fit.parameters[0] < 1.0
 
 
 @pytest.mark.skipif('not HAS_SCIPY')

--- a/astropy/modeling/tests/test_models.py
+++ b/astropy/modeling/tests/test_models.py
@@ -782,7 +782,7 @@ def test_with_bounding_box():
     # test the order of bbox is not reversed for 1D models
     p = models.Polynomial1D(1, c0=12, c1=2.3)
     p.bounding_box = (0, 5)
-    assert(p(1) == p(1, with_bounding_box=True))
+    assert p(1) == p(1, with_bounding_box=True)
 
     t3 = models.Shift(10) & models.Scale(2) & models.Shift(-1)
     t3.bounding_box = ((4.3, 6.9), (6, 15), (-1, 10))

--- a/astropy/modeling/tests/test_physical_models.py
+++ b/astropy/modeling/tests/test_physical_models.py
@@ -46,10 +46,10 @@ def test_blackbody_input_units():
     SNU = u.erg / (u.cm ** 2 * u.s * u.Hz * u.sr)
 
     b_lam = BlackBody(3000*u.K, scale=1*SLAM)
-    assert(b_lam.input_units['x'] == u.AA)
+    assert b_lam.input_units['x'] == u.AA
 
     b_nu = BlackBody(3000*u.K, scale=1*SNU)
-    assert(b_nu.input_units['x'] == u.Hz)
+    assert b_nu.input_units['x'] == u.Hz
 
 
 def test_blackbody_return_units():
@@ -182,7 +182,7 @@ def test_blackbody_dimensionless():
     bb2.evaluate(0.5, T.value, scale.to_value(u.dimensionless_unscaled))
 
     # bolometric flux for both cases should be equivalent
-    assert(bb1.bolometric_flux == bb2.bolometric_flux)
+    assert bb1.bolometric_flux == bb2.bolometric_flux
 
 
 @pytest.mark.skipif("not HAS_SCIPY")
@@ -203,7 +203,7 @@ def test_blackbody_dimensionless_fit():
     bb1_fit = fitter(bb1, wav, fnu, maxiter=1000)
     bb2_fit = fitter(bb2, wav, fnu, maxiter=1000)
 
-    assert(bb1_fit.temperature == bb2_fit.temperature)
+    assert bb1_fit.temperature == bb2_fit.temperature
 
 
 @pytest.mark.parametrize("mass", (2.0000000000000E15 * u.M_sun, 3.976819741e+45 * u.kg))


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

As pointed out by #13735, many flake8 checks set forth by the `setup.cfg` `flake8` configuration have not been enforced. This PR makes all the fixes to correct this for `astropy.modeling`.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
