### PR TITLE
Replace `tmpdir` with `tmp_path` in `visualization` tests

### DIFF
--- a/astropy/visualization/scripts/tests/test_fits2bitmap.py
+++ b/astropy/visualization/scripts/tests/test_fits2bitmap.py
@@ -20,7 +20,7 @@ class TestFits2Bitmap:
 
     @pytest.mark.openfiles_ignore
     def test_function(self, tmp_path):
-        filename = str(tmp_path / self.filename)
+        filename = tmp_path / self.filename
         fits.writeto(filename, self.array)
         fits2bitmap(filename)
 

--- a/astropy/visualization/scripts/tests/test_fits2bitmap.py
+++ b/astropy/visualization/scripts/tests/test_fits2bitmap.py
@@ -19,20 +19,20 @@ class TestFits2Bitmap:
         self.array = np.arange(16384).reshape((128, 128))
 
     @pytest.mark.openfiles_ignore
-    def test_function(self, tmpdir):
-        filename = tmpdir.join(self.filename).strpath
+    def test_function(self, tmp_path):
+        filename = str(tmp_path / self.filename)
         fits.writeto(filename, self.array)
         fits2bitmap(filename)
 
     @pytest.mark.openfiles_ignore
-    def test_script(self, tmpdir):
-        filename = tmpdir.join(self.filename).strpath
+    def test_script(self, tmp_path):
+        filename = str(tmp_path / self.filename)
         fits.writeto(filename, self.array)
         main([filename, '-e', '0'])
 
     @pytest.mark.openfiles_ignore
-    def test_exten_num(self, tmpdir):
-        filename = tmpdir.join(self.filename).strpath
+    def test_exten_num(self, tmp_path):
+        filename = str(tmp_path / self.filename)
         hdu1 = fits.PrimaryHDU()
         hdu2 = fits.ImageHDU(self.array)
         hdulist = fits.HDUList([hdu1, hdu2])
@@ -40,8 +40,8 @@ class TestFits2Bitmap:
         main([filename, '-e', '1'])
 
     @pytest.mark.openfiles_ignore
-    def test_exten_name(self, tmpdir):
-        filename = tmpdir.join(self.filename).strpath
+    def test_exten_name(self, tmp_path):
+        filename = str(tmp_path / self.filename)
         hdu1 = fits.PrimaryHDU()
         extname = 'SCI'
         hdu2 = fits.ImageHDU(self.array)
@@ -51,20 +51,20 @@ class TestFits2Bitmap:
         main([filename, '-e', extname])
 
     @pytest.mark.parametrize('file_exten', ['.gz', '.bz2'])
-    def test_compressed_fits(self, tmpdir, file_exten):
-        filename = tmpdir.join('test.fits' + file_exten).strpath
+    def test_compressed_fits(self, tmp_path, file_exten):
+        filename = str(tmp_path / f'test.fits{file_exten}')
         fits.writeto(filename, self.array)
         main([filename, '-e', '0'])
 
     @pytest.mark.openfiles_ignore
-    def test_orientation(self, tmpdir):
+    def test_orientation(self, tmp_path):
         """
         Regression test to check the image vertical orientation/origin.
         """
 
-        filename = tmpdir.join(self.filename).strpath
+        filename = str(tmp_path / self.filename)
         out_filename = 'fits2bitmap_test.png'
-        out_filename = tmpdir.join(out_filename).strpath
+        out_filename = str(tmp_path / out_filename)
         data = np.zeros((32, 32))
         data[0:16, :] = 1.
         fits.writeto(filename, data)

--- a/astropy/visualization/wcsaxes/tests/test_coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/tests/test_coordinate_helpers.py
@@ -85,7 +85,7 @@ def test_label_visibility_rules_always(ignore_matplotlibrc, ax):
     assert_label_draw(ax, True, True)
 
 
-def test_format_unit(tmpdir):
+def test_format_unit():
 
     fig = plt.figure()
     ax = WCSAxes(fig, [0.1, 0.1, 0.8, 0.8], wcs=WCS(MSX_HEADER))
@@ -102,7 +102,7 @@ def test_format_unit(tmpdir):
     assert fu == "arcsec"
 
 
