### PR TITLE
Add missing py311 wheels

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,41 +42,53 @@ jobs:
       test_command: pytest -p no:warnings --astropy-header -m "not hypothesis" -k "not test_data_out_of_range and not test_set_locale and not TestQuantityTyping" --pyargs astropy
       targets: |
         # Linux wheels
+
         - cp38-manylinux_i686
         - cp39-manylinux_i686
-        # - cp310*linux_i686  # We can't build this as PyYAML doesn't have i686 wheels for 3.10 yet so the build takes too long
+        # - cp310*manylinux_i686  # We can't build this as PyYAML doesn't have i686 wheels for 3.10 yet so the build takes too long
+        # - cp311*manylinux_i686
+
         - cp38-manylinux_x86_64
         - cp39-manylinux_x86_64
         - cp310-manylinux_x86_64
         - cp311-manylinux_x86_64
+
         # Note that following wheels are not currently tested:
+
         - cp38-manylinux_aarch64
         - cp39-manylinux_aarch64
         - cp310-manylinux_aarch64
+        - cp311-manylinux_aarch64
+
         - cp38-musllinux_x86_64
         - cp39-musllinux_x86_64
         - cp310-musllinux_x86_64
+        - cp311-musllinux_x86_64
 
         # MacOS X wheels - as noted in https://github.com/astropy/astropy/pull/12379 we deliberately
         # do not build universal2 wheels. Note that the arm64 wheels are not actually tested so we
         # rely on local manual testing of these to make sure they are ok.
+
         - cp38*macosx_x86_64
         - cp39*macosx_x86_64
         - cp310*macosx_x86_64
         - cp311*macosx_x86_64
+
         - cp38*macosx_arm64
         - cp39*macosx_arm64
         - cp310*macosx_arm64
         - cp311*macosx_arm64
 
         # Windows wheels
+
         - cp38*win32
-        - cp38*win_amd64
         - cp39*win32
-        - cp39*win_amd64
         - cp310*win32
-        - cp310*win_amd64
         - cp311*win32
+
+        - cp38*win_amd64
+        - cp39*win_amd64
+        - cp310*win_amd64
         - cp311*win_amd64
 
     secrets:


### PR DESCRIPTION
### Description

The aarch64 and musllinux Python 3.11 wheels were missing, so adding these in.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
