### PR TITLE
Fix testing for `pytest` 7.2 support

### DIFF
--- a/astropy/coordinates/tests/test_celestial_transformations.py
+++ b/astropy/coordinates/tests/test_celestial_transformations.py
@@ -188,7 +188,7 @@ class TestHCRS():
     coord.ICRS(coord.get_body_barycentric(tarr, 'sun')).
     """
 
-    def setup(self):
+    def setup_method(self):
         self.t1 = Time("2013-02-02T23:00")
         self.t2 = Time("2013-08-02T23:00")
         self.tarr = Time(["2013-02-02T23:00", "2013-08-02T23:00"])
@@ -237,7 +237,7 @@ class TestHelioBaryCentric():
     Uses the WHT observing site (information grabbed from data/sites.json).
     """
 
-    def setup(self):
+    def setup_method(self):
         wht = EarthLocation(342.12*u.deg, 28.758333333333333*u.deg, 2327*u.m)
         self.obstime = Time("2013-02-02T23:00")
         self.wht_itrs = wht.get_itrs(obstime=self.obstime)

--- a/astropy/coordinates/tests/test_earth.py
+++ b/astropy/coordinates/tests/test_earth.py
@@ -95,7 +95,7 @@ def test_gd2gc():
 
 
 class TestInput():
-    def setup(self):
+    def setup_method(self):
         self.lon = Longitude([0., 45., 90., 135., 180., -180, -90, -45], u.deg,
                              wrap_angle=180*u.deg)
         self.lat = Latitude([+0., 30., 60., +90., -90., -60., -30., 0.], u.deg)

--- a/astropy/coordinates/tests/test_representation_arithmetic.py
+++ b/astropy/coordinates/tests/test_representation_arithmetic.py
@@ -45,7 +45,7 @@ def representation_equal(first, second):
 
 class TestArithmetic():
 
-    def setup(self):
+    def setup_method(self):
         # Choose some specific coordinates, for which ``sum`` and ``dot``
         # works out nicely.
         self.lon = Longitude(np.arange(0, 12.1, 2), u.hourangle)
@@ -823,7 +823,7 @@ class TestUnitSphericalDifferential():
 
 
 class TestRadialDifferential():
-    def setup(self):
+    def setup_method(self):
         s = SphericalRepresentation(lon=[0., 6., 21.] * u.hourangle,
                                     lat=[0., -30., 85.] * u.deg,
                                     distance=[1, 2, 3] * u.kpc)
@@ -864,7 +864,7 @@ class TestRadialDifferential():
 class TestPhysicsSphericalDifferential():
     """Test copied from SphericalDifferential, so less extensive."""
 
-    def setup(self):
+    def setup_method(self):
         s = PhysicsSphericalRepresentation(phi=[0., 90., 315.] * u.deg,
                                            theta=[90., 120., 5.] * u.deg,
                                            r=[1, 2, 3] * u.kpc)
@@ -921,7 +921,7 @@ class TestPhysicsSphericalDifferential():
 class TestCylindricalDifferential():
     """Test copied from SphericalDifferential, so less extensive."""
 
-    def setup(self):
+    def setup_method(self):
         s = CylindricalRepresentation(rho=[1, 2, 3] * u.kpc,
                                       phi=[0., 90., 315.] * u.deg,
                                       z=[3, 2, 1] * u.kpc)
@@ -973,7 +973,7 @@ class TestCylindricalDifferential():
 class TestCartesianDifferential():
     """Test copied from SphericalDifferential, so less extensive."""
 
-    def setup(self):
+    def setup_method(self):
         s = CartesianRepresentation(x=[1, 2, 3] * u.kpc,
                                     y=[2, 3, 1] * u.kpc,
                                     z=[3, 1, 2] * u.kpc)
@@ -1018,7 +1018,7 @@ class TestCartesianDifferential():
 
 
 class TestDifferentialConversion():
-    def setup(self):
+    def setup_method(self):
         self.s = SphericalRepresentation(lon=[0., 6., 21.] * u.hourangle,
                                          lat=[0., -30., 85.] * u.deg,
                                          distance=[1, 2, 3] * u.kpc)