-def test_set_separator(tmpdir):
+def test_set_separator():
 
     fig = plt.figure()
     ax = WCSAxes(fig, [0.1, 0.1, 0.8, 0.8], wcs=WCS(MSX_HEADER))

--- a/astropy/visualization/wcsaxes/tests/test_display_world_coordinates.py
+++ b/astropy/visualization/wcsaxes/tests/test_display_world_coordinates.py
@@ -28,7 +28,7 @@ class TestDisplayWorldCoordinate(BaseImageTests):
 
         # On some systems, fig.canvas.draw is not enough to force a draw, so we
         # save to a temporary file.
-        fig.savefig(str(tmp_path / 'test1.png'))
+        fig.savefig(tmp_path / 'test1.png')
 
         # Testing default displayed world coordinates
         string_world = ax._display_world_coords(0.523412, 0.518311)
@@ -54,7 +54,7 @@ class TestDisplayWorldCoordinate(BaseImageTests):
 
         # On some systems, fig.canvas.draw is not enough to force a draw, so we
         # save to a temporary file.
-        fig.savefig(str(tmp_path / 'test2.png'))
+        fig.savefig(tmp_path / 'test2.png')
 
         event4 = KeyEvent('test_pixel_coords', canvas, 'w')
         fig.canvas.callbacks.process('key_press_event', event4)
@@ -71,7 +71,7 @@ class TestDisplayWorldCoordinate(BaseImageTests):
 
         # On some systems, fig.canvas.draw is not enough to force a draw, so we
         # save to a temporary file.
-        fig.savefig(str(tmp_path / 'test3.png'))
+        fig.savefig(tmp_path / 'test3.png')
 
         event5 = KeyEvent('test_pixel_coords', canvas, 'w')
         fig.canvas.callbacks.process('key_press_event', event5)
@@ -88,7 +88,7 @@ class TestDisplayWorldCoordinate(BaseImageTests):
 
         # On some systems, fig.canvas.draw is not enough to force a draw, so we
         # save to a temporary file.
-        fig.savefig(str(tmp_path / 'test4.png'))
+        fig.savefig(tmp_path / 'test4.png')
 
         event6 = KeyEvent('test_pixel_coords', canvas, 'w')
         fig.canvas.callbacks.process('key_press_event', event6)
@@ -108,7 +108,7 @@ class TestDisplayWorldCoordinate(BaseImageTests):
 
         # On some systems, fig.canvas.draw is not enough to force a draw, so we
         # save to a temporary file.
-        fig.savefig(str(tmp_path / 'test.png'))
+        fig.savefig(tmp_path / 'test.png')
 
         # Testing default displayed world coordinates
         string_world = ax._display_world_coords(0.523412, 0.518311)
@@ -135,7 +135,7 @@ class TestDisplayWorldCoordinate(BaseImageTests):
 
         # On some systems, fig.canvas.draw is not enough to force a draw, so we
         # save to a temporary file.
-        fig.savefig(str(tmp_path / 'test.png'))
+        fig.savefig(tmp_path / 'test.png')
 
         # Testing default displayed world coordinates
         string_world = ax._display_world_coords(0.523412, 0.518311)

--- a/astropy/visualization/wcsaxes/tests/test_display_world_coordinates.py
+++ b/astropy/visualization/wcsaxes/tests/test_display_world_coordinates.py
@@ -17,7 +17,7 @@ class TestDisplayWorldCoordinate(BaseImageTests):
     def teardown_method(self, method):
         plt.close('all')
 
-    def test_overlay_coords(self, ignore_matplotlibrc, tmpdir):
+    def test_overlay_coords(self, ignore_matplotlibrc, tmp_path):
         wcs = WCS(self.msx_header)
 
         fig = plt.figure(figsize=(4, 4))
@@ -28,7 +28,7 @@ class TestDisplayWorldCoordinate(BaseImageTests):
 
         # On some systems, fig.canvas.draw is not enough to force a draw, so we
         # save to a temporary file.
-        fig.savefig(tmpdir.join('test1.png').strpath)
+        fig.savefig(str(tmp_path / 'test1.png'))
 
         # Testing default displayed world coordinates
         string_world = ax._display_world_coords(0.523412, 0.518311)
