### PR TITLE
Replace `tmpdir` with `tmp_path` in `time` tests

### DIFF
--- a/astropy/time/tests/test_mask.py
+++ b/astropy/time/tests/test_mask.py
@@ -153,11 +153,11 @@ def test_all_masked_input():
         assert str(t.iso) == '[--]'
 
 
-def test_serialize_fits_masked(tmpdir):
+def test_serialize_fits_masked(tmp_path):
     tm = Time([1, 2, 3], format='cxcsec')
     tm[1] = np.ma.masked
 
-    fn = str(tmpdir.join('tempfile.fits'))
+    fn = tmp_path / 'tempfile.fits'
     t = Table([tm])
     t.write(fn)
 
@@ -172,11 +172,11 @@ def test_serialize_fits_masked(tmpdir):
 
 
 @pytest.mark.skipif(not HAS_H5PY, reason='Needs h5py')
-def test_serialize_hdf5_masked(tmpdir):
+def test_serialize_hdf5_masked(tmp_path):
     tm = Time([1, 2, 3], format='cxcsec')
     tm[1] = np.ma.masked
 
-    fn = str(tmpdir.join('tempfile.hdf5'))
+    fn = tmp_path / 'tempfile.hdf5'
     t = Table([tm])
     t.write(fn, path='root', serialize_meta=True)
     t2 = Table.read(fn)
@@ -189,13 +189,13 @@ def test_serialize_hdf5_masked(tmpdir):
 # Ignore warning in MIPS https://github.com/astropy/astropy/issues/9750
 @pytest.mark.filterwarnings('ignore:invalid value encountered')
 @pytest.mark.parametrize('serialize_method', ['jd1_jd2', 'formatted_value'])
-def test_serialize_ecsv_masked(serialize_method, tmpdir):
+def test_serialize_ecsv_masked(serialize_method, tmp_path):
     tm = Time([1, 2, 3], format='cxcsec')
     tm[1] = np.ma.masked
 
     tm.info.serialize_method['ecsv'] = serialize_method
 
-    fn = str(tmpdir.join('tempfile.ecsv'))
+    fn = tmp_path / 'tempfile.ecsv'
     t = Table([tm])
     t.write(fn)
     t2 = Table.read(fn)

--- a/astropy/time/tests/test_update_leap_seconds.py
+++ b/astropy/time/tests/test_update_leap_seconds.py
@@ -57,8 +57,8 @@ class TestUpdateLeapSeconds:
         with pytest.warns(AstropyWarning, match='FileNotFound'):
             update_leap_seconds(['nonsense'])
 
-    def test_auto_update_corrupt_file(self, tmpdir):
-        bad_file = str(tmpdir.join('no_expiration'))
+    def test_auto_update_corrupt_file(self, tmp_path):
+        bad_file = str(tmp_path / 'no_expiration')
         with open(iers.IERS_LEAP_SECOND_FILE) as fh:
 
             lines = fh.readlines()
@@ -70,12 +70,12 @@ class TestUpdateLeapSeconds:
                           match='ValueError.*did not find expiration'):
             update_leap_seconds([bad_file])
 
-    def test_auto_update_expired_file(self, tmpdir):
+    def test_auto_update_expired_file(self, tmp_path):
         # Set up expired ERFA leap seconds.
         expired = self.erfa_ls[self.erfa_ls['year'] < 2017]
         expired.update_erfa_leap_seconds(initialize_erfa='empty')
         # Create similarly expired file.
-        expired_file = str(tmpdir.join('expired.dat'))
+        expired_file = str(tmp_path / 'expired.dat')
         with open(expired_file, 'w') as fh:
             fh.write('\n'.join(['# File expires on 28 June 2010']
                                + [str(item) for item in expired]))


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request will replace the usage of `tmpdir` with `tmp_path` in `time` tests.

See #13787 for an explanation of why that should be done.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
