### PR TITLE
Add a tickable gridline to a WCSAxes plot

### DIFF
--- a/astropy/tests/figures/py39-test-image-mpl311.json
+++ b/astropy/tests/figures/py39-test-image-mpl311.json
@@ -45,6 +45,7 @@
   "astropy.visualization.wcsaxes.tests.test_images.test_1d_plot_put_varying_axis_on_bottom_lon[slices0-hpln]": "29758ba86b70bcf749f538cd8199a44a2ad61f67910b66986dba09376f967eb5",
   "astropy.visualization.wcsaxes.tests.test_images.test_1d_plot_put_varying_axis_on_bottom_lon[slices1-hplt]": "9c00ec53014504c1c5cb81c7d5f60ff08ba52e59c9c13c16679430b9c61ad4d6",
   "astropy.visualization.wcsaxes.tests.test_images.test_allsky_labels_wrap": "56f9fb3bcfbba326347ad91c94ae7beb4a615c042ab6c42c38b7ce8d528135bf",
+  "astropy.visualization.wcsaxes.tests.test_images.test_tickable_gridlines": "4bd6a2f21fe25d61b1edb93978df8b7a2ead184f29a0a98df6757e180c2b29c1",
   "astropy.visualization.wcsaxes.tests.test_transform_coord_meta.TestTransformCoordMeta.test_coords_overlay": "382af290d2231d93a6a529e581e07a76912be48ad974abe4a7021eda15f37ba2",
   "astropy.visualization.wcsaxes.tests.test_transform_coord_meta.TestTransformCoordMeta.test_coords_overlay_auto_coord_meta": "069adb197b6c078e5354c10dec96808cd8a61ab50e079ee8806a388a6a5be3a0",
   "astropy.visualization.wcsaxes.tests.test_transform_coord_meta.TestTransformCoordMeta.test_direct_init": "f1916439fdc8be04568545db6169687f3ea8af4692ad7a9bede5a39eb5562896",

--- a/astropy/tests/figures/py39-test-image-mpldev.json
+++ b/astropy/tests/figures/py39-test-image-mpldev.json
@@ -45,6 +45,7 @@
   "astropy.visualization.wcsaxes.tests.test_images.test_1d_plot_put_varying_axis_on_bottom_lon[slices0-hpln]": "faa499a2e433ab6b7b600c7163723af9bf075bbc55a7d82f8901b7667417990c",
   "astropy.visualization.wcsaxes.tests.test_images.test_1d_plot_put_varying_axis_on_bottom_lon[slices1-hplt]": "e29d3f05923fcdaa5804dbd0b2239b02745bfb1acaabcff054974f00271ad093",
   "astropy.visualization.wcsaxes.tests.test_images.test_allsky_labels_wrap": "2ddc0aa50392293e18962df062af6075c13d3c16685fee85320d3cd0a7d98b3e",
+  "astropy.visualization.wcsaxes.tests.test_images.test_tickable_gridlines": "8be2fd1fd4e60ad4675fd280b42bde9c2a043fac9c4a36a7eca2f2d8df6152be",
   "astropy.visualization.wcsaxes.tests.test_transform_coord_meta.TestTransformCoordMeta.test_coords_overlay": "0a87473ff8e5b5610f4adac1518c608afcd2178b25584fb42f77bcc594c4f47a",
   "astropy.visualization.wcsaxes.tests.test_transform_coord_meta.TestTransformCoordMeta.test_coords_overlay_auto_coord_meta": "4ab8cade790f7ab36c620cb136e076a14eccf1dac7109a3d4d5601cebc46ac8a",
   "astropy.visualization.wcsaxes.tests.test_transform_coord_meta.TestTransformCoordMeta.test_direct_init": "1f24c5243bfdf0f30e88afc4f2f5d66db85954cea50a2910af94975ff8765b45",

--- a/astropy/visualization/wcsaxes/frame.py
+++ b/astropy/visualization/wcsaxes/frame.py
@@ -18,12 +18,24 @@ class Spine:
 
     This does not need to be a straight line, but represents a 'side' when
     determining which part of the frame to put labels and ticks on.
