### PR TITLE
Remove PCOUNT GCOUNT from decompressed primary headers.

### DIFF
--- a/astropy/io/fits/hdu/compressed.py
+++ b/astropy/io/fits/hdu/compressed.py
@@ -1595,6 +1595,13 @@ class CompImageHDU(BinTableHDU):
                 image_header['EXTNAME'] == self._default_name):
             del image_header['EXTNAME']
 
+        # Remove the PCOUNT GCOUNT cards if the uncompressed header is
+        # from a primary HDU
+        if 'SIMPLE' in image_header and \
+                ('PCOUNT' in image_header or 'GCOUNT' in image_header):
+            del image_header['PCOUNT']
+            del image_header['GCOUNT']
+
         # Look to see if there are any blank cards in the table
         # header.  If there are, there should be the same number
         # of blank cards in the image header.  Add blank cards to

--- a/astropy/io/fits/tests/test_header.py
+++ b/astropy/io/fits/tests/test_header.py
@@ -2968,6 +2968,8 @@ class TestRecordValuedKeywordCards(FitsTestCase):
         chdu.writeto(self.temp('tmp2.fits'), overwrite=True)
         with fits.open(self.temp('tmp2.fits')) as hdul:
             assert 'XTENSION' not in hdul[1].header
+            assert 'PCOUNT' not in hdul[1].header
+            assert 'GCOUNT' not in hdul[1].header
 
     def test_fitsheader_table_feature(self):
         """Tests the `--table` feature of the `fitsheader` script."""

--- a/docs/changes/io.fits/13753.bugfix.rst
+++ b/docs/changes/io.fits/13753.bugfix.rst
@@ -1,0 +1,2 @@
+``PCOUNT`` and ``GCOUNT`` keywords are now removed from an uncompressed Primary header,
+for compliancy with ``fitsverify`` behavior.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address #12007, as a follow-up of #13557.
It removes the unnecessary keywords `PCOUNT` and `GCOUNT` from the uncompressed Primary header.
While I can't find in the FITS standard an explicit statement that `PCOUNT` and `GCOUNT` are not allowed in Primary headers, they are always used in extension examples and fitsverify throws an error when those keywords are encountered in Primary headers.
I think that this change is worth it for the sake of consistency between FITS tools.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #12007

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
