### PR TITLE
Fixes #13907: avoid `ResourceWarning` triggered by `asyncio.sslproto`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -134,6 +134,9 @@ filterwarnings =
     error
     ignore:unclosed <socket:ResourceWarning
     ignore:unclosed <ssl.SSLSocket:ResourceWarning
+    # Can be removed once Python>=3.11 is the minimum dependency,
+    # cf. https://github.com/astropy/astropy/issues/13907
+    ignore:unclosed transport <asyncio.sslproto
     ignore:numpy\.ufunc size changed:RuntimeWarning
     ignore:numpy\.ndarray size changed:RuntimeWarning
     ignore:Importing from numpy:DeprecationWarning:scipy


### PR DESCRIPTION
### Description

This PR should fix https://github.com/astropy/astropy/issues/13907 in the way explained in https://github.com/astropy/astropy/issues/13907#issuecomment-1292864978.


### Checklist for package maintainer(s)

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