+
+    Parameters
+    ----------
+    parent_axes : `~astropy.visualization.wcsaxes.WCSAxes`
+        The parent axes
+    transform : `~matplotlib.transforms.Transform`
+        The transform from data to world
+    data_func : callable
+        If not ``None``, it should be a function that returns the appropriate spine
+        data when called with this object as the sole argument.  If ``None``, the
+        spine data must be manually updated in ``update_spines()``.
     """
 
-    def __init__(self, parent_axes, transform):
+    def __init__(self, parent_axes, transform, *, data_func=None):
 
         self.parent_axes = parent_axes
         self.transform = transform
+        self.data_func = data_func
 
         self._data = None
         self._pixel = None
@@ -31,6 +43,8 @@ class Spine:
 
     @property
     def data(self):
+        if self._data is None and self.data_func:
+            self.data = self.data_func(self)
         return self._data
 
     @data.setter
@@ -179,7 +193,7 @@ class BaseFrame(OrderedDict, metaclass=abc.ABCMeta):
 
         self.update_spines()
         x, y = [], []
-        for axis in self:
+        for axis in self.spine_names:
             x.append(self[axis].data[:, 0])
             y.append(self[axis].data[:, 1])
         vertices = np.vstack([np.hstack(x), np.hstack(y)]).transpose()
@@ -196,7 +210,7 @@ class BaseFrame(OrderedDict, metaclass=abc.ABCMeta):
                          facecolor=rcParams['axes.facecolor'], edgecolor='white')
 
     def draw(self, renderer):
-        for axis in self:
+        for axis in self.spine_names:
             x, y = self[axis].pixel[:, 0], self[axis].pixel[:, 1]
             line = Line2D(x, y, linewidth=self._linewidth, color=self._color, zorder=1000)
             line.draw(renderer)
@@ -245,9 +259,10 @@ class BaseFrame(OrderedDict, metaclass=abc.ABCMeta):
     def get_linewidth(self):
         return self._linewidth
 
-    @abc.abstractmethod
     def update_spines(self):
-        raise NotImplementedError("")
+        for spine in self.values():
+            if spine.data_func:
+                spine.data = spine.data_func(spine)
 
 
 class RectangularFrame1D(BaseFrame):
@@ -265,6 +280,8 @@ class RectangularFrame1D(BaseFrame):
 
         self['b'].data = np.array(([xmin, ymin], [xmax, ymin]))
         self['t'].data = np.array(([xmax, ymax], [xmin, ymax]))
+
+        super().update_spines()
 
     def _update_patch_path(self):
 
@@ -312,6 +329,8 @@ class RectangularFrame(BaseFrame):
         self['t'].data = np.array(([xmax, ymax], [xmin, ymax]))
         self['l'].data = np.array(([xmin, ymax], [xmin, ymin]))
 
+        super().update_spines()
+
 
 class EllipticalFrame(BaseFrame):
     """
@@ -338,6 +357,8 @@ class EllipticalFrame(BaseFrame):
                                    np.repeat(ymid, 1000)]).transpose()
         self['v'].data = np.array([np.repeat(xmid, 1000),
                                    np.linspace(ymin, ymax, 1000)]).transpose()
