### PR TITLE
Fix blanket `# noqa` in astropy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,6 +49,8 @@ repos:
         # Detect mistake of inline code touching normal text in rst.
       - id: text-unicode-replacement-char
         # Forbid files which have a UTF-8 Unicode replacement character.
+      - id: python-check-blanket-noqa
+        # Enforce that all noqa annotations always occur with specific codes.
 
   - repo: https://github.com/pycqa/isort
     rev: 5.10.1

--- a/.pyinstaller/run_astropy_tests.py
+++ b/.pyinstaller/run_astropy_tests.py
@@ -2,11 +2,11 @@ import os
 import shutil
 import sys
 
-import erfa  # noqa
+import erfa  # noqa: F401
 import matplotlib
 import pytest
 
-import astropy  # noqa
+import astropy  # noqa: F401
 
 if len(sys.argv) == 3 and sys.argv[1] == '--astropy-root':
     ROOT = sys.argv[2]

--- a/astropy/config/tests/test_configs.py
+++ b/astropy/config/tests/test_configs.py
@@ -310,8 +310,6 @@ def test_configitem_options(tmp_path):
     class Conf(ConfigNamespace):
         tstnmo = cio
 
-    conf = Conf()  # noqa
-
     sec = get_config(cio.module)
 
     assert isinstance(cio(), str)
@@ -441,8 +439,6 @@ def test_configitem_unicode():
 
     class Conf(ConfigNamespace):
         tstunicode = cio
-
-    conf = Conf()  # noqa
 
     sec = get_config(cio.module)
 

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -890,8 +890,8 @@ def test_equal():
     ne = sc1 != sc2
     assert np.all(eq == [True, False])
     assert np.all(ne == [False, True])
-    assert (sc1[0] == sc2[0]) == True  # noqa  (numpy True not Python True)
-    assert (sc1[0] != sc2[0]) == False  # noqa
+    assert (sc1[0] == sc2[0]) == np.bool_(True)
+    assert (sc1[0] != sc2[0]) == np.bool_(False)
 
     # Broadcasting
     eq = sc1[0] == sc2
@@ -907,8 +907,8 @@ def test_equal():
     ne = sc1 != sc2
     assert np.all(eq == [True, False])
     assert np.all(ne == [False, True])
-    assert (sc1[0] == sc2[0]) == True  # noqa
-    assert (sc1[0] != sc2[0]) == False  # noqa
+    assert (sc1[0] == sc2[0]) is np.bool_(True)
+    assert (sc1[0] != sc2[0]) is np.bool_(False)
 
     assert (FK4() == ICRS()) is False
     assert (FK4() == FK4(obstime='J1999')) is False

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -890,8 +890,8 @@ def test_equal():
     ne = sc1 != sc2
     assert np.all(eq == [True, False])
     assert np.all(ne == [False, True])
-    assert (sc1[0] == sc2[0]) == np.bool_(True)
-    assert (sc1[0] != sc2[0]) == np.bool_(False)
+    assert isinstance(v := (sc1[0] == sc2[0]), (bool, np.bool_)) and v
+    assert isinstance(v := (sc1[0] != sc2[0]), (bool, np.bool_)) and not v
 
     # Broadcasting
     eq = sc1[0] == sc2
@@ -907,8 +907,8 @@ def test_equal():
     ne = sc1 != sc2
     assert np.all(eq == [True, False])
     assert np.all(ne == [False, True])
-    assert (sc1[0] == sc2[0]) is np.bool_(True)
-    assert (sc1[0] != sc2[0]) is np.bool_(False)
+    assert isinstance(v := (sc1[0] == sc2[0]), (bool, np.bool_)) and v
+    assert isinstance(v := (sc1[0] != sc2[0]), (bool, np.bool_)) and not v
 
     assert (FK4() == ICRS()) is False
     assert (FK4() == FK4(obstime='J1999')) is False

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -360,8 +360,8 @@ def test_equal():
     ne = sc1 != sc2
     assert np.all(eq == [True, False])
     assert np.all(ne == [False, True])
-    assert (sc1[0] == sc2[0]) == True  # noqa  (numpy True not Python True)
-    assert (sc1[0] != sc2[0]) == False  # noqa
+    assert (sc1[0] == sc2[0]) is np.bool_(True)
+    assert (sc1[0] != sc2[0]) is np.bool_(False)
 
     # Broadcasting
     eq = sc1[0] == sc2
@@ -377,8 +377,8 @@ def test_equal():
     ne = sc1 != sc2
     assert np.all(eq == [True, False])
     assert np.all(ne == [False, True])
-    assert (sc1[0] == sc2[0]) == True  # noqa
-    assert (sc1[0] != sc2[0]) == False  # noqa
+    assert (sc1[0] == sc2[0]) is np.bool(True)
+    assert (sc1[0] != sc2[0]) is np.bool(False)
 
 
 def test_equal_different_type():

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -360,8 +360,8 @@ def test_equal():
     ne = sc1 != sc2
     assert np.all(eq == [True, False])
     assert np.all(ne == [False, True])
