### PR TITLE
Flake8 fixes for astropy.constants

### DIFF
--- a/astropy/constants/codata2010.py
+++ b/astropy/constants/codata2010.py
@@ -10,6 +10,7 @@ from .constant import Constant, EMConstant
 
 # PHYSICAL CONSTANTS
 
+
 class CODATA2010(Constant):
     default_reference = 'CODATA 2010'
     _registry = {}

--- a/astropy/constants/codata2014.py
+++ b/astropy/constants/codata2014.py
@@ -10,6 +10,7 @@ from .constant import Constant, EMConstant
 
 # PHYSICAL CONSTANTS
 
+
 class CODATA2014(Constant):
     default_reference = 'CODATA 2014'
     _registry = {}

--- a/astropy/constants/codata2018.py
+++ b/astropy/constants/codata2018.py
@@ -10,6 +10,7 @@ from .constant import Constant, EMConstant
 # PHYSICAL CONSTANTS
 # https://en.wikipedia.org/wiki/2019_redefinition_of_SI_base_units
 
+
 class CODATA2018(Constant):
     default_reference = 'CODATA 2018'
     _registry = {}

--- a/astropy/constants/constant.py
+++ b/astropy/constants/constant.py
@@ -52,7 +52,7 @@ class ConstantMeta(type):
                         'units across all systems of units and cannot be '
                         'combined with other values without specifying a '
                         'system (eg. {}.{})'.format(self.abbrev, self.abbrev,
-                                                      systems[0]))
+                                                    systems[0]))
 
                 return meth(self, *args, **kwargs)
 
@@ -118,9 +118,9 @@ class Constant(Quantity, metaclass=ConstantMeta):
         inst = np.array(value).view(cls)
 
         if system in instances:
-                warnings.warn('Constant {!r} already has a definition in the '
-                              '{!r} system from {!r} reference'.format(
-                              name, system, reference), AstropyUserWarning)
+            warnings.warn(f'Constant {name!r} already has a definition in '
+                          f'the {system!r} system from {reference!r} reference',
+                          AstropyUserWarning)
         for c in instances.values():
             if system is not None and not hasattr(c.__class__, system):
                 setattr(c, system, inst)
@@ -143,8 +143,8 @@ class Constant(Quantity, metaclass=ConstantMeta):
     def __repr__(self):
         return ('<{} name={!r} value={} uncertainty={} unit={!r} '
                 'reference={!r}>'.format(self.__class__, self.name, self.value,
-                                          self.uncertainty, str(self.unit),
-                                          self.reference))
+                                         self.uncertainty, str(self.unit),
+                                         self.reference))
 
     def __str__(self):
         return ('  Name   = {}\n'
@@ -152,8 +152,8 @@ class Constant(Quantity, metaclass=ConstantMeta):
                 '  Uncertainty  = {}\n'
                 '  Unit  = {}\n'
                 '  Reference = {}'.format(self.name, self.value,
-                                           self.uncertainty, self.unit,
-                                           self.reference))
+                                          self.uncertainty, self.unit,
+                                          self.reference))
 
     def __quantity_subclass__(self, unit):
         return super().__quantity_subclass__(unit)[0], False


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

As pointed out by #13735, many flake8 checks set forth by the `setup.cfg` `flake8` configuration have not been enforced. This PR makes all the fixes to correct this for `astropy.constants`.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
