### PR TITLE
Update modeling tests to use `match` in `pytest.raises`

### DIFF
--- a/astropy/modeling/tests/test_compound.py
+++ b/astropy/modeling/tests/test_compound.py
@@ -2,7 +2,6 @@
 # pylint: disable=invalid-name, pointless-statement
 
 import pickle
-import re
 
 import numpy as np
 import pytest
@@ -40,7 +39,7 @@ def test_model_set_raises_value_error(expr, result):
     """Check that creating model sets with components whose _n_models are
        different raise a value error
     """
-    MESSAGE = r"Both operands must have equal values for n_models"
+    MESSAGE = r"Both operands must have equal values for .*"
     with pytest.raises(ValueError, match=MESSAGE):
         expr(Const1D((2, 2), n_models=2), Const1D(3, n_models=1))
 
@@ -212,8 +211,7 @@ def test_compound_unsupported_inverse(model):
     Ensure inverses aren't supported in cases where it shouldn't be.
     """
 
-    MESSAGE = (r"No analytical or user-supplied inverse transform "
-               r"has been implemented for this model.")
+    MESSAGE = r"No analytical or user-supplied inverse transform .*"
     with pytest.raises(NotImplementedError, match=MESSAGE):
         model.inverse
 
@@ -275,9 +273,7 @@ def test_invalid_operands():
     not match up correctly.
     """
 
-    MESSAGE = re.escape("Unsupported operands for |: None (n_inputs=2, n_outputs=2) and None "
-                        "(n_inputs=1, n_outputs=1); n_outputs for the left-hand model must "
-                        "match n_inputs for the right-hand model.")
+    MESSAGE = r"Unsupported operands for |:.*"
     with pytest.raises(ModelDefinitionError, match=MESSAGE):
         Rotation2D(90) | Gaussian1D(1, 0, 0.1)
 
@@ -320,7 +316,7 @@ def test_fix_inputs():
 def test_fix_inputs_invalid():
     g1 = Gaussian2D(1, 0, 0, 1, 2)
 
-    MESSAGE = r"Substitution key .* not among possible input choices."
+    MESSAGE = r"Substitution key .* not among possible input choices"
     with pytest.raises(ValueError, match=MESSAGE):
         fix_inputs(g1, {'x0': 0, 0: 0})
 
@@ -336,11 +332,11 @@ def test_fix_inputs_invalid():
     with pytest.raises(ValueError, match=MESSAGE):
         fix_inputs(g1, {'w': 2})
 
-    MESSAGE = r'Expected a dictionary for second argument of "fix_inputs".'
+    MESSAGE = r'Expected a dictionary for second argument of "fix_inputs"'
     with pytest.raises(ValueError, match=MESSAGE):
         fix_inputs(g1, (0, 1))
 
-    MESSAGE = re.escape("('Illegal operator: ', '#')")
+    MESSAGE = r".*Illegal operator: ', '#'.*"
     with pytest.raises(ModelDefinitionError, match=MESSAGE):
         CompoundModel('#', g1, g1)
 
@@ -591,7 +587,7 @@ def test_name_index():
     g1.name = 'bozo'
     assert g['bozo'].mean == 1
     g2.name = 'bozo'
-    MESSAGE = re.escape("Multiple components found using 'bozo' as name\nat indices [0, 1]")
+    MESSAGE = r"Multiple components found using 'bozo' as name.*"
     with pytest.raises(IndexError, match=MESSAGE):
         g['bozo']
 

--- a/astropy/modeling/tests/test_compound.py
+++ b/astropy/modeling/tests/test_compound.py
@@ -2,6 +2,7 @@
 # pylint: disable=invalid-name, pointless-statement
 
 import pickle
+import re
 
 import numpy as np
 import pytest
@@ -39,7 +40,8 @@ def test_model_set_raises_value_error(expr, result):
     """Check that creating model sets with components whose _n_models are
        different raise a value error
     """
-    with pytest.raises(ValueError):
+    MESSAGE = r"Both operands must have equal values for n_models"
+    with pytest.raises(ValueError, match=MESSAGE):
         expr(Const1D((2, 2), n_models=2), Const1D(3, n_models=1))
 
 
@@ -210,7 +212,9 @@ def test_compound_unsupported_inverse(model):
     Ensure inverses aren't supported in cases where it shouldn't be.
     """
 
-    with pytest.raises(NotImplementedError):
+    MESSAGE = (r"No analytical or user-supplied inverse transform "
+               r"has been implemented for this model.")
+    with pytest.raises(NotImplementedError, match=MESSAGE):
         model.inverse
 
 
@@ -271,10 +275,14 @@ def test_invalid_operands():
     not match up correctly.
     """
 
-    with pytest.raises(ModelDefinitionError):
+    MESSAGE = re.escape("Unsupported operands for |: None (n_inputs=2, n_outputs=2) and None "
+                        "(n_inputs=1, n_outputs=1); n_outputs for the left-hand model must "
+                        "match n_inputs for the right-hand model.")
+    with pytest.raises(ModelDefinitionError, match=MESSAGE):
         Rotation2D(90) | Gaussian1D(1, 0, 0.1)
 
-    with pytest.raises(ModelDefinitionError):
+    MESSAGE = r"Both operands must match numbers of inputs and outputs"
+    with pytest.raises(ModelDefinitionError, match=MESSAGE):
         Rotation2D(90) + Gaussian1D(1, 0, 0.1)
 
 
@@ -311,36 +319,41 @@ def test_fix_inputs():
 
 def test_fix_inputs_invalid():
     g1 = Gaussian2D(1, 0, 0, 1, 2)
-    with pytest.raises(ValueError):
+
+    MESSAGE = r"Substitution key .* not among possible input choices."
+    with pytest.raises(ValueError, match=MESSAGE):
         fix_inputs(g1, {'x0': 0, 0: 0})
 
-    with pytest.raises(ValueError):
-        fix_inputs(g1, (0, 1))
-
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=MESSAGE):
         fix_inputs(g1, {3: 2})
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=MESSAGE):
         fix_inputs(g1, {np.int32(3): 2})
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=MESSAGE):
         fix_inputs(g1, {np.int64(3): 2})
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=MESSAGE):
         fix_inputs(g1, {'w': 2})
 
-    with pytest.raises(ModelDefinitionError):
+    MESSAGE = r'Expected a dictionary for second argument of "fix_inputs".'
+    with pytest.raises(ValueError, match=MESSAGE):
+        fix_inputs(g1, (0, 1))
+
+    MESSAGE = re.escape("('Illegal operator: ', '#')")
+    with pytest.raises(ModelDefinitionError, match=MESSAGE):
         CompoundModel('#', g1, g1)
 
-    with pytest.raises(ValueError):
+    MESSAGE = r"Too many input arguments - expected 1, got 2"
+    with pytest.raises(ValueError, match=MESSAGE):
         gg1 = fix_inputs(g1, {0: 1})
         gg1(2, y=2)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=MESSAGE):
         gg1 = fix_inputs(g1, {np.int32(0): 1})
         gg1(2, y=2)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=MESSAGE):
         gg1 = fix_inputs(g1, {np.int64(0): 1})
         gg1(2, y=2)
 
@@ -406,10 +419,12 @@ def test_indexing_on_instance():
     assert isinstance(m[-1], Polynomial1D)
     assert isinstance(m[-2], Gaussian1D)
 
-    with pytest.raises(IndexError):
+    MESSAGE = r"list index out of range"
+    with pytest.raises(IndexError, match=MESSAGE):
         m[42]
 
-    with pytest.raises(IndexError):
+    MESSAGE = r"No component with name 'foobar' found"
+    with pytest.raises(IndexError, match=MESSAGE):
         m['foobar']
 
     # Confirm index-by-name works with fix_inputs
@@ -511,10 +526,11 @@ def test_compound_custom_inverse():
 
     # Make sure an inverse is not allowed if the models were combined with the
     # wrong operator, or if one of the models doesn't have an inverse defined
-    with pytest.raises(NotImplementedError):
+    MESSAGE = r"No analytical or user-supplied inverse transform has been implemented for this model"
+    with pytest.raises(NotImplementedError, match=MESSAGE):
         (shift + model1).inverse
 
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(NotImplementedError, match=MESSAGE):
         (model1 & poly).inverse
 
 
@@ -568,12 +584,15 @@ def test_name_index():
     g1 = Gaussian1D(1, 1, 1)
     g2 = Gaussian1D(1, 2, 1)
     g = g1 + g2
-    with pytest.raises(IndexError):
+
+    MESSAGE = r"No component with name 'bozo' found"
+    with pytest.raises(IndexError, match=MESSAGE):
         g['bozo']
     g1.name = 'bozo'
     assert g['bozo'].mean == 1
     g2.name = 'bozo'
-    with pytest.raises(IndexError):
+    MESSAGE = re.escape("Multiple components found using 'bozo' as name\nat indices [0, 1]")
+    with pytest.raises(IndexError, match=MESSAGE):
         g['bozo']
 
 
@@ -694,7 +713,8 @@ def test_replace_submodel():
     assert_allclose(m5(0), (-1, -6))
 
     # Check we get a value error when model name doesn't exist
-    with pytest.raises(ValueError):
+    MESSAGE = r"No submodels found named not_there"
+    with pytest.raises(ValueError, match=MESSAGE):
         m2 = m.replace_submodel('not_there', Scale(2))
 
     # And now a model set
@@ -702,7 +722,8 @@ def test_replace_submodel():
     S = Shift([1, 2], n_models=2)
     m = P | S
     assert_array_equal(m([0, 1]), (1, 2))
-    with pytest.raises(ValueError):
+    MESSAGE = r"New and old models must have equal values for n_models"
+    with pytest.raises(ValueError, match=MESSAGE):
         m2 = m.replace_submodel('poly', Polynomial1D(degree=1, c0=1))
     m2 = m.replace_submodel('poly', Polynomial1D(degree=1, c0=[1, 2],
                                                  n_models=2))

--- a/astropy/modeling/tests/test_convolution.py
+++ b/astropy/modeling/tests/test_convolution.py
@@ -88,6 +88,5 @@ def test__convolution_inputs():
     assert model._convolution_inputs(*grid1)[1] == grid1[0].shape
 
     # Error
-    with pytest.raises(ValueError) as err:
+    with pytest.raises(ValueError, match=r"Values have differing shapes"):
         model._convolution_inputs(grid0[0], grid1[1])
-    assert str(err.value) == "Values have differing shapes"

--- a/astropy/modeling/tests/test_core.py
+++ b/astropy/modeling/tests/test_core.py
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # pylint: disable=invalid-name
 import os
-import re
 import subprocess
 import sys
 import unittest.mock as mk
@@ -101,7 +100,7 @@ def test_inputless_model():
 
 
 def test_ParametericModel():
-    MESSAGE = re.escape("Gaussian1D.__init__() got an unrecognized parameter 'wrong'")
+    MESSAGE = r"Gaussian1D.__init__.* got an unrecognized parameter 'wrong'"
     with pytest.raises(TypeError, match=MESSAGE):
         models.Gaussian1D(1, 2, 3, wrong=4)
 
@@ -297,7 +296,7 @@ def test_custom_inverse():
     # A trivial inverse for a trivial polynomial
     inv = models.Polynomial1D(1, c0=(2./3.), c1=(1./3.))
 
-    MESSAGE = r"No analytical or user-supplied inverse transform has been implemented for this model."
+    MESSAGE = r"No analytical or user-supplied inverse transform has been implemented for this model"
     with pytest.raises(NotImplementedError, match=MESSAGE):
         p.inverse
 
@@ -619,7 +618,7 @@ def test_rename_inputs_outputs():
     assert g2.inputs == ("x", "y")
     assert g2.outputs == ("z",)
 
-    MESSAGE = r"Expected .* number of .*, got .*."
+    MESSAGE = r"Expected .* number of .*, got .*"
     with pytest.raises(ValueError, match=MESSAGE):
         g2.inputs = ("w", )
 
@@ -767,8 +766,7 @@ def test_prepare_outputs_sparse_grid():
 def test_coerce_units():
     model = models.Polynomial1D(1, c0=1, c1=2)
 
-    MESSAGE = re.escape("Can only apply 'add' function to dimensionless quantities when other "
-                        "argument is not a quantity (unless the latter is all zero/infinity/nan)")
+    MESSAGE = r"Can only apply 'add' function to dimensionless quantities when other .*"
     with pytest.raises(u.UnitsError, match=MESSAGE):
         model(u.Quantity(10, u.m))
 
@@ -817,7 +815,7 @@ def test_coerce_units():
 def test_bounding_box_general_inverse():
     model = NonFittableModel(42.5)
 
-    MESSAGE = r"No bounding box is defined for this model."
+    MESSAGE = r"No bounding box is defined for this model"
     with pytest.raises(NotImplementedError, match=MESSAGE):
         model.bounding_box
     model.bounding_box = ()
@@ -878,13 +876,12 @@ def test__validate_input_shape():
     assert model._validate_input_shape(_input, 0, model.inputs, 1, False) == (2, 3)
 
     # Fail number of axes
-    MESSAGE = r"For model_set_axis=2, all inputs must be at least 3-dimensional."
+    MESSAGE = r"For model_set_axis=2, all inputs must be at least 3-dimensional"
     with pytest.raises(ValueError, match=MESSAGE):
         model._validate_input_shape(_input, 0, model.inputs, 2, True)
 
     # Fail number of models (has argname)
-    MESSAGE = (r"Input argument '.*' does not have the correct dimensions in "
-               r"model_set_axis=1 for a model set with n_models=2.")
+    MESSAGE = r"Input argument '.*' does not have the correct dimensions in .*"
     with pytest.raises(ValueError, match=MESSAGE):
         model._validate_input_shape(_input, 0, model.inputs, 1, True)
 
@@ -915,7 +912,7 @@ def test__validate_input_shapes():
             ]
 
     # Fail check_broadcast
-    MESSAGE = r"All inputs must have identical shapes or must be scalars."
+    MESSAGE = r"All inputs must have identical shapes or must be scalars"
     with mk.patch.object(Model, '_validate_input_shape',
                          autospec=True, side_effect=all_shapes) as mkValidate:
         with mk.patch.object(core, 'check_broadcast',
@@ -957,7 +954,7 @@ def test_get_bounding_box():
     assert model.get_bounding_box(False) is None
 
     # No bounding_box
-    MESSAGE = r"No bounding box is defined for this model."
+    MESSAGE = r"No bounding box is defined for this model"
     with pytest.raises(NotImplementedError, match=MESSAGE):
         model.bounding_box
     assert model.get_bounding_box(True) is None
@@ -1003,7 +1000,7 @@ def test_compound_bounding_box():
     assert model(0.5) == truth(0.5)
     assert model(0.5, with_bounding_box=True) == truth(0.5)
 
-    MESSAGE = r"No bounding box is defined for selector: .*."
+    MESSAGE = r"No bounding box is defined for selector: .*"
     with pytest.raises(RuntimeError, match=MESSAGE):
         model(0, with_bounding_box=True)
 
@@ -1085,7 +1082,7 @@ def test_bind_compound_bounding_box_using_with_bounding_box_select():
     assert model(1, with_bounding_box=True) == truth(1)
 
     # Attempt to fall-back on implicit selector, but no bounding_box
-    MESSAGE = r"No bounding box is defined for selector: .*."
+    MESSAGE = r"No bounding box is defined for selector: .*"
     with pytest.raises(RuntimeError, match=MESSAGE):
         model(0.5, with_bounding_box=True)
 

--- a/astropy/modeling/tests/test_fitters.py
+++ b/astropy/modeling/tests/test_fitters.py
@@ -210,15 +210,15 @@ class TestJointFitter:
 class TestLinearLSQFitter:
     def test_compound_model_raises_error(self):
         """Test that if an user tries to use a compound model, raises an error"""
-        with pytest.raises(ValueError) as excinfo:
+        MESSAGE = r"Model must be simple, not compound"
+        with pytest.raises(ValueError, match=MESSAGE):
             init_model1 = models.Polynomial1D(degree=2, c0=[1, 1], n_models=2)
             init_model2 = models.Polynomial1D(degree=2, c0=[1, 1], n_models=2)
             init_model_comp = init_model1 + init_model2
             x = np.arange(10)
             y = init_model_comp(x, model_set_axis=False)
             fitter = LinearLSQFitter()
-            _ = fitter(init_model_comp, x, y)
-        assert "Model must be simple, not compound" in str(excinfo.value)
+            fitter(init_model_comp, x, y)
 
     def test_chebyshev1D(self):
         """Tests fitting a 1D Chebyshev polynomial to some real world data."""
@@ -1088,9 +1088,9 @@ def test_optimizers(fitter_class):
 @mk.patch.multiple(Optimization, __abstractmethods__=set())
 def test_Optimization_abstract_call():
     optimization = Optimization(mk.MagicMock())
-    with pytest.raises(NotImplementedError) as err:
+    MESSAGE = r"Subclasses should implement this method"
+    with pytest.raises(NotImplementedError, match=MESSAGE):
         optimization()
-    assert str(err.value) == "Subclasses should implement this method"
 
 
 def test_fitting_with_outlier_removal_niter():

--- a/astropy/modeling/tests/test_functional_models.py
+++ b/astropy/modeling/tests/test_functional_models.py
@@ -92,9 +92,9 @@ def test_Gaussian2DCovariance():
     cov_matrix = [[49., 3.14, -16.],
                   [3.14, -16., 9.],
                   [-16, 27, 3.14]]
-    with pytest.raises(ValueError) as err:
+    MESSAGE = r"Covariance matrix must be 2x2"
+    with pytest.raises(ValueError, match=MESSAGE):
         models.Gaussian2D(17., 2.0, 2.5, cov_matrix=cov_matrix)
-    assert str(err.value) == "Covariance matrix must be 2x2"
 
 
 def test_Gaussian2DRotation():
@@ -128,11 +128,12 @@ def test_Gaussian2D_invalid_inputs():
     models.Gaussian2D(x_stddev=x_stddev, y_stddev=y_stddev, theta=None)
     models.Gaussian2D(cov_matrix=cov_matrix)
 
-    with pytest.raises(InputParameterError):
+    MESSAGE = r"Cannot specify both cov_matrix and x/y_stddev/theta"
+    with pytest.raises(InputParameterError, match=MESSAGE):
         models.Gaussian2D(x_stddev=0, cov_matrix=cov_matrix)
-    with pytest.raises(InputParameterError):
+    with pytest.raises(InputParameterError, match=MESSAGE):
         models.Gaussian2D(y_stddev=0, cov_matrix=cov_matrix)
-    with pytest.raises(InputParameterError):
+    with pytest.raises(InputParameterError, match=MESSAGE):
         models.Gaussian2D(theta=0, cov_matrix=cov_matrix)
 
 
@@ -383,9 +384,9 @@ def test_Ring2D_rout():
     assert m.r_in.value == 1
     assert m.width.value == 6
     # Error when r_out is too small for default r_in
-    with pytest.raises(InputParameterError) as err:
+    MESSAGE = r"r_in=.* and width=.* must both be >=0"
+    with pytest.raises(InputParameterError, match=MESSAGE):
         models.Ring2D(amplitude=1, x_0=1, y_0=1, r_out=0.5)
-    assert str(err.value) == "r_in=1 and width=-0.5 must both be >=0"
 
     # Test with width specified only
     m = models.Ring2D(amplitude=1, x_0=1, y_0=1, width=11)
@@ -403,9 +404,8 @@ def test_Ring2D_rout():
     assert m.r_in.value == 2
     assert m.width.value == 3
     # Error when r_out is smaller than r_in
-    with pytest.raises(InputParameterError) as err:
+    with pytest.raises(InputParameterError, match=MESSAGE):
         models.Ring2D(amplitude=1, x_0=1, y_0=1, r_out=1, r_in=4)
-    assert str(err.value) == "r_in=4 and width=-3 must both be >=0"
 
     # Test with r_in and width specified only
     m = models.Ring2D(amplitude=1, x_0=1, y_0=1, r_in=2, width=4)
@@ -423,9 +423,8 @@ def test_Ring2D_rout():
     assert m.r_in.value == 5
     assert m.width.value == 7
     # Error when width is larger than r_out
-    with pytest.raises(InputParameterError) as err:
+    with pytest.raises(InputParameterError, match=MESSAGE):
         models.Ring2D(amplitude=1, x_0=1, y_0=1, r_out=1, width=4)
-    assert str(err.value) == "r_in=-3 and width=4 must both be >=0"
 
     # Test with r_in, r_out, and width all specified
     m = models.Ring2D(amplitude=1, x_0=1, y_0=1, r_in=3, r_out=11, width=8)
@@ -435,9 +434,9 @@ def test_Ring2D_rout():
     assert m.r_in.value == 3
     assert m.width.value == 8
     # error when specifying all
-    with pytest.raises(InputParameterError) as err:
+    MESSAGE = "Width must be r_out - r_in"
+    with pytest.raises(InputParameterError, match=MESSAGE):
         models.Ring2D(amplitude=1, x_0=1, y_0=1, r_in=3, r_out=11, width=7)
-    assert str(err.value) == "Width must be r_out - r_in"
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason='requires scipy')
@@ -453,9 +452,9 @@ def test_Voigt1D(fitter):
     assert_allclose(voi_fit.param_sets, voi.param_sets)
 
     # Invalid method
