### PR TITLE
Replace `tmpdir` with `tmp_path` in `io.registry` tests

### DIFF
--- a/astropy/io/registry/tests/test_registries.py
+++ b/astropy/io/registry/tests/test_registries.py
@@ -583,7 +583,8 @@ class TestUnifiedInputRegistry(TestUnifiedIORegistryBase):
         )
         registry.register_reader("test_folder_format", cls, empty_reader)
 
-        (filename := tmp_path / "folder_dataset").mkdir()
+        filename = tmp_path / "folder_dataset"
+        filename.mkdir()
 
         # With the format explicitly specified
         dataset = cls.read(filename, format="test_folder_format", registry=registry)

--- a/astropy/io/registry/tests/test_registries.py
+++ b/astropy/io/registry/tests/test_registries.py
@@ -473,10 +473,10 @@ class TestUnifiedInputRegistry(TestUnifiedIORegistryBase):
             "please provide a 'format' argument."
         )
 
-    def test_read_noformat_arbitrary_file(self, tmpdir, registry, original):
+    def test_read_noformat_arbitrary_file(self, tmp_path, registry, original):
         """Tests that all identifier functions can accept arbitrary files"""
         registry._readers.update(original["readers"])
-        testfile = str(tmpdir.join("foo.example"))
+        testfile = tmp_path / "foo.example"
         with open(testfile, "w") as f:
             f.write("Hello world")
 
@@ -528,7 +528,7 @@ class TestUnifiedInputRegistry(TestUnifiedIORegistryBase):
             f"No reader defined for format '{fmt}' and class '{cls.__name__}'"
         )
 
-    def test_read_identifier(self, tmpdir, registry, fmtcls1, fmtcls2):
+    def test_read_identifier(self, tmp_path, registry, fmtcls1, fmtcls2):
         fmt1, cls = fmtcls1
         fmt2, _ = fmtcls2
 
@@ -543,7 +543,7 @@ class TestUnifiedInputRegistry(TestUnifiedIORegistryBase):
         # the reader. The registry.get_reader will fail but the error message
         # will tell us if the identifier worked.
 
-        filename = tmpdir.join("testfile.a").strpath
+        filename = tmp_path / "testfile.a"
         open(filename, "w").close()
         with pytest.raises(IORegistryError) as exc:
             cls.read(filename, registry=registry)
@@ -551,7 +551,7 @@ class TestUnifiedInputRegistry(TestUnifiedIORegistryBase):
             f"No reader defined for format '{fmt1}' and class '{cls.__name__}'"
         )
 
-        filename = tmpdir.join("testfile.b").strpath
+        filename = tmp_path / "testfile.b"
         open(filename, "w").close()
         with pytest.raises(IORegistryError) as exc:
             cls.read(filename, registry=registry)
@@ -571,7 +571,7 @@ class TestUnifiedInputRegistry(TestUnifiedIORegistryBase):
         with pytest.raises(OSError):
             data = fmtcls1[1].read("non-existing-file-with-unknown.ext")
 
-    def test_read_directory(self, tmpdir, registry, fmtcls1):
+    def test_read_directory(self, tmp_path, registry, fmtcls1):
         """
         Regression test for a bug that caused the I/O registry infrastructure to
         not work correctly for datasets that are represented by folders as
@@ -583,7 +583,7 @@ class TestUnifiedInputRegistry(TestUnifiedIORegistryBase):
         )
         registry.register_reader("test_folder_format", cls, empty_reader)
 
-        filename = tmpdir.mkdir("folder_dataset").strpath
+        (filename := tmp_path / "folder_dataset").mkdir()
 
         # With the format explicitly specified
         dataset = cls.read(filename, format="test_folder_format", registry=registry)
@@ -839,10 +839,10 @@ class TestUnifiedOutputRegistry(TestUnifiedIORegistryBase):
             "please provide a 'format' argument."
         )
 
-    def test_write_noformat_arbitrary_file(self, tmpdir, registry, original):
+    def test_write_noformat_arbitrary_file(self, tmp_path, registry, original):
         """Tests that all identifier functions can accept arbitrary files"""
         registry._writers.update(original["writers"])
-        testfile = str(tmpdir.join("foo.example"))
+        testfile = tmp_path / "foo.example"
 
         with pytest.raises(IORegistryError) as exc:
             Table().write(testfile, registry=registry)
@@ -1116,7 +1116,7 @@ class TestSubclass:
         mt.write(buffer, format="ascii")
         assert buffer.getvalue() == os.linesep.join(["a b", "1 2", ""])
 
-    def test_read_table_subclass_with_columns_attributes(self, tmpdir):
+    def test_read_table_subclass_with_columns_attributes(self, tmp_path):
         """Regression test for https://github.com/astropy/astropy/issues/7181"""
 
         class MTable(Table):
@@ -1127,7 +1127,7 @@ class TestSubclass:
         mt["a"].format = ".4f"
         mt["a"].description = "hello"
 
-        testfile = str(tmpdir.join("junk.fits"))
+        testfile = tmp_path / "junk.fits"
         mt.write(testfile, overwrite=True)
 
         t = MTable.read(testfile)


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request will replace the usage of `tmpdir` with `tmp_path` in `io.registry` tests.

See #13787 for an explanation of why that should be done.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