--- a/astropy/coordinates/tests/test_solar_system.py
+++ b/astropy/coordinates/tests/test_solar_system.py
@@ -107,7 +107,7 @@ class TestPositionsGeocentric:
     2016-03-28, with refraction turned on.
     """
 
-    def setup(self):
+    def setup_method(self):
         self.t = Time('1980-03-25 00:00')
         self.apparent_frame = TETE(obstime=self.t)
         # Results returned by JPL Horizons web interface
@@ -187,7 +187,7 @@ class TestPositionKittPeak:
     2016-03-28, with refraction turned on.
     """
 
-    def setup(self):
+    def setup_method(self):
         kitt_peak = EarthLocation.from_geodetic(lon=-111.6*u.deg,
                                                 lat=31.963333333333342*u.deg,
                                                 height=2120*u.m)

--- a/astropy/coordinates/tests/test_velocity_corrs.py
+++ b/astropy/coordinates/tests/test_velocity_corrs.py
@@ -158,7 +158,6 @@ def test_helio_iraf():
                        location=test_input_loc)
     vhs_astropy = targets.radial_velocity_correction('heliocentric')
     assert_quantity_allclose(vhs_astropy, vhs_iraf, atol=150*u.m/u.s)
-    return vhs_astropy, vhs_iraf  # for interactively examination
 
 
 def generate_IRAF_input(writefn=None):
@@ -235,7 +234,6 @@ def test_barycorr():
                                                       kind='barycentric')
 
     assert_quantity_allclose(bvcs_astropy, barycorr_bvcs, atol=10*u.mm/u.s)
-    return bvcs_astropy, barycorr_bvcs  # for interactively examination
 
 
 def _get_barycorr_bvcs(coos, loc, injupyter=False):
@@ -348,7 +346,6 @@ def test_barycorr_withvels():
     bvcs_astropy = coos.radial_velocity_correction(obstime=test_input_time,
                                                    location=test_input_loc)
     assert_quantity_allclose(bvcs_astropy, barycorr_bvcs, atol=10*u.mm/u.s)
-    return bvcs_astropy, barycorr_bvcs  # for interactively examination
 
 
 def _get_test_input_radecvels():

--- a/astropy/io/fits/tests/__init__.py
+++ b/astropy/io/fits/tests/__init__.py
@@ -55,7 +55,7 @@ def home_is_temp(request, monkeypatch):
 
 
 class FitsTestCase:
-    def setup(self):
+    def setup_method(self):
         self.data_dir = os.path.join(os.path.dirname(__file__), 'data')
         self.temp_dir = tempfile.mkdtemp(prefix='fits-test-')
 
@@ -72,7 +72,7 @@ class FitsTestCase:
         fits.conf.strip_header_whitespace = True
         fits.conf.use_memmap = True
 
-    def teardown(self):
+    def teardown_method(self):
         if self.home_is_temp:
             # Verify that no files were written to a literal tilde path
             for temp_file, temp_file_no_tilde in self.temp_files_used:

--- a/astropy/io/fits/tests/test_checksum.py
+++ b/astropy/io/fits/tests/test_checksum.py
@@ -16,8 +16,8 @@ from .test_table import comparerecords
 class TestChecksumFunctions(FitsTestCase):
 
     # All checksums have been verified against CFITSIO
