### PR TITLE
Update nddata tests to use newer pytest syntax

### DIFF
--- a/astropy/nddata/tests/test_ccddata.py
+++ b/astropy/nddata/tests/test_ccddata.py
@@ -68,9 +68,8 @@ def test_ccddata_unit_cannot_be_set_to_none():
 
 
 def test_ccddata_meta_header_conflict():
-    with pytest.raises(ValueError) as exc:
+    with pytest.raises(ValueError, match=".*can't have both header and meta.*"):
         CCDData([1, 2, 3], unit='', meta={1: 1}, header={2: 2})
-        assert "can't have both header and meta." in str(exc.value)
 
 
 def test_ccddata_simple():

--- a/astropy/nddata/tests/test_utils.py
+++ b/astropy/nddata/tests/test_utils.py
@@ -33,16 +33,14 @@ test_nonfinite_positions = [(np.nan, np.nan), (np.inf, np.inf), (1, np.nan),
 
 def test_slices_different_dim():
     '''Overlap from arrays with different number of dim is undefined.'''
-    with pytest.raises(ValueError) as e:
+    with pytest.raises(ValueError, match=".*the same number of dimensions.*"):
         overlap_slices((4, 5, 6), (1, 2), (0, 0))
-    assert "the same number of dimensions" in str(e.value)
 
 
 def test_slices_pos_different_dim():
     '''Position must have same dim as arrays.'''
-    with pytest.raises(ValueError) as e:
+    with pytest.raises(ValueError, match=".*the same number of dimensions.*"):
         overlap_slices((4, 5), (1, 2), (0, 0, 3))
-    assert "the same number of dimensions" in str(e.value)
 
 
 @pytest.mark.parametrize('pos', test_pos_bad)
@@ -61,9 +59,8 @@ def test_slices_partial_overlap():
     assert temp == ((slice(0, 2, None),), (slice(1, 3, None),))
 
     for pos in [0, 4]:
-        with pytest.raises(PartialOverlapError) as e:
+        with pytest.raises(PartialOverlapError, match=".*Arrays overlap only partially.*"):
             temp = overlap_slices((5,), (3,), (pos,), mode='strict')
-        assert 'Arrays overlap only partially.' in str(e.value)
 
 
 def test_slices_edges():
@@ -99,9 +96,8 @@ def test_slices_edges():
 
 def test_slices_overlap_wrong_mode():
     '''Call overlap_slices with non-existing mode.'''
-    with pytest.raises(ValueError) as e:
+    with pytest.raises(ValueError, match="^Mode can be only.*"):
         overlap_slices((5,), (3,), (0,), mode='full')
-    assert "Mode can be only" in str(e.value)
 
 
 @pytest.mark.parametrize('position', test_nonfinite_positions)


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

Updates the nddata tests to use the `match=...` argument in tests for exception messages.

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

This includes a fix for a broken test that was included in the (otherwise unrelated) PR #13743 

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
