### PR TITLE
PSF image representation in NDData/CCDData

### DIFF
--- a/astropy/nddata/ccddata.py
+++ b/astropy/nddata/ccddata.py
@@ -286,7 +286,7 @@ class CCDData(NDDataArray):
     def to_hdu(self, hdu_mask='MASK', hdu_uncertainty='UNCERT',
                hdu_flags=None, wcs_relax=True,
                key_uncertainty_type='UTYPE', as_image_hdu=False,
-               hdu_psf="PSFIMAGE"):
+               hdu_psf='PSFIMAGE'):
         """Creates an HDUList object from a CCDData object.
 
         Parameters
@@ -297,7 +297,7 @@ class CCDData(NDDataArray):
             Flags are not supported at this time. If ``None`` this attribute
             is not appended.
             Default is ``'MASK'`` for mask, ``'UNCERT'`` for uncertainty,
-            "PSFIMAGE" for psf, and ``None`` for flags.
+            ``'PSFIMAGE'`` for psf, and ``None`` for flags.
 
         wcs_relax : bool
             Value of the ``relax`` parameter to use in converting the WCS to a
@@ -556,7 +556,7 @@ def _generate_wcs_and_update_header(hdr):
 
 def fits_ccddata_reader(filename, hdu=0, unit=None, hdu_uncertainty='UNCERT',
                         hdu_mask='MASK', hdu_flags=None,
-                        key_uncertainty_type='UTYPE', hdu_psf="PSFIMAGE", **kwd):
+                        key_uncertainty_type='UTYPE', hdu_psf='PSFIMAGE', **kwd):
     """
     Generate a CCDData object from a FITS file.
 
@@ -707,7 +707,7 @@ def fits_ccddata_reader(filename, hdu=0, unit=None, hdu_uncertainty='UNCERT',
 def fits_ccddata_writer(
         ccd_data, filename, hdu_mask='MASK', hdu_uncertainty='UNCERT',
         hdu_flags=None, key_uncertainty_type='UTYPE', as_image_hdu=False,
-        hdu_psf="PSFIMAGE",
+        hdu_psf='PSFIMAGE',
         **kwd):
     """
     Write CCDData object to FITS file.
@@ -726,7 +726,7 @@ def fits_ccddata_writer(
         Flags are not supported at this time. If ``None`` this attribute
         is not appended.
         Default is ``'MASK'`` for mask, ``'UNCERT'`` for uncertainty,
-        "PSFIMAGE" for psf, and ``None`` for flags.
+        ``'PSFIMAGE'`` for psf, and ``None`` for flags.
 
     key_uncertainty_type : str, optional
         The header key name for the class name of the uncertainty (if any)

--- a/astropy/nddata/ccddata.py
+++ b/astropy/nddata/ccddata.py
@@ -702,6 +702,9 @@ def fits_ccddata_writer(
 
     Parameters
     ----------
+    ccd_data : CCDData
+        Object to write.
+
     filename : str
         Name of file.
 

--- a/astropy/nddata/ccddata.py
+++ b/astropy/nddata/ccddata.py
@@ -273,18 +273,19 @@ class CCDData(NDDataArray):
 
     def to_hdu(self, hdu_mask='MASK', hdu_uncertainty='UNCERT',
                hdu_flags=None, wcs_relax=True,
-               key_uncertainty_type='UTYPE', as_image_hdu=False):
+               key_uncertainty_type='UTYPE', as_image_hdu=False,
+               hdu_psf="PSFIMAGE"):
         """Creates an HDUList object from a CCDData object.
 
         Parameters
         ----------
-        hdu_mask, hdu_uncertainty, hdu_flags : str or None, optional
+        hdu_mask, hdu_uncertainty, hdu_flags, hdu_psf: str or None, optional
             If it is a string append this attribute to the HDUList as
             `~astropy.io.fits.ImageHDU` with the string as extension name.
             Flags are not supported at this time. If ``None`` this attribute
             is not appended.
-            Default is ``'MASK'`` for mask, ``'UNCERT'`` for uncertainty and
-            ``None`` for flags.
+            Default is ``'MASK'`` for mask, ``'UNCERT'`` for uncertainty,
+            "PSFIMAGE" for psf, and ``None`` for flags.
 
         wcs_relax : bool
             Value of the ``relax`` parameter to use in converting the WCS to a
@@ -400,6 +401,11 @@ class CCDData(NDDataArray):
         if hdu_flags and self.flags:
             raise NotImplementedError('adding the flags to a HDU is not '
                                       'supported at this time.')
+
+        if hdu_psf and self.psf is not None:
+            # The PSF is an image, so write it as a separate ImageHDU.
+            hdu_psf = fits.ImageHDU(self.psf, name=hdu_psf)
+            hdus.append(hdu_psf)
 
         hdulist = fits.HDUList(hdus)
 
@@ -538,7 +544,7 @@ def _generate_wcs_and_update_header(hdr):
 
 def fits_ccddata_reader(filename, hdu=0, unit=None, hdu_uncertainty='UNCERT',
                         hdu_mask='MASK', hdu_flags=None,
-                        key_uncertainty_type='UTYPE', **kwd):
+                        key_uncertainty_type='UTYPE', hdu_psf="PSFIMAGE", **kwd):
     """
     Generate a CCDData object from a FITS file.
 
@@ -581,6 +587,10 @@ def fits_ccddata_reader(filename, hdu=0, unit=None, hdu_uncertainty='UNCERT',
 
         .. versionadded:: 3.1
 
+    hdu_psf : str or None, optional
+        FITS extension from which the psf image should be initialized. If the
+        extension does not exist the psf of the CCDData is ``None``.
+
     kwd :
         Any additional keyword parameters are passed through to the FITS reader
         in :mod:`astropy.io.fits`; see Notes for additional discussion.
@@ -622,6 +632,11 @@ def fits_ccddata_reader(filename, hdu=0, unit=None, hdu_uncertainty='UNCERT',
         if hdu_flags is not None and hdu_flags in hdus:
             raise NotImplementedError('loading flags is currently not '
                                       'supported.')
+
+        if hdu_psf is not None and hdu_psf in hdus:
+            psf = hdus[hdu_psf].data
+        else:
+            psf = None
 
         # search for the first instance with data if
         # the primary header is empty.
@@ -672,7 +687,7 @@ def fits_ccddata_reader(filename, hdu=0, unit=None, hdu_uncertainty='UNCERT',
         use_unit = unit or fits_unit_string
         hdr, wcs = _generate_wcs_and_update_header(hdr)
         ccd_data = CCDData(hdus[hdu].data, meta=hdr, unit=use_unit,
-                           mask=mask, uncertainty=uncertainty, wcs=wcs)
+                           mask=mask, uncertainty=uncertainty, wcs=wcs, psf=psf)
 
     return ccd_data
 
@@ -680,6 +695,7 @@ def fits_ccddata_reader(filename, hdu=0, unit=None, hdu_uncertainty='UNCERT',
 def fits_ccddata_writer(
         ccd_data, filename, hdu_mask='MASK', hdu_uncertainty='UNCERT',
         hdu_flags=None, key_uncertainty_type='UTYPE', as_image_hdu=False,
+        hdu_psf="PSFIMAGE",
         **kwd):
     """
     Write CCDData object to FITS file.