-    with pytest.raises(ValueError) as err:
+    MESSAGE = "Not a valid method for Voigt1D Faddeeva function: test."
+    with pytest.raises(ValueError, match=MESSAGE):
         models.Voigt1D(method='test')
-    assert str(err.value) == "Not a valid method for Voigt1D Faddeeva function: test."
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason='requires scipy')
@@ -512,11 +511,10 @@ def test_ExponentialAndLogarithmic1D_fit(model):
 
 @pytest.mark.parametrize('model', [models.Exponential1D(), models.Logarithmic1D()])
 def test_ExponentialAndLogarithmic_set_tau(model):
-    message = "0 is not an allowed value for tau"
+    MESSAGE = "0 is not an allowed value for tau"
 
-    with pytest.raises(ValueError) as err:
+    with pytest.raises(ValueError, match=MESSAGE):
         model.tau = 0
-    assert str(err.value) == message
 
 
 def test_Linear1D_inverse():

--- a/astropy/modeling/tests/test_functional_models.py
+++ b/astropy/modeling/tests/test_functional_models.py
@@ -434,7 +434,7 @@ def test_Ring2D_rout():
     assert m.r_in.value == 3
     assert m.width.value == 8
     # error when specifying all
-    MESSAGE = "Width must be r_out - r_in"
+    MESSAGE = r"Width must be r_out - r_in"
     with pytest.raises(InputParameterError, match=MESSAGE):
         models.Ring2D(amplitude=1, x_0=1, y_0=1, r_in=3, r_out=11, width=7)
 
@@ -452,7 +452,7 @@ def test_Voigt1D(fitter):
     assert_allclose(voi_fit.param_sets, voi.param_sets)
 
     # Invalid method
-    MESSAGE = "Not a valid method for Voigt1D Faddeeva function: test."
+    MESSAGE = r"Not a valid method for Voigt1D Faddeeva function: test"
     with pytest.raises(ValueError, match=MESSAGE):
         models.Voigt1D(method='test')
 
@@ -511,7 +511,7 @@ def test_ExponentialAndLogarithmic1D_fit(model):
 
 @pytest.mark.parametrize('model', [models.Exponential1D(), models.Logarithmic1D()])
 def test_ExponentialAndLogarithmic_set_tau(model):
-    MESSAGE = "0 is not an allowed value for tau"
+    MESSAGE = r"0 is not an allowed value for tau"
 
     with pytest.raises(ValueError, match=MESSAGE):
         model.tau = 0

--- a/astropy/modeling/tests/test_input.py
+++ b/astropy/modeling/tests/test_input.py
@@ -188,7 +188,7 @@ class TestFitting:
         """1 set 1D x, 1 set 1D y, 2 param_sets, NonLinearFitter"""
         fitter = fitter()
 
-        MESSAGE = r"Non-linear fitters can only fit one data set at a time."
+        MESSAGE = r"Non-linear fitters can only fit one data set at a time"
         with pytest.raises(ValueError, match=MESSAGE):
             g1 = models.Gaussian1D([10.2, 10], mean=[3, 3.2], stddev=[.23, .2],
                                    n_models=2)
@@ -213,7 +213,7 @@ class TestFitting:
         """1 set 2d x, 1set 2D y, 2 param_sets, NonLinearFitter"""
         fitter = fitter()
 
-        MESSAGE = r"Input argument 'x' does not have the correct dimensions in model_set_axis=0 for a model set with n_models=2."
+        MESSAGE = r"Input argument .* does not have the correct dimensions in .* for a model set with .*"
         with pytest.raises(ValueError, match=MESSAGE):
             g2 = models.Gaussian2D([10, 10], [3, 3], [4, 4], x_stddev=[.3, .3],
                                    y_stddev=[.2, .2], theta=[0, 0], n_models=2)
@@ -428,7 +428,7 @@ class TestSingleInputSingleOutputSingleModel:
                              [[[311, 322], [333, 344]],
                               [[411, 422], [433, 444]]]])
 
-        MESSAGE = r"self input argument 'x' of shape .* cannot be broadcast with parameter 'p1' of shape .*"
+        MESSAGE = r"self input argument .* of shape .* cannot be broadcast with parameter .* of shape .*"
         with pytest.raises(ValueError, match=MESSAGE):
             # Doesn't broadcast
             t([[100, 200, 300], [400, 500, 600]])
@@ -499,7 +499,7 @@ class TestSingleInputSingleOutputTwoModel:
 
         t = TModel_1_1([1, 2], [10, 20], n_models=2)
 
-        MESSAGE = r"Input argument 'x' does not have the correct dimensions in model_set_axis=0 for a model set with n_models=2."
+        MESSAGE = r"Input argument .* does not have the correct dimensions in .* for a model set with .*"
         with pytest.raises(ValueError, match=MESSAGE):
             t(np.arange(5) * 100)
 
@@ -582,7 +582,7 @@ class TestSingleInputSingleOutputTwoModel:
         t = TModel_1_1([[1, 2, 3], [4, 5, 6]],
                        [[10, 20, 30], [40, 50, 60]], n_models=2)
 
-        MESSAGE = r"Input argument 'x' does not have the correct dimensions in model_set_axis=0 for a model set with n_models=2."
+        MESSAGE = r"Input argument .* does not have the correct dimensions in .* for a model set with .*"
         with pytest.raises(ValueError, match=MESSAGE):
             y1 = t([100, 200, 300])
 
@@ -590,7 +590,7 @@ class TestSingleInputSingleOutputTwoModel:
         assert np.shape(y1) == (2, 3)
         assert np.all(y1 == [[111, 122, 133], [244, 255, 266]])
 
-        MESSAGE = r"Model input argument 'x' of shape .* cannot be broadcast with parameter 'p1' of shape .*."
+        MESSAGE = r"Model input argument .* of shape .* cannot be broadcast with parameter .* of shape .*"
         with pytest.raises(ValueError, match=MESSAGE):
             # Doesn't broadcast with the shape of the parameters, (3,)
             y2 = t([100, 200], model_set_axis=False)
@@ -609,7 +609,7 @@ class TestSingleInputSingleOutputTwoModel:
         assert np.all(y1 == [[[111, 222], [133, 244]],
                              [[355, 466], [377, 488]]])
 
-        MESSAGE = r"Model input argument 'x' of shape .* cannot be broadcast with parameter 'p1' of shape .*."
+        MESSAGE = r"Model input argument .* of shape .* cannot be broadcast with parameter .* of shape .*"
         with pytest.raises(ValueError, match=MESSAGE):
             y2 = t([[100, 200, 300], [400, 500, 600]])
 
@@ -623,7 +623,7 @@ class TestSingleInputSingleOutputTwoModel:
                         [[0.07, 0.08, 0.09], [0.10, 0.11, 0.12]]],
                        [[1, 2, 3], [4, 5, 6]], n_models=2)
 
-        MESSAGE = r"Input argument 'x' does not have the correct dimensions in model_set_axis=0 for a model set with n_models=2."
+        MESSAGE = r"Input argument .* does not have the correct dimensions in .* for a model set with .*"
         with pytest.raises(ValueError, match=MESSAGE):
             y = t([10, 20, 30])
 
@@ -748,7 +748,7 @@ class TestSingleInputDoubleOutputSingleModel:
         assert np.all(y2 == [[111, 122], [211, 222]])
         assert np.all(z2 == [[1111, 2122], [1211, 2222]])
 
-        MESSAGE = r"self input argument 'x0' of shape .* cannot be broadcast with parameter 'p1' of shape .*"
+        MESSAGE = r"self input argument .* of shape .* cannot be broadcast with parameter .* of shape .*"
         with pytest.raises(ValueError, match=MESSAGE):
             # Doesn't broadcast
             y3, z3 = t([100, 200, 300])
@@ -778,7 +778,7 @@ class TestSingleInputDoubleOutputSingleModel:
                              [[[1311, 2322], [3333, 4344]],
                               [[1411, 2422], [3433, 4444]]]])
 
-        MESSAGE = r"self input argument 'x0' of shape .* cannot be broadcast with parameter 'p1' of shape .*"
+        MESSAGE = r"self input argument .* of shape .* cannot be broadcast with parameter .* of shape .*"
         with pytest.raises(ValueError, match=MESSAGE):
             # Doesn't broadcast
             y3, z3 = t([[100, 200, 300], [400, 500, 600]])

