### PR TITLE
Replace `tmpdir` with `tmp_path` in `io.ascii` tests

### DIFF
--- a/astropy/io/ascii/tests/test_c_reader.py
+++ b/astropy/io/ascii/tests/test_c_reader.py
@@ -56,7 +56,7 @@ def assert_table_equal(t1, t2, check_meta=False, rtol=1.e-15, atol=1.e-300):
 _filename_counter = 0
 
 
-def _read(tmpdir, table, Reader=None, format=None, parallel=False, check_meta=False, **kwargs):
+def _read(tmp_path, table, Reader=None, format=None, parallel=False, check_meta=False, **kwargs):
     # make sure we have a newline so table can't be misinterpreted as a filename
     global _filename_counter
 
@@ -79,7 +79,7 @@ def _read(tmpdir, table, Reader=None, format=None, parallel=False, check_meta=Fa
             'parallel': True}, **kwargs)
         assert_table_equal(t1, t6, check_meta=check_meta)
 
-    filename = str(tmpdir.join(f'table{_filename_counter}.txt'))
+    filename = tmp_path / f'table{_filename_counter}.txt'
     _filename_counter += 1
 
     with open(filename, 'wb') as f:
@@ -98,34 +98,34 @@ def _read(tmpdir, table, Reader=None, format=None, parallel=False, check_meta=Fa
 
 
 @pytest.fixture(scope='function')
-def read_basic(tmpdir, request):
-    return functools.partial(_read, tmpdir, Reader=FastBasic, format='basic')
+def read_basic(tmp_path, request):
+    return functools.partial(_read, tmp_path, Reader=FastBasic, format='basic')
 
 
 @pytest.fixture(scope='function')
-def read_csv(tmpdir, request):
-    return functools.partial(_read, tmpdir, Reader=FastCsv, format='csv')
+def read_csv(tmp_path, request):
+    return functools.partial(_read, tmp_path, Reader=FastCsv, format='csv')
 
 
 @pytest.fixture(scope='function')
-def read_tab(tmpdir, request):
-    return functools.partial(_read, tmpdir, Reader=FastTab, format='tab')
+def read_tab(tmp_path, request):
+    return functools.partial(_read, tmp_path, Reader=FastTab, format='tab')
 
 
 @pytest.fixture(scope='function')
-def read_commented_header(tmpdir, request):
-    return functools.partial(_read, tmpdir, Reader=FastCommentedHeader,
+def read_commented_header(tmp_path, request):
+    return functools.partial(_read, tmp_path, Reader=FastCommentedHeader,
                              format='commented_header')
 
 
 @pytest.fixture(scope='function')
-def read_rdb(tmpdir, request):
-    return functools.partial(_read, tmpdir, Reader=FastRdb, format='rdb')
+def read_rdb(tmp_path, request):
+    return functools.partial(_read, tmp_path, Reader=FastRdb, format='rdb')
 
 
 @pytest.fixture(scope='function')
-def read_no_header(tmpdir, request):
-    return functools.partial(_read, tmpdir, Reader=FastNoHeader,
+def read_no_header(tmp_path, request):
+    return functools.partial(_read, tmp_path, Reader=FastNoHeader,
                              format='no_header')
 
 
@@ -1037,7 +1037,7 @@ def test_fast_tab_with_names(parallel, read_tab):
 
 
 @pytest.mark.hugemem
-def test_read_big_table(tmpdir):
+def test_read_big_table(tmp_path):
     """Test reading of a huge file.
 
     This test generates a huge CSV file (~2.3Gb) before reading it (see
@@ -1048,7 +1048,7 @@ def test_read_big_table(tmpdir):
     """
     NB_ROWS = 250000
     NB_COLS = 500
-    filename = str(tmpdir.join("big_table.csv"))
+    filename = tmp_path / "big_table.csv"
 
     print(f"Creating a {NB_ROWS} rows table ({NB_COLS} columns).")
     data = np.random.random(NB_ROWS)
@@ -1069,14 +1069,14 @@ def test_read_big_table(tmpdir):
 
 
 @pytest.mark.hugemem
-def test_read_big_table2(tmpdir):
+def test_read_big_table2(tmp_path):
     """Test reading of a file with a huge column.
     """
     # (2**32 // 2) : max value for int
     # // 10 : we use a value for rows that have 10 chars (1e9)
     # + 5 : add a few lines so the length cannot be stored by an int
     NB_ROWS = 2**32 // 2 // 10 + 5
-    filename = str(tmpdir.join("big_table.csv"))
+    filename = tmp_path / "big_table.csv"
 
     print(f"Creating a {NB_ROWS} rows table.")
     data = np.full(NB_ROWS, int(1e9), dtype=np.int32)

--- a/astropy/io/ascii/tests/test_connect.py
+++ b/astropy/io/ascii/tests/test_connect.py
@@ -20,11 +20,11 @@ def test_read_generic(filename):
     Table.read(get_pkg_data_filename(filename), format='ascii')
 
 
-def test_write_generic(tmpdir):
+def test_write_generic(tmp_path):
     t = Table()
     t.add_column(Column(name='a', data=[1, 2, 3]))
     t.add_column(Column(name='b', data=['a', 'b', 'c']))
-    t.write(str(tmpdir.join("test")), format='ascii')
+    t.write(tmp_path / "test", format='ascii')
 
 
 def test_read_ipac():
@@ -47,19 +47,19 @@ def test_read_latex_noformat():
     Table.read(get_pkg_data_filename('data/latex1.tex'))
 
 
-def test_write_latex(tmpdir):
+def test_write_latex(tmp_path):
     t = Table()
     t.add_column(Column(name='a', data=[1, 2, 3]))
     t.add_column(Column(name='b', data=['a', 'b', 'c']))
-    path = str(tmpdir.join("data.tex"))
+    path = tmp_path / "data.tex"
     t.write(path, format='latex')
 
 
-def test_write_latex_noformat(tmpdir):
+def test_write_latex_noformat(tmp_path):
     t = Table()
     t.add_column(Column(name='a', data=[1, 2, 3]))
     t.add_column(Column(name='b', data=['a', 'b', 'c']))
-    path = str(tmpdir.join("data.tex"))
+    path = tmp_path / "data.tex"
     t.write(path)
 
 
@@ -73,19 +73,19 @@ def test_read_html_noformat():
     Table.read(get_pkg_data_filename('data/html.html'))
 
 
-def test_write_html(tmpdir):
+def test_write_html(tmp_path):
     t = Table()
     t.add_column(Column(name='a', data=[1, 2, 3]))
     t.add_column(Column(name='b', data=['a', 'b', 'c']))
-    path = str(tmpdir.join("data.html"))
+    path = tmp_path / "data.html"
     t.write(path, format='html')
 
 
-def test_write_html_noformat(tmpdir):
+def test_write_html_noformat(tmp_path):
     t = Table()
     t.add_column(Column(name='a', data=[1, 2, 3]))
     t.add_column(Column(name='b', data=['a', 'b', 'c']))
-    path = str(tmpdir.join("data.html"))
+    path = tmp_path / "data.html"
     t.write(path)
 
 
@@ -97,19 +97,19 @@ def test_read_rdb_noformat():
     Table.read(get_pkg_data_filename('data/short.rdb'))
 
 
-def test_write_rdb(tmpdir):
+def test_write_rdb(tmp_path):
     t = Table()
     t.add_column(Column(name='a', data=[1, 2, 3]))
     t.add_column(Column(name='b', data=['a', 'b', 'c']))
-    path = str(tmpdir.join("data.rdb"))
+    path = tmp_path / "data.rdb"
     t.write(path, format='rdb')
 
 
-def test_write_rdb_noformat(tmpdir):
+def test_write_rdb_noformat(tmp_path):
     t = Table()
     t.add_column(Column(name='a', data=[1, 2, 3]))
     t.add_column(Column(name='b', data=['a', 'b', 'c']))
-    path = str(tmpdir.join("data.rdb"))
+    path = tmp_path / "data.rdb"
     t.write(path)
 
 
@@ -121,7 +121,7 @@ def test_read_csv():
     Table.read(get_pkg_data_filename('data/simple_csv.csv'))
 
 
-def test_write_csv(tmpdir):
+def test_write_csv(tmp_path):
     '''If properly registered, filename should be sufficient to specify format
 
     #3189
@@ -129,13 +129,13 @@ def test_write_csv(tmpdir):
     t = Table()
     t.add_column(Column(name='a', data=[1, 2, 3]))
     t.add_column(Column(name='b', data=['a', 'b', 'c']))
-    path = str(tmpdir.join("data.csv"))
+    path = tmp_path / "data.csv"
     t.write(path)
 
 
-def test_auto_identify_ecsv(tmpdir):
+def test_auto_identify_ecsv(tmp_path):
     tbl = simple_table()
-    tmpfile = str(tmpdir.join('/tmpFile.ecsv'))
+    tmpfile = tmp_path / 'tmpFile.ecsv'
     tbl.write(tmpfile)
     tbl2 = Table.read(tmpfile)
     assert np.all(tbl == tbl2)

--- a/astropy/io/ascii/tests/test_ecsv.py
+++ b/astropy/io/ascii/tests/test_ecsv.py
@@ -424,7 +424,7 @@ def test_ecsv_mixins_per_column(table_cls, name_col, ndim):
         assert t2[name]._time.jd2.__class__ is np.ndarray
 
 
-def test_round_trip_masked_table_default(tmpdir):
+def test_round_trip_masked_table_default(tmp_path):
     """Test (mostly) round-trip of MaskedColumn through ECSV using default serialization
     that uses an empty string "" to mark NULL values.  Note:
 
@@ -437,7 +437,7 @@ def test_round_trip_masked_table_default(tmpdir):
         2     2.0   --
         3      --    e
     """
-    filename = str(tmpdir.join('test.ecsv'))
+    filename = tmp_path / 'test.ecsv'
 
     t = simple_table(masked=True)  # int, float, and str cols with one masked element
     t.write(filename)
@@ -457,9 +457,9 @@ def test_round_trip_masked_table_default(tmpdir):
         assert not np.all(t2[name] == t[name])  # Expected diff
 
 
-def test_round_trip_masked_table_serialize_mask(tmpdir):
+def test_round_trip_masked_table_serialize_mask(tmp_path):
     """Same as prev but set the serialize_method to 'data_mask' so mask is written out"""
-    filename = str(tmpdir.join('test.ecsv'))
+    filename = tmp_path / 'test.ecsv'
 
     t = simple_table(masked=True)  # int, float, and str cols with one masked element
     t['c'][0] = ''  # This would come back as masked for default "" NULL marker
@@ -484,12 +484,12 @@ def test_round_trip_masked_table_serialize_mask(tmpdir):
 
 
 @pytest.mark.parametrize('table_cls', (Table, QTable))
-def test_ecsv_round_trip_user_defined_unit(table_cls, tmpdir):
+def test_ecsv_round_trip_user_defined_unit(table_cls, tmp_path):
     """Ensure that we can read-back enabled user-defined units."""
 
     # Test adapted from #8897, where it was noted that this works
     # but was not tested.
-    filename = str(tmpdir.join('test.ecsv'))
+    filename = tmp_path / 'test.ecsv'
     unit = u.def_unit('bandpass_sol_lum')
     t = table_cls()
     t['l'] = np.arange(5) * unit
@@ -515,8 +515,8 @@ def test_ecsv_round_trip_user_defined_unit(table_cls, tmpdir):
         assert t3['l'].unit is unit
         assert np.all(t3['l'] == t['l'])
 
-        # Just to be sure, aloso try writing with unit enabled.
-        filename2 = str(tmpdir.join('test2.ecsv'))
+        # Just to be sure, also try writing with unit enabled.
+        filename2 = tmp_path / 'test2.ecsv'
         t3.write(filename2)
         t4 = table_cls.read(filename)
         assert t4['l'].unit is unit

--- a/astropy/io/ascii/tests/test_qdp.py
+++ b/astropy/io/ascii/tests/test_qdp.py
@@ -7,7 +7,7 @@ from astropy.table import Column, MaskedColumn, Table
 from astropy.utils.exceptions import AstropyUserWarning
 
 
-def test_get_tables_from_qdp_file(tmpdir):
+def test_get_tables_from_qdp_file(tmp_path):
     example_qdp = """
     ! Swift/XRT hardness ratio of trigger: XXXX, name: BUBU X-2
     ! Columns are as labelled
@@ -29,7 +29,7 @@ def test_get_tables_from_qdp_file(tmpdir):
     55045.099887 1.14467592592593e-05    -1.14467592592593e-05   0.000000        -nan
     """
 
-    path = str(tmpdir.join('test.qdp'))
+    path = tmp_path / 'test.qdp'
 
     with open(path, "w") as fp:
         print(example_qdp, file=fp)
@@ -43,7 +43,7 @@ def test_get_tables_from_qdp_file(tmpdir):
     assert np.isclose(table2["MJD_nerr"][0], -2.37847222222222e-05)
 
 
-def test_roundtrip(tmpdir):
+def test_roundtrip(tmp_path):
     example_qdp = """
     ! Swift/XRT hardness ratio of trigger: XXXX, name: BUBU X-2
     ! Columns are as labelled
@@ -71,8 +71,8 @@ def test_roundtrip(tmpdir):
     NO 1.14467592592593e-05    -1.14467592592593e-05   0.000000        NO
     """
 
-    path = str(tmpdir.join('test.qdp'))
-    path2 = str(tmpdir.join('test2.qdp'))
+    path = str(tmp_path / 'test.qdp')
+    path2 = str(tmp_path / 'test2.qdp')
 
     with open(path, "w") as fp:
         print(example_qdp, file=fp)
@@ -106,7 +106,7 @@ def test_roundtrip(tmpdir):
         assert meta_name in new_table.meta
 
 
-def test_read_example(tmpdir):
+def test_read_example():
     example_qdp = """
         ! Initial comment line 1
         ! Initial comment line 2
@@ -136,7 +136,7 @@ def test_read_example(tmpdir):
         assert np.allclose(col1, col2, equal_nan=True)
 
 
-def test_roundtrip_example(tmpdir):
+def test_roundtrip_example(tmp_path):
     example_qdp = """
         ! Initial comment line 1
         ! Initial comment line 2
@@ -152,7 +152,7 @@ def test_roundtrip_example(tmpdir):
         54000.5   2.25  -2.5   NO  3.5  5.5 5
         55000.5   3.25  -3.5   4  4.5  6.5 nan
         """
-    test_file = str(tmpdir.join('test.qdp'))
+    test_file = tmp_path / 'test.qdp'
 
     t = Table.read(example_qdp, format='ascii.qdp', table_id=1,
                    names=['a', 'b', 'c', 'd'])
@@ -163,7 +163,7 @@ def test_roundtrip_example(tmpdir):
         assert np.allclose(col1, col2, equal_nan=True)
 
 
-def test_roundtrip_example_comma(tmpdir):
+def test_roundtrip_example_comma(tmp_path):
     example_qdp = """
         ! Initial comment line 1
         ! Initial comment line 2
@@ -179,7 +179,7 @@ def test_roundtrip_example_comma(tmpdir):
         54000.5,2.25,-2.5,NO,3.5,5.5,5
         55000.5,3.25,-3.5,4,4.5,6.5,nan
         """
-    test_file = str(tmpdir.join('test.qdp'))
+    test_file = tmp_path / 'test.qdp'
 
     t = Table.read(example_qdp, format='ascii.qdp', table_id=1,
                    names=['a', 'b', 'c', 'd'], sep=',')
@@ -191,8 +191,8 @@ def test_roundtrip_example_comma(tmpdir):
         assert np.allclose(col1, col2, equal_nan=True)
 
 
-def test_read_write_simple(tmpdir):
-    test_file = str(tmpdir.join('test.qdp'))
+def test_read_write_simple(tmp_path):
+    test_file = tmp_path / 'test.qdp'
     t1 = Table()
     t1.add_column(Column(name='a', data=[1, 2, 3, 4]))
     t1.add_column(MaskedColumn(data=[4., np.nan, 3., 1.], name='b',
@@ -211,8 +211,8 @@ def test_read_write_simple(tmpdir):
     assert np.allclose(t2['col2'][good], t1['b'][good])
 
 
-def test_read_write_simple_specify_name(tmpdir):
-    test_file = str(tmpdir.join('test.qdp'))
+def test_read_write_simple_specify_name(tmp_path):
+    test_file = tmp_path / 'test.qdp'
     t1 = Table()
     t1.add_column(Column(name='a', data=[1, 2, 3]))
     # Give a non-None err_specs
@@ -221,8 +221,8 @@ def test_read_write_simple_specify_name(tmpdir):
     assert np.all(t2['a'] == t1['a'])
 
 
-def test_get_lines_from_qdp(tmpdir):
-    test_file = str(tmpdir.join('test.qdp'))
+def test_get_lines_from_qdp(tmp_path):
+    test_file = str(tmp_path / 'test.qdp')
     text_string = "A\nB"
     text_output = _get_lines_from_file(text_string)
     with open(test_file, "w") as fobj:

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -1433,13 +1433,13 @@ def text_aastex_no_trailing_backslash():
 
 
 @pytest.mark.parametrize('encoding', ['utf8', 'latin1', 'cp1252'])
-def test_read_with_encoding(tmpdir, encoding):
+def test_read_with_encoding(tmp_path, encoding):
     data = {
         'commented_header': '# à b è \n 1 2 héllo',
         'csv': 'à,b,è\n1,2,héllo'
     }
 
-    testfile = str(tmpdir.join('test.txt'))
+    testfile = tmp_path / 'test.txt'
     for fmt, content in data.items():
         with open(testfile, 'w', encoding=encoding) as f:
             f.write(content)
@@ -1458,7 +1458,7 @@ def test_read_with_encoding(tmpdir, encoding):
                                        '  1   2 héllo']
 
 
-def test_unsupported_read_with_encoding(tmpdir):
+def test_unsupported_read_with_encoding():
     # Fast reader is not supported, make sure it raises an exception
     with pytest.raises(ascii.ParameterError):
         ascii.read('data/simple3.txt', guess=False, fast_reader='force',

--- a/astropy/io/ascii/tests/test_write.py
+++ b/astropy/io/ascii/tests/test_write.py
@@ -389,7 +389,7 @@ a,b,c
 
 
 @pytest.fixture
-def home_is_tmpdir(monkeypatch, tmpdir):
+def home_is_tmpdir(monkeypatch, tmp_path):
     """
     Pytest fixture to run a test case with tilde-prefixed paths.
 
@@ -397,9 +397,9 @@ def home_is_tmpdir(monkeypatch, tmpdir):
     modified so that '~' resolves to the temp directory.
     """
     # For Unix
-    monkeypatch.setenv('HOME', str(tmpdir))
+    monkeypatch.setenv('HOME', str(tmp_path))
     # For Windows
-    monkeypatch.setenv('USERPROFILE', str(tmpdir))
+    monkeypatch.setenv('USERPROFILE', str(tmp_path))
 
 
 def check_write_table(test_def, table, fast_writer, out=None):
@@ -474,17 +474,15 @@ def check_write_table_via_table(test_def, table, fast_writer, out=None):
 
 
 @pytest.mark.parametrize("fast_writer", [True, False])
-@pytest.mark.parametrize('path_format',
-        ['buffer', 'plain', 'tilde-str', 'tilde-pathlib'])
-def test_write_table(
-        fast_writer, tmpdir, home_is_tmpdir, path_format):
+@pytest.mark.parametrize('path_format', ['buffer', 'plain', 'tilde-str', 'tilde-pathlib'])
+def test_write_table(fast_writer, tmp_path, home_is_tmpdir, path_format):
     table = ascii.get_reader(Reader=ascii.Daophot)
     data = table.read('data/daophot.dat')
 
     if path_format == 'buffer':
         out_name = None
     elif path_format == 'plain':
-        out_name = os.path.join(tmpdir, 'table')
+        out_name = tmp_path / 'table'
     elif path_format == 'tilde-str':
         out_name = os.path.join('~', 'table')
     else:
@@ -747,10 +745,10 @@ def test_write_empty_table(fast_writer):
                                     'ascii.fixed_width', 'html'])
 @pytest.mark.parametrize("fast_writer", [True, False])
 @pytest.mark.parametrize('path_format', ['plain', 'tilde-str', 'tilde-pathlib'])
-def test_write_overwrite_ascii(format, fast_writer, tmpdir, home_is_tmpdir,
+def test_write_overwrite_ascii(format, fast_writer, tmp_path, home_is_tmpdir,
         path_format):
     """Test overwrite argument for various ASCII writers"""
-    true_filename = tmpdir.join("table-tmp.dat").strpath
+    true_filename = tmp_path / "table-tmp.dat"
     if path_format == 'plain':
         filename = true_filename
     elif path_format == 'tilde-str':
@@ -828,13 +826,13 @@ def test_roundtrip_masked(fmt_name_class):
 
 
 @pytest.mark.parametrize("fast_writer", [True, False])
-def test_write_newlines(fast_writer, tmpdir):
+def test_write_newlines(fast_writer, tmp_path):
 
     # Regression test for https://github.com/astropy/astropy/issues/5126
     # On windows, when writing to a filename (not e.g. StringIO), newlines were
     # \r\r\n instead of \r\n.
 
-    filename = tmpdir.join('test').strpath
+    filename = tmp_path / 'test'
 
     t = table.Table([['a', 'b', 'c']], names=['col'])
     ascii.write(t, filename, fast_writer=fast_writer)


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request will replace the usage of `tmpdir` with `tmp_path` in `io.ascii` tests.

See #13787 for an explanation of why that should be done.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