+
+        super().update_spines()
 
     def _update_patch_path(self):
         """Override path patch to include only the outer ellipse,

--- a/astropy/visualization/wcsaxes/frame.py
+++ b/astropy/visualization/wcsaxes/frame.py
@@ -224,10 +224,13 @@ class BaseFrame(OrderedDict, metaclass=abc.ABCMeta):
         for axis in self:
 
             data = self[axis].data
-            p = np.linspace(0., 1., data.shape[0])
-            p_new = np.linspace(0., 1., n_samples)
             spines[axis] = self.spine_class(self.parent_axes, self.transform)
-            spines[axis].data = np.array([np.interp(p_new, p, d) for d in data.T]).transpose()
+            if data.size > 0:
+                p = np.linspace(0., 1., data.shape[0])
+                p_new = np.linspace(0., 1., n_samples)
+                spines[axis].data = np.array([np.interp(p_new, p, d) for d in data.T]).transpose()
+            else:
+                spines[axis].data = data
 
         return spines
 

--- a/astropy/visualization/wcsaxes/tests/test_images.py
+++ b/astropy/visualization/wcsaxes/tests/test_images.py
@@ -4,6 +4,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 from matplotlib import rc_context
+from matplotlib.figure import Figure
 from matplotlib.patches import Circle, Rectangle
 
 from astropy import units as u
@@ -1016,5 +1017,47 @@ def test_allsky_labels_wrap():
             ax.coords[1].set_ticks_visible(False)
 
     fig.subplots_adjust(hspace=2, left=0.05, right=0.95, bottom=0.1, top=0.95)
+
+    return fig
+
+
+@figure_test
+def test_tickable_gridlines():
+    wcs = WCS({'naxis': 2,
+               'naxis1': 360,
+               'naxis2': 180,
+               'crpix1': 180.5,
+               'crpix2': 90.5,
+               'cdelt1': -1,
+               'cdelt2': 1,
+               'ctype1': 'RA---CAR',
+               'ctype2': 'DEC--CAR'})
+
+    fig = Figure()
+    ax = fig.add_subplot(projection=wcs)
+    ax.set_xlim(-0.5, 360-0.5)
+    ax.set_ylim(-0.5, 150-0.5)
+
+    lon, lat = ax.coords
+    lon.grid()
+    lat.grid()
+
+    overlay = ax.get_coords_overlay('galactic')
+    overlay[0].set_ticks(spacing=30*u.deg)
+    overlay[1].set_ticks(spacing=30*u.deg)
+
+    # Test both single-character and multi-character names
+    overlay[1].add_tickable_gridline('g', -30*u.deg)
+    overlay[0].add_tickable_gridline('const-glon', 30*u.deg)
+
+    overlay[0].grid(color='magenta')
+    overlay[0].set_ticklabel_position('gt')
+    overlay[0].set_ticklabel(color='magenta')
+    overlay[0].set_axislabel('Galactic longitude', color='magenta')
+
+    overlay[1].grid(color='blue')
+    overlay[1].set_ticklabel_position(('const-glon', 'r'))
+    overlay[1].set_ticklabel(color='blue')
+    overlay[1].set_axislabel('Galactic latitude', color='blue')
 
     return fig

--- a/docs/changes/visualization/13829.feature.rst
+++ b/docs/changes/visualization/13829.feature.rst
@@ -1,0 +1,1 @@
+It is now possible to define "tickable" gridlines for the purpose of placing ticks or tick labels in the interior of WCSAxes plots.

--- a/docs/visualization/wcsaxes/overlaying_coordinate_systems.rst
+++ b/docs/visualization/wcsaxes/overlaying_coordinate_systems.rst
@@ -59,3 +59,43 @@ as ``ax.coord`` to set the ticks, tick labels, and axis labels properties:
     overlay['dec'].set_axislabel('Declination')
 
     overlay.grid(color='white', linestyle='solid', alpha=0.5)
+
+
+Interior ticks and tick labels
+******************************
+
+The tick labels for an overlay grid can be difficult to associate correctly with
+gridlines because the default locations at the edges of the rectangular frame
+may result in multiple gridlines intersecting an edge near the same tick label
+or too few gridlines intersecting an edge.  As with the base grid, it is
+possible to add interior ticks or tick labels for the overlay grid.  Here we add
+a "tickable" gridline at constant RA (``const-ra``) and one at constant
+declination (``const-dec``).  Note that when you use a multi-character string as
+the name for one of these gridlines, you need to specify that name as a tuple to
+other methods.
+
+.. plot::
+   :context:
+   :include-source:
+
+    from astropy.coordinates import Angle
+
+    ax.coords[0].set_ticks_position('b')
+    ax.coords[1].set_ticks_position('l')
+
+    overlay['ra'].add_tickable_gridline('const-ra', Angle('266d15m'))
+    overlay['dec'].add_tickable_gridline('const-dec', Angle('-29d15m'))
+
+    overlay['ra'].set_ticks_position(('const-dec',))
+    overlay['ra'].set_ticks(color='red')
+    overlay['ra'].set_ticklabel_position(('const-dec',))
+    overlay['ra'].set_ticklabel(color='red', size=6)
+    overlay['ra'].set_axislabel_position('r')
+    overlay['ra'].set_axislabel('Right Ascension', color='red')
+
+    overlay['dec'].set_ticks_position(('const-ra',))
+    overlay['dec'].set_ticks(color='magenta')
+    overlay['dec'].set_ticklabel_position(('const-ra',))
+    overlay['dec'].set_ticklabel(color='magenta', size=6)
+    overlay['dec'].set_axislabel_position('t')
+    overlay['dec'].set_axislabel('Declination', color='magenta')

--- a/docs/visualization/wcsaxes/overlaying_coordinate_systems.rst
+++ b/docs/visualization/wcsaxes/overlaying_coordinate_systems.rst
@@ -71,8 +71,8 @@ or too few gridlines intersecting an edge.  As with the base grid, it is
 possible to add interior ticks or tick labels for the overlay grid.  Here we add
 a "tickable" gridline at constant RA (``const-ra``) and one at constant
 declination (``const-dec``).  Note that when you use a multi-character string as
-the name for one of these gridlines, you need to specify that name as a tuple to
-other methods.
+the name for one of these gridlines, you need to specify that name as a part of
+a tuple to other methods.
 
 .. plot::
    :context:
@@ -80,20 +80,20 @@ other methods.
 
     from astropy.coordinates import Angle
 
-    ax.coords[0].set_ticks_position('b')
-    ax.coords[1].set_ticks_position('l')
+    overlay['ra'].grid(color='red')
+    overlay['dec'].grid(color='magenta')
 
-    overlay['ra'].add_tickable_gridline('const-ra', Angle('266d15m'))
-    overlay['dec'].add_tickable_gridline('const-dec', Angle('-29d15m'))
+    overlay['ra'].add_tickable_gridline('const-ra', Angle('266d20m'))
+    overlay['dec'].add_tickable_gridline('const-dec', Angle('-29d00m'))
 
-    overlay['ra'].set_ticks_position(('const-dec',))
+    overlay['ra'].set_ticks_position(('const-dec', 't'))
     overlay['ra'].set_ticks(color='red')
     overlay['ra'].set_ticklabel_position(('const-dec',))
     overlay['ra'].set_ticklabel(color='red', size=6)
     overlay['ra'].set_axislabel_position('r')
     overlay['ra'].set_axislabel('Right Ascension', color='red')
 
-    overlay['dec'].set_ticks_position(('const-ra',))
+    overlay['dec'].set_ticks_position(('const-ra', 'r'))
     overlay['dec'].set_ticks(color='magenta')
     overlay['dec'].set_ticklabel_position(('const-ra',))
     overlay['dec'].set_ticklabel(color='magenta', size=6)

--- a/docs/visualization/wcsaxes/ticks_labels_grid.rst
+++ b/docs/visualization/wcsaxes/ticks_labels_grid.rst
@@ -355,3 +355,26 @@ one command:
 
 .. note:: If you use the pyplot interface, you can also plot the grid using
           ``plt.grid()``.
+
+
+Interior ticks and tick labels
+******************************
+
+The default locations of ticks and tick labels for the rectangular frame are the
+edges of the frame.  To place ticks or tick labels in the interior of the plot,
+one needs to add a "tickable" gridline.  Here we create one called ``v`` at the
+constant longitude of -5 arcmin, and then specify that it should have latitude
+ticks.
+
+.. plot::
+   :context:
+   :include-source:
+   :align: center
+
+    lon.add_tickable_gridline('v', -5*u.arcmin)
+
+    lat.set_ticks_position('lv')
+    lat.set_ticks(color='red')
+    lat.set_ticklabel_position('lv')
+    lat.set_ticklabel(color='red')
+    lat.set_axislabel('Galactic Latitude', color='red')

--- a/docs/visualization/wcsaxes/ticks_labels_grid.rst
+++ b/docs/visualization/wcsaxes/ticks_labels_grid.rst
@@ -222,8 +222,8 @@ We can apply this to the previous example:
    :align: center
 
     from astropy import units as u
-    lon.set_ticks(spacing=10 * u.arcmin, color='white')
-    lat.set_ticks(spacing=10 * u.arcmin, color='white')
+    lon.set_ticks(spacing=10 * u.arcmin, color='yellow')
+    lat.set_ticks(spacing=10 * u.arcmin, color='orange')
     lon.set_ticklabel(exclude_overlapping=True)
     lat.set_ticklabel(exclude_overlapping=True)
 
@@ -332,19 +332,7 @@ Coordinate grid
 
 Since the properties of a coordinate grid are linked to the properties of the
 ticks and labels, grid lines 'belong' to the coordinate objects described
-above. For example, you can show a grid with yellow lines for RA and orange lines
-for declination with:
-
-.. plot::
-   :context:
-   :include-source:
-   :align: center
-
-    lon.grid(color='yellow', alpha=0.5, linestyle='solid')
-    lat.grid(color='orange', alpha=0.5, linestyle='solid')
-
-For convenience, you can also simply draw a grid for all the coordinates in
-one command:
+above.  You can draw the grid for all coordinates at once:
 
 .. plot::
    :context:
@@ -356,14 +344,26 @@ one command:
 .. note:: If you use the pyplot interface, you can also plot the grid using
           ``plt.grid()``.
 
+Alternatively, you can draw the grid with different colors for the different
+coordinates.  For example, you can show a grid with yellow lines for RA and
+orange lines for declination with:
+
+.. plot::
+   :context:
+   :include-source:
+   :align: center
+
+    lon.grid(color='yellow', alpha=0.5, linestyle='solid')
+    lat.grid(color='orange', alpha=0.5, linestyle='solid')
+
 
 Interior ticks and tick labels
 ******************************
 
 The default locations of ticks and tick labels for the rectangular frame are the
 edges of the frame.  To place ticks or tick labels in the interior of the plot,
-one needs to add a "tickable" gridline.  Here we create one called ``v`` at the
-constant longitude of -5 arcmin, and then specify that it should have latitude
+one needs to add a "tickable" gridline.  Here we create one called ``i`` at the
+constant longitude of -10 arcmin, and then specify that it should have latitude
 ticks.
 
 .. plot::
@@ -371,10 +371,7 @@ ticks.
    :include-source:
    :align: center
 
-    lon.add_tickable_gridline('v', -5*u.arcmin)
+    lon.add_tickable_gridline('i', -10*u.arcmin)
 
-    lat.set_ticks_position('lv')
-    lat.set_ticks(color='red')
-    lat.set_ticklabel_position('lv')
-    lat.set_ticklabel(color='red')
-    lat.set_axislabel('Galactic Latitude', color='red')
+    lat.set_ticks_position('li')
+    lat.set_ticklabel_position('li')


### PR DESCRIPTION
For WCSAxes plot, gridlines are normally given ticks and/or labels only where they intersect with the outside rectangular frame of the plot.  (If using `EllipticalFrame` instead of `RectangularFrame`, the situation is a bit different.)  However, having gridline labels within the plot is at times desirable, and downright necessary when the gridlines do not intersect with the outside frame of the plot at all.

This PR makes it possible to add a tickable gridline to a WCSAxes plot.  For example, one can specify a particular gridline of constant latitude.  That gridline can then have ticks and labels added to it for every line of longitude that intersects with it, even in the interior of the plot.  (This behavior is conceptually a generalization of the major and minor axes of `EllipticalFrame`.)

Here's an example.  Currently, the final plot on https://docs.astropy.org/en/stable/visualization/wcsaxes/index.html is:
![download (64)](https://user-images.githubusercontent.com/991759/195480346-c9e4cce1-9ebf-42d4-88c6-1fed8dbb078d.png)
With this PR, one can add:
```python
from astropy.coordinates import Angle

overlay['ra'].add_tickable_gridline('m', Angle('266d15m'))
overlay['dec'].add_tickable_gridline('n', Angle('-29d15m'))

overlay['ra'].set_ticks_position('n')
overlay['ra'].set_ticks(color='red')
overlay['ra'].set_ticklabel_position('n')
overlay['ra'].set_ticklabel(color='red', size=6)
overlay['ra'].set_axislabel_position('r')
overlay['ra'].set_axislabel('Right Ascension (J2000)', color='red')

overlay['dec'].set_ticks_position('m')
overlay['dec'].set_ticks(color='magenta')
overlay['dec'].set_ticklabel_position('m')
overlay['dec'].set_ticklabel(color='magenta', size=6)
overlay['dec'].set_axislabel_position('t')
overlay['dec'].set_axislabel('Declination (J2000)', color='magenta')

ax.coords[0].set_ticks_position('b')
ax.coords[1].set_ticks_position('l')
```
to now get:
![download (67)](https://user-images.githubusercontent.com/991759/195481314-515923dd-797e-41f6-a982-e76757b71278.png)
Note that the tick labels are in the interior plot along the not-drawn tickable gridlines of constant RA and constant declination, respectively.

---

As a wackier example to showcase the possibilities:
![download (66)](https://user-images.githubusercontent.com/991759/195480779-fc68eab9-9d32-445b-ac0f-55d1e43f8f09.png)

---
TODO:
- [x] Add robustness for when the tickable gridline isn't in the view at all
- [x] Investigate why all ticks/labels disappear in some situations (could be related to the above bug)
- [x] Add a post to this PR showing how this approach provides an alternative to `EllipticalFrame`
- [x] Fix bug with discontinuous gridlines
- [x] Fix bug with longitude wrapping
- [x] Add an example for `add_tickable_gridline()` to the docs
- [x] Add a figure test for `add_tickable_gridline()`
- [ ] Check the compatibility with more than 2 world coordinates

Future work beyond this PR:
- Write an example showing how to draw the tickable gridline
- Figure out a way to clip the tickable gridline to a non-rectangular frame (there is catch-22 in the current implementation that prevents this)
- Try to reduce the small code duplication between `add_tickable_gridline()` and `_update_grid_lines()`
- Refactor the existing spines to use the new `data_func` functionality of `Spine`
- Consider deprecating `EllipticalFrame`