### PR TITLE
Update the docs for black

### DIFF
--- a/docs/development/codeguide.rst
+++ b/docs/development/codeguide.rst
@@ -135,8 +135,17 @@ Coding Style/Conventions
   <https://www.python.org/dev/peps/pep-0008/>`_. In particular, this includes
   using only 4 spaces for indentation, and never tabs.
 
+  * ``astropy`` itself enforces this style guide using the
+    `black <https://black.readthedocs.io/en/stable/>`_ code formatter.
+
+  * We recognize that sometimes ``black`` will autoformat things in undesirable
+    ways e.g. matricies.  In the cases that ``black`` produces undesirable code
+    formatting, one can wrap code the code in ``# fmt: off`` and ``# fmt: on``
+    to disable ``black`` formatting. This should be done sparingly, and only
+    when ``black`` produces undesirable formatting.
+
 * Our testing infrastructure currently enforces a subset of the PEP8 style
-  guide, and some sub-packages enforce stronger styling checks such as using
+  guide. In addition these checks also enforce
   `isort <https://pycqa.github.io/isort/>`_ to sort the module imports.
 
   * We provide a ``pre-commit`` hook which automatically enforces and fixes
@@ -147,15 +156,6 @@ Coding Style/Conventions
     following `tox <https://tox.readthedocs.io/>`__ command::
 
       tox -e codestyle
-
-* *Follow the existing coding style* within a subpackage and avoid making
-  changes that are purely stylistic.  In particular, there is variation in the
-  maximum line length for different subpackages (typically either 80 or 100
-  characters).  Please try to maintain the style when adding or modifying code.
-
-* The use of automatic code formatters (e.g.,
-  `Black <https://black.readthedocs.io/en/stable/>`_) is strongly discouraged in
-  contributions to Astropy.
 
 * Following PEP8's recommendation, absolute imports are to be used in general.
   The exception to this is relative imports of the form

--- a/docs/development/codeguide.rst
+++ b/docs/development/codeguide.rst
@@ -139,13 +139,13 @@ Coding Style/Conventions
     `black <https://black.readthedocs.io/en/stable/>`_ code formatter.
 
   * We recognize that sometimes ``black`` will autoformat things in undesirable
-    ways e.g. matricies.  In the cases that ``black`` produces undesirable code
+    ways, e.g., matrices.  In the cases that ``black`` produces undesirable code
     formatting, one can wrap code the code in ``# fmt: off`` and ``# fmt: on``
     to disable ``black`` formatting. This should be done sparingly, and only
     when ``black`` produces undesirable formatting.
 
 * Our testing infrastructure currently enforces a subset of the PEP8 style
-  guide. In addition these checks also enforce
+  guide. In addition, these checks also enforce
   `isort <https://pycqa.github.io/isort/>`_ to sort the module imports.
 
   * We provide a ``pre-commit`` hook which automatically enforces and fixes

--- a/docs/development/codeguide.rst
+++ b/docs/development/codeguide.rst
@@ -140,8 +140,15 @@ Coding Style/Conventions
 
   * We recognize that sometimes ``black`` will autoformat things in undesirable
     ways, e.g., matrices.  In the cases that ``black`` produces undesirable code
-    formatting, one can wrap code the code in ``# fmt: off`` and ``# fmt: on``
-    to disable ``black`` formatting. This should be done sparingly, and only
+    formatting:
+
+      * one can wrap code the code in ``# fmt: off`` and ``# fmt: on`` to disable
+        ``black`` formatting over multiple lines.
+
+      * or one can add a single ``# fmt: skip`` comment to the end of a line to
+        disable ``black`` formatting for that line.
+
+    This should be done sparingly, and only
     when ``black`` produces undesirable formatting.
 
 * Our testing infrastructure currently enforces a subset of the PEP8 style


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This PR updates the developer guide to detail the usage of `black`.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Resolves #13948

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
