### PR TITLE
Ensure we get a new mixin instance even when copy=False

### DIFF
--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -1264,8 +1264,10 @@ class Table:
 
         elif data_is_mixin:
             # Copy the mixin column attributes if they exist since the copy below
-            # may not get this attribute.
-            col = col_copy(data, copy_indices=self._init_indices) if copy else data
+            # may not get this attribute. If not copying, take a slice
+            # to ensure we get a new instance and we do not share metadata
+            # like info.
+            col = col_copy(data, copy_indices=self._init_indices) if copy else data[:]
             col.info.name = name
             return col
 

--- a/astropy/table/table_helpers.py
+++ b/astropy/table/table_helpers.py
@@ -168,8 +168,8 @@ class ArrayWrapper:
     """
     info = ArrayWrapperInfo()
 
-    def __init__(self, data):
-        self.data = np.array(data)
+    def __init__(self, data, copy=True):
+        self.data = np.array(data, copy=copy)
         if 'info' in getattr(data, '__dict__', ()):
             self.info = data.info
 
@@ -177,7 +177,7 @@ class ArrayWrapper:
         if isinstance(item, (int, np.integer)):
             out = self.data[item]
         else:
-            out = self.__class__(self.data[item])
+            out = self.__class__(self.data[item], copy=False)
             if 'info' in self.__dict__:
                 out.info = self.info
         return out

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -438,38 +438,76 @@ def test_info_preserved_pickle_copy_init(mixin_cols):
                 assert getattr(m2.info, attr) == original
 
 
-def test_add_column(mixin_cols):
+def check_share_memory(col1, col2, copy):
+    """Check whether data attributes in col1 and col2 share memory.
+
+    If copy=True, this should not be the case for any, while
+    if copy=False, all should share memory.
     """
-    Test that adding a column preserves values and attributes
+    if isinstance(col1, SkyCoord):
+        # For SkyCoord, .info does not access actual data by default,
+        # but rather attributes like .ra, which are copies.
+        map1 = col1.data.info._represent_as_dict()
+        map2 = col2.data.info._represent_as_dict()
+    else:
+        map1 = col1.info._represent_as_dict()
+        map2 = col2.info._represent_as_dict()
+
+    # Check array attributes only (in principle, could iterate on, e.g.,
+    # differentials in representations, but this is enough for table).
+    shared = [np.may_share_memory(v1, v2)
+              for (v1, v2) in zip(map1.values(), map2.values())
+              if isinstance(v1, np.ndarray) and v1.shape]
+    if copy:
+        assert not any(shared)
+    else:
+        assert all(shared)
+
+
+@pytest.mark.parametrize('copy', [True, False])
+def test_add_column(mixin_cols, copy):
+    """
+    Test that adding a column preserves values and attributes.
+    For copy=True, the data should be independent;
+    for copy=False, the data should be shared, but the instance independent.
     """
     attrs = ('name', 'unit', 'dtype', 'format', 'description', 'meta')
     m = mixin_cols['m']
     assert m.info.name is None
 
-    # Make sure adding column in various ways doesn't touch
-    t = QTable([m], names=['a'])
+    # Make sure adding column in various ways doesn't touch info.
+    t = QTable([m], names=['a'], copy=copy)
     assert m.info.name is None
+    check_share_memory(m, t['a'], copy=copy)
 
     t['new'] = m
     assert m.info.name is None
+    check_share_memory(m, t['new'], copy=True)
 
     m.info.name = 'm'
     m.info.format = '{0}'
     m.info.description = 'd'
     m.info.meta = {'a': 1}
-    t = QTable([m])
+    t = QTable([m], copy=copy)
+    assert t.colnames == ['m']
+    check_share_memory(m, t['m'], copy=copy)
+
+    t = QTable([m], names=['m1'], copy=copy)
+    assert m.info.name == 'm'
+    assert t.colnames == ['m1']
+    check_share_memory(m, t['m1'], copy=copy)
 
     # Add columns m2, m3, m4 by two different methods and test expected equality
     t['m2'] = m
+    check_share_memory(m, t['m2'], copy=True)
     m.info.name = 'm3'
-    t.add_columns([m], copy=True)
-    m.info.name = 'm4'
-    t.add_columns([m], copy=False)
-    for name in ('m2', 'm3', 'm4'):
+    t.add_columns([m], copy=copy)
+    check_share_memory(m, t['m3'], copy=copy)
+    for name in ('m2', 'm3'):
         assert_table_name_col_equal(t, name, m)
         for attr in attrs:
             if attr != 'name':
-                assert getattr(t['m'].info, attr) == getattr(t[name].info, attr)
+                assert getattr(t['m1'].info, attr) == getattr(t[name].info, attr)
     # Also check that one can set using a scalar.
     s = m[0]
     if type(s) is type(m) and 'info' in s.__dict__:
@@ -477,18 +515,20 @@ def test_add_column(mixin_cols):
         # are a different class than the real array, or where info is not copied.
         t['s'] = m[0]
         assert_table_name_col_equal(t, 's', m[0])
+        check_share_memory(m, t['s'], copy=True)
         for attr in attrs:
             if attr != 'name':
-                assert getattr(t['m'].info, attr) == getattr(t['s'].info, attr)
+                assert getattr(t['m1'].info, attr) == getattr(t['s'].info, attr)
 
     # While we're add it, also check a length-1 table.
-    t = QTable([m[1:2]], names=['m'])
+    t = QTable([m[1:2]], names=['m'], copy=copy)
+    check_share_memory(m, t['m'], copy=copy)
     if type(s) is type(m) and 'info' in s.__dict__:
         t['s'] = m[0]
         assert_table_name_col_equal(t, 's', m[0])
         for attr in attrs:
             if attr != 'name':
-                assert getattr(t['m'].info, attr) == getattr(t['s'].info, attr)
+                assert getattr(t['m1'].info, attr) == getattr(t['s'].info, attr)
 
 
 def test_vstack():
@@ -852,8 +892,9 @@ def test_skycoord_with_velocity():
     assert skycoord_equal(t2['col0'], sc)
 
 
+@pytest.mark.parametrize('copy', [True, False])
 @pytest.mark.parametrize('table_cls', [Table, QTable])
-def test_ensure_input_info_is_unchanged(table_cls):
+def test_ensure_input_info_is_unchanged(table_cls, copy):
     """If a mixin input to a table has no info, it should stay that way.
 
     This since having 'info' slows down slicing, etc.
@@ -861,11 +902,11 @@ def test_ensure_input_info_is_unchanged(table_cls):
     """
     q = [1, 2] * u.m
     assert 'info' not in q.__dict__
-    t = table_cls([q], names=['q'])
+    t = table_cls([q], names=['q'], copy=copy)
     assert 'info' not in q.__dict__
-    t = table_cls([q])
+    t = table_cls([q], copy=copy)
     assert 'info' not in q.__dict__
-    t = table_cls({'q': q})
+    t = table_cls({'q': q}, copy=copy)
     assert 'info' not in q.__dict__
     t['q2'] = q
     assert 'info' not in q.__dict__

--- a/docs/changes/table/13842.bugfix.rst
+++ b/docs/changes/table/13842.bugfix.rst
@@ -1,0 +1,2 @@
+Ensure that mixin columns and their ``info`` are not shared between tables
+even when their underlying data is shared with ``copy=False``.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request ensures that when a mixin column of one table is added to another with `copy=False`, the columns will, as requested, share the data, but ensure that they are not the same instance.

This turned out to be much easier than worried about in #13840 - just take a full slice `[:]` of the column (which every mixin has to support).

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #13840

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
