### PR TITLE
Misc skipif fixes

### DIFF
--- a/astropy/io/fits/tests/test_core.py
+++ b/astropy/io/fits/tests/test_core.py
@@ -1185,7 +1185,7 @@ class TestFileFunctions(FitsTestCase):
 
         self._test_write_string_bytes_io(io.BytesIO())
 
-    @pytest.mark.skipif(sys.platform.startswith("win32"), reason="Requires Unix")
+    @pytest.mark.skipif(sys.platform.startswith("win32"), reason="Cannot test on Windows")
     def test_filename_with_colon(self):
         """
         Test reading and writing a file with a colon in the filename.

--- a/astropy/io/fits/tests/test_core.py
+++ b/astropy/io/fits/tests/test_core.py
@@ -7,6 +7,7 @@ import mmap
 import os
 import pathlib
 import shutil
+import sys
 import urllib.request
 import zipfile
 from unittest.mock import patch
@@ -1184,7 +1185,7 @@ class TestFileFunctions(FitsTestCase):
 
         self._test_write_string_bytes_io(io.BytesIO())
 
-    @pytest.mark.skipif('sys.platform.startswith("win32")')
+    @pytest.mark.skipif(sys.platform.startswith("win32"), reason="Requires Unix")
     def test_filename_with_colon(self):
         """
         Test reading and writing a file with a colon in the filename.

--- a/astropy/io/fits/tests/test_hdulist.py
+++ b/astropy/io/fits/tests/test_hdulist.py
@@ -1147,7 +1147,7 @@ class TestHDUListFunctions(FitsTestCase):
             assert hdu_popped is hdu1
 
     # Skip due to https://github.com/astropy/astropy/issues/8916
-    @pytest.mark.skipif('sys.platform.startswith("win32")')
+    @pytest.mark.skipif(sys.platform.startswith("win32"), reason="Requires Unix")
     def test_write_hdulist_to_stream(self):
         """
         Unit test for https://github.com/astropy/astropy/issues/7435

--- a/astropy/io/fits/tests/test_hdulist.py
+++ b/astropy/io/fits/tests/test_hdulist.py
@@ -1147,7 +1147,7 @@ class TestHDUListFunctions(FitsTestCase):
             assert hdu_popped is hdu1
 
     # Skip due to https://github.com/astropy/astropy/issues/8916
-    @pytest.mark.skipif(sys.platform.startswith("win32"), reason="Requires Unix")
+    @pytest.mark.skipif(sys.platform.startswith("win32"), reason="Cannot test on Windows")
     def test_write_hdulist_to_stream(self):
         """
         Unit test for https://github.com/astropy/astropy/issues/7435

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -3047,7 +3047,7 @@ class TestVLATables(FitsTestCase):
             assert hdu.data['var'].tolist() == [[45, 56], [11, 12, 13]]
 
     @pytest.mark.skipif(sys.maxsize < 2**32, reason='requires 64-bit system')
-    @pytest.mark.skipif(sys.platform == "win32", reason='requires unix')
+    @pytest.mark.skipif(sys.platform == "win32", reason='Cannot test on Windows')
     @pytest.mark.hugemem
     def test_heapsize_P_limit(self):
         """

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -2667,7 +2667,7 @@ class TestTableFunctions(FitsTestCase):
             assert hdul[1].header['TDIM1'] == '(3,3,2)'
             assert np.all(hdul[1].data['a'][0] == expected)
 
-    @pytest.mark.skipif('not HAVE_OBJGRAPH')
+    @pytest.mark.skipif(not HAVE_OBJGRAPH, reason='requires objgraph')
     def test_reference_leak(self):
         """Regression test for https://github.com/astropy/astropy/pull/520"""
 
@@ -2681,7 +2681,7 @@ class TestTableFunctions(FitsTestCase):
         with _refcounting('FITS_rec'):
             readfile(self.data('memtest.fits'))
 
-    @pytest.mark.skipif('not HAVE_OBJGRAPH')
+    @pytest.mark.skipif(not HAVE_OBJGRAPH, reason='requires objgraph')
     @pytest.mark.slow
     def test_reference_leak2(self, tmpdir):
         """
@@ -3046,8 +3046,8 @@ class TestVLATables(FitsTestCase):
             assert hdu.data.tolist() == [[[45, 56], [11, 3]], [[11, 12, 13], [12, 4]]]
             assert hdu.data['var'].tolist() == [[45, 56], [11, 12, 13]]
 
-    @pytest.mark.skipif('sys.maxsize < 2**32')
-    @pytest.mark.skipif('sys.platform == "win32"')
+    @pytest.mark.skipif(sys.maxsize < 2**32, reason='requires 64-bit system')
+    @pytest.mark.skipif(sys.platform == "win32", reason='requires unix')
     @pytest.mark.hugemem
     def test_heapsize_P_limit(self):
         """

--- a/astropy/io/fits/tests/test_util.py
+++ b/astropy/io/fits/tests/test_util.py
@@ -20,7 +20,7 @@ from . import FitsTestCase
 
 
 class TestUtils(FitsTestCase):
-    @pytest.mark.skipif(sys.platform.startswith('win'), reason='requires Unix')
+    @pytest.mark.skipif(sys.platform.startswith('win'), reason="Cannot test on Windows")
     def test_ignore_sigint(self):
         @ignore_sigint
         def test():

--- a/astropy/io/fits/tests/test_util.py
+++ b/astropy/io/fits/tests/test_util.py
@@ -3,6 +3,7 @@
 import gzip
 import os
 import signal
