### PR TITLE
Replace `tmpdir` with `tmp_path` in `utils` tests

### DIFF
--- a/astropy/utils/iers/tests/test_iers.py
+++ b/astropy/utils/iers/tests/test_iers.py
@@ -381,9 +381,9 @@ def test_iers_b_dl():
 
 
 @pytest.mark.remote_data
-def test_iers_out_of_range_handling(tmpdir):
+def test_iers_out_of_range_handling(tmp_path):
     # Make sure we don't have IERS-A data available anywhere
-    with set_temp_cache(tmpdir):
+    with set_temp_cache(tmp_path):
         iers.IERS_A.close()
         iers.IERS_Auto.close()
         iers.IERS.close()
@@ -406,9 +406,9 @@ def test_iers_out_of_range_handling(tmpdir):
 
 
 @pytest.mark.remote_data
-def test_iers_download_error_handling(tmpdir):
+def test_iers_download_error_handling(tmp_path):
     # Make sure we don't have IERS-A data available anywhere
-    with set_temp_cache(tmpdir):
+    with set_temp_cache(tmp_path):
         iers.IERS_A.close()
         iers.IERS_Auto.close()
         iers.IERS.close()

--- a/astropy/utils/masked/tests/test_table.py
+++ b/astropy/utils/masked/tests/test_table.py
@@ -64,8 +64,8 @@ class TestMaskedArrayTable(MaskedArrayTableSetup):
         assert t3['ma'].info.serialize_method['fits'] == 'nonsense'
 
     @pytest.mark.parametrize('file_format', FILE_FORMATS)
-    def test_table_write(self, file_format, tmpdir):
-        name = str(tmpdir.join(f"a.{file_format}"))
+    def test_table_write(self, file_format, tmp_path):
+        name = tmp_path / f'a.{file_format}'
         kwargs = {}
         if file_format == 'h5':
             kwargs['path'] = 'trial'
@@ -83,8 +83,8 @@ class TestMaskedArrayTable(MaskedArrayTableSetup):
             assert t2['ma'].info.format == self.t['ma'].info.format
 
     @pytest.mark.parametrize('serialize_method', ['data_mask', 'null_value'])
-    def test_table_write_serialization(self, serialize_method, tmpdir):
-        name = str(tmpdir.join("test.ecsv"))
+    def test_table_write_serialization(self, serialize_method, tmp_path):
+        name = tmp_path / 'test.ecsv'
         self.t.write(name, serialize_method=serialize_method)
         with open(name) as fh:
             lines = fh.readlines()
@@ -104,8 +104,8 @@ class TestMaskedArrayTable(MaskedArrayTableSetup):
             assert np.all(t2['ma'] == self.ma)
             assert np.all(t2['ma'].mask == self.mask_a)
 
-    def test_non_existing_serialize_method(self, tmpdir):
-        name = str(tmpdir.join('bad.ecsv'))
+    def test_non_existing_serialize_method(self, tmp_path):
+        name = tmp_path / 'bad.ecsv'
         with pytest.raises(ValueError, match='serialize method must be'):
             self.t.write(name, serialize_method='bad_serialize_method')
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request will replace the usage of `tmpdir` with `tmp_path` in `utils` tests.

See #13787 for an explanation of why that should be done.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
