### PR TITLE
Fix NumPy deprecation of setting `np.int16` with out-of-bound value

### DIFF
--- a/astropy/io/fits/tests/test_core.py
+++ b/astropy/io/fits/tests/test_core.py
@@ -51,7 +51,7 @@ class TestCore(FitsTestCase):
         p = fits.PrimaryHDU()
         lst = fits.HDUList()
 
-        n = np.array([1, 60000, 0]).astype('i2')
+        n = np.array([1, 60000, 0], dtype='u2').astype('i2')
 
         c = fits.Column(name='foo', format='i2', bscale=1, bzero=32768,
                         array=n)

--- a/astropy/io/fits/tests/test_core.py
+++ b/astropy/io/fits/tests/test_core.py
@@ -51,10 +51,7 @@ class TestCore(FitsTestCase):
         p = fits.PrimaryHDU()
         lst = fits.HDUList()
 
-        n = np.zeros(3, dtype='i2')
-        n[0] = 1
-        n[1] = 60000
-        n[2] = 2
+        n = np.array([1, 60000, 0]).astype('i2')
 
         c = fits.Column(name='foo', format='i2', bscale=1, bzero=32768,
                         array=n)


### PR DESCRIPTION
### Description
This pull request is to address deprecation in NumPy 1.24 of implicit casting of np.int types with out-of-bond numbers (thus forcing an overflow); replacing this with an explicit `np.array(a).astype(np.int16)`

Fixes #13834

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
