### PR TITLE
Recommend `tmp_path` fixture for temporary files in developer docs

### DIFF
--- a/docs/development/testguide.rst
+++ b/docs/development/testguide.rst
@@ -434,11 +434,12 @@ environment variable.
 Tests that create files
 =======================
 
-Tests may often be run from directories where users do not have write
-permissions so tests which create files should always do so in
-temporary directories. This can be done with the
-:ref:`pytest 'tmpdir' fixture <pytest:tmpdir>` or with
-Python's built-in :ref:`tempfile module <python:tempfile-examples>`.
+Some tests involve writing files. These files should not be saved permanently.
+The :ref:`pytest 'tmp_path' fixture <pytest:tmp_path>` allows for the
+convenient creation of temporary directories, which ensures test files will be
+cleaned up. Temporary directories can also be helpful in the case where the
+tests are run in an environment where the runner would otherwise not have write
+access.
 
 
 Setting up/Tearing down tests


### PR DESCRIPTION
### Description

The recommended way of creating temporary directories with `pytest` is the `tmp_path` fixture, which uses `pathlib.Path` from the Python standard library. Although it is not urgent to replace the legacy `tmpdir` in `astropy` testing, the developer documentation should not be making recommendations that contradict the recommendations `pytest` itself makes.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