--- a/astropy/modeling/tests/test_input.py
+++ b/astropy/modeling/tests/test_input.py
@@ -144,7 +144,8 @@ class TestFitting:
         with a model with multiple parameter sets.
         """
 
-        with pytest.raises(ValueError):
+        MESSAGE = r"Number of data sets .* is expected to equal the number of parameter sets"
+        with pytest.raises(ValueError, match=MESSAGE):
             p1 = models.Polynomial1D(5)
             y1 = p1(self.x1)
             p1 = models.Polynomial1D(5, n_models=2)
@@ -187,7 +188,8 @@ class TestFitting:
         """1 set 1D x, 1 set 1D y, 2 param_sets, NonLinearFitter"""
         fitter = fitter()
 
-        with pytest.raises(ValueError):
+        MESSAGE = r"Non-linear fitters can only fit one data set at a time."
+        with pytest.raises(ValueError, match=MESSAGE):
             g1 = models.Gaussian1D([10.2, 10], mean=[3, 3.2], stddev=[.23, .2],
                                    n_models=2)
             y1 = g1(self.x1, model_set_axis=False)
@@ -211,7 +213,8 @@ class TestFitting:
         """1 set 2d x, 1set 2D y, 2 param_sets, NonLinearFitter"""
         fitter = fitter()
 
-        with pytest.raises(ValueError):
+        MESSAGE = r"Input argument 'x' does not have the correct dimensions in model_set_axis=0 for a model set with n_models=2."
+        with pytest.raises(ValueError, match=MESSAGE):
             g2 = models.Gaussian2D([10, 10], [3, 3], [4, 4], x_stddev=[.3, .3],
                                    y_stddev=[.2, .2], theta=[0, 0], n_models=2)
             z = g2(self.x.flatten(), self.y.flatten())
@@ -401,7 +404,8 @@ class TestSingleInputSingleOutputSingleModel:
         assert np.shape(y2) == (2, 2)
         assert np.all(y2 == [[111, 122], [211, 222]])
 
-        with pytest.raises(ValueError):
+        MESSAGE = r"self input argument 'x' of shape .* cannot be broadcast with parameter 'p1' of shape .*"
+        with pytest.raises(ValueError, match=MESSAGE):
             # Doesn't broadcast
             t([100, 200, 300])
 
@@ -424,7 +428,8 @@ class TestSingleInputSingleOutputSingleModel:
                              [[[311, 322], [333, 344]],
                               [[411, 422], [433, 444]]]])
 
-        with pytest.raises(ValueError):
+        MESSAGE = r"self input argument 'x' of shape .* cannot be broadcast with parameter 'p1' of shape .*"
+        with pytest.raises(ValueError, match=MESSAGE):
             # Doesn't broadcast
             t([[100, 200, 300], [400, 500, 600]])
 
@@ -494,7 +499,8 @@ class TestSingleInputSingleOutputTwoModel:
 
         t = TModel_1_1([1, 2], [10, 20], n_models=2)
 
-        with pytest.raises(ValueError):
+        MESSAGE = r"Input argument 'x' does not have the correct dimensions in model_set_axis=0 for a model set with n_models=2."
+        with pytest.raises(ValueError, match=MESSAGE):
             t(np.arange(5) * 100)
 
         y1 = t([100, 200])
@@ -576,14 +582,16 @@ class TestSingleInputSingleOutputTwoModel:
         t = TModel_1_1([[1, 2, 3], [4, 5, 6]],
                        [[10, 20, 30], [40, 50, 60]], n_models=2)
 
-        with pytest.raises(ValueError):
+        MESSAGE = r"Input argument 'x' does not have the correct dimensions in model_set_axis=0 for a model set with n_models=2."
+        with pytest.raises(ValueError, match=MESSAGE):
             y1 = t([100, 200, 300])
 
         y1 = t([100, 200])
         assert np.shape(y1) == (2, 3)
         assert np.all(y1 == [[111, 122, 133], [244, 255, 266]])
 
-        with pytest.raises(ValueError):
+        MESSAGE = r"Model input argument 'x' of shape .* cannot be broadcast with parameter 'p1' of shape .*."
+        with pytest.raises(ValueError, match=MESSAGE):
             # Doesn't broadcast with the shape of the parameters, (3,)
             y2 = t([100, 200], model_set_axis=False)
 
@@ -601,7 +609,8 @@ class TestSingleInputSingleOutputTwoModel:
         assert np.all(y1 == [[[111, 222], [133, 244]],
                              [[355, 466], [377, 488]]])
 
-        with pytest.raises(ValueError):
+        MESSAGE = r"Model input argument 'x' of shape .* cannot be broadcast with parameter 'p1' of shape .*."
+        with pytest.raises(ValueError, match=MESSAGE):
             y2 = t([[100, 200, 300], [400, 500, 600]])
 
         y2 = t([[[100, 200], [300, 400]], [[500, 600], [700, 800]]])
@@ -614,7 +623,8 @@ class TestSingleInputSingleOutputTwoModel:
                         [[0.07, 0.08, 0.09], [0.10, 0.11, 0.12]]],
                        [[1, 2, 3], [4, 5, 6]], n_models=2)
 
-        with pytest.raises(ValueError):
+        MESSAGE = r"Input argument 'x' does not have the correct dimensions in model_set_axis=0 for a model set with n_models=2."
+        with pytest.raises(ValueError, match=MESSAGE):
             y = t([10, 20, 30])
 
         y = t([10, 20, 30], model_set_axis=False)
@@ -738,7 +748,8 @@ class TestSingleInputDoubleOutputSingleModel:
         assert np.all(y2 == [[111, 122], [211, 222]])
         assert np.all(z2 == [[1111, 2122], [1211, 2222]])
 
-        with pytest.raises(ValueError):
+        MESSAGE = r"self input argument 'x0' of shape .* cannot be broadcast with parameter 'p1' of shape .*"
+        with pytest.raises(ValueError, match=MESSAGE):
             # Doesn't broadcast
             y3, z3 = t([100, 200, 300])
 
@@ -767,7 +778,8 @@ class TestSingleInputDoubleOutputSingleModel:
                              [[[1311, 2322], [3333, 4344]],
                               [[1411, 2422], [3433, 4444]]]])
 
-        with pytest.raises(ValueError):
+        MESSAGE = r"self input argument 'x0' of shape .* cannot be broadcast with parameter 'p1' of shape .*"
+        with pytest.raises(ValueError, match=MESSAGE):
             # Doesn't broadcast
             y3, z3 = t([[100, 200, 300], [400, 500, 600]])
 
@@ -991,14 +1003,16 @@ def test_call_keyword_args_1(model):
     assert_allclose(positional, model(1, t=2))
     assert_allclose(positional, model(1, 2))
 
-    with pytest.raises(ValueError):
+    MESSAGE = r"Too many input arguments - expected 2, got .*"
+    with pytest.raises(ValueError, match=MESSAGE):
         model(1, 2, 3)
 
-    with pytest.raises(ValueError):
-        model(1)
-
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=MESSAGE):
         model(1, 2, t=12, r=3)
+
+    MESSAGE = r"Missing input arguments - expected 2, got 1"
+    with pytest.raises(ValueError, match=MESSAGE):
+        model(1)
 
 
 @pytest.mark.parametrize('model',
@@ -1015,14 +1029,16 @@ def test_call_keyword_args_2(model):
     model.inputs = ('r',)
     assert_allclose(positional, model(r=1))
 
-    with pytest.raises(ValueError):
+    MESSAGE = r"Too many input arguments - expected .*, got .*"
+    with pytest.raises(ValueError, match=MESSAGE):
         model(1, 2, 3)
 
-    with pytest.raises(ValueError):
-        model()
-
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=MESSAGE):
         model(1, 2, t=12, r=3)
+
+    MESSAGE = r"Missing input arguments - expected 1, got 0"
+    with pytest.raises(ValueError, match=MESSAGE):
+        model()
 
 
 @pytest.mark.parametrize('model',
@@ -1043,14 +1059,16 @@ def test_call_keyword_args_3(model):
 
     assert_allclose(positional, model(1, t=2))
 
-    with pytest.raises(ValueError):
+    MESSAGE = r"Too many input arguments - expected .*, got .*"
+    with pytest.raises(ValueError, match=MESSAGE):
         model(1, 2, 3)
 
-    with pytest.raises(ValueError):
-        model()
-
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=MESSAGE):
         model(1, 2, t=12, r=3)
+
+    MESSAGE = r"Missing input arguments - expected 2, got 0"
+    with pytest.raises(ValueError, match=MESSAGE):
+        model()
 
 
 @pytest.mark.parametrize('model',
@@ -1073,11 +1091,13 @@ def test_call_keyword_mappings(model):
     assert_allclose(positional, model(1, t=2))
     assert_allclose(positional, model(1, 2))
 
-    with pytest.raises(ValueError):
+    MESSAGE = r"Too many input arguments - expected .*, got .*"
+    with pytest.raises(ValueError, match=MESSAGE):
         model(1, 2, 3)
 
-    with pytest.raises(ValueError):
-        model(1)
-
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=MESSAGE):
         model(1, 2, t=12, r=3)
+
+    MESSAGE = r"Missing input arguments - expected 2, got 1"
+    with pytest.raises(ValueError, match=MESSAGE):
+        model(1)

--- a/astropy/modeling/tests/test_mappings.py
+++ b/astropy/modeling/tests/test_mappings.py
@@ -1,7 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # pylint: disable=invalid-name
-import re
-
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose, assert_array_equal
@@ -42,7 +40,7 @@ def test_drop_axes_1():
 def test_drop_axes_2():
     mapping = Mapping((1, ))
     assert mapping(1, 2) == (2.)
-    MESSAGE = re.escape("Mappings such as (1,) that drop one or more of their inputs are not invertible at this time.")
+    MESSAGE = r"Mappings such as .* that drop one or more of their inputs are not invertible at this time"
     with pytest.raises(NotImplementedError, match=MESSAGE):
         mapping.inverse
 

--- a/astropy/modeling/tests/test_mappings.py
+++ b/astropy/modeling/tests/test_mappings.py
@@ -1,5 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # pylint: disable=invalid-name
+import re
+
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose, assert_array_equal
@@ -40,7 +42,8 @@ def test_drop_axes_1():
 def test_drop_axes_2():
     mapping = Mapping((1, ))
     assert mapping(1, 2) == (2.)
-    with pytest.raises(NotImplementedError):
+    MESSAGE = re.escape("Mappings such as (1,) that drop one or more of their inputs are not invertible at this time.")
+    with pytest.raises(NotImplementedError, match=MESSAGE):
         mapping.inverse
 
 
@@ -64,9 +67,9 @@ def test_bad_inputs(name):
         if idx == 2:
             continue
 
-        with pytest.raises(TypeError) as err:
+        MESSAGE = f"{name} expects 2 inputs; got {idx}"
+        with pytest.raises(TypeError, match=MESSAGE):
             mapping.evaluate(*x[:idx])
-        assert str(err.value) == f"{name} expects 2 inputs; got {idx}"
 
 
 def test_identity():
@@ -145,9 +148,9 @@ class TestUnitsMapping:
         assert model._input_units == {'x': u.K}
 
         # Error
-        with pytest.raises(ValueError) as err:
+        MESSAGE = r"If one return unit is None, then all must be None"
+        with pytest.raises(ValueError, match=MESSAGE):
             UnitsMapping(((u.m, None), (u.m, u.K)))
-        assert str(err.value) == "If one return unit is None, then all must be None"
 
     def test_evaluate(self):
         model = UnitsMapping(((u.m, None),))

--- a/astropy/modeling/tests/test_model_sets.py
+++ b/astropy/modeling/tests/test_model_sets.py
@@ -56,7 +56,8 @@ def test_model1d_axis_1(model_class):
 
     p1 = model_class(1, c0=c0, c1=c1, n_models=n_models, model_set_axis=model_axis)
 
-    with pytest.raises(ValueError):
+    MESSAGE = r"For model_set_axis=1, all inputs must be at least 2-dimensional."
+    with pytest.raises(ValueError, match=MESSAGE):
         p1(x)
 
     y = p1(x, model_set_axis=False)
@@ -87,10 +88,11 @@ def test_model1d_axis_2(model_class):
     t2 = model_class(1, c0=2, c1=20)
     t3 = model_class(1, c0=3, c1=30)
 
-    with pytest.raises(ValueError):
+    MESSAGE = r"For model_set_axis=2, all inputs must be at least 3-dimensional."
+    with pytest.raises(ValueError, match=MESSAGE):
         p1(x)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=MESSAGE):
         p1(xx)
 
     y = p1(x, model_set_axis=False)
@@ -112,7 +114,9 @@ def test_model1d_axis_0(model_class):
     t1 = model_class(1, c0=2, c1=1)
     t2 = model_class(1, c0=3, c1=2)
 
-    with pytest.raises(ValueError):
+    MESSAGE = (r"Input argument 'x' does not have the correct dimensions in "
+               r"model_set_axis=0 for a model set with n_models=2.")
+    with pytest.raises(ValueError, match=MESSAGE):
         p1(x)
 
     y = p1(xx)
@@ -161,10 +165,12 @@ def test_negative_axis():
     t1 = Polynomial1D(1, c0=1, c1=3)
     t2 = Polynomial1D(1, c0=2, c1=4)
 
-    with pytest.raises(ValueError):
+    MESSAGE = (r"Input argument 'x' does not have the correct dimensions in "
+               r"model_set_axis=-1 for a model set with n_models=2.")
+    with pytest.raises(ValueError, match=MESSAGE):
         p1(x)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=MESSAGE):
         p1(xx)
 
     xxt = xx.T
@@ -217,7 +223,9 @@ def test_eval():
     assert_allclose(model(xx), p(xx))
     assert_allclose(model(x, model_set_axis=False), p(x, model_set_axis=False))
 
-    with pytest.raises(ValueError):
+    MESSAGE = (r"Input argument 'x' does not have the correct dimensions in "
+               r"model_set_axis=.* for a model set with n_models=2.")
+    with pytest.raises(ValueError, match=MESSAGE):
         model(x)
 
     model = Linear1D(slope=[[1, 2]], intercept=[[3, 4]], n_models=2, model_set_axis=1)
@@ -225,7 +233,7 @@ def test_eval():
 
     assert_allclose(model(xx.T), p(xx.T))
     assert_allclose(model(x, model_set_axis=False), p(x, model_set_axis=False))
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=MESSAGE):
         model(xx)
 
     model = Planar2D(slope_x=[1, 2], slope_y=[1, 2], intercept=[3, 4], n_models=2)
@@ -233,7 +241,8 @@ def test_eval():
 
     assert y.shape == (2, 4)
 
-    with pytest.raises(ValueError):
+    MESSAGE = r"Missing input arguments - expected 2, got 1"
+    with pytest.raises(ValueError, match=MESSAGE):
         model(x)
 
 
@@ -290,7 +299,9 @@ def test_model_set_axis_outputs():
     y1 = model_set(xx, model_set_axis=0)
     assert_allclose(y0[:, 0], y1[0])
     assert_allclose(y0[:, 1], y1[1])
-    with pytest.raises(ValueError):
+
+    MESSAGE = r"For model_set_axis=1, all inputs must be at least 2-dimensional."
+    with pytest.raises(ValueError, match=MESSAGE):
         model_set(x)
 
 
@@ -311,7 +322,8 @@ def test_fitting_shapes():
 
 
 def test_compound_model_sets():
-    with pytest.raises(ValueError):
+    MESSAGE = r"model_set_axis must be False or 0 and consistent for operands"
+    with pytest.raises(ValueError, match=MESSAGE):
         (Polynomial1D(1, n_models=2, model_set_axis=1) |
          Polynomial1D(1, n_models=2, model_set_axis=0))
 
@@ -322,9 +334,11 @@ def test_linear_fit_model_set_errors():
     y = init_model(x, model_set_axis=False)
 
     fitter = LinearLSQFitter()
-    with pytest.raises(ValueError):
+
+    MESSAGE = r"x and y should have the same shape"
+    with pytest.raises(ValueError, match=MESSAGE):
         fitter(init_model, x[:5], y)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=MESSAGE):
         fitter(init_model, x, y[:, :5])
 
 
@@ -350,7 +364,7 @@ def test_linear_fit_model_set_common_weight():
     # Check that using null weights raises an error
     # ValueError: On entry to DLASCL parameter number 4 had an illegal value
     with pytest.raises(ValueError,
-                       match='Found NaNs in the coefficient matrix'):
+                       match=r'Found NaNs in the coefficient matrix'):
         with pytest.warns(RuntimeWarning,
                           match=r'invalid value encountered in.*divide'):
             fitted_model = fitter(init_model, x, y, weights=np.zeros(10))
@@ -380,7 +394,7 @@ def test_linear_fit_model_set_weights():
     # Check that using null weights raises an error
     weights[0] = 0
     with pytest.raises(ValueError,
-                       match='Found NaNs in the coefficient matrix'):
+                       match=r'Found NaNs in the coefficient matrix'):
         with pytest.warns(RuntimeWarning,
                           match=r'invalid value encountered in.*divide'):
             fitted_model = fitter(init_model, x, y, weights=weights)
@@ -407,9 +421,11 @@ def test_linear_fit_2d_model_set_errors():
     z = init_model(x, y, model_set_axis=False)
 
     fitter = LinearLSQFitter()
-    with pytest.raises(ValueError):
+
+    MESSAGE = r"x, y and z should have the same shape"
+    with pytest.raises(ValueError, match=MESSAGE):
         fitter(init_model, x[:5], y, z)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=MESSAGE):
         fitter(init_model, x, y, z[:, :5])
 
 

--- a/astropy/modeling/tests/test_model_sets.py
+++ b/astropy/modeling/tests/test_model_sets.py
@@ -56,7 +56,7 @@ def test_model1d_axis_1(model_class):
 
     p1 = model_class(1, c0=c0, c1=c1, n_models=n_models, model_set_axis=model_axis)
 
-    MESSAGE = r"For model_set_axis=1, all inputs must be at least 2-dimensional."
+    MESSAGE = r"For model_set_axis=1, all inputs must be at least 2-dimensional"
     with pytest.raises(ValueError, match=MESSAGE):
         p1(x)
 
@@ -88,7 +88,7 @@ def test_model1d_axis_2(model_class):
     t2 = model_class(1, c0=2, c1=20)
     t3 = model_class(1, c0=3, c1=30)
 
-    MESSAGE = r"For model_set_axis=2, all inputs must be at least 3-dimensional."
+    MESSAGE = r"For model_set_axis=2, all inputs must be at least 3-dimensional"
     with pytest.raises(ValueError, match=MESSAGE):
         p1(x)
 
@@ -114,8 +114,7 @@ def test_model1d_axis_0(model_class):
     t1 = model_class(1, c0=2, c1=1)
     t2 = model_class(1, c0=3, c1=2)
 
-    MESSAGE = (r"Input argument 'x' does not have the correct dimensions in "
-               r"model_set_axis=0 for a model set with n_models=2.")
+    MESSAGE = r"Input argument 'x' does not have the correct dimensions in .*"
     with pytest.raises(ValueError, match=MESSAGE):
         p1(x)
 
@@ -165,8 +164,7 @@ def test_negative_axis():
     t1 = Polynomial1D(1, c0=1, c1=3)
     t2 = Polynomial1D(1, c0=2, c1=4)
 
-    MESSAGE = (r"Input argument 'x' does not have the correct dimensions in "
-               r"model_set_axis=-1 for a model set with n_models=2.")
+    MESSAGE = r"Input argument 'x' does not have the correct dimensions in .*"
     with pytest.raises(ValueError, match=MESSAGE):
         p1(x)
 
@@ -223,8 +221,7 @@ def test_eval():
     assert_allclose(model(xx), p(xx))
     assert_allclose(model(x, model_set_axis=False), p(x, model_set_axis=False))
 
-    MESSAGE = (r"Input argument 'x' does not have the correct dimensions in "
-               r"model_set_axis=.* for a model set with n_models=2.")
+    MESSAGE = r"Input argument 'x' does not have the correct dimensions in .*"
     with pytest.raises(ValueError, match=MESSAGE):
         model(x)
 
@@ -300,7 +297,7 @@ def test_model_set_axis_outputs():
     assert_allclose(y0[:, 0], y1[0])
     assert_allclose(y0[:, 1], y1[1])
 
-    MESSAGE = r"For model_set_axis=1, all inputs must be at least 2-dimensional."
+    MESSAGE = r"For model_set_axis=1, all inputs must be at least 2-dimensional"
     with pytest.raises(ValueError, match=MESSAGE):
         model_set(x)
 

--- a/astropy/modeling/tests/test_models.py
+++ b/astropy/modeling/tests/test_models.py
@@ -4,7 +4,6 @@
 Tests for model evaluation.
 Compare the results of some models with other programs.
 """
-import re
 import unittest.mock as mk
 
 import numpy as np
@@ -197,11 +196,7 @@ class Fittable2DModelTester:
         assert model.bounding_box == ((-5, 5), (-5, 5))
 
         model.bounding_box = None
-        MESSAGE = re.escape("No bounding box is defined for this model "
-                            "(note: the bounding box was explicitly disabled "
-                            "for this model; use `del model.bounding_box` to "
-                            "restore the default bounding box, if one is "
-                            "defined for this model)")
+        MESSAGE = r"No bounding box is defined for this model .*"
         with pytest.raises(NotImplementedError, match=MESSAGE):
             model.bounding_box
 
@@ -422,11 +417,7 @@ class Fittable1DModelTester:
         model.bounding_box = (-5, 5)
         model.bounding_box = None
 
-        MESSAGE = re.escape("No bounding box is defined for this model "
-                            "(note: the bounding box was explicitly disabled "
-                            "for this model; use `del model.bounding_box` to "
-                            "restore the default bounding box, if one is "
-                            "defined for this model)")
+        MESSAGE = r"No bounding box is defined for this model .*"
         with pytest.raises(NotImplementedError, match=MESSAGE):
             model.bounding_box
 
@@ -734,22 +725,22 @@ def test_tabular_interp_2d():
     r = t(y, x)
     assert_allclose(a, r)
 
-    MESSAGE = r"Only n_models=1 is supported."
+    MESSAGE = r"Only n_models=1 is supported"
     with pytest.raises(NotImplementedError, match=MESSAGE):
         model = LookupTable(n_models=2)
-    MESSAGE = r"Must provide a lookup table."
+    MESSAGE = r"Must provide a lookup table"
     with pytest.raises(ValueError, match=MESSAGE):
         model = LookupTable(points=([1.2, 2.3], [1.2, 6.7], [3, 4]))
-    MESSAGE = r"lookup_table should be an array with 2 dimensions."
+    MESSAGE = r"lookup_table should be an array with 2 dimensions"
     with pytest.raises(ValueError, match=MESSAGE):
         model = LookupTable(lookup_table=[1, 2, 3])
-    MESSAGE = r"lookup_table should be an array with 2 dimensions."
+    MESSAGE = r"lookup_table should be an array with 2 dimensions"
     with pytest.raises(ValueError, match=MESSAGE):
         model = LookupTable(([1, 2], [3, 4]), [5, 6])
-    MESSAGE = r"points must all have the same unit."
+    MESSAGE = r"points must all have the same unit"
     with pytest.raises(ValueError, match=MESSAGE):
         model = LookupTable(([1, 2] * u.m, [3, 4]), [[5, 6], [7, 8]])
-    MESSAGE = r"fill value is in Jy but expected to be unitless."
+    MESSAGE = r"fill value is in Jy but expected to be unitless"
     with pytest.raises(ValueError, match=MESSAGE):
         model = LookupTable(points, table, bounds_error=False,
                             fill_value=1*u.Jy)
@@ -777,7 +768,7 @@ def test_tabular_nd():
     result = t(x, y, z)
     assert_allclose(a, result)
 
-    MESSAGE = r"Lookup table must have at least one dimension."
+    MESSAGE = r"Lookup table must have at least one dimension"
     with pytest.raises(ValueError, match=MESSAGE):
         models.tabular_model(0)
 

--- a/astropy/modeling/tests/test_models.py
+++ b/astropy/modeling/tests/test_models.py
@@ -4,6 +4,7 @@
 Tests for model evaluation.
 Compare the results of some models with other programs.
 """
+import re
 import unittest.mock as mk
 
 import numpy as np
@@ -196,11 +197,17 @@ class Fittable2DModelTester:
         assert model.bounding_box == ((-5, 5), (-5, 5))
 
         model.bounding_box = None
-        with pytest.raises(NotImplementedError):
+        MESSAGE = re.escape("No bounding box is defined for this model "
+                            "(note: the bounding box was explicitly disabled "
+                            "for this model; use `del model.bounding_box` to "
+                            "restore the default bounding box, if one is "
+                            "defined for this model)")
+        with pytest.raises(NotImplementedError, match=MESSAGE):
             model.bounding_box
 
         # test the exception of dimensions don't match
-        with pytest.raises(ValueError):
+        MESSAGE = r"An interval must be some sort of sequence of length 2"
+        with pytest.raises(ValueError, match=MESSAGE):
             model.bounding_box = (-5, 5)
 
         del model.bounding_box
@@ -415,13 +422,19 @@ class Fittable1DModelTester:
         model.bounding_box = (-5, 5)
         model.bounding_box = None
 
-        with pytest.raises(NotImplementedError):
+        MESSAGE = re.escape("No bounding box is defined for this model "
+                            "(note: the bounding box was explicitly disabled "
+                            "for this model; use `del model.bounding_box` to "
+                            "restore the default bounding box, if one is "
+                            "defined for this model)")
+        with pytest.raises(NotImplementedError, match=MESSAGE):
             model.bounding_box
 
         del model.bounding_box
 
         # test exception if dimensions don't match
-        with pytest.raises(ValueError):
+        MESSAGE = r"An interval must be some sort of sequence of length 2"
+        with pytest.raises(ValueError, match=MESSAGE):
             model.bounding_box = 5
 
         try:
@@ -670,7 +683,8 @@ def test_tabular_interp_1d():
     assert_allclose(model(xnew), ans1)
     # Test bounds error.
     xextrap = [0., .7, 1.4, 2.1, 3.9, 4.1]
-    with pytest.raises(ValueError):
+    MESSAGE = r"One of the requested xi is out of bounds in dimension 0"
+    with pytest.raises(ValueError, match=MESSAGE):
         model(xextrap)
     # test extrapolation and fill value
     model = LookupTable(lookup_table=values, bounds_error=False,
@@ -720,17 +734,23 @@ def test_tabular_interp_2d():
     r = t(y, x)
     assert_allclose(a, r)
 
-    with pytest.raises(ValueError):
-        model = LookupTable(points=([1.2, 2.3], [1.2, 6.7], [3, 4]))
-    with pytest.raises(ValueError):
-        model = LookupTable(lookup_table=[1, 2, 3])
-    with pytest.raises(NotImplementedError):
+    MESSAGE = r"Only n_models=1 is supported."
+    with pytest.raises(NotImplementedError, match=MESSAGE):
         model = LookupTable(n_models=2)
-    with pytest.raises(ValueError):
+    MESSAGE = r"Must provide a lookup table."
+    with pytest.raises(ValueError, match=MESSAGE):
+        model = LookupTable(points=([1.2, 2.3], [1.2, 6.7], [3, 4]))
+    MESSAGE = r"lookup_table should be an array with 2 dimensions."
+    with pytest.raises(ValueError, match=MESSAGE):
+        model = LookupTable(lookup_table=[1, 2, 3])
+    MESSAGE = r"lookup_table should be an array with 2 dimensions."
+    with pytest.raises(ValueError, match=MESSAGE):
         model = LookupTable(([1, 2], [3, 4]), [5, 6])
-    with pytest.raises(ValueError):
+    MESSAGE = r"points must all have the same unit."
+    with pytest.raises(ValueError, match=MESSAGE):
         model = LookupTable(([1, 2] * u.m, [3, 4]), [[5, 6], [7, 8]])
-    with pytest.raises(ValueError):
+    MESSAGE = r"fill value is in Jy but expected to be unitless."
+    with pytest.raises(ValueError, match=MESSAGE):
         model = LookupTable(points, table, bounds_error=False,
                             fill_value=1*u.Jy)
 
@@ -757,7 +777,8 @@ def test_tabular_nd():
     result = t(x, y, z)
     assert_allclose(a, result)
 
-    with pytest.raises(ValueError):
+    MESSAGE = r"Lookup table must have at least one dimension."
+    with pytest.raises(ValueError, match=MESSAGE):
         models.tabular_model(0)
 
 
@@ -841,7 +862,7 @@ def test_tabular1d_inverse():
     points = np.arange(5)
     values = np.array([1.5, 3.4, 3.4, 32, 25])
     t = models.Tabular1D(points, values)
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(NotImplementedError, match=r""):
         t.inverse((3.4, 7.))
 
     # Check that Tabular2D.inverse raises an error
@@ -849,14 +870,15 @@ def test_tabular1d_inverse():
     points = np.arange(0, 5)
     points = (points, points)
     t3 = models.Tabular2D(points=points, lookup_table=table)
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(NotImplementedError, match=r""):
         t3.inverse((3, 3))
 
     # Check that it uses the same kwargs as the original model
     points = np.arange(5)
     values = np.array([1.5, 3.4, 6.7, 7, 32])
     t = models.Tabular1D(points, values)
-    with pytest.raises(ValueError):
+    MESSAGE = r"One of the requested xi is out of bounds in dimension 0"
+    with pytest.raises(ValueError, match=MESSAGE):
         t.inverse(100)
     t = models.Tabular1D(points, values, bounds_error=False, fill_value=None)
     result = t.inverse(100)
@@ -867,9 +889,9 @@ def test_tabular1d_inverse():
 def test_tabular_grid_shape_mismatch_error():
     points = np.arange(5)
     lt = np.mgrid[0:5, 0:5][0]
-    with pytest.raises(ValueError) as err:
+    MESSAGE = r"Expected grid points in 2 directions, got 5."
+    with pytest.raises(ValueError, match=MESSAGE):
         models.Tabular2D(points, lt)
-    assert str(err.value) == "Expected grid points in 2 directions, got 5."
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason='requires scipy')
@@ -1004,13 +1026,13 @@ def test_parameter_description():
 
 
 def test_SmoothlyBrokenPowerLaw1D_validators():
-    with pytest.raises(InputParameterError) as err:
+    MESSAGE = r"amplitude parameter must be > 0"
+    with pytest.raises(InputParameterError, match=MESSAGE):
         SmoothlyBrokenPowerLaw1D(amplitude=-1)
-    assert str(err.value) == "amplitude parameter must be > 0"
 
-    with pytest.raises(InputParameterError) as err:
+    MESSAGE = r"delta parameter must be >= 0.001"
+    with pytest.raises(InputParameterError, match=MESSAGE):
         SmoothlyBrokenPowerLaw1D(delta=0)
-    assert str(err.value) == "delta parameter must be >= 0.001"
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason='requires scipy')

--- a/astropy/modeling/tests/test_models_quantities.py
+++ b/astropy/modeling/tests/test_models_quantities.py
@@ -481,7 +481,7 @@ def test_models_evaluate_with_units_param_array(model):
 
     if model['class'] == Drude1D:
         params['x_0'][-1] = 0 * u.AA
-        MESSAGE = '0 is not an allowed value for x_0'
+        MESSAGE = r'0 is not an allowed value for x_0'
         with pytest.raises(InputParameterError, match=MESSAGE):
             model['class'](**params)
 
@@ -503,7 +503,7 @@ def test_models_bounding_box(model):
         # Check that NotImplementedError is raised, so that if bounding_box is
         # implemented we remember to set bounding_box=True in the list of models
         # above
-        MESSAGE = r"No bounding box is defined for this model."
+        MESSAGE = r"No bounding box is defined for this model"
         with pytest.raises(NotImplementedError, match=MESSAGE):
             m.bounding_box
     else:

--- a/astropy/modeling/tests/test_parameters.py
+++ b/astropy/modeling/tests/test_parameters.py
@@ -6,6 +6,7 @@ Tests models.parameters
 
 import functools
 import itertools
+import re
 import unittest.mock as mk
 
 import numpy as np
@@ -84,9 +85,9 @@ def test__tofloat():
     assert isinstance(value, np.ndarray)
     assert (value == np.array([1, 2, 3])).all()
     assert np.all([isinstance(val, float) for val in value])
-    with pytest.raises(InputParameterError) as err:
+    MESSAGE = r"Parameter of <class 'str'> could not be converted to float"
+    with pytest.raises(InputParameterError, match=MESSAGE):
         _tofloat('test')
-    assert str(err.value) == "Parameter of <class 'str'> could not be converted to float"
 
     # quantity
     assert _tofloat(1 * u.m) == 1 * u.m
@@ -117,20 +118,18 @@ def test__tofloat():
     assert value == 3
 
     # boolean
-    message = "Expected parameter to be of numerical type, not boolean"
-    with pytest.raises(InputParameterError) as err:
+    MESSAGE = r"Expected parameter to be of numerical type, not boolean"
+    with pytest.raises(InputParameterError, match=MESSAGE):
         _tofloat(True)
-    assert str(err.value) == message
-    with pytest.raises(InputParameterError) as err:
+    with pytest.raises(InputParameterError, match=MESSAGE):
         _tofloat(False)
-    assert str(err.value) == message
 
     # other
     class Value:
         pass
-    with pytest.raises(InputParameterError) as err:
+    MESSAGE = r"Don't know how to convert parameter of <class 'type'> to float"
+    with pytest.raises(InputParameterError, match=MESSAGE):
         _tofloat(Value)
-    assert str(err.value) == "Don't know how to convert parameter of <class 'type'> to float"
 
 
 def test_parameter_properties():
@@ -302,7 +301,8 @@ class TestParameters:
         using a list of a different size.
         """
 
