### PR TITLE
Add ``get_frame`` to coordinates

### DIFF
--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -15,7 +15,7 @@ from astropy.utils.data_info import MixinInfo
 from astropy.utils.exceptions import AstropyUserWarning
 
 from .angles import Angle
-from .baseframe import BaseCoordinateFrame, GenericFrame, frame_transform_graph
+from .baseframe import BaseCoordinateFrame, GenericFrame, frame_transform_graph, get_frame
 from .builtin_frames import ICRS, SkyOffsetFrame
 from .distances import Distance
 from .representation import (
@@ -2125,3 +2125,14 @@ class SkyCoord(ShapedLikeNDArray):
             return icrs_sky_coord
         else:
             return icrs_sky_coord.transform_to(frame)
+
+
+# ===================================================================
+# Convenience Functions
+
+@get_frame.register
+def _get_frame_from_skycoord(frame: SkyCoord) -> BaseCoordinateFrame:
+    return frame.frame.replicate_without_data(
+        representation_type=frame.frame.representation_type,
+        differential_type=frame.frame.differential_type,
+    )

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -12,7 +12,7 @@ from astropy.coordinates import representation as r
 from astropy.coordinates.attributes import (
     Attribute, CoordinateAttribute, DifferentialAttribute, EarthLocationAttribute,
     QuantityAttribute, TimeAttribute)
-from astropy.coordinates.baseframe import BaseCoordinateFrame, RepresentationMapping
+from astropy.coordinates.baseframe import BaseCoordinateFrame, RepresentationMapping, get_frame
 from astropy.coordinates.builtin_frames import (
     FK4, FK5, GCRS, HCRS, ICRS, ITRS, AltAz, Galactic, Galactocentric, HADec)
 from astropy.coordinates.representation import REPRESENTATION_CLASSES, CartesianDifferential
@@ -1507,3 +1507,32 @@ def test_nameless_frame_subclass():
     # This subclassing is the test!
     class NewFrame(ICRS, Test):
         pass
+
+
+def test_get_frame_error():
+    """Test an unregistered type for ``get_frame``."""
+    with pytest.raises(NotImplementedError):
+        get_frame(object)
+
+
+def test_get_frame_from_str():
+    assert get_frame("icrs") == ICRS()
+
+
+def test_get_frame_from_frame_type():
+    assert get_frame(ICRS) == ICRS()
+
+    with pytest.raises(NotImplementedError):
+        get_frame(object)
+
+
+def test_get_frame_from_frame():
+    inp = ICRS()
+    frame = get_frame(inp)
+    assert frame == inp
+    assert frame is not inp  # b/c replicated
+
+    inp = ICRS(ra=10*u.deg, dec=10*u.deg)
+    frame = get_frame(inp)
+    assert not frame.has_data
+    assert frame == ICRS()

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -18,6 +18,7 @@ from astropy.coordinates import (
     FK4, FK5, GCRS, ICRS, AltAz, Angle, Attribute, BaseCoordinateFrame, CartesianRepresentation,
     EarthLocation, Galactic, Latitude, RepresentationMapping, SkyCoord, SphericalRepresentation,
     UnitSphericalRepresentation, frame_transform_graph)
+from astropy.coordinates.baseframe import get_frame
 from astropy.coordinates.representation import DUPLICATE_REPRESENTATIONS, REPRESENTATION_CLASSES
 from astropy.coordinates.tests.helper import skycoord_equal
 from astropy.coordinates.transformations import FunctionTransform
@@ -1890,3 +1891,10 @@ def test_match_to_catalog_3d_and_sky():
     npt.assert_array_equal(idx, [0, 1, 2, 3])
     assert_allclose(angle, 0 * u.deg, atol=1e-14*u.deg, rtol=0)
     assert_allclose(distance, 0*u.kpc, atol=1e-14*u.kpc, rtol=0)
+
+
+def test_get_frame_from_skycoord():
+    inp = SkyCoord(ICRS(ra=10*u.deg, dec=10*u.deg))
+    frame = get_frame(inp)
+    assert not frame.has_data
+    assert frame == ICRS()

--- a/docs/changes/coordinates/13772.feature.rst
+++ b/docs/changes/coordinates/13772.feature.rst
@@ -1,0 +1,3 @@
+Added a ``functools.singledispatch`` method for getting a frame from input data.
+The built-in registrants are the frame name, a frame class or instance, and a
+SkyCoord.

--- a/docs/coordinates/frames.rst
+++ b/docs/coordinates/frames.rst
@@ -268,6 +268,46 @@ take a different lower-level approach which is described in the section
   The current cache implementation is similarly unable to handle in-place changes
   to the representation (``.data``) or frame attributes such as ``.obstime``.
 
+
+Getting the Frame
+-----------------
+
+In astropy and affiliate packages, frame instances are often passed as inputs to
+functions. For convenience it is useful for frame-like inputs, like the frame's
+name or a |SkyCoord| with the desired frame, to also be valid inputs. To support
+these use cases and to get the frame given input, use the
+:func:`~astropy.coordinates.get_frame` function. ``get_frame`` accepts the frame
+name, a frame instance (or class), or a SkyCoord and returns the frame
+(replicated, and without data).
+
+    >>> from astropy.coordinates import ICRS, SkyCoord, get_frame
+
+    >>> get_frame('icrs')
+    <ICRS Frame>
+
+    >>> get_frame(ICRS)
+    <ICRS Frame>
+
+    >>> get_frame(ICRS())
+    <ICRS Frame>
+
+    >>> get_frame(ICRS(ra=10 * u.deg, dec=10*u.deg))
+    <ICRS Frame>
+
+    >>> get_frame(SkyCoord(ICRS(ra=10 * u.deg, dec=10*u.deg)))
+    <ICRS Frame>
+
+As an example function accepting a frame::
+
+    >>> def transform_to(x, frame: "str | BaseCoordinateFrame | SkyCoord"):
+    ...     frame = get_frame(frame)
+    ...     ...
+
+:func:`~astropy.coordinates.get_frame` uses :func:`~functools.singledispatch`,
+so custom frame-like objects can be registered and will work anywhere
+``get_frame`` is used.
+
+
 Transforming between Frames
 ===========================
 


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

### Description

In astropy and affiliate packages, frame instances are often passed as inputs to functions. For convenience it is useful for frame-like inputs, like the frame's name or a SkyCoord with the desired frame, to also be valid inputs. To support these use cases and to get the frame given input, this PR adds the `get_frame` function. ``get_frame`` accepts the frame name, a frame instance (or class), or a SkyCoord and returns the frame (replicated, and without data).

```python
    >>> get_frame('icrs')
    <ICRS Frame>

    >>> get_frame(ICRS)
    <ICRS Frame>

    >>> get_frame(ICRS())
    <ICRS Frame>

    >>> get_frame(ICRS(ra=10 * u.deg, dec=10*u.deg))
    <ICRS Frame>

    >>> get_frame(SkyCoord(ICRS(ra=10 * u.deg, dec=10*u.deg)))
    <ICRS Frame>
```

As an example function accepting a frame::

```
    >>> def transform_to(x, frame: str | BaseCoordinateFrame | SkyCoord):
    ...     frame = get_frame(frame)
    ...     ...
```

`get_frame` uses `functools.singledispatch`, so custom frame-like objects can be registered and will work anywhere ``get_frame`` is used.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
