### PR TITLE
Replace `tmpdir` with `tmp_path` in `cosmology` tests

### DIFF
--- a/astropy/cosmology/tests/test_connect.py
+++ b/astropy/cosmology/tests/test_connect.py
@@ -41,14 +41,14 @@ class ReadWriteTestMixin(test_ecsv.ReadWriteECSVTestMixin, test_json.ReadWriteJS
     """
 
     @pytest.mark.parametrize("format", readwrite_formats)
-    def test_readwrite_complete_info(self, cosmo, tmpdir, format):
+    def test_readwrite_complete_info(self, cosmo, tmp_path, format):
         """
         Test writing from an instance and reading from the base class.
         This requires full information.
         The round-tripped metadata can be in a different order, so the
         OrderedDict must be converted to a dict before testing equality.
         """
-        fname = str(tmpdir / f"{cosmo.name}.{format}")
+        fname = str(tmp_path / f"{cosmo.name}.{format}")
         cosmo.write(fname, format=format)
 
         # Also test kwarg "overwrite"
@@ -66,12 +66,12 @@ class ReadWriteTestMixin(test_ecsv.ReadWriteECSVTestMixin, test_json.ReadWriteJS
         assert dict(got.meta) == dict(cosmo.meta)
 
     @pytest.mark.parametrize("format", readwrite_formats)
-    def test_readwrite_from_subclass_complete_info(self, cosmo_cls, cosmo, tmpdir, format):
+    def test_readwrite_from_subclass_complete_info(self, cosmo_cls, cosmo, tmp_path, format):
         """
         Test writing from an instance and reading from that class, when there's
         full information saved.
         """
-        fname = str(tmpdir / f"{cosmo.name}.{format}")
+        fname = str(tmp_path / f"{cosmo.name}.{format}")
         cosmo.write(fname, format=format)
 
         # read with the same class that wrote.
@@ -114,11 +114,11 @@ class TestCosmologyReadWrite(ReadWriteTestMixin):
         assert "overwrite : bool" in writer.__doc__
 
     @pytest.mark.parametrize("format", readwrite_formats)
-    def test_readwrite_reader_class_mismatch(self, cosmo, tmpdir, format):
+    def test_readwrite_reader_class_mismatch(self, cosmo, tmp_path, format):
         """Test when the reader class doesn't match the file."""
 
-        fname = tmpdir / f"{cosmo.name}.{format}"
-        cosmo.write(str(fname), format=format)
+        fname = str(tmp_path / f"{cosmo.name}.{format}")
+        cosmo.write(fname, format=format)
 
         # class mismatch
         # when reading directly


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request will replace the usage of `tmpdir` with `tmp_path` in `cosmology` tests.

See #13787 for an explanation of why that should be done.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