-        with pytest.raises(InputParameterError):
+        MESSAGE = r"Input parameter values not compatible with the model parameters array: .*"
+        with pytest.raises(InputParameterError, match=MESSAGE):
             self.model.parameters = [1, 2, 3]
 
     def test_wrong_size2(self):
@@ -311,7 +311,8 @@ class TestParameters:
         parameter (in this case coeff) with a sequence of the wrong size.
         """
 
-        with pytest.raises(InputParameterError):
+        MESSAGE = r"Value for parameter c0 does not match shape or size\nexpected by model .* vs .*"
+        with pytest.raises(InputParameterError, match=MESSAGE):
             self.model.c0 = [1, 2, 3]
 
     def test_wrong_shape(self):
@@ -320,7 +321,8 @@ class TestParameters:
         parameter and the new value has the wrong shape.
         """
 
-        with pytest.raises(InputParameterError):
+        MESSAGE = r"Value for parameter amplitude does not match shape or size\nexpected by model .* vs .*"
+        with pytest.raises(InputParameterError, match=MESSAGE):
             self.gmodel.amplitude = [1, 2]
 
     def test_par_against_iraf(self):
@@ -392,29 +394,25 @@ class TestParameters:
         assert param.bounds == (1, 2)
 
         # Errors __init__
-        message = ("bounds may not be specified simultaneously with min or max"
-                   " when instantiating Parameter test")
-        with pytest.raises(ValueError) as err:
+        MESSAGE = (r"bounds may not be specified simultaneously with min or max"
+                   r" when instantiating Parameter test")
+        with pytest.raises(ValueError, match=MESSAGE):
             Parameter(bounds=(1, 2), min=1, name='test')
-        assert str(err.value) == message
-        with pytest.raises(ValueError) as err:
+        with pytest.raises(ValueError, match=MESSAGE):
             Parameter(bounds=(1, 2), max=2, name='test')
-        assert str(err.value) == message
-        with pytest.raises(ValueError) as err:
+        with pytest.raises(ValueError, match=MESSAGE):
             Parameter(bounds=(1, 2), min=1, max=2, name='test')
-        assert str(err.value) == message
 
         # Setters
         param = Parameter(name='test', default=[1, 2, 3, 4])
         assert param.bounds == (None, None) == param._bounds
 
         # Set errors
-        with pytest.raises(TypeError) as err:
+        MESSAGE = "{} value must be a number or a Quantity"
+        with pytest.raises(TypeError, match=MESSAGE.format('Min')):
             param.bounds = ('test', None)
-        assert str(err.value) == "Min value must be a number or a Quantity"
-        with pytest.raises(TypeError) as err:
+        with pytest.raises(TypeError, match=MESSAGE.format('Max')):
             param.bounds = (None, 'test')
-        assert str(err.value) == "Max value must be a number or a Quantity"
 
         # Set number
         param.bounds = (1, 2)
@@ -429,13 +427,13 @@ class TestParameters:
         assert (param.value == [1, 2, 3]).all()
 
         # Errors
-        with pytest.raises(InputParameterError) as err:
+        MESSAGE = r"Slice assignment outside the parameter dimensions for 'test'"
+        with pytest.raises(InputParameterError, match=MESSAGE):
             param[slice(0, 0)] = 2
-        assert str(err.value) == "Slice assignment outside the parameter dimensions for 'test'"
 
-        with pytest.raises(InputParameterError) as err:
+        MESSAGE = r"Input dimension 3 invalid for 'test' parameter with dimension 1"
+        with pytest.raises(InputParameterError, match=MESSAGE):
             param[3] = np.array([5])
-        assert str(err.value) == "Input dimension 3 invalid for 'test' parameter with dimension 1"
 
         # assignment of a slice
         param[slice(0, 2)] = [4, 5]
@@ -450,18 +448,18 @@ class TestParameters:
         assert param.unit is None
 
         # No force Error (no existing unit)
-        with pytest.raises(ValueError) as err:
+        MESSAGE = (r"Cannot attach units to parameters that were "
+                   r"not initially specified with units")
+        with pytest.raises(ValueError, match=MESSAGE):
             param._set_unit(u.m)
-        assert str(err.value) == ("Cannot attach units to parameters that were "
-                                  "not initially specified with units")
 
         # Force
         param._set_unit(u.m, True)
         assert param.unit == u.m
 
         # Force magnitude unit (mag=False)
-        with pytest.raises(ValueError,
-                           match=r"This parameter does not support the magnitude units such as .*"):
+        MESSAGE = r"This parameter does not support the magnitude units such as .*"
+        with pytest.raises(ValueError, match=MESSAGE):
             param._set_unit(u.ABmag, True)
 
         # Force magnitude unit (mag=True)
@@ -470,10 +468,10 @@ class TestParameters:
         assert param._unit == u.ABmag
 
         # No force Error (existing unit)
-        with pytest.raises(ValueError) as err:
+        MESSAGE = (r"Cannot change the unit attribute directly, instead change the "
+                   r"parameter to a new quantity")
+        with pytest.raises(ValueError, match=MESSAGE):
             param._set_unit(u.K)
-        assert str(err.value) == ("Cannot change the unit attribute directly, instead change the "
-                                  "parameter to a new quantity")
 
     def test_quantity(self):
         param = Parameter(name='test', default=[1, 2, 3])
@@ -489,9 +487,9 @@ class TestParameters:
         param = Parameter(name='test', default=[1, 2, 3, 4])
         assert param.shape == (4,)
         # Reshape error
-        with pytest.raises(ValueError) as err:
+        MESSAGE = re.escape("cannot reshape array of size 4 into shape (5,)")
+        with pytest.raises(ValueError, match=MESSAGE):
             param.shape = (5,)
-        assert str(err.value) == "cannot reshape array of size 4 into shape (5,)"
         # Reshape success
         param.shape = (2, 2)
         assert param.shape == (2, 2)
@@ -501,18 +499,17 @@ class TestParameters:
         param = Parameter(name='test', default=1)
         assert param.shape == ()
         # Reshape error
-        with pytest.raises(ValueError) as err:
+        MESSAGE = r"Cannot assign this shape to a scalar quantity"
+        with pytest.raises(ValueError, match=MESSAGE):
             param.shape = (5,)
-        assert str(err.value) == "Cannot assign this shape to a scalar quantity"
         param.shape = (1,)
 
         # single value
         param = Parameter(name='test', default=np.array([1]))
         assert param.shape == (1,)
         # Reshape error
-        with pytest.raises(ValueError) as err:
+        with pytest.raises(ValueError, match=MESSAGE):
             param.shape = (5,)
-        assert str(err.value) == "Cannot assign this shape to a scalar quantity"
         param.shape = ()
 
     def test_size(self):
@@ -539,9 +536,9 @@ class TestParameters:
         assert param._fixed is False
 
         # Set error
-        with pytest.raises(ValueError) as err:
+        MESSAGE = r"Value must be boolean"
+        with pytest.raises(ValueError, match=MESSAGE):
             param.fixed = 3
-        assert str(err.value) == "Value must be boolean"
 
         # Set
         param.fixed = True
@@ -554,9 +551,9 @@ class TestParameters:
         assert param._tied is False
 
         # Set error
-        with pytest.raises(TypeError) as err:
+        MESSAGE = r"Tied must be a callable or set to False or None"
+        with pytest.raises(TypeError, match=MESSAGE):
             param.tied = mk.NonCallableMagicMock()
-        assert str(err.value) == "Tied must be a callable or set to False or None"
 
         # Set None
         param.tied = None
@@ -581,11 +578,11 @@ class TestParameters:
         param.validator(valid)
         assert param._validator == valid
 
-        with pytest.raises(ValueError) as err:
+        MESSAGE = (r"This decorator method expects a callable.\n"
+                   r"The use of this method as a direct validator is\n"
+                   r"deprecated; use the new validate method instead\n")
+        with pytest.raises(ValueError, match=MESSAGE):
             param.validator(mk.NonCallableMagicMock())
-        assert str(err.value) == ("This decorator method expects a callable.\n"
-                                  "The use of this method as a direct validator is\n"
-                                  "deprecated; use the new validate method instead\n")
 
     def test_validate(self):
         param = Parameter(name='test', default=[1, 2, 3, 4])
@@ -696,10 +693,10 @@ class TestParameters:
         param = Parameter(name='test', default=[1, 2, 3, 4])
 
         # Bad ufunc
-        with pytest.raises(TypeError) as err:
+        MESSAGE = (r"A numpy.ufunc used for Parameter getter/setter "
+                   r"may only take one input argument")
+        with pytest.raises(TypeError, match=MESSAGE):
             param._create_value_wrapper(np.add, mk.MagicMock())
-        assert str(err.value) == ("A numpy.ufunc used for Parameter getter/setter "
-                                  "may only take one input argument")
         # Good ufunc
         assert param._create_value_wrapper(np.negative, mk.MagicMock()) == np.negative
 
@@ -727,10 +724,10 @@ class TestParameters:
         # wrapper with more than 2 arguments
         def wrapper3(a, b, c):
             pass
-        with pytest.raises(TypeError) as err:
+        MESSAGE = (r"Parameter getter/setter must be a function "
+                   r"of either one or two arguments")
+        with pytest.raises(TypeError, match=MESSAGE):
             param._create_value_wrapper(wrapper3, mk.MagicMock())
-        assert str(err.value) == ("Parameter getter/setter must be a function "
-                                  "of either one or two arguments")
 
     def test_bool(self):
         # single value is true
@@ -871,7 +868,10 @@ class TestParameterInitialization:
         assert t.e.shape == (2,)
 
     def test_single_model_1d_array_different_length_parameters(self):
-        with pytest.raises(InputParameterError):
+        MESSAGE = (r"Parameter 'coeff' of shape .* cannot be broadcast with parameter "
+                   r"'e' of shape .*.  All parameter arrays must have shapes that are "
+                   r"mutually compatible according to the broadcasting rules.")
+        with pytest.raises(InputParameterError, match=MESSAGE):
             # Not broadcastable
             TParModel([1, 2], [3, 4, 5])
 
@@ -910,10 +910,13 @@ class TestParameterInitialization:
         assert t2.e.shape == (2, 3)
 
         # Not broadcastable
-        with pytest.raises(InputParameterError):
+        MESSAGE = (r"Parameter 'coeff' of shape .* cannot be broadcast with parameter "
+                   r"'e' of shape .*.  All parameter arrays must have shapes that are "
+                   r"mutually compatible according to the broadcasting rules.")
+        with pytest.raises(InputParameterError, match=MESSAGE):
             TParModel(coeff, e.T)
 
-        with pytest.raises(InputParameterError):
+        with pytest.raises(InputParameterError, match=MESSAGE):
             TParModel(coeff.T, e)
 
     def test_single_model_2d_broadcastable_parameters(self):
@@ -930,7 +933,7 @@ class TestParameterInitialization:
         (1, 2), (1, [2, 3]), ([1, 2], 3), ([1, 2, 3], [4, 5]),
         ([1, 2], [3, 4, 5])])
     def test_two_model_incorrect_scalar_parameters(self, p1, p2):
-        with pytest.raises(InputParameterError):
+        with pytest.raises(InputParameterError, match=r".*"):
             TParModel(p1, p2, n_models=2)
 
     @pytest.mark.parametrize('kwargs', [
@@ -982,7 +985,10 @@ class TestParameterInitialization:
         assert t2.e.shape == (2, 3)
 
     def test_two_model_mixed_dimension_array_parameters(self):
-        with pytest.raises(InputParameterError):
+        MESSAGE = (r"Parameter 'coeff' of shape .* cannot be broadcast with parameter 'e' of shape .*.  "
+                   r"All parameter arrays must have shapes that are mutually compatible according to "
+                   r"the broadcasting rules.")
+        with pytest.raises(InputParameterError, match=MESSAGE):
             # Can't broadcast different array shapes
             TParModel([[[1, 2], [3, 4]], [[5, 6], [7, 8]]],
                       [[9, 10, 11], [12, 13, 14]], n_models=2)
@@ -1036,23 +1042,31 @@ class TestParameterInitialization:
         assert t.e.shape == (3, 2)  # note change in api
 
     def test_wrong_number_of_params(self):
-        with pytest.raises(InputParameterError):
+        MESSAGE = (r"Inconsistent dimensions for parameter 'e' for 2 model sets.  "
+                   r"The length of axis 0 must be the same for all input parameter values")
+        with pytest.raises(InputParameterError, match=MESSAGE):
             TParModel(coeff=[[1, 2], [3, 4]], e=(2, 3, 4), n_models=2)
-        with pytest.raises(InputParameterError):
+        with pytest.raises(InputParameterError, match=MESSAGE):
             TParModel(coeff=[[1, 2], [3, 4]], e=(2, 3, 4), model_set_axis=0)
 
     def test_wrong_number_of_params2(self):
-        with pytest.raises(InputParameterError):
+        MESSAGE = (r"All parameter values must be arrays of dimension at "
+                   r"least 1 for model_set_axis=0 .*")
+        with pytest.raises(InputParameterError, match=MESSAGE):
             TParModel(coeff=[[1, 2], [3, 4]], e=4, n_models=2)
-        with pytest.raises(InputParameterError):
+        with pytest.raises(InputParameterError, match=MESSAGE):
             TParModel(coeff=[[1, 2], [3, 4]], e=4, model_set_axis=0)
 
     def test_array_parameter1(self):
-        with pytest.raises(InputParameterError):
+        MESSAGE = (r"All parameter values must be arrays of dimension at "
+                   r"least 1 for model_set_axis=0 .*")
+        with pytest.raises(InputParameterError, match=MESSAGE):
             TParModel(np.array([[1, 2], [3, 4]]), 1, model_set_axis=0)
 
     def test_array_parameter2(self):
-        with pytest.raises(InputParameterError):
+        MESSAGE = (r"Inconsistent dimensions for parameter 'e' for 2 model sets.  "
+                   r"The length of axis 0 must be the same for all input parameter values")
+        with pytest.raises(InputParameterError, match=MESSAGE):
             TParModel(np.array([[1, 2], [3, 4]]), (1, 1, 11),
                       model_set_axis=0)
 
@@ -1092,8 +1106,10 @@ def test_non_broadcasting_parameters():
             return
 
     # a broadcasts with both b and c, but b does not broadcast with c
+    MESSAGE = (r"Parameter '.*' of shape .* cannot be broadcast with parameter '.*' of shape .*.  "
+               r"All parameter arrays must have shapes that are mutually compatible according to the broadcasting rules.")
     for args in itertools.permutations((a, b, c)):
-        with pytest.raises(InputParameterError):
+        with pytest.raises(InputParameterError, match=MESSAGE):
             TestModel(*args)
 
 

--- a/astropy/modeling/tests/test_physical_models.py
+++ b/astropy/modeling/tests/test_physical_models.py
@@ -484,19 +484,19 @@ def test_NFW_exceptions_and_warnings_and_misc():
                     7.50e+02, 1.00e+03, 1.50e+03, 2.50e+03, 6.50e+03, 1.15e+04]) * u.kpc
 
     # Massfactor exception tests
