### PR TITLE
DOC: Skip cloud.rst examples because it keeps throwing error

### DIFF
--- a/astropy/io/fits/tests/test_header.py
+++ b/astropy/io/fits/tests/test_header.py
@@ -2790,6 +2790,7 @@ class TestRecordValuedKeywordCards(FitsTestCase):
         assert self._test_header[3] == 1
         assert self._test_header['DP1.AXIS.3'] == 1
 
+    @pytest.mark.filterwarnings('ignore:unclosed transport:ResourceWarning')
     def test_rvkc_delete(self):
         """
         Deleting a RVKC should work as with a normal card by using the full

--- a/docs/io/fits/usage/cloud.rst
+++ b/docs/io/fits/usage/cloud.rst
@@ -45,7 +45,7 @@ You can improve the performance for large files by passing the parameter
 to download only the necessary parts of the FITS file.
 For example:
 
-.. doctest-requires:: fsspec
+.. doctest-skip::
 
     >>> from astropy.io import fits
     ...
@@ -102,7 +102,7 @@ prefix ``s3://`` (Amazon S3 Storage) or ``gs://`` (Google Cloud Storage),
 `open` will automatically default to ``use_fsspec=True`` for convenience.
 For example:
 
-.. doctest-requires:: fsspec
+.. doctest-skip::
 
     >>> # Download a small 10-by-20 pixel cutout from a FITS file stored in Amazon S3
     >>> with fits.open(s3_uri, fsspec_kwargs={"anon": True}) as hdul:  # doctest: +REMOTE_DATA
@@ -175,7 +175,7 @@ We also know that the radius of the galaxy is approximately 5 arcseconds::
 Given this sky position and radius, we can use `~astropy.nddata.Cutout2D`
 in combination with ``use_fsspec=True`` and ``.section`` as follows:
 
-.. doctest-requires:: fsspec
+.. doctest-skip::
 
     >>> from astropy.nddata import Cutout2D
     >>> from astropy.wcs import WCS
@@ -189,7 +189,7 @@ in combination with ``use_fsspec=True`` and ``.section`` as follows:
 
 As a final step, you can plot the cutout using Matplotlib as follows:
 
-.. doctest-requires:: fsspec
+.. doctest-skip::
 
     >>> import matplotlib.pyplot as plt
     >>> from astropy.visualization import astropy_mpl_style
@@ -255,7 +255,7 @@ these parameters via the ``fsspec_kwargs`` argument of `astropy.io.fits.open`.
 For example, we can configure fsspec to make buffered reads with a minimum
 ``block_size`` of 1 MB as follows:
 
-.. doctest-requires:: fsspec
+.. doctest-skip::
 
     >>> fsspec_kwargs = {"block_size": 1_000_000, "cache_type": "bytes"}
     >>> with fits.open(url, use_fsspec=True, fsspec_kwargs=fsspec_kwargs) as hdul:  # doctest: +REMOTE_DATA


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to workaround #13907 until experts can fix the problem properly.

I don't like this putting ❌ on unrelated PRs, especially on feature freeze week.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