-    assert (sc1[0] == sc2[0]) is np.bool_(True)
-    assert (sc1[0] != sc2[0]) is np.bool_(False)
+    assert isinstance(v := (sc1[0] == sc2[0]), (bool, np.bool_)) and v
+    assert isinstance(v := (sc1[0] != sc2[0]), (bool, np.bool_)) and not v
 
     # Broadcasting
     eq = sc1[0] == sc2
@@ -377,8 +377,8 @@ def test_equal():
     ne = sc1 != sc2
     assert np.all(eq == [True, False])
     assert np.all(ne == [False, True])
-    assert (sc1[0] == sc2[0]) is np.bool(True)
-    assert (sc1[0] != sc2[0]) is np.bool(False)
+    assert isinstance(v := (sc1[0] == sc2[0]), (bool, np.bool_)) and v
+    assert isinstance(v := (sc1[0] != sc2[0]), (bool, np.bool_)) and not v
 
 
 def test_equal_different_type():

--- a/astropy/io/ascii/connect.py
+++ b/astropy/io/ascii/connect.py
@@ -4,7 +4,7 @@
 
 import re
 
-from astropy.io import registry as io_registry  # noqa
+from astropy.io import registry as io_registry  # noqa: F401
 from astropy.table import Table
 
 __all__ = []

--- a/astropy/io/ascii/tests/test_ecsv.py
+++ b/astropy/io/ascii/tests/test_ecsv.py
@@ -965,7 +965,7 @@ def test_masked_vals_in_array_subtypes():
     assert t2.colnames == t.colnames
     for name in t2.colnames:
         assert t2[name].dtype == t[name].dtype
-        assert type(t2[name]) is type(t[name])  # noqa
+        assert type(t2[name]) is type(t[name])  # noqa: E721
         for val1, val2 in zip(t2[name], t[name]):
             if isinstance(val1, np.ndarray):
                 assert val1.dtype == val2.dtype

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -940,7 +940,7 @@ def get_testfiles(name=None):
     ]
 
     try:
-        import bs4  # noqa
+        import bs4  # noqa: F401
         testfiles.append({'cols': ('Column 1', 'Column 2', 'Column 3'),
                           'name': 'data/html.html',
                           'nrows': 3,

--- a/astropy/io/ascii/tests/test_write.py
+++ b/astropy/io/ascii/tests/test_write.py
@@ -20,9 +20,6 @@ from astropy.utils.misc import _NOT_OVERWRITING_MSG_MATCH
 
 from .common import setup_function, teardown_function  # noqa: F401
 
-if HAS_BS4:
-    from bs4 import BeautifulSoup, FeatureNotFound  # noqa
-
 test_defs = [
     dict(kwargs=dict(),
          out="""\
@@ -111,7 +108,7 @@ ID & XCENTER & YCENTER & MAG & MERR & MSKY & NITER & SHARPNESS & CHI & PIER & PE
 18 & 18.114 & 280.170 & 22.329 & 0.206 & 30.12784 & 4 & -2.544 & 1.104 & 0 & No_error
 \\enddata
 \\end{deluxetable}
-"""  # noqa
+"""  # noqa: E501
          ),
     dict(
         kwargs=dict(Writer=ascii.AASTex, caption='Mag values \\label{tab1}', latexdict={
@@ -126,7 +123,7 @@ ID & XCENTER & YCENTER & MAG & MERR & MSKY & NITER & SHARPNESS & CHI & PIER & PE
 18 & 18.114 & 280.170 & 22.329 & 0.206 & 30.12784 & 4 & -2.544 & 1.104 & 0 & No_error
 \\enddata
 \\end{deluxetable*}
-"""  # noqa
+"""  # noqa: E501
     ),
     dict(
         kwargs=dict(Writer=ascii.Latex, caption='Mag values \\label{tab1}',
@@ -278,7 +275,7 @@ table,th,td{border:1px solid black;  </style>
 |     null|      null|      null|        null|          null|           null|  null|                   null|        null|  null|         null|
  14        138.538    256.405    15.461       0.003          34.85955        4      -0.032                  0.802        0      No_error
  18        18.114     280.170    22.329       0.206          30.12784        4      -2.544                  1.104        0      No_error
-"""  # noqa
+"""  # noqa: E501
          ),
 ]
 

--- a/astropy/io/fits/tests/test_fitstime.py
+++ b/astropy/io/fits/tests/test_fitstime.py
@@ -195,7 +195,7 @@ class TestFitsTime(FitsTestCase):
             assert coord_info[colname]['coord_unit'] == 'd'
 
         assert coord_info['a']['time_ref_pos'] == 'TOPOCENTER'
-        assert coord_info['b']['time_ref_pos'] == None   # noqa
+        assert coord_info['b']['time_ref_pos'] is None
 
         assert len(hdr) == 0
 

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -1177,7 +1177,7 @@ class TestTableFunctions(FitsTestCase):
         assert tbhdu.columns.columns[2].array[0] == ''
         assert (tbhdu.columns.columns[3].array[0] ==
                 np.array([0., 0., 0., 0., 0.], dtype=np.float32)).all()
-        assert tbhdu.columns.columns[4].array[0] is np.bool_(True)
+        assert isinstance(v := (tbhdu.columns.columns[4].array[0] == np.True_), (bool, np.bool_)) and v
 
         assert tbhdu.data[3][1] == 33
         assert tbhdu.data._coldefs._arrays[1][3] == 33
@@ -1188,7 +1188,7 @@ class TestTableFunctions(FitsTestCase):
         assert tbhdu.columns.columns[2].array[3] == 'A Note'
         assert (tbhdu.columns.columns[3].array[3] ==
                 np.array([1., 2., 3., 4., 5.], dtype=np.float32)).all()
-        assert tbhdu.columns.columns[4].array[3] is np.bool_(True)
+        assert isinstance(v := (tbhdu.columns.columns[4].array[3] == np.True_), (bool, np.bool_)) and v
 
     def test_assign_multiple_rows_to_table(self):
         counts = np.array([312, 334, 308, 317])
@@ -1239,7 +1239,7 @@ class TestTableFunctions(FitsTestCase):
         assert tbhdu2.columns.columns[2].array[0] == ''
         assert (tbhdu2.columns.columns[3].array[0] ==
                 np.array([0., 0., 0., 0., 0.], dtype=np.float32)).all()
-        assert tbhdu2.columns.columns[4].array[0] is np.bool_(True)
+        assert isinstance(v := (tbhdu2.columns.columns[4].array[0] == np.True_), (bool, np.bool_)) and v
 
         assert tbhdu2.data[4][1] == 112
         assert tbhdu2.data._coldefs._arrays[1][4] == 112
@@ -1250,13 +1250,13 @@ class TestTableFunctions(FitsTestCase):
         assert tbhdu2.columns.columns[2].array[4] == ''
         assert (tbhdu2.columns.columns[3].array[4] ==
                 np.array([1., 2., 3., 4., 5.], dtype=np.float32)).all()
-        assert tbhdu2.columns.columns[4].array[4] is np.bool_(False)
+        assert isinstance(v := (tbhdu2.columns.columns[4].array[4] == np.False_), (bool, np.bool_)) and v
         assert tbhdu2.columns.columns[1].array[8] == 0
         assert tbhdu2.columns.columns[0].array[8] == ''
         assert tbhdu2.columns.columns[2].array[8] == ''
         assert (tbhdu2.columns.columns[3].array[8] ==
                 np.array([0., 0., 0., 0., 0.], dtype=np.float32)).all()
-        assert tbhdu2.columns.columns[4].array[8] is np.bool_(False)
+        assert isinstance(v := (tbhdu2.columns.columns[4].array[8] == np.False_), (bool, np.bool_)) and v
 
     def test_verify_data_references(self):
         counts = np.array([312, 334, 308, 317])

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -1177,7 +1177,7 @@ class TestTableFunctions(FitsTestCase):
         assert tbhdu.columns.columns[2].array[0] == ''
         assert (tbhdu.columns.columns[3].array[0] ==
                 np.array([0., 0., 0., 0., 0.], dtype=np.float32)).all()
-        assert tbhdu.columns.columns[4].array[0] == True  # noqa
+        assert tbhdu.columns.columns[4].array[0] is np.bool_(True)
 
         assert tbhdu.data[3][1] == 33
         assert tbhdu.data._coldefs._arrays[1][3] == 33
@@ -1188,7 +1188,7 @@ class TestTableFunctions(FitsTestCase):
         assert tbhdu.columns.columns[2].array[3] == 'A Note'
         assert (tbhdu.columns.columns[3].array[3] ==
                 np.array([1., 2., 3., 4., 5.], dtype=np.float32)).all()
-        assert tbhdu.columns.columns[4].array[3] == True  # noqa
+        assert tbhdu.columns.columns[4].array[3] is np.bool_(True)
 
     def test_assign_multiple_rows_to_table(self):
         counts = np.array([312, 334, 308, 317])
@@ -1239,7 +1239,7 @@ class TestTableFunctions(FitsTestCase):
         assert tbhdu2.columns.columns[2].array[0] == ''
         assert (tbhdu2.columns.columns[3].array[0] ==
                 np.array([0., 0., 0., 0., 0.], dtype=np.float32)).all()
-        assert tbhdu2.columns.columns[4].array[0] == True  # noqa
+        assert tbhdu2.columns.columns[4].array[0] is np.bool_(True)
 
         assert tbhdu2.data[4][1] == 112
         assert tbhdu2.data._coldefs._arrays[1][4] == 112
@@ -1250,13 +1250,13 @@ class TestTableFunctions(FitsTestCase):
         assert tbhdu2.columns.columns[2].array[4] == ''
         assert (tbhdu2.columns.columns[3].array[4] ==
                 np.array([1., 2., 3., 4., 5.], dtype=np.float32)).all()
-        assert tbhdu2.columns.columns[4].array[4] == False  # noqa
+        assert tbhdu2.columns.columns[4].array[4] is np.bool_(False)
         assert tbhdu2.columns.columns[1].array[8] == 0
         assert tbhdu2.columns.columns[0].array[8] == ''
         assert tbhdu2.columns.columns[2].array[8] == ''
         assert (tbhdu2.columns.columns[3].array[8] ==
                 np.array([0., 0., 0., 0., 0.], dtype=np.float32)).all()
-        assert tbhdu2.columns.columns[4].array[8] == False  # noqa
+        assert tbhdu2.columns.columns[4].array[8] is np.bool_(False)
 
     def test_verify_data_references(self):
         counts = np.array([312, 334, 308, 317])
@@ -1779,7 +1779,7 @@ class TestTableFunctions(FitsTestCase):
                            array=np.array([[45, 56], [11, 12, 13]],
                                           dtype=np.object_))
         hdu = fits.BinTableHDU.from_columns([col1])
-        assert type(hdu.data['x']) == type(hdu.data.x)  # noqa
+        assert type(hdu.data['x']) == type(hdu.data.x)  # noqa: E721
         assert (hdu.data['x'][0] == hdu.data.x[0]).all()
         assert (hdu.data['x'][1] == hdu.data.x[1]).all()
 

--- a/astropy/io/votable/tests/table_test.py
+++ b/astropy/io/votable/tests/table_test.py
@@ -200,7 +200,7 @@ def test_write_overwrite(tmpdir):
 def test_empty_table():
     votable = parse(get_pkg_data_filename('data/empty_table.xml'))
     table = votable.get_first_table()
-    astropy_table = table.to_table()  # noqa
+    table.to_table()
 
 
 def test_no_field_not_empty_table():

--- a/astropy/table/tests/test_column.py
+++ b/astropy/table/tests/test_column.py
@@ -737,7 +737,7 @@ def test_col_unicode_sandwich_bytes(Column):
     assert np.all(c == [uba, 'def'])
 
     ok = c == [uba8, b'def']
-    assert type(ok) is type(c.data)  # noqa
+    assert type(ok) is type(c.data)  # noqa: E721
     assert ok.dtype.char == '?'
     assert np.all(ok)
 
@@ -748,7 +748,7 @@ def test_col_unicode_sandwich_bytes(Column):
     cmps = (uba, uba8)
     for cmp in cmps:
         ok = c == cmp
-        assert type(ok) is type(c.data)  # noqa
+        assert type(ok) is type(c.data)  # noqa: E721
         assert np.all(ok == [True, False])
 
 
@@ -796,7 +796,7 @@ def test_masked_col_unicode_sandwich():
     assert c[:].dtype.char == 'S'
 
     ok = c == ['abc', 'def']
-    assert ok[0] == True  # noqa
+    assert ok[0]
     assert ok[1] is np.ma.masked
     assert np.all(c == [b'abc', b'def'])
     assert np.all(c == np.array(['abc', 'def']))
@@ -805,7 +805,7 @@ def test_masked_col_unicode_sandwich():
     for cmp in ('abc', b'abc'):
         ok = c == cmp
         assert type(ok) is np.ma.MaskedArray
-        assert ok[0] == True  # noqa
+        assert ok[0]
         assert ok[1] is np.ma.masked
 
 

--- a/astropy/table/tests/test_masked.py
+++ b/astropy/table/tests/test_masked.py
@@ -556,14 +556,14 @@ def test_masked_as_array_with_mixin():
     assert isinstance(ta, np.ma.MaskedArray)
     assert np.all(ta['a'].mask == [False, True])
     assert np.isclose(ta['a'][0].cxcsec, 1.0)
-    assert np.all(ta['b'].mask == False)  # noqa
-    assert np.all(ta['c'].mask == False)  # noqa
+    assert not np.any(ta['b'].mask)
+    assert not np.any(ta['c'].mask)
 
     # Check table ``mask`` property
     tm = t.mask
     assert np.all(tm['a'] == [False, True])
-    assert np.all(tm['b'] == False)  # noqa
-    assert np.all(tm['c'] == False)  # noqa
+    assert not np.any(tm['b'])
+    assert not np.any(tm['c'])
 
 
 def test_masked_column_with_unit_in_qtable():
@@ -576,7 +576,7 @@ def test_masked_column_with_unit_in_qtable():
 
     t['b'] = MaskedColumn([1, 2], unit=u.m)
     assert isinstance(t['b'], MaskedQuantity)
-    assert np.all(t['b'].mask == False)  # noqa
+    assert not np.any(t['b'].mask)
 
     t['c'] = MaskedColumn([1, 2], unit=u.m, mask=[True, False])
     assert isinstance(t['c'], MaskedQuantity)
@@ -588,7 +588,7 @@ def test_masked_quantity_in_table():
     t = Table()
     t['b'] = MaskedQuantity([1, 2], unit=u.m)
     assert isinstance(t['b'], MaskedColumn)
-    assert np.all(t['b'].mask == False)  # noqa
+    assert not np.any(t['b'].mask)
 
     t['c'] = MaskedQuantity([1, 2], unit=u.m, mask=[True, False])
     assert isinstance(t['c'], MaskedColumn)

--- a/astropy/table/tests/test_operations.py
+++ b/astropy/table/tests/test_operations.py
@@ -832,7 +832,7 @@ class TestSetdiff():
         self._setup(operation_table_type)
         out = table.setdiff(self.t1, self.t2)
         assert type(out['a']) is type(self.t1['a'])  # noqa: E721
-        assert type(out['a']) is type(self.t1['a'])  # noqa: E721
+        assert type(out['b']) is type(self.t1['b'])  # noqa: E721
         assert out.pformat() == [' a   b ',
                                  '--- ---',
                                  '  1 bar',
@@ -843,7 +843,7 @@ class TestSetdiff():
         out = table.setdiff(self.t1, self.t1)
 
         assert type(out['a']) is type(self.t1['a'])  # noqa: E721
-        assert type(out['a']) is type(self.t1['a'])  # noqa: E721
+        assert type(out['b']) is type(self.t1['b'])  # noqa: E721
         assert out.pformat() == [' a   b ',
                                  '--- ---']
 
@@ -858,7 +858,7 @@ class TestSetdiff():
         out = table.setdiff(self.t1, self.t3)
 
         assert type(out['a']) is type(self.t1['a'])  # noqa: E721
-        assert type(out['a']) is type(self.t1['a'])  # noqa: E721
+        assert type(out['b']) is type(self.t1['b'])  # noqa: E721
         assert out.pformat() == [' a   b ',
                                  '--- ---',
                                  '  1 foo',
@@ -869,7 +869,7 @@ class TestSetdiff():
         out = table.setdiff(self.t3, self.t1, keys=['a', 'b'])
 
         assert type(out['a']) is type(self.t1['a'])  # noqa: E721
-        assert type(out['a']) is type(self.t1['a'])  # noqa: E721
+        assert type(out['b']) is type(self.t1['b'])  # noqa: E721
         assert out.pformat() == [' a   b   d ',
                                  '--- --- ---',
                                  '  4 bar  R4',
@@ -923,7 +923,7 @@ class TestVStack():
         t2.meta.clear()
         out = table.vstack([self.t1, t2[1]])
         assert type(out['a']) is type(self.t1['a'])  # noqa: E721
-        assert type(out['a']) is type(self.t1['a'])  # noqa: E721
+        assert type(out['b']) is type(self.t1['b'])  # noqa: E721
         assert out.pformat() == [' a   b ',
                                  '--- ---',
                                  '0.0 foo',

--- a/astropy/table/tests/test_operations.py
+++ b/astropy/table/tests/test_operations.py
@@ -108,10 +108,10 @@ class TestJoin():
         # Basic join with default parameters (inner join on common keys)
         t12 = table.join(t1, t2)
         assert type(t12) is operation_table_type
-        assert type(t12['a']) is type(t1['a'])  # noqa
-        assert type(t12['b']) is type(t1['b'])  # noqa
-        assert type(t12['c']) is type(t1['c'])  # noqa
-        assert type(t12['d']) is type(t2['d'])  # noqa
+        assert type(t12['a']) is type(t1['a'])  # noqa: E721
+        assert type(t12['b']) is type(t1['b'])  # noqa: E721
+        assert type(t12['c']) is type(t1['c'])  # noqa: E721
+        assert type(t12['d']) is type(t2['d'])  # noqa: E721
         assert t12.masked is False
         assert sort_eq(t12.pformat(), [' a   b   c   d ',
                                        '--- --- --- ---',
@@ -180,11 +180,11 @@ class TestJoin():
         # Inner join on 'a' column
         t12 = table.join(t1, t2, keys='a')
         assert type(t12) is operation_table_type
-        assert type(t12['a']) is type(t1['a'])  # noqa
-        assert type(t12['b_1']) is type(t1['b'])  # noqa
-        assert type(t12['c']) is type(t1['c'])  # noqa
-        assert type(t12['b_2']) is type(t2['b'])  # noqa
-        assert type(t12['d']) is type(t2['d'])  # noqa
+        assert type(t12['a']) is type(t1['a'])  # noqa: E721
+        assert type(t12['b_1']) is type(t1['b'])  # noqa: E721
+        assert type(t12['c']) is type(t1['c'])  # noqa: E721
+        assert type(t12['b_2']) is type(t2['b'])  # noqa: E721
+        assert type(t12['d']) is type(t2['d'])  # noqa: E721
         assert t12.masked is False
         assert sort_eq(t12.pformat(), [' a  b_1  c  b_2  d ',
                                        '--- --- --- --- ---',
@@ -831,8 +831,8 @@ class TestSetdiff():
     def test_default_same_columns(self, operation_table_type):
         self._setup(operation_table_type)
         out = table.setdiff(self.t1, self.t2)
-        assert type(out['a']) is type(self.t1['a'])  # noqa
-        assert type(out['b']) is type(self.t1['b'])  # noqa
+        assert type(out['a']) is type(self.t1['a'])  # noqa: E721
+        assert type(out['a']) is type(self.t1['a'])  # noqa: E721
         assert out.pformat() == [' a   b ',
                                  '--- ---',
                                  '  1 bar',
@@ -842,8 +842,8 @@ class TestSetdiff():
         self._setup(operation_table_type)
         out = table.setdiff(self.t1, self.t1)
 
-        assert type(out['a']) is type(self.t1['a'])  # noqa
-        assert type(out['b']) is type(self.t1['b'])  # noqa
+        assert type(out['a']) is type(self.t1['a'])  # noqa: E721
+        assert type(out['a']) is type(self.t1['a'])  # noqa: E721
         assert out.pformat() == [' a   b ',
                                  '--- ---']
 
@@ -857,8 +857,8 @@ class TestSetdiff():
         self._setup(operation_table_type)
         out = table.setdiff(self.t1, self.t3)
 
-        assert type(out['a']) is type(self.t1['a'])  # noqa
-        assert type(out['b']) is type(self.t1['b'])  # noqa
+        assert type(out['a']) is type(self.t1['a'])  # noqa: E721
+        assert type(out['a']) is type(self.t1['a'])  # noqa: E721
         assert out.pformat() == [' a   b ',
                                  '--- ---',
                                  '  1 foo',
@@ -868,8 +868,8 @@ class TestSetdiff():
         self._setup(operation_table_type)
         out = table.setdiff(self.t3, self.t1, keys=['a', 'b'])
 
-        assert type(out['a']) is type(self.t1['a'])  # noqa
-        assert type(out['b']) is type(self.t1['b'])  # noqa
+        assert type(out['a']) is type(self.t1['a'])  # noqa: E721
+        assert type(out['a']) is type(self.t1['a'])  # noqa: E721
         assert out.pformat() == [' a   b   d ',
                                  '--- --- ---',
                                  '  4 bar  R4',
@@ -922,8 +922,8 @@ class TestVStack():
         t2 = self.t1.copy()
         t2.meta.clear()
         out = table.vstack([self.t1, t2[1]])
-        assert type(out['a']) is type(self.t1['a'])  # noqa
-        assert type(out['b']) is type(self.t1['b'])  # noqa
+        assert type(out['a']) is type(self.t1['a'])  # noqa: E721
+        assert type(out['a']) is type(self.t1['a'])  # noqa: E721
         assert out.pformat() == [' a   b ',
                                  '--- ---',
                                  '0.0 foo',
@@ -993,8 +993,8 @@ class TestVStack():
         t12 = table.vstack([t1, t2], join_type='inner')
         assert t12.masked is False
         assert type(t12) is operation_table_type
-        assert type(t12['a']) is type(t1['a'])  # noqa
-        assert type(t12['b']) is type(t1['b'])  # noqa
+        assert type(t12['a']) is type(t1['a'])  # noqa: E721
+        assert type(t12['b']) is type(t1['b'])  # noqa: E721
         assert t12.pformat() == [' a   b ',
                                  '--- ---',
                                  '0.0 foo',
@@ -1004,8 +1004,8 @@ class TestVStack():
 
         t124 = table.vstack([t1, t2, t4], join_type='inner')
         assert type(t124) is operation_table_type
-        assert type(t12['a']) is type(t1['a'])  # noqa
-        assert type(t12['b']) is type(t1['b'])  # noqa
+        assert type(t12['a']) is type(t1['a'])  # noqa: E721
+        assert type(t12['b']) is type(t1['b'])  # noqa: E721
         assert t124.pformat() == [' a   b ',
                                   '--- ---',
                                   '0.0 foo',
@@ -1375,15 +1375,15 @@ class TestDStack():
         # Test for non-masked table
         t12 = table.dstack([t1, t2], join_type='outer')
         assert type(t12) is operation_table_type
-        assert type(t12['a']) is type(t1['a'])  # noqa
-        assert type(t12['b']) is type(t1['b'])  # noqa
+        assert type(t12['a']) is type(t1['a'])  # noqa: E721
+        assert type(t12['b']) is type(t1['b'])  # noqa: E721
         self.compare_dstack([t1, t2], t12)
 
         # Test for masked table
         t124 = table.dstack([t1, t2, t4], join_type='outer')
         assert type(t124) is operation_table_type
-        assert type(t124['a']) is type(t4['a'])  # noqa
-        assert type(t124['b']) is type(t4['b'])  # noqa
+        assert type(t124['a']) is type(t4['a'])  # noqa: E721
+        assert type(t124['b']) is type(t4['b'])  # noqa: E721
         self.compare_dstack([t1, t2, t4], t124)
 
     def test_dstack_basic_inner(self, operation_table_type):
@@ -1395,8 +1395,8 @@ class TestDStack():
         # Test for masked table
         t124 = table.dstack([t1, t2, t4], join_type='inner')
         assert type(t124) is operation_table_type
-        assert type(t124['a']) is type(t4['a'])  # noqa
-        assert type(t124['b']) is type(t4['b'])  # noqa
+        assert type(t124['a']) is type(t4['a'])  # noqa: E721
+        assert type(t124['b']) is type(t4['b'])  # noqa: E721
         self.compare_dstack([t1, t2, t4], t124)
 
     def test_dstack_multi_dimension_column(self, operation_table_type):
@@ -1406,8 +1406,8 @@ class TestDStack():
         t2 = self.t2
         t35 = table.dstack([t3, t5])
         assert type(t35) is operation_table_type
-        assert type(t35['a']) is type(t3['a'])  # noqa
-        assert type(t35['b']) is type(t3['b'])  # noqa
+        assert type(t35['a']) is type(t3['a'])  # noqa: E721
+        assert type(t35['b']) is type(t3['b'])  # noqa: E721
         self.compare_dstack([t3, t5], t35)
 
         with pytest.raises(TableMergeError):
@@ -1528,9 +1528,9 @@ class TestHStack():
     def test_stack_columns(self, operation_table_type):
         self._setup(operation_table_type)
         out = table.hstack([self.t1, self.t2['c']])
-        assert type(out['a']) is type(self.t1['a'])  # noqa
-        assert type(out['b']) is type(self.t1['b'])  # noqa
-        assert type(out['c']) is type(self.t2['c'])  # noqa
+        assert type(out['a']) is type(self.t1['a'])  # noqa: E721
+        assert type(out['b']) is type(self.t1['b'])  # noqa: E721
+        assert type(out['c']) is type(self.t2['c'])  # noqa: E721
         assert out.pformat() == [' a   b   c ',
                                  '--- --- ---',
                                  '0.0 foo   4',
@@ -1587,10 +1587,10 @@ class TestHStack():
         out = table.hstack([t1, t2], join_type='inner')
         assert out.masked is False
         assert type(out) is operation_table_type
-        assert type(out['a_1']) is type(t1['a'])  # noqa
-        assert type(out['b_1']) is type(t1['b'])  # noqa
-        assert type(out['a_2']) is type(t2['a'])  # noqa
-        assert type(out['b_2']) is type(t2['b'])  # noqa
+        assert type(out['a_1']) is type(t1['a'])  # noqa: E721
+        assert type(out['b_1']) is type(t1['b'])  # noqa: E721
+        assert type(out['a_2']) is type(t2['a'])  # noqa: E721
+        assert type(out['b_2']) is type(t2['b'])  # noqa: E721
         assert out.pformat() == ['a_1 b_1 a_2 b_2  c ',
                                  '--- --- --- --- ---',
                                  '0.0 foo 2.0 pez   4',
@@ -1695,7 +1695,7 @@ class TestHStack():
         cls_name = type(col1).__name__
 
         out = table.hstack([t1, t2], join_type='inner')
-        assert type(out['col0_1']) is type(out['col0_2'])  # noqa
+        assert type(out['col0_1']) is type(out['col0_2'])  # noqa: E721
         assert len(out) == len(col2)
 
         # Check that columns are as expected.

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -905,8 +905,8 @@ class TestRemove(SetupData):
         assert self.t.as_array().size == 0
         # Regression test for gh-8640
         assert not self.t
-        assert isinstance(self.t == None, np.ndarray)  # noqa
-        assert (self.t == None).size == 0  # noqa
+        assert isinstance(self.t == None, np.ndarray)  # noqa: E711
+        assert (self.t == None).size == 0  # noqa: E711
 
     def test_2(self, table_types):
         self._setup(table_types)
@@ -1020,8 +1020,8 @@ class TestRemove(SetupData):
         assert self.t.as_array().size == 0
         # Regression test for gh-8640
         assert not self.t
-        assert isinstance(self.t == None, np.ndarray)  # noqa
-        assert (self.t == None).size == 0  # noqa
+        assert isinstance(self.t == None, np.ndarray)  # noqa: E711
+        assert (self.t == None).size == 0  # noqa: E711
 
     def test_delitem2(self, table_types):
         self._setup(table_types)
@@ -1050,8 +1050,8 @@ class TestKeep(SetupData):
         assert t.as_array().size == 0
         # Regression test for gh-8640
         assert not t
-        assert isinstance(t == None, np.ndarray)  # noqa
-        assert (t == None).size == 0  # noqa
+        assert isinstance(t == None, np.ndarray)  # noqa: E711
+        assert (t == None).size == 0  # noqa: E711
 
     def test_2(self, table_types):
         self._setup(table_types)
@@ -2518,7 +2518,7 @@ def test_replace_update_column_via_setitem_warnings_refcount():
     Reference count changes.
     """
     t = table.Table([[1, 2, 3], [4, 5, 6]], names=['a', 'b'])
-    ta = t['a']  # noqa : Generate an extra reference to original column
+    ta = t['a']  # noqa: F841 : Generate an extra reference to original column
 
     with pytest.warns(TableReplaceWarning, match="replaced column 'a' and the "
                       "number of references") as w:

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -1999,7 +1999,7 @@ class Time(TimeBase):
         and is rigorously corrected for polar motion.
         (except when ``longitude='tio'``).
 
-        """  # noqa
+        """  # noqa: E501
         if isinstance(longitude, str) and longitude == 'tio':
             longitude = 0
             include_tio = False
@@ -2061,7 +2061,7 @@ class Time(TimeBase):
         the equator of the Celestial Intermediate Pole (CIP) and is rigorously
         corrected for polar motion (except when ``longitude='tio'`` or ``'greenwich'``).
 
-        """  # noqa (docstring is formatted below)
+        """  # noqa: E501 (docstring is formatted below)
 
         if kind.lower() not in SIDEREAL_TIME_MODELS.keys():
             raise ValueError('The kind of sidereal time has to be {}'.format(
@@ -2113,7 +2113,7 @@ class Time(TimeBase):
         `~astropy.coordinates.Longitude`
             Local sidereal time or Earth rotation angle, with units of hourangle.
 
-        """  # noqa
+        """  # noqa: E501
         from astropy.coordinates import EarthLocation, Longitude
         from astropy.coordinates.builtin_frames.utils import get_polar_motion
         from astropy.coordinates.matrix_utilities import rotation_matrix

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -1965,4 +1965,4 @@ def _broadcast_writeable(jd1, jd2):
 
 # Import symbols from core.py that are used in this module. This succeeds
 # because __init__.py imports format.py just before core.py.
-from .core import TIME_DELTA_SCALES, TIME_SCALES, ScaleValueError, Time  # noqa
+from .core import TIME_DELTA_SCALES, TIME_SCALES, ScaleValueError, Time  # noqa: E402

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -2381,7 +2381,7 @@ def test_location_init(location):
     # Init from a scalar Time
     tm2 = Time(tm)
     assert np.all(tm.location == tm2.location)
-    assert type(tm.location) is type(tm2.location)  # noqa
+    assert type(tm.location) is type(tm2.location)  # noqa: E721
 
     # From a list of Times
     tm2 = Time([tm, tm])
@@ -2390,7 +2390,7 @@ def test_location_init(location):
     else:
         for loc in tm2.location:
             assert loc == tm.location
-    assert type(tm.location) is type(tm2.location)  # noqa
+    assert type(tm.location) is type(tm2.location)  # noqa: E721
 
     # Effectively the same as a list of Times, but just to be sure that
     # Table mixin inititialization is working as expected.
@@ -2400,7 +2400,7 @@ def test_location_init(location):
     else:
         for loc in tm2.location:
             assert loc == tm.location
-    assert type(tm.location) is type(tm2.location)  # noqa
+    assert type(tm.location) is type(tm2.location)  # noqa: E721
 
 
 def test_location_init_fail():

--- a/astropy/time/tests/test_comparisons.py
+++ b/astropy/time/tests/test_comparisons.py
@@ -31,8 +31,8 @@ class TestTimeComparisons:
                 op(t1, None)
         # Keep == and != as they are specifically meant to test Time.__eq__
         # and Time.__ne__
-        assert (t1 == None) is False  # noqa
-        assert (t1 != None) is True  # noqa
+        assert (t1 == None) is False  # noqa: E711
+        assert (t1 != None) is True  # noqa: E711
 
     def test_time(self):
         t1_lt_t2 = self.t1 < self.t2

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -171,7 +171,7 @@ def test_unknown_unit3():
     assert unit == "FOO"
     assert unit != u.m
     # next two from gh-7603.
-    assert unit != None  # noqa
+    assert unit != None  # noqa: E711
     assert unit not in (None, u.m)
 
     with pytest.raises(ValueError):
@@ -773,8 +773,8 @@ def test_compare_with_none():
     # Ensure that equality comparisons with `None` work, and don't
     # raise exceptions.  We are deliberately not using `is None` here
     # because that doesn't trigger the bug.  See #3108.
-    assert not (u.m == None)  # noqa
-    assert u.m != None  # noqa
+    assert not (u.m == None)  # noqa: E711
+    assert u.m != None  # noqa: E711
 
 
 def test_validate_power_detect_fraction():

--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -99,7 +99,7 @@ class TestSpectra:
             if _WCSLIB_VER >= Version('7.4'):
                 ctx = pytest.warns(
                     wcs.FITSFixedWarning,
-                    match=r"'datfix' made the change 'Set MJD-OBS to 53925\.853472 from DATE-OBS'\.")  # noqa
+                    match=r"'datfix' made the change 'Set MJD-OBS to 53925\.853472 from DATE-OBS'\.")  # noqa: E501
             else:
                 ctx = nullcontext()
             with ctx:


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request fixes all of the blanket `# noqa` throughout `astropy`. Either by fixing the reason for the `# noqa`, removing it as it was unnecessary, or by adding the appropriate  violation code to be skipped.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #13702

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