-    with pytest.raises(ValueError) as exc:
+    MESSAGE = r"Massfactor 'not' not one of 'critical', 'mean', or 'virial'"
+    with pytest.raises(ValueError, match=MESSAGE):
         NFW(mass=mass, concentration=concentration, redshift=redshift, cosmo=cosmo,
             massfactor=("not", "virial"))
-    assert exc.value.args[0] == "Massfactor 'not' not one of 'critical', 'mean', or 'virial'"
-    with pytest.raises(ValueError) as exc:
+    MESSAGE = (r"Massfactor not virial string not of the form "
+               r"'#m', '#c', or 'virial'")
+    with pytest.raises(ValueError, match=MESSAGE):
         NFW(mass=mass, concentration=concentration, redshift=redshift, cosmo=cosmo,
             massfactor="not virial")
-    assert exc.value.args[0] == ("Massfactor not virial string not of the form "
-                                 "'#m', '#c', or 'virial'")
-    with pytest.raises(TypeError) as exc:
+    MESSAGE = r"Massfactor 200 not a tuple or string"
+    with pytest.raises(TypeError, match=MESSAGE):
         NFW(mass=mass, concentration=concentration, redshift=redshift, cosmo=cosmo,
             massfactor=200)
-    assert exc.value.args[0] == "Massfactor 200 not a tuple or string"
 
     # Verify unitless mass
     # Density test

--- a/astropy/modeling/tests/test_physical_models.py
+++ b/astropy/modeling/tests/test_physical_models.py
@@ -488,8 +488,7 @@ def test_NFW_exceptions_and_warnings_and_misc():
     with pytest.raises(ValueError, match=MESSAGE):
         NFW(mass=mass, concentration=concentration, redshift=redshift, cosmo=cosmo,
             massfactor=("not", "virial"))
-    MESSAGE = (r"Massfactor not virial string not of the form "
-               r"'#m', '#c', or 'virial'")
+    MESSAGE = r"Massfactor not virial string not of the form '#m', '#c', or 'virial'"
     with pytest.raises(ValueError, match=MESSAGE):
         NFW(mass=mass, concentration=concentration, redshift=redshift, cosmo=cosmo,
             massfactor="not virial")

--- a/astropy/modeling/tests/test_polynomial.py
+++ b/astropy/modeling/tests/test_polynomial.py
@@ -405,15 +405,13 @@ def test_sip_hst():
     # Test get num of coeffs
     assert sip.sip1d_a.get_num_coeff(1) == 6
     # Test error
-    message = "Degree of polynomial must be 2< deg < 9"
+    MESSAGE = "Degree of polynomial must be 2< deg < 9"
     sip.sip1d_a.order = 1
-    with pytest.raises(ValueError) as err:
+    with pytest.raises(ValueError, match=MESSAGE):
         sip.sip1d_a.get_num_coeff(1)
-    assert str(err.value) == message
     sip.sip1d_a.order = 10
-    with pytest.raises(ValueError) as err:
+    with pytest.raises(ValueError, match=MESSAGE):
         sip.sip1d_a.get_num_coeff(1)
-    assert str(err.value) == message
 
 
 def test_sip_irac():
@@ -481,7 +479,8 @@ def test_sip_no_coeff():
     sip = SIP([10, 12], 2, 2)
     assert_allclose(sip.sip1d_a.parameters, [0., 0., 0])
     assert_allclose(sip.sip1d_b.parameters, [0., 0., 0])
-    with pytest.raises(NotImplementedError):
+    MESSAGE = r"SIP inverse coefficients are not available."
+    with pytest.raises(NotImplementedError, match=MESSAGE):
         sip.inverse
 
     # Test model set