@@ -54,7 +54,7 @@ class TestDisplayWorldCoordinate(BaseImageTests):
 
         # On some systems, fig.canvas.draw is not enough to force a draw, so we
         # save to a temporary file.
-        fig.savefig(tmpdir.join('test2.png').strpath)
+        fig.savefig(str(tmp_path / 'test2.png'))
 
         event4 = KeyEvent('test_pixel_coords', canvas, 'w')
         fig.canvas.callbacks.process('key_press_event', event4)
@@ -71,7 +71,7 @@ class TestDisplayWorldCoordinate(BaseImageTests):
 
         # On some systems, fig.canvas.draw is not enough to force a draw, so we
         # save to a temporary file.
-        fig.savefig(tmpdir.join('test3.png').strpath)
+        fig.savefig(str(tmp_path / 'test3.png'))
 
         event5 = KeyEvent('test_pixel_coords', canvas, 'w')
         fig.canvas.callbacks.process('key_press_event', event5)
@@ -88,7 +88,7 @@ class TestDisplayWorldCoordinate(BaseImageTests):
 
         # On some systems, fig.canvas.draw is not enough to force a draw, so we
         # save to a temporary file.
-        fig.savefig(tmpdir.join('test4.png').strpath)
+        fig.savefig(str(tmp_path / 'test4.png'))
 
         event6 = KeyEvent('test_pixel_coords', canvas, 'w')
         fig.canvas.callbacks.process('key_press_event', event6)
@@ -97,7 +97,7 @@ class TestDisplayWorldCoordinate(BaseImageTests):
 
         assert string_world5 == '267.652\xb0 -28\xb046\'23" (world, overlay 3)'
 
-    def test_cube_coords(self, ignore_matplotlibrc, tmpdir):
+    def test_cube_coords(self, ignore_matplotlibrc, tmp_path):
         wcs = WCS(self.cube_header)
 
         fig = plt.figure(figsize=(4, 4))
@@ -108,7 +108,7 @@ class TestDisplayWorldCoordinate(BaseImageTests):
 
         # On some systems, fig.canvas.draw is not enough to force a draw, so we
         # save to a temporary file.
-        fig.savefig(tmpdir.join('test.png').strpath)
+        fig.savefig(str(tmp_path / 'test.png'))
 
         # Testing default displayed world coordinates
         string_world = ax._display_world_coords(0.523412, 0.518311)
@@ -120,7 +120,7 @@ class TestDisplayWorldCoordinate(BaseImageTests):
         string_pixel = ax._display_world_coords(0.523412, 0.523412)
         assert string_pixel == "0.523412 0.523412 (pixel)"
 
-    def test_cube_coords_uncorr_slicing(self, ignore_matplotlibrc, tmpdir):
+    def test_cube_coords_uncorr_slicing(self, ignore_matplotlibrc, tmp_path):
 
         # Regression test for a bug that occurred with coordinate formatting if
         # some dimensions were uncorrelated and sliced out.
@@ -135,7 +135,7 @@ class TestDisplayWorldCoordinate(BaseImageTests):
 
         # On some systems, fig.canvas.draw is not enough to force a draw, so we
         # save to a temporary file.
-        fig.savefig(tmpdir.join('test.png').strpath)
+        fig.savefig(str(tmp_path / 'test.png'))
 
         # Testing default displayed world coordinates
         string_world = ax._display_world_coords(0.523412, 0.518311)

--- a/astropy/visualization/wcsaxes/tests/test_frame.py
+++ b/astropy/visualization/wcsaxes/tests/test_frame.py
@@ -75,7 +75,7 @@ class TestFrame(BaseImageTests):
         return fig
 
     @figure_test
-    def test_update_clip_path_rectangular(self, tmpdir):
+    def test_update_clip_path_rectangular(self, tmp_path):
 
         fig = plt.figure()
         ax = WCSAxes(fig, [0.1, 0.1, 0.8, 0.8], aspect='equal')
@@ -86,7 +86,7 @@ class TestFrame(BaseImageTests):
         ax.set_ylim(0., 2.)
 
         # Force drawing, which freezes the clip path returned by WCSAxes
