### PR TITLE
`ZScaleInterval` parameter name change

### DIFF
--- a/astropy/visualization/interval.py
+++ b/astropy/visualization/interval.py
@@ -9,6 +9,8 @@ import abc
 
 import numpy as np
 
+from astropy.utils.decorators import deprecated_attribute, deprecated_renamed_argument
+
 from .transform import BaseTransform
 
 __all__ = ['BaseInterval', 'ManualInterval', 'MinMaxInterval',
@@ -203,9 +205,14 @@ class ZScaleInterval(BaseInterval):
 
     Parameters
     ----------
-    nsamples : int, optional
+    n_samples : int, optional
         The number of points in the array to sample for determining
         scaling factors.  Defaults to 1000.
+
+        .. versionchanged:: 5.2
+            ``n_samples`` replaces the deprecated ``nsamples`` argument,
+            which will be removed in the future.
+
     contrast : float, optional
         The scaling factor (between 0 and 1) for determining the minimum
         and maximum value.  Larger values increase the difference
@@ -226,21 +233,25 @@ class ZScaleInterval(BaseInterval):
         5.
     """
 
-    def __init__(self, nsamples=1000, contrast=0.25, max_reject=0.5,
+    @deprecated_renamed_argument("nsamples", "n_samples", "5.2")
+    def __init__(self, n_samples=1000, contrast=0.25, max_reject=0.5,
                  min_npixels=5, krej=2.5, max_iterations=5):
-        self.nsamples = nsamples
+        self.n_samples = n_samples
         self.contrast = contrast
         self.max_reject = max_reject
         self.min_npixels = min_npixels
         self.krej = krej
         self.max_iterations = max_iterations
 
+    # Mark `nsamples` as deprecated
+    nsamples = deprecated_attribute("nsamples", "5.2", alternative="n_samples")
+
     def get_limits(self, values):
         # Sample the image
         values = np.asarray(values)
         values = values[np.isfinite(values)]
-        stride = int(max(1.0, values.size / self.nsamples))
-        samples = values[::stride][:self.nsamples]
+        stride = int(max(1.0, values.size / self.n_samples))
+        samples = values[::stride][:self.n_samples]
         samples.sort()
 
         npix = len(samples)

--- a/docs/changes/visualization/13810.api.rst
+++ b/docs/changes/visualization/13810.api.rst
@@ -1,0 +1,3 @@
+Rename number-of-samples keyword ``nsamples`` in ``ZScaleInterval`` to align
+with the ``n_samples`` keyword used in all other ``Interval`` classes in
+this module.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request addresses non-uniform number-of-samples keywords among the classes in the ``astropy.visualization.interval`` module.

Adds module-standard ``n_samples`` keyword to``ZScaleInterval``, while preserving backward-compatibility with the existing ``nsamples`` keyword.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Needs

* https://github.com/astropy/astropy/pull/13824

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