@@ -689,13 +705,13 @@ def fits_ccddata_writer(
     filename : str
         Name of file.
 
-    hdu_mask, hdu_uncertainty, hdu_flags : str or None, optional
+    hdu_mask, hdu_uncertainty, hdu_flags, hdu_psf : str or None, optional
         If it is a string append this attribute to the HDUList as
         `~astropy.io.fits.ImageHDU` with the string as extension name.
         Flags are not supported at this time. If ``None`` this attribute
         is not appended.
-        Default is ``'MASK'`` for mask, ``'UNCERT'`` for uncertainty and
-        ``None`` for flags.
+        Default is ``'MASK'`` for mask, ``'UNCERT'`` for uncertainty,
+        "PSFIMAGE" for psf, and ``None`` for flags.
 
     key_uncertainty_type : str, optional
         The header key name for the class name of the uncertainty (if any)
@@ -727,7 +743,7 @@ def fits_ccddata_writer(
     hdu = ccd_data.to_hdu(
         hdu_mask=hdu_mask, hdu_uncertainty=hdu_uncertainty,
         key_uncertainty_type=key_uncertainty_type, hdu_flags=hdu_flags,
-        as_image_hdu=as_image_hdu)
+        as_image_hdu=as_image_hdu, hdu_psf=hdu_psf)
     if as_image_hdu:
         hdu.insert(0, fits.PrimaryHDU())
     hdu.writeto(filename, **kwd)

--- a/astropy/nddata/ccddata.py
+++ b/astropy/nddata/ccddata.py
@@ -130,8 +130,9 @@ class CCDData(NDDataArray):
             ``ValueError``
 
     psf : `numpy.ndarray` or None, optional
-        Normalized image representing the PSF at the center of this
-        image.
+        Image representation of the PSF at the center of this image. In order
+        for convolution to be flux-preserving, this should generally be
+        normalized to sum to unity.
 
     Raises
     ------

--- a/astropy/nddata/ccddata.py
+++ b/astropy/nddata/ccddata.py
@@ -130,7 +130,8 @@ class CCDData(NDDataArray):
             ``ValueError``
 
     psf : `numpy.ndarray` or None, optional
-        Normalized PSF image at the center of this image.
+        Normalized image representing the PSF at the center of this
+        image.
 
     Raises
     ------

--- a/astropy/nddata/ccddata.py
+++ b/astropy/nddata/ccddata.py
@@ -129,6 +129,9 @@ class CCDData(NDDataArray):
             If the unit is ``None`` or not otherwise specified it will raise a
             ``ValueError``
 
+    psf : `numpy.ndarray` or None, optional
+        Normalized PSF image at the center of this image.
+
     Raises
     ------
     ValueError

--- a/astropy/nddata/ccddata.py
+++ b/astropy/nddata/ccddata.py
@@ -297,7 +297,7 @@ class CCDData(NDDataArray):
             Flags are not supported at this time. If ``None`` this attribute
             is not appended.
             Default is ``'MASK'`` for mask, ``'UNCERT'`` for uncertainty,
-            ``'PSFIMAGE'`` for psf, and ``None`` for flags.
+            ``'PSFIMAGE'`` for psf, and `None` for flags.
 
         wcs_relax : bool
             Value of the ``relax`` parameter to use in converting the WCS to a
@@ -726,7 +726,7 @@ def fits_ccddata_writer(
         Flags are not supported at this time. If ``None`` this attribute
         is not appended.
         Default is ``'MASK'`` for mask, ``'UNCERT'`` for uncertainty,
-        ``'PSFIMAGE'`` for psf, and ``None`` for flags.
+        ``'PSFIMAGE'`` for psf, and `None` for flags.
 
     key_uncertainty_type : str, optional
         The header key name for the class name of the uncertainty (if any)

--- a/astropy/nddata/ccddata.py
+++ b/astropy/nddata/ccddata.py
@@ -241,6 +241,16 @@ class CCDData(NDDataArray):
         self._unit = u.Unit(value)
 
     @property
+    def psf(self):
+        return self._psf
+
+    @psf.setter
+    def psf(self, value):
+        if value is not None and not isinstance(value, np.ndarray):
+            raise TypeError("The psf must be a numpy array.")
+        self._psf = value
+
+    @property
     def header(self):
         return self._meta
 

--- a/astropy/nddata/ccddata.py
+++ b/astropy/nddata/ccddata.py
@@ -291,7 +291,7 @@ class CCDData(NDDataArray):
 
         Parameters
         ----------
-        hdu_mask, hdu_uncertainty, hdu_flags, hdu_psf: str or None, optional
+        hdu_mask, hdu_uncertainty, hdu_flags, hdu_psf : str or None, optional
             If it is a string append this attribute to the HDUList as
             `~astropy.io.fits.ImageHDU` with the string as extension name.
             Flags are not supported at this time. If ``None`` this attribute
@@ -601,7 +601,7 @@ def fits_ccddata_reader(filename, hdu=0, unit=None, hdu_uncertainty='UNCERT',
 
     hdu_psf : str or None, optional
         FITS extension from which the psf image should be initialized. If the
-        extension does not exist the psf of the CCDData is ``None``.
+        extension does not exist the psf of the CCDData is `None`.
 
     kwd :
         Any additional keyword parameters are passed through to the FITS reader

--- a/astropy/nddata/mixins/ndarithmetic.py
+++ b/astropy/nddata/mixins/ndarithmetic.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # This module implements the Arithmetic mixin to the NDData class.
 
+import warnings
 
 from copy import deepcopy
 
@@ -256,6 +257,10 @@ class NDArithmeticMixin:
             kwargs['uncertainty'] = self._arithmetic_uncertainty(
                 operation, operand, result, uncertainty_correlation,
                 **kwds2['uncertainty'])
+
+        # If both are None, there is nothing to do.
+        if self.psf is not None or operand.psf is not None:
+            warnings.warn(f"Not setting psf attribute during {operation.__name__}.", RuntimeWarning)
 
         if handle_mask is None:
             kwargs['mask'] = None

--- a/astropy/nddata/mixins/ndarithmetic.py
+++ b/astropy/nddata/mixins/ndarithmetic.py
@@ -2,7 +2,6 @@
 # This module implements the Arithmetic mixin to the NDData class.
 
 import warnings
-
 from copy import deepcopy
 
 import numpy as np

--- a/astropy/nddata/mixins/ndarithmetic.py
+++ b/astropy/nddata/mixins/ndarithmetic.py
@@ -9,6 +9,7 @@ import numpy as np
 from astropy.nddata.nduncertainty import NDUncertainty
 from astropy.units import dimensionless_unscaled
 from astropy.utils import format_doc, sharedmethod
+from astropy.utils.exceptions import AstropyUserWarning
 
 __all__ = ['NDArithmeticMixin']
 
@@ -259,7 +260,8 @@ class NDArithmeticMixin:
 
         # If both are None, there is nothing to do.
         if self.psf is not None or operand.psf is not None:
-            warnings.warn(f"Not setting psf attribute during {operation.__name__}.", RuntimeWarning)
+            warnings.warn(f"Not setting psf attribute during {operation.__name__}.",
+                          AstropyUserWarning)
 
         if handle_mask is None:
             kwargs['mask'] = None

--- a/astropy/nddata/mixins/tests/test_ndarithmetic.py
+++ b/astropy/nddata/mixins/tests/test_ndarithmetic.py
@@ -1,5 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+import warnings
+
 import numpy as np
 import pytest
 from numpy.testing import assert_array_almost_equal, assert_array_equal
@@ -1213,3 +1215,21 @@ def test_arithmetics_unknown_uncertainties():
 
     ndd4 = ndd1.add(ndd2, propagate_uncertainties=None)
     assert ndd4.uncertainty is None
+
+
+def test_psf_warning():
+    """Test that math on objects with a psf warn."""
+    ndd1 = NDDataArithmetic(np.ones((3, 3)), psf=np.zeros(3))
+    ndd2 = NDDataArithmetic(np.ones((3, 3)), psf=None)
+
+    # no warning if both are None
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        ndd2.add(ndd2)
+
+    with pytest.warns(RuntimeWarning, match="Not setting psf attribute during add"):
+        ndd1.add(ndd2)
+    with pytest.warns(RuntimeWarning, match="Not setting psf attribute during add"):
+        ndd2.add(ndd1)
+    with pytest.warns(RuntimeWarning, match="Not setting psf attribute during add"):
+        ndd1.add(ndd1)

--- a/astropy/nddata/mixins/tests/test_ndarithmetic.py
+++ b/astropy/nddata/mixins/tests/test_ndarithmetic.py
@@ -1,7 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-import warnings
-
 import numpy as np
 import pytest
 from numpy.testing import assert_array_almost_equal, assert_array_equal

--- a/astropy/nddata/mixins/tests/test_ndarithmetic.py
+++ b/astropy/nddata/mixins/tests/test_ndarithmetic.py
@@ -13,6 +13,7 @@ from astropy.nddata.nduncertainty import (
     IncompatibleUncertaintiesException, InverseVariance, StdDevUncertainty, UnknownUncertainty,
     VarianceUncertainty)
 from astropy.units import Quantity, UnitsError
+from astropy.utils.exceptions import AstropyUserWarning
 from astropy.wcs import WCS
 
 # Alias NDDataAllMixins in case this will be renamed ... :-)
@@ -1223,13 +1224,11 @@ def test_psf_warning():
     ndd2 = NDDataArithmetic(np.ones((3, 3)), psf=None)
 
     # no warning if both are None
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
-        ndd2.add(ndd2)
+    ndd2.add(ndd2)
 
-    with pytest.warns(RuntimeWarning, match="Not setting psf attribute during add"):
+    with pytest.warns(AstropyUserWarning, match="Not setting psf attribute during add"):
         ndd1.add(ndd2)
-    with pytest.warns(RuntimeWarning, match="Not setting psf attribute during add"):
+    with pytest.warns(AstropyUserWarning, match="Not setting psf attribute during add"):
         ndd2.add(ndd1)
-    with pytest.warns(RuntimeWarning, match="Not setting psf attribute during add"):
+    with pytest.warns(AstropyUserWarning, match="Not setting psf attribute during add"):
         ndd1.add(ndd1)

--- a/astropy/nddata/nddata.py
+++ b/astropy/nddata/nddata.py
@@ -78,8 +78,8 @@ class NDData(NDDataBase):
         .. versionadded:: 1.2
 
     psf : `numpy.ndarray` or None, optional
-        Normalized image representing the PSF at the center of this
-        image.
+        Image representation of the PSF. In order for convolution to be flux-
+        preserving, this should generally be normalized to sum to unity.
 
     Raises
     ------

--- a/astropy/nddata/nddata.py
+++ b/astropy/nddata/nddata.py
@@ -77,6 +77,9 @@ class NDData(NDDataBase):
 
         .. versionadded:: 1.2
 
+    psf : `numpy.ndarray` or None, optional
+        Normalized PSF image at the center of this image.
+
     Raises
     ------
     TypeError
@@ -119,7 +122,7 @@ class NDData(NDDataBase):
     meta = MetaData(doc=_meta_doc, copy=False)
 
     def __init__(self, data, uncertainty=None, mask=None, wcs=None,
-                 meta=None, unit=None, copy=False):
+                 meta=None, unit=None, copy=False, psf=None):
 
         # Rather pointless since the NDDataBase does not implement any setting
         # but before the NDDataBase did call the uncertainty
@@ -165,6 +168,12 @@ class NDData(NDDataBase):
                          "wcs with specified wcs.")
             elif data.wcs is not None:
                 wcs = data.wcs
+
+            if psf is not None and data.psf is not None:
+                log.info("Overwriting NDData's current "
+                         "psf with specified psf.")
+            elif data.psf is not None:
+                psf = data.psf
 
             if meta is not None and data.meta is not None:
                 log.info("overwriting NDData's current "
@@ -218,6 +227,7 @@ class NDData(NDDataBase):
             data = deepcopy(data)
             mask = deepcopy(mask)
             wcs = deepcopy(wcs)
+            psf = deepcopy(psf)
             meta = deepcopy(meta)
             uncertainty = deepcopy(uncertainty)
             # Actually - copying the unit is unnecessary but better safe
@@ -235,6 +245,7 @@ class NDData(NDDataBase):
         self._unit = unit
         # Call the setter for uncertainty to further check the uncertainty
         self.uncertainty = uncertainty
+        self.psf = psf
 
     def __str__(self):
         data = str(self.data)
@@ -296,6 +307,16 @@ class NDData(NDDataBase):
         else:
             raise TypeError("The wcs argument must implement either the high or"
                             " low level WCS API.")
+
+    @property
+    def psf(self):
+        return self._psf
+
+    @psf.setter
+    def psf(self, value):
+        if value is not None and not isinstance(value, np.ndarray):
+            raise TypeError("The psf must be a numpy array.")
+        self._psf = value
 
     @property
     def uncertainty(self):

--- a/astropy/nddata/nddata.py
+++ b/astropy/nddata/nddata.py
@@ -315,8 +315,6 @@ class NDData(NDDataBase):
 
     @psf.setter
     def psf(self, value):
-        if value is not None and not isinstance(value, np.ndarray):
-            raise TypeError("The psf must be a numpy array.")
         self._psf = value
 
     @property

--- a/astropy/nddata/nddata.py
+++ b/astropy/nddata/nddata.py
@@ -78,7 +78,8 @@ class NDData(NDDataBase):
         .. versionadded:: 1.2
 
     psf : `numpy.ndarray` or None, optional
-        Normalized PSF image at the center of this image.
+        Normalized image representing the PSF at the center of this
+        image.
 
     Raises
     ------

--- a/astropy/nddata/nddata_base.py
+++ b/astropy/nddata/nddata_base.py
@@ -56,6 +56,15 @@ class NDDataBase(metaclass=ABCMeta):
 
     @property
     @abstractmethod
+    def psf(self):
+        """Image representation of the PSF for the dataset.
+
+        Should be `ndarray`-like.
+        """
+        return None
+
+    @property
+    @abstractmethod
     def meta(self):
         """Additional meta information about the dataset.
 

--- a/astropy/nddata/nddata_base.py
+++ b/astropy/nddata/nddata_base.py
@@ -54,8 +54,8 @@ class NDDataBase(metaclass=ABCMeta):
         """
         return None
 
+    # psf is concrete to avoid introducing a breaking change in release 5.2.
     @property
-    @abstractmethod
     def psf(self):
         """Image representation of the PSF for the dataset.
 

--- a/astropy/nddata/tests/test_ccddata.py
+++ b/astropy/nddata/tests/test_ccddata.py
@@ -1105,19 +1105,19 @@ def test_psf_setter():
         ccd.psf = "something"
 
 
-def test_write_read_psf(tmpdir):
+def test_write_read_psf(tmp_path):
     """Test that we can round-trip a CCDData with an attached PSF image."""
     ccd_data = create_ccd_data()
     ccd_data.psf = _random_psf
 
-    filename = tmpdir.join('test_write_read_psf.fits').strpath
+    filename = tmp_path / 'test_write_read_psf.fits'
     ccd_data.write(filename)
     ccd_disk = CCDData.read(filename)
     np.testing.assert_array_equal(ccd_data.data, ccd_disk.data)
     np.testing.assert_array_equal(ccd_data.psf, ccd_disk.psf)
 
     # Try a different name for the PSF HDU.
-    filename = tmpdir.join('test_write_read_psf_hdu.fits').strpath
+    filename = tmp_path / 'test_write_read_psf_hdu.fits'
     ccd_data.write(filename, hdu_psf="PSFOTHER")
     # psf will be None if we don't supply the new HDU name to the reader.
     ccd_disk = CCDData.read(filename)

--- a/astropy/nddata/tests/test_ccddata.py
+++ b/astropy/nddata/tests/test_ccddata.py
@@ -23,7 +23,7 @@ DEFAULT_DATA_SIZE = 100
 
 with NumpyRNGContext(123):
     _random_array = np.random.normal(size=[DEFAULT_DATA_SIZE, DEFAULT_DATA_SIZE])
-    _random_psf = np.random.normal(size=[20, 20])
+    _random_psf = np.random.normal(size=(20, 20))
 
 
 @pytest.fixture
@@ -1106,7 +1106,7 @@ def test_psf_setter():
 
 
 def test_write_read_psf(tmpdir):
-    """Test that we can round-trip a ccddata with an attached psf image."""
+    """Test that we can round-trip a CCDData with an attached PSF image."""
     ccd_data = create_ccd_data()
     ccd_data.psf = _random_psf
 

--- a/astropy/nddata/tests/test_ccddata.py
+++ b/astropy/nddata/tests/test_ccddata.py
@@ -23,6 +23,7 @@ DEFAULT_DATA_SIZE = 100
 
 with NumpyRNGContext(123):
     _random_array = np.random.normal(size=[DEFAULT_DATA_SIZE, DEFAULT_DATA_SIZE])
+    _random_psf = np.random.normal(size=[20, 20])
 
 
 @pytest.fixture
@@ -1081,3 +1082,26 @@ def test_read_write_tilde_paths(home_is_tmpdir):
     # Ensure the unexpanded path doesn't exist (e.g. no directory whose name is
     # a literal ~ was created)
     assert not os.path.exists(filename)
+
+
+def test_ccddata_with_psf():
+    psf = _random_psf.copy()
+    ccd = CCDData(_random_array.copy(), unit=u.adu, psf=psf)
+    assert (ccd.psf == psf).all()
+
+    # cannot pass in non-ndarray
+    with pytest.raises(TypeError) as exc:
+        CCDData(_random_array.copy(), unit=u.adu, psf="something")
+    assert "The psf must be a numpy array." in str(exc.value)
+
+
+def test_psf_setter():
+    psf = _random_psf.copy()
+    ccd = CCDData(_random_array.copy(), unit=u.adu)
+    ccd.psf = psf
+    assert (ccd.psf == psf).all()
+
+    # cannot set with non-ndarray
+    with pytest.raises(TypeError) as exc:
+        ccd.psf = "something"
+    assert "The psf must be a numpy array." in str(exc.value)

--- a/astropy/nddata/tests/test_ccddata.py
+++ b/astropy/nddata/tests/test_ccddata.py
@@ -1102,7 +1102,7 @@ def test_psf_setter():
 
     # cannot set with non-ndarray
     with pytest.raises(TypeError, match="The psf must be a numpy array."):
-        ccd.psf = "something"
+        ccd.psf = _random_array * u.pix
 
 
 def test_write_read_psf(tmp_path):

--- a/astropy/nddata/tests/test_ccddata.py
+++ b/astropy/nddata/tests/test_ccddata.py
@@ -1102,7 +1102,7 @@ def test_psf_setter():
 
     # cannot set with non-ndarray
     with pytest.raises(TypeError, match="The psf must be a numpy array."):
-        ccd.psf = _random_array * u.pix
+        ccd.psf = 5
 
 
 def test_write_read_psf(tmp_path):

--- a/astropy/nddata/tests/test_ccddata.py
+++ b/astropy/nddata/tests/test_ccddata.py
@@ -1090,9 +1090,8 @@ def test_ccddata_with_psf():
     assert (ccd.psf == psf).all()
 
     # cannot pass in non-ndarray
-    with pytest.raises(TypeError) as exc:
+    with pytest.raises(TypeError, match="The psf must be a numpy array."):
         CCDData(_random_array.copy(), unit=u.adu, psf="something")
-    assert "The psf must be a numpy array." in str(exc.value)
 
 
 def test_psf_setter():
@@ -1102,9 +1101,8 @@ def test_psf_setter():
     assert (ccd.psf == psf).all()
 
     # cannot set with non-ndarray
-    with pytest.raises(TypeError) as exc:
+    with pytest.raises(TypeError, match="The psf must be a numpy array."):
         ccd.psf = "something"
-    assert "The psf must be a numpy array." in str(exc.value)
 
 
 def test_write_read_psf(tmpdir):

--- a/astropy/nddata/tests/test_nddata.py
+++ b/astropy/nddata/tests/test_nddata.py
@@ -58,11 +58,12 @@ class MinimalUncertainty:
 class BadNDDataSubclass(NDData):
 
     def __init__(self, data, uncertainty=None, mask=None, wcs=None,
-                 meta=None, unit=None):
+                 meta=None, unit=None, psf=None):
         self._data = data
         self._uncertainty = uncertainty
         self._mask = mask
         self._wcs = wcs
+        self._psf = psf
         self._unit = unit
         self._meta = meta
 
@@ -205,6 +206,7 @@ def test_nddata_init_data_nddata():
     assert nd2.mask == nd1.mask
     assert nd2.unit == nd1.unit
     assert nd2.meta == nd1.meta
+    assert nd2.psf == nd1.psf
 
     # Check that it is copied by reference
     nd1 = NDData(np.ones((5, 5)))
@@ -218,7 +220,7 @@ def test_nddata_init_data_nddata():
 
     # Now let's see what happens if we have all explicitly set
     nd1 = NDData(np.array([1]), mask=False, uncertainty=StdDevUncertainty(10), unit=u.s,
-                 meta={'dest': 'mordor'}, wcs=WCS(naxis=1))
+                 meta={'dest': 'mordor'}, wcs=WCS(naxis=1), psf=np.array([10]))
     nd2 = NDData(nd1)
     assert nd2.data is nd1.data
     assert nd2.wcs is nd1.wcs
@@ -226,22 +228,24 @@ def test_nddata_init_data_nddata():
     assert nd2.mask == nd1.mask
     assert nd2.unit == nd1.unit
     assert nd2.meta == nd1.meta
+    assert nd2.psf == nd1.psf
 
     # now what happens if we overwrite them all too
     nd3 = NDData(nd1, mask=True, uncertainty=StdDevUncertainty(200), unit=u.km,
-                 meta={'observer': 'ME'}, wcs=WCS(naxis=1))
+                 meta={'observer': 'ME'}, wcs=WCS(naxis=1), psf=np.array([20]))
     assert nd3.data is nd1.data
     assert nd3.wcs is not nd1.wcs
     assert nd3.uncertainty.array != nd1.uncertainty.array
     assert nd3.mask != nd1.mask
     assert nd3.unit != nd1.unit
     assert nd3.meta != nd1.meta
+    assert nd3.psf != nd1.psf
 
 
 def test_nddata_init_data_nddata_subclass():
     uncert = StdDevUncertainty(3)
     # There might be some incompatible subclasses of NDData around.
-    bnd = BadNDDataSubclass(False, True, 3, 2, 'gollum', 100)
+    bnd = BadNDDataSubclass(False, True, 3, 2, 'gollum', 100, 12)
     # Before changing the NDData init this would not have raised an error but
     # would have lead to a compromised nddata instance
     with pytest.raises(TypeError):

--- a/astropy/nddata/tests/test_nddata_base.py
+++ b/astropy/nddata/tests/test_nddata_base.py
@@ -33,6 +33,10 @@ class MinimalSubclass(NDDataBase):
     def uncertainty(self):
         return super().uncertainty
 
+    @property
+    def psf(self):
+        return super().psf
+
 
 def test_nddata_base_subclass():
     a = MinimalSubclass()

--- a/astropy/nddata/tests/test_nddata_base.py
+++ b/astropy/nddata/tests/test_nddata_base.py
@@ -38,6 +38,35 @@ class MinimalSubclass(NDDataBase):
         return super().psf
 
 
+class MinimalSubclassNoPSF(NDDataBase):
+    def __init__(self):
+        super().__init__()
+
+    @property
+    def data(self):
+        return None
+
+    @property
+    def mask(self):
+        return super().mask
+
+    @property
+    def unit(self):
+        return super().unit
+
+    @property
+    def wcs(self):
+        return super().wcs
+
+    @property
+    def meta(self):
+        return super().meta
+
+    @property
+    def uncertainty(self):
+        return super().uncertainty
+
+
 def test_nddata_base_subclass():
     a = MinimalSubclass()
     assert a.meta is None
@@ -46,3 +75,10 @@ def test_nddata_base_subclass():
     assert a.unit is None
     assert a.wcs is None
     assert a.uncertainty is None
+    assert a.psf is None
+
+
+def test_omitting_psf_is_ok():
+    # Make sure that psf does not need to be overridden when creating a subclass
+    b = MinimalSubclassNoPSF()
+    assert b.psf is None

--- a/docs/changes/nddata/13743.feature.rst
+++ b/docs/changes/nddata/13743.feature.rst
@@ -1,1 +1,1 @@
-Add a PSF image representation to ``astropy.nddata.CCDData`` and ``astropy.nddata.CCDData``.
+Add a PSF image representation to ``astropy.nddata.NDData`` and ``astropy.nddata.CCDData``.

--- a/docs/changes/nddata/13743.feature.rst
+++ b/docs/changes/nddata/13743.feature.rst
@@ -1,0 +1,1 @@
+Add a PSF image representation to ``astropy.nddata.CCDData`` and ``astropy.nddata.CCDData``.

--- a/docs/convolution/kernels.rst
+++ b/docs/convolution/kernels.rst
@@ -356,6 +356,7 @@ Especially in the range where the kernel width is in order of only a few pixels,
 it can be advantageous to use the mode ``oversample`` or ``integrate`` to
 conserve the integral on a subpixel scale.
 
+.. _kernel_normalization:
 
 Normalization
 =============

--- a/docs/nddata/ccddata.rst
+++ b/docs/nddata/ccddata.rst
@@ -139,7 +139,7 @@ The ``wcs`` and ``psf`` attributes of a `~astropy.nddata.CCDData` object can be 
 Either way, the ``wcs`` attribute is kept up to date if the
 `~astropy.nddata.CCDData` image is trimmed.
 
-The ``psf`` attribute should be a normalized PSF image at the center of the `~astropy.nddata.CCDData`, sized appropriately for the data; users are responsible for managing and interpreting it in context.
+The ``psf`` attribute should be a normalized image representing the PSF at the center of the `~astropy.nddata.CCDData`, sized appropriately for the data; users are responsible for managing and interpreting it in context.
 
 Uncertainty
 -----------

--- a/docs/nddata/ccddata.rst
+++ b/docs/nddata/ccddata.rst
@@ -151,7 +151,7 @@ The ``psf`` attributes of a `~astropy.nddata.CCDData` object can be set two ways
 The ``psf`` attribute should be a normalized image representing the PSF at the center of the `~astropy.nddata.CCDData`, sized appropriately for the data; users are responsible for managing and interpreting it in context.
 For more on normalizing a PSF image, see :ref:`astropy:kernel_normalization`.
 
-The ``psf`` attribute is set to ``None`` in the output of an arithmetic operation, no matter the inputs. A warning message is emitted if either of the input images contain a non-``None`` psf; users are responsible for determining the appropriate thing to do in that context.
+The ``psf`` attribute is set to `None` in the output of an arithmetic operation, no matter the inputs. A warning message is emitted if either of the input images contain a non-`None` PSF; users are responsible for determining the appropriate thing to do in that context.
 
 Uncertainty
 -----------

--- a/docs/nddata/ccddata.rst
+++ b/docs/nddata/ccddata.rst
@@ -123,23 +123,35 @@ more details about bit planes and the functions ``astropy`` provides for
 converting them to binary masks, see :ref:`bitmask_details`. For more details
 on setting flags, see `~astropy.nddata.NDData`.
 
-WCS and PSF
-+++++++++++
+WCS
++++
 
-The ``wcs`` and ``psf`` attributes of a `~astropy.nddata.CCDData` object can be set two ways.
+The ``wcs`` attribute of a `~astropy.nddata.CCDData` object can be set two ways.
 
 + If the `~astropy.nddata.CCDData` object is created from a FITS file that has
   WCS keywords in the header, the ``wcs`` attribute is set to a
   `~astropy.wcs.WCS` object using the information in the FITS header.
-  Similarly, if the FITS file has an image HDU extension matching the appropriate name (defaulted to ``"PSFIMAGE"``), the ``psf`` attribute is loaded from that image HDU.
 
-+ The WCS and PSF can also be provided when the `~astropy.nddata.CCDData` object is
-  constructed with the ``wcs`` and ``psf`` arguments, respectively.
++ The WCS can also be provided when the `~astropy.nddata.CCDData` object is
+  constructed with the ``wcs`` argument.
 
 Either way, the ``wcs`` attribute is kept up to date if the
 `~astropy.nddata.CCDData` image is trimmed.
 
+PSF
++++
+
+The ``psf`` attributes of a `~astropy.nddata.CCDData` object can be set two ways.
+
++ If the FITS file has an image HDU extension matching the appropriate name (defaulted to ``"PSFIMAGE"``), the ``psf`` attribute is loaded from that image HDU.
+
++ The PSF can also be provided when the `~astropy.nddata.CCDData` object is
+  constructed with the ``psf`` argument.
+
 The ``psf`` attribute should be a normalized image representing the PSF at the center of the `~astropy.nddata.CCDData`, sized appropriately for the data; users are responsible for managing and interpreting it in context.
+For more on normalizing a PSF image, see :ref:`astropy:kernel_normalization`.
+
+The ``psf`` attribute is set to ``None`` in the output of an arithmetic operation, no matter the inputs. A warning message is emitted if either of the input images contain a non-``None`` psf; users are responsible for determining the appropriate thing to do in that context.
 
 Uncertainty
 -----------

--- a/docs/nddata/ccddata.rst
+++ b/docs/nddata/ccddata.rst
@@ -123,20 +123,23 @@ more details about bit planes and the functions ``astropy`` provides for
 converting them to binary masks, see :ref:`bitmask_details`. For more details
 on setting flags, see `~astropy.nddata.NDData`.
 
-WCS
-+++
+WCS and PSF
++++++++++++
 
-The ``wcs`` attribute of a `~astropy.nddata.CCDData` object can be set two ways.
+The ``wcs`` and ``psf`` attributes of a `~astropy.nddata.CCDData` object can be set two ways.
 
 + If the `~astropy.nddata.CCDData` object is created from a FITS file that has
   WCS keywords in the header, the ``wcs`` attribute is set to a
   `~astropy.wcs.WCS` object using the information in the FITS header.
+  Similarly, if the FITS file has an image HDU extension matching the appropriate name (defaulted to ``"PSFIMAGE"``), the ``psf`` attribute is loaded from that image HDU.
 
-+ The WCS can also be provided when the `~astropy.nddata.CCDData` object is
-  constructed with the ``wcs`` argument.
++ The WCS and PSF can also be provided when the `~astropy.nddata.CCDData` object is
+  constructed with the ``wcs`` and ``psf`` arguments, respectively.
 
 Either way, the ``wcs`` attribute is kept up to date if the
 `~astropy.nddata.CCDData` image is trimmed.
+
+The ``psf`` attribute should be a normalized PSF image at the center of the `~astropy.nddata.CCDData`, sized appropriately for the data; users are responsible for managing and interpreting it in context.
 
 Uncertainty
 -----------

--- a/docs/nddata/nddata.rst
+++ b/docs/nddata/nddata.rst
@@ -15,7 +15,7 @@ additional meta attributes:
 + ``mask`` indicates invalid points in the data
 + ``wcs`` represents the relationship between the data grid and world
   coordinates
-+ ``psf`` holds a normalized image representation of the point spread function (PSF) at the center of the array.
++ ``psf`` holds an image representation of the point spread function (PSF)
 
 Each of these attributes can be set during initialization or directly on the
 instance. Only the ``data`` cannot be directly set after creating the instance.

--- a/docs/nddata/nddata.rst
+++ b/docs/nddata/nddata.rst
@@ -15,6 +15,7 @@ additional meta attributes:
 + ``mask`` indicates invalid points in the data
 + ``wcs`` represents the relationship between the data grid and world
   coordinates
++ ``psf`` holds a normalized image representation of the point spread function (PSF) at the center of the array.
 
 Each of these attributes can be set during initialization or directly on the
 instance. Only the ``data`` cannot be directly set after creating the instance.

--- a/docs/nddata/subclassing.rst
+++ b/docs/nddata/subclassing.rst
@@ -435,13 +435,14 @@ To implement the NDDataBase interface by creating a read-only container::
     >>> from astropy.nddata import NDDataBase
 
     >>> class NDDataReadOnlyNoRestrictions(NDDataBase):
-    ...     def __init__(self, data, unit, mask, uncertainty, meta, wcs):
+    ...     def __init__(self, data, unit, mask, uncertainty, meta, wcs, psf):
     ...         self._data = data
     ...         self._unit = unit
     ...         self._mask = mask
     ...         self._uncertainty = uncertainty
     ...         self._meta = meta
     ...         self._wcs = wcs
+    ...         self._psf = psf
     ...
     ...     @property
     ...     def data(self):
@@ -466,9 +467,13 @@ To implement the NDDataBase interface by creating a read-only container::
     ...     @property
     ...     def wcs(self):
     ...         return self._wcs
+    ...
+    ...     @property
+    ...     def psf(self):
+    ...         return self._psf
 
     >>> # A meaningless test to show that creating this class is possible:
-    >>> NDDataReadOnlyNoRestrictions(1,2,3,4,5,6) is not None
+    >>> NDDataReadOnlyNoRestrictions(1,2,3,4,5,6,7) is not None
     True
 
 .. note::

--- a/docs/whatsnew/5.2.rst
+++ b/docs/whatsnew/5.2.rst
@@ -19,6 +19,7 @@ In particular, this release includes:
 * :ref:`whatsnew-5.2-fits`
 * :ref:`whatsnew-5.2-visualization-wcsaxes-helpers`
 * :ref:`whatsnew-5.2-tilde-paths`
+* :ref:`whatsnew-5.2-ccddata-psf`
 
 
 .. _whatsnew-5.2-quantity-dtype:
@@ -202,6 +203,14 @@ This support has been added throughout the ``astropy.io`` module. This feature
 is also supported within the I/O functionality of `astropy.table` and the
 FITS-file functionality in `astropy.nddata`.
 
+
+.. _whatsnew-5.2-ccddata-psf:
+
+CCDData PSF Image representation
+================================
+
+The ``NDData``/``CCDData`` objects now have a specific attribute for an image representation of the point spread function (PSF) at the image center.
+This was added to support the Rubin Observatory/LSST alert packets, which will be distributed as ``CCDData`` objects.
 
 Full change log
 ===============


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request adds a simple PSF image to NDData/CCDData, to support the Rubin Observatory LSST Prompt Processing alert distribution system. The LSST alert packet image cutouts will be sent as [astropy CCDData objects](https://jira.lsstcorp.org/browse/RFC-696), and the only thing we see as missing from that format is the PSF. For our purposes for these image cutouts, all we need is a realization of the PSF image at the image center, not a generic parameterized or model PSF.

TODO:

* Are any further tests or functionality necessary?
* Does this serialize to the various astropy outputs, or do I need to add code for that?
* Document how to make use of this PSF representation (but I'm not sure where such documentation would go).
* Document how to use the astropy flux-preserving warping code to move the PSF around within the image?

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
