### PR TITLE
Ensure that angle.to_string() continues to work after pickling

### DIFF
--- a/astropy/coordinates/angles.py
+++ b/astropy/coordinates/angles.py
@@ -157,7 +157,7 @@ class Angle(u.SpecificTypeQuantity):
 
     @staticmethod
     def _convert_unit_to_angle_unit(unit):
-        return u.hourangle if unit is u.hour else unit
+        return u.hourangle if unit == u.hour else unit
 
     def _set_unit(self, unit):
         super()._set_unit(self._convert_unit_to_angle_unit(unit))
@@ -297,7 +297,7 @@ class Angle(u.SpecificTypeQuantity):
 
         # Create an iterator so we can format each element of what
         # might be an array.
-        if unit is u.degree:
+        if unit == u.degree:
             if decimal:
                 values = self.degree
                 if precision is not None:
@@ -312,7 +312,7 @@ class Angle(u.SpecificTypeQuantity):
                     x, precision=precision, sep=sep, pad=pad,
                     fields=fields)
 
-        elif unit is u.hourangle:
+        elif unit == u.hourangle:
             if decimal:
                 values = self.hour
                 if precision is not None:
@@ -581,6 +581,8 @@ class Latitude(Angle):
         if angles is None:
             angles = self
 
+        # For speed, compare using "is", which is not strictly guaranteed to hold,
+        # but if it doesn't we'll just convert correctly in the 'else' clause.
         if angles.unit is u.deg:
             limit = 90
         elif angles.unit is u.rad:

--- a/astropy/coordinates/angles.py
+++ b/astropy/coordinates/angles.py
@@ -5,6 +5,7 @@ This module contains the fundamental classes used for representing
 coordinates in astropy.
 """
 
+import functools
 from collections import namedtuple
 
 import numpy as np
@@ -211,8 +212,10 @@ class Angle(u.SpecificTypeQuantity):
             used.
 
         decimal : bool, optional
-            If `True`, a decimal representation will be used, otherwise
-            the returned string will be in sexagesimal form.
+            If `False`, the returned string will be in sexagesimal form
+            if possible (for units of degrees or hourangle).  If `True`,
+            a decimal representation will be used. In that case, no unit
+            will be appended if ``format`` is not explicitly given.
 
         sep : str, optional
             The separator between numbers in a sexagesimal
@@ -274,7 +277,7 @@ class Angle(u.SpecificTypeQuantity):
             unit = self._convert_unit_to_angle_unit(u.Unit(unit))
 
         separators = {
-            None: {
+            'generic': {
                 u.degree: 'dms',
                 u.hourangle: 'hms'},
             'latex': {
@@ -287,75 +290,31 @@ class Angle(u.SpecificTypeQuantity):
         # 'latex_inline' provides no functionality beyond what 'latex' offers,
         # but it should be implemented to avoid ValueErrors in user code.
         separators['latex_inline'] = separators['latex']
-
-        if sep == 'fromunit':
-            if format not in separators:
-                raise ValueError(f"Unknown format '{format}'")
-            seps = separators[format]
-            if unit in seps:
-                sep = seps[unit]
+        # Default separators are as for generic.
+        separators[None] = separators['generic']
 
         # Create an iterator so we can format each element of what
         # might be an array.
-        if unit == u.degree:
-            if decimal:
-                values = self.degree
-                if precision is not None:
-                    func = ("{0:0." + str(precision) + "f}").format
-                else:
-                    func = '{:g}'.format
-            else:
-                if sep == 'fromunit':
-                    sep = 'dms'
-                values = self.degree
-                func = lambda x: form.degrees_to_string(
-                    x, precision=precision, sep=sep, pad=pad,
-                    fields=fields)
-
-        elif unit == u.hourangle:
-            if decimal:
-                values = self.hour
-                if precision is not None:
-                    func = ("{0:0." + str(precision) + "f}").format
-                else:
-                    func = '{:g}'.format
-            else:
-                if sep == 'fromunit':
-                    sep = 'hms'
-                values = self.hour
-                func = lambda x: form.hours_to_string(
-                    x, precision=precision, sep=sep, pad=pad,
-                    fields=fields)
-
-        elif unit.is_equivalent(u.radian):
-            if decimal:
-                values = self.to_value(unit)
-                if precision is not None:
-                    func = ("{0:1." + str(precision) + "f}").format
-                else:
-                    func = "{:g}".format
-            elif sep == 'fromunit':
-                values = self.to_value(unit)
+        if not decimal and (unit_is_deg := unit == u.degree
+                            or unit == u.hourangle):
+            # Sexagesimal.
+            if sep == 'fromunit':
+                if format not in separators:
+                    raise ValueError(f"Unknown format '{format}'")
+                sep = separators[format][unit]
+            func = functools.partial(
+                form.degrees_to_string if unit_is_deg else form.hours_to_string,
+                precision=precision, sep=sep, pad=pad, fields=fields)
+        else:
+            if sep != 'fromunit':
+                raise ValueError(f"'{unit}' can not be represented in sexagesimal notation")
+            func = ("{:g}" if precision is None else f"{{0:0.{precision}f}}").format
+            if not (decimal and format is None):  # Don't add unit by default for decimal.
                 unit_string = unit.to_string(format=format)
                 if format == 'latex' or format == 'latex_inline':
                     unit_string = unit_string[1:-1]
-
-                if precision is not None:
-                    def plain_unit_format(val):
-                        return ("{0:0." + str(precision) + "f}{1}").format(
-                            val, unit_string)
-                    func = plain_unit_format
-                else:
-                    def plain_unit_format(val):
-                        return f"{val:g}{unit_string}"
-                    func = plain_unit_format
-            else:
-                raise ValueError(
-                    f"'{unit.name}' can not be represented in sexagesimal notation")
-
-        else:
-            raise u.UnitsError(
-                "The unit value provided is not an angular unit.")
+                format_func = func
+                func = lambda x: format_func(x) + unit_string
 
         def do_format(val):
             # Check if value is not nan to avoid ValueErrors when turning it into
@@ -370,6 +329,7 @@ class Angle(u.SpecificTypeQuantity):
             s = f"{val}"
             return s
 
+        values = self.to_value(unit)
         format_ufunc = np.vectorize(do_format, otypes=['U'])
         result = format_ufunc(values)
 

--- a/astropy/coordinates/tests/test_angles.py
+++ b/astropy/coordinates/tests/test_angles.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Test initialization and other aspects of Angle and subclasses"""
 