+import sys
 
 import numpy as np
 import pytest
@@ -19,7 +20,7 @@ from . import FitsTestCase
 
 
 class TestUtils(FitsTestCase):
-    @pytest.mark.skipif("sys.platform.startswith('win')")
+    @pytest.mark.skipif(sys.platform.startswith('win'), reason='requires Unix')
     def test_ignore_sigint(self):
         @ignore_sigint
         def test():

--- a/astropy/modeling/tests/test_models.py
+++ b/astropy/modeling/tests/test_models.py
@@ -858,7 +858,7 @@ def test_tabular1d_inverse():
     assert_allclose(t(result), 100)
 
 
-@pytest.mark.skipif("not HAS_SCIPY")
+@pytest.mark.skipif(not HAS_SCIPY, reason='requires scipy')
 def test_tabular_grid_shape_mismatch_error():
     points = np.arange(5)
     lt = np.mgrid[0:5, 0:5][0]

--- a/astropy/tests/test_logger.py
+++ b/astropy/tests/test_logger.py
@@ -181,8 +181,6 @@ def test_exception_logging_enable_twice():
     assert e.value.args[0] == 'Exception logging has already been enabled'
 
 
-# You can't really override the exception handler in IPython this way, so
-# this test doesn't really make sense in the IPython context.
 @pytest.mark.skipif(ip is not None, reason="Cannot override exception handler in IPython")
 def test_exception_logging_overridden():
     log.enable_exception_logging()

--- a/astropy/tests/test_logger.py
+++ b/astropy/tests/test_logger.py
@@ -183,7 +183,7 @@ def test_exception_logging_enable_twice():
 
 # You can't really override the exception handler in IPython this way, so
 # this test doesn't really make sense in the IPython context.
-@pytest.mark.skipif("ip is not None")
+@pytest.mark.skipif(ip is not None, reason="Cannot override exception handler in IPython")
 def test_exception_logging_overridden():
     log.enable_exception_logging()
     sys.excepthook = lambda etype, evalue, tb: None

--- a/astropy/utils/tests/test_console.py
+++ b/astropy/utils/tests/test_console.py
@@ -61,7 +61,7 @@ def test_fake_tty():
     assert f2.getvalue() == ''
 
 
-@pytest.mark.skipif(sys.platform.startswith('win'), reason='requires unix')
+@pytest.mark.skipif(sys.platform.startswith('win'), reason="Cannot test on Windows")
 def test_color_text():
     assert console._color_text("foo", "green") == '\033[0;32mfoo\033[0m'
 
@@ -85,7 +85,7 @@ def test_color_print2():
     assert stream.getvalue() == 'foobarbaz\n'
 
 
-@pytest.mark.skipif(sys.platform.startswith('win'), reason='requires unix')
+@pytest.mark.skipif(sys.platform.startswith('win'), reason="Cannot test on Windows")
 def test_color_print3():
     # Test that this thinks the FakeTTY is a tty and applies colors.
 

--- a/astropy/utils/tests/test_console.py
+++ b/astropy/utils/tests/test_console.py
@@ -2,6 +2,7 @@
 
 
 import io
+import sys
 
 import pytest
 
@@ -60,7 +61,7 @@ def test_fake_tty():
     assert f2.getvalue() == ''
 
 
-@pytest.mark.skipif("sys.platform.startswith('win')")
+@pytest.mark.skipif(sys.platform.startswith('win'), reason='requires unix')
 def test_color_text():
     assert console._color_text("foo", "green") == '\033[0;32mfoo\033[0m'
 
@@ -84,7 +85,7 @@ def test_color_print2():
     assert stream.getvalue() == 'foobarbaz\n'
 
 
-@pytest.mark.skipif("sys.platform.startswith('win')")
+@pytest.mark.skipif(sys.platform.startswith('win'), reason='requires unix')
 def test_color_print3():
     # Test that this thinks the FakeTTY is a tty and applies colors.
 

--- a/astropy/visualization/wcsaxes/tests/test_misc.py
+++ b/astropy/visualization/wcsaxes/tests/test_misc.py
@@ -454,7 +454,7 @@ def test_time_wcs(time_spectral_wcs_2d):
     plt.subplot(projection=time_spectral_wcs_2d)
 
 
-@pytest.mark.skipif('TEX_UNAVAILABLE')
+@pytest.mark.skipif(TEX_UNAVAILABLE, reason='TeX is unavailable')
 def test_simplify_labels_usetex(ignore_matplotlibrc, tmpdir):
     """Regression test for https://github.com/astropy/astropy/issues/8004."""
     plt.rc('text', usetex=True)

--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -884,7 +884,7 @@ def test_no_iteration():
     assert exc.value.args[0] == "'NewWCS' object is not iterable"
 
 
-@pytest.mark.skipif('_wcs.__version__[0] < "5"',
+@pytest.mark.skipif(_wcs.__version__[0] < "5",
                     reason="TPV only works with wcslib 5.x or later")
 def test_sip_tpv_agreement():
     sip_header = get_pkg_data_contents(
@@ -914,7 +914,7 @@ def test_sip_tpv_agreement():
             w_tpv2.all_pix2world([w_tpv.wcs.crpix], 1))
 
 
-@pytest.mark.skipif('_wcs.__version__[0] < "5"',
+@pytest.mark.skipif(_wcs.__version__[0] < "5",
                     reason="TPV only works with wcslib 5.x or later")
 def test_tpv_copy():
     # See #3904


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

Follow up to #13784. I managed to find more `reasons` to add.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
