### PR TITLE
TST: samp tests should use tmp_path

### DIFF
--- a/astropy/samp/tests/test_standard_profile.py
+++ b/astropy/samp/tests/test_standard_profile.py
@@ -1,5 +1,3 @@
-import tempfile
-
 import pytest
 
 # By default, tests should not use the internet.
@@ -29,9 +27,10 @@ class TestStandardProfile:
     def client_connect_kwargs(self):
         return {}
 
-    def setup_method(self, method):
+    @pytest.fixture(autouse=True)
+    def setup_method(self, tmp_path):
 
-        self.tmpdir = tempfile.mkdtemp()
+        self.tmpdir = str(tmp_path)
 
         self.hub = SAMPHubServer(web_profile=False, mode='multiple', pool_size=1,
                                  **self.hub_init_kwargs)
@@ -43,7 +42,7 @@ class TestStandardProfile:
         self.client2 = SAMPIntegratedClient(**self.client_init_kwargs)
         self.client2.connect(hub=self.hub, pool_size=1, **self.client_connect_kwargs)
 
-    def teardown_method(self, method):
+    def teardown_method(self):
 
         if self.client1.is_connected:
             self.client1.disconnect()

--- a/astropy/samp/tests/test_standard_profile.py
+++ b/astropy/samp/tests/test_standard_profile.py
@@ -178,8 +178,8 @@ class TestStandardProfile:
 
         params = random_params(self.tmpdir)
         self.client1.call(self.client2.get_public_id(), 'test-tag',
-                            {'samp.mtype': 'table.load.votable',
-                             'samp.params': params})
+                          {'samp.mtype': 'table.load.votable',
+                           'samp.params': params})
 
         assert_output('table.load.votable', self.client2.get_private_key(),
                       self.client1_id, params, timeout=60)

--- a/astropy/samp/tests/test_web_profile.py
+++ b/astropy/samp/tests/test_web_profile.py
@@ -68,7 +68,7 @@ class TestWebProfile(BaseTestStandardProfile):
         with get_readable_fileobj(f'http://localhost:{self.hub._web_port}/crossdomain.xml') as f:
             assert f.read() == CROSS_DOMAIN
 
-        with get_readable_fileobj(f'http://localhost:{self.hub._web_port}/clientaccesspolicy.xml') as f:
+        with get_readable_fileobj(f'http://localhost:{self.hub._web_port}/clientaccesspolicy.xml') as f:  # noqa: E501
             assert f.read() == CLIENT_ACCESS_POLICY
 
         # Check headers


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to fix #13900 .

Kinda related: https://github.com/astropy/astropy/issues/13787

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