-    def setup(self):
-        super().setup()
+    def setup_method(self):
+        super().setup_method()
         self._oldfilters = warnings.filters[:]
         warnings.filterwarnings(
             'error',
@@ -31,8 +31,8 @@ class TestChecksumFunctions(FitsTestCase):
         self._old_get_timestamp = _ValidHDU._get_timestamp
         _ValidHDU._get_timestamp = lambda self: '2013-12-20T13:36:10'
 
-    def teardown(self):
-        super().teardown()
+    def teardown_method(self):
+        super().teardown_method()
         warnings.filters = self._oldfilters
         _ValidHDU._get_timestamp = self._old_get_timestamp
 

--- a/astropy/io/fits/tests/test_header.py
+++ b/astropy/io/fits/tests/test_header.py
@@ -2596,8 +2596,8 @@ class TestRecordValuedKeywordCards(FitsTestCase):
     but will be stripped in the cards.
     """
 
-    def setup(self):
-        super().setup()
+    def setup_method(self):
+        super().setup_method()
         self._test_header = fits.Header()
         self._test_header.set('DP1', 'NAXIS: 2')
         self._test_header.set('DP1', 'AXIS.1: 1')

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -2697,12 +2697,12 @@ class TestTableFunctions(FitsTestCase):
         from .test_core import TestCore
 
         t1 = TestCore()
-        t1.setup()
+        t1.setup_method()
         try:
             with _refcounting('FITS_rec'):
                 t1.test_add_del_columns2()
         finally:
-            t1.teardown()
+            t1.teardown_method()
         del t1
 
         t2 = self.__class__()
@@ -2710,12 +2710,12 @@ class TestTableFunctions(FitsTestCase):
                           'test_numpy_ndarray_to_bintablehdu',
                           'test_new_table_from_recarray',
                           'test_new_fitsrec']:
-            t2.setup()
+            t2.setup_method()
             try:
                 with _refcounting('FITS_rec'):
                     getattr(t2, test_name)()
             finally:
-                t2.teardown()
+                t2.teardown_method()
         del t2
 
         t3 = TestMultipleHDU()

--- a/astropy/modeling/tests/test_bounding_box.py
+++ b/astropy/modeling/tests/test_bounding_box.py
@@ -200,7 +200,7 @@ class Test_Interval:
 
 
 class Test_BoundingDomain:
-    def setup(self):
+    def setup_method(self):
         class BoundingDomain(_BoundingDomain):
             def fix_inputs(self, model, fix_inputs):
                 super().fix_inputs(model, fixed_inputs=fix_inputs)

--- a/astropy/modeling/tests/test_utils.py
+++ b/astropy/modeling/tests/test_utils.py
@@ -95,7 +95,7 @@ def test_get_inputs_and_params():
 
 
 class Test_SpecialOperatorsDict:
-    def setup(self):
+    def setup_method(self):
         self.key = 'test'
         self.val = 'value'
 

--- a/astropy/tests/figures/helpers.py
+++ b/astropy/tests/figures/helpers.py
@@ -4,6 +4,8 @@ from functools import wraps
 
 import pytest
 
+from astropy.utils.compat.optional_deps import HAS_PYTEST_MPL
+
 
 def figure_test(*args, **kwargs):
     """
@@ -30,6 +32,7 @@ def figure_test(*args, **kwargs):
                                        style=style,
                                        savefig_kwargs=savefig_kwargs,
                                        **kwargs)
+        @pytest.mark.skipif(not HAS_PYTEST_MPL, reason='pytest-mpl is required for the figure tests')
         @wraps(test_function)
         def test_wrapper(*args, **kwargs):
             return test_function(*args, **kwargs)

--- a/astropy/time/tests/test_comparisons.py
+++ b/astropy/time/tests/test_comparisons.py
@@ -12,7 +12,7 @@ from astropy.time import Time, TimeDelta
 class TestTimeComparisons:
     """Test Comparisons of Time and TimeDelta classes"""
 
-    def setup(self):
+    def setup_method(self):
         self.t1 = Time(np.arange(49995, 50005), format='mjd', scale='utc')
         self.t2 = Time(np.arange(49000, 51000, 200), format='mjd', scale='utc')
 

--- a/astropy/time/tests/test_corrs.py
+++ b/astropy/time/tests/test_corrs.py
@@ -26,7 +26,7 @@ class TestHelioBaryCentric:
     def teardown_class(cls):
         iers.conf.auto_download = cls.orig_auto_download
 
-    def setup(self):
+    def setup_method(self):
         wht = EarthLocation(342.12 * u.deg, 28.758333333333333 * u.deg, 2327 * u.m)
         self.obstime = Time("2013-02-02T23:00", location=wht)
         self.obstime2 = Time("2013-08-02T23:00", location=wht)

