### PR TITLE
Speed up ManualInterval if both limits are specified

### DIFF
--- a/astropy/visualization/interval.py
+++ b/astropy/visualization/interval.py
@@ -103,6 +103,12 @@ class ManualInterval(BaseInterval):
         self.vmax = vmax
 
     def get_limits(self, values):
+
+        # Avoid overhead of preparing array if both limits have been specified
+        # manually, for performance.
+        if self.vmin is not None and self.vmax is not None:
+            return self.vmin, self.vmax
+
         # Make sure values is a Numpy array
         values = np.asarray(values).ravel()
 
@@ -111,6 +117,7 @@ class ManualInterval(BaseInterval):
 
         vmin = np.min(values) if self.vmin is None else self.vmin
         vmax = np.max(values) if self.vmax is None else self.vmax
+
         return vmin, vmax
 
 

--- a/docs/changes/visualization/13898.bugfix.rst
+++ b/docs/changes/visualization/13898.bugfix.rst
@@ -1,0 +1,2 @@
+Significantly improve performance of ``ManualInterval`` when both limits
+are specified manually.


### PR DESCRIPTION
### Description

I can try and provide some numbers shortly for the speedup, but basically this avoids calling e.g. ``np.asarray`` ad ``np.isfinite`` on the array if both limits are specified manually (which is probably a common use case).

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
