### PR TITLE
More tmpdir clean-ups

### DIFF
--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -339,7 +339,7 @@ def get_readable_fileobj(name_or_obj, encoding=None, cache=False,
             # text mode, which won't work. .read_binary() does, and
             # surely other ducks would return binary contents when
             # called like this.
-            # py.path.LocalPath is what comes from the tmpdir fixture
+            # py.path.LocalPath is what comes from the legacy tmpdir fixture
             # in pytest.
             fileobj = io.BytesIO(fileobj.read_binary())
         except AttributeError:

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -146,7 +146,7 @@ def readonly_dir(d):
 @pytest.fixture
 def readonly_cache(tmp_path, valid_urls):
     with TemporaryDirectory(dir=tmp_path) as d:
-        # other fixtures use the same tmpdir so we need a subdirectory
+        # other fixtures use the same tmp_path so we need a subdirectory
         # to make into the cache
         d = pathlib.Path(d)
         with paths.set_temp_cache(d):
@@ -179,7 +179,7 @@ def fake_readonly_cache(tmp_path, valid_urls, monkeypatch):
                       "_SafeTemporaryDirectory monkeypatched out")
 
     with TemporaryDirectory(dir=tmp_path) as d:
-        # other fixtures use the same tmpdir so we need a subdirectory
+        # other fixtures use the same tmp_path so we need a subdirectory
         # to make into the cache
         d = pathlib.Path(d)
         with paths.set_temp_cache(d):
@@ -627,7 +627,7 @@ def test_download_certificate_verification_failed():
 
     with pytest.warns(AstropyWarning, match=msg) as warning_lines:
         fnout = download_file(TESTURL_SSL, cache=False,
-                ssl_context=ssl_context, allow_insecure=True)
+                              ssl_context=ssl_context, allow_insecure=True)
 
     assert len(warning_lines) == 1
     assert os.path.isfile(fnout)
@@ -667,7 +667,7 @@ def test_download_parallel_from_internet_works(temp_cache):
 @pytest.mark.parametrize("method", [None, "spawn"])
 def test_download_parallel_fills_cache(tmp_path, valid_urls, method):
     urls = []
-    # tmpdir is shared between many tests, and that can cause weird
+    # tmp_path is shared between many tests, and that can cause weird
     # interactions if we set the temporary cache too directly
     with paths.set_temp_cache(tmp_path):
         for um, c in islice(valid_urls, FEW):

--- a/astropy/visualization/wcsaxes/tests/test_images.py
+++ b/astropy/visualization/wcsaxes/tests/test_images.py
@@ -48,8 +48,8 @@ class TestBasic(BaseImageTests):
     def test_tight_layout(self):
         # Check that tight_layout works on a WCSAxes.
         fig = plt.figure(figsize=(8, 6))
-        axs = [fig.add_subplot(2, 1, i, projection=WCS(self.msx_header))
-               for i in [1, 2]]
+        for i in (1, 2):
+            fig.add_subplot(2, 1, i, projection=WCS(self.msx_header))
         fig.tight_layout()
         return fig
 
@@ -659,9 +659,10 @@ class TestBasic(BaseImageTests):
 
         with pytest.warns(AstropyUserWarning,
                           match="Received `center` of representation type "
-                                "<class 'astropy.coordinates.representation.CartesianRepresentation'> "
+                                "<class 'astropy.coordinates.representation.CartesianRepresentation'> "  # noqa: E501
                                 "will be converted to SphericalRepresentation"):
-            r3 = SphericalCircle(SkyCoord(x=-0.05486461, y=-0.87204803, z=-0.48633538, representation_type='cartesian'),
+            r3 = SphericalCircle(SkyCoord(x=-0.05486461, y=-0.87204803, z=-0.48633538,
+                                          representation_type='cartesian'),
                                  0.15 * u.degree, edgecolor='purple',
                                  facecolor='none', transform=ax.get_transform('fk5'))
 
@@ -693,8 +694,8 @@ class TestBasic(BaseImageTests):
 
         # Add a rectangle patch (100 degrees by 20 degrees)
         r = Rectangle((255, -70), 100, 20,
-                       label='Rectangle', edgecolor='red', facecolor='none', linestyle='--',
-                       transform=ax.get_transform('icrs'))
+                      label='Rectangle', edgecolor='red', facecolor='none', linestyle='--',
+                      transform=ax.get_transform('icrs'))
         ax.add_patch(r)
 
         ax.coords[0].set_ticklabel_visible(False)
@@ -703,7 +704,7 @@ class TestBasic(BaseImageTests):
         return fig
 
     @figure_test
-    def test_beam_shape_from_args(self, tmpdir):
+    def test_beam_shape_from_args(self, tmp_path):
         # Test for adding the beam shape with the beam parameters as arguments
         wcs = WCS(self.msx_header)
         fig = plt.figure(figsize=(4, 3))
@@ -718,7 +719,7 @@ class TestBasic(BaseImageTests):
         return fig
 
     @figure_test
-    def test_beam_shape_from_header(self, tmpdir):
+    def test_beam_shape_from_header(self, tmp_path):
         # Test for adding the beam shape with the beam parameters from a header
         hdr = self.msx_header
         hdr['BMAJ'] = (2 * u.arcmin).to(u.degree).value
@@ -736,7 +737,7 @@ class TestBasic(BaseImageTests):
         return fig
 
     @figure_test
-    def test_scalebar(self, tmpdir):
+    def test_scalebar(self, tmp_path):
         # Test for adding a scale bar
         wcs = WCS(self.msx_header)
         fig = plt.figure(figsize=(4, 3))

--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -27,15 +27,18 @@ os.mkdir(os.path.join(os.environ['XDG_CACHE_HOME'], 'astropy'))
 
 @pytest.fixture(autouse=True)
 def _docdir(request):
-    """Run doctests in isolated tmpdir so outputs do not end up in repo"""
+    """Run doctests in isolated tmp_path so outputs do not end up in repo"""
     # Trigger ONLY for doctestplus
     doctest_plugin = request.config.pluginmanager.getplugin("doctestplus")
     if isinstance(request.node.parent, doctest_plugin._doctest_textfile_item_cls):
-        # Don't apply this fixture to io.rst.  It reads files and doesn't write
+        # Don't apply this fixture to io.rst.  It reads files and doesn't write.
+        # Implementation from https://github.com/pytest-dev/pytest/discussions/10437
         if "io.rst" not in request.node.name:
-            tmpdir = request.getfixturevalue('tmpdir')
-            with tmpdir.as_cwd():
-                yield
+            old_cwd = os.getcwd()
+            tmp_path = request.getfixturevalue('tmp_path')
+            os.chdir(tmp_path)
+            yield
+            os.chdir(old_cwd)
         else:
             yield
     else:


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address some stragglers to close #13787 .

The doctest refactoring is based on answer from https://github.com/pytest-dev/pytest/discussions/10437 .

`cosmology` stuff still under discussion and not included here. `samp` is handled separately in https://github.com/astropy/astropy/pull/13901 .

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
