### PR TITLE
Add sinh stretch option to simple_norm

### DIFF
--- a/astropy/visualization/mpl_normalize.py
+++ b/astropy/visualization/mpl_normalize.py
@@ -10,7 +10,8 @@ from numpy import ma
 
 from .interval import (
     AsymmetricPercentileInterval, BaseInterval, ManualInterval, MinMaxInterval, PercentileInterval)
-from .stretch import AsinhStretch, BaseStretch, LinearStretch, LogStretch, PowerStretch, SqrtStretch
+from .stretch import (
+    AsinhStretch, BaseStretch, LinearStretch, LogStretch, PowerStretch, SinhStretch, SqrtStretch)
 
 try:
     import matplotlib  # pylint: disable=W0611
@@ -188,7 +189,8 @@ class ImageNormalize(Normalize):
 
 def simple_norm(data, stretch='linear', power=1.0, asinh_a=0.1, min_cut=None,
                 max_cut=None, min_percent=None, max_percent=None,
-                percent=None, clip=False, log_a=1000, invalid=-1.0):
+                percent=None, clip=False, log_a=1000, invalid=-1.0,
+                sinh_a=0.3):
     """
     Return a Normalization class that can be used for displaying images
     with Matplotlib.
@@ -204,7 +206,7 @@ def simple_norm(data, stretch='linear', power=1.0, asinh_a=0.1, min_cut=None,
     data : ndarray
         The image array.
 
-    stretch : {'linear', 'sqrt', 'power', log', 'asinh'}, optional
+    stretch : {'linear', 'sqrt', 'power', log', 'asinh', 'sinh'}, optional
         The stretch function to apply to the image.  The default is
         'linear'.
 
@@ -262,6 +264,10 @@ def simple_norm(data, stretch='linear', power=1.0, asinh_a=0.1, min_cut=None,
         If `None`, then NaN values are not replaced.  This keyword has
         no effect if ``clip=True``.
 
+    sinh_a : float, optional
+        The scaling parameter for ``stretch='sinh'``. The default is
+        0.3.
+
     Returns
     -------
     result : `ImageNormalize` instance
@@ -289,6 +295,8 @@ def simple_norm(data, stretch='linear', power=1.0, asinh_a=0.1, min_cut=None,
         stretch = LogStretch(log_a)
     elif stretch == 'asinh':
         stretch = AsinhStretch(asinh_a)
+    elif stretch == 'sinh':
+        stretch = SinhStretch(sinh_a)
     else:
         raise ValueError(f'Unknown stretch: {stretch}.')
 

--- a/astropy/visualization/tests/test_norm.py
+++ b/astropy/visualization/tests/test_norm.py
@@ -239,6 +239,13 @@ class TestImageScaling:
         ref = np.arcsinh(DATA2SCL / asinh_a) / np.arcsinh(1. / asinh_a)
         assert_allclose(norm(DATA2), ref, atol=0, rtol=1.e-5)
 
+    def test_sinh(self):
+        """Test sinh scaling."""
+        sinh_a = 0.5
+        norm = simple_norm(DATA2, stretch='sinh', sinh_a=sinh_a)
+        ref = np.sinh(DATA2SCL / sinh_a) / np.sinh(1 / sinh_a)
+        assert_allclose(norm(DATA2), ref, atol=0, rtol=1.e-5)
+
     def test_min(self):
         """Test linear scaling."""
         norm = simple_norm(DATA2, stretch='linear', min_cut=1., clip=True)

--- a/docs/changes/visualization/13746.feature.rst
+++ b/docs/changes/visualization/13746.feature.rst
@@ -1,0 +1,1 @@
+Added a ``sinh`` stretch option to ``simple_norm``.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This PR adds a `sinh` stretch option to `simple_norm`, which already has the inverse `asinh` stretch.
 
<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
