### PR TITLE
Tilde paths wrapup

### DIFF
--- a/docs/whatsnew/5.2.rst
+++ b/docs/whatsnew/5.2.rst
@@ -18,6 +18,7 @@ In particular, this release includes:
 * :ref:`whatsnew-5.2-io-ascii-fixed-width`
 * :ref:`whatsnew-5.2-fits`
 * :ref:`whatsnew-5.2-visualization-wcsaxes-helpers`
+* :ref:`whatsnew-5.2-tilde-paths`
 
 
 .. _whatsnew-5.2-quantity-dtype:
@@ -180,6 +181,27 @@ observations) and a physical scale bar on celestial images:
     ...
     ...    # Draw a scale bar corresponding to 100 au at a distance of 126 pc
     ...    add_scalebar(ax, 100./126. * u.arcsec, label="100 au", color="white")
+
+.. _whatsnew-5.2-tilde-paths:
+
+Support for tilde-prefixed paths
+================================
+
+This release finishes adding support for tilde-prefixed paths, which began in
+5.1. These are paths of the form ``~/data/file.fits`` or
+``~<username>/data/file.fits``. The single tilde refers to the current user's
+home directory, while a tilde followed by a valid username refers to that
+user's home directory (e.g. ``/home/<username>`` on Linux or
+``/Users/<username>`` on macOS). This syntax is common in command-line oriented
+applications, especially on Unix-based systems. It serves as a convenient
+shortcut, and it also allows code to be shared and run by multiple people
+without having to update file paths if each person keeps data in the same
+directory structure relative to their home directory.
+
+This support has been added throughout the ``astropy.io`` module. This feature
+is also supported within the I/O functionality of `astropy.table` and the
+FITS-file functionality in `astropy.nddata`.
+
 
 Full change log
 ===============


### PR DESCRIPTION
@pllim This should be the last bits to close #12778. Since `nddata` inherits `io.fits`'s tilde-path support, this adds a regression test for that module. (No other code changes in `nddata`.) I've also added a What's New entry, as was discussed someone in one of the tilde-path-related PRs.

I haven't exhaustively determined that there aren't any other modules that inherited the tilde-path support in `io`, it's just that `nddata` must have caught my eye at some point.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