-        fig.savefig(tmpdir.join('nothing').strpath)
+        fig.savefig(str(tmp_path / 'nothing'))
 
         ax.imshow(np.zeros((12, 4)))
 
@@ -99,7 +99,7 @@ class TestFrame(BaseImageTests):
         return fig
 
     @figure_test
-    def test_update_clip_path_nonrectangular(self, tmpdir):
+    def test_update_clip_path_nonrectangular(self, tmp_path):
 
         fig = plt.figure()
         ax = WCSAxes(fig, [0.1, 0.1, 0.8, 0.8], aspect='equal',
@@ -111,7 +111,7 @@ class TestFrame(BaseImageTests):
         ax.set_ylim(0., 2.)
 
         # Force drawing, which freezes the clip path returned by WCSAxes
-        fig.savefig(tmpdir.join('nothing').strpath)
+        fig.savefig(str(tmp_path / 'nothing'))
 
         ax.imshow(np.zeros((12, 4)))
 
@@ -121,7 +121,7 @@ class TestFrame(BaseImageTests):
         return fig
 
     @figure_test
-    def test_update_clip_path_change_wcs(self, tmpdir):
+    def test_update_clip_path_change_wcs(self, tmp_path):
 
         # When WCS is changed, a new frame is created, so we need to make sure
         # that the path is carried over to the new frame.
@@ -135,7 +135,7 @@ class TestFrame(BaseImageTests):
         ax.set_ylim(0., 2.)
 
         # Force drawing, which freezes the clip path returned by WCSAxes
-        fig.savefig(tmpdir.join('nothing').strpath)
+        fig.savefig(str(tmp_path / 'nothing'))
 
         ax.reset_wcs()
 

--- a/astropy/visualization/wcsaxes/tests/test_frame.py
+++ b/astropy/visualization/wcsaxes/tests/test_frame.py
@@ -86,7 +86,7 @@ class TestFrame(BaseImageTests):
         ax.set_ylim(0., 2.)
 
         # Force drawing, which freezes the clip path returned by WCSAxes
-        fig.savefig(str(tmp_path / 'nothing'))
+        fig.savefig(tmp_path / 'nothing')
 
         ax.imshow(np.zeros((12, 4)))
 
@@ -111,7 +111,7 @@ class TestFrame(BaseImageTests):
         ax.set_ylim(0., 2.)
 
         # Force drawing, which freezes the clip path returned by WCSAxes
-        fig.savefig(str(tmp_path / 'nothing'))
+        fig.savefig(tmp_path / 'nothing')
 
         ax.imshow(np.zeros((12, 4)))
 
@@ -135,7 +135,7 @@ class TestFrame(BaseImageTests):
         ax.set_ylim(0., 2.)
 
         # Force drawing, which freezes the clip path returned by WCSAxes
-        fig.savefig(str(tmp_path / 'nothing'))
+        fig.savefig(tmp_path / 'nothing')
 
         ax.reset_wcs()
 

--- a/astropy/visualization/wcsaxes/tests/test_images.py
+++ b/astropy/visualization/wcsaxes/tests/test_images.py
@@ -610,7 +610,7 @@ class TestBasic(BaseImageTests):
         ax.grid(color='white', ls='solid')
 
         # Force drawing (needed for format_coord)
-        fig.savefig(str(tmp_path / 'nothing'))
+        fig.savefig(tmp_path / 'nothing')
 
         assert ax.format_coord(512, 512) == '513.0 513.0 (world)'
 

--- a/astropy/visualization/wcsaxes/tests/test_images.py
+++ b/astropy/visualization/wcsaxes/tests/test_images.py
@@ -581,7 +581,7 @@ class TestBasic(BaseImageTests):
         return fig
 
     @figure_test(savefig_kwargs={'bbox_inches': 'tight'})
-    def test_noncelestial_angular(self, tmpdir):
+    def test_noncelestial_angular(self, tmp_path):
         # Regression test for a bug that meant that when passing a WCS that had
         # angular axes and using set_coord_type to set the coordinates to
         # longitude/latitude, but where the WCS wasn't recognized as celestial,
@@ -610,14 +610,14 @@ class TestBasic(BaseImageTests):
         ax.grid(color='white', ls='solid')
 
         # Force drawing (needed for format_coord)
-        fig.savefig(tmpdir.join('nothing').strpath)
+        fig.savefig(str(tmp_path / 'nothing'))
 
         assert ax.format_coord(512, 512) == '513.0 513.0 (world)'
 
         return fig
 
     @figure_test
-    def test_patches_distortion(self, tmpdir):
+    def test_patches_distortion(self, tmp_path):
 
         # Check how patches get distorted (and make sure that scatter markers
         # and SphericalCircle don't)
@@ -677,7 +677,7 @@ class TestBasic(BaseImageTests):
         return fig
 
     @figure_test
-    def test_quadrangle(self, tmpdir):
+    def test_quadrangle(self, tmp_path):
         # Test that Quadrangle can have curved edges while Rectangle does not
         wcs = WCS(self.msx_header)
         fig = plt.figure(figsize=(3, 3))

--- a/astropy/visualization/wcsaxes/tests/test_misc.py
+++ b/astropy/visualization/wcsaxes/tests/test_misc.py
@@ -51,7 +51,7 @@ def test_format_coord_regression(ignore_matplotlibrc, tmp_path):
     assert ax.format_coord(10, 10) == ""
     assert ax.coords[0].format_coord(10) == ""
     assert ax.coords[1].format_coord(10) == ""
-    fig.savefig(str(tmp_path / 'nothing'))
+    fig.savefig(tmp_path / 'nothing')
     assert ax.format_coord(10, 10) == "10.0 10.0 (world)"
     assert ax.coords[0].format_coord(10) == "10.0"
     assert ax.coords[1].format_coord(10) == "10.0"
@@ -93,7 +93,7 @@ def test_no_numpy_warnings(ignore_matplotlibrc, tmp_path, grid_type):
         warnings.filterwarnings('ignore', message=r'.*No contour levels were found within the data range.*')
         warnings.filterwarnings('ignore', message=r'.*np\.asscalar\(a\) is deprecated since NumPy v1\.16.*')
         warnings.filterwarnings('ignore', message=r'.*PY_SSIZE_T_CLEAN will be required.*')
-        fig.savefig(str(tmp_path / 'test.png'))
+        fig.savefig(tmp_path / 'test.png')
 
 
 def test_invalid_frame_overlay(ignore_matplotlibrc):
@@ -205,7 +205,7 @@ def test_slicing_warnings(ignore_matplotlibrc, tmp_path):
         # https://github.com/astropy/astropy/issues/9690
         warnings.filterwarnings('ignore', message=r'.*PY_SSIZE_T_CLEAN.*')
         plt.subplot(1, 1, 1, projection=wcs3d, slices=('x', 'y', 1))
-        plt.savefig(str(tmp_path / 'test.png'))
+        plt.savefig(tmp_path / 'test.png')
 
     # Angle case
 
@@ -216,7 +216,7 @@ def test_slicing_warnings(ignore_matplotlibrc, tmp_path):
         warnings.filterwarnings('ignore', message=r'.*PY_SSIZE_T_CLEAN.*')
         plt.clf()
         plt.subplot(1, 1, 1, projection=wcs3d, slices=('x', 'y', 2))
-        plt.savefig(str(tmp_path / 'test.png'))
+        plt.savefig(tmp_path / 'test.png')
 
 
 def test_plt_xlabel_ylabel(tmp_path):
@@ -227,7 +227,7 @@ def test_plt_xlabel_ylabel(tmp_path):
     plt.subplot(projection=WCS())
     plt.xlabel('Galactic Longitude')
     plt.ylabel('Galactic Latitude')
-    plt.savefig(str(tmp_path / 'test.png'))
+    plt.savefig(tmp_path / 'test.png')
 
 
 def test_grid_type_contours_transform(tmp_path):
@@ -254,7 +254,7 @@ def test_grid_type_contours_transform(tmp_path):
                  transform=transform, coord_meta=coord_meta)
     fig.add_axes(ax)
     ax.grid(grid_type='contours')
