### PR TITLE
Ensure dimensionless quantities can be added inplace to regular ndarray

### DIFF
--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -675,10 +675,14 @@ class Quantity(np.ndarray):
             # View the result array as a Quantity with the proper unit.
             return result if unit is None else self._new_view(result, unit)
 
-        # For given output, just set the unit. We know the unit is not None and
-        # the output is of the correct Quantity subclass, as it was passed
-        # through check_output.
-        out._set_unit(unit)
+        elif isinstance(out, Quantity):
+            # For given Quantity output, just set the unit. We know the unit
+            # is not None and the output is of the correct Quantity subclass,
+            # as it was passed through check_output.
+            # (We cannot do this unconditionally, though, since it is possible
+            # for out to be ndarray and the unit to be dimensionless.)
+            out._set_unit(unit)
+
         return out
 
     def __quantity_subclass__(self, unit):

--- a/astropy/units/tests/test_quantity_ufuncs.py
+++ b/astropy/units/tests/test_quantity_ufuncs.py
@@ -8,7 +8,7 @@ from collections import namedtuple
 import numpy as np
 import pytest
 from erfa import ufunc as erfa_ufunc
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_array_equal
 
 from astropy import units as u
 from astropy.units import quantity_helper as qh
@@ -944,6 +944,13 @@ class TestInplaceUfuncs:
         assert out.dtype == q.dtype
         assert np.all((out == np.sign(q.value)) |
                       (np.isnan(out) & np.isnan(q.value)))
+
+    def test_ndarray_inplace_op_with_quantity(self):
+        """Regression test for gh-13911."""
+        a = np.arange(3.)
+        q = u.Quantity([12.5, 25.], u.percent)
+        a[:2] += q  # This used to fail
+        assert_array_equal(a, np.array([0.125, 1.25, 2.]))
 
 
 @pytest.mark.skipif(not hasattr(np.core.umath, 'clip'),

--- a/docs/changes/units/13913.bugfix.rst
+++ b/docs/changes/units/13913.bugfix.rst
@@ -1,0 +1,1 @@
+Ensure dimensionless quantities can be added inplace to regular ndarray.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address the problem that a dimensionless quantity cannot be added in-place to an array (while it can be added out-of-place).

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #13911

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
