### PR TITLE
Backport PR #13731 on branch v5.0.x (Fix bug in time parsing of fractional digits in date string)

### DIFF
--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -1295,13 +1295,15 @@ class TimeString(TimeUnique):
         try:
             idot = timestr.rindex('.')
         except Exception:
-            fracsec = 0.0
+            timestr_has_fractional_digits = False
         else:
             timestr, fracsec = timestr[:idot], timestr[idot:]
             fracsec = float(fracsec)
+            timestr_has_fractional_digits = True
 
         for _, strptime_fmt_or_regex, _ in subfmts:
             if isinstance(strptime_fmt_or_regex, str):
+                subfmt_has_sec = '%S' in strptime_fmt_or_regex
                 try:
                     tm = time.strptime(timestr, strptime_fmt_or_regex)
                 except ValueError:
@@ -1317,9 +1319,18 @@ class TimeString(TimeUnique):
                 tm = tm.groupdict()
                 vals = [int(tm.get(component, default)) for component, default
                         in zip(components, defaults)]
+                subfmt_has_sec = 'sec' in tm
 
-            # Add fractional seconds
-            vals[-1] = vals[-1] + fracsec
+            # Add fractional seconds if they were in the original time string
+            # and the subformat has seconds. A time like "2022-08-01.123" will
+            # never pass this for a format like ISO and will raise a parsing
+            # exception.
+            if timestr_has_fractional_digits:
+                if subfmt_has_sec:
+                    vals[-1] = vals[-1] + fracsec
+                else:
+                    continue
+
             return vals
         else:
             raise ValueError(f'Time {timestr} does not match {self.name} format')

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -15,13 +15,12 @@ from erfa import ErfaWarning
 
 from astropy.utils.exceptions import AstropyDeprecationWarning
 from astropy.utils import isiterable, iers
-from astropy.time import (Time, TimeDelta, ScaleValueError, STANDARD_TIME_SCALES,
+from astropy.time import (conf, Time, TimeDelta, ScaleValueError, STANDARD_TIME_SCALES,
                           TimeString, TimezoneInfo, TIME_FORMATS)
 from astropy.coordinates import EarthLocation
 from astropy import units as u
 from astropy.table import Column, Table
 from astropy.utils.compat.optional_deps import HAS_PYTZ  # noqa
-
 
 allclose_jd = functools.partial(np.allclose, rtol=np.finfo(float).eps, atol=0)
 allclose_jd2 = functools.partial(np.allclose, rtol=np.finfo(float).eps,
@@ -2285,6 +2284,17 @@ def test_format_subformat_compatibility():
     t = Time('2019-12-20', out_subfmt='date')
     assert t.mjd == 58837.0
     assert t.yday == '2019:354'
+
+
+@pytest.mark.parametrize('use_fast_parser', ["force", "False"])
+def test_format_fractional_string_parsing(use_fast_parser):
+    """Test that string like "2022-08-01.123" does not parse as ISO.
+    See #6476 and the fix."""
+    with pytest.raises(
+        ValueError, match=r"Input values did not match the format class iso"
+    ):
+        with conf.set_temp("use_fast_parser", use_fast_parser):
+            Time("2022-08-01.123", format='iso')
 
 
 @pytest.mark.parametrize('fmt_name,fmt_class', TIME_FORMATS.items())

--- a/docs/changes/time/13731.bugfix.rst
+++ b/docs/changes/time/13731.bugfix.rst
@@ -1,0 +1,4 @@
+Fix a bug in Time where a date string like "2022-08-01.123" was being parsed
+as an ISO-format time "2022-08-01 00:00:00.123". The fractional part at the
+end of the string was being taken as seconds. Now this raises an exception
+because the string is not in ISO format.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to manually backport https://github.com/astropy/astropy/pull/13731 to v5.0.x branch.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
