### PR TITLE
Replace `tmpdir` with `tmp_path` in `astropy/tests`

### DIFF
--- a/astropy/tests/test_logger.py
+++ b/astropy/tests/test_logger.py
@@ -362,11 +362,11 @@ def test_log_to_list_origin2():
 
 
 @pytest.mark.parametrize(('level'), [None, 'DEBUG', 'INFO', 'WARN', 'ERROR'])
-def test_log_to_file(tmpdir, level):
+def test_log_to_file(tmp_path, level):
 
-    local_path = tmpdir.join('test.log')
+    local_path = tmp_path / 'test.log'
     log_file = local_path.open('wb')
-    log_path = str(local_path.realpath())
+    log_path = str(local_path.resolve())
     orig_level = log.level
 
     try:
@@ -419,11 +419,11 @@ def test_log_to_file(tmpdir, level):
             'astropy.tests.test_logger', 'DEBUG', 'Debug message')
 
 
-def test_log_to_file_level(tmpdir):
+def test_log_to_file_level(tmp_path):
 
-    local_path = tmpdir.join('test.log')
+    local_path = tmp_path / 'test.log'
     log_file = local_path.open('wb')
-    log_path = str(local_path.realpath())
+    log_path = str(local_path.resolve())
 
     with log.log_to_file(log_path, filter_level='ERROR'):
         log.error("Error message")
@@ -440,11 +440,11 @@ def test_log_to_file_level(tmpdir):
         'ERROR', 'Error message')
 
 
-def test_log_to_file_origin1(tmpdir):
+def test_log_to_file_origin1(tmp_path):
 
-    local_path = tmpdir.join('test.log')
+    local_path = tmp_path / 'test.log'
     log_file = local_path.open('wb')
-    log_path = str(local_path.realpath())
+    log_path = str(local_path.resolve())
 
     with log.log_to_file(log_path, filter_origin='astropy.tests'):
         log.error("Error message")
@@ -459,11 +459,11 @@ def test_log_to_file_origin1(tmpdir):
     assert len(log_entries) == 2
 
 
-def test_log_to_file_origin2(tmpdir):
+def test_log_to_file_origin2(tmp_path):
 
-    local_path = tmpdir.join('test.log')
+    local_path = tmp_path / 'test.log'
     log_file = local_path.open('wb')
-    log_path = str(local_path.realpath())
+    log_path = str(local_path.resolve())
 
     with log.log_to_file(log_path, filter_origin='astropy.wcs'):
         log.error("Error message")
@@ -479,10 +479,10 @@ def test_log_to_file_origin2(tmpdir):
 
 
 @pytest.mark.parametrize(('encoding'), ['', 'utf-8', 'cp1252'])
-def test_log_to_file_encoding(tmpdir, encoding):
+def test_log_to_file_encoding(tmp_path, encoding):
 
-    local_path = tmpdir.join('test.log')
-    log_path = str(local_path.realpath())
+    local_path = tmp_path / 'test.log'
+    log_path = str(local_path.resolve())
 
     orig_encoding = conf.log_file_encoding
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request will replace the usage of `tmpdir` with `tmp_path` in `astropy/tests`.

See #13787 for an explanation of why that should be done.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