@@ -500,7 +499,7 @@ def test_zero_degree_polynomial(cls):
     Regression test for https://github.com/astropy/astropy/pull/3589
     """
 
-    message = "Degree of polynomial must be positive or null"
+    MESSAGE = "Degree of polynomial must be positive or null"
 
     if cls.n_inputs == 1:  # Test 1D polynomials
         p1 = cls(degree=0, c0=1)
@@ -520,9 +519,8 @@ def test_zero_degree_polynomial(cls):
         assert_allclose(p1_fit.c0, 1, atol=0.10)
 
         # Error from negative degree
-        with pytest.raises(ValueError) as err:
+        with pytest.raises(ValueError, match=MESSAGE):
             cls(degree=-1)
-        assert str(err.value) == message
     elif cls.n_inputs == 2:  # Test 2D polynomials
         if issubclass(cls, OrthoPolynomialBase):
             p2 = cls(x_degree=0, y_degree=0, c0_0=1)
@@ -532,24 +530,22 @@ def test_zero_degree_polynomial(cls):
             b = np.array([1, 2])
             with mk.patch.object(PolynomialBase, 'prepare_inputs', autospec=True,
                                  return_value=((a, b), mk.MagicMock())):
-                with pytest.raises(ValueError) as err:
+
+                with pytest.raises(ValueError,
+                                   match=r"Expected input arrays to have the same shape"):
                     p2.prepare_inputs(mk.MagicMock(), mk.MagicMock())
-                assert str(err.value) == "Expected input arrays to have the same shape"
 
             # Error from negative degree
-            with pytest.raises(ValueError) as err:
+            with pytest.raises(ValueError, match=MESSAGE):
                 cls(x_degree=-1, y_degree=0)
-            assert str(err.value) == message
-            with pytest.raises(ValueError) as err:
+            with pytest.raises(ValueError, match=MESSAGE):
                 cls(x_degree=0, y_degree=-1)
-            assert str(err.value) == message
         else:
             p2 = cls(degree=0, c0_0=1)
 
             # Error from negative degree
-            with pytest.raises(ValueError) as err:
+            with pytest.raises(ValueError, match=MESSAGE):
                 cls(degree=-1)
-            assert str(err.value) == message
 
         assert p2(0, 0) == 1
         assert np.all(p2(np.zeros(5), np.zeros(5)) == np.ones(5))
@@ -607,9 +603,9 @@ def test_Hermite1D_clenshaw():
 
 def test__fcache():
     model = OrthoPolynomialBase(x_degree=2, y_degree=2)
-    with pytest.raises(NotImplementedError) as err:
+    MESSAGE = r"Subclasses should implement this"
+    with pytest.raises(NotImplementedError, match=MESSAGE):
         model._fcache(np.asanyarray(1), np.asanyarray(1))
-    assert str(err.value) == "Subclasses should implement this"
 
     model = Hermite2D(x_degree=2, y_degree=2)
     assert model._fcache(np.asanyarray(1), np.asanyarray(1)) == {
@@ -644,21 +640,19 @@ def test__fcache():
 
 def test_fit_deriv_shape_error():
     model = Hermite2D(x_degree=2, y_degree=2)
-    with pytest.raises(ValueError) as err:
+    MESSAGE = r"x and y must have the same shape"
+    with pytest.raises(ValueError, match=MESSAGE):
         model.fit_deriv(np.array([1, 2]), np.array([3, 4, 5]))
-    assert str(err.value) == "x and y must have the same shape"
 
     model = Chebyshev2D(x_degree=2, y_degree=2)
-    with pytest.raises(ValueError) as err:
+    with pytest.raises(ValueError, match=MESSAGE):
         model.fit_deriv(np.array([1, 2]), np.array([3, 4, 5]))
-    assert str(err.value) == "x and y must have the same shape"
 
     model = Legendre2D(x_degree=2, y_degree=2)
-    with pytest.raises(ValueError) as err:
+    with pytest.raises(ValueError, match=MESSAGE):
         model.fit_deriv(np.array([1, 2]), np.array([3, 4, 5]))
-    assert str(err.value) == "x and y must have the same shape"
 
     model = Polynomial2D(degree=2)
-    with pytest.raises(ValueError) as err:
+    MESSAGE = r"Expected x and y to be of equal size"
+    with pytest.raises(ValueError, match=MESSAGE):
         model.fit_deriv(np.array([1, 2]), np.array([3, 4, 5]))
-    assert str(err.value) == "Expected x and y to be of equal size"

--- a/astropy/modeling/tests/test_polynomial.py
+++ b/astropy/modeling/tests/test_polynomial.py
@@ -479,7 +479,7 @@ def test_sip_no_coeff():
     sip = SIP([10, 12], 2, 2)
     assert_allclose(sip.sip1d_a.parameters, [0., 0., 0])
     assert_allclose(sip.sip1d_b.parameters, [0., 0., 0])
-    MESSAGE = r"SIP inverse coefficients are not available."
+    MESSAGE = r"SIP inverse coefficients are not available"
     with pytest.raises(NotImplementedError, match=MESSAGE):
         sip.inverse
 

--- a/astropy/modeling/tests/test_projections.py
+++ b/astropy/modeling/tests/test_projections.py
@@ -206,23 +206,19 @@ class TestZenithalPerspective:
         assert_almost_equal(np.asarray(y), wcs_pix[:, 1])
 
     def test_validate(self):
-        message = "Zenithal perspective projection is not defined for mu = -1"
+        MESSAGE = r"Zenithal perspective projection is not defined for mu = -1"
 
-        with pytest.raises(InputParameterError) as err:
+        with pytest.raises(InputParameterError, match=MESSAGE):
             projections.Pix2Sky_ZenithalPerspective(-1)
-        assert str(err.value) == message
 
-        with pytest.raises(InputParameterError) as err:
+        with pytest.raises(InputParameterError, match=MESSAGE):
             projections.Sky2Pix_ZenithalPerspective(-1)
-        assert str(err.value) == message
 
-        with pytest.raises(InputParameterError) as err:
+        with pytest.raises(InputParameterError, match=MESSAGE):
             projections.Pix2Sky_SlantZenithalPerspective(-1)
-        assert str(err.value) == message
 
-        with pytest.raises(InputParameterError) as err:
+        with pytest.raises(InputParameterError, match=MESSAGE):
             projections.Sky2Pix_SlantZenithalPerspective(-1)
-        assert str(err.value) == message
 
 
 class TestCylindricalPerspective:
@@ -256,38 +252,33 @@ class TestCylindricalPerspective:
         assert_almost_equal(np.asarray(y), wcs_pix[:, 1])
 
     def test_validate(self):
-        message0 = "CYP projection is not defined for mu = -lambda"
-        message1 = "CYP projection is not defined for lambda = -mu"
+        MESSAGE = r"CYP projection is not defined for .*"
+        MESSAGE0 = r"CYP projection is not defined for mu = -lambda"
+        MESSAGE1 = r"CYP projection is not defined for lambda = -mu"
 
         # Pix2Sky_CylindricalPerspective
-        with pytest.raises(InputParameterError) as err:
+        with pytest.raises(InputParameterError, match=MESSAGE):
             projections.Pix2Sky_CylindricalPerspective(1, -1)
-        assert str(err.value) == message0 or str(err.value) == message1
-        with pytest.raises(InputParameterError) as err:
+        with pytest.raises(InputParameterError, match=MESSAGE):
             projections.Pix2Sky_CylindricalPerspective(-1, 1)
-        assert str(err.value) == message0 or str(err.value) == message1
+
         model = projections.Pix2Sky_CylindricalPerspective()
-        with pytest.raises(InputParameterError) as err:
+        with pytest.raises(InputParameterError, match=MESSAGE0):
             model.mu = -1
-        assert str(err.value) == message0
-        with pytest.raises(InputParameterError) as err:
+        with pytest.raises(InputParameterError, match=MESSAGE1):
             model.lam = -1
-        assert str(err.value) == message1
 
         # Sky2Pix_CylindricalPerspective
-        with pytest.raises(InputParameterError) as err:
+        with pytest.raises(InputParameterError, match=MESSAGE):
             projections.Sky2Pix_CylindricalPerspective(1, -1)
-        assert str(err.value) == message0 or str(err.value) == message1
-        with pytest.raises(InputParameterError) as err:
+        with pytest.raises(InputParameterError, match=MESSAGE):
             projections.Sky2Pix_CylindricalPerspective(-1, 1)
-        assert str(err.value) == message0 or str(err.value) == message1
+
         model = projections.Sky2Pix_CylindricalPerspective()
-        with pytest.raises(InputParameterError) as err:
+        with pytest.raises(InputParameterError, match=MESSAGE0):
             model.mu = -1
-        assert str(err.value) == message0
-        with pytest.raises(InputParameterError) as err:
+        with pytest.raises(InputParameterError, match=MESSAGE1):
             model.lam = -1
-        assert str(err.value) == message1
 
 
 def test_AffineTransformation2D():
@@ -305,45 +296,38 @@ def test_AffineTransformation2D():
     assert np.all(new_rect == [[1, 1], [3, 1], [1, 7], [3, 7]])
 
     # Matrix validation error
-    with pytest.raises(InputParameterError) as err:
+    MESSAGE = r"Expected transformation matrix to be a 2x2 array"
+    with pytest.raises(InputParameterError, match=MESSAGE):
         model.matrix = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
-    assert str(err.value) == "Expected transformation matrix to be a 2x2 array"
 
     # Translation validation error
-    with pytest.raises(InputParameterError) as err:
+    MESSAGE = (r"Expected translation vector to be a "
+               r"2 element row or column vector array")
+    with pytest.raises(InputParameterError, match=MESSAGE):
         model.translation = [1, 2, 3]
-    assert str(err.value) == ("Expected translation vector to be a "
-                              "2 element row or column vector array")
-    with pytest.raises(InputParameterError) as err:
+    with pytest.raises(InputParameterError, match=MESSAGE):
         model.translation = [[1], [2]]
-    assert str(err.value) == ("Expected translation vector to be a "
-                              "2 element row or column vector array")
-    with pytest.raises(InputParameterError) as err:
+    with pytest.raises(InputParameterError, match=MESSAGE):
         model.translation = [[1, 2, 3]]
-    assert str(err.value) == ("Expected translation vector to be a "
-                              "2 element row or column vector array")
 
     # Incompatible shape error
     a = np.array([[1], [2], [3], [4]])
     b = a.ravel()
     with mk.patch.object(np, 'vstack', autospec=True,
                          side_effect=[a, b]) as mk_vstack:
-        message = "Incompatible input shapes"
-        with pytest.raises(ValueError) as err:
+        MESSAGE = r"Incompatible input shapes"
+        with pytest.raises(ValueError, match=MESSAGE):
             model(x, y)
-        assert str(err.value) == message
-        with pytest.raises(ValueError) as err:
+        with pytest.raises(ValueError, match=MESSAGE):
             model(x, y)
-        assert str(err.value) == message
-
         assert mk_vstack.call_count == 2
 
     # Input shape evaluation error
     x = np.array([1, 2])
     y = np.array([1, 2, 3])
-    with pytest.raises(ValueError) as err:
+    MESSAGE = r"Expected input arrays to have the same shape"
+    with pytest.raises(ValueError, match=MESSAGE):
         model.evaluate(x, y, model.matrix, model.translation)
-    assert str(err.value) == "Expected input arrays to have the same shape"
 
 
 def test_AffineTransformation2D_inverse():
@@ -351,7 +335,8 @@ def test_AffineTransformation2D_inverse():
     model1 = projections.AffineTransformation2D(
         matrix=[[1, 1], [1, 1]])
 
-    with pytest.raises(InputParameterError):
+    MESSAGE = r"Transformation matrix is singular; .* model does not have an inverse"
+    with pytest.raises(InputParameterError, match=MESSAGE):
         model1.inverse
 
     model2 = projections.AffineTransformation2D(
@@ -373,9 +358,9 @@ def test_AffineTransformation2D_inverse():
 
     model4 = projections.AffineTransformation2D(
         matrix=[[1.2, 3.4], [5.6, 7.8]] * u.m, translation=[9.1, 10.11] * u.km)
-    with pytest.raises(ValueError) as err:
+    MESSAGE = r"matrix and translation must have the same units."
+    with pytest.raises(ValueError, match=MESSAGE):
         model4.inverse(*model4(x * u.m, y * u.m))
-    assert str(err.value) == "matrix and translation must have the same units."
 
 
 def test_c_projection_striding():
@@ -427,7 +412,8 @@ def test_affine_with_quantities():
 
     # test affine with matrix only
     qaff = projections.AffineTransformation2D(matrix=[[1, 2], [2, 1]] * u.deg)
-    with pytest.raises(ValueError):
+    MESSAGE = r"To use AffineTransformation with quantities, both matrix and unit need to be quantities."
+    with pytest.raises(ValueError, match=MESSAGE):
         qx1, qy1 = qaff(xpix, ypix, equivalencies={
             'x': u.pixel_scale(2.5 * u.deg / u.pix),
             'y': u.pixel_scale(2.5 * u.deg / u.pix)})

--- a/astropy/modeling/tests/test_projections.py
+++ b/astropy/modeling/tests/test_projections.py
@@ -358,7 +358,7 @@ def test_AffineTransformation2D_inverse():
 
     model4 = projections.AffineTransformation2D(
         matrix=[[1.2, 3.4], [5.6, 7.8]] * u.m, translation=[9.1, 10.11] * u.km)
-    MESSAGE = r"matrix and translation must have the same units."
+    MESSAGE = r"matrix and translation must have the same units"
     with pytest.raises(ValueError, match=MESSAGE):
         model4.inverse(*model4(x * u.m, y * u.m))
 
@@ -412,7 +412,7 @@ def test_affine_with_quantities():
 
     # test affine with matrix only
     qaff = projections.AffineTransformation2D(matrix=[[1, 2], [2, 1]] * u.deg)
-    MESSAGE = r"To use AffineTransformation with quantities, both matrix and unit need to be quantities."
+    MESSAGE = r"To use AffineTransformation with quantities, both matrix and unit need to be quantities"
     with pytest.raises(ValueError, match=MESSAGE):
         qx1, qy1 = qaff(xpix, ypix, equivalencies={
             'x': u.pixel_scale(2.5 * u.deg / u.pix),

--- a/astropy/modeling/tests/test_quantities_evaluation.py
+++ b/astropy/modeling/tests/test_quantities_evaluation.py
@@ -3,7 +3,7 @@
 """
 Tests that relate to evaluating models with quantity parameters
 """
-# pylint: disable=invalid-name, no-member
+import re
 
 import numpy as np
 import pytest
@@ -18,6 +18,9 @@ from astropy.units import UnitsError
 # We start off by taking some simple cases where the units are defined by
 # whatever the model is initialized with, and we check that the model evaluation
 # returns quantities.
+
+
+MESSAGE = "{}: Units of input 'x', {}({}), could not be converted to required input units of {}({})"
 
 
 def test_evaluate_with_quantities():
@@ -38,10 +41,11 @@ def test_evaluate_with_quantities():
 
     # Units have to be specified for the Gaussian with quantities - if not, an
     # error is raised
-    with pytest.raises(UnitsError) as exc:
+    with pytest.raises(
+                UnitsError,
+                match=re.escape(MESSAGE.format('Gaussian1D', '', 'dimensionless', 'm ', 'length'))
+            ):
         gq(1)
-    assert exc.value.args[0] == ("Gaussian1D: Units of input 'x', (dimensionless), could not be "
-                                 "converted to required input units of m (length)")
 
     # However, zero is a special case
     assert_quantity_allclose(gq(0), g(0) * u.J)
@@ -50,13 +54,18 @@ def test_evaluate_with_quantities():
     assert_allclose(gq(0.0005 * u.km).value, g(0.5))
 
     # But not with incompatible units
-    with pytest.raises(UnitsError) as exc:
+    with pytest.raises(
+                UnitsError,
+                match=re.escape(MESSAGE.format('Gaussian1D', 's ', 'time', 'm ', 'length'))
+            ):
         gq(3 * u.s)
-    assert exc.value.args[0] == ("Gaussian1D: Units of input 'x', s (time), could not be "
-                                 "converted to required input units of m (length)")
 
     # We also can't evaluate the model without quantities with a quantity
-    with pytest.raises(UnitsError) as exc:
+    with pytest.raises(
+                UnitsError,
+                match=r"Can only apply 'subtract' function to dimensionless quantities "
+                      r"when other argument is not a quantity .*"
+            ):
         g(3 * u.m)
     # TODO: determine what error message should be here
     # assert exc.value.args[0] == ("Units of input 'x', m (length), could not be "
@@ -71,11 +80,11 @@ def test_evaluate_with_quantities_and_equivalencies():
     g = Gaussian1D(1 * u.Jy, 10 * u.nm, 2 * u.nm)
 
     # We aren't setting the equivalencies, so this won't work
-    with pytest.raises(UnitsError) as exc:
+    with pytest.raises(
+                UnitsError,
+                match=re.escape(MESSAGE.format('Gaussian1D', 'PHz ', 'frequency', 'nm ', 'length'))
+            ):
         g(30 * u.PHz)
-    assert exc.value.args[0] == ("Gaussian1D: Units of input 'x', PHz (frequency), could "
-                                 "not be converted to required input units of "
-                                 "nm (length)")
 
     # But it should now work if we pass equivalencies when evaluating
     assert_quantity_allclose(g(30 * u.PHz, equivalencies={'x': u.spectral()}),
@@ -112,14 +121,17 @@ class TestInputUnits():
         assert_quantity_allclose(self.model(4 * u.rad, 2), 8 * u.rad)
         assert_quantity_allclose(self.model(4 * u.rad, 2 * u.s), 8 * u.rad * u.s)
 
-        with pytest.raises(UnitsError) as exc:
+        with pytest.raises(
+                    UnitsError,
+                    match=re.escape(MESSAGE.format('MyTestModel', 's ', 'time', 'deg ', 'angle'))
+                ):
             self.model(4 * u.s, 3)
-        assert exc.value.args[0] == ("MyTestModel: Units of input 'x', s (time), could not be "
-                                     "converted to required input units of deg (angle)")
-        with pytest.raises(UnitsError) as exc:
+
+        with pytest.raises(
+                    UnitsError,
+                    match=re.escape(MESSAGE.format('MyTestModel', '', 'dimensionless', 'deg ', 'angle'))
+                ):
             self.model(3, 3)
-        assert exc.value.args[0] == ("MyTestModel: Units of input 'x', (dimensionless), could "
-                                     "not be converted to required input units of deg (angle)")
 
     def test_input_units_allow_dimensionless(self):
 
@@ -129,10 +141,11 @@ class TestInputUnits():
         assert_quantity_allclose(self.model(3 * u.deg, 4), 12 * u.deg)
         assert_quantity_allclose(self.model(4 * u.rad, 2), 8 * u.rad)
 
-        with pytest.raises(UnitsError) as exc:
+        with pytest.raises(
+                    UnitsError,
+                    match=re.escape(MESSAGE.format('MyTestModel', 's ', 'time', 'deg ', 'angle'))
+                ):
             self.model(4 * u.s, 3)
-        assert exc.value.args[0] == ("MyTestModel: Units of input 'x', s (time), could not be "
-                                     "converted to required input units of deg (angle)")
 
         assert_quantity_allclose(self.model(3, 3), 9)
 
@@ -151,11 +164,11 @@ class TestInputUnits():
 
         self.model._input_units = {'x': u.micron}
 
-        with pytest.raises(UnitsError) as exc:
+        with pytest.raises(
+                    UnitsError,
+                    match=re.escape(MESSAGE.format('MyTestModel', 'PHz ', 'frequency', 'micron ', 'length'))
+                ):
             self.model(3 * u.PHz, 3)
-        assert exc.value.args[0] == ("MyTestModel: Units of input 'x', PHz (frequency), could "
-                                     "not be converted to required input units of "
-                                     "micron (length)")
 
         self.model.input_units_equivalencies = {'x': u.spectral()}
 
@@ -238,7 +251,10 @@ def test_compound_input_units_fail():
 
     cs = s1 | s2
 
-    with pytest.raises(UnitsError):
+    with pytest.raises(
+                UnitsError,
+                match=re.escape(MESSAGE.format('Shift', 'pix ', 'unknown', 'deg ', 'angle'))
+            ):
         cs(10 * u.pix)
 
 
@@ -251,7 +267,10 @@ def test_compound_incompatible_units_fail():
 
     cs = s1 | s2
 
-    with pytest.raises(UnitsError):
+    with pytest.raises(
+                UnitsError,
+                match=re.escape(MESSAGE.format('Shift', 'pix ', 'unknown', 'deg ', 'angle'))
+            ):
         cs(10 * u.pix)
 
 
@@ -314,10 +333,11 @@ def test_compound_input_units_equivalencies():
     out = cs(20 * u.pix, 10 * u.deg)
     assert_quantity_allclose(out, 20 * u.deg)
 
-    with pytest.raises(UnitsError) as exc:
+    with pytest.raises(
+                UnitsError,
+                match=re.escape(MESSAGE.format('Shift', 'pix ', 'unknown', 'deg ', 'angle'))
+            ):
         out = cs(20 * u.pix, 10 * u.pix)
-    assert exc.value.args[0] == ("Shift: Units of input 'x', pix (unknown), could not be converted "
-                                 "to required input units of deg (angle)")
 
 
 def test_compound_input_units_strict():
@@ -371,20 +391,22 @@ def test_compound_input_units_allow_dimensionless():
     out = cs(10 * u.arcsec)
     assert_quantity_allclose(out, 40 * u.arcsec)
 
-    with pytest.raises(UnitsError) as exc:
+    with pytest.raises(
+                UnitsError,
+                match=re.escape(MESSAGE.format('ScaleDegrees', 'm ', 'length', 'deg ', 'angle'))
+            ):
         out = cs(10 * u.m)
-    assert exc.value.args[0] == ("ScaleDegrees: Units of input 'x', m (length), "
-                                 "could not be converted to required input units of deg (angle)")
 
     s1._input_units_allow_dimensionless = False
 
     cs = s1 | s2
     cs = cs.rename('TestModel')
 
-    with pytest.raises(UnitsError) as exc:
+    with pytest.raises(
+                UnitsError,
+                match=re.escape(MESSAGE.format('ScaleDegrees', '', 'dimensionless', 'deg ', 'angle'))
+            ):
         out = cs(10)
-    assert exc.value.args[0] == ("ScaleDegrees: Units of input 'x', (dimensionless), "
-                                 "could not be converted to required input units of deg (angle)")
 
     s1._input_units_allow_dimensionless = True
 
@@ -397,19 +419,21 @@ def test_compound_input_units_allow_dimensionless():
     out = cs(10 * u.arcsec)
     assert_quantity_allclose(out, 40 * u.arcsec)
 
-    with pytest.raises(UnitsError) as exc:
+    with pytest.raises(
+                UnitsError,
+                match=re.escape(MESSAGE.format('ScaleDegrees', 'm ', 'length', 'deg ', 'angle'))
+            ):
         out = cs(10 * u.m)
-    assert exc.value.args[0] == ("ScaleDegrees: Units of input 'x', m (length), "
-                                 "could not be converted to required input units of deg (angle)")
 
     s1._input_units_allow_dimensionless = False
 
     cs = s2 | s1
 
-    with pytest.raises(UnitsError) as exc:
+    with pytest.raises(
+                UnitsError,
+                match=re.escape(MESSAGE.format('ScaleDegrees', '', 'dimensionless', 'deg ', 'angle'))
+            ):
         out = cs(10)
-    assert exc.value.args[0] == ("ScaleDegrees: Units of input 'x', (dimensionless), "
-                                 "could not be converted to required input units of deg (angle)")
 
     s1._input_units_allow_dimensionless = True
 
@@ -425,10 +449,11 @@ def test_compound_input_units_allow_dimensionless():
     assert_quantity_allclose(out[0], 20 * u.one)
     assert_quantity_allclose(out[1], 20 * u.arcsec)
 
-    with pytest.raises(UnitsError) as exc:
+    with pytest.raises(
+                UnitsError,
+                match=re.escape(MESSAGE.format('ScaleDegrees', '', 'dimensionless', 'deg ', 'angle'))
+            ):
         out = cs(10, 10)
-    assert exc.value.args[0] == ("ScaleDegrees: Units of input 'x', (dimensionless), "
-                                 "could not be converted to required input units of deg (angle)")
 
 
 def test_compound_return_units():

--- a/astropy/modeling/tests/test_quantities_evaluation.py
+++ b/astropy/modeling/tests/test_quantities_evaluation.py
@@ -3,8 +3,6 @@
 """
 Tests that relate to evaluating models with quantity parameters
 """
-import re
-
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
@@ -20,7 +18,7 @@ from astropy.units import UnitsError
 # returns quantities.
 
 
-MESSAGE = "{}: Units of input 'x', {}({}), could not be converted to required input units of {}({})"
+MESSAGE = "{}: Units of input 'x', {}.*, could not be converted to required input units of {}.*"
 
 
 def test_evaluate_with_quantities():
@@ -43,7 +41,7 @@ def test_evaluate_with_quantities():
     # error is raised
     with pytest.raises(
                 UnitsError,
-                match=re.escape(MESSAGE.format('Gaussian1D', '', 'dimensionless', 'm ', 'length'))
+                match=MESSAGE.format('Gaussian1D', '', 'm ')
             ):
         gq(1)
 
@@ -56,15 +54,14 @@ def test_evaluate_with_quantities():
     # But not with incompatible units
     with pytest.raises(
                 UnitsError,
-                match=re.escape(MESSAGE.format('Gaussian1D', 's ', 'time', 'm ', 'length'))
+                match=MESSAGE.format('Gaussian1D', 's', 'm')
             ):
         gq(3 * u.s)
 
     # We also can't evaluate the model without quantities with a quantity
     with pytest.raises(
                 UnitsError,
-                match=r"Can only apply 'subtract' function to dimensionless quantities "
-                      r"when other argument is not a quantity .*"
+                match=r"Can only apply 'subtract' function to dimensionless quantities .*"
             ):
         g(3 * u.m)
     # TODO: determine what error message should be here
@@ -82,7 +79,7 @@ def test_evaluate_with_quantities_and_equivalencies():
     # We aren't setting the equivalencies, so this won't work
     with pytest.raises(
                 UnitsError,
-                match=re.escape(MESSAGE.format('Gaussian1D', 'PHz ', 'frequency', 'nm ', 'length'))
+                match=MESSAGE.format('Gaussian1D', 'PHz', 'nm')
             ):
         g(30 * u.PHz)
 
@@ -123,13 +120,13 @@ class TestInputUnits():
 
         with pytest.raises(
                     UnitsError,
-                    match=re.escape(MESSAGE.format('MyTestModel', 's ', 'time', 'deg ', 'angle'))
+                    match=MESSAGE.format('MyTestModel', 's', 'deg')
                 ):
             self.model(4 * u.s, 3)
 
         with pytest.raises(
                     UnitsError,
-                    match=re.escape(MESSAGE.format('MyTestModel', '', 'dimensionless', 'deg ', 'angle'))
+                    match=MESSAGE.format('MyTestModel', '', 'deg')
                 ):
             self.model(3, 3)
 
@@ -143,7 +140,7 @@ class TestInputUnits():
 
         with pytest.raises(
                     UnitsError,
-                    match=re.escape(MESSAGE.format('MyTestModel', 's ', 'time', 'deg ', 'angle'))
+                    match=MESSAGE.format('MyTestModel', 's', 'deg')
                 ):
             self.model(4 * u.s, 3)
 
@@ -166,7 +163,7 @@ class TestInputUnits():
 
         with pytest.raises(
                     UnitsError,
-                    match=re.escape(MESSAGE.format('MyTestModel', 'PHz ', 'frequency', 'micron ', 'length'))
+                    match=MESSAGE.format('MyTestModel', 'PHz', 'micron')
                 ):
             self.model(3 * u.PHz, 3)
 
@@ -253,7 +250,7 @@ def test_compound_input_units_fail():
 
     with pytest.raises(
                 UnitsError,
-                match=re.escape(MESSAGE.format('Shift', 'pix ', 'unknown', 'deg ', 'angle'))
+                match=MESSAGE.format('Shift', 'pix', 'deg')
             ):
         cs(10 * u.pix)
 
@@ -269,7 +266,7 @@ def test_compound_incompatible_units_fail():
 
     with pytest.raises(
                 UnitsError,
-                match=re.escape(MESSAGE.format('Shift', 'pix ', 'unknown', 'deg ', 'angle'))
+                match=MESSAGE.format('Shift', 'pix', 'deg')
             ):
         cs(10 * u.pix)
 
@@ -335,7 +332,7 @@ def test_compound_input_units_equivalencies():
 
     with pytest.raises(
                 UnitsError,
-                match=re.escape(MESSAGE.format('Shift', 'pix ', 'unknown', 'deg ', 'angle'))
+                match=MESSAGE.format('Shift', 'pix', 'deg')
             ):
         out = cs(20 * u.pix, 10 * u.pix)
 
@@ -393,7 +390,7 @@ def test_compound_input_units_allow_dimensionless():
 
     with pytest.raises(
                 UnitsError,
-                match=re.escape(MESSAGE.format('ScaleDegrees', 'm ', 'length', 'deg ', 'angle'))
+                match=MESSAGE.format('ScaleDegrees', 'm', 'deg')
             ):
         out = cs(10 * u.m)
 
@@ -404,7 +401,7 @@ def test_compound_input_units_allow_dimensionless():
 
     with pytest.raises(
                 UnitsError,
-                match=re.escape(MESSAGE.format('ScaleDegrees', '', 'dimensionless', 'deg ', 'angle'))
+                match=MESSAGE.format('ScaleDegrees', '', 'deg')
             ):
         out = cs(10)
 
@@ -421,7 +418,7 @@ def test_compound_input_units_allow_dimensionless():
 
     with pytest.raises(
                 UnitsError,
-                match=re.escape(MESSAGE.format('ScaleDegrees', 'm ', 'length', 'deg ', 'angle'))
+                match=MESSAGE.format('ScaleDegrees', 'm', 'deg')
             ):
         out = cs(10 * u.m)
 
@@ -431,7 +428,7 @@ def test_compound_input_units_allow_dimensionless():
 
     with pytest.raises(
                 UnitsError,
-                match=re.escape(MESSAGE.format('ScaleDegrees', '', 'dimensionless', 'deg ', 'angle'))
+                match=MESSAGE.format('ScaleDegrees', '', 'deg')
             ):
         out = cs(10)
 
@@ -451,7 +448,7 @@ def test_compound_input_units_allow_dimensionless():
 
     with pytest.raises(
                 UnitsError,
-                match=re.escape(MESSAGE.format('ScaleDegrees', '', 'dimensionless', 'deg ', 'angle'))
+                match=MESSAGE.format('ScaleDegrees', '', 'deg')
             ):
         out = cs(10, 10)
 

--- a/astropy/modeling/tests/test_quantities_fitting.py
+++ b/astropy/modeling/tests/test_quantities_fitting.py
@@ -2,8 +2,6 @@
 """
 Tests that relate to fitting models with quantity parameters
 """
-import re
-
 import numpy as np
 import pytest
 
@@ -146,12 +144,12 @@ def test_fitting_missing_data_units(fitter):
     # We define flux unit so that conversion fails at wavelength unit.
     # This is because the order of parameter unit conversion seems to
     # follow the order defined in _parameter_units_for_data_units method.
-    MESSAGE = re.escape("'cm' (length) and '' (dimensionless) are not convertible")
+    MESSAGE = r"'cm' .* and '' .* are not convertible"
     with pytest.raises(UnitsError, match=MESSAGE):
         fitter(g_init, [1, 2, 3],
                [4, 5, 6] * (u.erg / (u.s * u.cm * u.cm * u.Hz)))
 
-    MESSAGE = re.escape("'mJy' (spectral flux density) and '' (dimensionless) are not convertible")
+    MESSAGE = r"'mJy' .* and '' .* are not convertible"
     with pytest.raises(UnitsError, match=MESSAGE):
         fitter(g_init, [1, 2, 3] * u.m, [4, 5, 6])
 
@@ -192,7 +190,7 @@ def test_fitting_incompatible_units(fitter):
     g_init = models.Gaussian1D(amplitude=1. * u.Jy,
                                mean=3 * u.m,
                                stddev=2 * u.cm)
-    MESSAGE = re.escape("'Hz' (frequency) and 'm' (length) are not convertible")
+    MESSAGE = r"'Hz' .* and 'm' .* are not convertible"
     with pytest.raises(UnitsError, match=MESSAGE):
         fitter(g_init, [1, 2, 3] * u.Hz, [4, 5, 6] * u.Jy)
 

--- a/astropy/modeling/tests/test_quantities_fitting.py
+++ b/astropy/modeling/tests/test_quantities_fitting.py
@@ -2,7 +2,8 @@
 """
 Tests that relate to fitting models with quantity parameters
 """
-# pylint: disable=invalid-name, no-member
+import re
+
 import numpy as np
 import pytest
 
@@ -145,16 +146,14 @@ def test_fitting_missing_data_units(fitter):
     # We define flux unit so that conversion fails at wavelength unit.
     # This is because the order of parameter unit conversion seems to
     # follow the order defined in _parameter_units_for_data_units method.
-    with pytest.raises(UnitsError) as exc:
+    MESSAGE = re.escape("'cm' (length) and '' (dimensionless) are not convertible")
+    with pytest.raises(UnitsError, match=MESSAGE):
         fitter(g_init, [1, 2, 3],
                [4, 5, 6] * (u.erg / (u.s * u.cm * u.cm * u.Hz)))
-    assert exc.value.args[0] == ("'cm' (length) and '' (dimensionless) are "
-                                 "not convertible")
 
-    with pytest.raises(UnitsError) as exc:
+    MESSAGE = re.escape("'mJy' (spectral flux density) and '' (dimensionless) are not convertible")
+    with pytest.raises(UnitsError, match=MESSAGE):
         fitter(g_init, [1, 2, 3] * u.m, [4, 5, 6])
-    assert exc.value.args[0] == ("'mJy' (spectral flux density) and '' "
-                                 "(dimensionless) are not convertible")
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason='requires scipy')
@@ -193,9 +192,9 @@ def test_fitting_incompatible_units(fitter):
     g_init = models.Gaussian1D(amplitude=1. * u.Jy,
                                mean=3 * u.m,
                                stddev=2 * u.cm)
-    with pytest.raises(UnitsError) as exc:
+    MESSAGE = re.escape("'Hz' (frequency) and 'm' (length) are not convertible")
+    with pytest.raises(UnitsError, match=MESSAGE):
         fitter(g_init, [1, 2, 3] * u.Hz, [4, 5, 6] * u.Jy)
-    assert exc.value.args[0] == ("'Hz' (frequency) and 'm' (length) are not convertible")
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason='requires scipy')

--- a/astropy/modeling/tests/test_quantities_model.py
+++ b/astropy/modeling/tests/test_quantities_model.py
@@ -1,5 +1,7 @@
 # Various tests of models not related to evaluation, fitting, or parameters
 # pylint: disable=invalid-name, no-member
+import re
+
 import pytest
 
 from astropy import units as u
@@ -44,7 +46,11 @@ def test_quantity_call():
 
     g(10 * u.m)
 
-    with pytest.raises(u.UnitsError):
+    with pytest.raises(
+                u.UnitsError,
+                match=re.escape("Gaussian1D: Units of input 'x', (dimensionless), "
+                                "could not be converted to required input units of m (length)")
+            ):
         g(10)
 
 

--- a/astropy/modeling/tests/test_quantities_model.py
+++ b/astropy/modeling/tests/test_quantities_model.py
@@ -1,7 +1,5 @@
 # Various tests of models not related to evaluation, fitting, or parameters
 # pylint: disable=invalid-name, no-member
-import re
-
 import pytest
 
 from astropy import units as u
@@ -46,11 +44,8 @@ def test_quantity_call():
 
     g(10 * u.m)
 
-    with pytest.raises(
-                u.UnitsError,
-                match=re.escape("Gaussian1D: Units of input 'x', (dimensionless), "
-                                "could not be converted to required input units of m (length)")
-            ):
+    MESSAGE = r".* Units of input 'x', .* could not be converted to required input units of m .*"
+    with pytest.raises(u.UnitsError, match=MESSAGE):
         g(10)
 
 

--- a/astropy/modeling/tests/test_quantities_parameters.py
+++ b/astropy/modeling/tests/test_quantities_parameters.py
@@ -3,8 +3,6 @@
 """
 Tests that relate to using quantities/units on parameters of models.
 """
-import re
-
 import numpy as np
 import pytest
 
@@ -82,9 +80,7 @@ def test_parameter_lose_units():
 
     g = Gaussian1D(1 * u.Jy, 3, 0.1)
 
-    MESSAGE = (r"The 'amplitude' parameter should be given as "
-               r"a Quantity because it was originally "
-               r"initialized as a Quantity")
+    MESSAGE = r"The .* parameter should be given as a .* because it was originally initialized as a .*"
     with pytest.raises(UnitsError, match=MESSAGE):
         g.amplitude = 2
 
@@ -111,14 +107,12 @@ def test_parameter_change_unit():
     g = Gaussian1D(1, 1 * u.m, 0.1 * u.m)
 
     # Setting a unit on a unitless parameter should not work
-    MESSAGE = (r"Cannot attach units to parameters that were "
-               r"not initially specified with units")
+    MESSAGE = r"Cannot attach units to parameters that were not initially specified with units"
     with pytest.raises(ValueError, match=MESSAGE):
         g.amplitude.unit = u.Jy
 
     # But changing to another unit should not, even if it is an equivalent unit
-    MESSAGE = (r"Cannot change the unit attribute directly, "
-               r"instead change the parameter to a new quantity")
+    MESSAGE = r"Cannot change the unit attribute directly, instead change the parameter to a new quantity"
     with pytest.raises(ValueError, match=MESSAGE):
         g.mean.unit = u.cm
 
@@ -141,12 +135,7 @@ def test_parameter_set_value():
     assert g.amplitude.unit is u.Jy
 
     # If we try setting it to a Quantity, we raise an error
-    MESSAGE = (
-        r"The .value property on parameters should be set"
-        r" to unitless values, not Quantity objects. To set"
-        r"a parameter to a quantity simply set the "
-        r"parameter directly without using .value"
-    )
+    MESSAGE = r"The .value property on parameters should be set to unitless values, not Quantity objects.*"
     with pytest.raises(TypeError, match=MESSAGE):
         g.amplitude.value = 3 * u.Jy
 
@@ -234,7 +223,7 @@ def test_parameter_defaults(unit, default):
     assert m.a.default == 1.0
 
     # Instantiating with different units works, and just replaces the original unit
-    MESSAGE = re.escape("TestModel.__init__() requires a Quantity for parameter 'a'")
+    MESSAGE = r".* requires a Quantity for parameter .*"
     with pytest.raises(InputParameterError, match=MESSAGE):
         TestModel(1.0)
 
@@ -264,10 +253,7 @@ def test_parameter_quantity_arithmetic():
     assert abs(-g.mean) == g.mean
 
     # However, addition of a quantity + scalar should not work
-    MESSAGE = re.escape("Can only apply 'add' function to "
-                        "dimensionless quantities when other argument "
-                        "is not a quantity (unless the latter is all "
-                        "zero/infinity/nan)")
+    MESSAGE = r"Can only apply 'add' function to dimensionless quantities when other argument .*"
     with pytest.raises(UnitsError, match=MESSAGE):
         g.mean + 1
     with pytest.raises(UnitsError, match=MESSAGE):
@@ -291,10 +277,7 @@ def test_parameter_quantity_comparison():
     assert g.mean < 2 * u.m
     assert 2 * u.m > g.mean
 
-    MESSAGE = re.escape("Can only apply 'less' function to "
-                        "dimensionless quantities when other argument "
-                        "is not a quantity (unless the latter is all "
-                        "zero/infinity/nan)")
+    MESSAGE = r"Can only apply 'less' function to dimensionless quantities when other argument .*"
     with pytest.raises(UnitsError, match=MESSAGE):
         g.mean < 2
 

--- a/astropy/modeling/tests/test_quantities_parameters.py
+++ b/astropy/modeling/tests/test_quantities_parameters.py
@@ -3,7 +3,7 @@
 """
 Tests that relate to using quantities/units on parameters of models.
 """
-# pylint: disable=invalid-name, no-member
+import re
 
 import numpy as np
 import pytest
@@ -82,11 +82,11 @@ def test_parameter_lose_units():
 
     g = Gaussian1D(1 * u.Jy, 3, 0.1)
 
-    with pytest.raises(UnitsError) as exc:
+    MESSAGE = (r"The 'amplitude' parameter should be given as "
+               r"a Quantity because it was originally "
+               r"initialized as a Quantity")
+    with pytest.raises(UnitsError, match=MESSAGE):
         g.amplitude = 2
-    assert exc.value.args[0] == ("The 'amplitude' parameter should be given as "
-                                 "a Quantity because it was originally "
-                                 "initialized as a Quantity")
 
 
 def test_parameter_add_units():
@@ -111,16 +111,16 @@ def test_parameter_change_unit():
     g = Gaussian1D(1, 1 * u.m, 0.1 * u.m)
 
     # Setting a unit on a unitless parameter should not work
-    with pytest.raises(ValueError) as exc:
+    MESSAGE = (r"Cannot attach units to parameters that were "
+               r"not initially specified with units")
+    with pytest.raises(ValueError, match=MESSAGE):
         g.amplitude.unit = u.Jy
-    assert exc.value.args[0] == ("Cannot attach units to parameters that were "
-                                 "not initially specified with units")
 
     # But changing to another unit should not, even if it is an equivalent unit
-    with pytest.raises(ValueError) as exc:
+    MESSAGE = (r"Cannot change the unit attribute directly, "
+               r"instead change the parameter to a new quantity")
+    with pytest.raises(ValueError, match=MESSAGE):
         g.mean.unit = u.cm
-    assert exc.value.args[0] == ("Cannot change the unit attribute directly, "
-                                 "instead change the parameter to a new quantity")
 
 
 def test_parameter_set_value():
@@ -141,14 +141,14 @@ def test_parameter_set_value():
     assert g.amplitude.unit is u.Jy
 
     # If we try setting it to a Quantity, we raise an error
-    with pytest.raises(TypeError) as exc:
-        g.amplitude.value = 3 * u.Jy
-    assert exc.value.args[0] == (
-        "The .value property on parameters should be set"
-        " to unitless values, not Quantity objects. To set"
-        "a parameter to a quantity simply set the "
-        "parameter directly without using .value"
+    MESSAGE = (
+        r"The .value property on parameters should be set"
+        r" to unitless values, not Quantity objects. To set"
+        r"a parameter to a quantity simply set the "
+        r"parameter directly without using .value"
     )
+    with pytest.raises(TypeError, match=MESSAGE):
+        g.amplitude.value = 3 * u.Jy
 
 
 def test_parameter_quantity_property():
@@ -175,19 +175,18 @@ def test_parameter_quantity_property():
     assert g.amplitude.unit is u.s
 
     # But not to a value without units
-    with pytest.raises(TypeError) as exc:
+    MESSAGE = r"The .quantity attribute should be set to a Quantity object"
+    with pytest.raises(TypeError, match=MESSAGE):
         g.amplitude.quantity = 3
-    assert exc.value.args[0] == "The .quantity attribute should be set to a Quantity object"
 
 
 def test_parameter_default_units_match():
 
     # If the unit and default quantity units are different, raise an error
-    with pytest.raises(ParameterDefinitionError) as exc:
+    MESSAGE = r"parameter default 1.0 m does not have units equivalent to the required unit Jy"
+    with pytest.raises(ParameterDefinitionError, match=MESSAGE):
         class TestC(Fittable1DModel):
             a = Parameter(default=1.0 * u.m, unit=u.Jy)
-    assert exc.value.args[0] == ("parameter default 1.0 m does not have units "
-                                 "equivalent to the required unit Jy")
 
 
 @pytest.mark.parametrize(('unit', 'default'), ((u.m, 1.0), (None, 1 * u.m)))
@@ -235,10 +234,9 @@ def test_parameter_defaults(unit, default):
     assert m.a.default == 1.0
 
     # Instantiating with different units works, and just replaces the original unit
-    with pytest.raises(InputParameterError) as exc:
+    MESSAGE = re.escape("TestModel.__init__() requires a Quantity for parameter 'a'")
+    with pytest.raises(InputParameterError, match=MESSAGE):
         TestModel(1.0)
-    assert exc.value.args[0] == ("TestModel.__init__() requires a "
-                                 "Quantity for parameter 'a'")
 
 
 def test_parameter_quantity_arithmetic():
@@ -266,18 +264,14 @@ def test_parameter_quantity_arithmetic():
     assert abs(-g.mean) == g.mean
 
     # However, addition of a quantity + scalar should not work
-    with pytest.raises(UnitsError) as exc:
+    MESSAGE = re.escape("Can only apply 'add' function to "
+                        "dimensionless quantities when other argument "
+                        "is not a quantity (unless the latter is all "
+                        "zero/infinity/nan)")
+    with pytest.raises(UnitsError, match=MESSAGE):
         g.mean + 1
-    assert exc.value.args[0] == ("Can only apply 'add' function to "
-                                 "dimensionless quantities when other argument "
-                                 "is not a quantity (unless the latter is all "
-                                 "zero/infinity/nan)")
-    with pytest.raises(UnitsError) as exc:
+    with pytest.raises(UnitsError, match=MESSAGE):
         1 + g.mean
-    assert exc.value.args[0] == ("Can only apply 'add' function to "
-                                 "dimensionless quantities when other argument "
-                                 "is not a quantity (unless the latter is all "
-                                 "zero/infinity/nan)")
 
 
 def test_parameter_quantity_comparison():
@@ -297,19 +291,15 @@ def test_parameter_quantity_comparison():
     assert g.mean < 2 * u.m
     assert 2 * u.m > g.mean
 
-    with pytest.raises(UnitsError) as exc:
+    MESSAGE = re.escape("Can only apply 'less' function to "
+                        "dimensionless quantities when other argument "
+                        "is not a quantity (unless the latter is all "
+                        "zero/infinity/nan)")
+    with pytest.raises(UnitsError, match=MESSAGE):
         g.mean < 2
-    assert exc.value.args[0] == ("Can only apply 'less' function to "
-                                 "dimensionless quantities when other argument "
-                                 "is not a quantity (unless the latter is all "
-                                 "zero/infinity/nan)")
 
-    with pytest.raises(UnitsError) as exc:
+    with pytest.raises(UnitsError, match=MESSAGE):
         2 > g.mean
-    assert exc.value.args[0] == ("Can only apply 'less' function to "
-                                 "dimensionless quantities when other argument "
-                                 "is not a quantity (unless the latter is all "
-                                 "zero/infinity/nan)")
 
     g = Gaussian1D([1, 2] * u.J, [1, 2] * u.m, [0.1, 0.2] * u.m)
 
@@ -318,19 +308,11 @@ def test_parameter_quantity_comparison():
     assert np.all(g.mean != [1, 2])
     assert np.all([1, 2] != g.mean)
 
-    with pytest.raises(UnitsError) as exc:
+    with pytest.raises(UnitsError, match=MESSAGE):
         g.mean < [3, 4]
-    assert exc.value.args[0] == ("Can only apply 'less' function to "
-                                 "dimensionless quantities when other argument "
-                                 "is not a quantity (unless the latter is all "
-                                 "zero/infinity/nan)")
 
-    with pytest.raises(UnitsError) as exc:
+    with pytest.raises(UnitsError, match=MESSAGE):
         [3, 4] > g.mean
-    assert exc.value.args[0] == ("Can only apply 'less' function to "
-                                 "dimensionless quantities when other argument "
-                                 "is not a quantity (unless the latter is all "
-                                 "zero/infinity/nan)")
 
 
 def test_parameters_compound_models():

--- a/astropy/modeling/tests/test_rotations.py
+++ b/astropy/modeling/tests/test_rotations.py
@@ -104,22 +104,19 @@ def test_Rotation2D_errors():
     # Bad evaluation input shapes
     x = np.array([1, 2])
     y = np.array([1, 2, 3])
-    message = "Expected input arrays to have the same shape"
+    MESSAGE = r"Expected input arrays to have the same shape"
 
-    with pytest.raises(ValueError) as err:
+    with pytest.raises(ValueError, match=MESSAGE):
         model.evaluate(x, y, model.angle)
-    assert str(err.value) == message
-    with pytest.raises(ValueError) as err:
+    with pytest.raises(ValueError, match=MESSAGE):
         model.evaluate(y, x, model.angle)
-    assert str(err.value) == message
 
     # Bad evaluation units
     x = np.array([1, 2])
     y = np.array([1, 2])
-    message = "x and y must have compatible units"
-    with pytest.raises(u.UnitsError) as err:
+    MESSAGE = r"x and y must have compatible units"
+    with pytest.raises(u.UnitsError, match=MESSAGE):
         model.evaluate(x * u.m, y, model.angle)
-    assert str(err.value) == message
 
 
 def test_euler_angle_rotations():
@@ -256,31 +253,28 @@ def test_RotationSequence3D_errors():
         rotations.RotationSequence3D(mk.MagicMock(), axes_order="abc")
 
     # Bad number of angles
-    with pytest.raises(ValueError) as err:
+    MESSAGE = r"The number of angles 4 should match the number of axes 3."
+    with pytest.raises(ValueError, match=MESSAGE):
         rotations.RotationSequence3D([1, 2, 3, 4], axes_order="zyx")
-    assert str(err.value) == "The number of angles 4 should match the number of axes 3."
 
     # Bad evaluation input shapes
     model = rotations.RotationSequence3D([1, 2, 3], axes_order="zyx")
-    message = "Expected input arrays to have the same shape"
-    with pytest.raises(ValueError) as err:
+    MESSAGE = r"Expected input arrays to have the same shape"
+    with pytest.raises(ValueError, match=MESSAGE):
         model.evaluate(np.array([1, 2, 3]),
                        np.array([1, 2]),
                        np.array([1, 2]),
                        [1, 2, 3])
-    assert str(err.value) == message
-    with pytest.raises(ValueError) as err:
+    with pytest.raises(ValueError, match=MESSAGE):
         model.evaluate(np.array([1, 2]),
                        np.array([1, 2, 3]),
                        np.array([1, 2]),
                        [1, 2, 3])
-    assert str(err.value) == message
-    with pytest.raises(ValueError) as err:
+    with pytest.raises(ValueError, match=MESSAGE):
         model.evaluate(np.array([1, 2]),
                        np.array([1, 2]),
                        np.array([1, 2, 3]),
                        [1, 2, 3])
-    assert str(err.value) == message
 
 
 def test_RotationSequence3D_inverse():
@@ -292,10 +286,10 @@ def test_RotationSequence3D_inverse():
 
 def test_EulerAngleRotation_errors():
     # Bad length of axes_order
-    with pytest.raises(TypeError) as err:
+    MESSAGE = r"Expected axes_order to be a character sequence of length 3, got xyzx"
+    with pytest.raises(TypeError, match=MESSAGE):
         rotations.EulerAngleRotation(mk.MagicMock(), mk.MagicMock(), mk.MagicMock(),
                                      axes_order="xyzx")
-    assert str(err.value) == "Expected axes_order to be a character sequence of length 3, got xyzx"
 
     # Bad axes_order labels
     with pytest.raises(ValueError, match=r"Unrecognized axis label .* should be one of .*"):
@@ -303,19 +297,16 @@ def test_EulerAngleRotation_errors():
                                      axes_order="abc")
 
     # Bad units
-    message = "All parameters should be of the same type - float or Quantity."
-    with pytest.raises(TypeError) as err:
+    MESSAGE = r"All parameters should be of the same type - float or Quantity."
+    with pytest.raises(TypeError, match=MESSAGE):
         rotations.EulerAngleRotation(1 * u.m, 2, 3,
                                      axes_order="xyz")
-    assert str(err.value) == message
-    with pytest.raises(TypeError) as err:
+    with pytest.raises(TypeError, match=MESSAGE):
         rotations.EulerAngleRotation(1, 2 * u.m, 3,
                                      axes_order="xyz")
-    assert str(err.value) == message
-    with pytest.raises(TypeError) as err:
+    with pytest.raises(TypeError, match=MESSAGE):
         rotations.EulerAngleRotation(1, 2, 3 * u.m,
                                      axes_order="xyz")
-    assert str(err.value) == message
 
 
 def test_EulerAngleRotation_inverse():
@@ -329,16 +320,13 @@ def test_EulerAngleRotation_inverse():
 
 def test__SkyRotation_errors():
     # Bad units
-    message = "All parameters should be of the same type - float or Quantity."
-    with pytest.raises(TypeError) as err:
+    MESSAGE = r"All parameters should be of the same type - float or Quantity."
+    with pytest.raises(TypeError, match=MESSAGE):
         rotations._SkyRotation(1 * u.m, 2, 3)
-    assert str(err.value) == message
-    with pytest.raises(TypeError) as err:
+    with pytest.raises(TypeError, match=MESSAGE):
         rotations._SkyRotation(1, 2 * u.m, 3)
-    assert str(err.value) == message
-    with pytest.raises(TypeError) as err:
+    with pytest.raises(TypeError, match=MESSAGE):
         rotations._SkyRotation(1, 2, 3 * u.m)
-    assert str(err.value) == message
 
 
 def test__SkyRotation__evaluate():

--- a/astropy/modeling/tests/test_rotations.py
+++ b/astropy/modeling/tests/test_rotations.py
@@ -253,7 +253,7 @@ def test_RotationSequence3D_errors():
         rotations.RotationSequence3D(mk.MagicMock(), axes_order="abc")
 
     # Bad number of angles
-    MESSAGE = r"The number of angles 4 should match the number of axes 3."
+    MESSAGE = r"The number of angles 4 should match the number of axes 3"
     with pytest.raises(ValueError, match=MESSAGE):
         rotations.RotationSequence3D([1, 2, 3, 4], axes_order="zyx")
 
@@ -297,7 +297,7 @@ def test_EulerAngleRotation_errors():
                                      axes_order="abc")
 
     # Bad units
-    MESSAGE = r"All parameters should be of the same type - float or Quantity."
+    MESSAGE = r"All parameters should be of the same type - float or Quantity"
     with pytest.raises(TypeError, match=MESSAGE):
         rotations.EulerAngleRotation(1 * u.m, 2, 3,
                                      axes_order="xyz")
@@ -320,7 +320,7 @@ def test_EulerAngleRotation_inverse():
 
 def test__SkyRotation_errors():
     # Bad units
-    MESSAGE = r"All parameters should be of the same type - float or Quantity."
+    MESSAGE = r"All parameters should be of the same type - float or Quantity"
     with pytest.raises(TypeError, match=MESSAGE):
         rotations._SkyRotation(1 * u.m, 2, 3)
     with pytest.raises(TypeError, match=MESSAGE):

--- a/astropy/modeling/tests/test_spline.py
+++ b/astropy/modeling/tests/test_spline.py
@@ -75,9 +75,9 @@ class TestSpline:
             assert spl._test is None
 
         # Coeffs but no knots
-        with pytest.raises(ValueError) as err:
+        MESSAGE = r"If one passes a coeffs vector one needs to also pass knots!"
+        with pytest.raises(ValueError, match=MESSAGE):
             self.Spline(coeffs=mk.MagicMock())
-        assert str(err.value) == "If one passes a coeffs vector one needs to also pass knots!"
 
     def test_param_names(self):
         # no parameters
@@ -274,20 +274,19 @@ class TestSpline:
     def test__init_parameters(self):
         spl = self.Spline()
 
-        with pytest.raises(NotImplementedError) as err:
+        MESSAGE = r"This needs to be implemented"
+        with pytest.raises(NotImplementedError, match=MESSAGE):
             spl._init_parameters()
-        assert str(err.value) == "This needs to be implemented"
 
     def test__init_data(self):
         spl = self.Spline()
 
-        with pytest.raises(NotImplementedError) as err:
+        MESSAGE = r"This needs to be implemented"
+        with pytest.raises(NotImplementedError, match=MESSAGE):
             spl._init_data(mk.MagicMock(), mk.MagicMock(), mk.MagicMock())
-        assert str(err.value) == "This needs to be implemented"
 
-        with pytest.raises(NotImplementedError) as err:
+        with pytest.raises(NotImplementedError, match=MESSAGE):
             spl._init_data(mk.MagicMock(), mk.MagicMock())
-        assert str(err.value) == "This needs to be implemented"
 
     def test__init_spline(self):
         spl = self.Spline()
@@ -502,19 +501,20 @@ class TestSpline1D:
     def test___init__errors(self):
         # Bad knot type
         knots = 3.5
-        with pytest.raises(ValueError) as err:
+        MESSAGE = f"Knots: {knots} must be iterable or value"
+        with pytest.raises(ValueError, match=MESSAGE):
             Spline1D(knots=knots)
-        assert str(err.value) == f"Knots: {knots} must be iterable or value"
 
         # Not enough knots
+        MESSAGE = r"Must have at least 8 knots."
         for idx in range(8):
-            with pytest.raises(ValueError) as err:
+            with pytest.raises(ValueError, match=MESSAGE):
                 Spline1D(knots=np.arange(idx))
-            assert str(err.value) == "Must have at least 8 knots."
 
         # Bad scipy spline
         t = np.arange(20)[::-1]
-        with pytest.raises(ValueError):
+        MESSAGE = r"Knots must be in a non-decreasing order."
+        with pytest.raises(ValueError, match=MESSAGE):
             Spline1D(knots=t)
 
     def test_parameter_array_link(self):
@@ -689,9 +689,9 @@ class TestSpline1D:
         assert spl._t is None
         assert (spl.t == [0, 0, 0, 0, 1, 1, 1, 1]).all()
         # test set
-        with pytest.raises(ValueError) as err:
+        MESSAGE = r"The model parameters must be initialized before setting knots."
+        with pytest.raises(ValueError, match=MESSAGE):
             spl.t = mk.MagicMock()
-        assert str(err.value) == "The model parameters must be initialized before setting knots."
 
         # with parameters
         spl = Spline1D(10)
@@ -706,12 +706,12 @@ class TestSpline1D:
         assert (spl.t == (np.arange(18) + 15)).all()
         assert (spl.t != t).all()
         # set error
+        MESSAGE = r"There must be exactly as many knots as previously defined."
         for idx in range(30):
             if idx == 18:
                 continue
-            with pytest.raises(ValueError) as err:
+            with pytest.raises(ValueError, match=MESSAGE):
                 spl.t = np.arange(idx)
-            assert str(err.value) == "There must be exactly as many knots as previously defined."
 
     def test_c(self):
         # no parameters
@@ -720,9 +720,9 @@ class TestSpline1D:
         assert spl._c is None
         assert (spl.c == [0, 0, 0, 0, 0, 0, 0, 0]).all()
         # test set
-        with pytest.raises(ValueError) as err:
+        MESSAGE = r"The model parameters must be initialized before setting coeffs."
+        with pytest.raises(ValueError, match=MESSAGE):
             spl.c = mk.MagicMock()
-        assert str(err.value) == "The model parameters must be initialized before setting coeffs."
 
         # with parameters
         spl = Spline1D(10)
@@ -735,12 +735,12 @@ class TestSpline1D:
         assert (spl.c == (np.arange(18) + 15)).all()
         assert (spl.c != np.zeros(18)).all()
         # set error
+        MESSAGE = r"There must be exactly as many coeffs as previously defined."
         for idx in range(30):
             if idx == 18:
                 continue
-            with pytest.raises(ValueError) as err:
+            with pytest.raises(ValueError, match=MESSAGE):
                 spl.c = np.arange(idx)
-            assert str(err.value) == "There must be exactly as many coeffs as previously defined."
 
     def test_degree(self):
         # default degree
@@ -824,9 +824,9 @@ class TestSpline1D:
         assert tck[2] == spl.degree
 
         # Error
-        with pytest.raises(ValueError) as err:
+        MESSAGE = r"tck has incompatible degree!"
+        with pytest.raises(ValueError, match=MESSAGE):
             spl.tck = (t, c, 4)
-        assert str(err.value) == "tck has incompatible degree!"
 
     def test_bspline(self):
         from scipy.interpolate import BSpline
@@ -980,20 +980,20 @@ class TestSpline1D:
             assert mkBspline.call_args_list == [mk.call()]
 
             # error
+            MESSAGE = r"Must have at least 8 knots."
             for num in range(8):
                 knots = np.random.random(num)
                 spl = Spline1D()
                 assert spl._t is None
-                with pytest.raises(ValueError) as err:
+                with pytest.raises(ValueError, match=MESSAGE):
                     spl._init_knots(knots, False, lower, upper)
-                assert str(err.value) == "Must have at least 8 knots."
 
         # Error
         spl = Spline1D()
         assert spl._t is None
-        with pytest.raises(ValueError) as err:
+        MESSAGE = r"Knots: 0.5 must be iterable or value"
+        with pytest.raises(ValueError, match=MESSAGE):
             spl._init_knots(0.5, False, lower, upper)
-        assert str(err.value) == "Knots: 0.5 must be iterable or value"
 
     def test__init_coeffs(self):
         np.random.seed(492)
@@ -1061,12 +1061,12 @@ class TestSpline1D:
                 assert mkEval.call_args_list == [mk.call(spl, *args, **kwargs)]
 
         # Error
+        MESSAGE = r"Cannot evaluate a derivative of order higher than 4"
         for idx in range(5, 8):
             with mk.patch.object(_Spline, 'evaluate', autospec=True,
                                  return_value={'nu': idx}):
-                with pytest.raises(RuntimeError) as err:
+                with pytest.raises(RuntimeError, match=MESSAGE):
                     spl.evaluate(*args, **kwargs)
-                assert str(err.value) == "Cannot evaluate a derivative of order higher than 4"
 
     def check_knots_created(self, spl, k):
         def value0(idx):
@@ -1250,9 +1250,9 @@ class TestSpline1D:
 
         # pass no knots
         spl = Spline1D(degree=k)
-        with pytest.raises(RuntimeError) as err:
+        MESSAGE = r"No knots have been provided"
+        with pytest.raises(RuntimeError, match=MESSAGE):
             fitter(spl, self.x, self.y, weights=w)
-        assert str(err.value) == "No knots have been provided"
 
     @pytest.mark.parametrize('w', wieght_tests)
     @pytest.mark.parametrize('k', degree_tests)
@@ -1421,10 +1421,10 @@ class TestSpline1D:
         assert_allclose(der.evaluate(self.xs, nu=1), spl.evaluate(self.xs, nu=4))
 
         # Too many derivatives
+        MESSAGE = r"Must have nu <= 3"
         for nu in range(4, 9):
-            with pytest.raises(ValueError) as err:
+            with pytest.raises(ValueError, match=MESSAGE):
                 spl.derivative(nu=nu)
-            assert str(err.value) == "Must have nu <= 3"
 
     def test_antiderivative(self):
         bspline = self.generate_spline()
@@ -1470,10 +1470,10 @@ class TestSpline1D:
 
         # Too many anti derivatives
         for nu in range(3, 9):
-            with pytest.raises(ValueError) as err:
+            MESSAGE = ("Supported splines can have max degree 5, "
+                       f"antiderivative degree will be {nu + 3}")
+            with pytest.raises(ValueError, match=MESSAGE):
                 spl.antiderivative(nu=nu)
-            assert str(err.value) == ("Supported splines can have max degree 5, "
-                                      f"antiderivative degree will be {nu + 3}")
 
     def test__SplineFitter_error(self):
         spl = Spline1D()
@@ -1484,14 +1484,14 @@ class TestSpline1D:
 
         fitter = SplineFitter()
 
-        with pytest.raises(ValueError) as err:
+        MESSAGE = r"1D model can only have 2 data points."
+        with pytest.raises(ValueError, match=MESSAGE):
             fitter(spl, mk.MagicMock(), mk.MagicMock(), mk.MagicMock())
-        assert str(err.value) == "1D model can only have 2 data points."
 
-        with pytest.raises(ModelDefinitionError) as err:
+        MESSAGE = r"Only spline models are compatible with this fitter."
+        with pytest.raises(ModelDefinitionError, match=MESSAGE):
             fitter(mk.MagicMock(), mk.MagicMock(), mk.MagicMock())
-        assert str(err.value) == "Only spline models are compatible with this fitter."
 
-        with pytest.raises(NotImplementedError) as err:
+        MESSAGE = r"This has not been implemented for _SplineFitter."
+        with pytest.raises(NotImplementedError, match=MESSAGE):
             fitter(spl, mk.MagicMock(), mk.MagicMock())
-        assert str(err.value) == "This has not been implemented for _SplineFitter."

--- a/astropy/modeling/tests/test_spline.py
+++ b/astropy/modeling/tests/test_spline.py
@@ -506,14 +506,14 @@ class TestSpline1D:
             Spline1D(knots=knots)
 
         # Not enough knots
-        MESSAGE = r"Must have at least 8 knots."
+        MESSAGE = r"Must have at least 8 knots"
         for idx in range(8):
             with pytest.raises(ValueError, match=MESSAGE):
                 Spline1D(knots=np.arange(idx))
 
         # Bad scipy spline
         t = np.arange(20)[::-1]
-        MESSAGE = r"Knots must be in a non-decreasing order."
+        MESSAGE = r"Knots must be in a non-decreasing order"
         with pytest.raises(ValueError, match=MESSAGE):
             Spline1D(knots=t)
 
@@ -689,7 +689,7 @@ class TestSpline1D:
         assert spl._t is None
         assert (spl.t == [0, 0, 0, 0, 1, 1, 1, 1]).all()
         # test set
-        MESSAGE = r"The model parameters must be initialized before setting knots."
+        MESSAGE = r"The model parameters must be initialized before setting knots"
         with pytest.raises(ValueError, match=MESSAGE):
             spl.t = mk.MagicMock()
 
@@ -706,7 +706,7 @@ class TestSpline1D:
         assert (spl.t == (np.arange(18) + 15)).all()
         assert (spl.t != t).all()
         # set error
-        MESSAGE = r"There must be exactly as many knots as previously defined."
+        MESSAGE = r"There must be exactly as many knots as previously defined"
         for idx in range(30):
             if idx == 18:
                 continue
@@ -720,7 +720,7 @@ class TestSpline1D:
         assert spl._c is None
         assert (spl.c == [0, 0, 0, 0, 0, 0, 0, 0]).all()
         # test set
-        MESSAGE = r"The model parameters must be initialized before setting coeffs."
+        MESSAGE = r"The model parameters must be initialized before setting coeffs"
         with pytest.raises(ValueError, match=MESSAGE):
             spl.c = mk.MagicMock()
 
@@ -735,7 +735,7 @@ class TestSpline1D:
         assert (spl.c == (np.arange(18) + 15)).all()
         assert (spl.c != np.zeros(18)).all()
         # set error
-        MESSAGE = r"There must be exactly as many coeffs as previously defined."
+        MESSAGE = r"There must be exactly as many coeffs as previously defined"
         for idx in range(30):
             if idx == 18:
                 continue
@@ -980,7 +980,7 @@ class TestSpline1D:
             assert mkBspline.call_args_list == [mk.call()]
 
             # error
-            MESSAGE = r"Must have at least 8 knots."
+            MESSAGE = r"Must have at least 8 knots"
             for num in range(8):
                 knots = np.random.random(num)
                 spl = Spline1D()
@@ -1470,8 +1470,7 @@ class TestSpline1D:
 
         # Too many anti derivatives
         for nu in range(3, 9):
-            MESSAGE = ("Supported splines can have max degree 5, "
-                       f"antiderivative degree will be {nu + 3}")
+            MESSAGE = f"Supported splines can have max degree 5, antiderivative degree will be {nu + 3}"
             with pytest.raises(ValueError, match=MESSAGE):
                 spl.antiderivative(nu=nu)
 
@@ -1484,14 +1483,14 @@ class TestSpline1D:
 
         fitter = SplineFitter()
 
-        MESSAGE = r"1D model can only have 2 data points."
+        MESSAGE = r"1D model can only have 2 data points"
         with pytest.raises(ValueError, match=MESSAGE):
             fitter(spl, mk.MagicMock(), mk.MagicMock(), mk.MagicMock())
 
-        MESSAGE = r"Only spline models are compatible with this fitter."
+        MESSAGE = r"Only spline models are compatible with this fitter"
         with pytest.raises(ModelDefinitionError, match=MESSAGE):
             fitter(mk.MagicMock(), mk.MagicMock(), mk.MagicMock())
 
-        MESSAGE = r"This has not been implemented for _SplineFitter."
+        MESSAGE = r"This has not been implemented for _SplineFitter"
         with pytest.raises(NotImplementedError, match=MESSAGE):
             fitter(spl, mk.MagicMock(), mk.MagicMock())

--- a/astropy/modeling/tests/test_statistics.py
+++ b/astropy/modeling/tests/test_statistics.py
@@ -86,5 +86,6 @@ class TestLeastSquare_ND:
         assert_almost_equal(lsq, self.lsq_exp)
 
     def test_shape_mismatch(self):
-        with pytest.raises(ValueError):
+        MESSAGE = r"Shape mismatch between model .* and measured .*"
+        with pytest.raises(ValueError, match=MESSAGE):
             leastsquare(0, self.model1D, None, self.x)

--- a/astropy/modeling/tests/test_utils.py
+++ b/astropy/modeling/tests/test_utils.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # pylint: disable=invalid-name
+import re
 from inspect import Parameter
 
 import numpy as np
@@ -17,18 +18,14 @@ def test_poly_map_domain():
 
     # errors
     MESSAGE = 'Expected "domain" and "window" to be a tuple of size 2.'
-    with pytest.raises(ValueError) as err:
+    with pytest.raises(ValueError, match=MESSAGE):
         poly_map_domain(oldx, (-4,), (-3, 3))
-    assert str(err.value) == MESSAGE
-    with pytest.raises(ValueError) as err:
+    with pytest.raises(ValueError, match=MESSAGE):
         poly_map_domain(oldx, (-4, 4, -4), (-3, 3))
-    assert str(err.value) == MESSAGE
-    with pytest.raises(ValueError) as err:
+    with pytest.raises(ValueError, match=MESSAGE):
         poly_map_domain(oldx, (-4, 4), (-3,))
-    assert str(err.value) == MESSAGE
-    with pytest.raises(ValueError) as err:
+    with pytest.raises(ValueError, match=MESSAGE):
         poly_map_domain(oldx, (-4, 4), (-3, 3, -3))
-    assert str(err.value) == MESSAGE
 
 
 def test__validate_domain_window():
@@ -42,21 +39,16 @@ def test__validate_domain_window():
 
     # Test error
     MESSAGE = 'domain and window should be tuples of size 2.'
-    with pytest.raises(ValueError) as err:
+    with pytest.raises(ValueError, match=MESSAGE):
         _validate_domain_window((-2, 2, -2))
-    assert str(err.value) == MESSAGE
-    with pytest.raises(ValueError) as err:
+    with pytest.raises(ValueError, match=MESSAGE):
         _validate_domain_window((-2,))
-    assert str(err.value) == MESSAGE
-    with pytest.raises(ValueError) as err:
+    with pytest.raises(ValueError, match=MESSAGE):
         _validate_domain_window([-2])
-    assert str(err.value) == MESSAGE
-    with pytest.raises(ValueError) as err:
+    with pytest.raises(ValueError, match=MESSAGE):
         _validate_domain_window(np.array([-2]))
-    assert str(err.value) == MESSAGE
-    with pytest.raises(ValueError) as err:
+    with pytest.raises(ValueError, match=MESSAGE):
         _validate_domain_window(-2)
-    assert str(err.value) == MESSAGE
 
 
 def test_get_inputs_and_params():
@@ -78,7 +70,7 @@ def test_get_inputs_and_params():
         assert param.default == default[index]
 
     # Error
-    MESSAGE = "Signature must not have *args or **kwargs"
+    MESSAGE = re.escape("Signature must not have *args or **kwargs")
 
     def func2(input0, input1, *args, param0=5, param1=7):
         pass
@@ -86,12 +78,10 @@ def test_get_inputs_and_params():
     def func3(input0, input1, param0=5, param1=7, **kwargs):
         pass
 
-    with pytest.raises(ValueError) as err:
+    with pytest.raises(ValueError, match=MESSAGE):
         get_inputs_and_params(func2)
-    assert str(err.value) == MESSAGE
-    with pytest.raises(ValueError) as err:
+    with pytest.raises(ValueError, match=MESSAGE):
         get_inputs_and_params(func3)
-    assert str(err.value) == MESSAGE
 
 
 class Test_SpecialOperatorsDict:

--- a/astropy/modeling/tests/test_utils.py
+++ b/astropy/modeling/tests/test_utils.py
@@ -17,7 +17,7 @@ def test_poly_map_domain():
     assert (poly_map_domain(oldx, (-4, 4), (-3, 3)) == [0.75, 1.5, 2.25, 3]).all()
 
     # errors
-    MESSAGE = 'Expected "domain" and "window" to be a tuple of size 2.'
+    MESSAGE = r'Expected "domain" and "window" to be a tuple of size 2'
     with pytest.raises(ValueError, match=MESSAGE):
         poly_map_domain(oldx, (-4,), (-3, 3))
     with pytest.raises(ValueError, match=MESSAGE):
@@ -38,7 +38,7 @@ def test__validate_domain_window():
     assert _validate_domain_window(np.array([-2, 2])) == (-2, 2)
 
     # Test error
-    MESSAGE = 'domain and window should be tuples of size 2.'
+    MESSAGE = r'domain and window should be tuples of size 2'
     with pytest.raises(ValueError, match=MESSAGE):
         _validate_domain_window((-2, 2, -2))
     with pytest.raises(ValueError, match=MESSAGE):


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

Updates `modeling` to use `match` in `pytest.raises`. This was inspired by #13905 doing the same for `nddata`.

In addition it added message matching for error testing which where missing previously.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
