### PR TITLE
Flake8 fixes for astropy.cosmology

### DIFF
--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -82,7 +82,7 @@ class Cosmology(metaclass=abc.ABCMeta):
     write = UnifiedReadWriteMethod(CosmologyWrite)
 
     # Parameters
-    __parameters__: tuple[str, ...]  = ()
+    __parameters__: tuple[str, ...] = ()
     __all_parameters__: tuple[str, ...] = ()
 
     # ---------------------------------------------------------------
@@ -413,7 +413,7 @@ class FlatCosmologyMixin(metaclass=abc.ABCMeta):
     # ===============================================================
 
     @classmethod  # TODO! make metaclass-method
-    def _get_nonflat_cls(cls, kls: type[_CosmoT] | None=None) -> type[Cosmology] | None:
+    def _get_nonflat_cls(cls, kls: type[_CosmoT] | None = None) -> type[Cosmology] | None:
         """Find the corresponding non-flat class.
 
         The class' bases are searched recursively.

--- a/astropy/cosmology/flrw/base.py
+++ b/astropy/cosmology/flrw/base.py
@@ -1441,7 +1441,7 @@ class FlatFLRWMixin(FlatCosmologyMixin):
         # Create BoundArgument to handle args versus kwargs.
         # This also handles all errors from mismatched arguments
         ba = self.__nonflatclass__._init_signature.bind_partial(**self._init_arguments,
-                                                             Ode0=self.Ode0)
+                                                                Ode0=self.Ode0)
         # Make new instance, respecting args vs kwargs
         inst = self.__nonflatclass__(*ba.args, **ba.kwargs)
         # Because of machine precision, make sure parameters exactly match

--- a/astropy/cosmology/funcs/__init__.py
+++ b/astropy/cosmology/funcs/__init__.py
@@ -4,6 +4,6 @@
 
 from .comparison import cosmology_equal
 # _z_at_scalar_value is imported for backards compat
-from .optimize import _z_at_scalar_value, z_at_value  # F401, F403
+from .optimize import _z_at_scalar_value, z_at_value  # noqa: F401, F403
 
 __all__ = ["z_at_value", "cosmology_equal"]

--- a/astropy/cosmology/funcs/comparison.py
+++ b/astropy/cosmology/funcs/comparison.py
@@ -70,7 +70,7 @@ def _wrap_to_ufunc(nin: int, nout: int) -> Callable[[_CompFnT], np.ufunc]:
 
 
 @_wrap_to_ufunc(2, 1)
-def _parse_format(cosmo: Any, format: _FormatType, /,) -> Cosmology:
+def _parse_format(cosmo: Any, format: _FormatType, /) -> Cosmology:
     """Parse Cosmology-like input into Cosmologies, given a format hint.
 
     Parameters
@@ -207,7 +207,7 @@ def _comparison_decorator(pyfunc: Callable[..., Any]) -> Callable[..., Any]:
 
 
 @_comparison_decorator
-def cosmology_equal(cosmo1: Any, cosmo2: Any, /, *, allow_equivalent: bool=False) -> bool:
+def cosmology_equal(cosmo1: Any, cosmo2: Any, /, *, allow_equivalent: bool = False) -> bool:
     r"""Return element-wise equality check on the cosmologies.
 
     .. note::
@@ -322,7 +322,7 @@ def cosmology_equal(cosmo1: Any, cosmo2: Any, /, *, allow_equivalent: bool=False
 
 
 @_comparison_decorator
-def _cosmology_not_equal(cosmo1: Any, cosmo2: Any, /, *, allow_equivalent: bool=False) -> bool:
+def _cosmology_not_equal(cosmo1: Any, cosmo2: Any, /, *, allow_equivalent: bool = False) -> bool:
     r"""Return element-wise cosmology non-equality check.
 
     .. note::

