### PR TITLE
 Add fix and tests for float32 pi/2 Latitude

### DIFF
--- a/astropy/coordinates/angles.py
+++ b/astropy/coordinates/angles.py
@@ -587,7 +587,7 @@ class Latitude(Angle):
         if angles.unit is u.deg:
             limit = 90
         elif angles.unit is u.rad:
-            limit = 0.5 * np.pi
+            limit = self.dtype.type(0.5 * np.pi)
         else:
             limit = u.degree.to(angles.unit, 90.0)
 

--- a/astropy/coordinates/tests/test_angles.py
+++ b/astropy/coordinates/tests/test_angles.py
@@ -1092,3 +1092,54 @@ def test_str_repr_angles_nan(cls, input, expstr, exprepr):
     # Deleting whitespaces since repr appears to be adding them for some values
     # making the test fail.
     assert repr(q).replace(" ", "") == f'<{cls.__name__}{exprepr}>'.replace(" ","")
+
+
+@pytest.mark.parametrize("sign", (-1, 1))
+@pytest.mark.parametrize(
+    "value,expected_value,dtype,expected_dtype",
+    [
+        (np.pi / 2, np.pi / 2, None, np.float64),
+        (np.pi / 2, np.pi / 2, np.float64, np.float64),
+        (np.float32(np.pi / 2), np.float32(np.pi / 2), None, np.float32),
+        (np.float32(np.pi / 2), np.float32(np.pi / 2), np.float32, np.float32),
+        # these cases would require coercing the float32 value to the float64 value
+        # making validate have side effects, so it's not implemented for now
+        # (np.float32(np.pi / 2), np.pi / 2, np.float64, np.float64),
+        # (np.float32(-np.pi / 2), -np.pi / 2, np.float64, np.float64),
+    ]
+)
+def test_latitude_limits(value, expected_value, dtype, expected_dtype, sign):
+    """
+    Test that the validation of the Latitude value range in radians works
+    in both float32 and float64.
+
+    As discussed in issue #13708, before, the float32 represenation of pi/2
+    was rejected as invalid because the comparison always used the float64
+    representation.
+    """
+    # this prevents upcasting to float64 as sign * value would do
+    if sign < 0:
+        value = -value
+        expected_value = -expected_value
+
+    result = Latitude(value, u.rad, dtype=dtype)
+    assert result.value == expected_value
+    assert result.dtype == expected_dtype
+    assert result.unit == u.rad
+
+
+@pytest.mark.parametrize(
+    "value,dtype",
+    [
+        (0.50001 * np.pi, np.float32),
+        (np.float32(0.50001 * np.pi), np.float32),
+        (0.50001 * np.pi, np.float64),
+    ]
+)
+def test_latitude_out_of_limits(value, dtype):
+    """
+    Test that values slightly larger than pi/2 are rejected for different dtypes.
+    Test cases for issue #13708
+    """
+    with pytest.raises(ValueError, match=r"Latitude angle\(s\) must be within.*"):
+        Latitude(value, u.rad, dtype=dtype)

--- a/docs/changes/coordinates/13745.bugfix.rst
+++ b/docs/changes/coordinates/13745.bugfix.rst
@@ -1,0 +1,4 @@
+Fixed the check for invalid ``Latitude`` values for float32 values.
+``Latitude`` now accepts the float32 value of pi/2, which was rejected
+before because a comparison was made using the slightly smaller float64 representation.
+See issue #13708.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description

This adds test cases and for now the easy part (everything float32) for the `Latitude._validate_angle` method as discussed here:


<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

(Hopefully soon) Fixes #13708 

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
