### PR TITLE
Update `WCSAxes` to pass multiple positional arguments to `Axes`

### DIFF
--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -53,9 +53,17 @@ class WCSAxes(Axes):
     ----------
     fig : `~matplotlib.figure.Figure`
         The figure to add the axes to
-    rect : list
-        The position of the axes in the figure in relative units. Should be
-        given as ``[left, bottom, width, height]``.
+    *args
+        ``*args`` can be a single ``(left, bottom, width, height)``
+        rectangle or a single `matplotlib.transforms.Bbox`.  This specifies
+        the rectangle (in figure coordinates) where the Axes is positioned.
+        ``*args`` can also consist of three numbers or a single three-digit
+        number; in the latter case, the digits are considered as
+        independent numbers.  The numbers are interpreted as ``(nrows,
+        ncols, index)``: ``(nrows, ncols)`` specifies the size of an array
+        of subplots, and ``index`` is the 1-based index of the subplot
+        being created.  Finally, ``*args`` can also directly be a
+        `matplotlib.gridspec.SubplotSpec` instance.
     wcs : :class:`~astropy.wcs.WCS`, optional
         The WCS for the data. If this is specified, ``transform`` cannot be
         specified.
@@ -94,13 +102,13 @@ class WCSAxes(Axes):
         :class:`~astropy.visualization.wcsaxes.frame.RectangularFrame`
     """
 
-    def __init__(self, fig, rect, wcs=None, transform=None, coord_meta=None,
+    def __init__(self, fig, *args, wcs=None, transform=None, coord_meta=None,
                  transData=None, slices=None, frame_class=None,
                  **kwargs):
         """
         """
 
-        super().__init__(fig, rect, **kwargs)
+        super().__init__(fig, *args, **kwargs)
         self._bboxes = []
 
         if frame_class is not None:


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address a change in the Matplotlib `Axes.__init__` signature. The change in this PR should be backwards compatible with older Matplotlib versions, however, it will break code which initialises `WCSAxes` with positional arguments for `wcs` etc. If that's an issue, it should be possible to "clean" `*args` before passing it to `Axes`.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #13873

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