--- a/astropy/cosmology/funcs/tests/test_comparison.py
+++ b/astropy/cosmology/funcs/tests/test_comparison.py
@@ -40,7 +40,7 @@ class ComparisonFunctionTestBase(ToFromTestMixinBase):
                     "so does not have an equivalent non-flat cosmology.")
 
     @pytest.fixture(scope="class",
-    params={k for k, _ in convert_registry._readers.keys()} - {"astropy.cosmology"})
+                    params={k for k, _ in convert_registry._readers.keys()} - {"astropy.cosmology"})
     def format(self, request):
         return request.param
 
@@ -144,7 +144,7 @@ class Test_parse_format(ComparisonFunctionTestBase):
 
         # more complex broadcast
         out = _parse_format([[cosmo, converted], [converted, cosmo]],
-                             [[None, format], [format, None]])
+                            [[None, format], [format, None]])
         assert out.shape == (2, 2)
         assert np.all(out == cosmo)
 
@@ -203,10 +203,13 @@ class Test_cosmology_equal(ComparisonFunctionTestBase):
         # non-equality
         assert cosmology_equal(cosmo, pert_converted, format=[None, format]) is False
 
-    def test_cosmology_equal_equivalent_format_specify(self, cosmo, format, converted, cosmo_eqvxflat):
+    def test_cosmology_equal_equivalent_format_specify(self, cosmo, format, converted,
+                                                       cosmo_eqvxflat):
         # specifying the format
-        assert cosmology_equal(cosmo_eqvxflat, converted, format=[None, format], allow_equivalent=True) is True
-        assert cosmology_equal(converted, cosmo_eqvxflat, format=[format, None], allow_equivalent=True) is True
+        assert cosmology_equal(cosmo_eqvxflat, converted, format=[None, format],
+                               allow_equivalent=True) is True
+        assert cosmology_equal(converted, cosmo_eqvxflat, format=[format, None],
+                               allow_equivalent=True) is True
 
 
 class Test_cosmology_not_equal(ComparisonFunctionTestBase):
@@ -252,9 +255,13 @@ class Test_cosmology_not_equal(ComparisonFunctionTestBase):
         # equality
         assert _cosmology_not_equal(cosmo, converted, format=[None, format]) is False
 
-    def test_cosmology_not_equal_equivalent_format_specify(self, cosmo, format, converted, cosmo_eqvxflat):
+    def test_cosmology_not_equal_equivalent_format_specify(self, cosmo, format, converted,
+                                                           cosmo_eqvxflat):
         # specifying the format
-        assert _cosmology_not_equal(cosmo_eqvxflat, converted, format=[None, format], allow_equivalent=False) is True
-        assert _cosmology_not_equal(cosmo_eqvxflat, converted, format=[None, format], allow_equivalent=True) is False
+        assert _cosmology_not_equal(cosmo_eqvxflat, converted, format=[None, format],
+                                    allow_equivalent=False) is True
+        assert _cosmology_not_equal(cosmo_eqvxflat, converted, format=[None, format],
+                                    allow_equivalent=True) is False
 
-        assert _cosmology_not_equal(converted, cosmo_eqvxflat, format=[format, None], allow_equivalent=True) is False
+        assert _cosmology_not_equal(converted, cosmo_eqvxflat, format=[format, None],
+                                    allow_equivalent=True) is False

--- a/astropy/cosmology/tests/test_core.py
+++ b/astropy/cosmology/tests/test_core.py
@@ -306,7 +306,6 @@ class TestCosmology(ParameterTestMixin, MetaTestMixin,
 
         # parameters in string rep
         ps = {k: getattr(cosmo, k) for k in cosmo.__parameters__}
-        cps = {k: getattr(cosmo_cls, k) for k in cosmo.__parameters__}
         for k, v in ps.items():
             sv = f"{k}={v}"
             assert sv in r


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

As pointed out by #13735, many flake8 checks set forth by the `setup.cfg` `flake8` configuration have not been enforced. This PR makes all the fixes to correct this for `astropy.cosmology`.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