+import pickle
 import threading
 
 import numpy as np
@@ -77,6 +78,7 @@ def test_create_angles():
     a22 = Angle("3.6h", unit=u.hour)
     a23 = Angle("- 3h", unit=u.hour)
     a24 = Angle("+ 3h", unit=u.hour)
+    a25 = Angle(3., unit=u.hour**1)
 
     # ensure the above angles that should match do
     assert a1 == a2 == a3 == a4 == a5 == a6 == a8 == a18 == a19 == a20
@@ -90,6 +92,7 @@ def test_create_angles():
     assert a11 == a12 == a13 == a14
     assert a21 == a22
     assert a23 == -a24
+    assert a24 == a25
 
     # check for illegal ranges / values
     with pytest.raises(IllegalSecondError):
@@ -352,6 +355,9 @@ def test_angle_formatting():
     assert angle.to_string(unit=u.hour) == '-0h04m56.2962936s'
     assert angle2.to_string(unit=u.hour, pad=True) == '-01h14m04.444404s'
     assert angle.to_string(unit=u.radian, decimal=True) == '-0.0215473'
+
+    # We should recognize units that are equal but not identical
+    assert angle.to_string(unit=u.hour**1) == '-0h04m56.2962936s'
 
 
 def test_to_string_vector():
@@ -1142,3 +1148,16 @@ def test_latitude_out_of_limits(value, dtype):
     """
     with pytest.raises(ValueError, match=r"Latitude angle\(s\) must be within.*"):
         Latitude(value, u.rad, dtype=dtype)
+
+
+def test_angle_pickle_to_string():
+    """
+    Ensure that after pickling we can still do to_string on hourangle.
+
+    Regression test for gh-13923.
+    """
+    angle = Angle(0.25 * u.hourangle)
+    expected = angle.to_string()
+    via_pickle = pickle.loads(pickle.dumps(angle))
+    via_pickle_string = via_pickle.to_string()  # This used to fail.
+    assert via_pickle_string == expected

--- a/astropy/coordinates/tests/test_formatting.py
+++ b/astropy/coordinates/tests/test_formatting.py
@@ -2,7 +2,7 @@
 Tests the Angle string formatting capabilities.  SkyCoord formatting is in
 test_sky_coord
 """
