### PR TITLE
Known issues update

### DIFF
--- a/docs/known_issues.rst
+++ b/docs/known_issues.rst
@@ -77,16 +77,10 @@ See: https://github.com/astropy/astropy/issues/7582
 
 Numpy array creation functions cannot be used to initialize Quantity
 --------------------------------------------------------------------
-Trying the following example will throw an UnitConversionError
-on NumPy before version 1.20 and ignore the unit in later versions:
+Trying the following example will ignore the unit:
 
-.. doctest-requires:: numpy<1.20
-
-    >>> my_quantity = u.Quantity(1, u.m)
-    >>> np.full(10, my_quantity)  # doctest: +IGNORE_EXCEPTION_DETAIL
-    Traceback (most recent call last):
-    ...
-    UnitConversionError: 'm' (length) and '' (dimensionless) are not convertible
+    >>> np.full(10, 1 * u.m)
+    array([1., 1., 1., 1., 1., 1., 1., 1., 1., 1.])
 
 A workaround for this at the moment would be to do::
 

--- a/docs/known_issues.rst
+++ b/docs/known_issues.rst
@@ -67,7 +67,7 @@ Either set single array entries or use lists of Quantities::
 Both will throw an exception if units do not cancel, e.g.::
 
     >>> a = np.ones(4)
-    >>> a[2] = 1*u.cm # doctest: +SKIP
+    >>> a[2] = 1*u.cm
     Traceback (most recent call last):
     ...
     TypeError: only dimensionless scalar quantities can be converted to Python scalars
@@ -91,7 +91,7 @@ As well as with `~numpy.full` one cannot do `~numpy.zeros`, `~numpy.ones`, and `
 
 The `~numpy.arange` function does not work either::
 
-    >>> np.arange(0 * u.m, 10 * u.m, 1 * u.m)  # doctest: +IGNORE_EXCEPTION_DETAIL
+    >>> np.arange(0 * u.m, 10 * u.m, 1 * u.m)
     Traceback (most recent call last):
     ...
     TypeError: only dimensionless scalar quantities can be converted to Python scalars


### PR DESCRIPTION
### Description

#13885 dropped support for `numpy` 1.20, so it should not be mentioned in the known issues page. I also saw two more opportunities for increasing test coverage.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