--- a/astropy/time/tests/test_delta.py
+++ b/astropy/time/tests/test_delta.py
@@ -36,7 +36,7 @@ def teardown_module(module):
 class TestTimeDelta:
     """Test TimeDelta class"""
 
-    def setup(self):
+    def setup_method(self):
         self.t = Time('2010-01-01', scale='utc')
         self.t2 = Time('2010-01-02 00:00:01', scale='utc')
         self.t3 = Time('2010-01-03 01:02:03', scale='utc', precision=9,
@@ -303,7 +303,7 @@ class TestTimeDeltaScales:
     """Test scale conversion for Time Delta.
     Go through @taldcroft's list of expected behavior from #1932"""
 
-    def setup(self):
+    def setup_method(self):
         # pick a date that includes a leap second for better testing
         self.iso_times = ['2012-06-30 12:00:00', '2012-06-30 23:59:59',
                           '2012-07-01 00:00:00', '2012-07-01 12:00:00']

--- a/astropy/time/tests/test_update_leap_seconds.py
+++ b/astropy/time/tests/test_update_leap_seconds.py
@@ -12,13 +12,13 @@ from astropy.utils.exceptions import AstropyWarning
 
 
 class TestUpdateLeapSeconds:
-    def setup(self):
+    def setup_method(self):
         self.built_in = iers.LeapSeconds.from_iers_leap_seconds()
         self.erfa_ls = iers.LeapSeconds.from_erfa()
         now = datetime.now()
         self.good_enough = now + timedelta(150)
 
-    def teardown(self):
+    def teardown_method(self):
         self.erfa_ls.update_erfa_leap_seconds(initialize_erfa=True)
 
     def test_auto_update_leap_seconds(self):

--- a/astropy/units/tests/test_logarithmic.py
+++ b/astropy/units/tests/test_logarithmic.py
@@ -593,7 +593,7 @@ def test_quantity_decomposition():
 
 
 class TestLogQuantityViews:
-    def setup(self):
+    def setup_method(self):
         self.lq = u.Magnitude(np.arange(1., 10.) * u.Jy)
         self.lq2 = u.Magnitude(np.arange(1., 5.))
 
@@ -913,7 +913,7 @@ class TestLogQuantityComparisons:
 
 
 class TestLogQuantityMethods:
-    def setup(self):
+    def setup_method(self):
         self.mJy = np.arange(1., 5.).reshape(2, 2) * u.mag(u.Jy)
         self.m1 = np.arange(1., 5.5, 0.5).reshape(3, 3) * u.mag()
         self.mags = (self.mJy, self.m1)

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -1539,7 +1539,7 @@ def test_repr_array_of_quantity():
 
 
 class TestSpecificTypeQuantity:
-    def setup(self):
+    def setup_method(self):
         class Length(u.SpecificTypeQuantity):
             _equivalent_unit = u.m
 

--- a/astropy/units/tests/test_quantity_array_methods.py
+++ b/astropy/units/tests/test_quantity_array_methods.py
@@ -626,7 +626,7 @@ class TestRecArray:
     """Record arrays are not specifically supported, but we should not
     prevent their use unnecessarily"""
 
-    def setup(self):
+    def setup_method(self):
         self.ra = (np.array(np.arange(12.).reshape(4, 3))
               .view(dtype=('f8,f8,f8')).squeeze())
 

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -57,7 +57,7 @@ class BasicTestSetup(metaclass=CoverageMeta):
 
     Also provides a default Quantity with shape (3, 3) and units of m.
     """
-    def setup(self):
+    def setup_method(self):
         self.q = np.arange(9.).reshape(3, 3) / 4. * u.m
 
 
@@ -260,7 +260,7 @@ class TestIndicesFrom(NoUnitTestSetup):
 
 
 class TestRealImag(InvariantUnitTestSetup):
-    def setup(self):
+    def setup_method(self):
         self.q = (np.arange(9.).reshape(3, 3) + 1j) * u.m
 
     def test_real(self):
@@ -443,7 +443,7 @@ class TestRepeat(InvariantUnitTestSetup):
 
 
 class TestConcatenate(metaclass=CoverageMeta):
-    def setup(self):
+    def setup_method(self):
         self.q1 = np.arange(6.).reshape(2, 3) * u.m
         self.q2 = self.q1.to(u.cm)
 
@@ -568,7 +568,7 @@ class TestConcatenate(metaclass=CoverageMeta):
 
 
 class TestSplit(metaclass=CoverageMeta):
-    def setup(self):
+    def setup_method(self):
         self.q = np.arange(54.).reshape(3, 3, 6) * u.m
 
     def check(self, func, *args, **kwargs):
@@ -757,7 +757,7 @@ class TestUfuncLike(InvariantUnitTestSetup):
 
 
 class TestUfuncLikeTests(metaclass=CoverageMeta):
-    def setup(self):
+    def setup_method(self):
         self.q = np.array([-np.inf, +np.inf, np.nan, 3., 4.]) * u.m
 
     def check(self, func):
@@ -920,8 +920,8 @@ class TestReductionLikeFunctions(InvariantUnitTestSetup):
 
 
 class TestNanFunctions(InvariantUnitTestSetup):
-    def setup(self):
-        super().setup()
+    def setup_method(self):
+        super().setup_method()
         self.q[1, 1] = np.nan
 
     def test_nanmax(self):
@@ -1250,7 +1250,7 @@ class TestBincountDigitize(metaclass=CoverageMeta):
 
 class TestHistogramFunctions(metaclass=CoverageMeta):
 
-    def setup(self):
+    def setup_method(self):
         self.x = np.array([1.1, 1.2, 1.3, 2.1, 5.1]) * u.m
         self.y = np.array([1.2, 2.2, 2.4, 3.0, 4.0]) * u.cm
         self.weights = np.arange(len(self.x)) / u.s
@@ -1516,7 +1516,7 @@ class TestSortFunctions(InvariantUnitTestSetup):
 class TestStringFunctions(metaclass=CoverageMeta):
     # For these, making behaviour work means deviating only slightly from
     # the docstring, and by default they fail miserably.  So, might as well.
-    def setup(self):
+    def setup_method(self):
         self.q = np.arange(3.) * u.Jy
 
     @needs_array_function
@@ -1561,7 +1561,7 @@ class TestStringFunctions(metaclass=CoverageMeta):
 class TestBitAndIndexFunctions(metaclass=CoverageMeta):
     # Index/bit functions generally fail for floats, so the usual
     # float quantity are safe, but the integer ones are not.
-    def setup(self):
+    def setup_method(self):
         self.q = np.arange(3) * u.m
         self.uint_q = u.Quantity(np.arange(3), 'm', dtype='u1')
 
@@ -1643,7 +1643,7 @@ class TestMemoryFunctions(NoUnitTestSetup):
 
 
 class TestSetOpsFcuntions(metaclass=CoverageMeta):
-    def setup(self):
+    def setup_method(self):
         self.q = np.array([[0., 1., -1.],
                            [3., 5., 3.],
                            [0., 1., -1]]) * u.m
@@ -1758,7 +1758,7 @@ def test_fft_frequencies(function):
 @needs_array_function
 class TestFFT(InvariantUnitTestSetup):
     # These are all trivial, just preserve the unit.
-    def setup(self):
+    def setup_method(self):
         # Use real input; gets turned into complex as needed.
         self.q = np.arange(128.).reshape(8, -1) * u.s
 
@@ -1812,7 +1812,7 @@ class TestFFT(InvariantUnitTestSetup):
 
 
 class TestLinAlg(metaclass=CoverageMeta):
-    def setup(self):
+    def setup_method(self):
         # Use a matrix safe for inversion, etc.
         self.q = np.array([[1., -1., 2.],
                            [0., 3., -1.],

--- a/astropy/units/tests/test_quantity_ufuncs.py
+++ b/astropy/units/tests/test_quantity_ufuncs.py
@@ -954,7 +954,7 @@ class TestClip:
     In numpy, this is hidden behind a function that does not backwards
     compatibility checks.  We explicitly test the ufunc here.
     """
-    def setup(self):
+    def setup_method(self):
         self.clip = np.core.umath.clip
 
     def test_clip_simple(self):

--- a/astropy/utils/compat/optional_deps.py
+++ b/astropy/utils/compat/optional_deps.py
@@ -13,7 +13,7 @@ _optional_deps = ['asdf', 'asdf_astropy', 'bleach', 'bottleneck', 'bs4', 'bz2',
                   'fsspec', 'h5py', 'html5lib', 'IPython', 'jplephem',
                   'lxml', 'matplotlib', 'mpmath', 'pandas', 'PIL', 'pytz',
                   's3fs', 'scipy', 'skyfield', 'sortedcontainers', 'lzma',
-                  'pyarrow']
+                  'pyarrow', 'pytest_mpl']
 _formerly_optional_deps = ['yaml']  # for backward compatibility
 _deps = {k.upper(): k for k in _optional_deps + _formerly_optional_deps}
 