-    fig.savefig(str(tmp_path / 'test.png'))
+    fig.savefig(tmp_path / 'test.png')
 
 
 def test_plt_imshow_origin():
@@ -285,7 +285,7 @@ def test_grid_contour_large_spacing(tmp_path):
     # didn't produce grid lines (due e.g. to too large spacing) and was then
     # called again.
 
-    filename = str(tmp_path / 'test.png')
+    filename = tmp_path / 'test.png'
 
     ax = plt.subplot(projection=WCS())
     ax.set_xlim(-0.5, 1.5)

--- a/astropy/visualization/wcsaxes/tests/test_misc.py
+++ b/astropy/visualization/wcsaxes/tests/test_misc.py
@@ -42,7 +42,7 @@ def test_grid_regression(ignore_matplotlibrc):
     WCSAxes(fig, [0.1, 0.1, 0.8, 0.8])
 
 
-def test_format_coord_regression(ignore_matplotlibrc, tmpdir):
+def test_format_coord_regression(ignore_matplotlibrc, tmp_path):
     # Regression test for a bug that meant that if format_coord was called by
     # Matplotlib before the axes were drawn, an error occurred.
     fig = plt.figure(figsize=(3, 3))
@@ -51,7 +51,7 @@ def test_format_coord_regression(ignore_matplotlibrc, tmpdir):
     assert ax.format_coord(10, 10) == ""
     assert ax.coords[0].format_coord(10) == ""
     assert ax.coords[1].format_coord(10) == ""
