### PR TITLE
Fix keyword duplication in compressed image headers.

### DIFF
--- a/astropy/io/fits/hdu/compressed.py
+++ b/astropy/io/fits/hdu/compressed.py
@@ -198,13 +198,16 @@ class CompImageHeader(Header):
 
         card = Card(remapped_keyword, card.value, card.comment)
 
-        # Here we disable the use of blank cards, because the call above to
-        # Header.append may have already deleted a blank card in the table
-        # header, thanks to inheritance: Header.append calls 'del self[-1]'
-        # to delete a blank card, which calls CompImageHeader.__deltitem__,
-        # which deletes the blank card both in the image and the table headers!
-        self._table_header.append(card=card, useblanks=False,
-                                  bottom=bottom, end=end)
+        # Here we append a keyword only if it is blank or is not in the header already
+        if card.keyword not in self._table_header or not card.keyword:
+
+            # Here we disable the use of blank cards, because the call above to
+            # Header.append may have already deleted a blank card in the table
+            # header, thanks to inheritance: Header.append calls 'del self[-1]'
+            # to delete a blank card, which calls CompImageHeader.__deltitem__,
+            # which deletes the blank card both in the image and the table headers!
+            self._table_header.append(card=card, useblanks=False,
+                                      bottom=bottom, end=end)
 
     def insert(self, key, card, useblanks=True, after=False):
         if isinstance(key, int):

--- a/astropy/io/fits/tests/test_header.py
+++ b/astropy/io/fits/tests/test_header.py
@@ -2971,6 +2971,13 @@ class TestRecordValuedKeywordCards(FitsTestCase):
             assert 'PCOUNT' not in hdul[1].header
             assert 'GCOUNT' not in hdul[1].header
 
+    def test_fitsheader_compressed_with_duplicate_key(self):
+        """Regression test for issue https://github.com/astropy/astropy/issues/11927"""
+        chdu = fits.CompImageHDU()
+        chdu._header['FOO'] = 'A'
+        chdu.header['FOO'] = 'A'
+        assert chdu._header.count('FOO') == 1
+
     def test_fitsheader_table_feature(self):
         """Tests the `--table` feature of the `fitsheader` script."""
         from astropy.io import fits

--- a/docs/changes/io.fits/13856.bugfix.rst
+++ b/docs/changes/io.fits/13856.bugfix.rst
@@ -1,0 +1,1 @@
+``append`` cards to compressed headers no longer outputs duplicated keywords.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address keyword duplication in compressed headers on some specific conditions.
I am unable to offer a refactoring of the class: if the reviewers think a quick workaround would be useful, here it is... :)
Thanks for considering it.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #11927

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