-
+import pytest
 
 from astropy import units as u
 from astropy.coordinates.angles import Angle
@@ -56,6 +56,9 @@ def test_to_string_decimal():
     assert angle3.to_string(decimal=True, precision=1) == '4.0'
     assert angle3.to_string(decimal=True, precision=0) == '4'
 
+    with pytest.raises(ValueError, match='sexagesimal notation'):
+        angle3.to_string(decimal=True, sep='abc')
+
 
 def test_to_string_formats():
     a = Angle(1.113355, unit=u.deg)
@@ -74,6 +77,28 @@ def test_to_string_formats():
     assert a.to_string(format='latex') == r'$1.11336\mathrm{rad}$'
     assert a.to_string(format='latex_inline') == r'$1.11336\mathrm{rad}$'
     assert a.to_string(format='unicode') == '1.11336rad'
+
+
+def test_to_string_decimal_formats():
+    angle1 = Angle(2., unit=u.degree)
+
+    assert angle1.to_string(decimal=True, format='generic') == '2deg'
+    assert angle1.to_string(decimal=True, format='latex') == '$2\\mathrm{{}^{\\circ}}$'
+    assert angle1.to_string(decimal=True, format='unicode') == '2°'
+
+    angle2 = Angle(3., unit=u.hourangle)
+    assert angle2.to_string(decimal=True, format='generic') == '3hourangle'
+    assert angle2.to_string(decimal=True, format='latex') == '$3\\mathrm{{}^{h}}$'
+    assert angle2.to_string(decimal=True, format='unicode') == '3ʰ'
+
+    angle3 = Angle(4., unit=u.radian)
+
+    assert angle3.to_string(decimal=True, format='generic') == '4rad'
+    assert angle3.to_string(decimal=True, format='latex') == '$4\\mathrm{rad}$'
+    assert angle3.to_string(decimal=True, format='unicode') == '4rad'
+
+    with pytest.raises(ValueError, match='Unknown format'):
+        angle3.to_string(decimal=True, format='myformat')
 
 
 def test_to_string_fields():

--- a/astropy/visualization/wcsaxes/formatter_locator.py
+++ b/astropy/visualization/wcsaxes/formatter_locator.py
@@ -394,14 +394,7 @@ class AngleFormatterLocator(BaseFormatterLocator):
             is_latex = format == 'latex' or (format == 'auto' and rcParams['text.usetex'])
 
             if decimal:
-                # At the moment, the Angle class doesn't have a consistent way
-                # to always convert angles to strings in decimal form with
-                # symbols for units (instead of e.g 3arcsec). So as a workaround
-                # we take advantage of the fact that Angle.to_string converts
-                # the unit to a string manually when decimal=False and the unit
-                # is not strictly u.degree or u.hourangle
                 if self.show_decimal_unit:
-                    decimal = False
                     sep = 'fromunit'
                     if is_latex:
                         fmt = 'latex'
@@ -409,10 +402,10 @@ class AngleFormatterLocator(BaseFormatterLocator):
                         if unit is u.hourangle:
                             fmt = 'unicode'
                         else:
-                            fmt = None
+                            fmt = 'generic'
                     unit = CUSTOM_UNITS.get(unit, unit)
                 else:
-                    sep = None
+                    sep = 'fromunit'
                     fmt = None
             elif self.sep is not None:
                 sep = self.sep

--- a/docs/changes/coordinates/13933.bugfix.rst
+++ b/docs/changes/coordinates/13933.bugfix.rst
@@ -1,0 +1,4 @@
+Ensure that ``angle.to_string()`` continues to work after pickling,
+and that units passed on to ``to_string()`` or the ``Angle``
+initializer can be composite units (like ``u.hour**1``), which might
+result from preceding calculations.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address that after pickling `angle.to_string()` did not work any more. In the process, it also ensures that composite units like `u.deg ** 1` are valid as well.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #13923

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