-    fig.savefig(tmpdir.join('nothing').strpath)
+    fig.savefig(str(tmp_path / 'nothing'))
     assert ax.format_coord(10, 10) == "10.0 10.0 (world)"
     assert ax.coords[0].format_coord(10) == "10.0"
     assert ax.coords[1].format_coord(10) == "10.0"
@@ -76,7 +76,7 @@ COORDSYS= 'icrs    '
 
 
 @pytest.mark.parametrize('grid_type', ['lines', 'contours'])
-def test_no_numpy_warnings(ignore_matplotlibrc, tmpdir, grid_type):
+def test_no_numpy_warnings(ignore_matplotlibrc, tmp_path, grid_type):
     fig = plt.figure()
     ax = fig.add_subplot(1, 1, 1, projection=WCS(TARGET_HEADER))
     ax.imshow(np.zeros((100, 200)))
@@ -93,7 +93,7 @@ def test_no_numpy_warnings(ignore_matplotlibrc, tmpdir, grid_type):
         warnings.filterwarnings('ignore', message=r'.*No contour levels were found within the data range.*')
         warnings.filterwarnings('ignore', message=r'.*np\.asscalar\(a\) is deprecated since NumPy v1\.16.*')
         warnings.filterwarnings('ignore', message=r'.*PY_SSIZE_T_CLEAN will be required.*')
-        fig.savefig(tmpdir.join('test.png').strpath)
+        fig.savefig(str(tmp_path / 'test.png'))
 
 
 def test_invalid_frame_overlay(ignore_matplotlibrc):
