### PR TITLE
Fix bug printing multi-d column with a zero dimension

### DIFF
--- a/astropy/table/pprint.py
+++ b/astropy/table/pprint.py
@@ -392,7 +392,8 @@ class TableFormatter:
         if multidims:
             multidim0 = tuple(0 for n in multidims)
             multidim1 = tuple(n - 1 for n in multidims)
-            trivial_multidims = np.prod(multidims) == 1
+            multidims_all_ones = np.prod(multidims) == 1
+            multidims_has_zero = 0 in multidims
 
         i_dashes = None
         i_centers = []  # Line indexes where content should be centered
@@ -475,8 +476,11 @@ class TableFormatter:
                 # Prevents columns like Column(data=[[(1,)],[(2,)]], name='a')
                 # with shape (n,1,...,1) from being printed as if there was
                 # more than one element in a row
-                if trivial_multidims:
+                if multidims_all_ones:
                     return format_func(col_format, col[(idx,) + multidim0])
+                elif multidims_has_zero:
+                    # Any zero dimension means there is no data to print
+                    return ""
                 else:
                     left = format_func(col_format, col[(idx,) + multidim0])
                     right = format_func(col_format, col[(idx,) + multidim1])

--- a/astropy/table/tests/test_pprint.py
+++ b/astropy/table/tests/test_pprint.py
@@ -972,3 +972,18 @@ def test_embedded_newline_tab():
         r'   a b \n c \t \n d',
         r'   x            y\n']
     assert t.pformat_all() == exp
+
+
+def test_multidims_with_zero_dim():
+    """Test of fix for #13836 when a zero-dim column is present"""
+    t = Table()
+    t["a"] = ["a", "b"]
+    t["b"] = np.ones(shape=(2, 0, 1), dtype=np.float64)
+    exp = [
+        " a        b      ",
+        "str1 float64[0,1]",
+        "---- ------------",
+        "   a             ",
+        "   b             ",
+    ]
+    assert t.pformat_all(show_dtype=True) == exp

--- a/docs/changes/table/13838.bugfix.rst
+++ b/docs/changes/table/13838.bugfix.rst
@@ -1,0 +1,2 @@
+Fix a bug when printing or getting the representation of a multidimensional
+table column that has a zero dimension.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to fix a bug when printing or getting the representation of a multidimensional table column that has a zero dimension. It makes a minor related change to update a variable name for better consistency.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #13836

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
