### PR TITLE
Allow a deprecated attribute to access its replacement

### DIFF
--- a/astropy/utils/decorators.py
+++ b/astropy/utils/decorators.py
@@ -210,7 +210,7 @@ def deprecated_attribute(name, since, message=None, alternative=None,
     property that will warn when the given attribute name is accessed.
     To prevent the warning (i.e. for internal code), use the private
     name for the attribute by prepending an underscore
-    (i.e. ``self._name``).
+    (i.e. ``self._name``), or set an alternative explicitly.
 
     Parameters
     ----------
@@ -248,12 +248,20 @@ def deprecated_attribute(name, since, message=None, alternative=None,
 
         class MyClass:
             # Mark the old_name as deprecated
-            old_name = misc.deprecated_attribute('old_name', '0.1')
+            old_name = deprecated_attribute("old_name", "0.1")
 
             def method(self):
                 self._old_name = 42
+
+        class MyClass2:
+            old_name = deprecated_attribute(
+                "old_name", "1.2", alternative="new_name"
+            )
+
+            def method(self):
+                self.new_name = 24
     """
-    private_name = '_' + name
+    private_name = alternative or "_" + name
 
     specific_deprecated = deprecated(since, name=name, obj_type='attribute',
                                      message=message, alternative=alternative,

--- a/astropy/utils/tests/test_decorators.py
+++ b/astropy/utils/tests/test_decorators.py
@@ -29,13 +29,6 @@ def test_deprecated_attribute():
             self._alternative = [42]
             self._pending = {42}
 
-        def set_private(self):
-            self._foo = 100
-            self._bar = 1000
-            self._message = '100'
-            self._alternative = [100]
-            self._pending = {100}
-
         foo = deprecated_attribute('foo', '0.2')
 
         bar = deprecated_attribute('bar', '0.2',
@@ -50,26 +43,45 @@ def test_deprecated_attribute():
 
     dummy = DummyClass()
 
-    with pytest.warns(AstropyDeprecationWarning, match="The foo attribute is "
-                      "deprecated and may be removed in a future version.") as w:
-        dummy.foo
+    default_msg = (
+        r"^The {} attribute is deprecated and may be removed in a future version\.$"
+    )
+
+    # Test getters and setters.
+    msg = default_msg.format("foo")
+    with pytest.warns(AstropyDeprecationWarning, match=msg) as w:
+        assert dummy.foo == 42
     assert len(w) == 1
+    with pytest.warns(AstropyDeprecationWarning, match=msg):
+        dummy.foo = 24
+    # Handling ``_foo`` should not cause deprecation warnings.
+    assert dummy._foo == 24
+    dummy._foo = 13
+    assert dummy._foo == 13
 
-    with pytest.warns(NewDeprecationWarning, match="The bar attribute is "
-                      "deprecated and may be removed in a future version.") as w:
-        dummy.bar
+    msg = default_msg.format("bar")
+    with pytest.warns(NewDeprecationWarning, match=msg) as w:
+        assert dummy.bar == 4242
     assert len(w) == 1
+    with pytest.warns(NewDeprecationWarning, match=msg):
+        dummy.bar = 2424
 
-    with pytest.warns(AstropyDeprecationWarning, match="MSG"):
-        dummy.message
+    with pytest.warns(AstropyDeprecationWarning, match="^MSG$"):
+        assert dummy.message == "42"
+    with pytest.warns(AstropyDeprecationWarning, match="^MSG$"):
+        dummy.message = "24"
 
-    with pytest.warns(AstropyDeprecationWarning, match=r"Use other instead\."):
-        dummy.alternative
+    msg = default_msg.format("alternative")[:-1] + r"\n        Use other instead\.$"
+    with pytest.warns(AstropyDeprecationWarning, match=msg):
+        assert dummy.alternative == [42]
+    with pytest.warns(AstropyDeprecationWarning, match=msg):
+        dummy.alternative = [24]
 
-    with pytest.warns(AstropyPendingDeprecationWarning):
-        dummy.pending
-
-    dummy.set_private()
+    msg = r"^The pending attribute will be deprecated in a future version\.$"
+    with pytest.warns(AstropyPendingDeprecationWarning, match=msg):
+        assert dummy.pending == {42}
+    with pytest.warns(AstropyPendingDeprecationWarning, match=msg):
+        dummy.pending = {24}
 
 
 # This needs to be defined outside of the test function, because we

--- a/astropy/utils/tests/test_decorators.py
+++ b/astropy/utils/tests/test_decorators.py
@@ -23,10 +23,10 @@ class NewDeprecationWarning(AstropyDeprecationWarning):
 def test_deprecated_attribute():
     class DummyClass:
         def __init__(self):
+            self.other = [42]
             self._foo = 42
             self._bar = 4242
             self._message = '42'
-            self._alternative = [42]
             self._pending = {42}
 
         foo = deprecated_attribute('foo', '0.2')
@@ -76,6 +76,9 @@ def test_deprecated_attribute():
         assert dummy.alternative == [42]
     with pytest.warns(AstropyDeprecationWarning, match=msg):
         dummy.alternative = [24]
+    # ``other`` is not deprecated.
+    assert dummy.other == [24]
+    dummy.other = [31]
 
     msg = r"^The pending attribute will be deprecated in a future version\.$"
     with pytest.warns(AstropyPendingDeprecationWarning, match=msg):

--- a/docs/changes/utils/13824.bugfix.rst
+++ b/docs/changes/utils/13824.bugfix.rst
@@ -1,0 +1,3 @@
+If an attribute is created using ``deprecated_attribute()`` with the
+``alternative`` argument then getting or setting the value of the deprecated
+attribute now accesses its replacement.


### PR DESCRIPTION
### Description

Deprecating a public attribute using `astropy.utils.decorators.deprecated_attribute()` currently requires setting up a corresponding private attribute even if it is being replaced by a new public attribute. This pull request simplifies renaming public attributes by allowing the deprecated attribute access its replacement.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