@@ -187,7 +187,7 @@ CRPIX3  =                241.0
 """, sep='\n')
 
 
-def test_slicing_warnings(ignore_matplotlibrc, tmpdir):
+def test_slicing_warnings(ignore_matplotlibrc, tmp_path):
 
     # Regression test to make sure that no warnings are emitted by the tick
     # locator for the sliced axis when slicing a cube.
@@ -205,7 +205,7 @@ def test_slicing_warnings(ignore_matplotlibrc, tmpdir):
         # https://github.com/astropy/astropy/issues/9690
         warnings.filterwarnings('ignore', message=r'.*PY_SSIZE_T_CLEAN.*')
         plt.subplot(1, 1, 1, projection=wcs3d, slices=('x', 'y', 1))
-        plt.savefig(tmpdir.join('test.png').strpath)
+        plt.savefig(str(tmp_path / 'test.png'))
 
     # Angle case
 
@@ -216,10 +216,10 @@ def test_slicing_warnings(ignore_matplotlibrc, tmpdir):
         warnings.filterwarnings('ignore', message=r'.*PY_SSIZE_T_CLEAN.*')
         plt.clf()
         plt.subplot(1, 1, 1, projection=wcs3d, slices=('x', 'y', 2))
-        plt.savefig(tmpdir.join('test.png').strpath)
+        plt.savefig(str(tmp_path / 'test.png'))
 
 
-def test_plt_xlabel_ylabel(tmpdir):
+def test_plt_xlabel_ylabel(tmp_path):
 
     # Regression test for a bug that happened when using plt.xlabel
     # and plt.ylabel with Matplotlib 3.0
@@ -227,10 +227,10 @@ def test_plt_xlabel_ylabel(tmpdir):
     plt.subplot(projection=WCS())
     plt.xlabel('Galactic Longitude')
     plt.ylabel('Galactic Latitude')
-    plt.savefig(tmpdir.join('test.png').strpath)
+    plt.savefig(str(tmp_path / 'test.png'))
 
 
-def test_grid_type_contours_transform(tmpdir):
+def test_grid_type_contours_transform(tmp_path):
 
     # Regression test for a bug that caused grid_type='contours' to not work
     # with custom transforms
@@ -254,7 +254,7 @@ def test_grid_type_contours_transform(tmpdir):
                  transform=transform, coord_meta=coord_meta)
     fig.add_axes(ax)
     ax.grid(grid_type='contours')
-    fig.savefig(tmpdir.join('test.png').strpath)
+    fig.savefig(str(tmp_path / 'test.png'))
 
 
 def test_plt_imshow_origin():
@@ -279,13 +279,13 @@ def test_ax_imshow_origin():
     assert ax.get_ylim() == (-0.5, 1.5)
 
 
-def test_grid_contour_large_spacing(tmpdir):
+def test_grid_contour_large_spacing(tmp_path):
 
     # Regression test for a bug that caused a crash when grid was called and
     # didn't produce grid lines (due e.g. to too large spacing) and was then
     # called again.
 
-    filename = tmpdir.join('test.png').strpath
+    filename = str(tmp_path / 'test.png')
 
     ax = plt.subplot(projection=WCS())
     ax.set_xlim(-0.5, 1.5)
@@ -327,7 +327,7 @@ def test_contour_empty():
         ax.contour(np.zeros((4, 4)), transform=ax.get_transform('world'))
 
 
-def test_iterate_coords(ignore_matplotlibrc, tmpdir):
+def test_iterate_coords(ignore_matplotlibrc):
 
     # Regression test for a bug that caused ax.coords to return too few axes
 
@@ -455,7 +455,7 @@ def test_time_wcs(time_spectral_wcs_2d):
 
 
 @pytest.mark.skipif(TEX_UNAVAILABLE, reason='TeX is unavailable')
-def test_simplify_labels_usetex(ignore_matplotlibrc, tmpdir):
+def test_simplify_labels_usetex(ignore_matplotlibrc, tmp_path):
     """Regression test for https://github.com/astropy/astropy/issues/8004."""
     plt.rc('text', usetex=True)
 
@@ -484,7 +484,7 @@ def test_simplify_labels_usetex(ignore_matplotlibrc, tmpdir):
     ax.coords[1].set_ticks(spacing=30 * u.deg)
     ax.grid()
 
-    fig.savefig(tmpdir / 'plot.png')
+    fig.savefig(tmp_path / 'plot.png')
 
 
 @pytest.mark.parametrize('frame_class', [RectangularFrame, EllipticalFrame])
@@ -547,9 +547,9 @@ def test_wcs_type_transform_regression():
     ax.get_transform(sliced_wcs)
 
 
-def test_multiple_draws_grid_contours(tmpdir):
+def test_multiple_draws_grid_contours(tmp_path):
     fig = plt.figure()
     ax = fig.add_subplot(1, 1, 1, projection=WCS())
     ax.grid(color='black', grid_type='contours')
-    fig.savefig(tmpdir / 'plot.png')
-    fig.savefig(tmpdir / 'plot.png')
+    fig.savefig(tmp_path / 'plot.png')
+    fig.savefig(tmp_path / 'plot.png')


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request will replace the usage of `tmpdir` with `tmp_path` in `visualization` tests.

See #13787 for an explanation of why that should be done.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