--- a/astropy/utils/iers/tests/test_leap_second.py
+++ b/astropy/utils/iers/tests/test_leap_second.py
@@ -220,14 +220,14 @@ class TestRemoteURLs:
 
 class TestDefaultAutoOpen:
     """Test auto_open with different _auto_open_files."""
-    def setup(self):
+    def setup_method(self):
         # Identical to what is used in LeapSeconds.auto_open().
         self.good_enough = (iers.LeapSeconds._today()
                             + TimeDelta(180 - iers._none_to_float(iers.conf.auto_max_age),
                                         format='jd'))
         self._auto_open_files = iers.LeapSeconds._auto_open_files.copy()
 
-    def teardown(self):
+    def teardown_method(self):
         iers.LeapSeconds._auto_open_files = self._auto_open_files
 
     def remove_auto_open_files(self, *files):
@@ -346,12 +346,12 @@ class ERFALeapSecondsSafe:
 
     It ensures the original state is restored.
     """
-    def setup(self):
+    def setup_method(self):
         # Keep current leap-second table and expiration.
         self.erfa_ls = self._erfa_ls = erfa.leap_seconds.get()
         self.erfa_expires = self._expires = erfa.leap_seconds._expires
 
-    def teardown(self):
+    def teardown_method(self):
         # Restore leap-second table and expiration.
         erfa.leap_seconds.set(self.erfa_ls)
         erfa.leap_seconds._expires = self._expires
@@ -396,8 +396,8 @@ class TestFromERFA(ERFALeapSecondsSafe):
 
 
 class TestUpdateLeapSeconds(ERFALeapSecondsSafe):
-    def setup(self):
-        super().setup()
+    def setup_method(self):
+        super().setup_method()
         # Read default leap second table.
         self.ls = iers.LeapSeconds.from_iers_leap_seconds()
         # For tests, reset ERFA table to built-in default.

--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -37,7 +37,7 @@ def ctx_for_v71_dateref_warnings():
 
 
 class TestMaps:
-    def setup(self):
+    def setup_method(self):
         # get the list of the hdr files that we want to test
         self._file_list = list(get_pkg_data_filenames(
             "data/maps", pattern="*.hdr"))
@@ -71,7 +71,7 @@ class TestMaps:
 
 
 class TestSpectra:
-    def setup(self):
+    def setup_method(self):
         self._file_list = list(get_pkg_data_filenames("data/spectra",
                                                       pattern="*.hdr"))
 
@@ -1376,7 +1376,7 @@ def test_cunit():
 
 
 class TestWcsWithTime:
-    def setup(self):
+    def setup_method(self):
         if _WCSLIB_VER >= Version('7.1'):
             fname = get_pkg_data_filename('data/header_with_time_wcslib71.fits')
         else:


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

`pytest` 7.2 was just released. It deprecates several things that `astropy` was using for testing, including `setup` and `teardown` functions. This PR fixes all those deprecations by switching them over to `setup_method` and `teardown_method`. 

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
