### PR TITLE
Apply `black` to `astropy.time`

### DIFF
--- a/astropy/time/__init__.py
+++ b/astropy/time/__init__.py
@@ -8,12 +8,13 @@ class Conf(_config.ConfigNamespace):
     """
 
     use_fast_parser = _config.ConfigItem(
-        ['True', 'False', 'force'],
+        ["True", "False", "force"],
         "Use fast C parser for supported time strings formats, including ISO, "
         "ISOT, and YearDayTime. Allowed values are the 'False' (use Python parser),"
         "'True' (use C parser and fall through to Python parser if fails), and "
         "'force' (use C parser and raise exception if it fails). Note that the"
-        "options are all strings.")
+        "options are all strings.",
+    )
 
 
 conf = Conf()
@@ -21,4 +22,5 @@ conf = Conf()
 # isort: off
 from .formats import *
 from .core import *
+
 # isort: on

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -524,9 +524,8 @@ class TimeBase(ShapedLikeNDArray):
         if scale is not None:
             if not (isinstance(scale, str) and scale.lower() in self.SCALES):
                 raise ScaleValueError(
-                    "Scale {!r} is not in the allowed scales {}".format(
-                        scale, sorted(self.SCALES)
-                    )
+                    f"Scale {scale!r} is not in the allowed scales "
+                    f"{sorted(self.SCALES)}"
                 )
 
         # If either of the input val, val2 are masked arrays then
@@ -587,9 +586,8 @@ class TimeBase(ShapedLikeNDArray):
                 )
             else:
                 raise ValueError(
-                    "Format {!r} is not one of the allowed formats {}".format(
-                        format, sorted(self.FORMATS)
-                    )
+                    f"Format {format!r} is not one of the allowed formats "
+                    f"{sorted(self.FORMATS)}"
                 )
         else:
             formats = [(format, self.FORMATS[format])]
@@ -615,9 +613,8 @@ class TimeBase(ShapedLikeNDArray):
                     problems[name] = err
         else:
             raise ValueError(
-                "Input values did not match any of the formats "
-                "where the format keyword is optional: "
-                f"{problems}"
+                "Input values did not match any of the formats where the format "
+                f"keyword is optional: {problems}"
             ) from problems[formats[0][0]]
 
     @property
@@ -736,9 +733,7 @@ class TimeBase(ShapedLikeNDArray):
             return
         if scale not in self.SCALES:
             raise ValueError(
-                "Scale {!r} is not in the allowed scales {}".format(
-                    scale, sorted(self.SCALES)
-                )
+                f"Scale {scale!r} is not in the allowed scales {sorted(self.SCALES)}"
             )
 
         if scale == "utc" or self.scale == "utc":
@@ -1073,9 +1068,7 @@ class TimeBase(ShapedLikeNDArray):
 
         if abs(idx0) > len(self):
             raise IndexError(
-                "index {} is out of bounds for axis 0 with size {}".format(
-                    idx0, len(self)
-                )
+                f"index {idx0} is out of bounds for axis 0 with size {len(self)}"
             )
 
         # Turn negative index into positive
@@ -1109,10 +1102,8 @@ class TimeBase(ShapedLikeNDArray):
         if not self.writeable:
             if self.shape:
                 raise ValueError(
-                    "{} object is read-only. Make a "
-                    'copy() or set "writeable" attribute to True.'.format(
-                        self.__class__.__name__
-                    )
+                    f"{self.__class__.__name__} object is read-only. Make a "
+                    'copy() or set "writeable" attribute to True.'
                 )
             else:
                 raise ValueError(
@@ -1659,9 +1650,8 @@ class TimeBase(ShapedLikeNDArray):
                 )
             else:
                 raise ScaleValueError(
-                    "Cannot convert {} with scale '{}' to scale '{}'".format(
-                        self.__class__.__name__, self.scale, attr
-                    )
+                    f"Cannot convert {self.__class__.__name__} with scale "
+                    f"'{self.scale}' to scale '{attr}'"
                 )
 
         else:
@@ -1683,9 +1673,8 @@ class TimeBase(ShapedLikeNDArray):
                 val = np.broadcast_to(val, self.shape, subok=True)
             except Exception:
                 raise ValueError(
-                    "Attribute shape must match or be "
-                    "broadcastable to that of Time object. "
-                    "Typically, give either a single value or "
+                    "Attribute shape must match or be broadcastable to that of "
+                    "Time object. Typically, give either a single value or "
                     "one for each time."
                 )
 
@@ -1711,9 +1700,8 @@ class TimeBase(ShapedLikeNDArray):
             # Other will also not be able to do it, so raise a TypeError
             # immediately, allowing us to explain why it doesn't work.
             raise TypeError(
-                "Cannot compare {} instances with scales '{}' and '{}'".format(
-                    self.__class__.__name__, self.scale, other.scale
-                )
+                f"Cannot compare {self.__class__.__name__} instances with "
+                f"scales '{self.scale}' and '{other.scale}'"
             )
 
         if self.scale is not None and other.scale is not None:
@@ -1875,10 +1863,9 @@ class Time(TimeBase):
                 self.location = np.broadcast_to(self.location, self.shape, subok=True)
             except Exception as err:
                 raise ValueError(
-                    "The location with shape {} cannot be "
-                    "broadcast against time with shape {}. "
-                    "Typically, either give a single location or "
-                    "one for each time.".format(self.location.shape, self.shape)
+                    f"The location with shape {self.location.shape} cannot be "
+                    f"broadcast against time with shape {self.shape}. "
+                    "Typically, either give a single location or one for each time."
                 ) from err
 
     def _make_value_equivalent(self, item, value):
@@ -1904,9 +1891,8 @@ class Time(TimeBase):
                 match = np.all(self_location == value.location)
             if not match:
                 raise ValueError(
-                    "cannot set to Time with different location: "
-                    "expected location={} and "
-                    "got location={}".format(self_location, value.location)
+                    "cannot set to Time with different location: expected "
+                    f"location={self_location} and got location={value.location}"
                 )
         else:
             try:
@@ -1921,9 +1907,7 @@ class Time(TimeBase):
                     )
                 except Exception as err:
                     raise ValueError(
-                        "cannot convert value to a compatible Time object: {}".format(
-                            err
-                        )
+                        f"cannot convert value to a compatible Time object: {err}"
                     )
         return value
 
@@ -1980,11 +1964,10 @@ class Time(TimeBase):
         time_array = np.asarray(time_string)
 
         if time_array.dtype.kind not in ("U", "S"):
-            err = (
-                "Expected type is string, a bytes-like object or a sequence"
-                " of these. Got dtype '{}'".format(time_array.dtype.kind)
+            raise TypeError(
+                "Expected type is string, a bytes-like object or a sequence "
+                f"of these. Got dtype '{time_array.dtype.kind}'"
             )
-            raise TypeError(err)
 
         to_string = (
             str
@@ -2100,9 +2083,8 @@ class Time(TimeBase):
         if location is None:
             if self.location is None:
                 raise ValueError(
-                    "An EarthLocation needs to be set or passed "
-                    "in to calculate bary- or heliocentric "
-                    "corrections"
+                    "An EarthLocation needs to be set or passed in to calculate bary- "
+                    "or heliocentric corrections"
                 )
             location = self.location
 
@@ -2260,23 +2242,20 @@ class Time(TimeBase):
 
         """  # noqa: E501 (docstring is formatted below)
 
-        if kind.lower() not in SIDEREAL_TIME_MODELS.keys():
+        if kind.lower() not in SIDEREAL_TIME_MODELS:
             raise ValueError(
-                "The kind of sidereal time has to be {}".format(
-                    " or ".join(sorted(SIDEREAL_TIME_MODELS.keys()))
-                )
+                "The kind of sidereal time has to be "
+                + " or ".join(sorted(SIDEREAL_TIME_MODELS))
             )
 
         available_models = SIDEREAL_TIME_MODELS[kind.lower()]
 
         if model is None:
-            model = sorted(available_models.keys())[-1]
+            model = sorted(available_models)[-1]
         elif model.upper() not in available_models:
             raise ValueError(
-                "Model {} not implemented for {} sidereal time; "
-                "available models are {}".format(
-                    model, kind, sorted(available_models.keys())
-                )
+                f"Model {model} not implemented for {kind} sidereal time; "
+                f"available models are {sorted(available_models)}"
             )
 
         model_kwargs = available_models[model.upper()]
@@ -2291,9 +2270,9 @@ class Time(TimeBase):
     if isinstance(sidereal_time.__doc__, str):
         sidereal_time.__doc__ = sidereal_time.__doc__.format(
             "apparent",
-            sorted(SIDEREAL_TIME_MODELS["apparent"].keys()),
+            sorted(SIDEREAL_TIME_MODELS["apparent"]),
             "mean",
-            sorted(SIDEREAL_TIME_MODELS["mean"].keys()),
+            sorted(SIDEREAL_TIME_MODELS["mean"]),
         )
 
     def _sid_time_or_earth_rot_ang(self, longitude, function, scales, include_tio=True):
@@ -2480,9 +2459,8 @@ class Time(TimeBase):
             if jd1 is None or jd2 is None:
                 if self.scale not in ("tt", "tdb"):
                     raise ValueError(
-                        "Accessing the delta_tdb_tt attribute "
-                        "is only possible for TT or TDB time "
-                        "scales"
+                        "Accessing the delta_tdb_tt attribute is only "
+                        "possible for TT or TDB time scales"
                     )
                 else:
                     jd1 = self._time.jd1
@@ -2554,7 +2532,7 @@ class Time(TimeBase):
                     if self.scale not in TIME_TYPES[other.scale]:
                         raise TypeError(
                             "Cannot subtract Time and TimeDelta instances "
-                            "with scales '{}' and '{}'".format(self.scale, other.scale)
+                            f"with scales '{self.scale}' and '{other.scale}'"
                         )
                     out._set_scale(other.scale)
             # remove attributes that are invalidated by changing time
@@ -2566,9 +2544,8 @@ class Time(TimeBase):
             # the scales should be compatible (e.g., cannot convert TDB to LOCAL)
             if other.scale not in self.SCALES:
                 raise TypeError(
-                    "Cannot subtract Time instances with scales '{}' and '{}'".format(
-                        self.scale, other.scale
-                    )
+                    "Cannot subtract Time instances "
+                    f"with scales '{self.scale}' and '{other.scale}'"
                 )
             self_time = (
                 self._time if self.scale in TIME_DELTA_SCALES else self.tai._time
@@ -2619,7 +2596,7 @@ class Time(TimeBase):
                 if self.scale not in TIME_TYPES[other.scale]:
                     raise TypeError(
                         "Cannot add Time and TimeDelta instances "
-                        "with scales '{}' and '{}'".format(self.scale, other.scale)
+                        f"with scales '{self.scale}' and '{other.scale}'"
                     )
                 out._set_scale(other.scale)
         # remove attributes that are invalidated by changing time
@@ -2848,9 +2825,7 @@ class TimeDelta(TimeBase):
             return
         if scale not in self.SCALES:
             raise ValueError(
-                "Scale {!r} is not in the allowed scales {}".format(
-                    scale, sorted(self.SCALES)
-                )
+                "Scale {scale!r} is not in the allowed scales {sorted(self.SCALES)}"
             )
 
         # For TimeDelta, there can only be a change in scale factor,
@@ -3128,9 +3103,7 @@ class TimeDelta(TimeBase):
             except ValueError as exc:
                 raise ValueError(
                     "first argument is not one of the known "
-                    "formats ({}) and failed to parse as a unit.".format(
-                        list(self.FORMATS)
-                    )
+                    f"formats ({list(self.FORMATS)}) and failed to parse as a unit."
                 ) from exc
             args = (unit,) + args[1:]
 
@@ -3145,9 +3118,7 @@ class TimeDelta(TimeBase):
                 value = self.__class__(value, scale=self.scale, format=self.format)
             except Exception as err:
                 raise ValueError(
-                    "cannot convert value to a compatible TimeDelta object: {}".format(
-                        err
-                    )
+                    f"cannot convert value to a compatible TimeDelta object: {err}"
                 )
         return value
 

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -40,38 +40,61 @@ from .formats import (
 from .time_helper.function_helpers import CUSTOM_FUNCTIONS, UNSUPPORTED_FUNCTIONS
 from .utils import day_frac
 
-__all__ = ['TimeBase', 'Time', 'TimeDelta', 'TimeInfo', 'TimeInfoBase', 'update_leap_seconds',
-           'TIME_SCALES', 'STANDARD_TIME_SCALES', 'TIME_DELTA_SCALES',
-           'ScaleValueError', 'OperandTypeError', 'TimeDeltaMissingUnitWarning']
+__all__ = [
+    "TimeBase",
+    "Time",
+    "TimeDelta",
+    "TimeInfo",
+    "TimeInfoBase",
+    "update_leap_seconds",
+    "TIME_SCALES",
+    "STANDARD_TIME_SCALES",
+    "TIME_DELTA_SCALES",
+    "ScaleValueError",
+    "OperandTypeError",
+    "TimeDeltaMissingUnitWarning",
+]
 
 
-STANDARD_TIME_SCALES = ('tai', 'tcb', 'tcg', 'tdb', 'tt', 'ut1', 'utc')
-LOCAL_SCALES = ('local',)
-TIME_TYPES = {scale: scales for scales in (STANDARD_TIME_SCALES, LOCAL_SCALES) for scale in scales}
+STANDARD_TIME_SCALES = ("tai", "tcb", "tcg", "tdb", "tt", "ut1", "utc")
+LOCAL_SCALES = ("local",)
+TIME_TYPES = {
+    scale: scales for scales in (STANDARD_TIME_SCALES, LOCAL_SCALES) for scale in scales
+}
 TIME_SCALES = STANDARD_TIME_SCALES + LOCAL_SCALES
-MULTI_HOPS = {('tai', 'tcb'): ('tt', 'tdb'),
-              ('tai', 'tcg'): ('tt',),
-              ('tai', 'ut1'): ('utc',),
-              ('tai', 'tdb'): ('tt',),
-              ('tcb', 'tcg'): ('tdb', 'tt'),
-              ('tcb', 'tt'): ('tdb',),
-              ('tcb', 'ut1'): ('tdb', 'tt', 'tai', 'utc'),
-              ('tcb', 'utc'): ('tdb', 'tt', 'tai'),
-              ('tcg', 'tdb'): ('tt',),
-              ('tcg', 'ut1'): ('tt', 'tai', 'utc'),
-              ('tcg', 'utc'): ('tt', 'tai'),
-              ('tdb', 'ut1'): ('tt', 'tai', 'utc'),
-              ('tdb', 'utc'): ('tt', 'tai'),
-              ('tt', 'ut1'): ('tai', 'utc'),
-              ('tt', 'utc'): ('tai',),
-              }
-GEOCENTRIC_SCALES = ('tai', 'tt', 'tcg')
-BARYCENTRIC_SCALES = ('tcb', 'tdb')
-ROTATIONAL_SCALES = ('ut1',)
-TIME_DELTA_TYPES = {scale: scales
-                    for scales in (GEOCENTRIC_SCALES, BARYCENTRIC_SCALES,
-                                   ROTATIONAL_SCALES, LOCAL_SCALES) for scale in scales}
-TIME_DELTA_SCALES = GEOCENTRIC_SCALES + BARYCENTRIC_SCALES + ROTATIONAL_SCALES + LOCAL_SCALES
+MULTI_HOPS = {
+    ("tai", "tcb"): ("tt", "tdb"),
+    ("tai", "tcg"): ("tt",),
+    ("tai", "ut1"): ("utc",),
+    ("tai", "tdb"): ("tt",),
+    ("tcb", "tcg"): ("tdb", "tt"),
+    ("tcb", "tt"): ("tdb",),
+    ("tcb", "ut1"): ("tdb", "tt", "tai", "utc"),
+    ("tcb", "utc"): ("tdb", "tt", "tai"),
+    ("tcg", "tdb"): ("tt",),
+    ("tcg", "ut1"): ("tt", "tai", "utc"),
+    ("tcg", "utc"): ("tt", "tai"),
+    ("tdb", "ut1"): ("tt", "tai", "utc"),
+    ("tdb", "utc"): ("tt", "tai"),
+    ("tt", "ut1"): ("tai", "utc"),
+    ("tt", "utc"): ("tai",),
+}
+GEOCENTRIC_SCALES = ("tai", "tt", "tcg")
+BARYCENTRIC_SCALES = ("tcb", "tdb")
+ROTATIONAL_SCALES = ("ut1",)
+TIME_DELTA_TYPES = {
+    scale: scales
+    for scales in (
+        GEOCENTRIC_SCALES,
+        BARYCENTRIC_SCALES,
+        ROTATIONAL_SCALES,
+        LOCAL_SCALES,
+    )
+    for scale in scales
+}
+TIME_DELTA_SCALES = (
+    GEOCENTRIC_SCALES + BARYCENTRIC_SCALES + ROTATIONAL_SCALES + LOCAL_SCALES
+)
 # For time scale changes, we need L_G and L_B, which are stored in erfam.h as
 #   /* L_G = 1 - d(TT)/d(TCG) */
 #   define ERFA_ELG (6.969290134e-10)
@@ -81,34 +104,37 @@ TIME_DELTA_SCALES = GEOCENTRIC_SCALES + BARYCENTRIC_SCALES + ROTATIONAL_SCALES +
 # Implied: d(TT)/d(TCG) = 1-L_G
 # and      d(TCG)/d(TT) = 1/(1-L_G) = 1 + (1-(1-L_G))/(1-L_G) = 1 + L_G/(1-L_G)
 # scale offsets as second = first + first * scale_offset[(first,second)]
-SCALE_OFFSETS = {('tt', 'tai'): None,
-                 ('tai', 'tt'): None,
-                 ('tcg', 'tt'): -erfa.ELG,
-                 ('tt', 'tcg'): erfa.ELG / (1. - erfa.ELG),
-                 ('tcg', 'tai'): -erfa.ELG,
-                 ('tai', 'tcg'): erfa.ELG / (1. - erfa.ELG),
-                 ('tcb', 'tdb'): -erfa.ELB,
-                 ('tdb', 'tcb'): erfa.ELB / (1. - erfa.ELB)}
+SCALE_OFFSETS = {
+    ("tt", "tai"): None,
+    ("tai", "tt"): None,
+    ("tcg", "tt"): -erfa.ELG,
+    ("tt", "tcg"): erfa.ELG / (1.0 - erfa.ELG),
+    ("tcg", "tai"): -erfa.ELG,
+    ("tai", "tcg"): erfa.ELG / (1.0 - erfa.ELG),
+    ("tcb", "tdb"): -erfa.ELB,
+    ("tdb", "tcb"): erfa.ELB / (1.0 - erfa.ELB),
+}
 
 # triple-level dictionary, yay!
 SIDEREAL_TIME_MODELS = {
-    'mean': {
-        'IAU2006': {'function': erfa.gmst06, 'scales': ('ut1', 'tt')},
-        'IAU2000': {'function': erfa.gmst00, 'scales': ('ut1', 'tt')},
-        'IAU1982': {'function': erfa.gmst82, 'scales': ('ut1',), 'include_tio': False}
+    "mean": {
+        "IAU2006": {"function": erfa.gmst06, "scales": ("ut1", "tt")},
+        "IAU2000": {"function": erfa.gmst00, "scales": ("ut1", "tt")},
+        "IAU1982": {"function": erfa.gmst82, "scales": ("ut1",), "include_tio": False},
     },
-    'apparent': {
-        'IAU2006A': {'function': erfa.gst06a, 'scales': ('ut1', 'tt')},
-        'IAU2000A': {'function': erfa.gst00a, 'scales': ('ut1', 'tt')},
-        'IAU2000B': {'function': erfa.gst00b, 'scales': ('ut1',)},
-        'IAU1994': {'function': erfa.gst94, 'scales': ('ut1',), 'include_tio': False}
-    }}
+    "apparent": {
+        "IAU2006A": {"function": erfa.gst06a, "scales": ("ut1", "tt")},
+        "IAU2000A": {"function": erfa.gst00a, "scales": ("ut1", "tt")},
+        "IAU2000B": {"function": erfa.gst00b, "scales": ("ut1",)},
+        "IAU1994": {"function": erfa.gst94, "scales": ("ut1",), "include_tio": False},
+    },
+}
 
 
 class _LeapSecondsCheck(enum.Enum):
-    NOT_STARTED = 0     # No thread has reached the check
-    RUNNING = 1         # A thread is running update_leap_seconds (_LEAP_SECONDS_LOCK is held)
-    DONE = 2            # update_leap_seconds has completed
+    NOT_STARTED = 0  # No thread has reached the check
+    RUNNING = 1  # A thread is running update_leap_seconds (_LEAP_SECONDS_LOCK is held)
+    DONE = 2  # update_leap_seconds has completed
 
 
 _LEAP_SECONDS_CHECK = _LeapSecondsCheck.NOT_STARTED
@@ -161,17 +187,25 @@ class TimeInfoBase(MixinInfo):
 
     This base class is common between TimeInfo and TimeDeltaInfo.
     """
-    attr_names = MixinInfo.attr_names | {'serialize_method'}
+
+    attr_names = MixinInfo.attr_names | {"serialize_method"}
     _supports_indexing = True
 
     # The usual tuple of attributes needed for serialization is replaced
     # by a property, since Time can be serialized different ways.
-    _represent_as_dict_extra_attrs = ('format', 'scale', 'precision',
-                                      'in_subfmt', 'out_subfmt', 'location',
-                                      '_delta_ut1_utc', '_delta_tdb_tt')
+    _represent_as_dict_extra_attrs = (
+        "format",
+        "scale",
+        "precision",
+        "in_subfmt",
+        "out_subfmt",
+        "location",
+        "_delta_ut1_utc",
+        "_delta_tdb_tt",
+    )
 
     # When serializing, write out the `value` attribute using the column name.
-    _represent_as_dict_primary_data = 'value'
+    _represent_as_dict_primary_data = "value"
 
     mask_val = np.ma.masked
 
@@ -179,10 +213,10 @@ class TimeInfoBase(MixinInfo):
     def _represent_as_dict_attrs(self):
         method = self.serialize_method[self._serialize_context]
 
-        if method == 'formatted_value':
-            out = ('value',)
-        elif method == 'jd1_jd2':
-            out = ('jd1', 'jd2')
+        if method == "formatted_value":
+            out = ("value",)
+        elif method == "jd1_jd2":
+            out = ("jd1", "jd2")
         else:
             raise ValueError("serialize method must be 'formatted_value' or 'jd1_jd2'")
 
@@ -197,12 +231,14 @@ class TimeInfoBase(MixinInfo):
             # Specify how to serialize this object depending on context.
             # If ``True`` for a context, then use formatted ``value`` attribute
             # (e.g. the ISO time string).  If ``False`` then use float jd1 and jd2.
-            self.serialize_method = {'fits': 'jd1_jd2',
-                                     'ecsv': 'formatted_value',
-                                     'hdf5': 'jd1_jd2',
-                                     'yaml': 'jd1_jd2',
-                                     'parquet': 'jd1_jd2',
-                                     None: 'jd1_jd2'}
+            self.serialize_method = {
+                "fits": "jd1_jd2",
+                "ecsv": "formatted_value",
+                "hdf5": "jd1_jd2",
+                "yaml": "jd1_jd2",
+                "parquet": "jd1_jd2",
+                None: "jd1_jd2",
+            }
 
     def get_sortable_arrays(self):
         """
@@ -215,7 +251,7 @@ class TimeInfoBase(MixinInfo):
         """
         parent = self._parent
         jd_approx = parent.jd
-        jd_remainder = (parent - parent.__class__(jd_approx, format='jd')).jd
+        jd_remainder = (parent - parent.__class__(jd_approx, format="jd")).jd
         return [jd_approx, jd_remainder]
 
     @property
@@ -223,31 +259,34 @@ class TimeInfoBase(MixinInfo):
         return None
 
     info_summary_stats = staticmethod(
-        data_info_factory(names=MixinInfo._stats,
-                          funcs=[getattr(np, stat) for stat in MixinInfo._stats]))
+        data_info_factory(
+            names=MixinInfo._stats,
+            funcs=[getattr(np, stat) for stat in MixinInfo._stats],
+        )
+    )
     # When Time has mean, std, min, max methods:
     # funcs = [lambda x: getattr(x, stat)() for stat_name in MixinInfo._stats])
 
     def _construct_from_dict(self, map):
-        if 'jd1' in map and 'jd2' in map:
+        if "jd1" in map and "jd2" in map:
             # Initialize as JD but revert to desired format and out_subfmt (if needed)
-            format = map.pop('format')
-            out_subfmt = map.pop('out_subfmt', None)
-            map['format'] = 'jd'
-            map['val'] = map.pop('jd1')
-            map['val2'] = map.pop('jd2')
+            format = map.pop("format")
+            out_subfmt = map.pop("out_subfmt", None)
+            map["format"] = "jd"
+            map["val"] = map.pop("jd1")
+            map["val2"] = map.pop("jd2")
             out = self._parent_cls(**map)
             out.format = format
             if out_subfmt is not None:
                 out.out_subfmt = out_subfmt
 
         else:
-            map['val'] = map.pop('value')
+            map["val"] = map.pop("value")
             out = self._parent_cls(**map)
 
         return out
 
-    def new_like(self, cols, length, metadata_conflicts='warn', name=None):
+    def new_like(self, cols, length, metadata_conflicts="warn", name=None):
         """
         Return a new Time instance which is consistent with the input Time objects
         ``cols`` and has ``length`` rows.
@@ -275,9 +314,10 @@ class TimeInfoBase(MixinInfo):
 
         """
         # Get merged info attributes like shape, dtype, format, description, etc.
-        attrs = self.merge_cols_attributes(cols, metadata_conflicts, name,
-                                           ('meta', 'description'))
-        attrs.pop('dtype')  # Not relevant for Time
+        attrs = self.merge_cols_attributes(
+            cols, metadata_conflicts, name, ("meta", "description")
+        )
+        attrs.pop("dtype")  # Not relevant for Time
         col0 = cols[0]
 
         # Check that location is consistent for all Time objects
@@ -289,16 +329,17 @@ class TimeInfoBase(MixinInfo):
             try:
                 col0._make_value_equivalent(slice(None), col)
             except ValueError:
-                raise ValueError('input columns have inconsistent locations')
+                raise ValueError("input columns have inconsistent locations")
 
         # Make a new Time object with the desired shape and attributes
-        shape = (length,) + attrs.pop('shape')
+        shape = (length,) + attrs.pop("shape")
         jd2000 = 2451544.5  # Arbitrary JD value J2000.0 that will work with ERFA
-        jd1 = np.full(shape, jd2000, dtype='f8')
-        jd2 = np.zeros(shape, dtype='f8')
-        tm_attrs = {attr: getattr(col0, attr)
-                    for attr in ('scale', 'location', 'precision')}
-        out = self._parent_cls(jd1, jd2, format='jd', **tm_attrs)
+        jd1 = np.full(shape, jd2000, dtype="f8")
+        jd2 = np.zeros(shape, dtype="f8")
+        tm_attrs = {
+            attr: getattr(col0, attr) for attr in ("scale", "location", "precision")
+        }
+        out = self._parent_cls(jd1, jd2, format="jd", **tm_attrs)
         out.format = col0.format
         out.out_subfmt = col0.out_subfmt
         out.in_subfmt = col0.in_subfmt
@@ -316,6 +357,7 @@ class TimeInfo(TimeInfoBase):
     required when the object is used as a mixin column within a table, but can
     be used as a general way to store meta information.
     """
+
     def _represent_as_dict(self, attrs=None):
         """Get the values for the parent ``attrs`` and return as a dict.
 
@@ -328,14 +370,16 @@ class TimeInfo(TimeInfoBase):
         # The datetime64 format requires special handling for ECSV (see #12840).
         # The `value` has numpy dtype datetime64 but this is not an allowed
         # datatype for ECSV. Instead convert to a string representation.
-        if (self._serialize_context == 'ecsv'
-                and map['format'] == 'datetime64'
-                and 'value' in map):
-            map['value'] = map['value'].astype('U')
+        if (
+            self._serialize_context == "ecsv"
+            and map["format"] == "datetime64"
+            and "value" in map
+        ):
+            map["value"] = map["value"].astype("U")
 
         # The datetime format is serialized as ISO with no loss of precision.
-        if map['format'] == 'datetime' and 'value' in map:
-            map['value'] = np.vectorize(lambda x: x.isoformat())(map['value'])
+        if map["format"] == "datetime" and "value" in map:
+            map["value"] = np.vectorize(lambda x: x.isoformat())(map["value"])
 
         return map
 
@@ -343,18 +387,21 @@ class TimeInfo(TimeInfoBase):
         # See comment above. May need to convert string back to datetime64.
         # Note that _serialize_context is not set here so we just look for the
         # string value directly.
-        if (map['format'] == 'datetime64'
-                and 'value' in map
-                and map['value'].dtype.kind == 'U'):
-            map['value'] = map['value'].astype('datetime64')
+        if (
+            map["format"] == "datetime64"
+            and "value" in map
+            and map["value"].dtype.kind == "U"
+        ):
+            map["value"] = map["value"].astype("datetime64")
 
         # Convert back to datetime objects for datetime format.
-        if map['format'] == 'datetime' and 'value' in map:
+        if map["format"] == "datetime" and "value" in map:
             from datetime import datetime
-            map['value'] = np.vectorize(datetime.fromisoformat)(map['value'])
 
-        delta_ut1_utc = map.pop('_delta_ut1_utc', None)
-        delta_tdb_tt = map.pop('_delta_tdb_tt', None)
+            map["value"] = np.vectorize(datetime.fromisoformat)(map["value"])
+
+        delta_ut1_utc = map.pop("_delta_ut1_utc", None)
+        delta_tdb_tt = map.pop("_delta_tdb_tt", None)
 
         out = super()._construct_from_dict(map)
 
@@ -372,9 +419,10 @@ class TimeDeltaInfo(TimeInfoBase):
     required when the object is used as a mixin column within a table, but can
     be used as a general way to store meta information.
     """
-    _represent_as_dict_extra_attrs = ('format', 'scale')
 
-    def new_like(self, cols, length, metadata_conflicts='warn', name=None):
+    _represent_as_dict_extra_attrs = ("format", "scale")
+
+    def new_like(self, cols, length, metadata_conflicts="warn", name=None):
         """
         Return a new TimeDelta instance which is consistent with the input Time objects
         ``cols`` and has ``length`` rows.
@@ -402,16 +450,17 @@ class TimeDeltaInfo(TimeInfoBase):
 
         """
         # Get merged info attributes like shape, dtype, format, description, etc.
-        attrs = self.merge_cols_attributes(cols, metadata_conflicts, name,
-                                           ('meta', 'description'))
-        attrs.pop('dtype')  # Not relevant for Time
+        attrs = self.merge_cols_attributes(
+            cols, metadata_conflicts, name, ("meta", "description")
+        )
+        attrs.pop("dtype")  # Not relevant for Time
         col0 = cols[0]
 
         # Make a new Time object with the desired shape and attributes
-        shape = (length,) + attrs.pop('shape')
-        jd1 = np.zeros(shape, dtype='f8')
-        jd2 = np.zeros(shape, dtype='f8')
-        out = self._parent_cls(jd1, jd2, format='jd', scale=col0.scale)
+        shape = (length,) + attrs.pop("shape")
+        jd1 = np.zeros(shape, dtype="f8")
+        jd2 = np.zeros(shape, dtype="f8")
+        out = self._parent_cls(jd1, jd2, format="jd", scale=col0.scale)
         out.format = col0.format
 
         # Set remaining info attributes
@@ -435,8 +484,17 @@ class TimeBase(ShapedLikeNDArray):
     def __getnewargs__(self):
         return (self._time,)
 
-    def _init_from_vals(self, val, val2, format, scale, copy,
-                        precision=None, in_subfmt=None, out_subfmt=None):
+    def _init_from_vals(
+        self,
+        val,
+        val2,
+        format,
+        scale,
+        copy,
+        precision=None,
+        in_subfmt=None,
+        out_subfmt=None,
+    ):
         """
         Set the internal _format, scale, and _time attrs from user
         inputs.  This handles coercion into the correct shapes and
@@ -445,9 +503,9 @@ class TimeBase(ShapedLikeNDArray):
         if precision is None:
             precision = 3
         if in_subfmt is None:
-            in_subfmt = '*'
+            in_subfmt = "*"
         if out_subfmt is None:
-            out_subfmt = '*'
+            out_subfmt = "*"
 
         # Coerce val into an array
         val = _make_array(val, copy)
@@ -458,29 +516,33 @@ class TimeBase(ShapedLikeNDArray):
             try:
                 np.broadcast(val, val2)
             except ValueError:
-                raise ValueError('Input val and val2 have inconsistent shape; '
-                                 'they cannot be broadcast together.')
+                raise ValueError(
+                    "Input val and val2 have inconsistent shape; "
+                    "they cannot be broadcast together."
+                )
 
         if scale is not None:
-            if not (isinstance(scale, str)
-                    and scale.lower() in self.SCALES):
-                raise ScaleValueError("Scale {!r} is not in the allowed scales "
-                                      "{}".format(scale,
-                                                  sorted(self.SCALES)))
+            if not (isinstance(scale, str) and scale.lower() in self.SCALES):
+                raise ScaleValueError(
+                    "Scale {!r} is not in the allowed scales {}".format(
+                        scale, sorted(self.SCALES)
+                    )
+                )
 
         # If either of the input val, val2 are masked arrays then
         # find the masked elements and fill them.
         mask, val, val2 = _check_for_masked_and_fill(val, val2)
 
         # Parse / convert input values into internal jd1, jd2 based on format
-        self._time = self._get_time_fmt(val, val2, format, scale,
-                                        precision, in_subfmt, out_subfmt)
+        self._time = self._get_time_fmt(
+            val, val2, format, scale, precision, in_subfmt, out_subfmt
+        )
         self._format = self._time.name
 
         # Hack from #9969 to allow passing the location value that has been
         # collected by the TimeAstropyTime format class up to the Time level.
         # TODO: find a nicer way.
-        if hasattr(self._time, '_location'):
+        if hasattr(self._time, "_location"):
             self.location = self._time._location
             del self._time._location
 
@@ -492,8 +554,7 @@ class TimeBase(ShapedLikeNDArray):
             self._time.jd1[mask] = 2451544.5  # Set to JD for 2000-01-01
             self._time.jd2[mask] = np.nan
 
-    def _get_time_fmt(self, val, val2, format, scale,
-                      precision, in_subfmt, out_subfmt):
+    def _get_time_fmt(self, val, val2, format, scale, precision, in_subfmt, out_subfmt):
         """
         Given the supplied val, val2, format and scale try to instantiate
         the corresponding TimeFormat class to convert the input values into
@@ -503,27 +564,33 @@ class TimeBase(ShapedLikeNDArray):
         guess available formats and stop when one matches.
         """
 
-        if (format is None
-                and (val.dtype.kind in ('S', 'U', 'O', 'M') or val.dtype.names)):
+        if format is None and (
+            val.dtype.kind in ("S", "U", "O", "M") or val.dtype.names
+        ):
             # Input is a string, object, datetime, or a table-like ndarray
             # (structured array, recarray). These input types can be
             # uniquely identified by the format classes.
-            formats = [(name, cls) for name, cls in self.FORMATS.items()
-                       if issubclass(cls, TimeUnique)]
+            formats = [
+                (name, cls)
+                for name, cls in self.FORMATS.items()
+                if issubclass(cls, TimeUnique)
+            ]
 
             # AstropyTime is a pseudo-format that isn't in the TIME_FORMATS registry,
             # but try to guess it at the end.
-            formats.append(('astropy_time', TimeAstropyTime))
+            formats.append(("astropy_time", TimeAstropyTime))
 
-        elif not (isinstance(format, str)
-                  and format.lower() in self.FORMATS):
+        elif not (isinstance(format, str) and format.lower() in self.FORMATS):
             if format is None:
-                raise ValueError("No time format was given, and the input is "
-                                 "not unique")
+                raise ValueError(
+                    "No time format was given, and the input is not unique"
+                )
             else:
-                raise ValueError("Format {!r} is not one of the allowed "
-                                 "formats {}".format(format,
-                                                     sorted(self.FORMATS)))
+                raise ValueError(
+                    "Format {!r} is not one of the allowed formats {}".format(
+                        format, sorted(self.FORMATS)
+                    )
+                )
         else:
             formats = [(format, self.FORMATS[format])]
 
@@ -540,16 +607,18 @@ class TimeBase(ShapedLikeNDArray):
                 # easier for user to see what is wrong.
                 if len(formats) == 1:
                     raise ValueError(
-                        f'Input values did not match the format class {format}:'
+                        f"Input values did not match the format class {format}:"
                         + os.linesep
-                        + f'{err.__class__.__name__}: {err}'
+                        + f"{err.__class__.__name__}: {err}"
                     ) from err
                 else:
                     problems[name] = err
         else:
-            raise ValueError(f'Input values did not match any of the formats '
-                             f'where the format keyword is optional: '
-                             f'{problems}') from problems[formats[0][0]]
+            raise ValueError(
+                "Input values did not match any of the formats "
+                "where the format keyword is optional: "
+                f"{problems}"
+            ) from problems[formats[0][0]]
 
     @property
     def writeable(self):
@@ -581,18 +650,21 @@ class TimeBase(ShapedLikeNDArray):
     def format(self, format):
         """Set time format"""
         if format not in self.FORMATS:
-            raise ValueError(f'format must be one of {list(self.FORMATS)}')
+            raise ValueError(f"format must be one of {list(self.FORMATS)}")
         format_cls = self.FORMATS[format]
 
         # Get the new TimeFormat object to contain time in new format.  Possibly
         # coerce in/out_subfmt to '*' (default) if existing subfmt values are
         # not valid in the new format.
         self._time = format_cls(
-            self._time.jd1, self._time.jd2,
-            self._time._scale, self.precision,
+            self._time.jd1,
+            self._time.jd2,
+            self._time._scale,
+            self.precision,
             in_subfmt=format_cls._get_allowed_subfmt(self.in_subfmt),
             out_subfmt=format_cls._get_allowed_subfmt(self.out_subfmt),
-            from_jd=True)
+            from_jd=True,
+        )
 
         self._format = format
 
@@ -624,17 +696,16 @@ class TimeBase(ShapedLikeNDArray):
         return out
 
     def __repr__(self):
-        return ("<{} object: scale='{}' format='{}' value={}>"
-                .format(self.__class__.__name__, self.scale, self.format,
-                        self.to_string()))
+        return "<{} object: scale='{}' format='{}' value={}>".format(
+            self.__class__.__name__, self.scale, self.format, self.to_string()
+        )
 
     def __str__(self):
         return self.to_string()
 
     def __hash__(self):
-
         try:
-            loc = getattr(self, 'location', None)
+            loc = getattr(self, "location", None)
             if loc is not None:
                 loc = loc.x.to_value(u.m), loc.y.to_value(u.m), loc.z.to_value(u.m)
 
@@ -642,9 +713,9 @@ class TimeBase(ShapedLikeNDArray):
 
         except TypeError:
             if self.ndim != 0:
-                reason = '(must be scalar)'
+                reason = "(must be scalar)"
             elif self.masked:
-                reason = '(value is masked)'
+                reason = "(value is masked)"
             else:
                 raise
 
@@ -664,10 +735,13 @@ class TimeBase(ShapedLikeNDArray):
         if scale == self.scale:
             return
         if scale not in self.SCALES:
-            raise ValueError("Scale {!r} is not in the allowed scales {}"
-                             .format(scale, sorted(self.SCALES)))
+            raise ValueError(
+                "Scale {!r} is not in the allowed scales {}".format(
+                    scale, sorted(self.SCALES)
+                )
+            )
 
-        if scale == 'utc' or self.scale == 'utc':
+        if scale == "utc" or self.scale == "utc":
             # If doing a transform involving UTC then check that the leap
             # seconds table is up to date.
             _check_leapsec()
@@ -694,7 +768,7 @@ class TimeBase(ShapedLikeNDArray):
             # sys1, sys2 though the property applies for both xform directions.
             args = [jd1, jd2]
             for sys12 in ((sys1, sys2), (sys2, sys1)):
-                dt_method = '_get_delta_{}_{}'.format(*sys12)
+                dt_method = "_get_delta_{}_{}".format(*sys12)
                 try:
                     get_dt = getattr(self, dt_method)
                 except AttributeError:
@@ -710,9 +784,15 @@ class TimeBase(ShapedLikeNDArray):
         if self.masked:
             jd2[self.mask] = np.nan
 
-        self._time = self.FORMATS[self.format](jd1, jd2, scale, self.precision,
-                                               self.in_subfmt, self.out_subfmt,
-                                               from_jd=True)
+        self._time = self.FORMATS[self.format](
+            jd1,
+            jd2,
+            scale,
+            self.precision,
+            self.in_subfmt,
+            self.out_subfmt,
+            from_jd=True,
+        )
 
     @property
     def precision(self):
@@ -790,11 +870,13 @@ class TimeBase(ShapedLikeNDArray):
         # self.jd1/2 because the latter are not guaranteed to be the actual
         # data, and in fact should not be directly changeable from the public
         # API.
-        for obj, attr in ((self._time, 'jd1'),
-                          (self._time, 'jd2'),
-                          (self, '_delta_ut1_utc'),
-                          (self, '_delta_tdb_tt'),
-                          (self, 'location')):
+        for obj, attr in (
+            (self._time, "jd1"),
+            (self._time, "jd2"),
+            (self, "_delta_ut1_utc"),
+            (self, "_delta_tdb_tt"),
+            (self, "location"),
+        ):
             val = getattr(obj, attr, None)
             if val is not None and val.size > 1:
                 try:
@@ -812,14 +894,16 @@ class TimeBase(ShapedLikeNDArray):
                 return value
             else:
                 raise TypeError(
-                    f"JD is an array ({self._time.jd1!r}) but value "
-                    f"is not ({value!r})")
+                    f"JD is an array ({self._time.jd1!r}) but value is not ({value!r})"
+                )
         else:
             # zero-dimensional array, is it safe to unbox?
-            if (isinstance(value, np.ndarray)
-                    and not value.shape
-                    and not np.ma.is_masked(value)):
-                if value.dtype.kind == 'M':
+            if (
+                isinstance(value, np.ndarray)
+                and not value.shape
+                and not np.ma.is_masked(value)
+            ):
+                if value.dtype.kind == "M":
                     # existing test doesn't want datetime64 converted
                     return value[()]
                 elif value.dtype.fields:
@@ -847,7 +931,7 @@ class TimeBase(ShapedLikeNDArray):
         jd2 = self._time.mask_if_needed(self._time.jd2)
         return self._shaped_like_input(jd2)
 
-    def to_value(self, format, subfmt='*'):
+    def to_value(self, format, subfmt="*"):
         """Get time values expressed in specified output format.
 
         This method allows representing the ``Time`` object in the desired
@@ -884,9 +968,9 @@ class TimeBase(ShapedLikeNDArray):
         # TODO: add a precision argument (but ensure it is keyword argument
         # only, to make life easier for TimeDelta.to_value()).
         if format not in self.FORMATS:
-            raise ValueError(f'format must be one of {list(self.FORMATS)}')
+            raise ValueError(f"format must be one of {list(self.FORMATS)}")
 
-        cache = self.cache['format']
+        cache = self.cache["format"]
         # Try to keep cache behaviour like it was in astropy < 4.0.
         key = format if subfmt is None else (format, subfmt)
         if key not in cache:
@@ -902,7 +986,7 @@ class TimeBase(ShapedLikeNDArray):
             # the same, we do not pass it on.
             kwargs = {}
             if subfmt is not None and subfmt != tm.out_subfmt:
-                kwargs['out_subfmt'] = subfmt
+                kwargs["out_subfmt"] = subfmt
             try:
                 value = tm._time.to_value(parent=tm, **kwargs)
             except TypeError as exc:
@@ -918,7 +1002,8 @@ class TimeBase(ShapedLikeNDArray):
                 if "unexpected keyword argument 'out_subfmt'" in str(exc):
                     raise ValueError(
                         f"to_value() method for format {format!r} does not "
-                        f"support passing a 'subfmt' argument") from None
+                        "support passing a 'subfmt' argument"
+                    ) from None
                 else:
                     # Some unforeseen exception so raise.
                     raise
@@ -976,18 +1061,22 @@ class TimeBase(ShapedLikeNDArray):
         try:
             idx0 = operator.index(obj)
         except TypeError:
-            raise TypeError('obj arg must be an integer')
+            raise TypeError("obj arg must be an integer")
 
         if axis != 0:
-            raise ValueError('axis must be 0')
+            raise ValueError("axis must be 0")
 
         if not self.shape:
-            raise TypeError('cannot insert into scalar {} object'
-                            .format(self.__class__.__name__))
+            raise TypeError(
+                f"cannot insert into scalar {self.__class__.__name__} object"
+            )
 
         if abs(idx0) > len(self):
-            raise IndexError('index {} is out of bounds for axis 0 with size {}'
-                             .format(idx0, len(self)))
+            raise IndexError(
+                "index {} is out of bounds for axis 0 with size {}".format(
+                    idx0, len(self)
+                )
+            )
 
         # Turn negative index into positive
         if idx0 < 0:
@@ -1001,34 +1090,40 @@ class TimeBase(ShapedLikeNDArray):
 
         # Finally make the new object with the correct length and set values for the
         # three sections, before insert, the insert, and after the insert.
-        out = self.__class__.info.new_like([self], len(self) + n_values, name=self.info.name)
+        out = self.__class__.info.new_like(
+            [self], len(self) + n_values, name=self.info.name
+        )
 
         out._time.jd1[:idx0] = self._time.jd1[:idx0]
         out._time.jd2[:idx0] = self._time.jd2[:idx0]
 
         # This uses the Time setting machinery to coerce and validate as necessary.
-        out[idx0:idx0 + n_values] = values
+        out[idx0 : idx0 + n_values] = values
 
-        out._time.jd1[idx0 + n_values:] = self._time.jd1[idx0:]
-        out._time.jd2[idx0 + n_values:] = self._time.jd2[idx0:]
+        out._time.jd1[idx0 + n_values :] = self._time.jd1[idx0:]
+        out._time.jd2[idx0 + n_values :] = self._time.jd2[idx0:]
 
         return out
 
     def __setitem__(self, item, value):
         if not self.writeable:
             if self.shape:
-                raise ValueError('{} object is read-only. Make a '
-                                 'copy() or set "writeable" attribute to True.'
-                                 .format(self.__class__.__name__))
+                raise ValueError(
+                    "{} object is read-only. Make a "
+                    'copy() or set "writeable" attribute to True.'.format(
+                        self.__class__.__name__
+                    )
+                )
             else:
-                raise ValueError('scalar {} object is read-only.'
-                                 .format(self.__class__.__name__))
+                raise ValueError(
+                    f"scalar {self.__class__.__name__} object is read-only."
+                )
 
         # Any use of setitem results in immediate cache invalidation
         del self.cache
 
         # Setting invalidates transform deltas
-        for attr in ('_delta_tdb_tt', '_delta_ut1_utc'):
+        for attr in ("_delta_tdb_tt", "_delta_ut1_utc"):
             if hasattr(self, attr):
                 delattr(self, attr)
 
@@ -1068,8 +1163,10 @@ class TimeBase(ShapedLikeNDArray):
             atol = 2 * np.finfo(float).eps * u.day
 
         if not isinstance(atol, (u.Quantity, TimeDelta)):
-            raise TypeError("'atol' argument must be a Quantity or TimeDelta instance, got "
-                            f'{atol.__class__.__name__} instead')
+            raise TypeError(
+                "'atol' argument must be a Quantity or TimeDelta instance, got "
+                f"{atol.__class__.__name__} instead"
+            )
 
         try:
             # Separate these out so user sees where the problem is
@@ -1077,9 +1174,11 @@ class TimeBase(ShapedLikeNDArray):
             dt = abs(dt)
             out = dt <= atol
         except Exception as err:
-            raise TypeError("'other' argument must support subtraction with Time "
-                            f"and return a value that supports comparison with "
-                            f"{atol.__class__.__name__}: {err}")
+            raise TypeError(
+                "'other' argument must support subtraction with Time "
+                "and return a value that supports comparison with "
+                f"{atol.__class__.__name__}: {err}"
+            )
 
         return out
 
@@ -1106,7 +1205,7 @@ class TimeBase(ShapedLikeNDArray):
         tm : Time object
             Copy of this object
         """
-        return self._apply('copy', format=format)
+        return self._apply("copy", format=format)
 
     def replicate(self, format=None, copy=False, cls=None):
         """
@@ -1137,7 +1236,7 @@ class TimeBase(ShapedLikeNDArray):
         tm : Time object
             Replica of this object
         """
-        return self._apply('copy' if copy else 'replicate', format=format, cls=cls)
+        return self._apply("copy" if copy else "replicate", format=format, cls=cls)
 
     def _apply(self, method, *args, format=None, cls=None, **kwargs):
         """Create a new time object, possibly applying a method to the arrays.
@@ -1176,7 +1275,7 @@ class TimeBase(ShapedLikeNDArray):
             apply_method = lambda array: method(array, *args, **kwargs)
 
         else:
-            if method == 'replicate':
+            if method == "replicate":
                 apply_method = None
             else:
                 apply_method = operator.methodcaller(method, *args, **kwargs)
@@ -1188,11 +1287,18 @@ class TimeBase(ShapedLikeNDArray):
 
         # Get a new instance of our class and set its attributes directly.
         tm = super().__new__(cls or self.__class__)
-        tm._time = TimeJD(jd1, jd2, self.scale, precision=0,
-                          in_subfmt='*', out_subfmt='*', from_jd=True)
+        tm._time = TimeJD(
+            jd1,
+            jd2,
+            self.scale,
+            precision=0,
+            in_subfmt="*",
+            out_subfmt="*",
+            from_jd=True,
+        )
 
         # Optional ndarray attributes.
-        for attr in ('_delta_ut1_utc', '_delta_tdb_tt', 'location'):
+        for attr in ("_delta_ut1_utc", "_delta_tdb_tt", "location"):
             try:
                 val = getattr(self, attr)
             except AttributeError:
@@ -1202,9 +1308,9 @@ class TimeBase(ShapedLikeNDArray):
                 # Apply the method to any value arrays (though skip if there is
                 # only an array scalar and the method would return a view,
                 # since in that case nothing would change).
-                if getattr(val, 'shape', ()):
+                if getattr(val, "shape", ()):
                     val = apply_method(val)
-                elif method == 'copy' or method == 'flatten':
+                elif method == "copy" or method == "flatten":
                     # flatten should copy also for a single element array, but
                     # we cannot use it directly for array scalars, since it
                     # always returns a one-dimensional array. So, just copy.
@@ -1216,24 +1322,26 @@ class TimeBase(ShapedLikeNDArray):
         # time object is not a scalar (issue #10688).
         # See PR #3898 for further explanation and justification, along
         # with Quantity.__array_finalize__
-        if 'info' in self.__dict__:
+        if "info" in self.__dict__:
             tm.info = self.info
 
         # Make the new internal _time object corresponding to the format
         # in the copy.  If the format is unchanged this process is lightweight
         # and does not create any new arrays.
         if new_format not in tm.FORMATS:
-            raise ValueError(f'format must be one of {list(tm.FORMATS)}')
+            raise ValueError(f"format must be one of {list(tm.FORMATS)}")
 
         NewFormat = tm.FORMATS[new_format]
 
         tm._time = NewFormat(
-            tm._time.jd1, tm._time.jd2,
+            tm._time.jd1,
+            tm._time.jd2,
             tm._time._scale,
             precision=self.precision,
             in_subfmt=NewFormat._get_allowed_subfmt(self.in_subfmt),
             out_subfmt=NewFormat._get_allowed_subfmt(self.out_subfmt),
-            from_jd=True)
+            from_jd=True,
+        )
         tm._format = new_format
         tm.SCALES = self.SCALES
 
@@ -1294,14 +1402,16 @@ class TimeBase(ShapedLikeNDArray):
         if keepdims and indices.ndim < self.ndim:
             indices = np.expand_dims(indices, axis)
 
-        index = [indices
-                 if i == axis
-                 else np.arange(s).reshape(
-                     (1,) * (i if keepdims or i < axis else i - 1)
-                     + (s,)
-                     + (1,) * (ndim - i - (1 if keepdims or i > axis else 2))
-                 )
-                 for i, s in enumerate(self.shape)]
+        index = [
+            indices
+            if i == axis
+            else np.arange(s).reshape(
+                (1,) * (i if keepdims or i < axis else i - 1)
+                + (s,)
+                + (1,) * (ndim - i - (1 if keepdims or i > axis else 2))
+            )
+            for i, s in enumerate(self.shape)
+        ]
 
         return tuple(index)
 
@@ -1373,8 +1483,10 @@ class TimeBase(ShapedLikeNDArray):
         to have an actual ``out`` to store the result in.
         """
         if out is not None:
-            raise ValueError("Since `Time` instances are immutable, ``out`` "
-                             "cannot be set to anything but ``None``.")
+            raise ValueError(
+                "Since `Time` instances are immutable, ``out`` "
+                "cannot be set to anything but ``None``."
+            )
         return self[self._advanced_index(self.argmin(axis), axis, keepdims)]
 
     def max(self, axis=None, out=None, keepdims=False):
@@ -1389,8 +1501,10 @@ class TimeBase(ShapedLikeNDArray):
         to have an actual ``out`` to store the result in.
         """
         if out is not None:
-            raise ValueError("Since `Time` instances are immutable, ``out`` "
-                             "cannot be set to anything but ``None``.")
+            raise ValueError(
+                "Since `Time` instances are immutable, ``out`` "
+                "cannot be set to anything but ``None``."
+            )
         return self[self._advanced_index(self.argmax(axis), axis, keepdims)]
 
     def ptp(self, axis=None, out=None, keepdims=False):
@@ -1405,10 +1519,11 @@ class TimeBase(ShapedLikeNDArray):
         to have an actual ``out`` to store the result in.
         """
         if out is not None:
-            raise ValueError("Since `Time` instances are immutable, ``out`` "
-                             "cannot be set to anything but ``None``.")
-        return (self.max(axis, keepdims=keepdims)
-                - self.min(axis, keepdims=keepdims))
+            raise ValueError(
+                "Since `Time` instances are immutable, ``out`` "
+                "cannot be set to anything but ``None``."
+            )
+        return self.max(axis, keepdims=keepdims) - self.min(axis, keepdims=keepdims)
 
     def sort(self, axis=-1):
         """Return a copy sorted along the specified axis.
@@ -1424,8 +1539,7 @@ class TimeBase(ShapedLikeNDArray):
             Axis to be sorted.  If ``None``, the flattened array is sorted.
             By default, sort over the last axis.
         """
-        return self[self._advanced_index(self.argsort(axis), axis,
-                                         keepdims=True)]
+        return self[self._advanced_index(self.argsort(axis), axis, keepdims=True)]
 
     def mean(self, axis=None, dtype=None, out=None, keepdims=False, *, where=True):
         """Mean along a given axis.
@@ -1466,10 +1580,12 @@ class TimeBase(ShapedLikeNDArray):
             A new Time instance containing the mean values
         """
         if dtype is not None:
-            raise ValueError('Cannot set ``dtype`` on `Time` instances')
+            raise ValueError("Cannot set ``dtype`` on `Time` instances")
         if out is not None:
-            raise ValueError("Since `Time` instances are immutable, ``out`` "
-                             "cannot be set to anything but ``None``.")
+            raise ValueError(
+                "Since `Time` instances are immutable, ``out`` "
+                "cannot be set to anything but ``None``."
+            )
 
         where = where & ~self.mask
         where_broadcasted = np.broadcast_to(where, self.shape)
@@ -1483,8 +1599,8 @@ class TimeBase(ShapedLikeNDArray):
         divisor = np.sum(where_broadcasted, axis=axis, keepdims=keepdims)
         if np.any(divisor == 0):
             raise ValueError(
-                'Mean over zero elements is not supported as it would give an undefined time;'
-                'see issue https://github.com/astropy/astropy/issues/6509'
+                "Mean over zero elements is not supported as it would give an undefined"
+                " time;see issue https://github.com/astropy/astropy/issues/6509"
             )
 
         jd1, jd2 = day_frac(
@@ -1496,7 +1612,7 @@ class TimeBase(ShapedLikeNDArray):
         result = type(self)(
             val=jd1,
             val2=jd2,
-            format='jd',
+            format="jd",
             scale=self.scale,
             copy=False,
         )
@@ -1519,7 +1635,7 @@ class TimeBase(ShapedLikeNDArray):
         Get dynamic attributes to output format or do timescale conversion.
         """
         if attr in self.SCALES and self.scale is not None:
-            cache = self.cache['scale']
+            cache = self.cache["scale"]
             if attr not in cache:
                 if attr == self.scale:
                     tm = self
@@ -1537,13 +1653,16 @@ class TimeBase(ShapedLikeNDArray):
 
         elif attr in TIME_SCALES:  # allowed ones done above (self.SCALES)
             if self.scale is None:
-                raise ScaleValueError("Cannot convert TimeDelta with "
-                                      "undefined scale to any defined scale.")
+                raise ScaleValueError(
+                    "Cannot convert TimeDelta with "
+                    "undefined scale to any defined scale."
+                )
             else:
-                raise ScaleValueError("Cannot convert {} with scale "
-                                      "'{}' to scale '{}'"
-                                      .format(self.__class__.__name__,
-                                              self.scale, attr))
+                raise ScaleValueError(
+                    "Cannot convert {} with scale '{}' to scale '{}'".format(
+                        self.__class__.__name__, self.scale, attr
+                    )
+                )
 
         else:
             # Should raise AttributeError
@@ -1563,10 +1682,12 @@ class TimeBase(ShapedLikeNDArray):
                 # check the value can be broadcast to the shape of self.
                 val = np.broadcast_to(val, self.shape, subok=True)
             except Exception:
-                raise ValueError('Attribute shape must match or be '
-                                 'broadcastable to that of Time object. '
-                                 'Typically, give either a single value or '
-                                 'one for each time.')
+                raise ValueError(
+                    "Attribute shape must match or be "
+                    "broadcastable to that of Time object. "
+                    "Typically, give either a single value or "
+                    "one for each time."
+                )
 
         return val
 
@@ -1581,18 +1702,24 @@ class TimeBase(ShapedLikeNDArray):
                 # Let other have a go.
                 return NotImplemented
 
-        if (self.scale is not None and self.scale not in other.SCALES
-            or other.scale is not None and other.scale not in self.SCALES):
+        if (
+            self.scale is not None
+            and self.scale not in other.SCALES
+            or other.scale is not None
+            and other.scale not in self.SCALES
+        ):
             # Other will also not be able to do it, so raise a TypeError
             # immediately, allowing us to explain why it doesn't work.
-            raise TypeError("Cannot compare {} instances with scales "
-                            "'{}' and '{}'".format(self.__class__.__name__,
-                                                   self.scale, other.scale))
+            raise TypeError(
+                "Cannot compare {} instances with scales '{}' and '{}'".format(
+                    self.__class__.__name__, self.scale, other.scale
+                )
+            )
 
         if self.scale is not None and other.scale is not None:
             other = getattr(other, self.scale)
 
-        return op((self.jd1 - other.jd1) + (self.jd2 - other.jd2), 0.)
+        return op((self.jd1 - other.jd1) + (self.jd2 - other.jd2), 0.0)
 
     def __lt__(self, other):
         return self._time_comparison(other, operator.lt)
@@ -1672,16 +1799,25 @@ class Time(TimeBase):
     copy : bool, optional
         Make a copy of the input values
     """
+
     SCALES = TIME_SCALES
     """List of time scales"""
 
     FORMATS = TIME_FORMATS
     """Dict of time formats"""
 
-    def __new__(cls, val, val2=None, format=None, scale=None,
-                precision=None, in_subfmt=None, out_subfmt=None,
-                location=None, copy=False):
-
+    def __new__(
+        cls,
+        val,
+        val2=None,
+        format=None,
+        scale=None,
+        precision=None,
+        in_subfmt=None,
+        out_subfmt=None,
+        location=None,
+        copy=False,
+    ):
         if isinstance(val, Time):
             self = val.replicate(format=format, copy=copy, cls=cls)
         else:
@@ -1689,12 +1825,21 @@ class Time(TimeBase):
 
         return self
 
-    def __init__(self, val, val2=None, format=None, scale=None,
-                 precision=None, in_subfmt=None, out_subfmt=None,
-                 location=None, copy=False):
-
+    def __init__(
+        self,
+        val,
+        val2=None,
+        format=None,
+        scale=None,
+        precision=None,
+        in_subfmt=None,
+        out_subfmt=None,
+        location=None,
+        copy=False,
+    ):
         if location is not None:
             from astropy.coordinates import EarthLocation
+
             if isinstance(location, EarthLocation):
                 self.location = location
             else:
@@ -1702,7 +1847,7 @@ class Time(TimeBase):
             if self.location.size == 1:
                 self.location = self.location.squeeze()
         else:
-            if not hasattr(self, 'location'):
+            if not hasattr(self, "location"):
                 self.location = None
 
         if isinstance(val, Time):
@@ -1717,22 +1862,24 @@ class Time(TimeBase):
             if scale is not None:
                 self._set_scale(scale)
         else:
-            self._init_from_vals(val, val2, format, scale, copy,
-                                 precision, in_subfmt, out_subfmt)
+            self._init_from_vals(
+                val, val2, format, scale, copy, precision, in_subfmt, out_subfmt
+            )
             self.SCALES = TIME_TYPES[self.scale]
 
-        if self.location is not None and (self.location.size > 1
-                                          and self.location.shape != self.shape):
+        if self.location is not None and (
+            self.location.size > 1 and self.location.shape != self.shape
+        ):
             try:
                 # check the location can be broadcast to self's shape.
-                self.location = np.broadcast_to(self.location, self.shape,
-                                                subok=True)
+                self.location = np.broadcast_to(self.location, self.shape, subok=True)
             except Exception as err:
-                raise ValueError('The location with shape {} cannot be '
-                                 'broadcast against time with shape {}. '
-                                 'Typically, either give a single location or '
-                                 'one for each time.'
-                                 .format(self.location.shape, self.shape)) from err
+                raise ValueError(
+                    "The location with shape {} cannot be "
+                    "broadcast against time with shape {}. "
+                    "Typically, either give a single location or "
+                    "one for each time.".format(self.location.shape, self.shape)
+                ) from err
 
     def _make_value_equivalent(self, item, value):
         """Coerce setitem value into an equivalent Time object"""
@@ -1749,26 +1896,35 @@ class Time(TimeBase):
             # a Location object.
             if self_location is None and value.location is None:
                 match = True
-            elif ((self_location is None and value.location is not None)
-                  or (self_location is not None and value.location is None)):
+            elif (self_location is None and value.location is not None) or (
+                self_location is not None and value.location is None
+            ):
                 match = False
             else:
                 match = np.all(self_location == value.location)
             if not match:
-                raise ValueError('cannot set to Time with different location: '
-                                 'expected location={} and '
-                                 'got location={}'
-                                 .format(self_location, value.location))
+                raise ValueError(
+                    "cannot set to Time with different location: "
+                    "expected location={} and "
+                    "got location={}".format(self_location, value.location)
+                )
         else:
             try:
                 value = self.__class__(value, scale=self.scale, location=self_location)
             except Exception:
                 try:
-                    value = self.__class__(value, scale=self.scale, format=self.format,
-                                           location=self_location)
+                    value = self.__class__(
+                        value,
+                        scale=self.scale,
+                        format=self.format,
+                        location=self_location,
+                    )
                 except Exception as err:
-                    raise ValueError('cannot convert value to a compatible Time object: {}'
-                                     .format(err))
+                    raise ValueError(
+                        "cannot convert value to a compatible Time object: {}".format(
+                            err
+                        )
+                    )
         return value
 
     @classmethod
@@ -1791,7 +1947,7 @@ class Time(TimeBase):
         """
         # call `utcnow` immediately to be sure it's ASAP
         dtnow = datetime.utcnow()
-        return cls(val=dtnow, format='datetime', scale='utc')
+        return cls(val=dtnow, format="datetime", scale="utc")
 
     info = TimeInfo()
 
@@ -1823,24 +1979,29 @@ class Time(TimeBase):
         """
         time_array = np.asarray(time_string)
 
-        if time_array.dtype.kind not in ('U', 'S'):
-            err = "Expected type is string, a bytes-like object or a sequence"\
-                  " of these. Got dtype '{}'".format(time_array.dtype.kind)
+        if time_array.dtype.kind not in ("U", "S"):
+            err = (
+                "Expected type is string, a bytes-like object or a sequence"
+                " of these. Got dtype '{}'".format(time_array.dtype.kind)
+            )
             raise TypeError(err)
 
-        to_string = (str if time_array.dtype.kind == 'U' else
-                     lambda x: str(x.item(), encoding='ascii'))
-        iterator = np.nditer([time_array, None],
-                             op_dtypes=[time_array.dtype, 'U30'])
+        to_string = (
+            str
+            if time_array.dtype.kind == "U"
+            else lambda x: str(x.item(), encoding="ascii")
+        )
+        iterator = np.nditer([time_array, None], op_dtypes=[time_array.dtype, "U30"])
 
         for time, formatted in iterator:
             tt, fraction = _strptime._strptime(to_string(time), format_string)
             time_tuple = tt[:6] + (fraction,)
-            formatted[...] = '{:04}-{:02}-{:02}T{:02}:{:02}:{:02}.{:06}'\
-                .format(*time_tuple)
+            formatted[...] = "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}.{:06}".format(
+                *time_tuple
+            )
 
-        format = kwargs.pop('format', None)
-        out = cls(*iterator.operands[1:], format='isot', **kwargs)
+        format = kwargs.pop("format", None)
+        out = cls(*iterator.operands[1:], format="isot", **kwargs)
         if format is not None:
             out.format = format
 
@@ -1865,15 +2026,27 @@ class Time(TimeBase):
 
         """
         formatted_strings = []
-        for sk in self.replicate('iso')._time.str_kwargs():
-            date_tuple = date(sk['year'], sk['mon'], sk['day']).timetuple()
-            datetime_tuple = (sk['year'], sk['mon'], sk['day'],
-                              sk['hour'], sk['min'], sk['sec'],
-                              date_tuple[6], date_tuple[7], -1)
+        for sk in self.replicate("iso")._time.str_kwargs():
+            date_tuple = date(sk["year"], sk["mon"], sk["day"]).timetuple()
+            datetime_tuple = (
+                sk["year"],
+                sk["mon"],
+                sk["day"],
+                sk["hour"],
+                sk["min"],
+                sk["sec"],
+                date_tuple[6],
+                date_tuple[7],
+                -1,
+            )
             fmtd_str = format_spec
-            if '%f' in fmtd_str:
-                fmtd_str = fmtd_str.replace('%f', '{frac:0{precision}}'.format(
-                    frac=sk['fracsec'], precision=self.precision))
+            if "%f" in fmtd_str:
+                fmtd_str = fmtd_str.replace(
+                    "%f",
+                    "{frac:0{precision}}".format(
+                        frac=sk["fracsec"], precision=self.precision
+                    ),
+                )
             fmtd_str = strftime(fmtd_str, datetime_tuple)
             formatted_strings.append(fmtd_str)
 
@@ -1882,7 +2055,9 @@ class Time(TimeBase):
         else:
             return np.array(formatted_strings).reshape(self.shape)
 
-    def light_travel_time(self, skycoord, kind='barycentric', location=None, ephemeris=None):
+    def light_travel_time(
+        self, skycoord, kind="barycentric", location=None, ephemeris=None
+    ):
         """Light travel time correction to the barycentre or heliocentre.
 
         The frame transformations used to calculate the location of the solar
@@ -1917,15 +2092,18 @@ class Time(TimeBase):
             Also, the time conversion to BJD will then include the relativistic correction as well.
         """
 
-        if kind.lower() not in ('barycentric', 'heliocentric'):
-            raise ValueError("'kind' parameter must be one of 'heliocentric' "
-                             "or 'barycentric'")
+        if kind.lower() not in ("barycentric", "heliocentric"):
+            raise ValueError(
+                "'kind' parameter must be one of 'heliocentric' or 'barycentric'"
+            )
 
         if location is None:
             if self.location is None:
-                raise ValueError('An EarthLocation needs to be set or passed '
-                                 'in to calculate bary- or heliocentric '
-                                 'corrections')
+                raise ValueError(
+                    "An EarthLocation needs to be set or passed "
+                    "in to calculate bary- or heliocentric "
+                    "corrections"
+                )
             location = self.location
 
         from astropy.coordinates import (
@@ -1945,10 +2123,12 @@ class Time(TimeBase):
         try:
             itrs = location.get_itrs(obstime=self)
         except Exception:
-            raise ValueError("Supplied location does not have a valid `get_itrs` method")
+            raise ValueError(
+                "Supplied location does not have a valid `get_itrs` method"
+            )
 
         with solar_system_ephemeris.set(ephemeris):
-            if kind.lower() == 'heliocentric':
+            if kind.lower() == "heliocentric":
                 # convert to heliocentric coordinates, aligned with ICRS
                 cpos = itrs.transform_to(HCRS(obstime=self)).cartesian.xyz
             else:
@@ -1959,8 +2139,11 @@ class Time(TimeBase):
                 cpos = gcrs_coo.transform_to(ICRS()).cartesian.xyz
 
         # get unit ICRS vector to star
-        spos = (skycoord.icrs.represent_as(UnitSphericalRepresentation).
-                represent_as(CartesianRepresentation).xyz)
+        spos = (
+            skycoord.icrs.represent_as(UnitSphericalRepresentation)
+            .represent_as(CartesianRepresentation)
+            .xyz
+        )
 
         # Move X,Y,Z to last dimension, to enable possible broadcasting below.
         cpos = np.rollaxis(cpos, 0, cpos.ndim)
@@ -1968,7 +2151,7 @@ class Time(TimeBase):
 
         # calculate light travel time correction
         tcor_val = (spos * cpos).sum(axis=-1) / const.c
-        return TimeDelta(tcor_val, scale='tdb')
+        return TimeDelta(tcor_val, scale="tdb")
 
     def earth_rotation_angle(self, longitude=None):
         """Calculate local Earth rotation angle.
@@ -2011,15 +2194,18 @@ class Time(TimeBase):
         (except when ``longitude='tio'``).
 
         """  # noqa: E501
-        if isinstance(longitude, str) and longitude == 'tio':
+        if isinstance(longitude, str) and longitude == "tio":
             longitude = 0
             include_tio = False
         else:
             include_tio = True
 
-        return self._sid_time_or_earth_rot_ang(longitude=longitude,
-                                               function=erfa.era00, scales=('ut1',),
-                                               include_tio=include_tio)
+        return self._sid_time_or_earth_rot_ang(
+            longitude=longitude,
+            function=erfa.era00,
+            scales=("ut1",),
+            include_tio=include_tio,
+        )
 
     def sidereal_time(self, kind, longitude=None, model=None):
         """Calculate sidereal time.
@@ -2075,8 +2261,11 @@ class Time(TimeBase):
         """  # noqa: E501 (docstring is formatted below)
 
         if kind.lower() not in SIDEREAL_TIME_MODELS.keys():
-            raise ValueError('The kind of sidereal time has to be {}'.format(
-                ' or '.join(sorted(SIDEREAL_TIME_MODELS.keys()))))
+            raise ValueError(
+                "The kind of sidereal time has to be {}".format(
+                    " or ".join(sorted(SIDEREAL_TIME_MODELS.keys()))
+                )
+            )
 
         available_models = SIDEREAL_TIME_MODELS[kind.lower()]
 
@@ -2084,23 +2273,28 @@ class Time(TimeBase):
             model = sorted(available_models.keys())[-1]
         elif model.upper() not in available_models:
             raise ValueError(
-                'Model {} not implemented for {} sidereal time; '
-                'available models are {}'
-                .format(model, kind, sorted(available_models.keys())))
+                "Model {} not implemented for {} sidereal time; "
+                "available models are {}".format(
+                    model, kind, sorted(available_models.keys())
+                )
+            )
 
         model_kwargs = available_models[model.upper()]
 
-        if isinstance(longitude, str) and longitude in ('tio', 'greenwich'):
+        if isinstance(longitude, str) and longitude in ("tio", "greenwich"):
             longitude = 0
             model_kwargs = model_kwargs.copy()
-            model_kwargs['include_tio'] = False
+            model_kwargs["include_tio"] = False
 
         return self._sid_time_or_earth_rot_ang(longitude=longitude, **model_kwargs)
 
     if isinstance(sidereal_time.__doc__, str):
         sidereal_time.__doc__ = sidereal_time.__doc__.format(
-            'apparent', sorted(SIDEREAL_TIME_MODELS['apparent'].keys()),
-            'mean', sorted(SIDEREAL_TIME_MODELS['mean'].keys()))
+            "apparent",
+            sorted(SIDEREAL_TIME_MODELS["apparent"].keys()),
+            "mean",
+            sorted(SIDEREAL_TIME_MODELS["mean"].keys()),
+        )
 
     def _sid_time_or_earth_rot_ang(self, longitude, function, scales, include_tio=True):
         """Calculate a local sidereal time or Earth rotation angle.
@@ -2131,8 +2325,10 @@ class Time(TimeBase):
 
         if longitude is None:
             if self.location is None:
-                raise ValueError('No longitude is given but the location for '
-                                 'the Time object is not set.')
+                raise ValueError(
+                    "No longitude is given but the location for "
+                    "the Time object is not set."
+                )
             longitude = self.location.lon
         elif isinstance(longitude, EarthLocation):
             longitude = longitude.lon
@@ -2145,13 +2341,15 @@ class Time(TimeBase):
         if include_tio:
             # TODO: this duplicates part of coordinates.erfa_astrom.ErfaAstrom.apio;
             # maybe posisble to factor out to one or the other.
-            sp = self._call_erfa(erfa.sp00, ('tt',))
+            sp = self._call_erfa(erfa.sp00, ("tt",))
             xp, yp = get_polar_motion(self)
             # Form the rotation matrix, CIRS to apparent [HA,Dec].
-            r = (rotation_matrix(longitude, 'z')
-                 @ rotation_matrix(-yp, 'x', unit=u.radian)
-                 @ rotation_matrix(-xp, 'y', unit=u.radian)
-                 @ rotation_matrix(theta + sp, 'z', unit=u.radian))
+            r = (
+                rotation_matrix(longitude, "z")
+                @ rotation_matrix(-yp, "x", unit=u.radian)
+                @ rotation_matrix(-xp, "y", unit=u.radian)
+                @ rotation_matrix(theta + sp, "z", unit=u.radian)
+            )
             # Solve for angle.
             angle = np.arctan2(r[..., 0, 1], r[..., 0, 0]) << u.radian
 
@@ -2162,9 +2360,11 @@ class Time(TimeBase):
 
     def _call_erfa(self, function, scales):
         # TODO: allow erfa functions to be used on Time with __array_ufunc__.
-        erfa_parameters = [getattr(getattr(self, scale)._time, jd_part)
-                           for scale in scales
-                           for jd_part in ('jd1', 'jd2_filled')]
+        erfa_parameters = [
+            getattr(getattr(self, scale)._time, jd_part)
+            for scale in scales
+            for jd_part in ("jd1", "jd2_filled")
+        ]
 
         result = function(*erfa_parameters)
 
@@ -2217,6 +2417,7 @@ class Time(TimeBase):
         """
         if iers_table is None:
             from astropy.utils.iers import earth_orientation_table
+
             iers_table = earth_orientation_table.get()
 
         return iers_table.ut1_utc(self.utc, return_status=return_status)
@@ -2231,22 +2432,23 @@ class Time(TimeBase):
         """
         # Sec. 4.3.1: the arg DUT is the quantity delta_UT1 = UT1 - UTC in
         # seconds. It is obtained from tables published by the IERS.
-        if not hasattr(self, '_delta_ut1_utc'):
+        if not hasattr(self, "_delta_ut1_utc"):
             from astropy.utils.iers import earth_orientation_table
+
             iers_table = earth_orientation_table.get()
             # jd1, jd2 are normally set (see above), except if delta_ut1_utc
             # is access directly; ensure we behave as expected for that case
             if jd1 is None:
                 self_utc = self.utc
                 jd1, jd2 = self_utc._time.jd1, self_utc._time.jd2_filled
-                scale = 'utc'
+                scale = "utc"
             else:
                 scale = self.scale
             # interpolate UT1-UTC in IERS table
             delta = iers_table.ut1_utc(jd1, jd2)
             # if we interpolated using UT1 jds, we may be off by one
             # second near leap seconds (and very slightly off elsewhere)
-            if scale == 'ut1':
+            if scale == "ut1":
                 # calculate UTC using the offset we got; the ERFA routine
                 # is tolerant of leap seconds, so will do this right
                 jd1_utc, jd2_utc = erfa.ut1utc(jd1, jd2, delta.to_value(u.s))
@@ -2259,7 +2461,7 @@ class Time(TimeBase):
 
     def _set_delta_ut1_utc(self, val):
         del self.cache
-        if hasattr(val, 'to'):  # Matches Quantity but also TimeDelta.
+        if hasattr(val, "to"):  # Matches Quantity but also TimeDelta.
             val = val.to(u.second).value
         val = self._match_shape(val)
         self._delta_ut1_utc = val
@@ -2271,15 +2473,17 @@ class Time(TimeBase):
 
     # Property for ERFA DTR arg = TDB - TT
     def _get_delta_tdb_tt(self, jd1=None, jd2=None):
-        if not hasattr(self, '_delta_tdb_tt'):
+        if not hasattr(self, "_delta_tdb_tt"):
             # If jd1 and jd2 are not provided (which is the case for property
             # attribute access) then require that the time scale is TT or TDB.
             # Otherwise the computations here are not correct.
             if jd1 is None or jd2 is None:
-                if self.scale not in ('tt', 'tdb'):
-                    raise ValueError('Accessing the delta_tdb_tt attribute '
-                                     'is only possible for TT or TDB time '
-                                     'scales')
+                if self.scale not in ("tt", "tdb"):
+                    raise ValueError(
+                        "Accessing the delta_tdb_tt attribute "
+                        "is only possible for TT or TDB time "
+                        "scales"
+                    )
                 else:
                     jd1 = self._time.jd1
                     jd2 = self._time.jd2_filled
@@ -2295,7 +2499,7 @@ class Time(TimeBase):
 
             if self.location is None:
                 # Assume geocentric.
-                self._delta_tdb_tt = erfa.dtdb(jd1, jd2, ut, 0., 0., 0.)
+                self._delta_tdb_tt = erfa.dtdb(jd1, jd2, ut, 0.0, 0.0, 0.0)
             else:
                 location = self.location
                 # Geodetic params needed for d_tdb_tt()
@@ -2303,14 +2507,19 @@ class Time(TimeBase):
                 rxy = np.hypot(location.x, location.y)
                 z = location.z
                 self._delta_tdb_tt = erfa.dtdb(
-                    jd1, jd2, ut, lon.to_value(u.radian),
-                    rxy.to_value(u.km), z.to_value(u.km))
+                    jd1,
+                    jd2,
+                    ut,
+                    lon.to_value(u.radian),
+                    rxy.to_value(u.km),
+                    z.to_value(u.km),
+                )
 
         return self._delta_tdb_tt
 
     def _set_delta_tdb_tt(self, val):
         del self.cache
-        if hasattr(val, 'to'):  # Matches Quantity but also TimeDelta.
+        if hasattr(val, "to"):  # Matches Quantity but also TimeDelta.
             val = val.to(u.second).value
         val = self._match_shape(val)
         self._delta_tdb_tt = val
@@ -2340,29 +2549,34 @@ class Time(TimeBase):
                     other = getattr(other, out.scale)
             else:
                 if other.scale is None:
-                    out._set_scale('tai')
+                    out._set_scale("tai")
                 else:
                     if self.scale not in TIME_TYPES[other.scale]:
-                        raise TypeError("Cannot subtract Time and TimeDelta instances "
-                                        "with scales '{}' and '{}'"
-                                        .format(self.scale, other.scale))
+                        raise TypeError(
+                            "Cannot subtract Time and TimeDelta instances "
+                            "with scales '{}' and '{}'".format(self.scale, other.scale)
+                        )
                     out._set_scale(other.scale)
             # remove attributes that are invalidated by changing time
-            for attr in ('_delta_ut1_utc', '_delta_tdb_tt'):
+            for attr in ("_delta_ut1_utc", "_delta_tdb_tt"):
                 if hasattr(out, attr):
                     delattr(out, attr)
 
         else:  # T - T
             # the scales should be compatible (e.g., cannot convert TDB to LOCAL)
             if other.scale not in self.SCALES:
-                raise TypeError("Cannot subtract Time instances "
-                                "with scales '{}' and '{}'"
-                                .format(self.scale, other.scale))
-            self_time = (self._time if self.scale in TIME_DELTA_SCALES
-                         else self.tai._time)
+                raise TypeError(
+                    "Cannot subtract Time instances with scales '{}' and '{}'".format(
+                        self.scale, other.scale
+                    )
+                )
+            self_time = (
+                self._time if self.scale in TIME_DELTA_SCALES else self.tai._time
+            )
             # set up TimeDelta, subtraction to be done shortly
-            out = TimeDelta(self_time.jd1, self_time.jd2, format='jd',
-                            scale=self_time.scale)
+            out = TimeDelta(
+                self_time.jd1, self_time.jd2, format="jd", scale=self_time.scale
+            )
 
             if other.scale != out.scale:
                 other = getattr(other, out.scale)
@@ -2382,7 +2596,7 @@ class Time(TimeBase):
         # T      + Tdelta = T
         # T      + T      = error
         if isinstance(other, Time):
-            raise OperandTypeError(self, other, '+')
+            raise OperandTypeError(self, other, "+")
 
         # Check other is really a TimeDelta or something that can initialize.
         if not isinstance(other, TimeDelta):
@@ -2400,15 +2614,16 @@ class Time(TimeBase):
                 other = getattr(other, out.scale)
         else:
             if other.scale is None:
-                out._set_scale('tai')
+                out._set_scale("tai")
             else:
                 if self.scale not in TIME_TYPES[other.scale]:
-                    raise TypeError("Cannot add Time and TimeDelta instances "
-                                    "with scales '{}' and '{}'"
-                                    .format(self.scale, other.scale))
+                    raise TypeError(
+                        "Cannot add Time and TimeDelta instances "
+                        "with scales '{}' and '{}'".format(self.scale, other.scale)
+                    )
                 out._set_scale(other.scale)
         # remove attributes that are invalidated by changing time
-        for attr in ('_delta_ut1_utc', '_delta_tdb_tt'):
+        for attr in ("_delta_ut1_utc", "_delta_tdb_tt"):
             if hasattr(out, attr):
                 delattr(out, attr)
 
@@ -2428,12 +2643,13 @@ class Time(TimeBase):
         return self.__add__(other)
 
     def mean(self, axis=None, dtype=None, out=None, keepdims=False, *, where=True):
-
         scale = self.scale
-        if scale == 'utc':
+        if scale == "utc":
             self = self.tai
-        result = super().mean(axis=axis, dtype=dtype, out=out, keepdims=keepdims, where=where)
-        if scale == 'utc':
+        result = super().mean(
+            axis=axis, dtype=dtype, out=out, keepdims=keepdims, where=where
+        )
+        if scale == "utc":
             result = result.utc
 
         result.out_subfmt = self.out_subfmt
@@ -2441,11 +2657,10 @@ class Time(TimeBase):
         location = self.location
         if self.location is not None:
             if self.location.shape:
-
                 if axis is None:
                     axis_normalized = tuple(range(self.ndim))
                 elif isinstance(axis, int):
-                    axis_normalized = axis,
+                    axis_normalized = (axis,)
                 else:
                     axis_normalized = axis
 
@@ -2454,7 +2669,9 @@ class Time(TimeBase):
                     sl[a] = slice(0, 1)
 
                 if np.any(self.location != self.location[tuple(sl)]):
-                    raise ValueError("`location` must be constant over the reduction axes.")
+                    raise ValueError(
+                        "`location` must be constant over the reduction axes."
+                    )
 
                 if not keepdims:
                     for a in axis_normalized:
@@ -2494,7 +2711,7 @@ class Time(TimeBase):
     def to_datetime(self, timezone=None):
         # TODO: this could likely go through to_value, as long as that
         # had an **kwargs part that was just passed on to _time.
-        tm = self.replicate(format='datetime')
+        tm = self.replicate(format="datetime")
         return tm._shaped_like_input(tm._time.to_value(timezone))
 
     to_datetime.__doc__ = TimeDatetime.to_value.__doc__
@@ -2502,6 +2719,7 @@ class Time(TimeBase):
 
 class TimeDeltaMissingUnitWarning(AstropyDeprecationWarning):
     """Warning for missing unit or format in TimeDelta"""
+
     pass
 
 
@@ -2555,6 +2773,7 @@ class TimeDelta(TimeBase):
     copy : bool, optional
         Make a copy of the input values
     """
+
     SCALES = TIME_DELTA_SCALES
     """List of time delta scales."""
 
@@ -2563,10 +2782,18 @@ class TimeDelta(TimeBase):
 
     info = TimeDeltaInfo()
 
-    def __new__(cls, val, val2=None, format=None, scale=None,
-                precision=None, in_subfmt=None, out_subfmt=None,
-                location=None, copy=False):
-
+    def __new__(
+        cls,
+        val,
+        val2=None,
+        format=None,
+        scale=None,
+        precision=None,
+        in_subfmt=None,
+        out_subfmt=None,
+        location=None,
+        copy=False,
+    ):
         if isinstance(val, TimeDelta):
             self = val.replicate(format=format, copy=copy, cls=cls)
         else:
@@ -2588,13 +2815,16 @@ class TimeDelta(TimeBase):
     @staticmethod
     def _get_format(val):
         if isinstance(val, timedelta):
-            return 'datetime'
+            return "datetime"
 
-        if getattr(val, 'unit', None) is None:
-            warn('Numerical value without unit or explicit format passed to'
-                 ' TimeDelta, assuming days', TimeDeltaMissingUnitWarning)
+        if getattr(val, "unit", None) is None:
+            warn(
+                "Numerical value without unit or explicit format passed to"
+                " TimeDelta, assuming days",
+                TimeDeltaMissingUnitWarning,
+            )
 
-        return 'jd'
+        return "jd"
 
     def replicate(self, *args, **kwargs):
         out = super().replicate(*args, **kwargs)
@@ -2605,7 +2835,7 @@ class TimeDelta(TimeBase):
         """
         Convert to ``datetime.timedelta`` object.
         """
-        tm = self.replicate(format='datetime')
+        tm = self.replicate(format="datetime")
         return tm._shaped_like_input(tm._time.value)
 
     def _set_scale(self, scale):
@@ -2617,8 +2847,11 @@ class TimeDelta(TimeBase):
         if scale == self.scale:
             return
         if scale not in self.SCALES:
-            raise ValueError("Scale {!r} is not in the allowed scales {}"
-                             .format(scale, sorted(self.SCALES)))
+            raise ValueError(
+                "Scale {!r} is not in the allowed scales {}".format(
+                    scale, sorted(self.SCALES)
+                )
+            )
 
         # For TimeDelta, there can only be a change in scale factor,
         # which is written as time2 - time1 = scale_offset * time1
@@ -2629,9 +2862,14 @@ class TimeDelta(TimeBase):
             jd1, jd2 = self._time.jd1, self._time.jd2
             offset1, offset2 = day_frac(jd1, jd2, factor=scale_offset)
             self._time = self.FORMATS[self.format](
-                jd1 + offset1, jd2 + offset2, scale,
-                self.precision, self.in_subfmt,
-                self.out_subfmt, from_jd=True)
+                jd1 + offset1,
+                jd2 + offset2,
+                scale,
+                self.precision,
+                self.in_subfmt,
+                self.out_subfmt,
+                from_jd=True,
+            )
 
     def _add_sub(self, other, op):
         """Perform common elements of addition / subtraction for two delta times"""
@@ -2643,10 +2881,17 @@ class TimeDelta(TimeBase):
                 return NotImplemented
 
         # the scales should be compatible (e.g., cannot convert TDB to TAI)
-        if (self.scale is not None and self.scale not in other.SCALES
-            or other.scale is not None and other.scale not in self.SCALES):
-            raise TypeError("Cannot add TimeDelta instances with scales "
-                            "'{}' and '{}'".format(self.scale, other.scale))
+        if (
+            self.scale is not None
+            and self.scale not in other.SCALES
+            or other.scale is not None
+            and other.scale not in self.SCALES
+        ):
+            raise TypeError(
+                "Cannot add TimeDelta instances with scales '{}' and '{}'".format(
+                    self.scale, other.scale
+                )
+            )
 
         # adjust the scale of other if the scale of self is set (or no scales)
         if self.scale is not None or other.scale is None:
@@ -2673,7 +2918,7 @@ class TimeDelta(TimeBase):
     def __sub__(self, other):
         # TimeDelta - Time is an error
         if isinstance(other, Time):
-            raise OperandTypeError(self, other, '-')
+            raise OperandTypeError(self, other, "-")
 
         return self._add_sub(other, operator.sub)
 
@@ -2705,10 +2950,10 @@ class TimeDelta(TimeBase):
         # Check needed since otherwise the self.jd1 * other multiplication
         # would enter here again (via __rmul__)
         if isinstance(other, Time):
-            raise OperandTypeError(self, other, '*')
-        elif ((isinstance(other, u.UnitBase)
-               and other == u.dimensionless_unscaled)
-                or (isinstance(other, str) and other == '')):
+            raise OperandTypeError(self, other, "*")
+        elif (isinstance(other, u.UnitBase) and other == u.dimensionless_unscaled) or (
+            isinstance(other, str) and other == ""
+        ):
             return self.copy()
 
         # If other is something consistent with a dimensionless quantity
@@ -2726,9 +2971,9 @@ class TimeDelta(TimeBase):
                 return NotImplemented
 
         jd1, jd2 = day_frac(self.jd1, self.jd2, factor=other.value)
-        out = TimeDelta(jd1, jd2, format='jd', scale=self.scale)
+        out = TimeDelta(jd1, jd2, format="jd", scale=self.scale)
 
-        if self.format != 'jd':
+        if self.format != "jd":
             out = out.replicate(format=self.format)
         return out
 
@@ -2739,9 +2984,9 @@ class TimeDelta(TimeBase):
     def __truediv__(self, other):
         """Division of `TimeDelta` objects by numbers/arrays."""
         # Cannot do __mul__(1./other) as that looses precision
-        if ((isinstance(other, u.UnitBase)
-             and other == u.dimensionless_unscaled)
-                or (isinstance(other, str) and other == '')):
+        if (isinstance(other, u.UnitBase) and other == u.dimensionless_unscaled) or (
+            isinstance(other, str) and other == ""
+        ):
             return self.copy()
 
         # If other is something consistent with a dimensionless quantity
@@ -2759,9 +3004,9 @@ class TimeDelta(TimeBase):
                 return NotImplemented
 
         jd1, jd2 = day_frac(self.jd1, self.jd2, divisor=other.value)
-        out = TimeDelta(jd1, jd2, format='jd', scale=self.scale)
+        out = TimeDelta(jd1, jd2, format="jd", scale=self.scale)
 
-        if self.format != 'jd':
+        if self.format != "jd":
             out = out.replicate(format=self.format)
         return out
 
@@ -2794,8 +3039,9 @@ class TimeDelta(TimeBase):
         --------
         to_value : get the numerical value in a given unit.
         """
-        return u.Quantity(self._time.jd1 + self._time.jd2,
-                          u.day).to(unit, equivalencies=equivalencies)
+        return u.Quantity(self._time.jd1 + self._time.jd2, u.day).to(
+            unit, equivalencies=equivalencies
+        )
 
     def to_value(self, *args, **kwargs):
         """Get time delta values expressed in specified output format or unit.
@@ -2863,13 +3109,14 @@ class TimeDelta(TimeBase):
 
         """
         if not (args or kwargs):
-            raise TypeError('to_value() missing required format or unit argument')
+            raise TypeError("to_value() missing required format or unit argument")
 
         # TODO: maybe allow 'subfmt' also for units, keeping full precision
         # (effectively, by doing the reverse of quantity_day_frac)?
         # This way, only equivalencies could lead to possible precision loss.
-        if ('format' in kwargs
-                or (args != () and (args[0] is None or args[0] in self.FORMATS))):
+        if "format" in kwargs or (
+            args != () and (args[0] is None or args[0] in self.FORMATS)
+        ):
             # Super-class will error with duplicate arguments, etc.
             return super().to_value(*args, **kwargs)
 
@@ -2879,13 +3126,17 @@ class TimeDelta(TimeBase):
             try:
                 unit = u.Unit(args[0])
             except ValueError as exc:
-                raise ValueError("first argument is not one of the known "
-                                 "formats ({}) and failed to parse as a unit."
-                                 .format(list(self.FORMATS))) from exc
+                raise ValueError(
+                    "first argument is not one of the known "
+                    "formats ({}) and failed to parse as a unit.".format(
+                        list(self.FORMATS)
+                    )
+                ) from exc
             args = (unit,) + args[1:]
 
-        return u.Quantity(self._time.jd1 + self._time.jd2,
-                          u.day).to_value(*args, **kwargs)
+        return u.Quantity(self._time.jd1 + self._time.jd2, u.day).to_value(
+            *args, **kwargs
+        )
 
     def _make_value_equivalent(self, item, value):
         """Coerce setitem value into an equivalent TimeDelta object"""
@@ -2893,8 +3144,11 @@ class TimeDelta(TimeBase):
             try:
                 value = self.__class__(value, scale=self.scale, format=self.format)
             except Exception as err:
-                raise ValueError('cannot convert value to a compatible TimeDelta '
-                                 'object: {}'.format(err))
+                raise ValueError(
+                    "cannot convert value to a compatible TimeDelta object: {}".format(
+                        err
+                    )
+                )
         return value
 
     def isclose(self, other, atol=None, rtol=0.0):
@@ -2925,11 +3179,14 @@ class TimeDelta(TimeBase):
             atol = np.finfo(float).eps * u.day
 
         if not isinstance(atol, (u.Quantity, TimeDelta)):
-            raise TypeError("'atol' argument must be a Quantity or TimeDelta instance, got "
-                            f'{atol.__class__.__name__} instead')
+            raise TypeError(
+                "'atol' argument must be a Quantity or TimeDelta instance, got "
+                f"{atol.__class__.__name__} instead"
+            )
 
-        return np.isclose(self.to_value(u.day), other_day,
-                          rtol=rtol, atol=atol.to_value(u.day))
+        return np.isclose(
+            self.to_value(u.day), other_day, rtol=rtol, atol=atol.to_value(u.day)
+        )
 
 
 class ScaleValueError(Exception):
@@ -2958,7 +3215,7 @@ def _make_array(val, copy=False):
     # This also ensures the right byteorder for float64 (closes #2942).
     if val.dtype.kind == "f" and val.dtype.itemsize >= np.dtype(np.float64).itemsize:
         pass
-    elif val.dtype.kind in 'OSUMaV':
+    elif val.dtype.kind in "OSUMaV":
         pass
     else:
         val = np.asanyarray(val, dtype=np.float64)
@@ -2990,6 +3247,7 @@ def _check_for_masked_and_fill(val, val2):
     mask, val, val2: ndarray or None
         Mask: (None or bool ndarray), val, val2: ndarray
     """
+
     def get_as_filled_ndarray(mask, val):
         """
         Fill the given MaskedArray ``val`` from the first non-masked
@@ -3029,12 +3287,12 @@ def _check_for_masked_and_fill(val, val2):
 
 class OperandTypeError(TypeError):
     def __init__(self, left, right, op=None):
-        op_string = '' if op is None else f' for {op}'
+        op_string = "" if op is None else f" for {op}"
         super().__init__(
-            "Unsupported operand type(s){}: "
-            "'{}' and '{}'".format(op_string,
-                                   left.__class__.__name__,
-                                   right.__class__.__name__))
+            "Unsupported operand type(s){}: '{}' and '{}'".format(
+                op_string, left.__class__.__name__, right.__class__.__name__
+            )
+        )
 
 
 def _check_leapsec():
@@ -3083,6 +3341,8 @@ def update_leap_seconds(files=None):
         return erfa.leap_seconds.update(table)
 
     except Exception as exc:
-        warn("leap-second auto-update failed due to the following "
-             f"exception: {exc!r}", AstropyWarning)
+        warn(
+            f"leap-second auto-update failed due to the following exception: {exc!r}",
+            AstropyWarning,
+        )
         return 0

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -17,18 +17,44 @@ from astropy.utils.exceptions import AstropyDeprecationWarning
 from . import _parse_times, conf, utils
 from .utils import day_frac, quantity_day_frac, two_product, two_sum
 
-__all__ = ['TimeFormat', 'TimeJD', 'TimeMJD', 'TimeFromEpoch', 'TimeUnix',
-           'TimeUnixTai', 'TimeCxcSec', 'TimeGPS', 'TimeDecimalYear',
-           'TimePlotDate', 'TimeUnique', 'TimeDatetime', 'TimeString',
-           'TimeISO', 'TimeISOT', 'TimeFITS', 'TimeYearDayTime',
-           'TimeEpochDate', 'TimeBesselianEpoch', 'TimeJulianEpoch',
-           'TimeDeltaFormat', 'TimeDeltaSec', 'TimeDeltaJD',
-           'TimeEpochDateString', 'TimeBesselianEpochString',
-           'TimeJulianEpochString', 'TIME_FORMATS', 'TIME_DELTA_FORMATS',
-           'TimezoneInfo', 'TimeDeltaDatetime', 'TimeDatetime64', 'TimeYMDHMS',
-           'TimeNumeric', 'TimeDeltaNumeric']
+__all__ = [
+    "TimeFormat",
+    "TimeJD",
+    "TimeMJD",
+    "TimeFromEpoch",
+    "TimeUnix",
+    "TimeUnixTai",
+    "TimeCxcSec",
+    "TimeGPS",
+    "TimeDecimalYear",
+    "TimePlotDate",
+    "TimeUnique",
+    "TimeDatetime",
+    "TimeString",
+    "TimeISO",
+    "TimeISOT",
+    "TimeFITS",
+    "TimeYearDayTime",
+    "TimeEpochDate",
+    "TimeBesselianEpoch",
+    "TimeJulianEpoch",
+    "TimeDeltaFormat",
+    "TimeDeltaSec",
+    "TimeDeltaJD",
+    "TimeEpochDateString",
+    "TimeBesselianEpochString",
+    "TimeJulianEpochString",
+    "TIME_FORMATS",
+    "TIME_DELTA_FORMATS",
+    "TimezoneInfo",
+    "TimeDeltaDatetime",
+    "TimeDatetime64",
+    "TimeYMDHMS",
+    "TimeNumeric",
+    "TimeDeltaNumeric",
+]
 
-__doctest_skip__ = ['TimePlotDate']
+__doctest_skip__ = ["TimePlotDate"]
 
 # These both get filled in at end after TimeFormat subclasses defined.
 # Use an OrderedDict to fix the order in which formats are tried.
@@ -38,8 +64,13 @@ TIME_DELTA_FORMATS = OrderedDict()
 
 # Translations between deprecated FITS timescales defined by
 # Rots et al. 2015, A&A 574:A36, and timescales used here.
-FITS_DEPRECATED_SCALES = {'TDT': 'tt', 'ET': 'tt',
-                          'GMT': 'utc', 'UT': 'utc', 'IAT': 'tai'}
+FITS_DEPRECATED_SCALES = {
+    "TDT": "tt",
+    "ET": "tt",
+    "GMT": "utc",
+    "UT": "utc",
+    "IAT": "tai",
+}
 
 
 def _regexify_subfmts(subfmts):
@@ -56,18 +87,22 @@ def _regexify_subfmts(subfmts):
     for subfmt_tuple in subfmts:
         subfmt_in = subfmt_tuple[1]
         if isinstance(subfmt_in, str):
-            for strptime_code, regex in (('%Y', r'(?P<year>\d\d\d\d)'),
-                                         ('%m', r'(?P<mon>\d{1,2})'),
-                                         ('%d', r'(?P<mday>\d{1,2})'),
-                                         ('%H', r'(?P<hour>\d{1,2})'),
-                                         ('%M', r'(?P<min>\d{1,2})'),
-                                         ('%S', r'(?P<sec>\d{1,2})')):
+            for strptime_code, regex in (
+                ("%Y", r"(?P<year>\d\d\d\d)"),
+                ("%m", r"(?P<mon>\d{1,2})"),
+                ("%d", r"(?P<mday>\d{1,2})"),
+                ("%H", r"(?P<hour>\d{1,2})"),
+                ("%M", r"(?P<min>\d{1,2})"),
+                ("%S", r"(?P<sec>\d{1,2})"),
+            ):
                 subfmt_in = subfmt_in.replace(strptime_code, regex)
 
-            if '%' not in subfmt_in:
-                subfmt_tuple = (subfmt_tuple[0],
-                                re.compile(subfmt_in + '$'),
-                                subfmt_tuple[2])
+            if "%" not in subfmt_in:
+                subfmt_tuple = (
+                    subfmt_tuple[0],
+                    re.compile(subfmt_in + "$"),
+                    subfmt_tuple[2],
+                )
         new_subfmts.append(subfmt_tuple)
 
     return tuple(new_subfmts)
@@ -96,12 +131,13 @@ class TimeFormat:
         If true then val1, val2 are jd1, jd2
     """
 
-    _default_scale = 'utc'  # As of astropy 0.4
+    _default_scale = "utc"  # As of astropy 0.4
     subfmts = ()
     _registry = TIME_FORMATS
 
-    def __init__(self, val1, val2, scale, precision,
-                 in_subfmt, out_subfmt, from_jd=False):
+    def __init__(
+        self, val1, val2, scale, precision, in_subfmt, out_subfmt, from_jd=False
+    ):
         self.scale = scale  # validation of scale done later with _check_scale
         self.precision = precision
         self.in_subfmt = in_subfmt
@@ -120,19 +156,19 @@ class TimeFormat:
         # Register time formats that define a name, but leave out astropy_time since
         # it is not a user-accessible format and is only used for initialization into
         # a different format.
-        if 'name' in cls.__dict__ and cls.name != 'astropy_time':
+        if "name" in cls.__dict__ and cls.name != "astropy_time":
             # FIXME: check here that we're not introducing a collision with
             # an existing method or attribute; problem is it could be either
             # astropy.time.Time or astropy.time.TimeDelta, and at the point
             # where this is run neither of those classes have necessarily been
             # constructed yet.
-            if 'value' in cls.__dict__ and not hasattr(cls.value, "fget"):
+            if "value" in cls.__dict__ and not hasattr(cls.value, "fget"):
                 raise ValueError("If defined, 'value' must be a property")
 
             cls._registry[cls.name] = cls
 
         # If this class defines its own subfmts, preprocess the definitions.
-        if 'subfmts' in cls.__dict__:
+        if "subfmts" in cls.__dict__:
             cls.subfmts = _regexify_subfmts(cls.subfmts)
 
         return super().__init_subclass__(**kwargs)
@@ -148,7 +184,7 @@ class TimeFormat:
         try:
             cls._select_subfmts(subfmt)
         except ValueError:
-            subfmt = '*'
+            subfmt = "*"
         return subfmt
 
     @property
@@ -211,17 +247,17 @@ class TimeFormat:
 
     @property
     def mask(self):
-        if 'mask' not in self.cache:
-            self.cache['mask'] = np.isnan(self.jd2)
-            if self.cache['mask'].shape:
-                self.cache['mask'].flags.writeable = False
-        return self.cache['mask']
+        if "mask" not in self.cache:
+            self.cache["mask"] = np.isnan(self.jd2)
+            if self.cache["mask"].shape:
+                self.cache["mask"].flags.writeable = False
+        return self.cache["mask"]
 
     @property
     def masked(self):
-        if 'masked' not in self.cache:
-            self.cache['masked'] = bool(np.any(self.mask))
-        return self.cache['masked']
+        if "masked" not in self.cache:
+            self.cache["masked"] = bool(np.any(self.mask))
+        return self.cache["masked"]
 
     @property
     def jd2_filled(self):
@@ -235,8 +271,7 @@ class TimeFormat:
     def precision(self, val):
         # Verify precision is 0-9 (inclusive)
         if not isinstance(val, int) or val < 0 or val > 9:
-            raise ValueError('precision attribute must be an int between '
-                             '0 and 9')
+            raise ValueError("precision attribute must be an int between 0 and 9")
         self._precision = val
 
     @lazyproperty
@@ -251,19 +286,32 @@ class TimeFormat:
         # val1 cannot contain nan, but val2 can contain nan
         isfinite1 = np.isfinite(val1)
         if val1.size > 1:  # Calling .all() on a scalar is surprisingly slow
-            isfinite1 = isfinite1.all()  # Note: arr.all() about 3x faster than np.all(arr)
+            isfinite1 = (
+                isfinite1.all()
+            )  # Note: arr.all() about 3x faster than np.all(arr)
         elif val1.size == 0:
             isfinite1 = False
-        ok1 = (val1.dtype.kind == 'f' and val1.dtype.itemsize >= 8
-               and isfinite1 or val1.size == 0)
-        ok2 = val2 is None or (
-            val2.dtype.kind == 'f' and val2.dtype.itemsize >= 8
-            and not np.any(np.isinf(val2))) or val2.size == 0
+        ok1 = (
+            val1.dtype.kind == "f"
+            and val1.dtype.itemsize >= 8
+            and isfinite1
+            or val1.size == 0
+        )
+        ok2 = (
+            val2 is None
+            or (
+                val2.dtype.kind == "f"
+                and val2.dtype.itemsize >= 8
+                and not np.any(np.isinf(val2))
+            )
+            or val2.size == 0
+        )
         if not (ok1 and ok2):
-            raise TypeError('Input values for {} class must be finite doubles'
-                            .format(self.name))
+            raise TypeError(
+                f"Input values for {self.name} class must be finite doubles"
+            )
 
-        if getattr(val1, 'unit', None) is not None:
+        if getattr(val1, "unit", None) is not None:
             # Convert any quantity-likes to days first, attempting to be
             # careful with the conversion, so that, e.g., large numbers of
             # seconds get converted without losing precision because
@@ -277,20 +325,21 @@ class TimeFormat:
             except u.UnitsError:
                 raise u.UnitConversionError(
                     "only quantities with time units can be "
-                    "used to instantiate Time instances.")
+                    "used to instantiate Time instances."
+                )
             # We now have days, but the format may expect another unit.
             # On purpose, multiply with 1./day_unit because typically it is
             # 1./erfa.DAYSEC, and inverting it recovers the integer.
             # (This conversion will get undone in format's set_jds, hence
             # there may be room for optimizing this.)
-            factor = 1. / getattr(self, 'unit', 1.)
-            if factor != 1.:
+            factor = 1.0 / getattr(self, "unit", 1.0)
+            if factor != 1.0:
                 val1, carry = two_product(val1, factor)
                 carry += val2 * factor
                 val1, val2 = two_sum(val1, carry)
 
-        elif getattr(val2, 'unit', None) is not None:
-            raise TypeError('Cannot mix float and Quantity inputs')
+        elif getattr(val2, "unit", None) is not None:
+            raise TypeError("Cannot mix float and Quantity inputs")
 
         if val2 is None:
             val2 = np.array(0, dtype=val1.dtype)
@@ -321,9 +370,9 @@ class TimeFormat:
             scale = self._default_scale
 
         if scale not in TIME_SCALES:
-            raise ScaleValueError("Scale value '{}' not in "
-                                  "allowed values {}"
-                                  .format(scale, TIME_SCALES))
+            raise ScaleValueError(
+                f"Scale value '{scale}' not in allowed values {TIME_SCALES}"
+            )
 
         return scale
 
@@ -388,31 +437,31 @@ class TimeFormat:
         validation of an out_subfmt.
         """
         if not isinstance(pattern, str):
-            raise ValueError('subfmt attribute must be a string')
-        elif pattern == '*':
+            raise ValueError("subfmt attribute must be a string")
+        elif pattern == "*":
             return cls.subfmts
 
         subfmts = [x for x in cls.subfmts if fnmatch.fnmatchcase(x[0], pattern)]
         if len(subfmts) == 0:
             if len(cls.subfmts) == 0:
-                raise ValueError(f'subformat not allowed for format {cls.name}')
+                raise ValueError(f"subformat not allowed for format {cls.name}")
             else:
                 subfmt_names = [x[0] for x in cls.subfmts]
-                raise ValueError(f'subformat {pattern!r} must match one of '
-                                 f'{subfmt_names} for format {cls.name}')
+                raise ValueError(
+                    f"subformat {pattern!r} must match one of "
+                    f"{subfmt_names} for format {cls.name}"
+                )
 
         return subfmts
 
 
 class TimeNumeric(TimeFormat):
     subfmts = (
-        ('float', np.float64, None, np.add),
-        ('long', np.longdouble, utils.longdouble_to_twoval,
-         utils.twoval_to_longdouble),
-        ('decimal', np.object_, utils.decimal_to_twoval,
-         utils.twoval_to_decimal),
-        ('str', np.str_, utils.decimal_to_twoval, utils.twoval_to_string),
-        ('bytes', np.bytes_, utils.bytes_to_twoval, utils.twoval_to_bytes),
+        ("float", np.float64, None, np.add),
+        ("long", np.longdouble, utils.longdouble_to_twoval, utils.twoval_to_longdouble),
+        ("decimal", np.object_, utils.decimal_to_twoval, utils.twoval_to_decimal),
+        ("str", np.str_, utils.decimal_to_twoval, utils.twoval_to_string),
+        ("bytes", np.bytes_, utils.bytes_to_twoval, utils.twoval_to_bytes),
     )
 
     def _check_val_type(self, val1, val2):
@@ -423,34 +472,39 @@ class TimeNumeric(TimeFormat):
         # most common use-case of providing only val1.
         orig_val2_is_none = val2 is None
 
-        if val1.dtype.kind == 'f':
+        if val1.dtype.kind == "f":
             val1, val2 = super()._check_val_type(val1, val2)
-        elif (not orig_val2_is_none
-              or not (val1.dtype.kind in 'US'
-                      or (val1.dtype.kind == 'O'
-                          and all(isinstance(v, Decimal) for v in val1.flat)))):
+        elif not orig_val2_is_none or not (
+            val1.dtype.kind in "US"
+            or (
+                val1.dtype.kind == "O"
+                and all(isinstance(v, Decimal) for v in val1.flat)
+            )
+        ):
             raise TypeError(
-                'for {} class, input should be doubles, string, or Decimal, '
-                'and second values are only allowed for doubles.'
-                .format(self.name))
+                "for {} class, input should be doubles, string, or Decimal, "
+                "and second values are only allowed for doubles.".format(self.name)
+            )
 
-        val_dtype = (val1.dtype if orig_val2_is_none else
-                     np.result_type(val1.dtype, val2.dtype))
+        val_dtype = (
+            val1.dtype if orig_val2_is_none else np.result_type(val1.dtype, val2.dtype)
+        )
         subfmts = self._select_subfmts(self.in_subfmt)
         for subfmt, dtype, convert, _ in subfmts:
             if np.issubdtype(val_dtype, dtype):
                 break
         else:
-            raise ValueError('input type not among selected sub-formats.')
+            raise ValueError("input type not among selected sub-formats.")
 
         if convert is not None:
             try:
                 val1, val2 = convert(val1, val2)
             except Exception:
                 raise TypeError(
-                    'for {} class, input should be (long) doubles, string, '
-                    'or Decimal, and second values are only allowed for '
-                    '(long) doubles.'.format(self.name))
+                    "for {} class, input should be (long) doubles, string, "
+                    "or Decimal, and second values are only allowed for "
+                    "(long) doubles.".format(self.name)
+                )
 
         return val1, val2
 
@@ -472,11 +526,11 @@ class TimeNumeric(TimeFormat):
             out_subfmt = self.out_subfmt
         subfmt = self._select_subfmts(out_subfmt)[0]
         kwargs = {}
-        if subfmt[0] in ('str', 'bytes'):
-            unit = getattr(self, 'unit', 1)
+        if subfmt[0] in ("str", "bytes"):
+            unit = getattr(self, "unit", 1)
             digits = int(np.ceil(np.log10(unit / np.finfo(float).eps)))
             # TODO: allow a way to override the format.
-            kwargs['fmt'] = f'.{digits}f'
+            kwargs["fmt"] = f".{digits}f"
         value = subfmt[3](jd1, jd2, **kwargs)
         return self.mask_if_needed(value)
 
@@ -490,7 +544,8 @@ class TimeJD(TimeNumeric):
     the Julian Period.
     For example, 2451544.5 in JD is midnight on January 1, 2000.
     """
-    name = 'jd'
+
+    name = "jd"
 
     def set_jds(self, val1, val2):
         self._check_scale(self._scale)  # Validate scale.
@@ -503,7 +558,8 @@ class TimeMJD(TimeNumeric):
     This represents the number of days since midnight on November 17, 1858.
     For example, 51544.0 in MJD is midnight on January 1, 2000.
     """
-    name = 'mjd'
+
+    name = "mjd"
 
     def set_jds(self, val1, val2):
         self._check_scale(self._scale)  # Validate scale.
@@ -525,7 +581,8 @@ class TimeDecimalYear(TimeNumeric):
     of the first day of each year.  For example 2000.5 corresponds to the
     ISO time '2000-07-02 00:00:00'.
     """
-    name = 'decimalyear'
+
+    name = "decimalyear"
 
     def set_jds(self, val1, val2):
         self._check_scale(self._scale)  # Validate scale.
@@ -546,22 +603,21 @@ class TimeDecimalYear(TimeNumeric):
 
         # Possible enhancement: use np.unique to only compute start, stop
         # for unique values of iy_start.
-        scale = self.scale.upper().encode('ascii')
-        jd1_start, jd2_start = erfa.dtf2d(scale, iy_start, imon, iday,
-                                          ihr, imin, isec)
-        jd1_end, jd2_end = erfa.dtf2d(scale, iy_start + 1, imon, iday,
-                                      ihr, imin, isec)
+        scale = self.scale.upper().encode("ascii")
+        jd1_start, jd2_start = erfa.dtf2d(scale, iy_start, imon, iday, ihr, imin, isec)
+        jd1_end, jd2_end = erfa.dtf2d(scale, iy_start + 1, imon, iday, ihr, imin, isec)
 
-        t_start = Time(jd1_start, jd2_start, scale=self.scale, format='jd')
-        t_end = Time(jd1_end, jd2_end, scale=self.scale, format='jd')
+        t_start = Time(jd1_start, jd2_start, scale=self.scale, format="jd")
+        t_end = Time(jd1_end, jd2_end, scale=self.scale, format="jd")
         t_frac = t_start + (t_end - t_start) * y_frac
 
         self.jd1, self.jd2 = day_frac(t_frac.jd1, t_frac.jd2)
 
     def to_value(self, **kwargs):
-        scale = self.scale.upper().encode('ascii')
-        iy_start, ims, ids, ihmsfs = erfa.d2dtf(scale, 0,  # precision=0
-                                                self.jd1, self.jd2_filled)
+        scale = self.scale.upper().encode("ascii")
+        iy_start, ims, ids, ihmsfs = erfa.d2dtf(
+            scale, 0, self.jd1, self.jd2_filled  # precision=0
+        )
         imon = np.ones_like(iy_start)
         iday = np.ones_like(iy_start)
         ihr = np.zeros_like(iy_start)
@@ -570,11 +626,9 @@ class TimeDecimalYear(TimeNumeric):
 
         # Possible enhancement: use np.unique to only compute start, stop
         # for unique values of iy_start.
-        scale = self.scale.upper().encode('ascii')
-        jd1_start, jd2_start = erfa.dtf2d(scale, iy_start, imon, iday,
-                                          ihr, imin, isec)
-        jd1_end, jd2_end = erfa.dtf2d(scale, iy_start + 1, imon, iday,
-                                      ihr, imin, isec)
+        scale = self.scale.upper().encode("ascii")
+        jd1_start, jd2_start = erfa.dtf2d(scale, iy_start, imon, iday, ihr, imin, isec)
+        jd1_end, jd2_end = erfa.dtf2d(scale, iy_start + 1, imon, iday, ihr, imin, isec)
         # Trying to be precise, but more than float64 not useful.
         dt = (self.jd1 - jd1_start) + (self.jd2 - jd2_start)
         dt_end = (jd1_end - jd1_start) + (jd2_end - jd2_start)
@@ -597,8 +651,12 @@ class TimeFromEpoch(TimeNumeric):
         # Ideally we would use `def epoch(cls)` here and not have the instance
         # property below. However, this breaks the sphinx API docs generation
         # in a way that was not resolved. See #10406 for details.
-        return Time(cls.epoch_val, cls.epoch_val2, scale=cls.epoch_scale,
-                    format=cls.epoch_format)
+        return Time(
+            cls.epoch_val,
+            cls.epoch_val2,
+            scale=cls.epoch_scale,
+            format=cls.epoch_format,
+        )
 
     @property
     def epoch(self):
@@ -622,7 +680,7 @@ class TimeFromEpoch(TimeNumeric):
         # and 1/86400 is not exactly representable as a float64, so multiplying
         # by that will cause rounding errors. (But inverting it as a float64
         # recovers the exact number)
-        day, frac = day_frac(val1, val2, divisor=1. / self.unit)
+        day, frac = day_frac(val1, val2, divisor=1.0 / self.unit)
 
         jd1 = self.epoch.jd1 + day
         jd2 = self.epoch.jd2 + frac
@@ -647,13 +705,16 @@ class TimeFromEpoch(TimeNumeric):
         # A known limitation is that the transform from self.epoch_scale to
         # self.scale cannot involve any metadata like lat or lon.
         try:
-            tm = getattr(Time(jd1, jd2, scale=self.epoch_scale,
-                              format='jd'), self.scale)
+            tm = getattr(
+                Time(jd1, jd2, scale=self.epoch_scale, format="jd"), self.scale
+            )
         except Exception as err:
-            raise ScaleValueError("Cannot convert from '{}' epoch scale '{}'"
-                                  "to specified scale '{}', got error:\n{}"
-                                  .format(self.name, self.epoch_scale,
-                                          self.scale, err)) from err
+            raise ScaleValueError(
+                "Cannot convert from '{}' epoch scale '{}'"
+                "to specified scale '{}', got error:\n{}".format(
+                    self.name, self.epoch_scale, self.scale, err
+                )
+            ) from err
 
         self.jd1, self.jd2 = day_frac(tm._time.jd1, tm._time.jd2)
 
@@ -662,14 +723,16 @@ class TimeFromEpoch(TimeNumeric):
         # subtract the epoch and convert
         if self.scale != self.epoch_scale:
             if parent is None:
-                raise ValueError('cannot compute value without parent Time object')
+                raise ValueError("cannot compute value without parent Time object")
             try:
                 tm = getattr(parent, self.epoch_scale)
             except Exception as err:
-                raise ScaleValueError("Cannot convert from '{}' epoch scale '{}'"
-                                      "to specified scale '{}', got error:\n{}"
-                                      .format(self.name, self.epoch_scale,
-                                              self.scale, err)) from err
+                raise ScaleValueError(
+                    "Cannot convert from '{}' epoch scale '{}'"
+                    "to specified scale '{}', got error:\n{}".format(
+                        self.name, self.epoch_scale, self.scale, err
+                    )
+                ) from err
 
             jd1, jd2 = tm._time.jd1, tm._time.jd2
         else:
@@ -677,7 +740,7 @@ class TimeFromEpoch(TimeNumeric):
 
         # This factor is guaranteed to be exactly representable, which
         # means time_from_epoch1 is calculated exactly.
-        factor = 1. / self.unit
+        factor = 1.0 / self.unit
         time_from_epoch1 = (jd1 - self.epoch.jd1) * factor
         time_from_epoch2 = (jd2 - self.epoch.jd2) * factor
 
@@ -702,12 +765,13 @@ class TimeUnix(TimeFromEpoch):
     days while this class value is monotonically increasing at 86400 seconds
     per UTC day.
     """
-    name = 'unix'
+
+    name = "unix"
     unit = 1.0 / erfa.DAYSEC  # in days (1 day == 86400 seconds)
-    epoch_val = '1970-01-01 00:00:00'
+    epoch_val = "1970-01-01 00:00:00"
     epoch_val2 = None
-    epoch_scale = 'utc'
-    epoch_format = 'iso'
+    epoch_scale = "utc"
+    epoch_format = "iso"
 
 
 class TimeUnixTai(TimeUnix):
@@ -757,9 +821,10 @@ class TimeUnixTai(TimeUnix):
       >>> t.unix_tai - t.unix
       10.0
     """
-    name = 'unix_tai'
-    epoch_val = '1970-01-01 00:00:00'
-    epoch_scale = 'tai'
+
+    name = "unix_tai"
+    epoch_val = "1970-01-01 00:00:00"
+    epoch_scale = "tai"
 
 
 class TimeCxcSec(TimeFromEpoch):
@@ -767,12 +832,13 @@ class TimeCxcSec(TimeFromEpoch):
     Chandra X-ray Center seconds from 1998-01-01 00:00:00 TT.
     For example, 63072064.184 is midnight on January 1, 2000.
     """
-    name = 'cxcsec'
+
+    name = "cxcsec"
     unit = 1.0 / erfa.DAYSEC  # in days (1 day == 86400 seconds)
-    epoch_val = '1998-01-01 00:00:00'
+    epoch_val = "1998-01-01 00:00:00"
     epoch_val2 = None
-    epoch_scale = 'tt'
-    epoch_format = 'iso'
+    epoch_scale = "tt"
+    epoch_format = "iso"
 
 
 class TimeGPS(TimeFromEpoch):
@@ -788,13 +854,14 @@ class TimeGPS(TimeFromEpoch):
 
     For details, see https://www.usno.navy.mil/USNO/time/gps/usno-gps-time-transfer
     """
-    name = 'gps'
+
+    name = "gps"
     unit = 1.0 / erfa.DAYSEC  # in days (1 day == 86400 seconds)
-    epoch_val = '1980-01-06 00:00:19'
+    epoch_val = "1980-01-06 00:00:19"
     # above epoch is the same as Time('1980-01-06 00:00:00', scale='utc').tai
     epoch_val2 = None
-    epoch_scale = 'tai'
-    epoch_format = 'iso'
+    epoch_scale = "tai"
+    epoch_format = "iso"
 
 
 class TimePlotDate(TimeFromEpoch):
@@ -814,14 +881,15 @@ class TimePlotDate(TimeFromEpoch):
 
     For example, 730120.0003703703 is midnight on January 1, 2000.
     """
+
     # This corresponds to the zero reference time for matplotlib plot_date().
     # Note that TAI and UTC are equivalent at the reference time.
-    name = 'plot_date'
+    name = "plot_date"
     unit = 1.0
     epoch_val = 1721424.5  # Time('0001-01-01 00:00:00', scale='tai').jd - 1
     epoch_val2 = None
-    epoch_scale = 'utc'
-    epoch_format = 'jd'
+    epoch_scale = "utc"
+    epoch_format = "jd"
 
     @lazyproperty
     def epoch(self):
@@ -836,11 +904,12 @@ class TimePlotDate(TimeFromEpoch):
             # Get the matplotlib date epoch as an ISOT string in UTC
             epoch_utc = get_epoch()
             from erfa import ErfaWarning
+
             with warnings.catch_warnings():
                 # Catch possible dubious year warnings from erfa
-                warnings.filterwarnings('ignore', category=ErfaWarning)
-                _epoch = Time(epoch_utc, scale='utc', format='isot')
-            _epoch.format = 'jd'
+                warnings.filterwarnings("ignore", category=ErfaWarning)
+                _epoch = Time(epoch_utc, scale="utc", format="isot")
+            _epoch.format = "jd"
 
         return _epoch
 
@@ -851,12 +920,13 @@ class TimeStardate(TimeFromEpoch):
     For example, stardate 41153.7 is 00:52 on April 30, 2363.
     See http://trekguide.com/Stardates.htm#TNG for calculations and reference points
     """
-    name = 'stardate'
+
+    name = "stardate"
     unit = 0.397766856  # Stardate units per day
-    epoch_val = '2318-07-05 11:00:00'  # Date and time of stardate 00000.00
+    epoch_val = "2318-07-05 11:00:00"  # Date and time of stardate 00000.00
     epoch_val2 = None
-    epoch_scale = 'tai'
-    epoch_format = 'iso'
+    epoch_scale = "tai"
+    epoch_format = "iso"
 
 
 class TimeUnique(TimeFormat):
@@ -874,19 +944,26 @@ class TimeAstropyTime(TimeUnique):
     This is purely for instantiating from a Time object.  The output
     format is the same as the first time instance.
     """
-    name = 'astropy_time'
 
-    def __new__(cls, val1, val2, scale, precision,
-                in_subfmt, out_subfmt, from_jd=False):
+    name = "astropy_time"
+
+    def __new__(
+        cls, val1, val2, scale, precision, in_subfmt, out_subfmt, from_jd=False
+    ):
         """
         Use __new__ instead of __init__ to output a class instance that
         is the same as the class of the first Time object in the list.
         """
         val1_0 = val1.flat[0]
-        if not (isinstance(val1_0, Time) and all(type(val) is type(val1_0)
-                                                 for val in val1.flat)):
-            raise TypeError('Input values for {} class must all be same '
-                            'astropy Time type.'.format(cls.name))
+        if not (
+            isinstance(val1_0, Time)
+            and all(type(val) is type(val1_0) for val in val1.flat)
+        ):
+            raise TypeError(
+                "Input values for {} class must all be same astropy Time type.".format(
+                    cls.name
+                )
+            )
 
         if scale is None:
             scale = val1_0.scale
@@ -899,12 +976,15 @@ class TimeAstropyTime(TimeUnique):
             # Collect individual location values and merge into a single location.
             if any(tm.location is not None for tm in val1):
                 if any(tm.location is None for tm in val1):
-                    raise ValueError('cannot concatenate times unless all locations '
-                                     'are set or no locations are set')
+                    raise ValueError(
+                        "cannot concatenate times unless all locations "
+                        "are set or no locations are set"
+                    )
                 locations = []
                 for tm in val1:
-                    location = np.broadcast_to(tm.location, tm._time.jd1.shape,
-                                               subok=True)
+                    location = np.broadcast_to(
+                        tm.location, tm._time.jd1.shape, subok=True
+                    )
                     locations.append(np.atleast_1d(location))
 
                 location = np.concatenate(locations)
@@ -917,8 +997,9 @@ class TimeAstropyTime(TimeUnique):
             location = val1_0.location
 
         OutTimeFormat = val1_0._time.__class__
-        self = OutTimeFormat(jd1, jd2, scale, precision, in_subfmt, out_subfmt,
-                             from_jd=True)
+        self = OutTimeFormat(
+            jd1, jd2, scale, precision, in_subfmt, out_subfmt, from_jd=True
+        )
 
         # Make a temporary hidden attribute to transfer location back to the
         # parent Time object where it needs to live.
@@ -941,23 +1022,28 @@ class TimeDatetime(TimeUnique):
       >>> t.tt.datetime
       datetime.datetime(2000, 1, 2, 12, 1, 4, 184000)
     """
-    name = 'datetime'
+
+    name = "datetime"
 
     def _check_val_type(self, val1, val2):
         if not all(isinstance(val, datetime.datetime) for val in val1.flat):
-            raise TypeError('Input values for {} class must be '
-                            'datetime objects'.format(self.name))
+            raise TypeError(
+                f"Input values for {self.name} class must be datetime objects"
+            )
         if val2 is not None:
             raise ValueError(
-                f'{self.name} objects do not accept a val2 but you provided {val2}')
+                f"{self.name} objects do not accept a val2 but you provided {val2}"
+            )
         return val1, None
 
     def set_jds(self, val1, val2):
         """Convert datetime object contained in val1 to jd1, jd2"""
         # Iterate through the datetime objects, getting year, month, etc.
-        iterator = np.nditer([val1, None, None, None, None, None, None],
-                             flags=['refs_ok', 'zerosize_ok'],
-                             op_dtypes=[None] + 5*[np.intc] + [np.double])
+        iterator = np.nditer(
+            [val1, None, None, None, None, None, None],
+            flags=["refs_ok", "zerosize_ok"],
+            op_dtypes=[None] + 5 * [np.intc] + [np.double],
+        )
         for val, iy, im, id, ihr, imin, dsec in iterator:
             dt = val.item()
 
@@ -971,8 +1057,9 @@ class TimeDatetime(TimeUnique):
             imin[...] = dt.minute
             dsec[...] = dt.second + dt.microsecond / 1e6
 
-        jd1, jd2 = erfa.dtf2d(self.scale.upper().encode('ascii'),
-                              *iterator.operands[1:])
+        jd1, jd2 = erfa.dtf2d(
+            self.scale.upper().encode("ascii"), *iterator.operands[1:]
+        )
         self.jd1, self.jd2 = day_frac(jd1, jd2)
 
     def to_value(self, timezone=None, parent=None, out_subfmt=None):
@@ -998,31 +1085,41 @@ class TimeDatetime(TimeUnique):
             self._select_subfmts(out_subfmt)
 
         if timezone is not None:
-            if self._scale != 'utc':
-                raise ScaleValueError("scale is {}, must be 'utc' when timezone "
-                                      "is supplied.".format(self._scale))
+            if self._scale != "utc":
+                raise ScaleValueError(
+                    "scale is {}, must be 'utc' when timezone is supplied.".format(
+                        self._scale
+                    )
+                )
 
         # Rather than define a value property directly, we have a function,
         # since we want to be able to pass in timezone information.
-        scale = self.scale.upper().encode('ascii')
-        iys, ims, ids, ihmsfs = erfa.d2dtf(scale, 6,  # 6 for microsec
-                                           self.jd1, self.jd2_filled)
-        ihrs = ihmsfs['h']
-        imins = ihmsfs['m']
-        isecs = ihmsfs['s']
-        ifracs = ihmsfs['f']
-        iterator = np.nditer([iys, ims, ids, ihrs, imins, isecs, ifracs, None],
-                             flags=['refs_ok', 'zerosize_ok'],
-                             op_dtypes=7*[None] + [object])
+        scale = self.scale.upper().encode("ascii")
+        iys, ims, ids, ihmsfs = erfa.d2dtf(
+            scale, 6, self.jd1, self.jd2_filled  # 6 for microsec
+        )
+        ihrs = ihmsfs["h"]
+        imins = ihmsfs["m"]
+        isecs = ihmsfs["s"]
+        ifracs = ihmsfs["f"]
+        iterator = np.nditer(
+            [iys, ims, ids, ihrs, imins, isecs, ifracs, None],
+            flags=["refs_ok", "zerosize_ok"],
+            op_dtypes=7 * [None] + [object],
+        )
 
         for iy, im, id, ihr, imin, isec, ifracsec, out in iterator:
             if isec >= 60:
-                raise ValueError('Time {} is within a leap second but datetime '
-                                 'does not support leap seconds'
-                                 .format((iy, im, id, ihr, imin, isec, ifracsec)))
+                raise ValueError(
+                    "Time {} is within a leap second but datetime "
+                    "does not support leap seconds".format(
+                        (iy, im, id, ihr, imin, isec, ifracsec)
+                    )
+                )
             if timezone is not None:
-                out[...] = datetime.datetime(iy, im, id, ihr, imin, isec, ifracsec,
-                                             tzinfo=TimezoneInfo()).astimezone(timezone)
+                out[...] = datetime.datetime(
+                    iy, im, id, ihr, imin, isec, ifracsec, tzinfo=TimezoneInfo()
+                ).astimezone(timezone)
             else:
                 out[...] = datetime.datetime(iy, im, id, ihr, imin, isec, ifracsec)
 
@@ -1062,7 +1159,8 @@ class TimeYMDHMS(TimeUnique):
       >>> t.ymdhms.year
       2015
     """
-    name = 'ymdhms'
+
+    name = "ymdhms"
 
     def _check_val_type(self, val1, val2):
         """
@@ -1084,9 +1182,9 @@ class TimeYMDHMS(TimeUnique):
 
         """
         if val2 is not None:
-            raise ValueError('val2 must be None for ymdhms format')
+            raise ValueError("val2 must be None for ymdhms format")
 
-        ymdhms = ['year', 'month', 'day', 'hour', 'minute', 'second']
+        ymdhms = ["year", "month", "day", "hour", "minute", "second"]
 
         if val1.dtype.names:
             # Convert to a dict of ndarray
@@ -1096,9 +1194,11 @@ class TimeYMDHMS(TimeUnique):
             # Input was empty list [], so set to None and set_jds will handle this
             return None, None
 
-        elif (val1.dtype.kind == 'O'
-              and val1.shape == ()
-              and isinstance(val1.item(), dict)):
+        elif (
+            val1.dtype.kind == "O"
+            and val1.shape == ()
+            and isinstance(val1.item(), dict)
+        ):
             # Code gets here for input as a dict.  The dict input
             # can be either scalar values or N-d arrays.
 
@@ -1106,26 +1206,31 @@ class TimeYMDHMS(TimeUnique):
             # same shape here.
             names = val1.item().keys()
             values = val1.item().values()
-            val1_as_dict = {name: value for name, value
-                            in zip(names, np.broadcast_arrays(*values))}
+            val1_as_dict = {
+                name: value for name, value in zip(names, np.broadcast_arrays(*values))
+            }
 
         else:
-            raise ValueError('input must be dict or table-like')
+            raise ValueError("input must be dict or table-like")
 
         # Check that the key names now are good.
         names = val1_as_dict.keys()
-        required_names = ymdhms[:len(names)]
+        required_names = ymdhms[: len(names)]
 
         def comma_repr(vals):
-            return ', '.join(repr(val) for val in vals)
+            return ", ".join(repr(val) for val in vals)
 
         bad_names = set(names) - set(ymdhms)
         if bad_names:
-            raise ValueError(f'{comma_repr(bad_names)} not allowed as YMDHMS key name(s)')
+            raise ValueError(
+                f"{comma_repr(bad_names)} not allowed as YMDHMS key name(s)"
+            )
 
         if set(names) != set(required_names):
-            raise ValueError(f'for {len(names)} input key names '
-                             f'you must supply {comma_repr(required_names)}')
+            raise ValueError(
+                f"for {len(names)} input key names "
+                f"you must supply {comma_repr(required_names)}"
+            )
 
         return val1_as_dict, val2
 
@@ -1136,34 +1241,40 @@ class TimeYMDHMS(TimeUnique):
             jd2 = np.array([], dtype=np.float64)
 
         else:
-            jd1, jd2 = erfa.dtf2d(self.scale.upper().encode('ascii'),
-                                  val1['year'],
-                                  val1.get('month', 1),
-                                  val1.get('day', 1),
-                                  val1.get('hour', 0),
-                                  val1.get('minute', 0),
-                                  val1.get('second', 0))
+            jd1, jd2 = erfa.dtf2d(
+                self.scale.upper().encode("ascii"),
+                val1["year"],
+                val1.get("month", 1),
+                val1.get("day", 1),
+                val1.get("hour", 0),
+                val1.get("minute", 0),
+                val1.get("second", 0),
+            )
 
         self.jd1, self.jd2 = day_frac(jd1, jd2)
 
     @property
     def value(self):
-        scale = self.scale.upper().encode('ascii')
-        iys, ims, ids, ihmsfs = erfa.d2dtf(scale, 9,
-                                           self.jd1, self.jd2_filled)
+        scale = self.scale.upper().encode("ascii")
+        iys, ims, ids, ihmsfs = erfa.d2dtf(scale, 9, self.jd1, self.jd2_filled)
 
-        out = np.empty(self.jd1.shape, dtype=[('year', 'i4'),
-                                              ('month', 'i4'),
-                                              ('day', 'i4'),
-                                              ('hour', 'i4'),
-                                              ('minute', 'i4'),
-                                              ('second', 'f8')])
-        out['year'] = iys
-        out['month'] = ims
-        out['day'] = ids
-        out['hour'] = ihmsfs['h']
-        out['minute'] = ihmsfs['m']
-        out['second'] = ihmsfs['s'] + ihmsfs['f'] * 10**(-9)
+        out = np.empty(
+            self.jd1.shape,
+            dtype=[
+                ("year", "i4"),
+                ("month", "i4"),
+                ("day", "i4"),
+                ("hour", "i4"),
+                ("minute", "i4"),
+                ("second", "f8"),
+            ],
+        )
+        out["year"] = iys
+        out["month"] = ims
+        out["day"] = ids
+        out["hour"] = ihmsfs["h"]
+        out["minute"] = ihmsfs["m"]
+        out["second"] = ihmsfs["s"] + ihmsfs["f"] * 10 ** (-9)
         out = out.view(np.recarray)
 
         return self.mask_if_needed(out)
@@ -1178,6 +1289,7 @@ class TimezoneInfo(datetime.tzinfo):
     pytz rather than defining your own timezones - this class is mainly
     a workaround for users without pytz.
     """
+
     @u.quantity_input(utc_offset=u.day, dst=u.day)
     def __init__(self, utc_offset=0 * u.day, dst=0 * u.day, tzname=None):
         """
@@ -1205,7 +1317,7 @@ class TimezoneInfo(datetime.tzinfo):
         1999-12-31 23:00:00+00:00
         """
         if utc_offset == 0 and dst == 0 and tzname is None:
-            tzname = 'UTC'
+            tzname = "UTC"
         self._utcoffset = datetime.timedelta(utc_offset.to_value(u.day))
         self._tzname = tzname
         self._dst = datetime.timedelta(dst.to_value(u.day))
@@ -1262,37 +1374,44 @@ class TimeString(TimeUnique):
     """
 
     def __init_subclass__(cls, **kwargs):
-        if 'fast_parser_pars' in cls.__dict__:
+        if "fast_parser_pars" in cls.__dict__:
             fpp = cls.fast_parser_pars
-            fpp = np.array(list(zip(map(chr, fpp['delims']),
-                                    fpp['starts'],
-                                    fpp['stops'],
-                                    fpp['break_allowed'])),
-                           _parse_times.dt_pars)
-            if cls.fast_parser_pars['has_day_of_year']:
-                fpp['start'][1] = fpp['stop'][1] = -1
+            fpp = np.array(
+                list(
+                    zip(
+                        map(chr, fpp["delims"]),
+                        fpp["starts"],
+                        fpp["stops"],
+                        fpp["break_allowed"],
+                    )
+                ),
+                _parse_times.dt_pars,
+            )
+            if cls.fast_parser_pars["has_day_of_year"]:
+                fpp["start"][1] = fpp["stop"][1] = -1
             cls._fast_parser = _parse_times.create_parser(fpp)
 
         super().__init_subclass__(**kwargs)
 
     def _check_val_type(self, val1, val2):
-        if val1.dtype.kind not in ('S', 'U') and val1.size:
-            raise TypeError(f'Input values for {self.name} class must be strings')
+        if val1.dtype.kind not in ("S", "U") and val1.size:
+            raise TypeError(f"Input values for {self.name} class must be strings")
         if val2 is not None:
             raise ValueError(
-                f'{self.name} objects do not accept a val2 but you provided {val2}')
+                f"{self.name} objects do not accept a val2 but you provided {val2}"
+            )
         return val1, None
 
     def parse_string(self, timestr, subfmts):
         """Read time from a single string, using a set of possible formats."""
         # Datetime components required for conversion to JD by ERFA, along
         # with the default values.
-        components = ('year', 'mon', 'mday', 'hour', 'min', 'sec')
+        components = ("year", "mon", "mday", "hour", "min", "sec")
         defaults = (None, 1, 1, 0, 0, 0)
         # Assume that anything following "." on the right side is a
         # floating fraction of a second.
         try:
-            idot = timestr.rindex('.')
+            idot = timestr.rindex(".")
         except Exception:
             timestr_has_fractional_digits = False
         else:
@@ -1302,23 +1421,24 @@ class TimeString(TimeUnique):
 
         for _, strptime_fmt_or_regex, _ in subfmts:
             if isinstance(strptime_fmt_or_regex, str):
-                subfmt_has_sec = '%S' in strptime_fmt_or_regex
+                subfmt_has_sec = "%S" in strptime_fmt_or_regex
                 try:
                     tm = time.strptime(timestr, strptime_fmt_or_regex)
                 except ValueError:
                     continue
                 else:
-                    vals = [getattr(tm, 'tm_' + component)
-                            for component in components]
+                    vals = [getattr(tm, "tm_" + component) for component in components]
 
             else:
                 tm = re.match(strptime_fmt_or_regex, timestr)
                 if tm is None:
                     continue
                 tm = tm.groupdict()
-                vals = [int(tm.get(component, default)) for component, default
-                        in zip(components, defaults)]
-                subfmt_has_sec = 'sec' in tm
+                vals = [
+                    int(tm.get(component, default))
+                    for component, default in zip(components, defaults)
+                ]
+                subfmt_has_sec = "sec" in tm
 
             # Add fractional seconds if they were in the original time string
             # and the subformat has seconds. A time like "2022-08-01.123" will
@@ -1332,7 +1452,7 @@ class TimeString(TimeUnique):
 
             return vals
         else:
-            raise ValueError(f'Time {timestr} does not match {self.name} format')
+            raise ValueError(f"Time {timestr} does not match {self.name} format")
 
     def set_jds(self, val1, val2):
         """Parse the time strings contained in val1 and set jd1, jd2"""
@@ -1340,16 +1460,18 @@ class TimeString(TimeUnique):
         # Also do this if Time format class does not define `use_fast_parser` or
         # if the fast parser is entirely disabled. Note that `use_fast_parser`
         # is ignored for format classes that don't have a fast parser.
-        if (self.in_subfmt != '*'
-                or '_fast_parser' not in self.__class__.__dict__
-                or conf.use_fast_parser == 'False'):
+        if (
+            self.in_subfmt != "*"
+            or "_fast_parser" not in self.__class__.__dict__
+            or conf.use_fast_parser == "False"
+        ):
             jd1, jd2 = self.get_jds_python(val1, val2)
         else:
             try:
                 jd1, jd2 = self.get_jds_fast(val1, val2)
             except Exception:
                 # Fall through to the Python parser unless fast is forced.
-                if conf.use_fast_parser == 'force':
+                if conf.use_fast_parser == "force":
                     raise
                 else:
                     jd1, jd2 = self.get_jds_python(val1, val2)
@@ -1364,18 +1486,28 @@ class TimeString(TimeUnique):
         # Be liberal in what we accept: convert bytes to ascii.
         # Here .item() is needed for arrays with entries of unequal length,
         # to strip trailing 0 bytes.
-        to_string = (str if val1.dtype.kind == 'U' else
-                     lambda x: str(x.item(), encoding='ascii'))
-        iterator = np.nditer([val1, None, None, None, None, None, None],
-                             flags=['zerosize_ok'],
-                             op_dtypes=[None] + 5 * [np.intc] + [np.double])
+        to_string = (
+            str if val1.dtype.kind == "U" else lambda x: str(x.item(), encoding="ascii")
+        )
+        iterator = np.nditer(
+            [val1, None, None, None, None, None, None],
+            flags=["zerosize_ok"],
+            op_dtypes=[None] + 5 * [np.intc] + [np.double],
+        )
         for val, iy, im, id, ihr, imin, dsec in iterator:
             val = to_string(val)
-            iy[...], im[...], id[...], ihr[...], imin[...], dsec[...] = (
-                self.parse_string(val, subfmts))
+            (
+                iy[...],
+                im[...],
+                id[...],
+                ihr[...],
+                imin[...],
+                dsec[...],
+            ) = self.parse_string(val, subfmts)
 
-        jd1, jd2 = erfa.dtf2d(self.scale.upper().encode('ascii'),
-                              *iterator.operands[1:])
+        jd1, jd2 = erfa.dtf2d(
+            self.scale.upper().encode("ascii"), *iterator.operands[1:]
+        )
         jd1, jd2 = day_frac(jd1, jd2)
 
         return jd1, jd2
@@ -1386,12 +1518,12 @@ class TimeString(TimeUnique):
         # dtype _parse_times.dt_u1 instead of uint8, since otherwise it is
         # not possible to create a gufunc with structured dtype output.
         # See note about ufunc type resolver in pyerfa/erfa/ufunc.c.templ.
-        if val1.dtype.kind == 'U':
+        if val1.dtype.kind == "U":
             # Note: val1.astype('S') is *very* slow, so we check ourselves
             # that the input is pure ASCII.
             val1_uint32 = val1.view((np.uint32, val1.dtype.itemsize // 4))
             if np.any(val1_uint32 > 127):
-                raise ValueError('input is not pure ASCII')
+                raise ValueError("input is not pure ASCII")
 
             # It might be possible to avoid making a copy via astype with
             # cleverness in parse_times.c but leave that for another day.
@@ -1402,13 +1534,15 @@ class TimeString(TimeUnique):
 
         # Call the fast parsing ufunc.
         time_struct = self._fast_parser(chars)
-        jd1, jd2 = erfa.dtf2d(self.scale.upper().encode('ascii'),
-                              time_struct['year'],
-                              time_struct['month'],
-                              time_struct['day'],
-                              time_struct['hour'],
-                              time_struct['minute'],
-                              time_struct['second'])
+        jd1, jd2 = erfa.dtf2d(
+            self.scale.upper().encode("ascii"),
+            time_struct["year"],
+            time_struct["month"],
+            time_struct["day"],
+            time_struct["hour"],
+            time_struct["minute"],
+            time_struct["second"],
+        )
         return day_frac(jd1, jd2)
 
     def str_kwargs(self):
@@ -1416,29 +1550,37 @@ class TimeString(TimeUnique):
         Generator that yields a dict of values corresponding to the
         calendar date and time for the internal JD values.
         """
-        scale = self.scale.upper().encode('ascii'),
-        iys, ims, ids, ihmsfs = erfa.d2dtf(scale, self.precision,
-                                           self.jd1, self.jd2_filled)
+        scale = (self.scale.upper().encode("ascii"),)
+        iys, ims, ids, ihmsfs = erfa.d2dtf(
+            scale, self.precision, self.jd1, self.jd2_filled
+        )
 
         # Get the str_fmt element of the first allowed output subformat
         _, _, str_fmt = self._select_subfmts(self.out_subfmt)[0]
 
         yday = None
-        has_yday = '{yday:' in str_fmt
+        has_yday = "{yday:" in str_fmt
 
-        ihrs = ihmsfs['h']
-        imins = ihmsfs['m']
-        isecs = ihmsfs['s']
-        ifracs = ihmsfs['f']
+        ihrs = ihmsfs["h"]
+        imins = ihmsfs["m"]
+        isecs = ihmsfs["s"]
+        ifracs = ihmsfs["f"]
         for iy, im, id, ihr, imin, isec, ifracsec in np.nditer(
-                [iys, ims, ids, ihrs, imins, isecs, ifracs],
-                flags=['zerosize_ok']):
+            [iys, ims, ids, ihrs, imins, isecs, ifracs], flags=["zerosize_ok"]
+        ):
             if has_yday:
                 yday = datetime.datetime(iy, im, id).timetuple().tm_yday
 
-            yield {'year': int(iy), 'mon': int(im), 'day': int(id),
-                   'hour': int(ihr), 'min': int(imin), 'sec': int(isec),
-                   'fracsec': int(ifracsec), 'yday': yday}
+            yield {
+                "year": int(iy),
+                "mon": int(im),
+                "day": int(id),
+                "hour": int(ihr),
+                "min": int(imin),
+                "sec": int(isec),
+                "fracsec": int(ifracsec),
+                "yday": yday,
+            }
 
     def format_string(self, str_fmt, **kwargs):
         """Write time to a string using a given format.
@@ -1456,8 +1598,8 @@ class TimeString(TimeUnique):
         _, _, str_fmt = subfmts[0]
 
         # TODO: fix this ugly hack
-        if self.precision > 0 and str_fmt.endswith('{sec:02d}'):
-            str_fmt += '.{fracsec:0' + str(self.precision) + 'd}'
+        if self.precision > 0 and str_fmt.endswith("{sec:02d}"):
+            str_fmt += ".{fracsec:0" + str(self.precision) + "d}"
 
         # Try to optimize this later.  Can't pre-allocate because length of
         # output could change, e.g. year rolls from 999 to 1000.
@@ -1480,17 +1622,21 @@ class TimeISO(TimeString):
     - 'date': date
     """
 
-    name = 'iso'
-    subfmts = (('date_hms',
-                '%Y-%m-%d %H:%M:%S',
-                # XXX To Do - use strftime for output ??
-                '{year:d}-{mon:02d}-{day:02d} {hour:02d}:{min:02d}:{sec:02d}'),
-               ('date_hm',
-                '%Y-%m-%d %H:%M',
-                '{year:d}-{mon:02d}-{day:02d} {hour:02d}:{min:02d}'),
-               ('date',
-                '%Y-%m-%d',
-                '{year:d}-{mon:02d}-{day:02d}'))
+    name = "iso"
+    subfmts = (
+        (
+            "date_hms",
+            "%Y-%m-%d %H:%M:%S",
+            # XXX To Do - use strftime for output ??
+            "{year:d}-{mon:02d}-{day:02d} {hour:02d}:{min:02d}:{sec:02d}",
+        ),
+        (
+            "date_hm",
+            "%Y-%m-%d %H:%M",
+            "{year:d}-{mon:02d}-{day:02d} {hour:02d}:{min:02d}",
+        ),
+        ("date", "%Y-%m-%d", "{year:d}-{mon:02d}-{day:02d}"),
+    )
 
     # Define positions and starting delimiter for year, month, day, hour,
     # minute, seconds components of an ISO time. This is used by the fast
@@ -1501,20 +1647,20 @@ class TimeISO(TimeString):
     #   yyyy-mm-dd hh:mm:ss.fff
     # Parsed as ('yyyy', '-mm', '-dd', ' hh', ':mm', ':ss', '.fff')
     fast_parser_pars = dict(
-        delims=(0, ord('-'), ord('-'), ord(' '), ord(':'), ord(':'), ord('.')),
+        delims=(0, ord("-"), ord("-"), ord(" "), ord(":"), ord(":"), ord(".")),
         starts=(0, 4, 7, 10, 13, 16, 19),
         stops=(3, 6, 9, 12, 15, 18, -1),
         # Break allowed *before*
         #              y  m  d  h  m  s  f
         break_allowed=(0, 0, 0, 1, 0, 1, 1),
-        has_day_of_year=0)
+        has_day_of_year=0,
+    )
 
     def parse_string(self, timestr, subfmts):
         # Handle trailing 'Z' for UTC time
-        if timestr.endswith('Z'):
-            if self.scale != 'utc':
-                raise ValueError("Time input terminating in 'Z' must have "
-                                 "scale='UTC'")
+        if timestr.endswith("Z"):
+            if self.scale != "utc":
+                raise ValueError("Time input terminating in 'Z' must have scale='UTC'")
             timestr = timestr[:-1]
         return super().parse_string(timestr, subfmts)
 
@@ -1533,26 +1679,31 @@ class TimeISOT(TimeISO):
     - 'date': date
     """
 
-    name = 'isot'
-    subfmts = (('date_hms',
-                '%Y-%m-%dT%H:%M:%S',
-                '{year:d}-{mon:02d}-{day:02d}T{hour:02d}:{min:02d}:{sec:02d}'),
-               ('date_hm',
-                '%Y-%m-%dT%H:%M',
-                '{year:d}-{mon:02d}-{day:02d}T{hour:02d}:{min:02d}'),
-               ('date',
-                '%Y-%m-%d',
-                '{year:d}-{mon:02d}-{day:02d}'))
+    name = "isot"
+    subfmts = (
+        (
+            "date_hms",
+            "%Y-%m-%dT%H:%M:%S",
+            "{year:d}-{mon:02d}-{day:02d}T{hour:02d}:{min:02d}:{sec:02d}",
+        ),
+        (
+            "date_hm",
+            "%Y-%m-%dT%H:%M",
+            "{year:d}-{mon:02d}-{day:02d}T{hour:02d}:{min:02d}",
+        ),
+        ("date", "%Y-%m-%d", "{year:d}-{mon:02d}-{day:02d}"),
+    )
 
     # See TimeISO for explanation
     fast_parser_pars = dict(
-        delims=(0, ord('-'), ord('-'), ord('T'), ord(':'), ord(':'), ord('.')),
+        delims=(0, ord("-"), ord("-"), ord("T"), ord(":"), ord(":"), ord(".")),
         starts=(0, 4, 7, 10, 13, 16, 19),
         stops=(3, 6, 9, 12, 15, 18, -1),
         # Break allowed *before*
         #              y  m  d  h  m  s  f
         break_allowed=(0, 0, 0, 1, 0, 1, 1),
-        has_day_of_year=0)
+        has_day_of_year=0,
+    )
 
 
 class TimeYearDayTime(TimeISO):
@@ -1568,16 +1719,16 @@ class TimeYearDayTime(TimeISO):
     - 'date': date
     """
 
-    name = 'yday'
-    subfmts = (('date_hms',
-                '%Y:%j:%H:%M:%S',
-                '{year:d}:{yday:03d}:{hour:02d}:{min:02d}:{sec:02d}'),
-               ('date_hm',
-                '%Y:%j:%H:%M',
-                '{year:d}:{yday:03d}:{hour:02d}:{min:02d}'),
-               ('date',
-                '%Y:%j',
-                '{year:d}:{yday:03d}'))
+    name = "yday"
+    subfmts = (
+        (
+            "date_hms",
+            "%Y:%j:%H:%M:%S",
+            "{year:d}:{yday:03d}:{hour:02d}:{min:02d}:{sec:02d}",
+        ),
+        ("date_hm", "%Y:%j:%H:%M", "{year:d}:{yday:03d}:{hour:02d}:{min:02d}"),
+        ("date", "%Y:%j", "{year:d}:{yday:03d}"),
+    )
 
     # Define positions and starting delimiter for year, month, day, hour,
     # minute, seconds components of an ISO time. This is used by the fast
@@ -1593,28 +1744,33 @@ class TimeYearDayTime(TimeISO):
     # stops: position where component ends (-1 => continue to end of string)
 
     fast_parser_pars = dict(
-        delims=(0, 0, ord(':'), ord(':'), ord(':'), ord(':'), ord('.')),
+        delims=(0, 0, ord(":"), ord(":"), ord(":"), ord(":"), ord(".")),
         starts=(0, -1, 4, 8, 11, 14, 17),
         stops=(3, -1, 7, 10, 13, 16, -1),
         # Break allowed before:
         #              y  m  d  h  m  s  f
         break_allowed=(0, 0, 0, 1, 0, 1, 1),
-        has_day_of_year=1)
+        has_day_of_year=1,
+    )
 
 
 class TimeDatetime64(TimeISOT):
-    name = 'datetime64'
+    name = "datetime64"
 
     def _check_val_type(self, val1, val2):
-        if not val1.dtype.kind == 'M':
+        if not val1.dtype.kind == "M":
             if val1.size > 0:
-                raise TypeError('Input values for {} class must be '
-                                'datetime64 objects'.format(self.name))
+                raise TypeError(
+                    "Input values for {} class must be datetime64 objects".format(
+                        self.name
+                    )
+                )
             else:
-                val1 = np.array([], 'datetime64[D]')
+                val1 = np.array([], "datetime64[D]")
         if val2 is not None:
             raise ValueError(
-                f'{self.name} objects do not accept a val2 but you provided {val2}')
+                f"{self.name} objects do not accept a val2 but you provided {val2}"
+            )
 
         return val1, None
 
@@ -1627,12 +1783,12 @@ class TimeDatetime64(TimeISOT):
         masked = np.any(mask)
         if masked:
             val1 = val1.copy()
-            val1[mask] = '2000'
+            val1[mask] = "2000"
 
         # Make sure M(onth) and Y(ear) dates will parse and convert to bytestring
-        if val1.dtype.name in ['datetime64[M]', 'datetime64[Y]']:
-            val1 = val1.astype('datetime64[D]')
-        val1 = val1.astype('S')
+        if val1.dtype.name in ["datetime64[M]", "datetime64[Y]"]:
+            val1 = val1.astype("datetime64[D]")
+        val1 = val1.astype("S")
 
         # Standard ISO string parsing now
         super().set_jds(val1, val2)
@@ -1647,7 +1803,7 @@ class TimeDatetime64(TimeISOT):
         self.precision = 9
         ret = super().value
         self.precision = precision
-        return ret.astype('datetime64')
+        return ret.astype("datetime64")
 
 
 class TimeFITS(TimeString):
@@ -1665,29 +1821,47 @@ class TimeFITS(TimeString):
 
     See Rots et al., 2015, A&A 574:A36 (arXiv:1409.7583).
     """
-    name = 'fits'
+
+    name = "fits"
     subfmts = (
-        ('date_hms',
-         (r'(?P<year>\d{4})-(?P<mon>\d\d)-(?P<mday>\d\d)T'
-          r'(?P<hour>\d\d):(?P<min>\d\d):(?P<sec>\d\d(\.\d*)?)'),
-         '{year:04d}-{mon:02d}-{day:02d}T{hour:02d}:{min:02d}:{sec:02d}'),
-        ('date',
-         r'(?P<year>\d{4})-(?P<mon>\d\d)-(?P<mday>\d\d)',
-         '{year:04d}-{mon:02d}-{day:02d}'),
-        ('longdate_hms',
-         (r'(?P<year>[+-]\d{5})-(?P<mon>\d\d)-(?P<mday>\d\d)T'
-          r'(?P<hour>\d\d):(?P<min>\d\d):(?P<sec>\d\d(\.\d*)?)'),
-         '{year:+06d}-{mon:02d}-{day:02d}T{hour:02d}:{min:02d}:{sec:02d}'),
-        ('longdate',
-         r'(?P<year>[+-]\d{5})-(?P<mon>\d\d)-(?P<mday>\d\d)',
-         '{year:+06d}-{mon:02d}-{day:02d}'))
+        (
+            "date_hms",
+            (
+                r"(?P<year>\d{4})-(?P<mon>\d\d)-(?P<mday>\d\d)T"
+                r"(?P<hour>\d\d):(?P<min>\d\d):(?P<sec>\d\d(\.\d*)?)"
+            ),
+            "{year:04d}-{mon:02d}-{day:02d}T{hour:02d}:{min:02d}:{sec:02d}",
+        ),
+        (
+            "date",
+            r"(?P<year>\d{4})-(?P<mon>\d\d)-(?P<mday>\d\d)",
+            "{year:04d}-{mon:02d}-{day:02d}",
+        ),
+        (
+            "longdate_hms",
+            (
+                r"(?P<year>[+-]\d{5})-(?P<mon>\d\d)-(?P<mday>\d\d)T"
+                r"(?P<hour>\d\d):(?P<min>\d\d):(?P<sec>\d\d(\.\d*)?)"
+            ),
+            "{year:+06d}-{mon:02d}-{day:02d}T{hour:02d}:{min:02d}:{sec:02d}",
+        ),
+        (
+            "longdate",
+            r"(?P<year>[+-]\d{5})-(?P<mon>\d\d)-(?P<mday>\d\d)",
+            "{year:+06d}-{mon:02d}-{day:02d}",
+        ),
+    )
     # Add the regex that parses the scale and possible realization.
     # Support for this is deprecated.  Read old style but no longer write
     # in this style.
     subfmts = tuple(
-        (subfmt[0],
-         subfmt[1] + r'(\((?P<scale>\w+)(\((?P<realization>\w+)\))?\))?',
-         subfmt[2]) for subfmt in subfmts)
+        (
+            subfmt[0],
+            subfmt[1] + r"(\((?P<scale>\w+)(\((?P<realization>\w+)\))?\))?",
+            subfmt[2],
+        )
+        for subfmt in subfmts
+    )
 
     def parse_string(self, timestr, subfmts):
         """Read time and deprecated scale if present"""
@@ -1697,20 +1871,25 @@ class TimeFITS(TimeString):
             if tm:
                 break
         else:
-            raise ValueError(f'Time {timestr} does not match {self.name} format')
+            raise ValueError(f"Time {timestr} does not match {self.name} format")
         tm = tm.groupdict()
         # Scale and realization are deprecated and strings in this form
         # are no longer created.  We issue a warning but still use the value.
-        if tm['scale'] is not None:
-            warnings.warn("FITS time strings should no longer have embedded time scale.",
-                          AstropyDeprecationWarning)
+        if tm["scale"] is not None:
+            warnings.warn(
+                "FITS time strings should no longer have embedded time scale.",
+                AstropyDeprecationWarning,
+            )
             # If a scale was given, translate from a possible deprecated
             # timescale identifier to the scale used by Time.
-            fits_scale = tm['scale'].upper()
+            fits_scale = tm["scale"].upper()
             scale = FITS_DEPRECATED_SCALES.get(fits_scale, fits_scale.lower())
             if scale not in TIME_SCALES:
-                raise ValueError("Scale {!r} is not in the allowed scales {}"
-                                 .format(scale, sorted(TIME_SCALES)))
+                raise ValueError(
+                    "Scale {!r} is not in the allowed scales {}".format(
+                        scale, sorted(TIME_SCALES)
+                    )
+                )
             # If no scale was given in the initialiser, set the scale to
             # that given in the string.  Realization is ignored
             # and is only supported to allow old-style strings to be
@@ -1718,22 +1897,28 @@ class TimeFITS(TimeString):
             if self._scale is None:
                 self._scale = scale
             if scale != self.scale:
-                raise ValueError("Input strings for {} class must all "
-                                 "have consistent time scales."
-                                 .format(self.name))
-        return [int(tm['year']), int(tm['mon']), int(tm['mday']),
-                int(tm.get('hour', 0)), int(tm.get('min', 0)),
-                float(tm.get('sec', 0.))]
+                raise ValueError(
+                    "Input strings for {} class must all "
+                    "have consistent time scales.".format(self.name)
+                )
+        return [
+            int(tm["year"]),
+            int(tm["mon"]),
+            int(tm["mday"]),
+            int(tm.get("hour", 0)),
+            int(tm.get("min", 0)),
+            float(tm.get("sec", 0.0)),
+        ]
 
     @property
     def value(self):
         """Convert times to strings, using signed 5 digit if necessary."""
-        if 'long' not in self.out_subfmt:
+        if "long" not in self.out_subfmt:
             # If we have times before year 0 or after year 9999, we can
             # output only in a "long" format, using signed 5-digit years.
             jd = self.jd1 + self.jd2
             if jd.size and (jd.min() < 1721425.5 or jd.max() >= 5373484.5):
-                self.out_subfmt = 'long' + self.out_subfmt
+                self.out_subfmt = "long" + self.out_subfmt
         return super().value
 
 
@@ -1741,7 +1926,8 @@ class TimeEpochDate(TimeNumeric):
     """
     Base class for support floating point Besselian and Julian epoch dates
     """
-    _default_scale = 'tt'  # As of astropy 3.2, this is no longer 'utc'.
+
+    _default_scale = "tt"  # As of astropy 3.2, this is no longer 'utc'.
 
     def set_jds(self, val1, val2):
         self._check_scale(self._scale)  # validate scale.
@@ -1759,26 +1945,30 @@ class TimeEpochDate(TimeNumeric):
 
 class TimeBesselianEpoch(TimeEpochDate):
     """Besselian Epoch year as floating point value(s) like 1950.0"""
-    name = 'byear'
-    epoch_to_jd = 'epb2jd'
-    jd_to_epoch = 'epb'
+
+    name = "byear"
+    epoch_to_jd = "epb2jd"
+    jd_to_epoch = "epb"
 
     def _check_val_type(self, val1, val2):
         """Input value validation, typically overridden by derived classes"""
-        if hasattr(val1, 'to') and hasattr(val1, 'unit') and val1.unit is not None:
-            raise ValueError("Cannot use Quantities for 'byear' format, "
-                             "as the interpretation would be ambiguous. "
-                             "Use float with Besselian year instead. ")
+        if hasattr(val1, "to") and hasattr(val1, "unit") and val1.unit is not None:
+            raise ValueError(
+                "Cannot use Quantities for 'byear' format, "
+                "as the interpretation would be ambiguous. "
+                "Use float with Besselian year instead. "
+            )
         # FIXME: is val2 really okay here?
         return super()._check_val_type(val1, val2)
 
 
 class TimeJulianEpoch(TimeEpochDate):
     """Julian Epoch year as floating point value(s) like 2000.0"""
-    name = 'jyear'
+
+    name = "jyear"
     unit = erfa.DJY  # 365.25, the Julian year, for conversion to quantities
-    epoch_to_jd = 'epj2jd'
-    jd_to_epoch = 'epj'
+    epoch_to_jd = "epj2jd"
+    jd_to_epoch = "epj"
 
 
 class TimeEpochDateString(TimeString):
@@ -1786,15 +1976,18 @@ class TimeEpochDateString(TimeString):
     Base class to support string Besselian and Julian epoch dates
     such as 'B1950.0' or 'J2000.0' respectively.
     """
-    _default_scale = 'tt'  # As of astropy 3.2, this is no longer 'utc'.
+
+    _default_scale = "tt"  # As of astropy 3.2, this is no longer 'utc'.
 
     def set_jds(self, val1, val2):
         epoch_prefix = self.epoch_prefix
         # Be liberal in what we accept: convert bytes to ascii.
-        to_string = (str if val1.dtype.kind == 'U' else
-                     lambda x: str(x.item(), encoding='ascii'))
-        iterator = np.nditer([val1, None], op_dtypes=[val1.dtype, np.double],
-                             flags=['zerosize_ok'])
+        to_string = (
+            str if val1.dtype.kind == "U" else lambda x: str(x.item(), encoding="ascii")
+        )
+        iterator = np.nditer(
+            [val1, None], op_dtypes=[val1.dtype, np.double], flags=["zerosize_ok"]
+        )
         for val, years in iterator:
             try:
                 time_str = to_string(val)
@@ -1803,7 +1996,7 @@ class TimeEpochDateString(TimeString):
                 if epoch_type.upper() != epoch_prefix:
                     raise ValueError
             except (IndexError, ValueError, UnicodeEncodeError):
-                raise ValueError(f'Time {val} does not match {self.name} format')
+                raise ValueError(f"Time {val} does not match {self.name} format")
             else:
                 years[...] = year
 
@@ -1817,25 +2010,27 @@ class TimeEpochDateString(TimeString):
         jd_to_epoch = getattr(erfa, self.jd_to_epoch)
         years = jd_to_epoch(self.jd1, self.jd2)
         # Use old-style format since it is a factor of 2 faster
-        str_fmt = self.epoch_prefix + '%.' + str(self.precision) + 'f'
+        str_fmt = self.epoch_prefix + "%." + str(self.precision) + "f"
         outs = [str_fmt % year for year in years.flat]
         return np.array(outs).reshape(self.jd1.shape)
 
 
 class TimeBesselianEpochString(TimeEpochDateString):
     """Besselian Epoch year as string value(s) like 'B1950.0'"""
-    name = 'byear_str'
-    epoch_to_jd = 'epb2jd'
-    jd_to_epoch = 'epb'
-    epoch_prefix = 'B'
+
+    name = "byear_str"
+    epoch_to_jd = "epb2jd"
+    jd_to_epoch = "epb"
+    epoch_prefix = "B"
 
 
 class TimeJulianEpochString(TimeEpochDateString):
     """Julian Epoch year as string value(s) like 'J2000.0'"""
-    name = 'jyear_str'
-    epoch_to_jd = 'epj2jd'
-    jd_to_epoch = 'epj'
-    epoch_prefix = 'J'
+
+    name = "jyear_str"
+    epoch_to_jd = "epj2jd"
+    jd_to_epoch = "epj"
+    epoch_prefix = "J"
 
 
 class TimeDeltaFormat(TimeFormat):
@@ -1848,23 +2043,24 @@ class TimeDeltaFormat(TimeFormat):
         Check that the scale is in the allowed list of scales, or is `None`
         """
         if scale is not None and scale not in TIME_DELTA_SCALES:
-            raise ScaleValueError("Scale value '{}' not in "
-                                  "allowed values {}"
-                                  .format(scale, TIME_DELTA_SCALES))
+            raise ScaleValueError(
+                "Scale value '{}' not in allowed values {}".format(
+                    scale, TIME_DELTA_SCALES
+                )
+            )
 
         return scale
 
 
 class TimeDeltaNumeric(TimeDeltaFormat, TimeNumeric):
-
     def set_jds(self, val1, val2):
         self._check_scale(self._scale)  # Validate scale.
-        self.jd1, self.jd2 = day_frac(val1, val2, divisor=1. / self.unit)
+        self.jd1, self.jd2 = day_frac(val1, val2, divisor=1.0 / self.unit)
 
     def to_value(self, **kwargs):
         # Note that 1/unit is always exactly representable, so the
         # following multiplications are exact.
-        factor = 1. / self.unit
+        factor = 1.0 / self.unit
         jd1 = self.jd1 * factor
         jd2 = self.jd2 * factor
         return super().to_value(jd1=jd1, jd2=jd2, **kwargs)
@@ -1874,53 +2070,62 @@ class TimeDeltaNumeric(TimeDeltaFormat, TimeNumeric):
 
 class TimeDeltaSec(TimeDeltaNumeric):
     """Time delta in SI seconds"""
-    name = 'sec'
-    unit = 1. / erfa.DAYSEC  # for quantity input
+
+    name = "sec"
+    unit = 1.0 / erfa.DAYSEC  # for quantity input
 
 
 class TimeDeltaJD(TimeDeltaNumeric):
     """Time delta in Julian days (86400 SI seconds)"""
-    name = 'jd'
-    unit = 1.
+
+    name = "jd"
+    unit = 1.0
 
 
 class TimeDeltaDatetime(TimeDeltaFormat, TimeUnique):
     """Time delta in datetime.timedelta"""
-    name = 'datetime'
+
+    name = "datetime"
 
     def _check_val_type(self, val1, val2):
         if not all(isinstance(val, datetime.timedelta) for val in val1.flat):
-            raise TypeError('Input values for {} class must be '
-                            'datetime.timedelta objects'.format(self.name))
+            raise TypeError(
+                "Input values for {} class must be datetime.timedelta objects".format(
+                    self.name
+                )
+            )
         if val2 is not None:
             raise ValueError(
-                f'{self.name} objects do not accept a val2 but you provided {val2}')
+                f"{self.name} objects do not accept a val2 but you provided {val2}"
+            )
         return val1, None
 
     def set_jds(self, val1, val2):
         self._check_scale(self._scale)  # Validate scale.
-        iterator = np.nditer([val1, None, None],
-                             flags=['refs_ok', 'zerosize_ok'],
-                             op_dtypes=[None, np.double, np.double])
+        iterator = np.nditer(
+            [val1, None, None],
+            flags=["refs_ok", "zerosize_ok"],
+            op_dtypes=[None, np.double, np.double],
+        )
 
         day = datetime.timedelta(days=1)
         for val, jd1, jd2 in iterator:
             jd1[...], other = divmod(val.item(), day)
             jd2[...] = other / day
 
-        self.jd1, self.jd2 = day_frac(iterator.operands[-2],
-                                      iterator.operands[-1])
+        self.jd1, self.jd2 = day_frac(iterator.operands[-2], iterator.operands[-1])
 
     @property
     def value(self):
-        iterator = np.nditer([self.jd1, self.jd2, None],
-                             flags=['refs_ok', 'zerosize_ok'],
-                             op_dtypes=[None, None, object])
+        iterator = np.nditer(
+            [self.jd1, self.jd2, None],
+            flags=["refs_ok", "zerosize_ok"],
+            op_dtypes=[None, None, object],
+        )
 
         for jd1, jd2, out in iterator:
             jd1_, jd2_ = day_frac(jd1, jd2)
-            out[...] = datetime.timedelta(days=jd1_,
-                                          microseconds=jd2_ * 86400 * 1e6)
+            out[...] = datetime.timedelta(days=jd1_, microseconds=jd2_ * 86400 * 1e6)
 
         return self.mask_if_needed(iterator.operands[-1])
 
@@ -1928,18 +2133,17 @@ class TimeDeltaDatetime(TimeDeltaFormat, TimeUnique):
 def _validate_jd_for_storage(jd):
     if isinstance(jd, (float, int)):
         return np.array(jd, dtype=np.float_)
-    if (isinstance(jd, np.generic)
-        and (jd.dtype.kind == 'f' and jd.dtype.itemsize <= 8
-             or jd.dtype.kind in 'iu')):
+    if isinstance(jd, np.generic) and (
+        jd.dtype.kind == "f" and jd.dtype.itemsize <= 8 or jd.dtype.kind in "iu"
+    ):
         return np.array(jd, dtype=np.float_)
-    elif (isinstance(jd, np.ndarray)
-          and jd.dtype.kind == 'f'
-          and jd.dtype.itemsize == 8):
+    elif isinstance(jd, np.ndarray) and jd.dtype.kind == "f" and jd.dtype.itemsize == 8:
         return jd
     else:
         raise TypeError(
-            f"JD values must be arrays (possibly zero-dimensional) "
-            f"of floats but we got {jd!r} of type {type(jd)}")
+            "JD values must be arrays (possibly zero-dimensional) "
+            f"of floats but we got {jd!r} of type {type(jd)}"
+        )
 
 
 def _broadcast_writeable(jd1, jd2):
@@ -1953,13 +2157,11 @@ def _broadcast_writeable(jd1, jd2):
     if jd1.shape == shape:
         s_jd1 = jd1
     else:
-        s_jd1 = np.require(np.broadcast_to(jd1, shape),
-                           requirements=["C", "W"])
+        s_jd1 = np.require(np.broadcast_to(jd1, shape), requirements=["C", "W"])
     if jd2.shape == shape:
         s_jd2 = jd2
     else:
-        s_jd2 = np.require(np.broadcast_to(jd2, shape),
-                           requirements=["C", "W"])
+        s_jd2 = np.require(np.broadcast_to(jd2, shape), requirements=["C", "W"])
     return s_jd1, s_jd2
 
 

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -482,8 +482,8 @@ class TimeNumeric(TimeFormat):
             )
         ):
             raise TypeError(
-                "for {} class, input should be doubles, string, or Decimal, "
-                "and second values are only allowed for doubles.".format(self.name)
+                f"for {self.name} class, input should be doubles, string, or Decimal, "
+                "and second values are only allowed for doubles."
             )
 
         val_dtype = (
@@ -501,9 +501,9 @@ class TimeNumeric(TimeFormat):
                 val1, val2 = convert(val1, val2)
             except Exception:
                 raise TypeError(
-                    "for {} class, input should be (long) doubles, string, "
+                    f"for {self.name} class, input should be (long) doubles, string, "
                     "or Decimal, and second values are only allowed for "
-                    "(long) doubles.".format(self.name)
+                    "(long) doubles."
                 )
 
         return val1, val2
@@ -710,10 +710,8 @@ class TimeFromEpoch(TimeNumeric):
             )
         except Exception as err:
             raise ScaleValueError(
-                "Cannot convert from '{}' epoch scale '{}'"
-                "to specified scale '{}', got error:\n{}".format(
-                    self.name, self.epoch_scale, self.scale, err
-                )
+                f"Cannot convert from '{self.name}' epoch scale '{self.epoch_scale}' "
+                f"to specified scale '{self.scale}', got error:\n{err}"
             ) from err
 
         self.jd1, self.jd2 = day_frac(tm._time.jd1, tm._time.jd2)
@@ -728,10 +726,9 @@ class TimeFromEpoch(TimeNumeric):
                 tm = getattr(parent, self.epoch_scale)
             except Exception as err:
                 raise ScaleValueError(
-                    "Cannot convert from '{}' epoch scale '{}'"
-                    "to specified scale '{}', got error:\n{}".format(
-                        self.name, self.epoch_scale, self.scale, err
-                    )
+                    f"Cannot convert from '{self.name}' epoch scale "
+                    f"'{self.epoch_scale}' to specified scale '{self.scale}', "
+                    f"got error:\n{err}"
                 ) from err
 
             jd1, jd2 = tm._time.jd1, tm._time.jd2
@@ -960,9 +957,8 @@ class TimeAstropyTime(TimeUnique):
             and all(type(val) is type(val1_0) for val in val1.flat)
         ):
             raise TypeError(
-                "Input values for {} class must all be same astropy Time type.".format(
-                    cls.name
-                )
+                f"Input values for {cls.name} class must all be the same "
+                "astropy Time type."
             )
 
         if scale is None:
@@ -1087,9 +1083,7 @@ class TimeDatetime(TimeUnique):
         if timezone is not None:
             if self._scale != "utc":
                 raise ScaleValueError(
-                    "scale is {}, must be 'utc' when timezone is supplied.".format(
-                        self._scale
-                    )
+                    f"scale is {self._scale}, must be 'utc' when timezone is supplied."
                 )
 
         # Rather than define a value property directly, we have a function,
@@ -1111,10 +1105,8 @@ class TimeDatetime(TimeUnique):
         for iy, im, id, ihr, imin, isec, ifracsec, out in iterator:
             if isec >= 60:
                 raise ValueError(
-                    "Time {} is within a leap second but datetime "
-                    "does not support leap seconds".format(
-                        (iy, im, id, ihr, imin, isec, ifracsec)
-                    )
+                    f"Time {(iy, im, id, ihr, imin, isec, ifracsec)} is within "
+                    "a leap second but datetime does not support leap seconds"
                 )
             if timezone is not None:
                 out[...] = datetime.datetime(
@@ -1761,9 +1753,7 @@ class TimeDatetime64(TimeISOT):
         if not val1.dtype.kind == "M":
             if val1.size > 0:
                 raise TypeError(
-                    "Input values for {} class must be datetime64 objects".format(
-                        self.name
-                    )
+                    f"Input values for {self.name} class must be datetime64 objects"
                 )
             else:
                 val1 = np.array([], "datetime64[D]")
@@ -1886,9 +1876,8 @@ class TimeFITS(TimeString):
             scale = FITS_DEPRECATED_SCALES.get(fits_scale, fits_scale.lower())
             if scale not in TIME_SCALES:
                 raise ValueError(
-                    "Scale {!r} is not in the allowed scales {}".format(
-                        scale, sorted(TIME_SCALES)
-                    )
+                    f"Scale {scale!r} is not in the allowed scales "
+                    f"{sorted(TIME_SCALES)}"
                 )
             # If no scale was given in the initialiser, set the scale to
             # that given in the string.  Realization is ignored
@@ -1898,8 +1887,8 @@ class TimeFITS(TimeString):
                 self._scale = scale
             if scale != self.scale:
                 raise ValueError(
-                    "Input strings for {} class must all "
-                    "have consistent time scales.".format(self.name)
+                    f"Input strings for {self.name} class must all "
+                    "have consistent time scales."
                 )
         return [
             int(tm["year"]),
@@ -1954,9 +1943,8 @@ class TimeBesselianEpoch(TimeEpochDate):
         """Input value validation, typically overridden by derived classes"""
         if hasattr(val1, "to") and hasattr(val1, "unit") and val1.unit is not None:
             raise ValueError(
-                "Cannot use Quantities for 'byear' format, "
-                "as the interpretation would be ambiguous. "
-                "Use float with Besselian year instead. "
+                "Cannot use Quantities for 'byear' format, as the interpretation "
+                "would be ambiguous. Use float with Besselian year instead."
             )
         # FIXME: is val2 really okay here?
         return super()._check_val_type(val1, val2)
@@ -2044,9 +2032,7 @@ class TimeDeltaFormat(TimeFormat):
         """
         if scale is not None and scale not in TIME_DELTA_SCALES:
             raise ScaleValueError(
-                "Scale value '{}' not in allowed values {}".format(
-                    scale, TIME_DELTA_SCALES
-                )
+                f"Scale value '{scale}' not in allowed values {TIME_DELTA_SCALES}"
             )
 
         return scale
@@ -2090,9 +2076,7 @@ class TimeDeltaDatetime(TimeDeltaFormat, TimeUnique):
     def _check_val_type(self, val1, val2):
         if not all(isinstance(val, datetime.timedelta) for val in val1.flat):
             raise TypeError(
-                "Input values for {} class must be datetime.timedelta objects".format(
-                    self.name
-                )
+                f"Input values for {self.name} class must be datetime.timedelta objects"
             )
         if val2 is not None:
             raise ValueError(

--- a/astropy/time/setup_package.py
+++ b/astropy/time/setup_package.py
@@ -9,16 +9,19 @@ from setuptools import Extension
 
 C_TIME_PKGDIR = os.path.relpath(os.path.dirname(__file__))
 
-SRC_FILES = [os.path.join(C_TIME_PKGDIR, filename)
-             for filename in ['src/parse_times.c']]
+SRC_FILES = [
+    os.path.join(C_TIME_PKGDIR, filename) for filename in ["src/parse_times.c"]
+]
 
 
 def get_extensions():
     # Add '-Rpass-missed=.*' to ``extra_compile_args`` when compiling with clang
     # to report missed optimizations
-    _time_ext = Extension(name='astropy.time._parse_times',
-                          sources=SRC_FILES,
-                          include_dirs=[numpy.get_include()],
-                          language='c')
+    _time_ext = Extension(
+        name="astropy.time._parse_times",
+        sources=SRC_FILES,
+        include_dirs=[numpy.get_include()],
+        language="c",
+    )
 
     return [_time_ext]

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -32,12 +32,15 @@ from astropy.utils.compat.optional_deps import HAS_H5PY, HAS_PYTZ
 from astropy.utils.exceptions import AstropyDeprecationWarning
 
 allclose_jd = functools.partial(np.allclose, rtol=np.finfo(float).eps, atol=0)
-allclose_jd2 = functools.partial(np.allclose, rtol=np.finfo(float).eps,
-                                 atol=np.finfo(float).eps)  # 20 ps atol
-allclose_sec = functools.partial(np.allclose, rtol=np.finfo(float).eps,
-                                 atol=np.finfo(float).eps * 24 * 3600)
-allclose_year = functools.partial(np.allclose, rtol=np.finfo(float).eps,
-                                  atol=0.)  # 14 microsec at current epoch
+allclose_jd2 = functools.partial(
+    np.allclose, rtol=np.finfo(float).eps, atol=np.finfo(float).eps
+)  # 20 ps atol
+allclose_sec = functools.partial(
+    np.allclose, rtol=np.finfo(float).eps, atol=np.finfo(float).eps * 24 * 3600
+)
+allclose_year = functools.partial(
+    np.allclose, rtol=np.finfo(float).eps, atol=0.0
+)  # 14 microsec at current epoch
 
 
 def setup_function(func):
@@ -53,55 +56,66 @@ class TestBasic:
     """Basic tests stemming from initial example and API reference"""
 
     def test_simple(self):
-        times = ['1999-01-01 00:00:00.123456789', '2010-01-01 00:00:00']
-        t = Time(times, format='iso', scale='utc')
-        assert (repr(t) == "<Time object: scale='utc' format='iso' "
-                "value=['1999-01-01 00:00:00.123' '2010-01-01 00:00:00.000']>")
-        assert allclose_jd(t.jd1, np.array([2451180., 2455198.]))
-        assert allclose_jd2(t.jd2, np.array([-0.5 + 1.4288980208333335e-06,
-                                             -0.50000000e+00]))
+        times = ["1999-01-01 00:00:00.123456789", "2010-01-01 00:00:00"]
+        t = Time(times, format="iso", scale="utc")
+        assert (
+            repr(t) == "<Time object: scale='utc' format='iso' "
+            "value=['1999-01-01 00:00:00.123' '2010-01-01 00:00:00.000']>"
+        )
+        assert allclose_jd(t.jd1, np.array([2451180.0, 2455198.0]))
+        assert allclose_jd2(
+            t.jd2, np.array([-0.5 + 1.4288980208333335e-06, -0.50000000e00])
+        )
 
         # Set scale to TAI
         t = t.tai
-        assert (repr(t) == "<Time object: scale='tai' format='iso' "
-                "value=['1999-01-01 00:00:32.123' '2010-01-01 00:00:34.000']>")
-        assert allclose_jd(t.jd1, np.array([2451180., 2455198.]))
-        assert allclose_jd2(t.jd2, np.array([-0.5 + 0.00037179926839122024,
-                                             -0.5 + 0.00039351851851851852]))
+        assert (
+            repr(t) == "<Time object: scale='tai' format='iso' "
+            "value=['1999-01-01 00:00:32.123' '2010-01-01 00:00:34.000']>"
+        )
+        assert allclose_jd(t.jd1, np.array([2451180.0, 2455198.0]))
+        assert allclose_jd2(
+            t.jd2,
+            np.array([-0.5 + 0.00037179926839122024, -0.5 + 0.00039351851851851852]),
+        )
 
         # Get a new ``Time`` object which is referenced to the TT scale
         # (internal JD1 and JD1 are now with respect to TT scale)"""
 
-        assert (repr(t.tt) == "<Time object: scale='tt' format='iso' "
-                "value=['1999-01-01 00:01:04.307' '2010-01-01 00:01:06.184']>")
+        assert (
+            repr(t.tt) == "<Time object: scale='tt' format='iso' "
+            "value=['1999-01-01 00:01:04.307' '2010-01-01 00:01:06.184']>"
+        )
 
         # Get the representation of the ``Time`` object in a particular format
         # (in this case seconds since 1998.0).  This returns either a scalar or
         # array, depending on whether the input was a scalar or array"""
 
-        assert allclose_sec(t.cxcsec, np.array([31536064.307456788, 378691266.18400002]))
+        assert allclose_sec(
+            t.cxcsec, np.array([31536064.307456788, 378691266.18400002])
+        )
 
     def test_different_dimensions(self):
         """Test scalars, vector, and higher-dimensions"""
         # scalar
         val, val1 = 2450000.0, 0.125
-        t1 = Time(val, val1, format='jd')
+        t1 = Time(val, val1, format="jd")
         assert t1.isscalar is True and t1.shape == ()
         # vector
-        val = np.arange(2450000., 2450010.)
-        t2 = Time(val, format='jd')
+        val = np.arange(2450000.0, 2450010.0)
+        t2 = Time(val, format="jd")
         assert t2.isscalar is False and t2.shape == val.shape
         # explicitly check broadcasting for mixed vector, scalar.
-        val2 = 0.
-        t3 = Time(val, val2, format='jd')
+        val2 = 0.0
+        t3 = Time(val, val2, format="jd")
         assert t3.isscalar is False and t3.shape == val.shape
-        val2 = (np.arange(5.) / 10.).reshape(5, 1)
+        val2 = (np.arange(5.0) / 10.0).reshape(5, 1)
         # now see if broadcasting to two-dimensional works
-        t4 = Time(val, val2, format='jd')
+        t4 = Time(val, val2, format="jd")
         assert t4.isscalar is False
         assert t4.shape == np.broadcast(val, val2).shape
 
-    @pytest.mark.parametrize('format_', Time.FORMATS)
+    @pytest.mark.parametrize("format_", Time.FORMATS)
     def test_empty_value(self, format_):
         t = Time([], format=format_)
         assert t.size == 0
@@ -118,14 +132,14 @@ class TestBasic:
         assert t3.size == 0
         assert t3.shape == (0,)
         assert t3.format == format_
-        assert t3.scale == 'tai'
+        assert t3.scale == "tai"
 
-    @pytest.mark.parametrize('value', [2455197.5, [2455197.5]])
+    @pytest.mark.parametrize("value", [2455197.5, [2455197.5]])
     def test_copy_time(self, value):
         """Test copying the values of a Time object by passing it into the
         Time initializer.
         """
-        t = Time(value, format='jd', scale='utc')
+        t = Time(value, format="jd", scale="utc")
 
         t2 = Time(t, copy=False)
         assert np.all(t.jd - t2.jd == 0)
@@ -140,22 +154,22 @@ class TestBasic:
         assert t._time.jd2 is not t2._time.jd2
 
         # Include initializers
-        t2 = Time(t, format='iso', scale='tai', precision=1)
-        assert t2.value == '2010-01-01 00:00:34.0'
-        t2 = Time(t, format='iso', scale='tai', out_subfmt='date')
-        assert t2.value == '2010-01-01'
+        t2 = Time(t, format="iso", scale="tai", precision=1)
+        assert t2.value == "2010-01-01 00:00:34.0"
+        t2 = Time(t, format="iso", scale="tai", out_subfmt="date")
+        assert t2.value == "2010-01-01"
 
     def test_getitem(self):
         """Test that Time objects holding arrays are properly subscriptable,
         set isscalar as appropriate, and also subscript delta_ut1_utc, etc."""
 
         mjd = np.arange(50000, 50010)
-        t = Time(mjd, format='mjd', scale='utc', location=('45d', '50d'))
+        t = Time(mjd, format="mjd", scale="utc", location=("45d", "50d"))
         t1 = t[3]
         assert t1.isscalar is True
         assert t1._time.jd1 == t._time.jd1[3]
         assert t1.location is t.location
-        t1a = Time(mjd[3], format='mjd', scale='utc')
+        t1a = Time(mjd[3], format="mjd", scale="utc")
         assert t1a.isscalar is True
         assert np.all(t1._time.jd1 == t1a._time.jd1)
         t1b = Time(t[3])
@@ -177,8 +191,12 @@ class TestBasic:
         t.delta_tdb_tt = np.arange(len(t))  # Explicitly set (not testing .tdb)
         t3 = t[4:6]
         assert np.all(t3._delta_tdb_tt == t._delta_tdb_tt[4:6])
-        t4 = Time(mjd, format='mjd', scale='utc',
-                  location=(np.arange(len(mjd)), np.arange(len(mjd))))
+        t4 = Time(
+            mjd,
+            format="mjd",
+            scale="utc",
+            location=(np.arange(len(mjd)), np.arange(len(mjd))),
+        )
         t5a = t4[3]
         assert t5a.location == t4.location[3]
         assert t5a.location.shape == ()
@@ -192,15 +210,19 @@ class TestBasic:
         assert np.all(t6.location == t4.location[4:6])
         # check it is a view
         # (via ndarray, since quantity setter problematic for structured array)
-        allzeros = np.array((0., 0., 0.), dtype=t4.location.dtype)
+        allzeros = np.array((0.0, 0.0, 0.0), dtype=t4.location.dtype)
         assert t6.location.view(np.ndarray)[-1] != allzeros
         assert t4.location.view(np.ndarray)[5] != allzeros
         t6.location.view(np.ndarray)[-1] = allzeros
         assert t4.location.view(np.ndarray)[5] == allzeros
         # Test subscription also works for two-dimensional arrays.
-        frac = np.arange(0., 0.999, 0.2)
-        t7 = Time(mjd[:, np.newaxis] + frac, format='mjd', scale='utc',
-                  location=('45d', '50d'))
+        frac = np.arange(0.0, 0.999, 0.2)
+        t7 = Time(
+            mjd[:, np.newaxis] + frac,
+            format="mjd",
+            scale="utc",
+            location=("45d", "50d"),
+        )
         assert t7[0, 0]._time.jd1 == t7._time.jd1[0, 0]
         assert t7[0, 0].isscalar is True
         assert np.all(t7[5]._time.jd1 == t7._time.jd1[5])
@@ -221,8 +243,12 @@ class TestBasic:
         assert t7_tdb2[5].delta_tdb_tt == 0.1
         assert t7_tdb2[:, 2].delta_tdb_tt == 0.1
         # Check broadcasting of location.
-        t8 = Time(mjd[:, np.newaxis] + frac, format='mjd', scale='utc',
-                  location=(np.arange(len(frac)), np.arange(len(frac))))
+        t8 = Time(
+            mjd[:, np.newaxis] + frac,
+            format="mjd",
+            scale="utc",
+            location=(np.arange(len(frac)), np.arange(len(frac))),
+        )
         assert t8[0, 0].location == t8.location[0, 0]
         assert np.all(t8[5].location == t8.location[5])
         assert np.all(t8[:, 2].location == t8.location[:, 2])
@@ -238,15 +264,15 @@ class TestBasic:
         that can be obtained by interpolating from a table supplied by IERS.
         This is tested separately."""
 
-        t = Time('2010-01-01 00:00:00', format='iso', scale='utc')
+        t = Time("2010-01-01 00:00:00", format="iso", scale="utc")
         t.delta_ut1_utc = 0.3341  # Explicitly set one part of the xform
         assert allclose_jd(t.jd, 2455197.5)
-        assert t.iso == '2010-01-01 00:00:00.000'
-        assert t.tt.iso == '2010-01-01 00:01:06.184'
-        assert t.tai.fits == '2010-01-01T00:00:34.000'
+        assert t.iso == "2010-01-01 00:00:00.000"
+        assert t.tt.iso == "2010-01-01 00:01:06.184"
+        assert t.tai.fits == "2010-01-01T00:00:34.000"
         assert allclose_jd(t.utc.jd, 2455197.5)
         assert allclose_jd(t.ut1.jd, 2455197.500003867)
-        assert t.tcg.isot == '2010-01-01T00:01:06.910'
+        assert t.tcg.isot == "2010-01-01T00:01:06.910"
         assert allclose_sec(t.unix, 1262304000.0)
         assert allclose_sec(t.cxcsec, 378691266.184)
         assert allclose_sec(t.gps, 946339215.0)
@@ -257,27 +283,26 @@ class TestBasic:
         also a test of the code that provides a dict for global and instance
         options."""
 
-        t = Time('2010-01-01 00:00:00', format='iso', scale='utc')
+        t = Time("2010-01-01 00:00:00", format="iso", scale="utc")
         # Uses initial class-defined precision=3
-        assert t.iso == '2010-01-01 00:00:00.000'
+        assert t.iso == "2010-01-01 00:00:00.000"
 
         # Set instance precision to 9
         t.precision = 9
-        assert t.iso == '2010-01-01 00:00:00.000000000'
-        assert t.tai.utc.iso == '2010-01-01 00:00:00.000000000'
+        assert t.iso == "2010-01-01 00:00:00.000000000"
+        assert t.tai.utc.iso == "2010-01-01 00:00:00.000000000"
 
     def test_precision_input(self):
         """Verifies that precision can only be 0-9 (inclusive). Any other
         value should raise a ValueError exception."""
 
-        err_message = 'precision attribute must be an int'
+        err_message = "precision attribute must be an int"
 
         with pytest.raises(ValueError, match=err_message):
-            t = Time('2010-01-01 00:00:00', format='iso', scale='utc',
-                     precision=10)
+            t = Time("2010-01-01 00:00:00", format="iso", scale="utc", precision=10)
 
         with pytest.raises(ValueError, match=err_message):
-            t = Time('2010-01-01 00:00:00', format='iso', scale='utc')
+            t = Time("2010-01-01 00:00:00", format="iso", scale="utc")
             t.precision = -1
 
     def test_transforms(self):
@@ -287,32 +312,40 @@ class TestBasic:
 
         lat = 19.48125
         lon = -155.933222
-        t = Time('2006-01-15 21:24:37.5', format='iso', scale='utc',
-                 precision=7, location=(lon, lat))
+        t = Time(
+            "2006-01-15 21:24:37.5",
+            format="iso",
+            scale="utc",
+            precision=7,
+            location=(lon, lat),
+        )
         t.delta_ut1_utc = 0.3341  # Explicitly set one part of the xform
-        assert t.utc.iso == '2006-01-15 21:24:37.5000000'
-        assert t.ut1.iso == '2006-01-15 21:24:37.8341000'
-        assert t.tai.iso == '2006-01-15 21:25:10.5000000'
-        assert t.tt.iso == '2006-01-15 21:25:42.6840000'
-        assert t.tcg.iso == '2006-01-15 21:25:43.3226905'
-        assert t.tdb.iso == '2006-01-15 21:25:42.6843728'
-        assert t.tcb.iso == '2006-01-15 21:25:56.8939523'
+        assert t.utc.iso == "2006-01-15 21:24:37.5000000"
+        assert t.ut1.iso == "2006-01-15 21:24:37.8341000"
+        assert t.tai.iso == "2006-01-15 21:25:10.5000000"
+        assert t.tt.iso == "2006-01-15 21:25:42.6840000"
+        assert t.tcg.iso == "2006-01-15 21:25:43.3226905"
+        assert t.tdb.iso == "2006-01-15 21:25:42.6843728"
+        assert t.tcb.iso == "2006-01-15 21:25:56.8939523"
 
     def test_transforms_no_location(self):
         """Location should default to geocenter (relevant for TDB, TCB)."""
-        t = Time('2006-01-15 21:24:37.5', format='iso', scale='utc',
-                 precision=7)
+        t = Time("2006-01-15 21:24:37.5", format="iso", scale="utc", precision=7)
         t.delta_ut1_utc = 0.3341  # Explicitly set one part of the xform
-        assert t.utc.iso == '2006-01-15 21:24:37.5000000'
-        assert t.ut1.iso == '2006-01-15 21:24:37.8341000'
-        assert t.tai.iso == '2006-01-15 21:25:10.5000000'
-        assert t.tt.iso == '2006-01-15 21:25:42.6840000'
-        assert t.tcg.iso == '2006-01-15 21:25:43.3226905'
-        assert t.tdb.iso == '2006-01-15 21:25:42.6843725'
-        assert t.tcb.iso == '2006-01-15 21:25:56.8939519'
+        assert t.utc.iso == "2006-01-15 21:24:37.5000000"
+        assert t.ut1.iso == "2006-01-15 21:24:37.8341000"
+        assert t.tai.iso == "2006-01-15 21:25:10.5000000"
+        assert t.tt.iso == "2006-01-15 21:25:42.6840000"
+        assert t.tcg.iso == "2006-01-15 21:25:43.3226905"
+        assert t.tdb.iso == "2006-01-15 21:25:42.6843725"
+        assert t.tcb.iso == "2006-01-15 21:25:56.8939519"
         # Check we get the same result
-        t2 = Time('2006-01-15 21:24:37.5', format='iso', scale='utc',
-                  location=(0*u.m, 0*u.m, 0*u.m))
+        t2 = Time(
+            "2006-01-15 21:24:37.5",
+            format="iso",
+            scale="utc",
+            location=(0 * u.m, 0 * u.m, 0 * u.m),
+        )
         assert t == t2
         assert t.tdb == t2.tdb
 
@@ -322,16 +355,31 @@ class TestBasic:
         """
         lat = 19.48125
         lon = -155.933222
-        t = Time(['2006-01-15 21:24:37.5'], format='iso', scale='utc',
-                 precision=6, location=(lon, lat))
+        t = Time(
+            ["2006-01-15 21:24:37.5"],
+            format="iso",
+            scale="utc",
+            precision=6,
+            location=(lon, lat),
+        )
         assert isinstance(t.location, EarthLocation)
         location = EarthLocation(lon, lat)
-        t2 = Time(['2006-01-15 21:24:37.5'], format='iso', scale='utc',
-                  precision=6, location=location)
+        t2 = Time(
+            ["2006-01-15 21:24:37.5"],
+            format="iso",
+            scale="utc",
+            precision=6,
+            location=location,
+        )
         assert isinstance(t2.location, EarthLocation)
         assert t2.location == t.location
-        t3 = Time(['2006-01-15 21:24:37.5'], format='iso', scale='utc',
-                  precision=6, location=(location.x, location.y, location.z))
+        t3 = Time(
+            ["2006-01-15 21:24:37.5"],
+            format="iso",
+            scale="utc",
+            precision=6,
+            location=(location.x, location.y, location.z),
+        )
         assert isinstance(t3.location, EarthLocation)
         assert t3.location == t.location
 
@@ -343,38 +391,65 @@ class TestBasic:
 
         lat = 19.48125
         lon = -155.933222
-        t = Time(['2006-01-15 21:24:37.5'] * 2, format='iso', scale='utc',
-                 precision=6, location=(lon, lat))
-        assert np.all(t.utc.iso == '2006-01-15 21:24:37.500000')
-        assert np.all(t.tdb.iso[0] == '2006-01-15 21:25:42.684373')
-        t2 = Time(['2006-01-15 21:24:37.5'] * 2, format='iso', scale='utc',
-                  precision=6, location=(np.array([lon, 0]),
-                                         np.array([lat, 0])))
-        assert np.all(t2.utc.iso == '2006-01-15 21:24:37.500000')
-        assert t2.tdb.iso[0] == '2006-01-15 21:25:42.684373'
-        assert t2.tdb.iso[1] != '2006-01-15 21:25:42.684373'
+        t = Time(
+            ["2006-01-15 21:24:37.5"] * 2,
+            format="iso",
+            scale="utc",
+            precision=6,
+            location=(lon, lat),
+        )
+        assert np.all(t.utc.iso == "2006-01-15 21:24:37.500000")
+        assert np.all(t.tdb.iso[0] == "2006-01-15 21:25:42.684373")
+        t2 = Time(
+            ["2006-01-15 21:24:37.5"] * 2,
+            format="iso",
+            scale="utc",
+            precision=6,
+            location=(np.array([lon, 0]), np.array([lat, 0])),
+        )
+        assert np.all(t2.utc.iso == "2006-01-15 21:24:37.500000")
+        assert t2.tdb.iso[0] == "2006-01-15 21:25:42.684373"
+        assert t2.tdb.iso[1] != "2006-01-15 21:25:42.684373"
         with pytest.raises(ValueError):  # 1 time, but two locations
-            Time('2006-01-15 21:24:37.5', format='iso', scale='utc',
-                 precision=6, location=(np.array([lon, 0]),
-                                        np.array([lat, 0])))
+            Time(
+                "2006-01-15 21:24:37.5",
+                format="iso",
+                scale="utc",
+                precision=6,
+                location=(np.array([lon, 0]), np.array([lat, 0])),
+            )
         with pytest.raises(ValueError):  # 3 times, but two locations
-            Time(['2006-01-15 21:24:37.5'] * 3, format='iso', scale='utc',
-                 precision=6, location=(np.array([lon, 0]),
-                                        np.array([lat, 0])))
+            Time(
+                ["2006-01-15 21:24:37.5"] * 3,
+                format="iso",
+                scale="utc",
+                precision=6,
+                location=(np.array([lon, 0]), np.array([lat, 0])),
+            )
         # multidimensional
-        mjd = np.arange(50000., 50008.).reshape(4, 2)
-        t3 = Time(mjd, format='mjd', scale='utc', location=(lon, lat))
+        mjd = np.arange(50000.0, 50008.0).reshape(4, 2)
+        t3 = Time(mjd, format="mjd", scale="utc", location=(lon, lat))
         assert t3.shape == (4, 2)
         assert t3.location.shape == ()
         assert t3.tdb.shape == t3.shape
-        t4 = Time(mjd, format='mjd', scale='utc',
-                  location=(np.array([lon, 0]), np.array([lat, 0])))
+        t4 = Time(
+            mjd,
+            format="mjd",
+            scale="utc",
+            location=(np.array([lon, 0]), np.array([lat, 0])),
+        )
         assert t4.shape == (4, 2)
         assert t4.location.shape == t4.shape
         assert t4.tdb.shape == t4.shape
-        t5 = Time(mjd, format='mjd', scale='utc',
-                  location=(np.array([[lon], [0], [0], [0]]),
-                            np.array([[lat], [0], [0], [0]])))
+        t5 = Time(
+            mjd,
+            format="mjd",
+            scale="utc",
+            location=(
+                np.array([[lon], [0], [0], [0]]),
+                np.array([[lat], [0], [0], [0]]),
+            ),
+        )
         assert t5.shape == (4, 2)
         assert t5.location.shape == t5.shape
         assert t5.tdb.shape == t5.shape
@@ -385,46 +460,50 @@ class TestBasic:
         converted to local scales"""
         lat = 19.48125
         lon = -155.933222
-        with iers.conf.set_temp('auto_download', False):
+        with iers.conf.set_temp("auto_download", False):
             for scale1 in STANDARD_TIME_SCALES:
-                t1 = Time('2006-01-15 21:24:37.5', format='iso', scale=scale1,
-                          location=(lon, lat))
+                t1 = Time(
+                    "2006-01-15 21:24:37.5",
+                    format="iso",
+                    scale=scale1,
+                    location=(lon, lat),
+                )
                 for scale2 in STANDARD_TIME_SCALES:
                     t2 = getattr(t1, scale2)
                     t21 = getattr(t2, scale1)
                     assert allclose_jd(t21.jd, t1.jd)
 
                 # test for conversion to local scale
-                scale3 = 'local'
+                scale3 = "local"
                 with pytest.raises(ScaleValueError):
                     t2 = getattr(t1, scale3)
 
     def test_creating_all_formats(self):
         """Create a time object using each defined format"""
-        Time(2000.5, format='decimalyear')
-        Time(100.0, format='cxcsec')
-        Time(100.0, format='unix')
-        Time(100.0, format='gps')
-        Time(1950.0, format='byear', scale='tai')
-        Time(2000.0, format='jyear', scale='tai')
-        Time('B1950.0', format='byear_str', scale='tai')
-        Time('J2000.0', format='jyear_str', scale='tai')
-        Time('2000-01-01 12:23:34.0', format='iso', scale='tai')
-        Time('2000-01-01 12:23:34.0Z', format='iso', scale='utc')
-        Time('2000-01-01T12:23:34.0', format='isot', scale='tai')
-        Time('2000-01-01T12:23:34.0Z', format='isot', scale='utc')
-        Time('2000-01-01T12:23:34.0', format='fits')
-        Time('2000-01-01T12:23:34.0', format='fits', scale='tdb')
-        Time(2400000.5, 51544.0333981, format='jd', scale='tai')
-        Time(0.0, 51544.0333981, format='mjd', scale='tai')
-        Time('2000:001:12:23:34.0', format='yday', scale='tai')
-        Time('2000:001:12:23:34.0Z', format='yday', scale='utc')
+        Time(2000.5, format="decimalyear")
+        Time(100.0, format="cxcsec")
+        Time(100.0, format="unix")
+        Time(100.0, format="gps")
+        Time(1950.0, format="byear", scale="tai")
+        Time(2000.0, format="jyear", scale="tai")
+        Time("B1950.0", format="byear_str", scale="tai")
+        Time("J2000.0", format="jyear_str", scale="tai")
+        Time("2000-01-01 12:23:34.0", format="iso", scale="tai")
+        Time("2000-01-01 12:23:34.0Z", format="iso", scale="utc")
+        Time("2000-01-01T12:23:34.0", format="isot", scale="tai")
+        Time("2000-01-01T12:23:34.0Z", format="isot", scale="utc")
+        Time("2000-01-01T12:23:34.0", format="fits")
+        Time("2000-01-01T12:23:34.0", format="fits", scale="tdb")
+        Time(2400000.5, 51544.0333981, format="jd", scale="tai")
+        Time(0.0, 51544.0333981, format="mjd", scale="tai")
+        Time("2000:001:12:23:34.0", format="yday", scale="tai")
+        Time("2000:001:12:23:34.0Z", format="yday", scale="utc")
         dt = datetime.datetime(2000, 1, 2, 3, 4, 5, 123456)
-        Time(dt, format='datetime', scale='tai')
-        Time([dt, dt], format='datetime', scale='tai')
-        dt64 = np.datetime64('2012-06-18T02:00:05.453000000')
-        Time(dt64, format='datetime64', scale='tai')
-        Time([dt64, dt64], format='datetime64', scale='tai')
+        Time(dt, format="datetime", scale="tai")
+        Time([dt, dt], format="datetime", scale="tai")
+        dt64 = np.datetime64("2012-06-18T02:00:05.453000000")
+        Time(dt64, format="datetime64", scale="tai")
+        Time([dt64, dt64], format="datetime64", scale="tai")
 
     def test_local_format_transforms(self):
         """
@@ -432,18 +511,27 @@ class TestBasic:
         Transformation to formats with reference time should give
         ScalevalueError
         """
-        t = Time('2006-01-15 21:24:37.5', scale='local')
-        assert_allclose(t.jd, 2453751.3921006946, atol=0.001 / 3600. / 24., rtol=0.)
-        assert_allclose(t.mjd, 53750.892100694444, atol=0.001 / 3600. / 24., rtol=0.)
-        assert_allclose(t.decimalyear, 2006.0408002758752, atol=0.001 / 3600. / 24. / 365., rtol=0.)
+        t = Time("2006-01-15 21:24:37.5", scale="local")
+        assert_allclose(t.jd, 2453751.3921006946, atol=0.001 / 3600.0 / 24.0, rtol=0.0)
+        assert_allclose(t.mjd, 53750.892100694444, atol=0.001 / 3600.0 / 24.0, rtol=0.0)
+        assert_allclose(
+            t.decimalyear,
+            2006.0408002758752,
+            atol=0.001 / 3600.0 / 24.0 / 365.0,
+            rtol=0.0,
+        )
         assert t.datetime == datetime.datetime(2006, 1, 15, 21, 24, 37, 500000)
-        assert t.isot == '2006-01-15T21:24:37.500'
-        assert t.yday == '2006:015:21:24:37.500'
-        assert t.fits == '2006-01-15T21:24:37.500'
-        assert_allclose(t.byear, 2006.04217888831, atol=0.001 / 3600. / 24. / 365., rtol=0.)
-        assert_allclose(t.jyear, 2006.0407723496082, atol=0.001 / 3600. / 24. / 365., rtol=0.)
-        assert t.byear_str == 'B2006.042'
-        assert t.jyear_str == 'J2006.041'
+        assert t.isot == "2006-01-15T21:24:37.500"
+        assert t.yday == "2006:015:21:24:37.500"
+        assert t.fits == "2006-01-15T21:24:37.500"
+        assert_allclose(
+            t.byear, 2006.04217888831, atol=0.001 / 3600.0 / 24.0 / 365.0, rtol=0.0
+        )
+        assert_allclose(
+            t.jyear, 2006.0407723496082, atol=0.001 / 3600.0 / 24.0 / 365.0, rtol=0.0
+        )
+        assert t.byear_str == "B2006.042"
+        assert t.jyear_str == "J2006.041"
 
         # epochTimeFormats
         with pytest.raises(ScaleValueError):
@@ -462,22 +550,22 @@ class TestBasic:
         """
         dt = datetime.datetime(2000, 1, 2, 3, 4, 5, 123456)
         dt2 = datetime.datetime(2001, 1, 1)
-        t = Time(dt, scale='utc', precision=9)
-        assert t.iso == '2000-01-02 03:04:05.123456000'
+        t = Time(dt, scale="utc", precision=9)
+        assert t.iso == "2000-01-02 03:04:05.123456000"
         assert t.datetime == dt
         assert t.value == dt
-        t2 = Time(t.iso, scale='utc')
+        t2 = Time(t.iso, scale="utc")
         assert t2.datetime == dt
 
-        t = Time([dt, dt2], scale='utc')
+        t = Time([dt, dt2], scale="utc")
         assert np.all(t.value == [dt, dt2])
 
-        t = Time('2000-01-01 01:01:01.123456789', scale='tai')
+        t = Time("2000-01-01 01:01:01.123456789", scale="tai")
         assert t.datetime == datetime.datetime(2000, 1, 1, 1, 1, 1, 123457)
 
         # broadcasting
-        dt3 = (dt + (dt2-dt) * np.arange(12)).reshape(4, 3)
-        t3 = Time(dt3, scale='utc')
+        dt3 = (dt + (dt2 - dt) * np.arange(12)).reshape(4, 3)
+        t3 = Time(dt3, scale="utc")
         assert t3.shape == (4, 3)
         assert t3[2, 1].value == dt3[2, 1]
         assert t3[2, 1] == Time(dt3[2, 1])
@@ -487,121 +575,123 @@ class TestBasic:
         assert Time(t3[2, 0]) == t3[2, 0]
 
     def test_datetime64(self):
-        dt64 = np.datetime64('2000-01-02T03:04:05.123456789')
-        dt64_2 = np.datetime64('2000-01-02')
-        t = Time(dt64, scale='utc', precision=9, format='datetime64')
-        assert t.iso == '2000-01-02 03:04:05.123456789'
+        dt64 = np.datetime64("2000-01-02T03:04:05.123456789")
+        dt64_2 = np.datetime64("2000-01-02")
+        t = Time(dt64, scale="utc", precision=9, format="datetime64")
+        assert t.iso == "2000-01-02 03:04:05.123456789"
         assert t.datetime64 == dt64
         assert t.value == dt64
-        t2 = Time(t.iso, scale='utc')
+        t2 = Time(t.iso, scale="utc")
         assert t2.datetime64 == dt64
 
-        t = Time(dt64_2, scale='utc', precision=3, format='datetime64')
-        assert t.iso == '2000-01-02 00:00:00.000'
+        t = Time(dt64_2, scale="utc", precision=3, format="datetime64")
+        assert t.iso == "2000-01-02 00:00:00.000"
         assert t.datetime64 == dt64_2
         assert t.value == dt64_2
-        t2 = Time(t.iso, scale='utc')
+        t2 = Time(t.iso, scale="utc")
         assert t2.datetime64 == dt64_2
 
-        t = Time([dt64, dt64_2], scale='utc', format='datetime64')
+        t = Time([dt64, dt64_2], scale="utc", format="datetime64")
         assert np.all(t.value == [dt64, dt64_2])
 
-        t = Time('2000-01-01 01:01:01.123456789', scale='tai')
-        assert t.datetime64 == np.datetime64('2000-01-01T01:01:01.123456789')
+        t = Time("2000-01-01 01:01:01.123456789", scale="tai")
+        assert t.datetime64 == np.datetime64("2000-01-01T01:01:01.123456789")
 
         # broadcasting
-        dt3 = (dt64 + (dt64_2-dt64) * np.arange(12)).reshape(4, 3)
-        t3 = Time(dt3, scale='utc', format='datetime64')
+        dt3 = (dt64 + (dt64_2 - dt64) * np.arange(12)).reshape(4, 3)
+        t3 = Time(dt3, scale="utc", format="datetime64")
         assert t3.shape == (4, 3)
         assert t3[2, 1].value == dt3[2, 1]
-        assert t3[2, 1] == Time(dt3[2, 1], format='datetime64')
+        assert t3[2, 1] == Time(dt3[2, 1], format="datetime64")
         assert np.all(t3.value == dt3)
         assert np.all(t3[1].value == dt3[1])
-        assert np.all(t3[:, 2] == Time(dt3[:, 2], format='datetime64'))
-        assert Time(t3[2, 0], format='datetime64') == t3[2, 0]
+        assert np.all(t3[:, 2] == Time(dt3[:, 2], format="datetime64"))
+        assert Time(t3[2, 0], format="datetime64") == t3[2, 0]
 
     def test_epoch_transform(self):
         """Besselian and julian epoch transforms"""
         jd = 2457073.05631
-        t = Time(jd, format='jd', scale='tai', precision=6)
+        t = Time(jd, format="jd", scale="tai", precision=6)
         assert allclose_year(t.byear, 2015.1365941020817)
         assert allclose_year(t.jyear, 2015.1349933196439)
-        assert t.byear_str == 'B2015.136594'
-        assert t.jyear_str == 'J2015.134993'
-        t2 = Time(t.byear, format='byear', scale='tai')
+        assert t.byear_str == "B2015.136594"
+        assert t.jyear_str == "J2015.134993"
+        t2 = Time(t.byear, format="byear", scale="tai")
         assert allclose_jd(t2.jd, jd)
-        t2 = Time(t.jyear, format='jyear', scale='tai')
+        t2 = Time(t.jyear, format="jyear", scale="tai")
         assert allclose_jd(t2.jd, jd)
 
-        t = Time('J2015.134993', scale='tai', precision=6)
-        assert np.allclose(t.jd, jd, rtol=1e-10, atol=0)  # J2015.134993 has 10 digit precision
-        assert t.byear_str == 'B2015.136594'
+        t = Time("J2015.134993", scale="tai", precision=6)
+        assert np.allclose(
+            t.jd, jd, rtol=1e-10, atol=0
+        )  # J2015.134993 has 10 digit precision
+        assert t.byear_str == "B2015.136594"
 
     def test_input_validation(self):
         """Wrong input type raises error"""
         times = [10, 20]
         with pytest.raises(ValueError):
-            Time(times, format='iso', scale='utc')
+            Time(times, format="iso", scale="utc")
         with pytest.raises(ValueError):
-            Time('2000:001', format='jd', scale='utc')
+            Time("2000:001", format="jd", scale="utc")
         with pytest.raises(ValueError):  # unguessable
             Time([])
         with pytest.raises(ValueError):
-            Time([50000.0], ['bad'], format='mjd', scale='tai')
+            Time([50000.0], ["bad"], format="mjd", scale="tai")
         with pytest.raises(ValueError):
-            Time(50000.0, 'bad', format='mjd', scale='tai')
+            Time(50000.0, "bad", format="mjd", scale="tai")
         with pytest.raises(ValueError):
-            Time('2005-08-04T00:01:02.000Z', scale='tai')
+            Time("2005-08-04T00:01:02.000Z", scale="tai")
         # regression test against #3396
         with pytest.raises(ValueError):
-            Time(np.nan, format='jd', scale='utc')
+            Time(np.nan, format="jd", scale="utc")
         with pytest.raises(ValueError):
             with pytest.warns(AstropyDeprecationWarning):
-                Time('2000-01-02T03:04:05(TAI)', scale='utc')
+                Time("2000-01-02T03:04:05(TAI)", scale="utc")
         with pytest.raises(ValueError):
-            Time('2000-01-02T03:04:05(TAI')
+            Time("2000-01-02T03:04:05(TAI")
         with pytest.raises(ValueError):
-            Time('2000-01-02T03:04:05(UT(NIST)')
+            Time("2000-01-02T03:04:05(UT(NIST)")
 
     def test_utc_leap_sec(self):
         """Time behaves properly near or in UTC leap second.  This
         uses the 2012-06-30 leap second for testing."""
         for year, month, day in ((2012, 6, 30), (2016, 12, 31)):
             # Start with a day without a leap second and note rollover
-            yyyy_mm = f'{year:04d}-{month:02d}'
-            yyyy_mm_dd = f'{year:04d}-{month:02d}-{day:02d}'
+            yyyy_mm = f"{year:04d}-{month:02d}"
+            yyyy_mm_dd = f"{year:04d}-{month:02d}-{day:02d}"
             with pytest.warns(ErfaWarning):
-                t1 = Time(yyyy_mm + '-01 23:59:60.0', scale='utc')
-            assert t1.iso == yyyy_mm + '-02 00:00:00.000'
+                t1 = Time(yyyy_mm + "-01 23:59:60.0", scale="utc")
+            assert t1.iso == yyyy_mm + "-02 00:00:00.000"
 
             # Leap second is different
-            t1 = Time(yyyy_mm_dd + ' 23:59:59.900', scale='utc')
-            assert t1.iso == yyyy_mm_dd + ' 23:59:59.900'
+            t1 = Time(yyyy_mm_dd + " 23:59:59.900", scale="utc")
+            assert t1.iso == yyyy_mm_dd + " 23:59:59.900"
 
-            t1 = Time(yyyy_mm_dd + ' 23:59:60.000', scale='utc')
-            assert t1.iso == yyyy_mm_dd + ' 23:59:60.000'
+            t1 = Time(yyyy_mm_dd + " 23:59:60.000", scale="utc")
+            assert t1.iso == yyyy_mm_dd + " 23:59:60.000"
 
-            t1 = Time(yyyy_mm_dd + ' 23:59:60.999', scale='utc')
-            assert t1.iso == yyyy_mm_dd + ' 23:59:60.999'
+            t1 = Time(yyyy_mm_dd + " 23:59:60.999", scale="utc")
+            assert t1.iso == yyyy_mm_dd + " 23:59:60.999"
 
             if month == 6:
-                yyyy_mm_dd_plus1 = f'{year:04d}-07-01'
+                yyyy_mm_dd_plus1 = f"{year:04d}-07-01"
             else:
-                yyyy_mm_dd_plus1 = f'{year + 1:04d}-01-01'
+                yyyy_mm_dd_plus1 = f"{year + 1:04d}-01-01"
 
             with pytest.warns(ErfaWarning):
-                t1 = Time(yyyy_mm_dd + ' 23:59:61.0', scale='utc')
-            assert t1.iso == yyyy_mm_dd_plus1 + ' 00:00:00.000'
+                t1 = Time(yyyy_mm_dd + " 23:59:61.0", scale="utc")
+            assert t1.iso == yyyy_mm_dd_plus1 + " 00:00:00.000"
 
             # Delta time gives 2 seconds here as expected
-            t0 = Time(yyyy_mm_dd + ' 23:59:59', scale='utc')
-            t1 = Time(yyyy_mm_dd_plus1 + ' 00:00:00', scale='utc')
+            t0 = Time(yyyy_mm_dd + " 23:59:59", scale="utc")
+            t1 = Time(yyyy_mm_dd_plus1 + " 00:00:00", scale="utc")
             assert allclose_sec((t1 - t0).sec, 2.0)
 
     def test_init_from_time_objects(self):
         """Initialize from one or more Time objects"""
-        t1 = Time('2007:001', scale='tai')
-        t2 = Time(['2007-01-02', '2007-01-03'], scale='utc')
+        t1 = Time("2007:001", scale="tai")
+        t2 = Time(["2007-01-02", "2007-01-03"], scale="utc")
         # Init from a list of Time objects without an explicit scale
         t3 = Time([t1, t2])
         # Test that init appropriately combines a scalar (t1) and list (t2)
@@ -619,41 +709,54 @@ class TestBasic:
         assert np.all(t3.value == t1.value)
 
         # Init from a single Time object with scale specified
-        t3 = Time(t1, scale='utc')
-        assert t3.scale == 'utc'
+        t3 = Time(t1, scale="utc")
+        assert t3.scale == "utc"
         assert np.all(t3.value == t1.utc.value)
 
         # Init from a list of Time object with scale specified
-        t3 = Time([t1, t2], scale='tt')
-        assert t3.scale == 'tt'
+        t3 = Time([t1, t2], scale="tt")
+        assert t3.scale == "tt"
         assert t3.format == t1.format  # yday
         assert np.all(t3.value == np.concatenate([[t1.tt.yday], t2.tt.yday]))
 
         # OK, how likely is this... but might as well test.
-        mjd = np.arange(50000., 50006.)
-        frac = np.arange(0., 0.999, 0.2)
-        t4 = Time(mjd[:, np.newaxis] + frac, format='mjd', scale='utc')
+        mjd = np.arange(50000.0, 50006.0)
+        frac = np.arange(0.0, 0.999, 0.2)
+        t4 = Time(mjd[:, np.newaxis] + frac, format="mjd", scale="utc")
         t5 = Time([t4[:2], t4[4:5]])
         assert t5.shape == (3, 5)
 
         # throw error when deriving local scale time
         # from non local time scale
         with pytest.raises(ValueError):
-            Time(t1, scale='local')
+            Time(t1, scale="local")
 
 
 class TestVal2:
     """Tests related to val2"""
 
-    @pytest.mark.parametrize("d", [
-        dict(val="2001:001", val2="ignored", scale="utc"),
-        dict(val={'year': 2015, 'month': 2, 'day': 3,
-                  'hour': 12, 'minute': 13, 'second': 14.567},
-             val2="ignored", scale="utc"),
-        dict(val=np.datetime64('2005-02-25'), val2="ignored", scale="utc"),
-        dict(val=datetime.datetime(2000, 1, 2, 12, 0, 0),
-             val2="ignored", scale="utc"),
-    ])
+    @pytest.mark.parametrize(
+        "d",
+        [
+            dict(val="2001:001", val2="ignored", scale="utc"),
+            dict(
+                val={
+                    "year": 2015,
+                    "month": 2,
+                    "day": 3,
+                    "hour": 12,
+                    "minute": 13,
+                    "second": 14.567,
+                },
+                val2="ignored",
+                scale="utc",
+            ),
+            dict(val=np.datetime64("2005-02-25"), val2="ignored", scale="utc"),
+            dict(
+                val=datetime.datetime(2000, 1, 2, 12, 0, 0), val2="ignored", scale="utc"
+            ),
+        ],
+    )
     def test_unused_val2_raises(self, d):
         """Test that providing val2 is for string input lets user know we won't use it"""
         with pytest.raises(ValueError):
@@ -661,17 +764,17 @@ class TestVal2:
 
     def test_val2(self):
         """Various tests of the val2 input"""
-        t = Time([0.0, 50000.0], [50000.0, 0.0], format='mjd', scale='tai')
+        t = Time([0.0, 50000.0], [50000.0, 0.0], format="mjd", scale="tai")
         assert t.mjd[0] == t.mjd[1]
         assert t.jd[0] == t.jd[1]
 
     def test_val_broadcasts_against_val2(self):
-        mjd = np.arange(50000., 50007.)
-        frac = np.arange(0., 0.999, 0.2)
-        t = Time(mjd[:, np.newaxis], frac, format='mjd', scale='utc')
+        mjd = np.arange(50000.0, 50007.0)
+        frac = np.arange(0.0, 0.999, 0.2)
+        t = Time(mjd[:, np.newaxis], frac, format="mjd", scale="utc")
         assert t.shape == (7, 5)
         with pytest.raises(ValueError):
-            Time([0.0, 50000.0], [0.0, 1.0, 2.0], format='mjd', scale='tai')
+            Time([0.0, 50000.0], [0.0, 1.0, 2.0], format="mjd", scale="tai")
 
     def test_broadcast_not_writable(self):
         val = (2458000 + np.arange(3))[:, None]
@@ -687,7 +790,7 @@ class TestVal2:
         assert np.all(t_b == t), "behaved as expected"
 
     def test_broadcast_one_not_writable(self):
-        val = (2458000 + np.arange(3))
+        val = 2458000 + np.arange(3)
         val2 = np.arange(1)
         t = Time(val=val, val2=val2, format="jd", scale="tai")
         t_b = Time(val=val + 0 * val2, val2=0 * val + val2, format="jd", scale="tai")
@@ -705,193 +808,248 @@ class TestSubFormat:
     def test_input_subformat(self):
         """Input subformat selection"""
         # Heterogeneous input formats with in_subfmt='*' (default)
-        times = ['2000-01-01', '2000-01-01 01:01',
-                 '2000-01-01 01:01:01', '2000-01-01 01:01:01.123']
-        t = Time(times, format='iso', scale='tai')
-        assert np.all(t.iso == np.array(['2000-01-01 00:00:00.000',
-                                         '2000-01-01 01:01:00.000',
-                                         '2000-01-01 01:01:01.000',
-                                         '2000-01-01 01:01:01.123']))
+        times = [
+            "2000-01-01",
+            "2000-01-01 01:01",
+            "2000-01-01 01:01:01",
+            "2000-01-01 01:01:01.123",
+        ]
+        t = Time(times, format="iso", scale="tai")
+        assert np.all(
+            t.iso
+            == np.array(
+                [
+                    "2000-01-01 00:00:00.000",
+                    "2000-01-01 01:01:00.000",
+                    "2000-01-01 01:01:01.000",
+                    "2000-01-01 01:01:01.123",
+                ]
+            )
+        )
 
         # Heterogeneous input formats with in_subfmt='date_*'
-        times = ['2000-01-01 01:01',
-                 '2000-01-01 01:01:01', '2000-01-01 01:01:01.123']
-        t = Time(times, format='iso', scale='tai',
-                 in_subfmt='date_*')
-        assert np.all(t.iso == np.array(['2000-01-01 01:01:00.000',
-                                         '2000-01-01 01:01:01.000',
-                                         '2000-01-01 01:01:01.123']))
+        times = ["2000-01-01 01:01", "2000-01-01 01:01:01", "2000-01-01 01:01:01.123"]
+        t = Time(times, format="iso", scale="tai", in_subfmt="date_*")
+        assert np.all(
+            t.iso
+            == np.array(
+                [
+                    "2000-01-01 01:01:00.000",
+                    "2000-01-01 01:01:01.000",
+                    "2000-01-01 01:01:01.123",
+                ]
+            )
+        )
 
     def test_input_subformat_fail(self):
         """Failed format matching"""
         with pytest.raises(ValueError):
-            Time('2000-01-01 01:01', format='iso', scale='tai',
-                 in_subfmt='date')
+            Time("2000-01-01 01:01", format="iso", scale="tai", in_subfmt="date")
 
     def test_bad_input_subformat(self):
         """Non-existent input subformat"""
         with pytest.raises(ValueError):
-            Time('2000-01-01 01:01', format='iso', scale='tai',
-                 in_subfmt='doesnt exist')
+            Time(
+                "2000-01-01 01:01", format="iso", scale="tai", in_subfmt="doesnt exist"
+            )
 
     def test_output_subformat(self):
         """Input subformat selection"""
         # Heterogeneous input formats with in_subfmt='*' (default)
-        times = ['2000-01-01', '2000-01-01 01:01',
-                 '2000-01-01 01:01:01', '2000-01-01 01:01:01.123']
-        t = Time(times, format='iso', scale='tai',
-                 out_subfmt='date_hm')
-        assert np.all(t.iso == np.array(['2000-01-01 00:00',
-                                         '2000-01-01 01:01',
-                                         '2000-01-01 01:01',
-                                         '2000-01-01 01:01']))
+        times = [
+            "2000-01-01",
+            "2000-01-01 01:01",
+            "2000-01-01 01:01:01",
+            "2000-01-01 01:01:01.123",
+        ]
+        t = Time(times, format="iso", scale="tai", out_subfmt="date_hm")
+        assert np.all(
+            t.iso
+            == np.array(
+                [
+                    "2000-01-01 00:00",
+                    "2000-01-01 01:01",
+                    "2000-01-01 01:01",
+                    "2000-01-01 01:01",
+                ]
+            )
+        )
 
     def test_fits_format(self):
         """FITS format includes bigger years."""
         # Heterogeneous input formats with in_subfmt='*' (default)
-        times = ['2000-01-01', '2000-01-01T01:01:01', '2000-01-01T01:01:01.123']
-        t = Time(times, format='fits', scale='tai')
-        assert np.all(t.fits == np.array(['2000-01-01T00:00:00.000',
-                                          '2000-01-01T01:01:01.000',
-                                          '2000-01-01T01:01:01.123']))
+        times = ["2000-01-01", "2000-01-01T01:01:01", "2000-01-01T01:01:01.123"]
+        t = Time(times, format="fits", scale="tai")
+        assert np.all(
+            t.fits
+            == np.array(
+                [
+                    "2000-01-01T00:00:00.000",
+                    "2000-01-01T01:01:01.000",
+                    "2000-01-01T01:01:01.123",
+                ]
+            )
+        )
         # Explicit long format for output, default scale is UTC.
-        t2 = Time(times, format='fits', out_subfmt='long*')
-        assert np.all(t2.fits == np.array(['+02000-01-01T00:00:00.000',
-                                           '+02000-01-01T01:01:01.000',
-                                           '+02000-01-01T01:01:01.123']))
+        t2 = Time(times, format="fits", out_subfmt="long*")
+        assert np.all(
+            t2.fits
+            == np.array(
+                [
+                    "+02000-01-01T00:00:00.000",
+                    "+02000-01-01T01:01:01.000",
+                    "+02000-01-01T01:01:01.123",
+                ]
+            )
+        )
         # Implicit long format for output, because of negative year.
-        times[2] = '-00594-01-01'
-        t3 = Time(times, format='fits', scale='tai')
-        assert np.all(t3.fits == np.array(['+02000-01-01T00:00:00.000',
-                                           '+02000-01-01T01:01:01.000',
-                                           '-00594-01-01T00:00:00.000']))
+        times[2] = "-00594-01-01"
+        t3 = Time(times, format="fits", scale="tai")
+        assert np.all(
+            t3.fits
+            == np.array(
+                [
+                    "+02000-01-01T00:00:00.000",
+                    "+02000-01-01T01:01:01.000",
+                    "-00594-01-01T00:00:00.000",
+                ]
+            )
+        )
         # Implicit long format for output, because of large positive year.
-        times[2] = '+10594-01-01'
-        t4 = Time(times, format='fits', scale='tai')
-        assert np.all(t4.fits == np.array(['+02000-01-01T00:00:00.000',
-                                           '+02000-01-01T01:01:01.000',
-                                           '+10594-01-01T00:00:00.000']))
+        times[2] = "+10594-01-01"
+        t4 = Time(times, format="fits", scale="tai")
+        assert np.all(
+            t4.fits
+            == np.array(
+                [
+                    "+02000-01-01T00:00:00.000",
+                    "+02000-01-01T01:01:01.000",
+                    "+10594-01-01T00:00:00.000",
+                ]
+            )
+        )
 
     def test_yday_format(self):
         """Year:Day_of_year format"""
         # Heterogeneous input formats with in_subfmt='*' (default)
-        times = ['2000-12-01', '2001-12-01 01:01:01.123']
-        t = Time(times, format='iso', scale='tai')
-        t.out_subfmt = 'date_hm'
-        assert np.all(t.yday == np.array(['2000:336:00:00',
-                                          '2001:335:01:01']))
-        t.out_subfmt = '*'
-        assert np.all(t.yday == np.array(['2000:336:00:00:00.000',
-                                          '2001:335:01:01:01.123']))
+        times = ["2000-12-01", "2001-12-01 01:01:01.123"]
+        t = Time(times, format="iso", scale="tai")
+        t.out_subfmt = "date_hm"
+        assert np.all(t.yday == np.array(["2000:336:00:00", "2001:335:01:01"]))
+        t.out_subfmt = "*"
+        assert np.all(
+            t.yday == np.array(["2000:336:00:00:00.000", "2001:335:01:01:01.123"])
+        )
 
     def test_scale_input(self):
         """Test for issues related to scale input"""
         # Check case where required scale is defined by the TimeFormat.
         # All three should work.
-        t = Time(100.0, format='cxcsec', scale='utc')
-        assert t.scale == 'utc'
-        t = Time(100.0, format='unix', scale='tai')
-        assert t.scale == 'tai'
-        t = Time(100.0, format='gps', scale='utc')
-        assert t.scale == 'utc'
+        t = Time(100.0, format="cxcsec", scale="utc")
+        assert t.scale == "utc"
+        t = Time(100.0, format="unix", scale="tai")
+        assert t.scale == "tai"
+        t = Time(100.0, format="gps", scale="utc")
+        assert t.scale == "utc"
 
         # Check that bad scale is caught when format is specified
         with pytest.raises(ScaleValueError):
-            Time(1950.0, format='byear', scale='bad scale')
+            Time(1950.0, format="byear", scale="bad scale")
 
         # Check that bad scale is caught when format is auto-determined
         with pytest.raises(ScaleValueError):
-            Time('2000:001:00:00:00', scale='bad scale')
+            Time("2000:001:00:00:00", scale="bad scale")
 
     def test_fits_scale(self):
         """Test that the previous FITS-string formatting can still be handled
         but with a DeprecationWarning."""
-        for inputs in (("2000-01-02(TAI)", "tai"),
-                       ("1999-01-01T00:00:00.123(ET(NIST))", "tt"),
-                       ("2014-12-12T01:00:44.1(UTC)", "utc")):
+        for inputs in (
+            ("2000-01-02(TAI)", "tai"),
+            ("1999-01-01T00:00:00.123(ET(NIST))", "tt"),
+            ("2014-12-12T01:00:44.1(UTC)", "utc"),
+        ):
             with pytest.warns(AstropyDeprecationWarning):
                 t = Time(inputs[0])
             assert t.scale == inputs[1]
 
             # Create Time using normal ISOT syntax and compare with FITS
-            t2 = Time(inputs[0][:inputs[0].index("(")], format="isot",
-                      scale=inputs[1])
+            t2 = Time(inputs[0][: inputs[0].index("(")], format="isot", scale=inputs[1])
             assert t == t2
 
         # Explicit check that conversions still work despite warning
         with pytest.warns(AstropyDeprecationWarning):
-            t = Time('1999-01-01T00:00:00.123456789(UTC)')
+            t = Time("1999-01-01T00:00:00.123456789(UTC)")
         t = t.tai
-        assert t.isot == '1999-01-01T00:00:32.123'
+        assert t.isot == "1999-01-01T00:00:32.123"
 
         with pytest.warns(AstropyDeprecationWarning):
-            t = Time('1999-01-01T00:00:32.123456789(TAI)')
+            t = Time("1999-01-01T00:00:32.123456789(TAI)")
         t = t.utc
-        assert t.isot == '1999-01-01T00:00:00.123'
+        assert t.isot == "1999-01-01T00:00:00.123"
 
         # Check scale consistency
         with pytest.warns(AstropyDeprecationWarning):
-            t = Time('1999-01-01T00:00:32.123456789(TAI)', scale="tai")
+            t = Time("1999-01-01T00:00:32.123456789(TAI)", scale="tai")
         assert t.scale == "tai"
         with pytest.warns(AstropyDeprecationWarning):
-            t = Time('1999-01-01T00:00:32.123456789(ET)', scale="tt")
+            t = Time("1999-01-01T00:00:32.123456789(ET)", scale="tt")
         assert t.scale == "tt"
         with pytest.raises(ValueError), pytest.warns(AstropyDeprecationWarning):
-            t = Time('1999-01-01T00:00:32.123456789(TAI)', scale="utc")
+            t = Time("1999-01-01T00:00:32.123456789(TAI)", scale="utc")
 
     def test_scale_default(self):
         """Test behavior when no scale is provided"""
         # These first three are TimeFromEpoch and have an intrinsic time scale
-        t = Time(100.0, format='cxcsec')
-        assert t.scale == 'tt'
-        t = Time(100.0, format='unix')
-        assert t.scale == 'utc'
-        t = Time(100.0, format='gps')
-        assert t.scale == 'tai'
+        t = Time(100.0, format="cxcsec")
+        assert t.scale == "tt"
+        t = Time(100.0, format="unix")
+        assert t.scale == "utc"
+        t = Time(100.0, format="gps")
+        assert t.scale == "tai"
 
-        for date in ('2000:001', '2000-01-01T00:00:00'):
+        for date in ("2000:001", "2000-01-01T00:00:00"):
             t = Time(date)
-            assert t.scale == 'utc'
+            assert t.scale == "utc"
 
-        t = Time(2000.1, format='byear')
-        assert t.scale == 'tt'
-        t = Time('J2000')
-        assert t.scale == 'tt'
+        t = Time(2000.1, format="byear")
+        assert t.scale == "tt"
+        t = Time("J2000")
+        assert t.scale == "tt"
 
     def test_epoch_times(self):
         """Test time formats derived from EpochFromTime"""
-        t = Time(0.0, format='cxcsec', scale='tai')
-        assert t.tt.iso == '1998-01-01 00:00:00.000'
+        t = Time(0.0, format="cxcsec", scale="tai")
+        assert t.tt.iso == "1998-01-01 00:00:00.000"
 
         # Create new time object from this one and change scale, format
-        t2 = Time(t, scale='tt', format='iso')
-        assert t2.value == '1998-01-01 00:00:00.000'
+        t2 = Time(t, scale="tt", format="iso")
+        assert t2.value == "1998-01-01 00:00:00.000"
 
         # Value take from Chandra.Time.DateTime('2010:001:00:00:00').secs
         t_cxcsec = 378691266.184
-        t = Time(t_cxcsec, format='cxcsec', scale='utc')
+        t = Time(t_cxcsec, format="cxcsec", scale="utc")
         assert allclose_sec(t.value, t_cxcsec)
         assert allclose_sec(t.cxcsec, t_cxcsec)
         assert allclose_sec(t.tt.value, t_cxcsec)
         assert allclose_sec(t.tt.cxcsec, t_cxcsec)
-        assert t.yday == '2010:001:00:00:00.000'
-        t = Time('2010:001:00:00:00.000', scale='utc')
+        assert t.yday == "2010:001:00:00:00.000"
+        t = Time("2010:001:00:00:00.000", scale="utc")
         assert allclose_sec(t.cxcsec, t_cxcsec)
         assert allclose_sec(t.tt.cxcsec, t_cxcsec)
 
         # Round trip through epoch time
-        for scale in ('utc', 'tt'):
-            t = Time('2000:001', scale=scale)
-            t2 = Time(t.unix, scale=scale, format='unix')
-            assert getattr(t2, scale).iso == '2000-01-01 00:00:00.000'
+        for scale in ("utc", "tt"):
+            t = Time("2000:001", scale=scale)
+            t2 = Time(t.unix, scale=scale, format="unix")
+            assert getattr(t2, scale).iso == "2000-01-01 00:00:00.000"
 
         # Test unix time.  Values taken from http://en.wikipedia.org/wiki/Unix_time
-        t = Time('2013-05-20 21:18:46', scale='utc')
+        t = Time("2013-05-20 21:18:46", scale="utc")
         assert allclose_sec(t.unix, 1369084726.0)
         assert allclose_sec(t.tt.unix, 1369084726.0)
 
         # Values from issue #1118
-        t = Time('2004-09-16T23:59:59', scale='utc')
+        t = Time("2004-09-16T23:59:59", scale="utc")
         assert allclose_sec(t.unix, 1095379199.0)
 
     def test_plot_date(self):
@@ -914,183 +1072,209 @@ class TestSubFormat:
             val = 730120.0
         else:
             val = date2num(datetime.datetime(2000, 1, 1))
-        t = Time('2000-01-01 00:00:00', scale='utc')
+        t = Time("2000-01-01 00:00:00", scale="utc")
         assert np.allclose(t.plot_date, val, atol=1e-5, rtol=0)
 
 
 class TestNumericalSubFormat:
     def test_explicit_example(self):
-        t = Time('54321.000000000001', format='mjd')
-        assert t == Time(54321, 1e-12, format='mjd')
-        assert t.mjd == 54321.  # Lost precision!
-        assert t.value == 54321.  # Lost precision!
-        assert t.to_value('mjd') == 54321.  # Lost precision!
-        assert t.to_value('mjd', subfmt='str') == '54321.000000000001'
-        assert t.to_value('mjd', 'bytes') == b'54321.000000000001'
-        expected_long = np.longdouble(54321.) + np.longdouble(1e-12)
+        t = Time("54321.000000000001", format="mjd")
+        assert t == Time(54321, 1e-12, format="mjd")
+        assert t.mjd == 54321.0  # Lost precision!
+        assert t.value == 54321.0  # Lost precision!
+        assert t.to_value("mjd") == 54321.0  # Lost precision!
+        assert t.to_value("mjd", subfmt="str") == "54321.000000000001"
+        assert t.to_value("mjd", "bytes") == b"54321.000000000001"
+        expected_long = np.longdouble(54321.0) + np.longdouble(1e-12)
         # Check we're the same to within the double holding jd2
         # (which is less precise than longdouble on arm64).
-        assert np.allclose(t.to_value('mjd', subfmt='long'),
-                           expected_long, rtol=0, atol=np.finfo(float).eps)
-        t.out_subfmt = 'str'
-        assert t.value == '54321.000000000001'
-        assert t.to_value('mjd') == 54321.  # Lost precision!
-        assert t.mjd == '54321.000000000001'
-        assert t.to_value('mjd', subfmt='bytes') == b'54321.000000000001'
-        assert t.to_value('mjd', subfmt='float') == 54321.  # Lost precision!
-        t.out_subfmt = 'long'
-        assert np.allclose(t.value, expected_long,
-                           rtol=0., atol=np.finfo(float).eps)
-        assert np.allclose(t.to_value('mjd', subfmt=None), expected_long,
-                           rtol=0., atol=np.finfo(float).eps)
-        assert np.allclose(t.mjd, expected_long,
-                           rtol=0., atol=np.finfo(float).eps)
-        assert t.to_value('mjd', subfmt='str') == '54321.000000000001'
-        assert t.to_value('mjd', subfmt='float') == 54321.  # Lost precision!
+        assert np.allclose(
+            t.to_value("mjd", subfmt="long"),
+            expected_long,
+            rtol=0,
+            atol=np.finfo(float).eps,
+        )
+        t.out_subfmt = "str"
+        assert t.value == "54321.000000000001"
+        assert t.to_value("mjd") == 54321.0  # Lost precision!
+        assert t.mjd == "54321.000000000001"
+        assert t.to_value("mjd", subfmt="bytes") == b"54321.000000000001"
+        assert t.to_value("mjd", subfmt="float") == 54321.0  # Lost precision!
+        t.out_subfmt = "long"
+        assert np.allclose(t.value, expected_long, rtol=0.0, atol=np.finfo(float).eps)
+        assert np.allclose(
+            t.to_value("mjd", subfmt=None),
+            expected_long,
+            rtol=0.0,
+            atol=np.finfo(float).eps,
+        )
+        assert np.allclose(t.mjd, expected_long, rtol=0.0, atol=np.finfo(float).eps)
+        assert t.to_value("mjd", subfmt="str") == "54321.000000000001"
+        assert t.to_value("mjd", subfmt="float") == 54321.0  # Lost precision!
 
-    @pytest.mark.skipif(np.finfo(np.longdouble).eps >= np.finfo(float).eps,
-                        reason="long double is the same as float")
+    @pytest.mark.skipif(
+        np.finfo(np.longdouble).eps >= np.finfo(float).eps,
+        reason="long double is the same as float",
+    )
     def test_explicit_longdouble(self):
         i = 54321
         # Create a different long double (which will give a different jd2
         # even when long doubles are more precise than Time, as on arm64).
-        f = max(2.**(-np.finfo(np.longdouble).nmant) * 65536,
-                np.finfo(float).eps)
+        f = max(2.0 ** (-np.finfo(np.longdouble).nmant) * 65536, np.finfo(float).eps)
         mjd_long = np.longdouble(i) + np.longdouble(f)
         assert mjd_long != i, "longdouble failure!"
-        t = Time(mjd_long, format='mjd')
-        expected = Time(i, f, format='mjd')
-        assert abs(t - expected) <= 20. * u.ps
-        t_float = Time(i + f, format='mjd')
-        assert t_float == Time(i, format='mjd')
+        t = Time(mjd_long, format="mjd")
+        expected = Time(i, f, format="mjd")
+        assert abs(t - expected) <= 20.0 * u.ps
+        t_float = Time(i + f, format="mjd")
+        assert t_float == Time(i, format="mjd")
         assert t_float != t
-        assert t.value == 54321.  # Lost precision!
-        assert np.allclose(t.to_value('mjd', subfmt='long'), mjd_long,
-                           rtol=0., atol=np.finfo(float).eps)
-        t2 = Time(mjd_long, format='mjd', out_subfmt='long')
-        assert np.allclose(t2.value, mjd_long,
-                           rtol=0., atol=np.finfo(float).eps)
+        assert t.value == 54321.0  # Lost precision!
+        assert np.allclose(
+            t.to_value("mjd", subfmt="long"),
+            mjd_long,
+            rtol=0.0,
+            atol=np.finfo(float).eps,
+        )
+        t2 = Time(mjd_long, format="mjd", out_subfmt="long")
+        assert np.allclose(t2.value, mjd_long, rtol=0.0, atol=np.finfo(float).eps)
 
-    @pytest.mark.skipif(np.finfo(np.longdouble).eps >= np.finfo(float).eps,
-                        reason="long double is the same as float")
+    @pytest.mark.skipif(
+        np.finfo(np.longdouble).eps >= np.finfo(float).eps,
+        reason="long double is the same as float",
+    )
     def test_explicit_longdouble_one_val(self):
         """Ensure either val1 or val2 being longdouble is possible.
 
         Regression test for issue gh-10033.
         """
         i = 54321
-        f = max(2.**(-np.finfo(np.longdouble).nmant) * 65536,
-                np.finfo(float).eps)
-        t1 = Time(i, f, format='mjd')
-        t2 = Time(np.longdouble(i), f, format='mjd')
-        t3 = Time(i, np.longdouble(f), format='mjd')
-        t4 = Time(np.longdouble(i), np.longdouble(f), format='mjd')
+        f = max(2.0 ** (-np.finfo(np.longdouble).nmant) * 65536, np.finfo(float).eps)
+        t1 = Time(i, f, format="mjd")
+        t2 = Time(np.longdouble(i), f, format="mjd")
+        t3 = Time(i, np.longdouble(f), format="mjd")
+        t4 = Time(np.longdouble(i), np.longdouble(f), format="mjd")
         assert t1 == t2 == t3 == t4
 
-    @pytest.mark.skipif(np.finfo(np.longdouble).eps >= np.finfo(float).eps,
-                        reason="long double is the same as float")
+    @pytest.mark.skipif(
+        np.finfo(np.longdouble).eps >= np.finfo(float).eps,
+        reason="long double is the same as float",
+    )
     @pytest.mark.parametrize("fmt", ["mjd", "unix", "cxcsec"])
     def test_longdouble_for_other_types(self, fmt):
         t_fmt = getattr(Time(58000, format="mjd"), fmt)  # Get regular float
         t_fmt_long = np.longdouble(t_fmt)
         # Create a different long double (ensuring it will give a different jd2
         # even when long doubles are more precise than Time, as on arm64).
-        atol = np.finfo(float).eps * (1. if fmt == 'mjd' else 24. * 3600.)
+        atol = np.finfo(float).eps * (1.0 if fmt == "mjd" else 24.0 * 3600.0)
         t_fmt_long2 = t_fmt_long + max(
-            t_fmt_long * np.finfo(np.longdouble).eps * 2, atol)
+            t_fmt_long * np.finfo(np.longdouble).eps * 2, atol
+        )
         assert t_fmt_long != t_fmt_long2, "longdouble weird!"
         tm = Time(t_fmt_long, format=fmt)
         tm2 = Time(t_fmt_long2, format=fmt)
         assert tm != tm2
-        tm_long2 = tm2.to_value(fmt, subfmt='long')
-        assert np.allclose(tm_long2, t_fmt_long2, rtol=0., atol=atol)
+        tm_long2 = tm2.to_value(fmt, subfmt="long")
+        assert np.allclose(tm_long2, t_fmt_long2, rtol=0.0, atol=atol)
 
     def test_subformat_input(self):
-        s = '54321.01234567890123456789'
-        i, f = s.split('.')  # Note, OK only for fraction < 0.5
-        t = Time(float(i), float('.' + f), format='mjd')
-        t_str = Time(s, format='mjd')
-        t_bytes = Time(s.encode('ascii'), format='mjd')
-        t_decimal = Time(Decimal(s), format='mjd')
+        s = "54321.01234567890123456789"
+        i, f = s.split(".")  # Note, OK only for fraction < 0.5
+        t = Time(float(i), float("." + f), format="mjd")
+        t_str = Time(s, format="mjd")
+        t_bytes = Time(s.encode("ascii"), format="mjd")
+        t_decimal = Time(Decimal(s), format="mjd")
         assert t_str == t
         assert t_bytes == t
         assert t_decimal == t
 
-    @pytest.mark.parametrize('out_subfmt', ('str', 'bytes'))
+    @pytest.mark.parametrize("out_subfmt", ("str", "bytes"))
     def test_subformat_output(self, out_subfmt):
         i = 54321
-        f = np.array([0., 1e-9, 1e-12])
-        t = Time(i, f, format='mjd', out_subfmt=out_subfmt)
+        f = np.array([0.0, 1e-9, 1e-12])
+        t = Time(i, f, format="mjd", out_subfmt=out_subfmt)
         t_value = t.value
-        expected = np.array(['54321.0',
-                             '54321.000000001',
-                             '54321.000000000001'], dtype=out_subfmt)
+        expected = np.array(
+            ["54321.0", "54321.000000001", "54321.000000000001"], dtype=out_subfmt
+        )
         assert np.all(t_value == expected)
-        assert np.all(Time(expected, format='mjd') == t)
+        assert np.all(Time(expected, format="mjd") == t)
 
         # Explicit sub-format.
-        t = Time(i, f, format='mjd')
-        t_mjd_subfmt = t.to_value('mjd', subfmt=out_subfmt)
+        t = Time(i, f, format="mjd")
+        t_mjd_subfmt = t.to_value("mjd", subfmt=out_subfmt)
         assert np.all(t_mjd_subfmt == expected)
 
-    @pytest.mark.parametrize('fmt,string,val1,val2', [
-        ('jd', '2451544.5333981', 2451544.5, .0333981),
-        ('decimalyear', '2000.54321', 2000., .54321),
-        ('cxcsec', '100.0123456', 100.0123456, None),
-        ('unix', '100.0123456', 100.0123456, None),
-        ('gps', '100.0123456', 100.0123456, None),
-        ('byear', '1950.1', 1950.1, None),
-        ('jyear', '2000.1', 2000.1, None)])
+    @pytest.mark.parametrize(
+        "fmt,string,val1,val2",
+        [
+            ("jd", "2451544.5333981", 2451544.5, 0.0333981),
+            ("decimalyear", "2000.54321", 2000.0, 0.54321),
+            ("cxcsec", "100.0123456", 100.0123456, None),
+            ("unix", "100.0123456", 100.0123456, None),
+            ("gps", "100.0123456", 100.0123456, None),
+            ("byear", "1950.1", 1950.1, None),
+            ("jyear", "2000.1", 2000.1, None),
+        ],
+    )
     def test_explicit_string_other_formats(self, fmt, string, val1, val2):
         t = Time(string, format=fmt)
         assert t == Time(val1, val2, format=fmt)
-        assert t.to_value(fmt, subfmt='str') == string
+        assert t.to_value(fmt, subfmt="str") == string
 
     def test_basic_subformat_setting(self):
-        t = Time('2001', format='jyear', scale='tai')
+        t = Time("2001", format="jyear", scale="tai")
         t.format = "mjd"
         t.out_subfmt = "str"
         assert t.value.startswith("5")
 
     def test_basic_subformat_cache_does_not_crash(self):
-        t = Time('2001', format='jyear', scale='tai')
-        t.to_value('mjd', subfmt='str')
-        assert ('mjd', 'str') in t.cache['format']
-        t.to_value('mjd', 'str')
+        t = Time("2001", format="jyear", scale="tai")
+        t.to_value("mjd", subfmt="str")
+        assert ("mjd", "str") in t.cache["format"]
+        t.to_value("mjd", "str")
 
     @pytest.mark.parametrize("fmt", ["jd", "mjd", "cxcsec", "unix", "gps", "jyear"])
     def test_decimal_context_does_not_affect_string(self, fmt):
-        t = Time('2001', format='jyear', scale='tai')
+        t = Time("2001", format="jyear", scale="tai")
         t.format = fmt
         with localcontext() as ctx:
             ctx.prec = 2
             t_s_2 = t.to_value(fmt, "str")
-        t2 = Time('2001', format='jyear', scale='tai')
+        t2 = Time("2001", format="jyear", scale="tai")
         t2.format = fmt
         with localcontext() as ctx:
             ctx.prec = 40
             t2_s_40 = t.to_value(fmt, "str")
-        assert t_s_2 == t2_s_40, "String representation should not depend on Decimal context"
+        assert (
+            t_s_2 == t2_s_40
+        ), "String representation should not depend on Decimal context"
 
     def test_decimal_context_caching(self):
-        t = Time(val=58000, val2=1e-14, format='mjd', scale='tai')
+        t = Time(val=58000, val2=1e-14, format="mjd", scale="tai")
         with localcontext() as ctx:
             ctx.prec = 2
-            t_s_2 = t.to_value('mjd', subfmt='decimal')
-        t2 = Time(val=58000, val2=1e-14, format='mjd', scale='tai')
+            t_s_2 = t.to_value("mjd", subfmt="decimal")
+        t2 = Time(val=58000, val2=1e-14, format="mjd", scale="tai")
         with localcontext() as ctx:
             ctx.prec = 40
-            t_s_40 = t.to_value('mjd', subfmt='decimal')
-            t2_s_40 = t2.to_value('mjd', subfmt='decimal')
+            t_s_40 = t.to_value("mjd", subfmt="decimal")
+            t2_s_40 = t2.to_value("mjd", subfmt="decimal")
         assert t_s_2 == t_s_40, "Should be the same but cache might make this automatic"
         assert t_s_2 == t2_s_40, "Different precision should produce the same results"
 
-    @pytest.mark.parametrize("f, s, t", [("sec", "long", np.longdouble),
-                                         ("sec", "decimal", Decimal),
-                                         ("sec", "str", str)])
+    @pytest.mark.parametrize(
+        "f, s, t",
+        [
+            ("sec", "long", np.longdouble),
+            ("sec", "decimal", Decimal),
+            ("sec", "str", str),
+        ],
+    )
     def test_timedelta_basic(self, f, s, t):
-        dt = (Time("58000", format="mjd", scale="tai")
-              - Time("58001", format="mjd", scale="tai"))
+        dt = Time("58000", format="mjd", scale="tai") - Time(
+            "58001", format="mjd", scale="tai"
+        )
 
         value = dt.to_value(f, s)
         assert isinstance(value, t)
@@ -1100,64 +1284,64 @@ class TestNumericalSubFormat:
         assert isinstance(dt.to_value(f, None), t)
 
     def test_need_format_argument(self):
-        t = Time('J2000')
+        t = Time("J2000")
         with pytest.raises(TypeError, match="missing.*required.*'format'"):
             t.to_value()
-        with pytest.raises(ValueError, match='format must be one of'):
-            t.to_value('julian')
+        with pytest.raises(ValueError, match="format must be one of"):
+            t.to_value("julian")
 
     def test_wrong_in_subfmt(self):
-        with pytest.raises(ValueError, match='not among selected'):
-            Time("58000", format='mjd', in_subfmt='float')
+        with pytest.raises(ValueError, match="not among selected"):
+            Time("58000", format="mjd", in_subfmt="float")
 
-        with pytest.raises(ValueError, match='not among selected'):
-            Time(np.longdouble(58000), format='mjd', in_subfmt='float')
+        with pytest.raises(ValueError, match="not among selected"):
+            Time(np.longdouble(58000), format="mjd", in_subfmt="float")
 
-        with pytest.raises(ValueError, match='not among selected'):
-            Time(58000., format='mjd', in_subfmt='str')
+        with pytest.raises(ValueError, match="not among selected"):
+            Time(58000.0, format="mjd", in_subfmt="str")
 
-        with pytest.raises(ValueError, match='not among selected'):
-            Time(58000., format='mjd', in_subfmt='long')
+        with pytest.raises(ValueError, match="not among selected"):
+            Time(58000.0, format="mjd", in_subfmt="long")
 
     def test_wrong_subfmt(self):
-        t = Time(58000., format='mjd')
-        with pytest.raises(ValueError, match='must match one'):
-            t.to_value('mjd', subfmt='parrot')
+        t = Time(58000.0, format="mjd")
+        with pytest.raises(ValueError, match="must match one"):
+            t.to_value("mjd", subfmt="parrot")
 
-        with pytest.raises(ValueError, match='must match one'):
-            t.out_subfmt = 'parrot'
+        with pytest.raises(ValueError, match="must match one"):
+            t.out_subfmt = "parrot"
 
-        with pytest.raises(ValueError, match='must match one'):
-            t.in_subfmt = 'parrot'
+        with pytest.raises(ValueError, match="must match one"):
+            t.in_subfmt = "parrot"
 
     def test_not_allowed_subfmt(self):
         """Test case where format has no defined subfmts"""
-        t = Time('J2000')
-        match = 'subformat not allowed for format jyear_str'
+        t = Time("J2000")
+        match = "subformat not allowed for format jyear_str"
         with pytest.raises(ValueError, match=match):
-            t.to_value('jyear_str', subfmt='parrot')
+            t.to_value("jyear_str", subfmt="parrot")
 
         with pytest.raises(ValueError, match=match):
-            t.out_subfmt = 'parrot'
+            t.out_subfmt = "parrot"
 
         with pytest.raises(ValueError, match=match):
-            Time('J2000', out_subfmt='parrot')
+            Time("J2000", out_subfmt="parrot")
 
         with pytest.raises(ValueError, match=match):
-            t.in_subfmt = 'parrot'
+            t.in_subfmt = "parrot"
 
         with pytest.raises(ValueError, match=match):
-            Time('J2000', format='jyear_str', in_subfmt='parrot')
+            Time("J2000", format="jyear_str", in_subfmt="parrot")
 
     def test_switch_to_format_with_no_out_subfmt(self):
-        t = Time('2001-01-01', out_subfmt='date_hm')
-        assert t.out_subfmt == 'date_hm'
+        t = Time("2001-01-01", out_subfmt="date_hm")
+        assert t.out_subfmt == "date_hm"
 
         # Now do an in-place switch to format 'jyear_str' that has no subfmts
         # where out_subfmt is changed to '*'.
-        t.format = 'jyear_str'
-        assert t.out_subfmt == '*'
-        assert t.value == 'J2001.001'
+        t.format = "jyear_str"
+        assert t.out_subfmt == "*"
+        assert t.value == "J2001.001"
 
 
 class TestSofaErrors:
@@ -1176,12 +1360,12 @@ class TestSofaErrors:
             djm0, djm = erfa.cal2jd(iy, im, id)
 
         iy[0] = 2000
-        with pytest.warns(ErfaWarning, match=r'bad day    \(JD computed\)') as w:
+        with pytest.warns(ErfaWarning, match=r"bad day    \(JD computed\)") as w:
             djm0, djm = erfa.cal2jd(iy, im, id)
         assert len(w) == 1
 
         assert allclose_jd(djm0, [2400000.5])
-        assert allclose_jd(djm, [53574.])
+        assert allclose_jd(djm, [53574.0])
 
 
 class TestCopyReplicate:
@@ -1190,21 +1374,20 @@ class TestCopyReplicate:
     def test_immutable_input(self):
         """Internals are never mutable."""
         jds = np.array([2450000.5], dtype=np.double)
-        t = Time(jds, format='jd', scale='tai')
+        t = Time(jds, format="jd", scale="tai")
         assert allclose_jd(t.jd, jds)
         jds[0] = 2458654
         assert not allclose_jd(t.jd, jds)
 
         mjds = np.array([50000.0], dtype=np.double)
-        t = Time(mjds, format='mjd', scale='tai')
+        t = Time(mjds, format="mjd", scale="tai")
         assert allclose_jd(t.jd, [2450000.5])
         mjds[0] = 0.0
         assert allclose_jd(t.jd, [2450000.5])
 
     def test_replicate(self):
         """Test replicate method"""
-        t = Time(['2000:001'], format='yday', scale='tai',
-                 location=('45d', '45d'))
+        t = Time(["2000:001"], format="yday", scale="tai", location=("45d", "45d"))
         t_yday = t.yday
         t_loc_x = t.location.x.copy()
         t2 = t.replicate()
@@ -1231,8 +1414,7 @@ class TestCopyReplicate:
 
     def test_copy(self):
         """Test copy method"""
-        t = Time('2000:001', format='yday', scale='tai',
-                 location=('45d', '45d'))
+        t = Time("2000:001", format="yday", scale="tai", location=("45d", "45d"))
         t_yday = t.yday
         t_loc_x = t.location.x.copy()
         t2 = t.copy()
@@ -1259,23 +1441,27 @@ class TestStardate:
     """Sync chronometers with Starfleet Command"""
 
     def test_iso_to_stardate(self):
-        assert str(Time('2320-01-01', scale='tai').stardate)[:7] == '1368.99'
-        assert str(Time('2330-01-01', scale='tai').stardate)[:8] == '10552.76'
-        assert str(Time('2340-01-01', scale='tai').stardate)[:8] == '19734.02'
+        assert str(Time("2320-01-01", scale="tai").stardate)[:7] == "1368.99"
+        assert str(Time("2330-01-01", scale="tai").stardate)[:8] == "10552.76"
+        assert str(Time("2340-01-01", scale="tai").stardate)[:8] == "19734.02"
 
-    @pytest.mark.parametrize('dates',
-                             [(10000, '2329-05-26 03:02'),
-                              (20000, '2340-04-15 19:05'),
-                              (30000, '2351-03-07 11:08')])
+    @pytest.mark.parametrize(
+        "dates",
+        [
+            (10000, "2329-05-26 03:02"),
+            (20000, "2340-04-15 19:05"),
+            (30000, "2351-03-07 11:08"),
+        ],
+    )
     def test_stardate_to_iso(self, dates):
         stardate, iso = dates
-        t_star = Time(stardate, format='stardate')
-        t_iso = Time(t_star, format='iso', out_subfmt='date_hm')
+        t_star = Time(stardate, format="stardate")
+        t_iso = Time(t_star, format="iso", out_subfmt="date_hm")
         assert t_iso.value == iso
 
 
 def test_python_builtin_copy():
-    t = Time('2000:001', format='yday', scale='tai')
+    t = Time("2000:001", format="yday", scale="tai")
     t2 = copy.copy(t)
     t3 = copy.deepcopy(t)
 
@@ -1291,8 +1477,8 @@ def test_now():
     now = datetime.datetime.utcnow()
     t = Time.now()
 
-    assert t.format == 'datetime'
-    assert t.scale == 'utc'
+    assert t.format == "datetime"
+    assert t.scale == "utc"
 
     dt = t.datetime - now  # a datetime.timedelta object
 
@@ -1305,40 +1491,39 @@ def test_now():
 
 
 def test_decimalyear():
-    t = Time('2001:001', format='yday')
+    t = Time("2001:001", format="yday")
     assert t.decimalyear == 2001.0
 
-    t = Time(2000.0, [0.5, 0.75], format='decimalyear')
+    t = Time(2000.0, [0.5, 0.75], format="decimalyear")
     assert np.all(t.value == [2000.5, 2000.75])
 
-    jd0 = Time('2000:001').jd
-    jd1 = Time('2001:001').jd
+    jd0 = Time("2000:001").jd
+    jd1 = Time("2001:001").jd
     d_jd = jd1 - jd0
-    assert np.all(t.jd == [jd0 + 0.5 * d_jd,
-                           jd0 + 0.75 * d_jd])
+    assert np.all(t.jd == [jd0 + 0.5 * d_jd, jd0 + 0.75 * d_jd])
 
 
 def test_fits_year0():
-    t = Time(1721425.5, format='jd', scale='tai')
-    assert t.fits == '0001-01-01T00:00:00.000'
-    t = Time(1721425.5 - 366., format='jd', scale='tai')
-    assert t.fits == '+00000-01-01T00:00:00.000'
-    t = Time(1721425.5 - 366. - 365., format='jd', scale='tai')
-    assert t.fits == '-00001-01-01T00:00:00.000'
+    t = Time(1721425.5, format="jd", scale="tai")
+    assert t.fits == "0001-01-01T00:00:00.000"
+    t = Time(1721425.5 - 366.0, format="jd", scale="tai")
+    assert t.fits == "+00000-01-01T00:00:00.000"
+    t = Time(1721425.5 - 366.0 - 365.0, format="jd", scale="tai")
+    assert t.fits == "-00001-01-01T00:00:00.000"
 
 
 def test_fits_year10000():
-    t = Time(5373484.5, format='jd', scale='tai')
-    assert t.fits == '+10000-01-01T00:00:00.000'
-    t = Time(5373484.5 - 365., format='jd', scale='tai')
-    assert t.fits == '9999-01-01T00:00:00.000'
-    t = Time(5373484.5, -1. / 24. / 3600., format='jd', scale='tai')
-    assert t.fits == '9999-12-31T23:59:59.000'
+    t = Time(5373484.5, format="jd", scale="tai")
+    assert t.fits == "+10000-01-01T00:00:00.000"
+    t = Time(5373484.5 - 365.0, format="jd", scale="tai")
+    assert t.fits == "9999-01-01T00:00:00.000"
+    t = Time(5373484.5, -1.0 / 24.0 / 3600.0, format="jd", scale="tai")
+    assert t.fits == "9999-12-31T23:59:59.000"
 
 
 def test_dir():
-    t = Time('2000:001', format='yday', scale='tai')
-    assert 'utc' in dir(t)
+    t = Time("2000:001", format="yday", scale="tai")
+    assert "utc" in dir(t)
 
 
 def test_time_from_epoch_jds():
@@ -1349,11 +1534,11 @@ def test_time_from_epoch_jds():
     # catch jd2 == 0 and a case of abs(jd2) == 0.5.
     cxcsecs = np.linspace(0, 86400 * 1.5, 49)
     for cxcsec in cxcsecs:
-        t = Time(cxcsec, format='cxcsec')
+        t = Time(cxcsec, format="cxcsec")
         assert np.round(t.jd1) == t.jd1
         assert np.abs(t.jd2) <= 0.5
 
-    t = Time(cxcsecs, format='cxcsec')
+    t = Time(cxcsecs, format="cxcsec")
     assert np.all(np.round(t.jd1) == t.jd1)
     assert np.all(np.abs(t.jd2) <= 0.5)
     assert np.any(np.abs(t.jd2) == 0.5)  # At least one exactly 0.5
@@ -1361,7 +1546,7 @@ def test_time_from_epoch_jds():
 
 def test_bool():
     """Any Time object should evaluate to True unless it is empty [#3520]."""
-    t = Time(np.arange(50000, 50010), format='mjd', scale='utc')
+    t = Time(np.arange(50000, 50010), format="mjd", scale="utc")
     assert bool(t) is True
     assert bool(t[0]) is True
     assert bool(t[:0]) is False
@@ -1369,9 +1554,9 @@ def test_bool():
 
 def test_len_size():
     """Check length of Time objects and that scalar ones do not have one."""
-    t = Time(np.arange(50000, 50010), format='mjd', scale='utc')
+    t = Time(np.arange(50000, 50010), format="mjd", scale="utc")
     assert len(t) == 10 and t.size == 10
-    t1 = Time(np.arange(50000, 50010).reshape(2, 5), format='mjd', scale='utc')
+    t1 = Time(np.arange(50000, 50010).reshape(2, 5), format="mjd", scale="utc")
     assert len(t1) == 2 and t1.size == 10
     # Can have length 1 or length 0 arrays.
     t2 = t[:1]
@@ -1384,13 +1569,13 @@ def test_len_size():
         len(t4)
     # Ensure we're not just getting the old error of
     # "object of type 'float' has no len()".
-    assert 'Time' in str(err.value)
+    assert "Time" in str(err.value)
 
 
 def test_TimeFormat_scale():
     """guard against recurrence of #1122, where TimeFormat class looses uses
     attributes (delta_ut1_utc here), preventing conversion to unix, cxc"""
-    t = Time('1900-01-01', scale='ut1')
+    t = Time("1900-01-01", scale="ut1")
     t.delta_ut1_utc = 0.0
     with pytest.warns(ErfaWarning):
         t.unix
@@ -1402,18 +1587,18 @@ def test_scale_conversion(monkeypatch):
     # Check that if we have internet, and downloading is allowed, we
     # can get conversion to UT1 for the present, since we will download
     # IERS_A in IERS_Auto.
-    monkeypatch.setattr('astropy.utils.iers.conf.auto_download', True)
-    Time(Time.now().cxcsec, format='cxcsec', scale='ut1')
+    monkeypatch.setattr("astropy.utils.iers.conf.auto_download", True)
+    Time(Time.now().cxcsec, format="cxcsec", scale="ut1")
 
 
 def test_byteorder():
     """Ensure that bigendian and little-endian both work (closes #2942)"""
     mjd = np.array([53000.00, 54000.00])
-    big_endian = mjd.astype('>f8')
-    little_endian = mjd.astype('<f8')
-    time_mjd = Time(mjd, format='mjd')
-    time_big = Time(big_endian, format='mjd')
-    time_little = Time(little_endian, format='mjd')
+    big_endian = mjd.astype(">f8")
+    little_endian = mjd.astype("<f8")
+    time_mjd = Time(mjd, format="mjd")
+    time_big = Time(big_endian, format="mjd")
+    time_little = Time(little_endian, format="mjd")
     assert np.all(time_big == time_mjd)
     assert np.all(time_little == time_mjd)
 
@@ -1422,6 +1607,7 @@ def test_datetime_tzinfo():
     """
     Test #3160 that time zone info in datetime objects is respected.
     """
+
     class TZm6(datetime.tzinfo):
         def utcoffset(self, dt):
             return datetime.timedelta(hours=-6)
@@ -1435,26 +1621,34 @@ def test_subfmts_regex():
     """
     Test having a custom subfmts with a regular expression
     """
+
     class TimeLongYear(TimeString):
-        name = 'longyear'
-        subfmts = (('date',
-                    r'(?P<year>[+-]\d{5})-%m-%d',  # hybrid
-                    '{year:+06d}-{mon:02d}-{day:02d}'),)
-    t = Time('+02000-02-03', format='longyear')
-    assert t.value == '+02000-02-03'
-    assert t.jd == Time('2000-02-03').jd
+        name = "longyear"
+        subfmts = (
+            (
+                "date",
+                r"(?P<year>[+-]\d{5})-%m-%d",  # hybrid
+                "{year:+06d}-{mon:02d}-{day:02d}",
+            ),
+        )
+
+    t = Time("+02000-02-03", format="longyear")
+    assert t.value == "+02000-02-03"
+    assert t.jd == Time("2000-02-03").jd
 
 
 def test_set_format_basic():
     """
     Test basics of setting format attribute.
     """
-    for format, value in (('jd', 2451577.5),
-                          ('mjd', 51577.0),
-                          ('cxcsec', 65923264.184),  # confirmed with Chandra.Time
-                          ('datetime', datetime.datetime(2000, 2, 3, 0, 0)),
-                          ('iso', '2000-02-03 00:00:00.000')):
-        t = Time('+02000-02-03', format='fits')
+    for format, value in (
+        ("jd", 2451577.5),
+        ("mjd", 51577.0),
+        ("cxcsec", 65923264.184),  # confirmed with Chandra.Time
+        ("datetime", datetime.datetime(2000, 2, 3, 0, 0)),
+        ("iso", "2000-02-03 00:00:00.000"),
+    ):
+        t = Time("+02000-02-03", format="fits")
         t0 = t.replicate()
         t.format = format
         assert t.value == value
@@ -1464,9 +1658,9 @@ def test_set_format_basic():
 
 
 def test_unix_tai_format():
-    t = Time('2020-01-01', scale='utc')
+    t = Time("2020-01-01", scale="utc")
     assert allclose_sec(t.unix_tai - t.unix, 37.0)
-    t = Time('1970-01-01', scale='utc')
+    t = Time("1970-01-01", scale="utc")
     assert allclose_sec(t.unix_tai - t.unix, 8 + 8.2e-05)
 
 
@@ -1474,15 +1668,15 @@ def test_set_format_shares_subfmt():
     """
     Set format and round trip through a format that shares out_subfmt
     """
-    t = Time('+02000-02-03', format='fits', out_subfmt='date_hms', precision=5)
+    t = Time("+02000-02-03", format="fits", out_subfmt="date_hms", precision=5)
     tc = t.copy()
 
-    t.format = 'isot'
+    t.format = "isot"
     assert t.precision == 5
-    assert t.out_subfmt == 'date_hms'
-    assert t.value == '2000-02-03T00:00:00.00000'
+    assert t.out_subfmt == "date_hms"
+    assert t.value == "2000-02-03T00:00:00.00000"
 
-    t.format = 'fits'
+    t.format = "fits"
     assert t.value == tc.value
     assert t.precision == 5
 
@@ -1491,15 +1685,15 @@ def test_set_format_does_not_share_subfmt():
     """
     Set format and round trip through a format that does not share out_subfmt
     """
-    t = Time('+02000-02-03', format='fits', out_subfmt='longdate')
+    t = Time("+02000-02-03", format="fits", out_subfmt="longdate")
 
-    t.format = 'isot'
-    assert t.out_subfmt == '*'  # longdate_hms not there, goes to default
-    assert t.value == '2000-02-03T00:00:00.000'
+    t.format = "isot"
+    assert t.out_subfmt == "*"  # longdate_hms not there, goes to default
+    assert t.value == "2000-02-03T00:00:00.000"
 
-    t.format = 'fits'
-    assert t.out_subfmt == '*'
-    assert t.value == '2000-02-03T00:00:00.000'  # date_hms
+    t.format = "fits"
+    assert t.out_subfmt == "*"
+    assert t.value == "2000-02-03T00:00:00.000"  # date_hms
 
 
 def test_replicate_value_error():
@@ -1507,10 +1701,10 @@ def test_replicate_value_error():
     Passing a bad format to replicate should raise ValueError, not KeyError.
     PR #3857.
     """
-    t1 = Time('2007:001', scale='tai')
+    t1 = Time("2007:001", scale="tai")
     with pytest.raises(ValueError) as err:
-        t1.replicate(format='definitely_not_a_valid_format')
-    assert 'format must be one of' in str(err.value)
+        t1.replicate(format="definitely_not_a_valid_format")
+    assert "format must be one of" in str(err.value)
 
 
 def test_remove_astropy_time():
@@ -1518,11 +1712,11 @@ def test_remove_astropy_time():
     Make sure that 'astropy_time' format is really gone after #3857.  Kind of
     silly test but just to be sure.
     """
-    t1 = Time('2007:001', scale='tai')
-    assert 'astropy_time' not in t1.FORMATS
+    t1 = Time("2007:001", scale="tai")
+    assert "astropy_time" not in t1.FORMATS
     with pytest.raises(ValueError) as err:
-        Time(t1, format='astropy_time')
-    assert 'format must be one of' in str(err.value)
+        Time(t1, format="astropy_time")
+    assert "format must be one of" in str(err.value)
 
 
 def test_isiterable():
@@ -1536,16 +1730,19 @@ def test_isiterable():
     t1 = Time.now()
     assert not isiterable(t1)
 
-    t2 = Time(['1999-01-01 00:00:00.123456789', '2010-01-01 00:00:00'],
-              format='iso', scale='utc')
+    t2 = Time(
+        ["1999-01-01 00:00:00.123456789", "2010-01-01 00:00:00"],
+        format="iso",
+        scale="utc",
+    )
     assert isiterable(t2)
 
 
 def test_to_datetime():
-    tz = TimezoneInfo(utc_offset=-10 * u.hour, tzname='US/Hawaii')
+    tz = TimezoneInfo(utc_offset=-10 * u.hour, tzname="US/Hawaii")
     # The above lines produces a `datetime.tzinfo` object similar to:
     #     tzinfo = pytz.timezone('US/Hawaii')
-    time = Time('2010-09-03 00:00:00')
+    time = Time("2010-09-03 00:00:00")
     tz_aware_datetime = time.to_datetime(tz)
     assert tz_aware_datetime.time() == datetime.time(14, 0)
     forced_to_astropy_time = Time(tz_aware_datetime)
@@ -1553,23 +1750,23 @@ def test_to_datetime():
     assert time == forced_to_astropy_time
 
     # Test non-scalar time inputs:
-    time = Time(['2010-09-03 00:00:00', '2005-09-03 06:00:00',
-                 '1990-09-03 06:00:00'])
+    time = Time(["2010-09-03 00:00:00", "2005-09-03 06:00:00", "1990-09-03 06:00:00"])
     tz_aware_datetime = time.to_datetime(tz)
     forced_to_astropy_time = Time(tz_aware_datetime)
     for dt, tz_dt in zip(time.datetime, tz_aware_datetime):
         assert tz.tzname(dt) == tz_dt.tzname()
     assert np.all(time == forced_to_astropy_time)
 
-    with pytest.raises(ValueError, match=r'does not support leap seconds'):
-        Time('2015-06-30 23:59:60.000').to_datetime()
+    with pytest.raises(ValueError, match=r"does not support leap seconds"):
+        Time("2015-06-30 23:59:60.000").to_datetime()
 
 
-@pytest.mark.skipif(not HAS_PYTZ, reason='requires pytz')
+@pytest.mark.skipif(not HAS_PYTZ, reason="requires pytz")
 def test_to_datetime_pytz():
     import pytz
-    tz = pytz.timezone('US/Hawaii')
-    time = Time('2010-09-03 00:00:00')
+
+    tz = pytz.timezone("US/Hawaii")
+    time = Time("2010-09-03 00:00:00")
     tz_aware_datetime = time.to_datetime(tz)
     forced_to_astropy_time = Time(tz_aware_datetime)
     assert tz_aware_datetime.time() == datetime.time(14, 0)
@@ -1577,8 +1774,7 @@ def test_to_datetime_pytz():
     assert time == forced_to_astropy_time
 
     # Test non-scalar time inputs:
-    time = Time(['2010-09-03 00:00:00', '2005-09-03 06:00:00',
-                 '1990-09-03 06:00:00'])
+    time = Time(["2010-09-03 00:00:00", "2005-09-03 06:00:00", "1990-09-03 06:00:00"])
     tz_aware_datetime = time.to_datetime(tz)
     forced_to_astropy_time = Time(tz_aware_datetime)
     for dt, tz_dt in zip(time.datetime, tz_aware_datetime):
@@ -1587,29 +1783,29 @@ def test_to_datetime_pytz():
 
 
 def test_cache():
-    t = Time('2010-09-03 00:00:00')
-    t2 = Time('2010-09-03 00:00:00')
+    t = Time("2010-09-03 00:00:00")
+    t2 = Time("2010-09-03 00:00:00")
 
     # Time starts out without a cache
-    assert 'cache' not in t._time.__dict__
+    assert "cache" not in t._time.__dict__
 
     # Access the iso format and confirm that the cached version is as expected
     t.iso
-    assert t.cache['format']['iso'] == t2.iso
+    assert t.cache["format"]["iso"] == t2.iso
 
     # Access the TAI scale and confirm that the cached version is as expected
     t.tai
-    assert t.cache['scale']['tai'] == t2.tai
+    assert t.cache["scale"]["tai"] == t2.tai
 
     # New Time object after scale transform does not have a cache yet
-    assert 'cache' not in t.tt._time.__dict__
+    assert "cache" not in t.tt._time.__dict__
 
     # Clear the cache
     del t.cache
-    assert 'cache' not in t._time.__dict__
+    assert "cache" not in t._time.__dict__
     # Check accessing the cache creates an empty dictionary
     assert not t.cache
-    assert 'cache' in t._time.__dict__
+    assert "cache" in t._time.__dict__
 
 
 def test_epoch_date_jd_is_day_fraction():
@@ -1642,68 +1838,70 @@ def test_sum_is_equivalent():
 def test_string_valued_columns():
     # Columns have a nice shim that translates bytes to string as needed.
     # Ensure Time can handle these.  Use multi-d array just to be sure.
-    times = [[[f'{y:04d}-{m:02d}-{d:02d}' for d in range(1, 3)]
-              for m in range(5, 7)] for y in range(2012, 2014)]
+    times = [
+        [[f"{y:04d}-{m:02d}-{d:02d}" for d in range(1, 3)] for m in range(5, 7)]
+        for y in range(2012, 2014)
+    ]
     cutf32 = Column(times)
-    cbytes = cutf32.astype('S')
+    cbytes = cutf32.astype("S")
     tutf32 = Time(cutf32)
     tbytes = Time(cbytes)
     assert np.all(tutf32 == tbytes)
-    tutf32 = Time(Column(['B1950']))
-    tbytes = Time(Column([b'B1950']))
+    tutf32 = Time(Column(["B1950"]))
+    tbytes = Time(Column([b"B1950"]))
     assert tutf32 == tbytes
     # Regression tests for arrays with entries with unequal length. gh-6903.
-    times = Column([b'2012-01-01', b'2012-01-01T00:00:00'])
-    assert np.all(Time(times) == Time(['2012-01-01', '2012-01-01T00:00:00']))
+    times = Column([b"2012-01-01", b"2012-01-01T00:00:00"])
+    assert np.all(Time(times) == Time(["2012-01-01", "2012-01-01T00:00:00"]))
 
 
 def test_bytes_input():
-    tstring = '2011-01-02T03:04:05'
-    tbytes = b'2011-01-02T03:04:05'
-    assert tbytes.decode('ascii') == tstring
+    tstring = "2011-01-02T03:04:05"
+    tbytes = b"2011-01-02T03:04:05"
+    assert tbytes.decode("ascii") == tstring
     t0 = Time(tstring)
     t1 = Time(tbytes)
     assert t1 == t0
     tarray = np.array(tbytes)
-    assert tarray.dtype.kind == 'S'
+    assert tarray.dtype.kind == "S"
     t2 = Time(tarray)
     assert t2 == t0
 
 
 def test_writeable_flag():
-    t = Time([1, 2, 3], format='cxcsec')
+    t = Time([1, 2, 3], format="cxcsec")
     t[1] = 5.0
     assert allclose_sec(t[1].value, 5.0)
 
     t.writeable = False
     with pytest.raises(ValueError) as err:
         t[1] = 5.0
-    assert 'Time object is read-only. Make a copy()' in str(err.value)
+    assert "Time object is read-only. Make a copy()" in str(err.value)
 
     with pytest.raises(ValueError) as err:
         t[:] = 5.0
-    assert 'Time object is read-only. Make a copy()' in str(err.value)
+    assert "Time object is read-only. Make a copy()" in str(err.value)
 
     t.writeable = True
     t[1] = 10.0
     assert allclose_sec(t[1].value, 10.0)
 
     # Scalar is writeable because it gets boxed into a zero-d array
-    t = Time('2000:001', scale='utc')
-    t[()] = '2000:002'
-    assert t.value.startswith('2000:002')
+    t = Time("2000:001", scale="utc")
+    t[()] = "2000:002"
+    assert t.value.startswith("2000:002")
 
     # Transformed attribute is not writeable
-    t = Time(['2000:001', '2000:002'], scale='utc')
+    t = Time(["2000:001", "2000:002"], scale="utc")
     t2 = t.tt  # t2 is read-only now because t.tt is cached
     with pytest.raises(ValueError) as err:
-        t2[0] = '2005:001'
-    assert 'Time object is read-only. Make a copy()' in str(err.value)
+        t2[0] = "2005:001"
+    assert "Time object is read-only. Make a copy()" in str(err.value)
 
 
 def test_setitem_location():
     loc = EarthLocation(x=[1, 2] * u.m, y=[3, 4] * u.m, z=[5, 6] * u.m)
-    t = Time([[1, 2], [3, 4]], format='cxcsec', location=loc)
+    t = Time([[1, 2], [3, 4]], format="cxcsec", location=loc)
 
     # Succeeds because the right hand side makes no implication about
     # location and just inherits t.location
@@ -1712,102 +1910,114 @@ def test_setitem_location():
 
     # Fails because the right hand side has location=None
     with pytest.raises(ValueError) as err:
-        t[0, 0] = Time(-1, format='cxcsec')
-    assert ('cannot set to Time with different location: '
-            'expected location={} and '
-            'got location=None'.format(loc[0])) in str(err.value)
+        t[0, 0] = Time(-1, format="cxcsec")
+    assert (
+        "cannot set to Time with different location: "
+        "expected location={} and "
+        "got location=None".format(loc[0]) in str(err.value)
+    )
 
     # Succeeds because the right hand side correctly sets location
-    t[0, 0] = Time(-2, format='cxcsec', location=loc[0])
+    t[0, 0] = Time(-2, format="cxcsec", location=loc[0])
     assert allclose_sec(t.value, [[-2, 2], [3, 4]])
 
     # Fails because the right hand side has different location
     with pytest.raises(ValueError) as err:
-        t[0, 0] = Time(-2, format='cxcsec', location=loc[1])
-    assert ('cannot set to Time with different location: '
-            'expected location={} and '
-            'got location={}'.format(loc[0], loc[1])) in str(err.value)
+        t[0, 0] = Time(-2, format="cxcsec", location=loc[1])
+    assert (
+        "cannot set to Time with different location: "
+        "expected location={} and "
+        "got location={}".format(loc[0], loc[1]) in str(err.value)
+    )
 
     # Fails because the Time has None location and RHS has defined location
-    t = Time([[1, 2], [3, 4]], format='cxcsec')
+    t = Time([[1, 2], [3, 4]], format="cxcsec")
     with pytest.raises(ValueError) as err:
-        t[0, 0] = Time(-2, format='cxcsec', location=loc[1])
-    assert ('cannot set to Time with different location: '
-            'expected location=None and '
-            'got location={}'.format(loc[1])) in str(err.value)
+        t[0, 0] = Time(-2, format="cxcsec", location=loc[1])
+    assert (
+        "cannot set to Time with different location: "
+        "expected location=None and "
+        "got location={}".format(loc[1]) in str(err.value)
+    )
 
     # Broadcasting works
-    t = Time([[1, 2], [3, 4]], format='cxcsec', location=loc)
-    t[0, :] = Time([-3, -4], format='cxcsec', location=loc)
+    t = Time([[1, 2], [3, 4]], format="cxcsec", location=loc)
+    t[0, :] = Time([-3, -4], format="cxcsec", location=loc)
     assert allclose_sec(t.value, [[-3, -4], [3, 4]])
 
 
 def test_setitem_from_python_objects():
-    t = Time([[1, 2], [3, 4]], format='cxcsec')
+    t = Time([[1, 2], [3, 4]], format="cxcsec")
     assert t.cache == {}
     t.iso
-    assert 'iso' in t.cache['format']
-    assert np.all(t.iso == [['1998-01-01 00:00:01.000', '1998-01-01 00:00:02.000'],
-                            ['1998-01-01 00:00:03.000', '1998-01-01 00:00:04.000']])
+    assert "iso" in t.cache["format"]
+    assert np.all(
+        t.iso
+        == [
+            ["1998-01-01 00:00:01.000", "1998-01-01 00:00:02.000"],
+            ["1998-01-01 00:00:03.000", "1998-01-01 00:00:04.000"],
+        ]
+    )
 
     # Setting item clears cache
     t[0, 1] = 100
     assert t.cache == {}
-    assert allclose_sec(t.value, [[1, 100],
-                                  [3, 4]])
-    assert np.all(t.iso == [['1998-01-01 00:00:01.000', '1998-01-01 00:01:40.000'],
-                            ['1998-01-01 00:00:03.000', '1998-01-01 00:00:04.000']])
+    assert allclose_sec(t.value, [[1, 100], [3, 4]])
+    assert np.all(
+        t.iso
+        == [
+            ["1998-01-01 00:00:01.000", "1998-01-01 00:01:40.000"],
+            ["1998-01-01 00:00:03.000", "1998-01-01 00:00:04.000"],
+        ]
+    )
 
     # Set with a float value
     t.iso
     t[1, :] = 200
     assert t.cache == {}
-    assert allclose_sec(t.value, [[1, 100],
-                                  [200, 200]])
+    assert allclose_sec(t.value, [[1, 100], [200, 200]])
 
     # Array of strings in yday format
-    t[:, 1] = ['1998:002', '1998:003']
-    assert allclose_sec(t.value, [[1, 86400 * 1],
-                                  [200, 86400 * 2]])
+    t[:, 1] = ["1998:002", "1998:003"]
+    assert allclose_sec(t.value, [[1, 86400 * 1], [200, 86400 * 2]])
 
     # Incompatible numeric value
-    t = Time(['2000:001', '2000:002'])
-    t[0] = '2001:001'
+    t = Time(["2000:001", "2000:002"])
+    t[0] = "2001:001"
     with pytest.raises(ValueError) as err:
         t[0] = 100
-    assert 'cannot convert value to a compatible Time object' in str(err.value)
+    assert "cannot convert value to a compatible Time object" in str(err.value)
 
 
 def test_setitem_from_time_objects():
-    """Set from existing Time object.
-    """
+    """Set from existing Time object."""
     # Set from time object with different scale
-    t = Time(['2000:001', '2000:002'], scale='utc')
-    t2 = Time(['2000:010'], scale='tai')
+    t = Time(["2000:001", "2000:002"], scale="utc")
+    t2 = Time(["2000:010"], scale="tai")
     t[1] = t2[0]
     assert t.value[1] == t2.utc.value[0]
 
     # Time object with different scale and format
-    t = Time(['2000:001', '2000:002'], scale='utc')
-    t2.format = 'jyear'
+    t = Time(["2000:001", "2000:002"], scale="utc")
+    t2.format = "jyear"
     t[1] = t2[0]
     assert t.yday[1] == t2.utc.yday[0]
 
 
 def test_setitem_bad_item():
-    t = Time([1, 2], format='cxcsec')
+    t = Time([1, 2], format="cxcsec")
     with pytest.raises(IndexError):
-        t['asdf'] = 3
+        t["asdf"] = 3
 
 
 def test_setitem_deltas():
     """Setting invalidates any transform deltas"""
-    t = Time([1, 2], format='cxcsec')
+    t = Time([1, 2], format="cxcsec")
     t.delta_tdb_tt = [1, 2]
     t.delta_ut1_utc = [3, 4]
     t[1] = 3
-    assert not hasattr(t, '_delta_tdb_tt')
-    assert not hasattr(t, '_delta_ut1_utc')
+    assert not hasattr(t, "_delta_tdb_tt")
+    assert not hasattr(t, "_delta_ut1_utc")
 
 
 def test_subclass():
@@ -1817,7 +2027,7 @@ def test_subclass():
     class _Time(Time):
         pass
 
-    t1 = Time('1999-01-01T01:01:01')
+    t1 = Time("1999-01-01T01:01:01")
     t2 = _Time(t1)
 
     assert t2.__class__ == _Time
@@ -1825,68 +2035,72 @@ def test_subclass():
 
 
 def test_strftime_scalar():
-    """Test of Time.strftime
-    """
-    time_string = '2010-09-03 06:00:00'
+    """Test of Time.strftime"""
+    time_string = "2010-09-03 06:00:00"
     t = Time(time_string)
 
     for format in t.FORMATS:
         t.format = format
-        assert t.strftime('%Y-%m-%d %H:%M:%S') == time_string
+        assert t.strftime("%Y-%m-%d %H:%M:%S") == time_string
 
 
 def test_strftime_array():
-    tstrings = ['2010-09-03 00:00:00', '2005-09-03 06:00:00',
-                '1995-12-31 23:59:60']
+    tstrings = ["2010-09-03 00:00:00", "2005-09-03 06:00:00", "1995-12-31 23:59:60"]
     t = Time(tstrings)
 
     for format in t.FORMATS:
         t.format = format
-        assert t.strftime('%Y-%m-%d %H:%M:%S').tolist() == tstrings
+        assert t.strftime("%Y-%m-%d %H:%M:%S").tolist() == tstrings
 
 
 def test_strftime_array_2():
-    tstrings = [['1998-01-01 00:00:01', '1998-01-01 00:00:02'],
-                ['1998-01-01 00:00:03', '1995-12-31 23:59:60']]
+    tstrings = [
+        ["1998-01-01 00:00:01", "1998-01-01 00:00:02"],
+        ["1998-01-01 00:00:03", "1995-12-31 23:59:60"],
+    ]
     tstrings = np.array(tstrings)
 
     t = Time(tstrings)
 
     for format in t.FORMATS:
         t.format = format
-        assert np.all(t.strftime('%Y-%m-%d %H:%M:%S') == tstrings)
-        assert t.strftime('%Y-%m-%d %H:%M:%S').shape == tstrings.shape
+        assert np.all(t.strftime("%Y-%m-%d %H:%M:%S") == tstrings)
+        assert t.strftime("%Y-%m-%d %H:%M:%S").shape == tstrings.shape
 
 
 def test_strftime_leapsecond():
-    time_string = '1995-12-31 23:59:60'
+    time_string = "1995-12-31 23:59:60"
     t = Time(time_string)
 
     for format in t.FORMATS:
         t.format = format
-        assert t.strftime('%Y-%m-%d %H:%M:%S') == time_string
+        assert t.strftime("%Y-%m-%d %H:%M:%S") == time_string
 
 
 def test_strptime_scalar():
-    """Test of Time.strptime
-    """
-    time_string = '2007-May-04 21:08:12'
-    time_object = Time('2007-05-04 21:08:12')
-    t = Time.strptime(time_string, '%Y-%b-%d %H:%M:%S')
+    """Test of Time.strptime"""
+    time_string = "2007-May-04 21:08:12"
+    time_object = Time("2007-05-04 21:08:12")
+    t = Time.strptime(time_string, "%Y-%b-%d %H:%M:%S")
 
     assert t == time_object
 
 
 def test_strptime_array():
-    """Test of Time.strptime
-    """
-    tstrings = [['1998-Jan-01 00:00:01', '1998-Jan-01 00:00:02'],
-                ['1998-Jan-01 00:00:03', '1998-Jan-01 00:00:04']]
+    """Test of Time.strptime"""
+    tstrings = [
+        ["1998-Jan-01 00:00:01", "1998-Jan-01 00:00:02"],
+        ["1998-Jan-01 00:00:03", "1998-Jan-01 00:00:04"],
+    ]
     tstrings = np.array(tstrings)
 
-    time_object = Time([['1998-01-01 00:00:01', '1998-01-01 00:00:02'],
-                        ['1998-01-01 00:00:03', '1998-01-01 00:00:04']])
-    t = Time.strptime(tstrings, '%Y-%b-%d %H:%M:%S')
+    time_object = Time(
+        [
+            ["1998-01-01 00:00:01", "1998-01-01 00:00:02"],
+            ["1998-01-01 00:00:03", "1998-01-01 00:00:04"],
+        ]
+    )
+    t = Time.strptime(tstrings, "%Y-%b-%d %H:%M:%S")
 
     assert np.all(t == time_object)
     assert t.shape == tstrings.shape
@@ -1895,167 +2109,179 @@ def test_strptime_array():
 def test_strptime_badinput():
     tstrings = [1, 2, 3]
     with pytest.raises(TypeError):
-        Time.strptime(tstrings, '%S')
+        Time.strptime(tstrings, "%S")
 
 
 def test_strptime_input_bytes_scalar():
-    time_string = b'2007-May-04 21:08:12'
-    time_object = Time('2007-05-04 21:08:12')
-    t = Time.strptime(time_string, '%Y-%b-%d %H:%M:%S')
+    time_string = b"2007-May-04 21:08:12"
+    time_object = Time("2007-05-04 21:08:12")
+    t = Time.strptime(time_string, "%Y-%b-%d %H:%M:%S")
 
     assert t == time_object
 
 
 def test_strptime_input_bytes_array():
-    tstrings = [[b'1998-Jan-01 00:00:01', b'1998-Jan-01 00:00:02'],
-                [b'1998-Jan-01 00:00:03', b'1998-Jan-01 00:00:04']]
+    tstrings = [
+        [b"1998-Jan-01 00:00:01", b"1998-Jan-01 00:00:02"],
+        [b"1998-Jan-01 00:00:03", b"1998-Jan-01 00:00:04"],
+    ]
     tstrings = np.array(tstrings)
 
-    time_object = Time([['1998-01-01 00:00:01', '1998-01-01 00:00:02'],
-                        ['1998-01-01 00:00:03', '1998-01-01 00:00:04']])
-    t = Time.strptime(tstrings, '%Y-%b-%d %H:%M:%S')
+    time_object = Time(
+        [
+            ["1998-01-01 00:00:01", "1998-01-01 00:00:02"],
+            ["1998-01-01 00:00:03", "1998-01-01 00:00:04"],
+        ]
+    )
+    t = Time.strptime(tstrings, "%Y-%b-%d %H:%M:%S")
 
     assert np.all(t == time_object)
     assert t.shape == tstrings.shape
 
 
 def test_strptime_leapsecond():
-    time_obj1 = Time('1995-12-31T23:59:60', format='isot')
-    time_obj2 = Time.strptime('1995-Dec-31 23:59:60', '%Y-%b-%d %H:%M:%S')
+    time_obj1 = Time("1995-12-31T23:59:60", format="isot")
+    time_obj2 = Time.strptime("1995-Dec-31 23:59:60", "%Y-%b-%d %H:%M:%S")
 
     assert time_obj1 == time_obj2
 
 
 def test_strptime_3_digit_year():
-    time_obj1 = Time('0995-12-31T00:00:00', format='isot', scale='tai')
-    time_obj2 = Time.strptime('0995-Dec-31 00:00:00', '%Y-%b-%d %H:%M:%S',
-                              scale='tai')
+    time_obj1 = Time("0995-12-31T00:00:00", format="isot", scale="tai")
+    time_obj2 = Time.strptime("0995-Dec-31 00:00:00", "%Y-%b-%d %H:%M:%S", scale="tai")
 
     assert time_obj1 == time_obj2
 
 
 def test_strptime_fracsec_scalar():
-    time_string = '2007-May-04 21:08:12.123'
-    time_object = Time('2007-05-04 21:08:12.123')
-    t = Time.strptime(time_string, '%Y-%b-%d %H:%M:%S.%f')
+    time_string = "2007-May-04 21:08:12.123"
+    time_object = Time("2007-05-04 21:08:12.123")
+    t = Time.strptime(time_string, "%Y-%b-%d %H:%M:%S.%f")
 
     assert t == time_object
 
 
 def test_strptime_fracsec_array():
-    """Test of Time.strptime
-    """
-    tstrings = [['1998-Jan-01 00:00:01.123', '1998-Jan-01 00:00:02.000001'],
-                ['1998-Jan-01 00:00:03.000900', '1998-Jan-01 00:00:04.123456']]
+    """Test of Time.strptime"""
+    tstrings = [
+        ["1998-Jan-01 00:00:01.123", "1998-Jan-01 00:00:02.000001"],
+        ["1998-Jan-01 00:00:03.000900", "1998-Jan-01 00:00:04.123456"],
+    ]
     tstrings = np.array(tstrings)
 
-    time_object = Time([['1998-01-01 00:00:01.123', '1998-01-01 00:00:02.000001'],
-                        ['1998-01-01 00:00:03.000900', '1998-01-01 00:00:04.123456']])
-    t = Time.strptime(tstrings, '%Y-%b-%d %H:%M:%S.%f')
+    time_object = Time(
+        [
+            ["1998-01-01 00:00:01.123", "1998-01-01 00:00:02.000001"],
+            ["1998-01-01 00:00:03.000900", "1998-01-01 00:00:04.123456"],
+        ]
+    )
+    t = Time.strptime(tstrings, "%Y-%b-%d %H:%M:%S.%f")
 
     assert np.all(t == time_object)
     assert t.shape == tstrings.shape
 
 
 def test_strftime_scalar_fracsec():
-    """Test of Time.strftime
-    """
-    time_string = '2010-09-03 06:00:00.123'
+    """Test of Time.strftime"""
+    time_string = "2010-09-03 06:00:00.123"
     t = Time(time_string)
 
     for format in t.FORMATS:
         t.format = format
-        assert t.strftime('%Y-%m-%d %H:%M:%S.%f') == time_string
+        assert t.strftime("%Y-%m-%d %H:%M:%S.%f") == time_string
 
 
 def test_strftime_scalar_fracsec_precision():
-    time_string = '2010-09-03 06:00:00.123123123'
+    time_string = "2010-09-03 06:00:00.123123123"
     t = Time(time_string)
-    assert t.strftime('%Y-%m-%d %H:%M:%S.%f') == '2010-09-03 06:00:00.123'
+    assert t.strftime("%Y-%m-%d %H:%M:%S.%f") == "2010-09-03 06:00:00.123"
     t.precision = 9
-    assert t.strftime('%Y-%m-%d %H:%M:%S.%f') == '2010-09-03 06:00:00.123123123'
+    assert t.strftime("%Y-%m-%d %H:%M:%S.%f") == "2010-09-03 06:00:00.123123123"
 
 
 def test_strftime_array_fracsec():
-    tstrings = ['2010-09-03 00:00:00.123000', '2005-09-03 06:00:00.000001',
-                '1995-12-31 23:59:60.000900']
+    tstrings = [
+        "2010-09-03 00:00:00.123000",
+        "2005-09-03 06:00:00.000001",
+        "1995-12-31 23:59:60.000900",
+    ]
     t = Time(tstrings)
     t.precision = 6
 
     for format in t.FORMATS:
         t.format = format
-        assert t.strftime('%Y-%m-%d %H:%M:%S.%f').tolist() == tstrings
+        assert t.strftime("%Y-%m-%d %H:%M:%S.%f").tolist() == tstrings
 
 
 def test_insert_time():
-    tm = Time([1, 2], format='unix')
+    tm = Time([1, 2], format="unix")
 
     # Insert a scalar using an auto-parsed string
-    tm2 = tm.insert(1, '1970-01-01 00:01:00')
-    assert np.all(tm2 == Time([1, 60, 2], format='unix'))
+    tm2 = tm.insert(1, "1970-01-01 00:01:00")
+    assert np.all(tm2 == Time([1, 60, 2], format="unix"))
 
     # Insert scalar using a Time value
-    tm2 = tm.insert(1, Time('1970-01-01 00:01:00'))
-    assert np.all(tm2 == Time([1, 60, 2], format='unix'))
+    tm2 = tm.insert(1, Time("1970-01-01 00:01:00"))
+    assert np.all(tm2 == Time([1, 60, 2], format="unix"))
 
     # Insert length=1 array with a Time value
-    tm2 = tm.insert(1, [Time('1970-01-01 00:01:00')])
-    assert np.all(tm2 == Time([1, 60, 2], format='unix'))
+    tm2 = tm.insert(1, [Time("1970-01-01 00:01:00")])
+    assert np.all(tm2 == Time([1, 60, 2], format="unix"))
 
     # Insert length=2 list with float values matching unix format.
     # Also actually provide axis=0 unlike all other tests.
     tm2 = tm.insert(1, [10, 20], axis=0)
-    assert np.all(tm2 == Time([1, 10, 20, 2], format='unix'))
+    assert np.all(tm2 == Time([1, 10, 20, 2], format="unix"))
 
     # Insert length=2 np.array with float values matching unix format
     tm2 = tm.insert(1, np.array([10, 20]))
-    assert np.all(tm2 == Time([1, 10, 20, 2], format='unix'))
+    assert np.all(tm2 == Time([1, 10, 20, 2], format="unix"))
 
     # Insert length=2 np.array with float values at the end
     tm2 = tm.insert(2, np.array([10, 20]))
-    assert np.all(tm2 == Time([1, 2, 10, 20], format='unix'))
+    assert np.all(tm2 == Time([1, 2, 10, 20], format="unix"))
 
     # Insert length=2 np.array with float values at the beginning
     # with a negative index
     tm2 = tm.insert(-2, np.array([10, 20]))
-    assert np.all(tm2 == Time([10, 20, 1, 2], format='unix'))
+    assert np.all(tm2 == Time([10, 20, 1, 2], format="unix"))
 
 
 def test_insert_time_out_subfmt():
     # Check insert() with out_subfmt set
-    T = Time(['1999-01-01', '1999-01-02'], out_subfmt='date')
+    T = Time(["1999-01-01", "1999-01-02"], out_subfmt="date")
     T = T.insert(0, T[0])
-    assert T.out_subfmt == 'date'
+    assert T.out_subfmt == "date"
     assert T[0] == T[1]
-    T = T.insert(1, '1999-01-03')
-    assert T.out_subfmt == 'date'
-    assert str(T[1]) == '1999-01-03'
+    T = T.insert(1, "1999-01-03")
+    assert T.out_subfmt == "date"
+    assert str(T[1]) == "1999-01-03"
 
 
 def test_insert_exceptions():
-    tm = Time(1, format='unix')
+    tm = Time(1, format="unix")
     with pytest.raises(TypeError) as err:
         tm.insert(0, 50)
-    assert 'cannot insert into scalar' in str(err.value)
+    assert "cannot insert into scalar" in str(err.value)
 
-    tm = Time([1, 2], format='unix')
+    tm = Time([1, 2], format="unix")
     with pytest.raises(ValueError) as err:
         tm.insert(0, 50, axis=1)
-    assert 'axis must be 0' in str(err.value)
+    assert "axis must be 0" in str(err.value)
 
     with pytest.raises(TypeError) as err:
         tm.insert(slice(None), 50)
-    assert 'obj arg must be an integer' in str(err.value)
+    assert "obj arg must be an integer" in str(err.value)
 
     with pytest.raises(IndexError) as err:
         tm.insert(-100, 50)
-    assert 'index -100 is out of bounds for axis 0 with size 2' in str(err.value)
+    assert "index -100 is out of bounds for axis 0 with size 2" in str(err.value)
 
 
 def test_datetime64_no_format():
-    dt64 = np.datetime64('2000-01-02T03:04:05.123456789')
-    t = Time(dt64, scale='utc', precision=9)
-    assert t.iso == '2000-01-02 03:04:05.123456789'
+    dt64 = np.datetime64("2000-01-02T03:04:05.123456789")
+    t = Time(dt64, scale="utc", precision=9)
+    assert t.iso == "2000-01-02 03:04:05.123456789"
     assert t.datetime64 == dt64
     assert t.value == dt64
 
@@ -2063,7 +2289,7 @@ def test_datetime64_no_format():
 def test_hash_time():
     loc1 = EarthLocation(1 * u.m, 2 * u.m, 3 * u.m)
     for loc in None, loc1:
-        t = Time([1, 1, 2, 3], format='cxcsec', location=loc)
+        t = Time([1, 1, 2, 3], format="cxcsec", location=loc)
         t[3] = np.ma.masked
         h1 = hash(t[0])
         h2 = hash(t[1])
@@ -2079,20 +2305,19 @@ def test_hash_time():
             hash(t[3])
         assert exc.value.args[0] == "unhashable type: 'Time' (value is masked)"
 
-    t = Time(1, format='cxcsec', location=loc)
-    t2 = Time(1, format='cxcsec')
+    t = Time(1, format="cxcsec", location=loc)
+    t2 = Time(1, format="cxcsec")
 
     assert hash(t) != hash(t2)
 
-    t = Time('2000:180', scale='utc')
-    t2 = Time(t, scale='tai')
+    t = Time("2000:180", scale="utc")
+    t2 = Time(t, scale="tai")
     assert t == t2
     assert hash(t) != hash(t2)
 
 
 def test_hash_time_delta():
-
-    t = TimeDelta([1, 1, 2, 3], format='sec')
+    t = TimeDelta([1, 1, 2, 3], format="sec")
     t[3] = np.ma.masked
     h1 = hash(t[0])
     h2 = hash(t[1])
@@ -2115,48 +2340,54 @@ def test_get_time_fmt_exception_messages():
     assert "No time format was given, and the input is" in str(err.value)
 
     with pytest.raises(ValueError) as err:
-        Time('2000:001', format='not-a-format')
+        Time("2000:001", format="not-a-format")
     assert "Format 'not-a-format' is not one of the allowed" in str(err.value)
 
     with pytest.raises(ValueError) as err:
-        Time('200')
-    assert 'Input values did not match any of the formats where' in str(err.value)
+        Time("200")
+    assert "Input values did not match any of the formats where" in str(err.value)
 
     with pytest.raises(ValueError) as err:
-        Time('200', format='iso')
-    assert ('Input values did not match the format class iso:' + os.linesep
-            + 'ValueError: Time 200 does not match iso format') == str(err.value)
+        Time("200", format="iso")
+    assert (
+        "Input values did not match the format class iso:"
+        + os.linesep
+        + "ValueError: Time 200 does not match iso format"
+    ) == str(err.value)
 
     with pytest.raises(ValueError) as err:
-        Time(200, format='iso')
-    assert ('Input values did not match the format class iso:' + os.linesep
-            + 'TypeError: Input values for iso class must be strings') == str(err.value)
+        Time(200, format="iso")
+    assert (
+        "Input values did not match the format class iso:"
+        + os.linesep
+        + "TypeError: Input values for iso class must be strings"
+    ) == str(err.value)
 
 
 def test_ymdhms_defaults():
-    t1 = Time({'year': 2001}, format='ymdhms')
-    assert t1 == Time('2001-01-01')
+    t1 = Time({"year": 2001}, format="ymdhms")
+    assert t1 == Time("2001-01-01")
 
 
 times_dict_ns = {
-    'year': [2001, 2002],
-    'month': [2, 3],
-    'day': [4, 5],
-    'hour': [6, 7],
-    'minute': [8, 9],
-    'second': [10, 11]
+    "year": [2001, 2002],
+    "month": [2, 3],
+    "day": [4, 5],
+    "hour": [6, 7],
+    "minute": [8, 9],
+    "second": [10, 11],
 }
 table_ns = Table(times_dict_ns)
 struct_array_ns = table_ns.as_array()
 rec_array_ns = struct_array_ns.view(np.recarray)
-ymdhms_names = ('year', 'month', 'day', 'hour', 'minute', 'second')
+ymdhms_names = ("year", "month", "day", "hour", "minute", "second")
 
 
-@pytest.mark.parametrize('tm_input', [table_ns, struct_array_ns, rec_array_ns])
-@pytest.mark.parametrize('kwargs', [{}, {'format': 'ymdhms'}])
-@pytest.mark.parametrize('as_row', [False, True])
+@pytest.mark.parametrize("tm_input", [table_ns, struct_array_ns, rec_array_ns])
+@pytest.mark.parametrize("kwargs", [{}, {"format": "ymdhms"}])
+@pytest.mark.parametrize("as_row", [False, True])
 def test_ymdhms_init_from_table_like(tm_input, kwargs, as_row):
-    time_ns = Time(['2001-02-04 06:08:10', '2002-03-05 07:09:11'])
+    time_ns = Time(["2001-02-04 06:08:10", "2002-03-05 07:09:11"])
     if as_row:
         tm_input = tm_input[0]
         time_ns = time_ns[0]
@@ -2167,23 +2398,15 @@ def test_ymdhms_init_from_table_like(tm_input, kwargs, as_row):
 
 
 def test_ymdhms_init_from_dict_array():
-    times_dict_shape = {
-        'year': [[2001, 2002],
-                 [2003, 2004]],
-        'month': [2, 3],
-        'day': 4
-    }
-    time_shape = Time(
-        [['2001-02-04', '2002-03-04'],
-         ['2003-02-04', '2004-03-04']]
-    )
-    time = Time(times_dict_shape, format='ymdhms')
+    times_dict_shape = {"year": [[2001, 2002], [2003, 2004]], "month": [2, 3], "day": 4}
+    time_shape = Time([["2001-02-04", "2002-03-04"], ["2003-02-04", "2004-03-04"]])
+    time = Time(times_dict_shape, format="ymdhms")
 
     assert np.all(time == time_shape)
     assert time.ymdhms.shape == time_shape.shape
 
 
-@pytest.mark.parametrize('kwargs', [{}, {'format': 'ymdhms'}])
+@pytest.mark.parametrize("kwargs", [{}, {"format": "ymdhms"}])
 def test_ymdhms_init_from_dict_scalar(kwargs):
     """
     Test YMDHMS functionality for a dict input. This includes ensuring that
@@ -2191,19 +2414,20 @@ def test_ymdhms_init_from_dict_scalar(kwargs):
     second.
     """
     time_dict = {
-        'year': 2016,
-        'month': 12,
-        'day': 31,
-        'hour': 23,
-        'minute': 59,
-        'second': 60.123456789}
+        "year": 2016,
+        "month": 12,
+        "day": 31,
+        "hour": 23,
+        "minute": 59,
+        "second": 60.123456789,
+    }
 
     tm = Time(time_dict, **kwargs)
 
-    assert tm == Time('2016-12-31T23:59:60.123456789')
+    assert tm == Time("2016-12-31T23:59:60.123456789")
     for attr in time_dict:
         for value in (tm.value[attr], getattr(tm.value, attr)):
-            if attr == 'second':
+            if attr == "second":
                 assert allclose_sec(time_dict[attr], value)
             else:
                 assert time_dict[attr] == value
@@ -2211,33 +2435,33 @@ def test_ymdhms_init_from_dict_scalar(kwargs):
     # Now test initializing from a YMDHMS format time using the object
     tm_rt = Time(tm)
     assert tm_rt == tm
-    assert tm_rt.format == 'ymdhms'
+    assert tm_rt.format == "ymdhms"
 
     # Test initializing from a YMDHMS value (np.void, i.e. recarray row)
     # without specified format.
     tm_rt = Time(tm.ymdhms)
     assert tm_rt == tm
-    assert tm_rt.format == 'ymdhms'
+    assert tm_rt.format == "ymdhms"
 
 
 def test_ymdhms_exceptions():
-    with pytest.raises(ValueError, match='input must be dict or table-like'):
-        Time(10, format='ymdhms')
+    with pytest.raises(ValueError, match="input must be dict or table-like"):
+        Time(10, format="ymdhms")
 
     match = "'wrong' not allowed as YMDHMS key name(s)"
     # NB: for reasons unknown, using match=match in pytest.raises() fails, so we
     # fall back to old school ``match in str(err.value)``.
     with pytest.raises(ValueError) as err:
-        Time({'year': 2019, 'wrong': 1}, format='ymdhms')
+        Time({"year": 2019, "wrong": 1}, format="ymdhms")
     assert match in str(err.value)
 
     match = "for 2 input key names you must supply 'year', 'month'"
     with pytest.raises(ValueError, match=match):
-        Time({'year': 2019, 'minute': 1}, format='ymdhms')
+        Time({"year": 2019, "minute": 1}, format="ymdhms")
 
 
 def test_ymdhms_masked():
-    tm = Time({'year': [2000, 2001]}, format='ymdhms')
+    tm = Time({"year": [2000, 2001]}, format="ymdhms")
     tm[0] = np.ma.masked
     assert isinstance(tm.value[0], np.ma.core.mvoid)
     for name in ymdhms_names:
@@ -2246,72 +2470,74 @@ def test_ymdhms_masked():
 
 # Converted from doctest in astropy/test/formats.py for debugging
 def test_ymdhms_output():
-    t = Time({'year': 2015, 'month': 2, 'day': 3,
-              'hour': 12, 'minute': 13, 'second': 14.567},
-             scale='utc')
+    t = Time(
+        {
+            "year": 2015,
+            "month": 2,
+            "day": 3,
+            "hour": 12,
+            "minute": 13,
+            "second": 14.567,
+        },
+        scale="utc",
+    )
     # NOTE: actually comes back as np.void for some reason
     # NOTE: not necessarily a python int; might be an int32
     assert t.ymdhms.year == 2015
 
 
-@pytest.mark.parametrize('fmt', TIME_FORMATS)
+@pytest.mark.parametrize("fmt", TIME_FORMATS)
 def test_write_every_format_to_ecsv(fmt):
     """Test special-case serialization of certain Time formats"""
     t = Table()
     # Use a time that tests the default serialization of the time format
-    tm = (Time('2020-01-01')
-          + [[1, 1 / 7],
-             [3, 4.5]] * u.s)
+    tm = Time("2020-01-01") + [[1, 1 / 7], [3, 4.5]] * u.s
     tm.format = fmt
-    t['a'] = tm
+    t["a"] = tm
     out = StringIO()
-    t.write(out, format='ascii.ecsv')
-    t2 = Table.read(out.getvalue(), format='ascii.ecsv')
-    assert t['a'].format == t2['a'].format
+    t.write(out, format="ascii.ecsv")
+    t2 = Table.read(out.getvalue(), format="ascii.ecsv")
+    assert t["a"].format == t2["a"].format
     # Some loss of precision in the serialization
-    assert not np.all(t['a'] == t2['a'])
+    assert not np.all(t["a"] == t2["a"])
     # But no loss in the format representation
-    assert np.all(t['a'].value == t2['a'].value)
+    assert np.all(t["a"].value == t2["a"].value)
 
 
-@pytest.mark.parametrize('fmt', TIME_FORMATS)
+@pytest.mark.parametrize("fmt", TIME_FORMATS)
 def test_write_every_format_to_fits(fmt, tmp_path):
     """Test special-case serialization of certain Time formats"""
     t = Table()
     # Use a time that tests the default serialization of the time format
-    tm = (Time('2020-01-01')
-          + [[1, 1 / 7],
-             [3, 4.5]] * u.s)
+    tm = Time("2020-01-01") + [[1, 1 / 7], [3, 4.5]] * u.s
     tm.format = fmt
-    t['a'] = tm
-    out = tmp_path / 'out.fits'
-    t.write(out, format='fits')
-    t2 = Table.read(out, format='fits', astropy_native=True)
+    t["a"] = tm
+    out = tmp_path / "out.fits"
+    t.write(out, format="fits")
+    t2 = Table.read(out, format="fits", astropy_native=True)
     # Currently the format is lost in FITS so set it back
-    t2['a'].format = fmt
+    t2["a"].format = fmt
     # No loss of precision in the serialization or representation
-    assert np.all(t['a'] == t2['a'])
-    assert np.all(t['a'].value == t2['a'].value)
+    assert np.all(t["a"] == t2["a"])
+    assert np.all(t["a"].value == t2["a"].value)
 
 
-@pytest.mark.skipif(not HAS_H5PY, reason='Needs h5py')
-@pytest.mark.parametrize('fmt', TIME_FORMATS)
+@pytest.mark.skipif(not HAS_H5PY, reason="Needs h5py")
+@pytest.mark.parametrize("fmt", TIME_FORMATS)
 def test_write_every_format_to_hdf5(fmt, tmp_path):
     """Test special-case serialization of certain Time formats"""
     t = Table()
     # Use a time that tests the default serialization of the time format
-    tm = (Time('2020-01-01')
-          + [[1, 1 / 7],
-             [3, 4.5]] * u.s)
+    tm = Time("2020-01-01") + [[1, 1 / 7], [3, 4.5]] * u.s
     tm.format = fmt
-    t['a'] = tm
-    out = tmp_path / 'out.h5'
-    t.write(str(out), format='hdf5', path='root', serialize_meta=True)
-    t2 = Table.read(str(out), format='hdf5', path='root')
-    assert t['a'].format == t2['a'].format
+    t["a"] = tm
+    out = tmp_path / "out.h5"
+    t.write(str(out), format="hdf5", path="root", serialize_meta=True)
+    t2 = Table.read(str(out), format="hdf5", path="root")
+    assert t["a"].format == t2["a"].format
     # No loss of precision in the serialization or representation
-    assert np.all(t['a'] == t2['a'])
-    assert np.all(t['a'].value == t2['a'].value)
+    assert np.all(t["a"] == t2["a"])
+    assert np.all(t["a"].value == t2["a"].value)
 
 
 # There are two stages of validation now - one on input into a format, so that
@@ -2322,40 +2548,40 @@ def test_write_every_format_to_hdf5(fmt, tmp_path):
 # and can ensure that strange broadcasting anomalies can't happen.
 # This form of construction uses from_jd=True.
 def test_broadcasting_writeable():
-    t = Time('J2015') + np.linspace(-1, 1, 10) * u.day
+    t = Time("J2015") + np.linspace(-1, 1, 10) * u.day
     t[2] = Time(58000, format="mjd")
 
 
 def test_format_subformat_compatibility():
     """Test that changing format with out_subfmt defined is not a problem.
     See #9812, #9810."""
-    t = Time('2019-12-20', out_subfmt='date_??')
+    t = Time("2019-12-20", out_subfmt="date_??")
     assert t.mjd == 58837.0
-    assert t.yday == '2019:354:00:00'  # Preserves out_subfmt
+    assert t.yday == "2019:354:00:00"  # Preserves out_subfmt
 
-    t2 = t.replicate(format='mjd')
-    assert t2.out_subfmt == '*'  # Changes to default
+    t2 = t.replicate(format="mjd")
+    assert t2.out_subfmt == "*"  # Changes to default
 
-    t2 = t.copy(format='mjd')
-    assert t2.out_subfmt == '*'
+    t2 = t.copy(format="mjd")
+    assert t2.out_subfmt == "*"
 
-    t2 = Time(t, format='mjd')
-    assert t2.out_subfmt == '*'
+    t2 = Time(t, format="mjd")
+    assert t2.out_subfmt == "*"
 
-    t2 = t.copy(format='yday')
-    assert t2.out_subfmt == 'date_??'
-    assert t2.value == '2019:354:00:00'
+    t2 = t.copy(format="yday")
+    assert t2.out_subfmt == "date_??"
+    assert t2.value == "2019:354:00:00"
 
-    t.format = 'yday'
-    assert t.value == '2019:354:00:00'
-    assert t.out_subfmt == 'date_??'
+    t.format = "yday"
+    assert t.value == "2019:354:00:00"
+    assert t.out_subfmt == "date_??"
 
-    t = Time('2019-12-20', out_subfmt='date')
+    t = Time("2019-12-20", out_subfmt="date")
     assert t.mjd == 58837.0
-    assert t.yday == '2019:354'
+    assert t.yday == "2019:354"
 
 
-@pytest.mark.parametrize('use_fast_parser', ["force", "False"])
+@pytest.mark.parametrize("use_fast_parser", ["force", "False"])
 def test_format_fractional_string_parsing(use_fast_parser):
     """Test that string like "2022-08-01.123" does not parse as ISO.
     See #6476 and the fix."""
@@ -2363,27 +2589,27 @@ def test_format_fractional_string_parsing(use_fast_parser):
         ValueError, match=r"Input values did not match the format class iso"
     ):
         with conf.set_temp("use_fast_parser", use_fast_parser):
-            Time("2022-08-01.123", format='iso')
+            Time("2022-08-01.123", format="iso")
 
 
-@pytest.mark.parametrize('fmt_name,fmt_class', TIME_FORMATS.items())
+@pytest.mark.parametrize("fmt_name,fmt_class", TIME_FORMATS.items())
 def test_to_value_with_subfmt_for_every_format(fmt_name, fmt_class):
     """From a starting Time value, test that every valid combination of
     to_value(format, subfmt) works.  See #9812, #9361.
     """
-    t = Time('2000-01-01')
-    subfmts = list(subfmt[0] for subfmt in fmt_class.subfmts) + [None, '*']
+    t = Time("2000-01-01")
+    subfmts = list(subfmt[0] for subfmt in fmt_class.subfmts) + [None, "*"]
     for subfmt in subfmts:
         t.to_value(fmt_name, subfmt)
 
 
-@pytest.mark.parametrize('location', [None, (45, 45)])
+@pytest.mark.parametrize("location", [None, (45, 45)])
 def test_location_init(location):
     """Test fix in #9969 for issue #9962 where the location attribute is
     lost when initializing Time from an existing Time instance of list of
     Time instances.
     """
-    tm = Time('J2010', location=location)
+    tm = Time("J2010", location=location)
 
     # Init from a scalar Time
     tm2 = Time(tm)
@@ -2401,7 +2627,7 @@ def test_location_init(location):
 
     # Effectively the same as a list of Times, but just to be sure that
     # Table mixin inititialization is working as expected.
-    tm2 = Table([[tm, tm]])['col0']
+    tm2 = Table([[tm, tm]])["col0"]
     if location is None:
         assert tm2.location is None
     else:
@@ -2415,44 +2641,55 @@ def test_location_init_fail():
     lost when initializing Time from an existing Time instance of list of
     Time instances.  Make sure exception is correct.
     """
-    tm = Time('J2010', location=(45, 45))
-    tm2 = Time('J2010')
+    tm = Time("J2010", location=(45, 45))
+    tm2 = Time("J2010")
 
-    with pytest.raises(ValueError,
-                       match='cannot concatenate times unless all locations'):
+    with pytest.raises(
+        ValueError, match="cannot concatenate times unless all locations"
+    ):
         Time([tm, tm2])
 
 
 def test_linspace():
-    """Test `np.linspace` `__array_func__` implementation for scalar and arrays.
-    """
-    t1 = Time(['2021-01-01 00:00:00', '2021-01-02 00:00:00'])
-    t2 = Time(['2021-01-01 01:00:00', '2021-12-28 00:00:00'])
+    """Test `np.linspace` `__array_func__` implementation for scalar and arrays."""
+    t1 = Time(["2021-01-01 00:00:00", "2021-01-02 00:00:00"])
+    t2 = Time(["2021-01-01 01:00:00", "2021-12-28 00:00:00"])
     atol = 2 * np.finfo(float).eps * abs(t1 - t2).max()
 
     ts = np.linspace(t1[0], t2[0], 3)
-    assert ts[0].isclose(Time('2021-01-01 00:00:00'), atol=atol)
-    assert ts[1].isclose(Time('2021-01-01 00:30:00'), atol=atol)
-    assert ts[2].isclose(Time('2021-01-01 01:00:00'), atol=atol)
+    assert ts[0].isclose(Time("2021-01-01 00:00:00"), atol=atol)
+    assert ts[1].isclose(Time("2021-01-01 00:30:00"), atol=atol)
+    assert ts[2].isclose(Time("2021-01-01 01:00:00"), atol=atol)
 
     ts = np.linspace(t1, t2[0], 2, endpoint=False)
     assert ts.shape == (2, 2)
-    assert all(ts[0].isclose(Time(['2021-01-01 00:00:00', '2021-01-02 00:00:00']), atol=atol))
-    assert all(ts[1].isclose(Time(['2021-01-01 00:30:00', '2021-01-01 12:30:00']), atol=atol))
+    assert all(
+        ts[0].isclose(Time(["2021-01-01 00:00:00", "2021-01-02 00:00:00"]), atol=atol)
+    )
+    assert all(
+        ts[1].isclose(Time(["2021-01-01 00:30:00", "2021-01-01 12:30:00"]), atol=atol)
+    )
 
     ts = np.linspace(t1, t2, 7)
     assert ts.shape == (7, 2)
-    assert all(ts[0].isclose(Time(['2021-01-01 00:00:00', '2021-01-02 00:00:00']), atol=atol))
-    assert all(ts[1].isclose(Time(['2021-01-01 00:10:00', '2021-03-03 00:00:00']), atol=atol))
-    assert all(ts[5].isclose(Time(['2021-01-01 00:50:00', '2021-10-29 00:00:00']), atol=atol))
-    assert all(ts[6].isclose(Time(['2021-01-01 01:00:00', '2021-12-28 00:00:00']), atol=atol))
+    assert all(
+        ts[0].isclose(Time(["2021-01-01 00:00:00", "2021-01-02 00:00:00"]), atol=atol)
+    )
+    assert all(
+        ts[1].isclose(Time(["2021-01-01 00:10:00", "2021-03-03 00:00:00"]), atol=atol)
+    )
+    assert all(
+        ts[5].isclose(Time(["2021-01-01 00:50:00", "2021-10-29 00:00:00"]), atol=atol)
+    )
+    assert all(
+        ts[6].isclose(Time(["2021-01-01 01:00:00", "2021-12-28 00:00:00"]), atol=atol)
+    )
 
 
 def test_linspace_steps():
-    """Test `np.linspace` `retstep` option.
-    """
-    t1 = Time(['2021-01-01 00:00:00', '2021-01-01 12:00:00'])
-    t2 = Time('2021-01-02 00:00:00')
+    """Test `np.linspace` `retstep` option."""
+    t1 = Time(["2021-01-01 00:00:00", "2021-01-01 12:00:00"])
+    t2 = Time("2021-01-02 00:00:00")
     atol = 2 * np.finfo(float).eps * abs(t1 - t2).max()
 
     ts, st = np.linspace(t1, t2, 7, retstep=True)
@@ -2460,35 +2697,47 @@ def test_linspace_steps():
     assert st.shape == (2,)
     assert all(ts[1].isclose(ts[0] + st, atol=atol))
     assert all(ts[6].isclose(ts[0] + 6 * st, atol=atol))
-    assert all(st.isclose(TimeDelta([14400, 7200], format='sec'), atol=atol))
+    assert all(st.isclose(TimeDelta([14400, 7200], format="sec"), atol=atol))
 
 
 def test_linspace_fmts():
     """Test `np.linspace` `__array_func__` implementation for start/endpoints
     from different formats/systems.
     """
-    t1 = Time(['2020-01-01 00:00:00', '2020-01-02 00:00:00'])
-    t2 = Time(2458850, format='jd')
-    t3 = Time(1578009600, format='unix')
+    t1 = Time(["2020-01-01 00:00:00", "2020-01-02 00:00:00"])
+    t2 = Time(2458850, format="jd")
+    t3 = Time(1578009600, format="unix")
     atol = 2 * np.finfo(float).eps * abs(t1 - Time([t2, t3])).max()
 
     ts = np.linspace(t1, t2, 3)
     assert ts.shape == (3, 2)
-    assert all(ts[0].isclose(Time(['2020-01-01 00:00:00', '2020-01-02 00:00:00']), atol=atol))
-    assert all(ts[1].isclose(Time(['2020-01-01 06:00:00', '2020-01-01 18:00:00']), atol=atol))
-    assert all(ts[2].isclose(Time(['2020-01-01 12:00:00', '2020-01-01 12:00:00']), atol=atol))
+    assert all(
+        ts[0].isclose(Time(["2020-01-01 00:00:00", "2020-01-02 00:00:00"]), atol=atol)
+    )
+    assert all(
+        ts[1].isclose(Time(["2020-01-01 06:00:00", "2020-01-01 18:00:00"]), atol=atol)
+    )
+    assert all(
+        ts[2].isclose(Time(["2020-01-01 12:00:00", "2020-01-01 12:00:00"]), atol=atol)
+    )
 
     ts = np.linspace(t1, Time([t2, t3]), 3)
     assert ts.shape == (3, 2)
-    assert all(ts[0].isclose(Time(['2020-01-01 00:00:00', '2020-01-02 00:00:00']), atol=atol))
-    assert all(ts[1].isclose(Time(['2020-01-01 06:00:00', '2020-01-02 12:00:00']), atol=atol))
-    assert all(ts[2].isclose(Time(['2020-01-01 12:00:00', '2020-01-03 00:00:00']), atol=atol))
+    assert all(
+        ts[0].isclose(Time(["2020-01-01 00:00:00", "2020-01-02 00:00:00"]), atol=atol)
+    )
+    assert all(
+        ts[1].isclose(Time(["2020-01-01 06:00:00", "2020-01-02 12:00:00"]), atol=atol)
+    )
+    assert all(
+        ts[2].isclose(Time(["2020-01-01 12:00:00", "2020-01-03 00:00:00"]), atol=atol)
+    )
 
 
 def test_to_string():
     dims = [8, 2, 8]
     dx = np.arange(np.prod(dims)).reshape(dims)
-    tm = Time('2020-01-01', out_subfmt='date') + dx * u.day
+    tm = Time("2020-01-01", out_subfmt="date") + dx * u.day
     exp_lines = [
         "[[['2020-01-01' '2020-01-02' ... '2020-01-07' '2020-01-08']",
         "  ['2020-01-09' '2020-01-10' ... '2020-01-15' '2020-01-16']]",

--- a/astropy/time/tests/test_comparisons.py
+++ b/astropy/time/tests/test_comparisons.py
@@ -13,8 +13,8 @@ class TestTimeComparisons:
     """Test Comparisons of Time and TimeDelta classes"""
 
     def setup_method(self):
-        self.t1 = Time(np.arange(49995, 50005), format='mjd', scale='utc')
-        self.t2 = Time(np.arange(49000, 51000, 200), format='mjd', scale='utc')
+        self.t1 = Time(np.arange(49995, 50005), format="mjd", scale="utc")
+        self.t2 = Time(np.arange(49000, 51000, 200), format="mjd", scale="utc")
 
     def test_miscompares(self):
         """
@@ -22,11 +22,13 @@ class TestTimeComparisons:
         return False and != should return True. All other comparison
         operators should raise a TypeError.
         """
-        t1 = Time('J2000', scale='utc')
-        for op, op_str in ((operator.ge, '>='),
-                           (operator.gt, '>'),
-                           (operator.le, '<='),
-                           (operator.lt, '<')):
+        t1 = Time("J2000", scale="utc")
+        for op, op_str in (
+            (operator.ge, ">="),
+            (operator.gt, ">"),
+            (operator.le, "<="),
+            (operator.lt, "<"),
+        ):
             with pytest.raises(TypeError):
                 op(t1, None)
         # Keep == and != as they are specifically meant to test Time.__eq__
@@ -36,32 +38,49 @@ class TestTimeComparisons:
 
     def test_time(self):
         t1_lt_t2 = self.t1 < self.t2
-        assert np.all(t1_lt_t2 == np.array([False, False, False, False, False,
-                                            False, True, True, True, True]))
+        assert np.all(
+            t1_lt_t2
+            == np.array(
+                [False, False, False, False, False, False, True, True, True, True]
+            )
+        )
         t1_ge_t2 = self.t1 >= self.t2
         assert np.all(t1_ge_t2 != t1_lt_t2)
 
         t1_le_t2 = self.t1 <= self.t2
-        assert np.all(t1_le_t2 == np.array([False, False, False, False, False,
-                                            True, True, True, True, True]))
+        assert np.all(
+            t1_le_t2
+            == np.array(
+                [False, False, False, False, False, True, True, True, True, True]
+            )
+        )
         t1_gt_t2 = self.t1 > self.t2
         assert np.all(t1_gt_t2 != t1_le_t2)
 
         t1_eq_t2 = self.t1 == self.t2
-        assert np.all(t1_eq_t2 == np.array([False, False, False, False, False,
-                                            True, False, False, False, False]))
+        assert np.all(
+            t1_eq_t2
+            == np.array(
+                [False, False, False, False, False, True, False, False, False, False]
+            )
+        )
         t1_ne_t2 = self.t1 != self.t2
         assert np.all(t1_ne_t2 != t1_eq_t2)
 
         t1_0_gt_t2_0 = self.t1[0] > self.t2[0]
         assert t1_0_gt_t2_0 is True
         t1_0_gt_t2 = self.t1[0] > self.t2
-        assert np.all(t1_0_gt_t2 == np.array([True, True, True, True, True,
-                                              False, False, False, False,
-                                              False]))
+        assert np.all(
+            t1_0_gt_t2
+            == np.array(
+                [True, True, True, True, True, False, False, False, False, False]
+            )
+        )
         t1_gt_t2_0 = self.t1 > self.t2[0]
-        assert np.all(t1_gt_t2_0 == np.array([True, True, True, True, True,
-                                              True, True, True, True, True]))
+        assert np.all(
+            t1_gt_t2_0
+            == np.array([True, True, True, True, True, True, True, True, True, True])
+        )
 
     def test_time_boolean(self):
         t1_0_gt_t2_0 = self.t1[0] > self.t2[0]
@@ -71,13 +90,17 @@ class TestTimeComparisons:
         dt = self.t2 - self.t1
         with pytest.raises(TypeError):
             self.t1 > dt
-        dt_gt_td0 = dt > TimeDelta(0., format='sec')
-        assert np.all(dt_gt_td0 == np.array([False, False, False, False, False,
-                                             False, True, True, True, True]))
+        dt_gt_td0 = dt > TimeDelta(0.0, format="sec")
+        assert np.all(
+            dt_gt_td0
+            == np.array(
+                [False, False, False, False, False, False, True, True, True, True]
+            )
+        )
 
 
-@pytest.mark.parametrize('swap', [True, False])
-@pytest.mark.parametrize('time_delta', [True, False])
+@pytest.mark.parametrize("swap", [True, False])
+@pytest.mark.parametrize("time_delta", [True, False])
 def test_isclose_time(swap, time_delta):
     """Test functionality of Time.isclose() method.
 
@@ -87,8 +110,8 @@ def test_isclose_time(swap, time_delta):
     def isclose_swap(t1, t2, **kwargs):
         if swap:
             t1, t2 = t2, t1
-        if 'atol' in kwargs and time_delta:
-            kwargs['atol'] = TimeDelta(kwargs['atol'])
+        if "atol" in kwargs and time_delta:
+            kwargs["atol"] = TimeDelta(kwargs["atol"])
         return t1.isclose(t2, **kwargs)
 
     # Start with original demonstration from #8742. In this issue both t2 == t1
@@ -111,20 +134,22 @@ def test_isclose_time(swap, time_delta):
 
 
 def test_isclose_time_exceptions():
-    t1 = Time('2020:001')
+    t1 = Time("2020:001")
     t2 = t1 + 1 * u.s
     match = "'other' argument must support subtraction with Time"
     with pytest.raises(TypeError, match=match):
         t1.isclose(1.5)
 
-    match = "'atol' argument must be a Quantity or TimeDelta instance, got float instead"
+    match = (
+        "'atol' argument must be a Quantity or TimeDelta instance, got float instead"
+    )
     with pytest.raises(TypeError, match=match):
         t1.isclose(t2, 1.5)
 
 
-@pytest.mark.parametrize('swap', [True, False])
-@pytest.mark.parametrize('time_delta', [True, False])
-@pytest.mark.parametrize('other_quantity', [True, False])
+@pytest.mark.parametrize("swap", [True, False])
+@pytest.mark.parametrize("time_delta", [True, False])
+@pytest.mark.parametrize("other_quantity", [True, False])
 def test_isclose_timedelta(swap, time_delta, other_quantity):
     """Test functionality of TimeDelta.isclose() method.
 
@@ -135,15 +160,15 @@ def test_isclose_timedelta(swap, time_delta, other_quantity):
     def isclose_swap(t1, t2, **kwargs):
         if swap:
             t1, t2 = t2, t1
-        if 'atol' in kwargs and time_delta:
-            kwargs['atol'] = TimeDelta(kwargs['atol'])
+        if "atol" in kwargs and time_delta:
+            kwargs["atol"] = TimeDelta(kwargs["atol"])
         return t1.isclose(t2, **kwargs)
 
     def isclose_other_quantity(t1, t2, **kwargs):
         if other_quantity:
             t2 = t2.to(u.day)
-        if 'atol' in kwargs and time_delta:
-            kwargs['atol'] = TimeDelta(kwargs['atol'])
+        if "atol" in kwargs and time_delta:
+            kwargs["atol"] = TimeDelta(kwargs["atol"])
         return t1.isclose(t2, **kwargs)
 
     t1 = TimeDelta(1.0 * u.s)
@@ -183,6 +208,8 @@ def test_isclose_timedelta_exceptions():
     with pytest.raises(TypeError, match=match):
         t1.isclose(1.5)
 
-    match = "'atol' argument must be a Quantity or TimeDelta instance, got float instead"
+    match = (
+        "'atol' argument must be a Quantity or TimeDelta instance, got float instead"
+    )
     with pytest.raises(TypeError, match=match):
         t1.isclose(t2, 1.5)

--- a/astropy/time/tests/test_corrs.py
+++ b/astropy/time/tests/test_corrs.py
@@ -17,6 +17,7 @@ class TestHelioBaryCentric:
     routines.  They agree to an independent SLALIB based implementation
     to 20 microseconds.
     """
+
     @classmethod
     def setup_class(cls):
         cls.orig_auto_download = iers.conf.auto_download
@@ -30,42 +31,43 @@ class TestHelioBaryCentric:
         wht = EarthLocation(342.12 * u.deg, 28.758333333333333 * u.deg, 2327 * u.m)
         self.obstime = Time("2013-02-02T23:00", location=wht)
         self.obstime2 = Time("2013-08-02T23:00", location=wht)
-        self.obstimeArr = Time(["2013-02-02T23:00", "2013-08-02T23:00"],
-                               location=wht)
-        self.star = SkyCoord("08:08:08 +32:00:00", unit=(u.hour, u.degree),
-                             frame='icrs')
+        self.obstimeArr = Time(["2013-02-02T23:00", "2013-08-02T23:00"], location=wht)
+        self.star = SkyCoord(
+            "08:08:08 +32:00:00", unit=(u.hour, u.degree), frame="icrs"
+        )
 
     def test_heliocentric(self):
-        hval = self.obstime.light_travel_time(self.star, 'heliocentric')
+        hval = self.obstime.light_travel_time(self.star, "heliocentric")
         assert isinstance(hval, TimeDelta)
-        assert hval.scale == 'tdb'
-        assert abs(hval - 461.43037870502235 * u.s) < 1. * u.us
+        assert hval.scale == "tdb"
+        assert abs(hval - 461.43037870502235 * u.s) < 1.0 * u.us
 
     def test_barycentric(self):
-        bval = self.obstime.light_travel_time(self.star, 'barycentric')
+        bval = self.obstime.light_travel_time(self.star, "barycentric")
         assert isinstance(bval, TimeDelta)
-        assert bval.scale == 'tdb'
-        assert abs(bval - 460.58538779827836 * u.s) < 1. * u.us
+        assert bval.scale == "tdb"
+        assert abs(bval - 460.58538779827836 * u.s) < 1.0 * u.us
 
     def test_arrays(self):
-        bval1 = self.obstime.light_travel_time(self.star, 'barycentric')
-        bval2 = self.obstime2.light_travel_time(self.star, 'barycentric')
-        bval_arr = self.obstimeArr.light_travel_time(self.star, 'barycentric')
-        hval1 = self.obstime.light_travel_time(self.star, 'heliocentric')
-        hval2 = self.obstime2.light_travel_time(self.star, 'heliocentric')
-        hval_arr = self.obstimeArr.light_travel_time(self.star, 'heliocentric')
-        assert hval_arr[0] - hval1 < 1. * u.us
-        assert hval_arr[1] - hval2 < 1. * u.us
-        assert bval_arr[0] - bval1 < 1. * u.us
-        assert bval_arr[1] - bval2 < 1. * u.us
+        bval1 = self.obstime.light_travel_time(self.star, "barycentric")
+        bval2 = self.obstime2.light_travel_time(self.star, "barycentric")
+        bval_arr = self.obstimeArr.light_travel_time(self.star, "barycentric")
+        hval1 = self.obstime.light_travel_time(self.star, "heliocentric")
+        hval2 = self.obstime2.light_travel_time(self.star, "heliocentric")
+        hval_arr = self.obstimeArr.light_travel_time(self.star, "heliocentric")
+        assert hval_arr[0] - hval1 < 1.0 * u.us
+        assert hval_arr[1] - hval2 < 1.0 * u.us
+        assert bval_arr[0] - bval1 < 1.0 * u.us
+        assert bval_arr[1] - bval2 < 1.0 * u.us
 
     @pytest.mark.remote_data
-    @pytest.mark.skipif(not HAS_JPLEPHEM, reason='requires jplephem')
+    @pytest.mark.skipif(not HAS_JPLEPHEM, reason="requires jplephem")
     def test_ephemerides(self):
-        bval1 = self.obstime.light_travel_time(self.star, 'barycentric')
-        with solar_system_ephemeris.set('jpl'):
-            bval2 = self.obstime.light_travel_time(self.star, 'barycentric',
-                                                   ephemeris='jpl')
+        bval1 = self.obstime.light_travel_time(self.star, "barycentric")
+        with solar_system_ephemeris.set("jpl"):
+            bval2 = self.obstime.light_travel_time(
+                self.star, "barycentric", ephemeris="jpl"
+            )
         # should differ by less than 0.1 ms, but not be the same
-        assert abs(bval1 - bval2) < 1. * u.ms
-        assert abs(bval1 - bval2) > 1. * u.us
+        assert abs(bval1 - bval2) < 1.0 * u.ms
+        assert abs(bval1 - bval2) > 1.0 * u.us

--- a/astropy/time/tests/test_custom_formats.py
+++ b/astropy/time/tests/test_custom_formats.py
@@ -89,6 +89,7 @@ def test_custom_time_format_fine(custom_format_name):
 
 def test_custom_time_format_forgot_property(custom_format_name):
     with pytest.raises(ValueError):
+
         class Custom(TimeFormat):
             name = custom_format_name
 
@@ -107,7 +108,7 @@ def test_custom_time_format_problematic_name():
 
         class Custom(TimeFormat):
             name = "sort"
-            _dtype = np.dtype([('jd1', 'f8'), ('jd2', 'f8')])
+            _dtype = np.dtype([("jd1", "f8"), ("jd2", "f8")])
 
             def set_jds(self, val, val2):
                 self.jd1, self.jd2 = val, val2
@@ -115,8 +116,8 @@ def test_custom_time_format_problematic_name():
             @property
             def value(self):
                 result = np.empty(self.jd1.shape, self._dtype)
-                result['jd1'] = self.jd1
-                result['jd2'] = self.jd2
+                result["jd1"] = self.jd1
+                result["jd2"] = self.jd2
                 return result
 
         t = Time.now()
@@ -156,9 +157,10 @@ def test_mjd_longdouble_preserves_precision(custom_format_name):
     t = Time(m, format=custom_format_name)
     # Pick a different long double (ensuring it will give a different jd2
     # even when long doubles are more precise than Time, as on arm64).
-    m2 = np.longdouble(m) + max(2. * m * np.finfo(np.longdouble).eps,
-                                np.finfo(float).eps)
-    assert m2 != m, 'long double is weird!'
+    m2 = np.longdouble(m) + max(
+        2.0 * m * np.finfo(np.longdouble).eps, np.finfo(float).eps
+    )
+    assert m2 != m, "long double is weird!"
     t2 = Time(m2, format=custom_format_name)
     assert t != t2
     assert isinstance(getattr(t, custom_format_name), np.longdouble)
@@ -173,10 +175,13 @@ def test_mjd_longdouble_preserves_precision(custom_format_name):
         ("foo", "bar"),
         (1j, 2j),
         pytest.param(
-            np.longdouble(3), np.longdouble(5),
+            np.longdouble(3),
+            np.longdouble(5),
             marks=pytest.mark.skipif(
                 np.longdouble().itemsize == np.dtype(float).itemsize,
-                reason="long double == double on this platform")),
+                reason="long double == double on this platform",
+            ),
+        ),
         ({1: 2}, {3: 4}),
         ({1, 2}, {3, 4}),
         ([1, 2], [3, 4]),
@@ -224,7 +229,7 @@ def test_custom_format_scalar_jd1_jd2_okay(custom_format_name):
         b"foo",
         Time(5, format="mjd"),
         lambda: 7,
-        np.datetime64('2005-02-25'),
+        np.datetime64("2005-02-25"),
         date(2006, 2, 25),
     ],
 )
@@ -233,16 +238,18 @@ def test_custom_format_can_return_any_scalar(custom_format_name, thing):
         name = custom_format_name
 
         def set_jds(self, val, val2):
-            self.jd1, self.jd2 = 2., 0.
+            self.jd1, self.jd2 = 2.0, 0.0
 
         @property
         def value(self):
             return np.array(thing)
 
-    assert type(getattr(Time(5, format=custom_format_name),
-                        custom_format_name)) == type(thing)
-    assert np.all(getattr(Time(5, format=custom_format_name),
-                          custom_format_name) == thing)
+    assert type(
+        getattr(Time(5, format=custom_format_name), custom_format_name)
+    ) == type(thing)
+    assert np.all(
+        getattr(Time(5, format=custom_format_name), custom_format_name) == thing
+    )
 
 
 @pytest.mark.parametrize(
@@ -261,13 +268,15 @@ def test_custom_format_can_return_any_iterable(custom_format_name, thing):
         name = custom_format_name
 
         def set_jds(self, val, val2):
-            self.jd1, self.jd2 = 2., 0.
+            self.jd1, self.jd2 = 2.0, 0.0
 
         @property
         def value(self):
             return thing
 
-    assert type(getattr(Time(5, format=custom_format_name),
-                        custom_format_name)) == type(thing)
-    assert np.all(getattr(Time(5, format=custom_format_name),
-                          custom_format_name) == thing)
+    assert type(
+        getattr(Time(5, format=custom_format_name), custom_format_name)
+    ) == type(thing)
+    assert np.all(
+        getattr(Time(5, format=custom_format_name), custom_format_name) == thing
+    )

--- a/astropy/time/tests/test_delta.py
+++ b/astropy/time/tests/test_delta.py
@@ -22,11 +22,13 @@ from astropy.time import (
 )
 from astropy.utils import iers
 
-allclose_jd = functools.partial(np.allclose, rtol=2. ** -52, atol=0)
-allclose_jd2 = functools.partial(np.allclose, rtol=2. ** -52,
-                                 atol=2. ** -52)  # 20 ps atol
-allclose_sec = functools.partial(np.allclose, rtol=2. ** -52,
-                                 atol=2. ** -52 * 24 * 3600)  # 20 ps atol
+allclose_jd = functools.partial(np.allclose, rtol=2.0**-52, atol=0)
+allclose_jd2 = functools.partial(
+    np.allclose, rtol=2.0**-52, atol=2.0**-52
+)  # 20 ps atol
+allclose_sec = functools.partial(
+    np.allclose, rtol=2.0**-52, atol=2.0**-52 * 24 * 3600
+)  # 20 ps atol
 orig_auto_download = iers.conf.auto_download
 
 
@@ -44,20 +46,26 @@ class TestTimeDelta:
     """Test TimeDelta class"""
 
     def setup_method(self):
-        self.t = Time('2010-01-01', scale='utc')
-        self.t2 = Time('2010-01-02 00:00:01', scale='utc')
-        self.t3 = Time('2010-01-03 01:02:03', scale='utc', precision=9,
-                       in_subfmt='date_hms', out_subfmt='date_hm',
-                       location=(-75. * u.degree, 30. * u.degree, 500 * u.m))
-        self.t4 = Time('2010-01-01', scale='local')
-        self.dt = TimeDelta(100.0, format='sec')
-        self.dt_array = TimeDelta(np.arange(100, 1000, 100), format='sec')
+        self.t = Time("2010-01-01", scale="utc")
+        self.t2 = Time("2010-01-02 00:00:01", scale="utc")
+        self.t3 = Time(
+            "2010-01-03 01:02:03",
+            scale="utc",
+            precision=9,
+            in_subfmt="date_hms",
+            out_subfmt="date_hm",
+            location=(-75.0 * u.degree, 30.0 * u.degree, 500 * u.m),
+        )
+        self.t4 = Time("2010-01-01", scale="local")
+        self.dt = TimeDelta(100.0, format="sec")
+        self.dt_array = TimeDelta(np.arange(100, 1000, 100), format="sec")
 
     def test_sub(self):
         # time - time
         dt = self.t2 - self.t
-        assert (repr(dt).startswith("<TimeDelta object: scale='tai' "
-                                    "format='jd' value=1.00001157407"))
+        assert repr(dt).startswith(
+            "<TimeDelta object: scale='tai' format='jd' value=1.00001157407"
+        )
         assert allclose_jd(dt.jd, 86401.0 / 86400.0)
         assert allclose_sec(dt.sec, 86401.0)
 
@@ -95,10 +103,10 @@ class TestTimeDelta:
     def test_add_vector(self):
         """Check time arithmetic as well as properly keeping track of whether
         a time is a scalar or a vector"""
-        t = Time(0.0, format='mjd', scale='tai')
-        t2 = Time([0.0, 1.0], format='mjd', scale='tai')
-        dt = TimeDelta(100.0, format='jd')
-        dt2 = TimeDelta([100.0, 200.0], format='jd')
+        t = Time(0.0, format="mjd", scale="tai")
+        t2 = Time([0.0, 1.0], format="mjd", scale="tai")
+        dt = TimeDelta(100.0, format="jd")
+        dt2 = TimeDelta([100.0, 200.0], format="jd")
 
         out = t + dt
         assert allclose_jd(out.mjd, 100.0)
@@ -140,10 +148,10 @@ class TestTimeDelta:
     def test_sub_vector(self):
         """Check time arithmetic as well as properly keeping track of whether
         a time is a scalar or a vector"""
-        t = Time(0.0, format='mjd', scale='tai')
-        t2 = Time([0.0, 1.0], format='mjd', scale='tai')
-        dt = TimeDelta(100.0, format='jd')
-        dt2 = TimeDelta([100.0, 200.0], format='jd')
+        t = Time(0.0, format="mjd", scale="tai")
+        t2 = Time([0.0, 1.0], format="mjd", scale="tai")
+        dt = TimeDelta(100.0, format="jd")
+        dt2 = TimeDelta([100.0, 200.0], format="jd")
 
         out = t - dt
         assert allclose_jd(out.mjd, -100.0)
@@ -165,15 +173,16 @@ class TestTimeDelta:
         assert allclose_jd(out.jd, [0.0, -100.0])
         assert not out.isscalar
 
-    @pytest.mark.parametrize('values', [(2455197.5, 2455198.5),
-                                        ([2455197.5], [2455198.5])])
+    @pytest.mark.parametrize(
+        "values", [(2455197.5, 2455198.5), ([2455197.5], [2455198.5])]
+    )
     def test_copy_timedelta(self, values):
         """Test copying the values of a TimeDelta object by passing it into the
         Time initializer.
         """
         val1, val2 = values
-        t = Time(val1, format='jd', scale='utc')
-        t2 = Time(val2, format='jd', scale='utc')
+        t = Time(val1, format="jd", scale="utc")
+        t2 = Time(val2, format="jd", scale="utc")
         dt = t2 - t
 
         dt2 = TimeDelta(dt, copy=False)
@@ -187,7 +196,7 @@ class TestTimeDelta:
         assert dt._time.jd2 is not dt2._time.jd2
 
         # Include initializers
-        dt2 = TimeDelta(dt, format='sec')
+        dt2 = TimeDelta(dt, format="sec")
         assert allclose_sec(dt2.value, 86400.0)
 
     def test_neg_abs(self):
@@ -202,12 +211,12 @@ class TestTimeDelta:
     def test_mul_div(self):
         for dt in (self.dt, self.dt_array):
             dt2 = dt + dt + dt
-            dt3 = 3. * dt
+            dt3 = 3.0 * dt
             assert allclose_jd(dt2.jd, dt3.jd)
-            dt4 = dt3 / 3.
+            dt4 = dt3 / 3.0
             assert allclose_jd(dt4.jd, dt.jd)
         dt5 = self.dt * np.arange(3)
-        assert dt5[0].jd == 0.
+        assert dt5[0].jd == 0.0
         assert dt5[-1].jd == (self.dt + self.dt).jd
         dt6 = self.dt * [0, 1, 2]
         assert np.all(dt6.jd == dt5.jd)
@@ -217,9 +226,10 @@ class TestTimeDelta:
             self.dt * object()
 
     def test_mean(self):
-
         def is_consistent(time_delta: TimeDelta):
-            mean_expected = (np.sum(time_delta.jd1) + np.sum(time_delta.jd2)) / time_delta.size
+            mean_expected = (
+                np.sum(time_delta.jd1) + np.sum(time_delta.jd2)
+            ) / time_delta.size
             mean_test = time_delta.mean().jd1 + time_delta.mean().jd2
             return mean_test == mean_expected
 
@@ -228,7 +238,7 @@ class TestTimeDelta:
 
     def test_keep_properties(self):
         # closes #1924 (partially)
-        dt = TimeDelta(1000., format='sec')
+        dt = TimeDelta(1000.0, format="sec")
         for t in (self.t, self.t3):
             ta = t + dt
             assert ta.location is t.location
@@ -249,60 +259,62 @@ class TestTimeDelta:
             assert ts.out_subfmt == t.out_subfmt
 
         t_tdb = self.t.tdb
-        assert hasattr(t_tdb, '_delta_tdb_tt')
-        assert not hasattr(t_tdb, '_delta_ut1_utc')
+        assert hasattr(t_tdb, "_delta_tdb_tt")
+        assert not hasattr(t_tdb, "_delta_ut1_utc")
         t_tdb_ut1 = t_tdb.ut1
-        assert hasattr(t_tdb_ut1, '_delta_tdb_tt')
-        assert hasattr(t_tdb_ut1, '_delta_ut1_utc')
+        assert hasattr(t_tdb_ut1, "_delta_tdb_tt")
+        assert hasattr(t_tdb_ut1, "_delta_ut1_utc")
         t_tdb_ut1_utc = t_tdb_ut1.utc
-        assert hasattr(t_tdb_ut1_utc, '_delta_tdb_tt')
-        assert hasattr(t_tdb_ut1_utc, '_delta_ut1_utc')
+        assert hasattr(t_tdb_ut1_utc, "_delta_tdb_tt")
+        assert hasattr(t_tdb_ut1_utc, "_delta_ut1_utc")
         # adding or subtracting some time should remove the delta's
         # since these are time-dependent and should be recalculated
         for op in (operator.add, operator.sub):
             t1 = op(t_tdb, dt)
-            assert not hasattr(t1, '_delta_tdb_tt')
-            assert not hasattr(t1, '_delta_ut1_utc')
+            assert not hasattr(t1, "_delta_tdb_tt")
+            assert not hasattr(t1, "_delta_ut1_utc")
             t2 = op(t_tdb_ut1, dt)
-            assert not hasattr(t2, '_delta_tdb_tt')
-            assert not hasattr(t2, '_delta_ut1_utc')
+            assert not hasattr(t2, "_delta_tdb_tt")
+            assert not hasattr(t2, "_delta_ut1_utc")
             t3 = op(t_tdb_ut1_utc, dt)
-            assert not hasattr(t3, '_delta_tdb_tt')
-            assert not hasattr(t3, '_delta_ut1_utc')
+            assert not hasattr(t3, "_delta_tdb_tt")
+            assert not hasattr(t3, "_delta_ut1_utc")
 
     def test_set_format(self):
         """
         Test basics of setting format attribute.
         """
-        dt = TimeDelta(86400.0, format='sec')
+        dt = TimeDelta(86400.0, format="sec")
         assert dt.value == 86400.0
-        assert dt.format == 'sec'
+        assert dt.format == "sec"
 
-        dt.format = 'jd'
+        dt.format = "jd"
         assert dt.value == 1.0
-        assert dt.format == 'jd'
+        assert dt.format == "jd"
 
-        dt.format = 'datetime'
+        dt.format = "datetime"
         assert dt.value == timedelta(days=1)
-        assert dt.format == 'datetime'
+        assert dt.format == "datetime"
 
     def test_from_non_float(self):
-        dt = TimeDelta('1.000000000000001', format='jd')
-        assert dt != TimeDelta(1.000000000000001, format='jd')  # precision loss.
-        assert dt == TimeDelta(1, .000000000000001, format='jd')
-        dt2 = TimeDelta(Decimal('1.000000000000001'), format='jd')
+        dt = TimeDelta("1.000000000000001", format="jd")
+        assert dt != TimeDelta(1.000000000000001, format="jd")  # precision loss.
+        assert dt == TimeDelta(1, 0.000000000000001, format="jd")
+        dt2 = TimeDelta(Decimal("1.000000000000001"), format="jd")
         assert dt2 == dt
 
     def test_to_value(self):
-        dt = TimeDelta(86400.0, format='sec')
-        assert dt.to_value('jd') == 1.
-        assert dt.to_value('jd', 'str') == '1.0'
-        assert dt.to_value('sec', subfmt='str') == '86400.0'
-        with pytest.raises(ValueError, match=("not one of the known formats.*"
-                                              "failed to parse as a unit")):
-            dt.to_value('julian')
+        dt = TimeDelta(86400.0, format="sec")
+        assert dt.to_value("jd") == 1.0
+        assert dt.to_value("jd", "str") == "1.0"
+        assert dt.to_value("sec", subfmt="str") == "86400.0"
+        with pytest.raises(
+            ValueError,
+            match="not one of the known formats.*failed to parse as a unit",
+        ):
+            dt.to_value("julian")
 
-        with pytest.raises(TypeError, match='missing required format or unit'):
+        with pytest.raises(TypeError, match="missing required format or unit"):
             dt.to_value()
 
 
@@ -312,23 +324,29 @@ class TestTimeDeltaScales:
 
     def setup_method(self):
         # pick a date that includes a leap second for better testing
-        self.iso_times = ['2012-06-30 12:00:00', '2012-06-30 23:59:59',
-                          '2012-07-01 00:00:00', '2012-07-01 12:00:00']
-        self.t = {scale: Time(self.iso_times, scale=scale, precision=9)
-                  for scale in TIME_SCALES}
-        self.dt = {scale: self.t[scale] - self.t[scale][0]
-                   for scale in TIME_SCALES}
+        self.iso_times = [
+            "2012-06-30 12:00:00",
+            "2012-06-30 23:59:59",
+            "2012-07-01 00:00:00",
+            "2012-07-01 12:00:00",
+        ]
+        self.t = {
+            scale: Time(self.iso_times, scale=scale, precision=9)
+            for scale in TIME_SCALES
+        }
+        self.dt = {scale: self.t[scale] - self.t[scale][0] for scale in TIME_SCALES}
 
     def test_delta_scales_definition(self):
         for scale in list(TIME_DELTA_SCALES) + [None]:
-            TimeDelta([0., 1., 10.], format='sec', scale=scale)
+            TimeDelta([0.0, 1.0, 10.0], format="sec", scale=scale)
 
         with pytest.raises(ScaleValueError):
-            TimeDelta([0., 1., 10.], format='sec', scale='utc')
+            TimeDelta([0.0, 1.0, 10.0], format="sec", scale="utc")
 
-    @pytest.mark.parametrize(('scale1', 'scale2'),
-                             list(itertools.product(STANDARD_TIME_SCALES,
-                                                    STANDARD_TIME_SCALES)))
+    @pytest.mark.parametrize(
+        ("scale1", "scale2"),
+        list(itertools.product(STANDARD_TIME_SCALES, STANDARD_TIME_SCALES)),
+    )
     def test_standard_scales_for_time_minus_time(self, scale1, scale2):
         """T(X) - T2(Y)  -- does T(X) - T2(Y).X and return dT(X)
         and T(X) +/- dT(Y)  -- does (in essence) (T(X).Y +/- dT(Y)).X
@@ -344,8 +362,8 @@ class TestTimeDeltaScales:
         if scale1 in TIME_DELTA_SCALES:
             assert dt.scale == scale1
         else:
-            assert scale1 == 'utc'
-            assert dt.scale == 'tai'
+            assert scale1 == "utc"
+            assert dt.scale == "tai"
 
         # now check with delta time; also check reversibility
         t1_recover_t2_scale = t2 + dt
@@ -358,7 +376,7 @@ class TestTimeDeltaScales:
         assert allclose_jd(t2_recover.jd, t2.jd)
 
     def test_local_scales_for_time_minus_time(self):
-        """ T1(local) - T2(local) should return dT(local)
+        """T1(local) - T2(local) should return dT(local)
         T1(local) +/- dT(local) or T1(local) +/- Quantity(time-like) should
         also return T(local)
 
@@ -369,17 +387,17 @@ class TestTimeDeltaScales:
         Also tests that subtracting two Time objects, one having local time
         scale and other having standard time scale should raise TypeError.
         """
-        t1 = self.t['local']
-        t2 = Time('2010-01-01', scale='local')
+        t1 = self.t["local"]
+        t2 = Time("2010-01-01", scale="local")
         dt = t1 - t2
-        assert dt.scale == 'local'
+        assert dt.scale == "local"
 
         # now check with delta time
         t1_recover = t2 + dt
-        assert t1_recover.scale == 'local'
+        assert t1_recover.scale == "local"
         assert allclose_jd(t1_recover.jd, t1.jd)
         # check that dT(None) can be subtracted from T(local)
-        dt2 = TimeDelta([10.], format='sec', scale=None)
+        dt2 = TimeDelta([10.0], format="sec", scale=None)
         t3 = t2 - dt2
         assert t3.scale == t2.scale
         # check that time quantity can be subtracted from T(local)
@@ -387,7 +405,7 @@ class TestTimeDeltaScales:
         assert (t2 - q).value == (t2 - dt2).value
         # Check that one cannot subtract/add times with a standard scale
         # from a local one (or vice versa)
-        t1 = self.t['local']
+        t1 = self.t["local"]
         for scale in STANDARD_TIME_SCALES:
             t2 = self.t[scale]
             with pytest.raises(TypeError):
@@ -408,74 +426,75 @@ class TestTimeDeltaScales:
         Returns delta time in scale X
         """
         # geocentric timescales
-        dt_tai = self.dt['tai']
-        dt_tt = self.dt['tt']
+        dt_tai = self.dt["tai"]
+        dt_tt = self.dt["tt"]
         dt0 = dt_tai - dt_tt
-        assert dt0.scale == 'tai'
+        assert dt0.scale == "tai"
         # tai and tt have the same scale, so differences should be the same
-        assert allclose_sec(dt0.sec, 0.)
+        assert allclose_sec(dt0.sec, 0.0)
 
-        dt_tcg = self.dt['tcg']
+        dt_tcg = self.dt["tcg"]
         dt1 = dt_tai - dt_tcg
-        assert dt1.scale == 'tai'
+        assert dt1.scale == "tai"
         # tai and tcg do not have the same scale, so differences different
-        assert not allclose_sec(dt1.sec, 0.)
+        assert not allclose_sec(dt1.sec, 0.0)
 
-        t_tai_tcg = self.t['tai'].tcg
+        t_tai_tcg = self.t["tai"].tcg
         dt_tai_tcg = t_tai_tcg - t_tai_tcg[0]
         dt2 = dt_tai - dt_tai_tcg
-        assert dt2.scale == 'tai'
+        assert dt2.scale == "tai"
         # but if tcg difference calculated from tai, it should roundtrip
-        assert allclose_sec(dt2.sec, 0.)
+        assert allclose_sec(dt2.sec, 0.0)
         # check that if we put TCG first, we get a TCG scale back
         dt3 = dt_tai_tcg - dt_tai
-        assert dt3.scale == 'tcg'
-        assert allclose_sec(dt3.sec, 0.)
+        assert dt3.scale == "tcg"
+        assert allclose_sec(dt3.sec, 0.0)
 
-        for scale in 'tdb', 'tcb', 'ut1':
+        for scale in "tdb", "tcb", "ut1":
             with pytest.raises(TypeError):
                 dt_tai - self.dt[scale]
 
         # barycentric timescales
-        dt_tcb = self.dt['tcb']
-        dt_tdb = self.dt['tdb']
+        dt_tcb = self.dt["tcb"]
+        dt_tdb = self.dt["tdb"]
         dt4 = dt_tcb - dt_tdb
-        assert dt4.scale == 'tcb'
-        assert not allclose_sec(dt1.sec, 0.)
+        assert dt4.scale == "tcb"
+        assert not allclose_sec(dt1.sec, 0.0)
 
-        t_tcb_tdb = self.t['tcb'].tdb
+        t_tcb_tdb = self.t["tcb"].tdb
         dt_tcb_tdb = t_tcb_tdb - t_tcb_tdb[0]
         dt5 = dt_tcb - dt_tcb_tdb
-        assert dt5.scale == 'tcb'
-        assert allclose_sec(dt5.sec, 0.)
+        assert dt5.scale == "tcb"
+        assert allclose_sec(dt5.sec, 0.0)
 
-        for scale in 'utc', 'tai', 'tt', 'tcg', 'ut1':
+        for scale in "utc", "tai", "tt", "tcg", "ut1":
             with pytest.raises(TypeError):
                 dt_tcb - self.dt[scale]
 
         # rotational timescale
-        dt_ut1 = self.dt['ut1']
+        dt_ut1 = self.dt["ut1"]
         dt5 = dt_ut1 - dt_ut1[-1]
-        assert dt5.scale == 'ut1'
-        assert dt5[-1].sec == 0.
+        assert dt5.scale == "ut1"
+        assert dt5[-1].sec == 0.0
 
-        for scale in 'utc', 'tai', 'tt', 'tcg', 'tcb', 'tdb':
+        for scale in "utc", "tai", "tt", "tcg", "tcb", "tdb":
             with pytest.raises(TypeError):
                 dt_ut1 - self.dt[scale]
 
         # local time scale
-        dt_local = self.dt['local']
+        dt_local = self.dt["local"]
         dt6 = dt_local - dt_local[-1]
-        assert dt6.scale == 'local'
-        assert dt6[-1].sec == 0.
+        assert dt6.scale == "local"
+        assert dt6[-1].sec == 0.0
 
-        for scale in 'utc', 'tai', 'tt', 'tcg', 'tcb', 'tdb', 'ut1':
+        for scale in "utc", "tai", "tt", "tcg", "tcb", "tdb", "ut1":
             with pytest.raises(TypeError):
                 dt_local - self.dt[scale]
 
     @pytest.mark.parametrize(
-        ('scale', 'op'), list(itertools.product(TIME_SCALES,
-                                                (operator.add, operator.sub))))
+        ("scale", "op"),
+        list(itertools.product(TIME_SCALES, (operator.add, operator.sub))),
+    )
     def test_scales_for_delta_scale_is_none(self, scale, op):
         """T(X) +/- dT(None) or T(X) +/- Quantity(time-like)
 
@@ -484,9 +503,9 @@ class TestTimeDeltaScales:
         The one exception is again for X=UTC, where TAI is assumed instead,
         so that a day is always defined as 86400 seconds.
         """
-        dt_none = TimeDelta([0., 1., -1., 1000.], format='sec')
+        dt_none = TimeDelta([0.0, 1.0, -1.0, 1000.0], format="sec")
         assert dt_none.scale is None
-        q_time = dt_none.to('s')
+        q_time = dt_none.to("s")
 
         dt = self.dt[scale]
         dt1 = op(dt, dt_none)
@@ -511,7 +530,7 @@ class TestTimeDeltaScales:
         assert t3.scale == t.scale
         assert allclose_jd(t3.jd, t1.jd)
 
-    @pytest.mark.parametrize('scale', TIME_SCALES)
+    @pytest.mark.parametrize("scale", TIME_SCALES)
     def test_delta_day_is_86400_seconds(self, scale):
         """TimeDelta or Quantity holding 1 day always means 24*60*60 seconds
 
@@ -519,25 +538,25 @@ class TestTimeDeltaScales:
         days are longer or shorter by one second.
         """
         t = self.t[scale]
-        dt_day = TimeDelta(1., format='jd')
-        q_day = dt_day.to('day')
+        dt_day = TimeDelta(1.0, format="jd")
+        q_day = dt_day.to("day")
 
         dt_day_leap = t[-1] - t[0]
         # ^ = exclusive or, so either equal and not UTC, or not equal and UTC
-        assert allclose_jd(dt_day_leap.jd, dt_day.jd) ^ (scale == 'utc')
+        assert allclose_jd(dt_day_leap.jd, dt_day.jd) ^ (scale == "utc")
 
         t1 = t[0] + dt_day
-        assert allclose_jd(t1.jd, t[-1].jd) ^ (scale == 'utc')
+        assert allclose_jd(t1.jd, t[-1].jd) ^ (scale == "utc")
         t2 = q_day + t[0]
-        assert allclose_jd(t2.jd, t[-1].jd) ^ (scale == 'utc')
+        assert allclose_jd(t2.jd, t[-1].jd) ^ (scale == "utc")
         t3 = t[-1] - dt_day
-        assert allclose_jd(t3.jd, t[0].jd) ^ (scale == 'utc')
+        assert allclose_jd(t3.jd, t[0].jd) ^ (scale == "utc")
         t4 = t[-1] - q_day
-        assert allclose_jd(t4.jd, t[0].jd) ^ (scale == 'utc')
+        assert allclose_jd(t4.jd, t[0].jd) ^ (scale == "utc")
 
 
 def test_timedelta_setitem():
-    t = TimeDelta([1, 2, 3] * u.d, format='jd')
+    t = TimeDelta([1, 2, 3] * u.d, format="jd")
 
     t[0] = 0.5
     assert allclose_jd(t.value, [0.5, 2, 3])
@@ -548,16 +567,16 @@ def test_timedelta_setitem():
     t[:] = 86400 * u.s
     assert allclose_jd(t.value, [1, 1, 1])
 
-    t[1] = TimeDelta(2, format='jd')
+    t[1] = TimeDelta(2, format="jd")
     assert allclose_jd(t.value, [1, 2, 1])
 
     with pytest.raises(ValueError) as err:
         t[1] = 1 * u.m
-    assert 'cannot convert value to a compatible TimeDelta' in str(err.value)
+    assert "cannot convert value to a compatible TimeDelta" in str(err.value)
 
 
 def test_timedelta_setitem_sec():
-    t = TimeDelta([1, 2, 3], format='sec')
+    t = TimeDelta([1, 2, 3], format="sec")
 
     t[0] = 0.5
     assert allclose_jd(t.value, [0.5, 2, 3])
@@ -568,16 +587,16 @@ def test_timedelta_setitem_sec():
     t[:] = 1 * u.day
     assert allclose_jd(t.value, [86400, 86400, 86400])
 
-    t[1] = TimeDelta(2, format='jd')
+    t[1] = TimeDelta(2, format="jd")
     assert allclose_jd(t.value, [86400, 86400 * 2, 86400])
 
     with pytest.raises(ValueError) as err:
         t[1] = 1 * u.m
-    assert 'cannot convert value to a compatible TimeDelta' in str(err.value)
+    assert "cannot convert value to a compatible TimeDelta" in str(err.value)
 
 
 def test_timedelta_mask():
-    t = TimeDelta([1, 2] * u.d, format='jd')
+    t = TimeDelta([1, 2] * u.d, format="jd")
     t[1] = np.ma.masked
     assert np.all(t.mask == [False, True])
     assert allclose_jd(t[0].value, 1)
@@ -586,44 +605,48 @@ def test_timedelta_mask():
 
 def test_python_timedelta_scalar():
     td = timedelta(days=1, seconds=1)
-    td1 = TimeDelta(td, format='datetime')
+    td1 = TimeDelta(td, format="datetime")
 
     assert td1.sec == 86401.0
 
-    td2 = TimeDelta(86401.0, format='sec')
+    td2 = TimeDelta(86401.0, format="sec")
     assert td2.datetime == td
 
 
 def test_python_timedelta_vector():
-    td = [[timedelta(days=1), timedelta(days=2)],
-          [timedelta(days=3), timedelta(days=4)]]
+    td = [
+        [timedelta(days=1), timedelta(days=2)],
+        [timedelta(days=3), timedelta(days=4)],
+    ]
 
-    td1 = TimeDelta(td, format='datetime')
+    td1 = TimeDelta(td, format="datetime")
 
     assert np.all(td1.jd == [[1, 2], [3, 4]])
 
-    td2 = TimeDelta([[1, 2], [3, 4]], format='jd')
+    td2 = TimeDelta([[1, 2], [3, 4]], format="jd")
     assert np.all(td2.datetime == td)
 
 
 def test_timedelta_to_datetime():
-    td = TimeDelta(1, format='jd')
+    td = TimeDelta(1, format="jd")
 
     assert td.to_datetime() == timedelta(days=1)
 
-    td2 = TimeDelta([[1, 2], [3, 4]], format='jd')
-    td = [[timedelta(days=1), timedelta(days=2)],
-          [timedelta(days=3), timedelta(days=4)]]
+    td2 = TimeDelta([[1, 2], [3, 4]], format="jd")
+    td = [
+        [timedelta(days=1), timedelta(days=2)],
+        [timedelta(days=3), timedelta(days=4)],
+    ]
 
     assert np.all(td2.to_datetime() == td)
 
 
 def test_insert_timedelta():
-    tm = TimeDelta([1, 2], format='sec')
+    tm = TimeDelta([1, 2], format="sec")
 
     # Insert a scalar using an auto-parsed string
-    tm2 = tm.insert(1, TimeDelta([10, 20], format='sec'))
-    assert np.all(tm2 == TimeDelta([1, 10, 20, 2], format='sec'))
+    tm2 = tm.insert(1, TimeDelta([10, 20], format="sec"))
+    assert np.all(tm2 == TimeDelta([1, 10, 20, 2], format="sec"))
 
 
 def test_no_units_warning():
@@ -641,8 +664,8 @@ def test_no_units_warning():
         assert np.all(delta.to_value(u.day) == [1, 2, 3])
 
     with pytest.warns(TimeDeltaMissingUnitWarning):
-        t = Time('2012-01-01') + 1
-        assert t.isot[:10] == '2012-01-02'
+        t = Time("2012-01-01") + 1
+        assert t.isot[:10] == "2012-01-02"
 
     with pytest.warns(TimeDeltaMissingUnitWarning):
         comp = TimeDelta([1, 2, 3], format="jd") >= 2

--- a/astropy/time/tests/test_fast_parser.py
+++ b/astropy/time/tests/test_fast_parser.py
@@ -7,49 +7,64 @@ import pytest
 
 from astropy.time import Time, TimeYearDayTime, conf
 
-iso_times = ['2000-02-29', '1981-12-31 12:13', '1981-12-31 12:13:14', '2020-12-31 12:13:14.56']
-isot_times = [re.sub(' ', 'T', tm) for tm in iso_times]
-yday_times = ['2000:060', '1981:365:12:13:14', '1981:365:12:13', '2020:366:12:13:14.56']
+iso_times = [
+    "2000-02-29",
+    "1981-12-31 12:13",
+    "1981-12-31 12:13:14",
+    "2020-12-31 12:13:14.56",
+]
+isot_times = [re.sub(" ", "T", tm) for tm in iso_times]
+yday_times = ["2000:060", "1981:365:12:13:14", "1981:365:12:13", "2020:366:12:13:14.56"]
 # Transpose the array to check that strides are dealt with correctly.
-yday_array = np.array([['2000:060', '1981:365:12:13:14'],
-                       ['1981:365:12:13', '2020:366:12:13:14.56']]).T
+yday_array = np.array(
+    [["2000:060", "1981:365:12:13:14"], ["1981:365:12:13", "2020:366:12:13:14.56"]]
+).T
 
 
 def test_fast_conf():
     # Default is to try C parser and then Python parser. Both fail so we get the
     # Python message.
-    assert conf.use_fast_parser == 'True'  # default
-    with pytest.raises(ValueError, match='Time 2000:0601 does not match yday format'):
-        Time('2000:0601', format='yday')
+    assert conf.use_fast_parser == "True"  # default
+    with pytest.raises(ValueError, match="Time 2000:0601 does not match yday format"):
+        Time("2000:0601", format="yday")
 
     # This is one case where Python parser is different from C parser because the
     # Python parser has a bug and fails with a trailing ".", but C parser works.
-    Time('2020:150:12:13:14.', format='yday')
-    with conf.set_temp('use_fast_parser', 'force'):
-        Time('2020:150:12:13:14.', format='yday')
-    with conf.set_temp('use_fast_parser', 'False'):
-        with pytest.raises(ValueError, match='could not convert string to float'):
-            Time('2020:150:12:13:14.', format='yday')
+    Time("2020:150:12:13:14.", format="yday")
+    with conf.set_temp("use_fast_parser", "force"):
+        Time("2020:150:12:13:14.", format="yday")
+    with conf.set_temp("use_fast_parser", "False"):
+        with pytest.raises(ValueError, match="could not convert string to float"):
+            Time("2020:150:12:13:14.", format="yday")
 
-    with conf.set_temp('use_fast_parser', 'False'):
-        assert conf.use_fast_parser == 'False'
+    with conf.set_temp("use_fast_parser", "False"):
+        assert conf.use_fast_parser == "False"
         # Make sure that this is really giving the Python parser
-        with pytest.raises(ValueError, match='Time 2000:0601 does not match yday format'):
-            Time('2000:0601', format='yday')
+        with pytest.raises(
+            ValueError, match="Time 2000:0601 does not match yday format"
+        ):
+            Time("2000:0601", format="yday")
 
-    with conf.set_temp('use_fast_parser', 'force'):
-        assert conf.use_fast_parser == 'force'
+    with conf.set_temp("use_fast_parser", "force"):
+        assert conf.use_fast_parser == "force"
         # Make sure that this is really giving the Python parser
-        err = 'fast C time string parser failed: time string ends in middle of component'
+        err = (
+            "fast C time string parser failed: time string ends in middle of component"
+        )
         with pytest.raises(ValueError, match=err):
-            Time('2000:0601', format='yday')
+            Time("2000:0601", format="yday")
 
 
-@pytest.mark.parametrize('times,format', [(iso_times, 'iso'),
-                                          (isot_times, 'isot'),
-                                          (yday_times, 'yday'),
-                                          (yday_array, 'yday')])
-@pytest.mark.parametrize('variant', [0, 1, 2])
+@pytest.mark.parametrize(
+    "times,format",
+    [
+        (iso_times, "iso"),
+        (isot_times, "isot"),
+        (yday_times, "yday"),
+        (yday_array, "yday"),
+    ],
+)
+@pytest.mark.parametrize("variant", [0, 1, 2])
 def test_fast_matches_python(times, format, variant):
     if variant == 0:
         pass  # list/array of different values (null terminated strings included)
@@ -58,10 +73,10 @@ def test_fast_matches_python(times, format, variant):
     elif variant == 2:
         times = [times[-1]] * 2  # list/array of identical values (no null terminations)
 
-    with conf.set_temp('use_fast_parser', 'False'):
+    with conf.set_temp("use_fast_parser", "False"):
         tms_py = Time(times, format=format)
 
-    with conf.set_temp('use_fast_parser', 'force'):
+    with conf.set_temp("use_fast_parser", "force"):
         tms_c = Time(times, format=format)
 
     # Times are binary identical
@@ -75,48 +90,55 @@ def test_fast_yday_exceptions():
     #         4: 'non-digit found where digit (0-9) required',
     #         5: 'bad day of year (1 <= doy <= 365 or 366 for leap year'}
 
-    with conf.set_temp('use_fast_parser', 'force'):
-        for times, err in [('2020:150:12', 'time string ends at beginning of component'),
-                           ('2020:150:1', 'time string ends in middle of component'),
-                           ('2020:150*12:13:14', 'required delimiter character'),
-                           ('2020:15*:12:13:14', 'non-digit found where digit'),
-                           ('2020:999:12:13:14', 'bad day of year')]:
+    with conf.set_temp("use_fast_parser", "force"):
+        for times, err in [
+            ("2020:150:12", "time string ends at beginning of component"),
+            ("2020:150:1", "time string ends in middle of component"),
+            ("2020:150*12:13:14", "required delimiter character"),
+            ("2020:15*:12:13:14", "non-digit found where digit"),
+            ("2020:999:12:13:14", "bad day of year"),
+        ]:
             with pytest.raises(ValueError, match=err):
-                Time(times, format='yday')
+                Time(times, format="yday")
 
 
 def test_fast_iso_exceptions():
-    with conf.set_temp('use_fast_parser', 'force'):
-        for times, err in [('2020-10-10 12', 'time string ends at beginning of component'),
-                           ('2020-10-10 1', 'time string ends in middle of component'),
-                           ('2020*10-10 12:13:14', 'required delimiter character'),
-                           ('2020-10-10 *2:13:14', 'non-digit found where digit')]:
+    with conf.set_temp("use_fast_parser", "force"):
+        for times, err in [
+            ("2020-10-10 12", "time string ends at beginning of component"),
+            ("2020-10-10 1", "time string ends in middle of component"),
+            ("2020*10-10 12:13:14", "required delimiter character"),
+            ("2020-10-10 *2:13:14", "non-digit found where digit"),
+        ]:
             with pytest.raises(ValueError, match=err):
-                Time(times, format='iso')
+                Time(times, format="iso")
 
 
 def test_fast_non_ascii():
-    with pytest.raises(ValueError, match='input is not pure ASCII'):
-        with conf.set_temp('use_fast_parser', 'force'):
-            Time('2020-01-01 1ᛦ:13:14.4324')
+    with pytest.raises(ValueError, match="input is not pure ASCII"):
+        with conf.set_temp("use_fast_parser", "force"):
+            Time("2020-01-01 1ᛦ:13:14.4324")
 
 
 def test_fast_subclass():
     """Test subclass where use_fast_parser class attribute is not in __dict__"""
+
     class TimeYearDayTimeSubClass(TimeYearDayTime):
-        name = 'yday_subclass'
+        name = "yday_subclass"
 
     # Inheritance works
-    assert hasattr(TimeYearDayTimeSubClass, 'fast_parser_pars')
-    assert 'fast_parser_pars' not in TimeYearDayTimeSubClass.__dict__
+    assert hasattr(TimeYearDayTimeSubClass, "fast_parser_pars")
+    assert "fast_parser_pars" not in TimeYearDayTimeSubClass.__dict__
 
     try:
         # For YearDayTime, forcing the fast parser with a bad date will give
         # "fast C time string parser failed: time string ends in middle of component".
         # But since YearDayTimeSubClass does not have fast_parser_pars it will
         # use the Python parser.
-        with pytest.raises(ValueError, match='Time 2000:0601 does not match yday_subclass format'):
-            with conf.set_temp('use_fast_parser', 'force'):
-                Time('2000:0601', format='yday_subclass')
+        with pytest.raises(
+            ValueError, match="Time 2000:0601 does not match yday_subclass format"
+        ):
+            with conf.set_temp("use_fast_parser", "force"):
+                Time("2000:0601", format="yday_subclass")
     finally:
-        del TimeYearDayTimeSubClass._registry['yday_subclass']
+        del TimeYearDayTimeSubClass._registry["yday_subclass"]

--- a/astropy/time/tests/test_functions.py
+++ b/astropy/time/tests/test_functions.py
@@ -8,10 +8,8 @@ from astropy.units.quantity_helper.function_helpers import ARRAY_FUNCTION_ENABLE
 
 
 class TestFunctionsTime:
-
     def setup_class(cls):
-        cls.t = Time(50000, np.arange(8).reshape(4, 2), format='mjd',
-                     scale='tai')
+        cls.t = Time(50000, np.arange(8).reshape(4, 2), format="mjd", scale="tai")
 
     def check(self, func, cls=None, scale=None, format=None, *args, **kwargs):
         if cls is None:
@@ -29,30 +27,33 @@ class TestFunctionsTime:
 
         assert np.all(out == expected)
 
-    @pytest.mark.parametrize('axis', (0, 1))
+    @pytest.mark.parametrize("axis", (0, 1))
     def test_diff(self, axis):
-        self.check(np.diff, axis=axis, cls=TimeDelta, format='jd')
+        self.check(np.diff, axis=axis, cls=TimeDelta, format="jd")
 
 
 class TestFunctionsTimeDelta(TestFunctionsTime):
-
     def setup_class(cls):
-        cls.t = TimeDelta(np.arange(8).reshape(4, 2), format='jd',
-                          scale='tai')
+        cls.t = TimeDelta(np.arange(8).reshape(4, 2), format="jd", scale="tai")
 
-    @pytest.mark.parametrize('axis', (0, 1, None))
-    @pytest.mark.parametrize('func', (np.sum, np.mean, np.median))
+    @pytest.mark.parametrize("axis", (0, 1, None))
+    @pytest.mark.parametrize("func", (np.sum, np.mean, np.median))
     def test_sum_like(self, func, axis):
         self.check(func, axis=axis)
 
 
-@pytest.mark.xfail(not ARRAY_FUNCTION_ENABLED,
-                   reason="Needs __array_function__ support")
-@pytest.mark.parametrize('attribute', ['shape', 'ndim', 'size'])
-@pytest.mark.parametrize('t', [
-    Time('2001-02-03T04:05:06'),
-    Time(50000, np.arange(8).reshape(4, 2), format='mjd', scale='tai'),
-    TimeDelta(100, format='jd')])
+@pytest.mark.xfail(
+    not ARRAY_FUNCTION_ENABLED, reason="Needs __array_function__ support"
+)
+@pytest.mark.parametrize("attribute", ["shape", "ndim", "size"])
+@pytest.mark.parametrize(
+    "t",
+    [
+        Time("2001-02-03T04:05:06"),
+        Time(50000, np.arange(8).reshape(4, 2), format="mjd", scale="tai"),
+        TimeDelta(100, format="jd"),
+    ],
+)
 def test_shape_attribute_functions(t, attribute):
     # Regression test for
     # https://github.com/astropy/astropy/issues/8610#issuecomment-736855217

--- a/astropy/time/tests/test_guess.py
+++ b/astropy/time/tests/test_guess.py
@@ -9,23 +9,27 @@ class TestGuess:
     """Test guessing the input value format"""
 
     def test_guess1(self):
-        times = ['1999-01-01 00:00:00.123456789', '2010-01-01 00:00:00']
-        t = Time(times, scale='utc')
-        assert (repr(t) == "<Time object: scale='utc' format='iso' "
-                "value=['1999-01-01 00:00:00.123' '2010-01-01 00:00:00.000']>")
+        times = ["1999-01-01 00:00:00.123456789", "2010-01-01 00:00:00"]
+        t = Time(times, scale="utc")
+        assert (
+            repr(t) == "<Time object: scale='utc' format='iso' "
+            "value=['1999-01-01 00:00:00.123' '2010-01-01 00:00:00.000']>"
+        )
 
     def test_guess2(self):
-        times = ['1999-01-01 00:00:00.123456789', '2010-01 00:00:00']
+        times = ["1999-01-01 00:00:00.123456789", "2010-01 00:00:00"]
         with pytest.raises(ValueError):
-            Time(times, scale='utc')
+            Time(times, scale="utc")
 
     def test_guess3(self):
-        times = ['1999:001:00:00:00.123456789', '2010:001']
-        t = Time(times, scale='utc')
-        assert (repr(t) == "<Time object: scale='utc' format='yday' "
-                "value=['1999:001:00:00:00.123' '2010:001:00:00:00.000']>")
+        times = ["1999:001:00:00:00.123456789", "2010:001"]
+        t = Time(times, scale="utc")
+        assert (
+            repr(t) == "<Time object: scale='utc' format='yday' "
+            "value=['1999:001:00:00:00.123' '2010:001:00:00:00.000']>"
+        )
 
     def test_guess4(self):
         times = [10, 20]
         with pytest.raises(ValueError):
-            Time(times, scale='utc')
+            Time(times, scale="utc")

--- a/astropy/time/tests/test_mask.py
+++ b/astropy/time/tests/test_mask.py
@@ -12,18 +12,22 @@ from astropy.utils import iers
 from astropy.utils.compat import PYTHON_LT_3_11
 from astropy.utils.compat.optional_deps import HAS_H5PY
 
-allclose_sec = functools.partial(np.allclose, rtol=2. ** -52,
-                                 atol=2. ** -52 * 24 * 3600)  # 20 ps atol
+allclose_sec = functools.partial(
+    np.allclose, rtol=2.0**-52, atol=2.0**-52 * 24 * 3600
+)  # 20 ps atol
 is_masked = np.ma.is_masked
 
 # The first form is expanded to r"can't set attribute '{0}'" in Python 3.10, and replaced
 # with the more informative second form as of 3.11 (python/cpython#31311).
-no_setter_err = (r"can't set attribute" if PYTHON_LT_3_11
-                 else r"property '{0}' of '{1}' object has no setter")
+no_setter_err = (
+    r"can't set attribute"
+    if PYTHON_LT_3_11
+    else r"property '{0}' of '{1}' object has no setter"
+)
 
 
 def test_simple():
-    t = Time([1, 2, 3], format='cxcsec')
+    t = Time([1, 2, 3], format="cxcsec")
     assert t.masked is False
     assert np.all(t.mask == [False, False, False])
 
@@ -46,47 +50,54 @@ def test_simple():
 
 
 def test_scalar_init():
-    t = Time('2000:001')
+    t = Time("2000:001")
     assert t.masked is False
     assert t.mask == np.array(False)
 
 
 def test_mask_not_writeable():
-    t = Time('2000:001')
-    with pytest.raises(AttributeError, match=no_setter_err.format('mask', t.__class__.__name__)):
+    t = Time("2000:001")
+    with pytest.raises(
+        AttributeError, match=no_setter_err.format("mask", t.__class__.__name__)
+    ):
         t.mask = True
 
-    t = Time(['2000:001'])
+    t = Time(["2000:001"])
     with pytest.raises(ValueError) as err:
         t.mask[0] = True
     assert "assignment destination is read-only" in str(err.value)
 
 
 def test_str():
-    t = Time(['2000:001', '2000:002'])
+    t = Time(["2000:001", "2000:002"])
     t[1] = np.ma.masked
     assert str(t) == "['2000:001:00:00:00.000' --]"
-    assert repr(t) == "<Time object: scale='utc' format='yday' value=['2000:001:00:00:00.000' --]>"
+    assert (
+        repr(t)
+        == "<Time object: scale='utc' format='yday' value=['2000:001:00:00:00.000' --]>"
+    )
 
-    expected = ["masked_array(data=['2000-01-01 00:00:00.000', --],",
-                '             mask=[False,  True],',
-                "       fill_value='N/A',",
-                "            dtype='<U23')"]
+    expected = [
+        "masked_array(data=['2000-01-01 00:00:00.000', --],",
+        "             mask=[False,  True],",
+        "       fill_value='N/A',",
+        "            dtype='<U23')",
+    ]
 
     # Note that we need to take care to allow for big-endian platforms,
     # for which the dtype will be >U23 instead of <U23, which we do with
     # the call to replace().
-    assert repr(t.iso).replace('>U23', '<U23').splitlines() == expected
+    assert repr(t.iso).replace(">U23", "<U23").splitlines() == expected
 
     # Assign value to unmask
-    t[1] = '2000:111'
+    t[1] = "2000:111"
     assert str(t) == "['2000:001:00:00:00.000' '2000:111:00:00:00.000']"
     assert t.masked is False
 
 
 def test_transform():
-    with iers.conf.set_temp('auto_download', False):
-        t = Time(['2000:001', '2000:002'])
+    with iers.conf.set_temp("auto_download", False):
+        t = Time(["2000:001", "2000:002"])
         t[1] = np.ma.masked
 
         # Change scale (this tests the ERFA machinery with masking as well)
@@ -104,34 +115,32 @@ def test_transform():
 
 def test_masked_input():
     v0 = np.ma.MaskedArray([[1, 2], [3, 4]])  # No masked elements
-    v1 = np.ma.MaskedArray([[1, 2], [3, 4]],
-                           mask=[[True, False], [False, False]])
-    v2 = np.ma.MaskedArray([[10, 20], [30, 40]],
-                           mask=[[False, False], [False, True]])
+    v1 = np.ma.MaskedArray([[1, 2], [3, 4]], mask=[[True, False], [False, False]])
+    v2 = np.ma.MaskedArray([[10, 20], [30, 40]], mask=[[False, False], [False, True]])
 
     # Init from various combinations of masked arrays
-    t = Time(v0, format='cxcsec')
+    t = Time(v0, format="cxcsec")
     assert np.ma.allclose(t.value, v0)
     assert np.all(t.mask == [[False, False], [False, False]])
     assert t.masked is False
 
-    t = Time(v1, format='cxcsec')
+    t = Time(v1, format="cxcsec")
     assert np.ma.allclose(t.value, v1)
     assert np.all(t.mask == v1.mask)
     assert np.all(t.value.mask == v1.mask)
     assert t.masked is True
 
-    t = Time(v1, v2, format='cxcsec')
+    t = Time(v1, v2, format="cxcsec")
     assert np.ma.allclose(t.value, v1 + v2)
     assert np.all(t.mask == (v1 + v2).mask)
     assert t.masked is True
 
-    t = Time(v0, v1, format='cxcsec')
+    t = Time(v0, v1, format="cxcsec")
     assert np.ma.allclose(t.value, v0 + v1)
     assert np.all(t.mask == (v0 + v1).mask)
     assert t.masked is True
 
-    t = Time(0, v2, format='cxcsec')
+    t = Time(0, v2, format="cxcsec")
     assert np.ma.allclose(t.value, v2)
     assert np.all(t.mask == v2.mask)
     assert t.masked is True
@@ -149,59 +158,59 @@ def test_all_masked_input():
     # Test with jd=0 and jd=np.nan. Both triggered an exception prior to #9624
     # due to astropy.utils.exceptions.ErfaError.
     for val in (0, np.nan):
-        t = Time(np.ma.masked_array([val], mask=[True]), format='jd')
-        assert str(t.iso) == '[--]'
+        t = Time(np.ma.masked_array([val], mask=[True]), format="jd")
+        assert str(t.iso) == "[--]"
 
 
 def test_serialize_fits_masked(tmp_path):
-    tm = Time([1, 2, 3], format='cxcsec')
+    tm = Time([1, 2, 3], format="cxcsec")
     tm[1] = np.ma.masked
 
-    fn = tmp_path / 'tempfile.fits'
+    fn = tmp_path / "tempfile.fits"
     t = Table([tm])
     t.write(fn)
 
     t2 = Table.read(fn, astropy_native=True)
 
     # Time FITS handling does not current round-trip format in FITS
-    t2['col0'].format = tm.format
+    t2["col0"].format = tm.format
 
-    assert t2['col0'].masked
-    assert np.all(t2['col0'].mask == [False, True, False])
-    assert np.all(t2['col0'].value == t['col0'].value)
+    assert t2["col0"].masked
+    assert np.all(t2["col0"].mask == [False, True, False])
+    assert np.all(t2["col0"].value == t["col0"].value)
 
 
-@pytest.mark.skipif(not HAS_H5PY, reason='Needs h5py')
+@pytest.mark.skipif(not HAS_H5PY, reason="Needs h5py")
 def test_serialize_hdf5_masked(tmp_path):
-    tm = Time([1, 2, 3], format='cxcsec')
+    tm = Time([1, 2, 3], format="cxcsec")
     tm[1] = np.ma.masked
 
-    fn = tmp_path / 'tempfile.hdf5'
+    fn = tmp_path / "tempfile.hdf5"
     t = Table([tm])
-    t.write(fn, path='root', serialize_meta=True)
+    t.write(fn, path="root", serialize_meta=True)
     t2 = Table.read(fn)
 
-    assert t2['col0'].masked
-    assert np.all(t2['col0'].mask == [False, True, False])
-    assert np.all(t2['col0'].value == t['col0'].value)
+    assert t2["col0"].masked
+    assert np.all(t2["col0"].mask == [False, True, False])
+    assert np.all(t2["col0"].value == t["col0"].value)
 
 
 # Ignore warning in MIPS https://github.com/astropy/astropy/issues/9750
-@pytest.mark.filterwarnings('ignore:invalid value encountered')
-@pytest.mark.parametrize('serialize_method', ['jd1_jd2', 'formatted_value'])
+@pytest.mark.filterwarnings("ignore:invalid value encountered")
+@pytest.mark.parametrize("serialize_method", ["jd1_jd2", "formatted_value"])
 def test_serialize_ecsv_masked(serialize_method, tmp_path):
-    tm = Time([1, 2, 3], format='cxcsec')
+    tm = Time([1, 2, 3], format="cxcsec")
     tm[1] = np.ma.masked
 
-    tm.info.serialize_method['ecsv'] = serialize_method
+    tm.info.serialize_method["ecsv"] = serialize_method
 
-    fn = tmp_path / 'tempfile.ecsv'
+    fn = tmp_path / "tempfile.ecsv"
     t = Table([tm])
     t.write(fn)
     t2 = Table.read(fn)
 
-    assert t2['col0'].masked
-    assert np.all(t2['col0'].mask == [False, True, False])
+    assert t2["col0"].masked
+    assert np.all(t2["col0"].mask == [False, True, False])
     # Serializing formatted_value loses some precision.
-    atol = 0.1*u.us if serialize_method == 'formatted_value' else 1*u.ps
-    assert np.all(abs(t2['col0'] - t['col0']) <= atol)
+    atol = 0.1 * u.us if serialize_method == "formatted_value" else 1 * u.ps
+    assert np.all(abs(t2["col0"] - t["col0"]) <= atol)

--- a/astropy/time/tests/test_methods.py
+++ b/astropy/time/tests/test_methods.py
@@ -14,8 +14,8 @@ from astropy.units.quantity_helper.function_helpers import ARRAY_FUNCTION_ENABLE
 from astropy.utils import iers
 
 needs_array_function = pytest.mark.xfail(
-    not ARRAY_FUNCTION_ENABLED,
-    reason="Needs __array_function__ support")
+    not ARRAY_FUNCTION_ENABLED, reason="Needs __array_function__ support"
+)
 
 
 def assert_time_all_equal(t1, t2):
@@ -27,25 +27,41 @@ def assert_time_all_equal(t1, t2):
 class ShapeSetup:
     def setup_class(cls):
         mjd = np.arange(50000, 50010)
-        frac = np.arange(0., 0.999, 0.2)
+        frac = np.arange(0.0, 0.999, 0.2)
         frac_masked = np.ma.array(frac)
         frac_masked[1] = np.ma.masked
 
         cls.t0 = {
-            'not_masked': Time(mjd[:, np.newaxis] + frac, format='mjd', scale='utc'),
-            'masked': Time(mjd[:, np.newaxis] + frac_masked, format='mjd', scale='utc')
+            "not_masked": Time(mjd[:, np.newaxis] + frac, format="mjd", scale="utc"),
+            "masked": Time(mjd[:, np.newaxis] + frac_masked, format="mjd", scale="utc"),
         }
         cls.t1 = {
-            'not_masked': Time(mjd[:, np.newaxis] + frac, format='mjd', scale='utc',
-                               location=('45d', '50d')),
-            'masked': Time(mjd[:, np.newaxis] + frac_masked, format='mjd', scale='utc',
-                           location=('45d', '50d')),
+            "not_masked": Time(
+                mjd[:, np.newaxis] + frac,
+                format="mjd",
+                scale="utc",
+                location=("45d", "50d"),
+            ),
+            "masked": Time(
+                mjd[:, np.newaxis] + frac_masked,
+                format="mjd",
+                scale="utc",
+                location=("45d", "50d"),
+            ),
         }
         cls.t2 = {
-            'not_masked': Time(mjd[:, np.newaxis] + frac, format='mjd', scale='utc',
-                               location=(np.arange(len(frac)), np.arange(len(frac)))),
-            'masked': Time(mjd[:, np.newaxis] + frac_masked, format='mjd', scale='utc',
-                           location=(np.arange(len(frac_masked)), np.arange(len(frac_masked)))),
+            "not_masked": Time(
+                mjd[:, np.newaxis] + frac,
+                format="mjd",
+                scale="utc",
+                location=(np.arange(len(frac)), np.arange(len(frac))),
+            ),
+            "masked": Time(
+                mjd[:, np.newaxis] + frac_masked,
+                format="mjd",
+                scale="utc",
+                location=(np.arange(len(frac_masked)), np.arange(len(frac_masked))),
+            ),
         }
 
     def create_data(self, use_mask):
@@ -54,9 +70,10 @@ class ShapeSetup:
         self.t2 = self.__class__.t2[use_mask]
 
 
-@pytest.mark.parametrize('use_mask', ('masked', 'not_masked'))
+@pytest.mark.parametrize("use_mask", ("masked", "not_masked"))
 class TestManipulation(ShapeSetup):
     """Manipulation of Time objects, ensuring attributes are done correctly."""
+
     def test_ravel(self, use_mask):
         self.create_data(use_mask)
 
@@ -202,10 +219,10 @@ class TestManipulation(ShapeSetup):
         t2_reshape_t_reshape = t2_reshape_t.reshape(10, 5)
         assert t2_reshape_t_reshape.shape == (10, 5)
         assert not np.may_share_memory(t2_reshape_t_reshape.jd1, self.t2.jd1)
-        assert (t2_reshape_t_reshape.location.shape
-                == t2_reshape_t_reshape.shape)
-        assert not np.may_share_memory(t2_reshape_t_reshape.location,
-                                       t2_reshape_t.location)
+        assert t2_reshape_t_reshape.location.shape == t2_reshape_t_reshape.shape
+        assert not np.may_share_memory(
+            t2_reshape_t_reshape.location, t2_reshape_t.location
+        )
 
     def test_squeeze(self, use_mask):
         self.create_data(use_mask)
@@ -289,7 +306,7 @@ class TestManipulation(ShapeSetup):
         assert np.may_share_memory(t2_broadcast.location, self.t2.location)
 
 
-@pytest.mark.parametrize('use_mask', ('masked', 'not_masked'))
+@pytest.mark.parametrize("use_mask", ("masked", "not_masked"))
 class TestSetShape(ShapeSetup):
     def test_shape_setting(self, use_mask):
         # Shape-setting should be on the object itself, since copying removes
@@ -341,7 +358,7 @@ class TestSetShape(ShapeSetup):
         assert self.t2.location.shape == oldshape
 
 
-@pytest.mark.parametrize('use_mask', ('masked', 'not_masked'))
+@pytest.mark.parametrize("use_mask", ("masked", "not_masked"))
 class TestShapeFunctions(ShapeSetup):
     @needs_array_function
     def test_broadcast(self, use_mask):
@@ -450,21 +467,22 @@ class TestShapeFunctions(ShapeSetup):
         assert_time_all_equal(t0d[2:], self.t0[4:])
 
 
-@pytest.mark.parametrize('use_mask', ('masked', 'not_masked'))
+@pytest.mark.parametrize("use_mask", ("masked", "not_masked"))
 class TestArithmetic:
     """Arithmetic on Time objects, using both doubles."""
-    kwargs = ({}, {'axis': None}, {'axis': 0}, {'axis': 1}, {'axis': 2})
-    functions = ('min', 'max', 'sort')
+
+    kwargs = ({}, {"axis": None}, {"axis": 0}, {"axis": 1}, {"axis": 2})
+    functions = ("min", "max", "sort")
 
     def setup_class(cls):
         mjd = np.arange(50000, 50100, 10).reshape(2, 5, 1)
-        frac = np.array([0.1, 0.1 + 1.e-15, 0.1 - 1.e-15, 0.9 + 2.e-16, 0.9])
+        frac = np.array([0.1, 0.1 + 1.0e-15, 0.1 - 1.0e-15, 0.9 + 2.0e-16, 0.9])
         frac_masked = np.ma.array(frac)
         frac_masked[1] = np.ma.masked
 
         cls.t0 = {
-            'not_masked': Time(mjd, frac, format='mjd', scale='utc'),
-            'masked': Time(mjd, frac_masked, format='mjd', scale='utc')
+            "not_masked": Time(mjd, frac, format="mjd", scale="utc"),
+            "masked": Time(mjd, frac_masked, format="mjd", scale="utc"),
         }
 
         # Define arrays with same ordinal properties
@@ -473,19 +491,24 @@ class TestArithmetic:
         frac_masked[1] = np.ma.masked
 
         cls.t1 = {
-            'not_masked': Time(mjd + frac, format='mjd', scale='utc'),
-            'masked': Time(mjd + frac_masked, format='mjd', scale='utc'),
+            "not_masked": Time(mjd + frac, format="mjd", scale="utc"),
+            "masked": Time(mjd + frac_masked, format="mjd", scale="utc"),
         }
-        cls.jd = {
-            'not_masked': mjd + frac,
-            'masked': mjd + frac_masked
-            }
+        cls.jd = {"not_masked": mjd + frac, "masked": mjd + frac_masked}
 
         cls.t2 = {
-            'not_masked': Time(mjd + frac, format='mjd', scale='utc',
-                               location=(np.arange(len(frac)), np.arange(len(frac)))),
-            'masked': Time(mjd + frac_masked, format='mjd', scale='utc',
-                           location=(np.arange(len(frac_masked)), np.arange(len(frac_masked)))),
+            "not_masked": Time(
+                mjd + frac,
+                format="mjd",
+                scale="utc",
+                location=(np.arange(len(frac)), np.arange(len(frac))),
+            ),
+            "masked": Time(
+                mjd + frac_masked,
+                format="mjd",
+                scale="utc",
+                location=(np.arange(len(frac_masked)), np.arange(len(frac_masked))),
+            ),
         }
 
     def create_data(self, use_mask):
@@ -494,7 +517,7 @@ class TestArithmetic:
         self.t2 = self.__class__.t2[use_mask]
         self.jd = self.__class__.jd[use_mask]
 
-    @pytest.mark.parametrize('kw, func', itertools.product(kwargs, functions))
+    @pytest.mark.parametrize("kw, func", itertools.product(kwargs, functions))
     def test_argfuncs(self, kw, func, use_mask):
         """
         Test that ``np.argfunc(jd, **kw)`` is the same as ``t0.argfunc(**kw)``
@@ -504,11 +527,11 @@ class TestArithmetic:
         """
         self.create_data(use_mask)
 
-        t0v = getattr(self.t0, 'arg' + func)(**kw)
-        t1v = getattr(self.t1, 'arg' + func)(**kw)
-        jdv = getattr(np, 'arg' + func)(self.jd, **kw)
+        t0v = getattr(self.t0, "arg" + func)(**kw)
+        t1v = getattr(self.t1, "arg" + func)(**kw)
+        jdv = getattr(np, "arg" + func)(self.jd, **kw)
 
-        if self.t0.masked and kw == {'axis': None} and func == 'sort':
+        if self.t0.masked and kw == {"axis": None} and func == "sort":
             t0v = np.ma.array(t0v, mask=self.t0.mask.reshape(t0v.shape)[t0v])
             t1v = np.ma.array(t1v, mask=self.t1.mask.reshape(t1v.shape)[t1v])
             jdv = np.ma.array(jdv, mask=self.jd.mask.reshape(jdv.shape)[jdv])
@@ -518,7 +541,7 @@ class TestArithmetic:
         assert t0v.shape == jdv.shape
         assert t1v.shape == jdv.shape
 
-    @pytest.mark.parametrize('kw, func', itertools.product(kwargs, functions))
+    @pytest.mark.parametrize("kw, func", itertools.product(kwargs, functions))
     def test_funcs(self, kw, func, use_mask):
         """
         Test that ``np.func(jd, **kw)`` is the same as ``t1.func(**kw)`` where
@@ -543,7 +566,7 @@ class TestArithmetic:
         self.create_data(use_mask)
 
         assert self.t0.argmax() == self.t0.size - 2
-        if use_mask == 'masked':
+        if use_mask == "masked":
             # The 0 is where all entries are masked in that axis
             assert np.all(self.t0.argmax(axis=0) == [1, 0, 1, 1, 1])
             assert np.all(self.t0.argmax(axis=1) == [4, 0, 4, 4, 4])
@@ -555,13 +578,13 @@ class TestArithmetic:
     def test_argsort(self, use_mask):
         self.create_data(use_mask)
 
-        order = [2, 0, 4, 3, 1] if use_mask == 'masked' else [2, 0, 1, 4, 3]
+        order = [2, 0, 4, 3, 1] if use_mask == "masked" else [2, 0, 1, 4, 3]
         assert np.all(self.t0.argsort() == np.array(order))
         assert np.all(self.t0.argsort(axis=0) == np.arange(2).reshape(2, 1, 1))
         assert np.all(self.t0.argsort(axis=1) == np.arange(5).reshape(5, 1))
         assert np.all(self.t0.argsort(axis=2) == np.array(order))
         ravel = np.arange(50).reshape(-1, 5)[:, order].ravel()
-        if use_mask == 'masked':
+        if use_mask == "masked":
             t0v = self.t0.argsort(axis=None)
             # Manually remove elements in ravel that correspond to masked
             # entries in self.t0.  This removes the 10 entries that are masked
@@ -572,14 +595,14 @@ class TestArithmetic:
         else:
             assert np.all(self.t0.argsort(axis=None) == ravel)
 
-    @pytest.mark.parametrize('scale', Time.SCALES)
+    @pytest.mark.parametrize("scale", Time.SCALES)
     def test_argsort_warning(self, use_mask, scale):
         self.create_data(use_mask)
 
-        if scale == 'utc':
+        if scale == "utc":
             pytest.xfail()
         with warnings.catch_warnings(record=True) as wlist:
-            Time([1, 2, 3], format='jd', scale=scale).argsort()
+            Time([1, 2, 3], format="jd", scale=scale).argsort()
         assert len(wlist) == 0
 
     def test_min(self, use_mask):
@@ -617,33 +640,33 @@ class TestArithmetic:
     def test_sort(self, use_mask):
         self.create_data(use_mask)
 
-        order = [2, 0, 4, 3, 1] if use_mask == 'masked' else [2, 0, 1, 4, 3]
+        order = [2, 0, 4, 3, 1] if use_mask == "masked" else [2, 0, 1, 4, 3]
         assert np.all(self.t0.sort() == self.t0[:, :, order])
         assert np.all(self.t0.sort(0) == self.t0)
         assert np.all(self.t0.sort(1) == self.t0)
         assert np.all(self.t0.sort(2) == self.t0[:, :, order])
-        if use_mask == 'not_masked':
-            assert np.all(self.t0.sort(None)
-                          == self.t0[:, :, order].ravel())
+        if use_mask == "not_masked":
+            assert np.all(self.t0.sort(None) == self.t0[:, :, order].ravel())
             # Bit superfluous, but good to check.
             assert np.all(self.t0.sort(-1)[:, :, 0] == self.t0.min(-1))
             assert np.all(self.t0.sort(-1)[:, :, -1] == self.t0.max(-1))
 
-    @pytest.mark.parametrize('axis', [None, 0, 1, 2, (0, 1)])
-    @pytest.mark.parametrize('where', [True, np.array([True, False, True, True, False])[..., np.newaxis]])
-    @pytest.mark.parametrize('keepdims', [False, True])
+    @pytest.mark.parametrize("axis", [None, 0, 1, 2, (0, 1)])
+    @pytest.mark.parametrize(
+        "where", [True, np.array([True, False, True, True, False])[..., np.newaxis]]
+    )
+    @pytest.mark.parametrize("keepdims", [False, True])
     def test_mean(self, use_mask, axis, where, keepdims):
         self.create_data(use_mask)
 
         kwargs = dict(axis=axis, where=where, keepdims=keepdims)
 
         def is_consistent(time):
-
             where_expected = where & ~time.mask
             where_expected = np.broadcast_to(where_expected, time.shape)
 
             kw = kwargs.copy()
-            kw['where'] = where_expected
+            kw["where"] = where_expected
 
             divisor = where_expected.sum(axis=axis, keepdims=keepdims)
 
@@ -657,10 +680,10 @@ class TestArithmetic:
                     *day_frac(
                         val1=np.ma.getdata(time.tai.jd1).sum(**kw),
                         val2=np.ma.getdata(time.tai.jd2).sum(**kw),
-                        divisor=divisor
+                        divisor=divisor,
                     ),
-                    format='jd',
-                    scale='tai',
+                    format="jd",
+                    scale="tai",
                 )
                 time_expected._set_scale(time.scale)
                 assert np.all(time_mean == time_expected)
@@ -676,17 +699,16 @@ class TestArithmetic:
             is_consistent(self.t2)
 
     def test_mean_precision(self, use_mask):
-
-        scale = 'tai'
+        scale = "tai"
         epsilon = 1 * u.ns
 
-        t0 = Time('2021-07-27T00:00:00', scale=scale)
-        t1 = Time('2022-07-27T00:00:00', scale=scale)
-        t2 = Time('2023-07-27T00:00:00', scale=scale)
+        t0 = Time("2021-07-27T00:00:00", scale=scale)
+        t1 = Time("2022-07-27T00:00:00", scale=scale)
+        t2 = Time("2023-07-27T00:00:00", scale=scale)
 
         t = Time([t0, t2 + epsilon])
 
-        if use_mask == 'masked':
+        if use_mask == "masked":
             t[0] = np.ma.masked
             assert t.mean() == (t2 + epsilon)
 
@@ -701,26 +723,28 @@ class TestArithmetic:
     def test_mean_out(self, use_mask):
         self.create_data(use_mask)
         with pytest.raises(ValueError):
-            self.t0.mean(out=Time(np.zeros_like(self.t0.jd1), format='jd'))
+            self.t0.mean(out=Time(np.zeros_like(self.t0.jd1), format="jd"))
 
     def test_mean_leap_second(self, use_mask):
         # Check that leap second is dealt with correctly: for UTC, across a leap
         # second bounday, one cannot just average jd, but has to go through TAI.
-        if use_mask == 'not_masked':
-            t = Time(['2012-06-30 23:59:60.000', '2012-07-01 00:00:01.000'])
+        if use_mask == "not_masked":
+            t = Time(["2012-06-30 23:59:60.000", "2012-07-01 00:00:01.000"])
             mean_expected = t[0] + (t[1] - t[0]) / 2
-            mean_expected_explicit = Time('2012-07-01 00:00:00')
+            mean_expected_explicit = Time("2012-07-01 00:00:00")
             mean_test = t.mean()
             assert mean_expected == mean_expected_explicit
             assert mean_expected == mean_test
-            assert mean_test != Time(*day_frac(t.jd1.sum(), t.jd2.sum(), divisor=2), format='jd')
+            assert mean_test != Time(
+                *day_frac(t.jd1.sum(), t.jd2.sum(), divisor=2), format="jd"
+            )
 
 
 def test_regression():
     # For #5225, where a time with a single-element delta_ut1_utc could not
     # be copied, flattened, or ravelled. (For copy, it is in test_basic.)
-    with iers.conf.set_temp('auto_download', False):
-        t = Time(49580.0, scale='tai', format='mjd')
+    with iers.conf.set_temp("auto_download", False):
+        t = Time(49580.0, scale="tai", format="mjd")
         t_ut1 = t.ut1
         t_ut1_copy = copy.deepcopy(t_ut1)
         assert type(t_ut1_copy.delta_ut1_utc) is np.ndarray

--- a/astropy/time/tests/test_pickle.py
+++ b/astropy/time/tests/test_pickle.py
@@ -11,16 +11,15 @@ class TestPickle:
     """Basic pickle test of time"""
 
     def test_pickle(self):
-
-        times = ['1999-01-01 00:00:00.123456789', '2010-01-01 00:00:00']
-        t1 = Time(times, scale='utc')
+        times = ["1999-01-01 00:00:00.123456789", "2010-01-01 00:00:00"]
+        t1 = Time(times, scale="utc")
 
         for prot in range(pickle.HIGHEST_PROTOCOL):
             t1d = pickle.dumps(t1, prot)
             t1l = pickle.loads(t1d)
             assert np.all(t1l == t1)
 
-        t2 = Time('2012-06-30 12:00:00', scale='utc')
+        t2 = Time("2012-06-30 12:00:00", scale="utc")
 
         for prot in range(pickle.HIGHEST_PROTOCOL):
             t2d = pickle.dumps(t2, prot)

--- a/astropy/time/tests/test_precision.py
+++ b/astropy/time/tests/test_precision.py
@@ -29,22 +29,24 @@ from astropy.time.utils import day_frac, two_sum
 from astropy.utils import iers
 
 allclose_jd = functools.partial(np.allclose, rtol=np.finfo(float).eps, atol=0)
-allclose_jd2 = functools.partial(np.allclose, rtol=np.finfo(float).eps,
-                                 atol=np.finfo(float).eps)  # 20 ps atol
-allclose_sec = functools.partial(np.allclose, rtol=np.finfo(float).eps,
-                                 atol=np.finfo(float).eps * 24 * 3600)
+allclose_jd2 = functools.partial(
+    np.allclose, rtol=np.finfo(float).eps, atol=np.finfo(float).eps
+)  # 20 ps atol
+allclose_sec = functools.partial(
+    np.allclose, rtol=np.finfo(float).eps, atol=np.finfo(float).eps * 24 * 3600
+)
 
 tiny = np.finfo(float).eps
-dt_tiny = TimeDelta(tiny, format='jd')
+dt_tiny = TimeDelta(tiny, format="jd")
 
 
 def setup_module():
     # Pre-load leap seconds table to avoid flakiness in hypothesis runs.
     # See https://github.com/astropy/astropy/issues/11030
-    Time('2020-01-01').ut1
+    Time("2020-01-01").ut1
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def iers_b():
     """This is an expensive operation, so we share it between tests using a
     module-scoped fixture instead of using the context manager form.  This
@@ -62,7 +64,7 @@ def quiet_erfa():
         yield
 
 
-def assert_almost_equal(a, b, *, rtol=None, atol=None, label=''):
+def assert_almost_equal(a, b, *, rtol=None, atol=None, label=""):
     """Assert numbers are almost equal.
 
     This version also lets hypothesis know how far apart the inputs are, so
@@ -77,7 +79,7 @@ def assert_almost_equal(a, b, *, rtol=None, atol=None, label=''):
     else:
         thresh = atol + rtol * (abs(a) + abs(b)) / 2
 
-    amb = (a - b)
+    amb = a - b
     if isinstance(amb, TimeDelta):
         ambv = amb.to_value(u.s)
         target(ambv, label=label + " (a-b).to_value(u.s), from TimeDelta")
@@ -104,8 +106,9 @@ def assert_almost_equal(a, b, *, rtol=None, atol=None, label=''):
 leap_second_table = iers.LeapSeconds.from_iers_leap_seconds()
 # Days that contain leap_seconds
 leap_second_days = leap_second_table["mjd"] - 1
-leap_second_deltas = list(zip(leap_second_days[1:],
-                              np.diff(leap_second_table["tai_utc"])))
+leap_second_deltas = list(
+    zip(leap_second_days[1:], np.diff(leap_second_table["tai_utc"]))
+)
 
 today = Time.now()
 mjd0 = Time(0, format="mjd")
@@ -117,9 +120,13 @@ def reasonable_ordinary_jd():
 
 @composite
 def leap_second_tricky(draw):
-    mjd = draw(one_of(sampled_from(leap_second_days),
-                      sampled_from(leap_second_days + 1),
-                      sampled_from(leap_second_days - 1)))
+    mjd = draw(
+        one_of(
+            sampled_from(leap_second_days),
+            sampled_from(leap_second_days + 1),
+            sampled_from(leap_second_days - 1),
+        )
+    )
     return mjd + mjd0.jd1 + mjd0.jd2, draw(floats(0, 1))
 
 
@@ -133,10 +140,8 @@ def reasonable_jd():
     reasonable date) so that hypothesis' example simplification produces
     obviously simple examples when they trigger problems.
     """
-    moments = [(2455000., 0.), (mjd0.jd1, mjd0.jd2), (today.jd1, today.jd2)]
-    return one_of(sampled_from(moments),
-                  reasonable_ordinary_jd(),
-                  leap_second_tricky())
+    moments = [(2455000.0, 0.0), (mjd0.jd1, mjd0.jd2), (today.jd1, today.jd2)]
+    return one_of(sampled_from(moments), reasonable_ordinary_jd(), leap_second_tricky())
 
 
 def unreasonable_ordinary_jd():
@@ -173,11 +178,12 @@ def reasonable_delta():
 # redundant?
 def test_abs_jd2_always_less_than_half():
     """Make jd2 approach +/-0.5, and check that it doesn't go over."""
-    t1 = Time(2400000.5, [-tiny, +tiny], format='jd')
+    t1 = Time(2400000.5, [-tiny, +tiny], format="jd")
     assert np.all(t1.jd1 % 1 == 0)
     assert np.all(abs(t1.jd2) < 0.5)
-    t2 = Time(2400000., [[0.5 - tiny, 0.5 + tiny],
-                         [-0.5 - tiny, -0.5 + tiny]], format='jd')
+    t2 = Time(
+        2400000.0, [[0.5 - tiny, 0.5 + tiny], [-0.5 - tiny, -0.5 + tiny]], format="jd"
+    )
     assert np.all(t2.jd1 % 1 == 0)
     assert np.all(abs(t2.jd2) < 0.5)
 
@@ -192,7 +198,7 @@ def test_abs_jd2_always_less_than_half_on_construction(jds):
     assert np.all((abs(t.jd2) < 0.5) | (t.jd1 % 2 == 0))
 
 
-@given(integers(-10**8, 10**8), sampled_from([-0.5, 0.5]))
+@given(integers(-(10**8), 10**8), sampled_from([-0.5, 0.5]))
 def test_round_to_even(jd1, jd2):
     t = Time(jd1, jd2, format="jd")
     assert (abs(t.jd2) == 0.5) and (t.jd1 % 2 == 0)
@@ -200,7 +206,7 @@ def test_round_to_even(jd1, jd2):
 
 def test_addition():
     """Check that an addition at the limit of precision (2^-52) is seen"""
-    t = Time(2455555., 0.5, format='jd', scale='utc')
+    t = Time(2455555.0, 0.5, format="jd", scale="utc")
 
     t_dt = t + dt_tiny
     assert t_dt.jd1 == t.jd1 and t_dt.jd2 != t.jd2
@@ -215,18 +221,18 @@ def test_mult_div():
     """Test precision with multiply and divide"""
     dt_small = 6 * dt_tiny
     # pick a number that will leave remainder if divided by 6.
-    dt_big = TimeDelta(20000., format='jd')
-    dt_big_small_by_6 = (dt_big + dt_small) / 6.
-    dt_frac = dt_big_small_by_6 - TimeDelta(3333., format='jd')
+    dt_big = TimeDelta(20000.0, format="jd")
+    dt_big_small_by_6 = (dt_big + dt_small) / 6.0
+    dt_frac = dt_big_small_by_6 - TimeDelta(3333.0, format="jd")
     assert allclose_jd2(dt_frac.jd2, 0.33333333333333354)
 
 
 def test_init_variations():
     """Check that 3 ways of specifying a time + small offset are equivalent"""
-    dt_tiny_sec = dt_tiny.jd2 * 86400.
-    t1 = Time(1e11, format='cxcsec') + dt_tiny
-    t2 = Time(1e11, dt_tiny_sec, format='cxcsec')
-    t3 = Time(dt_tiny_sec, 1e11, format='cxcsec')
+    dt_tiny_sec = dt_tiny.jd2 * 86400.0
+    t1 = Time(1e11, format="cxcsec") + dt_tiny
+    t2 = Time(1e11, dt_tiny_sec, format="cxcsec")
+    t3 = Time(dt_tiny_sec, 1e11, format="cxcsec")
     assert t1.jd1 == t2.jd1
     assert t1.jd2 == t3.jd2
     assert t1.jd1 == t2.jd1
@@ -239,15 +245,15 @@ def test_precision_exceeds_64bit():
     at the (naively) summed 64-bit result and asserting equality at the
     bit level.
     """
-    t1 = Time(1.23456789e11, format='cxcsec')
+    t1 = Time(1.23456789e11, format="cxcsec")
     t2 = t1 + dt_tiny
     assert t1.jd == t2.jd
 
 
 def test_through_scale_change():
     """Check that precision holds through scale change (cxcsec is TT)"""
-    t0 = Time(1.0, format='cxcsec')
-    t1 = Time(1.23456789e11, format='cxcsec')
+    t0 = Time(1.0, format="cxcsec")
+    t1 = Time(1.23456789e11, format="cxcsec")
     dt_tt = t1 - t0
     dt_tai = t1.tai - t0.tai
     assert allclose_jd(dt_tt.jd1, dt_tai.jd1)
@@ -256,19 +262,19 @@ def test_through_scale_change():
 
 def test_iso_init():
     """Check when initializing from ISO date"""
-    t1 = Time('2000:001:00:00:00.00000001', scale='tai')
-    t2 = Time('3000:001:13:00:00.00000002', scale='tai')
+    t1 = Time("2000:001:00:00:00.00000001", scale="tai")
+    t2 = Time("3000:001:13:00:00.00000002", scale="tai")
     dt = t2 - t1
-    assert allclose_jd2(dt.jd2, 13. / 24. + 1e-8 / 86400. - 1.0)
+    assert allclose_jd2(dt.jd2, 13.0 / 24.0 + 1e-8 / 86400.0 - 1.0)
 
 
 def test_jd1_is_mult_of_one():
     """
     Check that jd1 is a multiple of 1.
     """
-    t1 = Time('2000:001:00:00:00.00000001', scale='tai')
+    t1 = Time("2000:001:00:00:00.00000001", scale="tai")
     assert np.round(t1.jd1) == t1.jd1
-    t1 = Time(1.23456789, 12345678.90123456, format='jd', scale='tai')
+    t1 = Time(1.23456789, 12345678.90123456, format="jd", scale="tai")
     assert np.round(t1.jd1) == t1.jd1
 
 
@@ -278,7 +284,7 @@ def test_precision_neg():
     routines use a test like jd1 > jd2 to decide which component to update.
     It was updated to abs(jd1) > abs(jd2) in erfa 1.6 (sofa 20190722).
     """
-    t1 = Time(-100000.123456, format='jd', scale='tt')
+    t1 = Time(-100000.123456, format="jd", scale="tt")
     assert np.round(t1.jd1) == t1.jd1
     t1_tai = t1.tai
     assert np.round(t1_tai.jd1) == t1_tai.jd1
@@ -289,8 +295,8 @@ def test_precision_epoch():
     Check that input via epoch also has full precision, i.e., against
     regression on https://github.com/astropy/astropy/pull/366
     """
-    t_utc = Time(range(1980, 2001), format='jyear', scale='utc')
-    t_tai = Time(range(1980, 2001), format='jyear', scale='tai')
+    t_utc = Time(range(1980, 2001), format="jyear", scale="utc")
+    t_tai = Time(range(1980, 2001), format="jyear", scale="tai")
     dt = t_utc - t_tai
     assert allclose_sec(dt.sec, np.round(dt.sec))
 
@@ -298,15 +304,19 @@ def test_precision_epoch():
 def test_leap_seconds_rounded_correctly():
     """Regression tests against #2083, where a leap second was rounded
     incorrectly by the underlying ERFA routine."""
-    with iers.conf.set_temp('auto_download', False):
-        t = Time(['2012-06-30 23:59:59.413',
-                  '2012-07-01 00:00:00.413'], scale='ut1', precision=3).utc
-        assert np.all(t.iso == np.array(['2012-06-30 23:59:60.000',
-                                         '2012-07-01 00:00:00.000']))
+    with iers.conf.set_temp("auto_download", False):
+        t = Time(
+            ["2012-06-30 23:59:59.413", "2012-07-01 00:00:00.413"],
+            scale="ut1",
+            precision=3,
+        ).utc
+        assert np.all(
+            t.iso == np.array(["2012-06-30 23:59:60.000", "2012-07-01 00:00:00.000"])
+        )
     # with the bug, both yielded '2012-06-30 23:59:60.000'
 
 
-@given(integers(-2**52+2, 2**52-2), floats(-1, 1))
+@given(integers(-(2**52) + 2, 2**52 - 2), floats(-1, 1))
 @example(i=65536, f=3.637978807091714e-12)
 def test_two_sum(i, f):
     with decimal.localcontext(decimal.Context(prec=40)):
@@ -320,25 +330,31 @@ def test_two_sum(i, f):
 # which does not have to be completely symmetric; e.g., this used to fail:
 #     @example(f1=-3.089785075544792e307, f2=1.7976931348623157e308)
 # See https://github.com/astropy/astropy/issues/12955#issuecomment-1186293703
-@given(floats(min_value=np.finfo(float).min/2, max_value=np.finfo(float).max/2),
-       floats(min_value=np.finfo(float).min/2, max_value=np.finfo(float).max/2))
+@given(
+    floats(min_value=np.finfo(float).min / 2, max_value=np.finfo(float).max / 2),
+    floats(min_value=np.finfo(float).min / 2, max_value=np.finfo(float).max / 2),
+)
 def test_two_sum_symmetric(f1, f2):
     np.testing.assert_equal(two_sum(f1, f2), two_sum(f2, f1))
 
 
-@given(floats(allow_nan=False, allow_infinity=False),
-       floats(allow_nan=False, allow_infinity=False))
-@example(f1=8.988465674311579e+307, f2=8.98846567431158e+307)
-@example(f1=8.988465674311579e+307, f2=-8.98846567431158e+307)
-@example(f1=-8.988465674311579e+307, f2=-8.98846567431158e+307)
+@given(
+    floats(allow_nan=False, allow_infinity=False),
+    floats(allow_nan=False, allow_infinity=False),
+)
+@example(f1=8.988465674311579e307, f2=8.98846567431158e307)
+@example(f1=8.988465674311579e307, f2=-8.98846567431158e307)
+@example(f1=-8.988465674311579e307, f2=-8.98846567431158e307)
 def test_two_sum_size(f1, f2):
     r1, r2 = two_sum(f1, f2)
-    assert (abs(r1) > abs(r2) / np.finfo(float).eps
-            or r1 == r2 == 0
-            or not np.isfinite(f1 + f2))
+    assert (
+        abs(r1) > abs(r2) / np.finfo(float).eps
+        or r1 == r2 == 0
+        or not np.isfinite(f1 + f2)
+    )
 
 
-@given(integers(-2**52+2, 2**52-2), floats(-1, 1))
+@given(integers(-(2**52) + 2, 2**52 - 2), floats(-1, 1))
 @example(i=65536, f=3.637978807091714e-12)
 def test_day_frac_harmless(i, f):
     with decimal.localcontext(decimal.Context(prec=40)):
@@ -348,7 +364,7 @@ def test_day_frac_harmless(i, f):
         assert_almost_equal(a, a_d, atol=Decimal(tiny), rtol=Decimal(0))
 
 
-@given(integers(-2**52+2, 2**52-2), floats(-0.5, 0.5))
+@given(integers(-(2**52) + 2, 2**52 - 2), floats(-0.5, 0.5))
 @example(i=65536, f=3.637978807091714e-12)
 @example(i=1, f=0.49999999999999994)
 def test_day_frac_exact(i, f):
@@ -358,14 +374,14 @@ def test_day_frac_exact(i, f):
     assert f == f_d
 
 
-@given(integers(-2**52+2, 2**52-2), floats(-1, 1))
+@given(integers(-(2**52) + 2, 2**52 - 2), floats(-1, 1))
 @example(i=65536, f=3.637978807091714e-12)
 def test_day_frac_idempotent(i, f):
     i_d, f_d = day_frac(i, f)
     assert (i_d, f_d) == day_frac(i_d, f_d)
 
 
-@given(integers(-2**52+2, 2**52-int(erfa.DJM0)-3), floats(-1, 1))
+@given(integers(-(2**52) + 2, 2**52 - int(erfa.DJM0) - 3), floats(-1, 1))
 @example(i=65536, f=3.637978807091714e-12)
 def test_mjd_initialization_precise(i, f):
     t = Time(val=i, val2=f, format="mjd", scale="tai")
@@ -383,14 +399,16 @@ def test_day_frac_always_less_than_half(jds):
     assert np.all((abs(t_jd2) < 0.5) | (t_jd1 % 2 == 0))
 
 
-@given(integers(-10**8, 10**8), sampled_from([-0.5, 0.5]))
+@given(integers(-(10**8), 10**8), sampled_from([-0.5, 0.5]))
 def test_day_frac_round_to_even(jd1, jd2):
     t_jd1, t_jd2 = day_frac(jd1, jd2)
     assert (abs(t_jd2) == 0.5) and (t_jd1 % 2 == 0)
 
 
-@given(scale=sampled_from([sc for sc in STANDARD_TIME_SCALES if sc != 'utc']),
-       jds=unreasonable_jd())
+@given(
+    scale=sampled_from([sc for sc in STANDARD_TIME_SCALES if sc != "utc"]),
+    jds=unreasonable_jd(),
+)
 @example(scale="tai", jds=(0.0, 0.0))
 @example(scale="tai", jds=(0.0, -31738.500000000346))
 def test_resolution_never_decreases(scale, jds):
@@ -414,15 +432,17 @@ def test_resolution_never_decreases_utc(jds):
     jd1, jd2 = jds
     t = Time(jd1, jd2, format="jd", scale="utc")
     with quiet_erfa():
-        assert t != t + 2*dt_tiny
+        assert t != t + 2 * dt_tiny
 
 
-@given(scale1=sampled_from(STANDARD_TIME_SCALES),
-       scale2=sampled_from(STANDARD_TIME_SCALES),
-       jds=unreasonable_jd())
-@example(scale1='tcg', scale2='ut1', jds=(2445149.5, 0.47187700984387526))
-@example(scale1='tai', scale2='tcb', jds=(2441316.5, 0.0))
-@example(scale1='tai', scale2='tcb', jds=(0.0, 0.0))
+@given(
+    scale1=sampled_from(STANDARD_TIME_SCALES),
+    scale2=sampled_from(STANDARD_TIME_SCALES),
+    jds=unreasonable_jd(),
+)
+@example(scale1="tcg", scale2="ut1", jds=(2445149.5, 0.47187700984387526))
+@example(scale1="tai", scale2="tcb", jds=(2441316.5, 0.0))
+@example(scale1="tai", scale2="tcb", jds=(0.0, 0.0))
 def test_conversion_preserves_jd1_jd2_invariant(iers_b, scale1, scale2, jds):
     jd1, jd2 = jds
     t = Time(jd1, jd2, scale=scale1, format="jd")
@@ -438,12 +458,14 @@ def test_conversion_preserves_jd1_jd2_invariant(iers_b, scale1, scale2, jds):
     assert abs(t2.jd2) < 0.5 or t2.jd1 % 2 == 0
 
 
-@given(scale1=sampled_from(STANDARD_TIME_SCALES),
-       scale2=sampled_from(STANDARD_TIME_SCALES),
-       jds=unreasonable_jd())
-@example(scale1='tai', scale2='utc', jds=(0.0, 0.0))
-@example(scale1='utc', scale2='ut1', jds=(2441316.5, 0.9999999999999991))
-@example(scale1='ut1', scale2='tai', jds=(2441498.5, 0.9999999999999999))
+@given(
+    scale1=sampled_from(STANDARD_TIME_SCALES),
+    scale2=sampled_from(STANDARD_TIME_SCALES),
+    jds=unreasonable_jd(),
+)
+@example(scale1="tai", scale2="utc", jds=(0.0, 0.0))
+@example(scale1="utc", scale2="ut1", jds=(2441316.5, 0.9999999999999991))
+@example(scale1="ut1", scale2="tai", jds=(2441498.5, 0.9999999999999999))
 def test_conversion_never_loses_precision(iers_b, scale1, scale2, jds):
     """Check that time ordering remains if we convert to another scale.
 
@@ -455,10 +477,10 @@ def test_conversion_never_loses_precision(iers_b, scale1, scale2, jds):
     t = Time(jd1, jd2, scale=scale1, format="jd")
     # Near-zero UTC JDs degrade accuracy; not clear why,
     # but also not so relevant, so ignoring.
-    if (scale1 == 'utc' or scale2 == 'utc') and abs(jd1+jd2) < 1:
-        tiny = 100*u.us
+    if (scale1 == "utc" or scale2 == "utc") and abs(jd1 + jd2) < 1:
+        tiny = 100 * u.us
     else:
-        tiny = 2*dt_tiny
+        tiny = 2 * dt_tiny
     try:
         with quiet_erfa():
             t2 = t + tiny
@@ -466,16 +488,16 @@ def test_conversion_never_loses_precision(iers_b, scale1, scale2, jds):
             t2_scale2 = getattr(t2, scale2)
             assert t_scale2 < t2_scale2
     except iers.IERSRangeError:  # UT1 conversion needs IERS data
-        assume(scale1 != 'ut1' or 2440000 < jd1 + jd2 < 2458000)
-        assume(scale2 != 'ut1' or 2440000 < jd1 + jd2 < 2458000)
+        assume(scale1 != "ut1" or 2440000 < jd1 + jd2 < 2458000)
+        assume(scale2 != "ut1" or 2440000 < jd1 + jd2 < 2458000)
         raise
     except ErfaError:
         # If the generated date is too early to compute a UTC julian date,
         # and we're not converting between scales which are known to be safe,
         # tell Hypothesis that this example is invalid and to try another.
         # See https://docs.astropy.org/en/latest/time/index.html#time-scale
-        barycentric = {scale1, scale2}.issubset({'tcb', 'tdb'})
-        geocentric = {scale1, scale2}.issubset({'tai', 'tt', 'tcg'})
+        barycentric = {scale1, scale2}.issubset({"tcb", "tdb"})
+        geocentric = {scale1, scale2}.issubset({"tai", "tt", "tcg"})
         assume(jd1 + jd2 >= -31738.5 or geocentric or barycentric)
         raise
     except AssertionError:
@@ -486,8 +508,8 @@ def test_conversion_never_loses_precision(iers_b, scale1, scale2, jds):
         # Furthermore, exactly at leap-second boundaries, it is possible to
         # get the wrong leap-second correction due to rounding errors.
         # The latter is xfail'd for now, but should be fixed; see gh-13517.
-        if 'ut1' in (scale1, scale2):
-            if abs(t_scale2 - t2_scale2 - 1 * u.s) < 1*u.ms:
+        if "ut1" in (scale1, scale2):
+            if abs(t_scale2 - t2_scale2 - 1 * u.s) < 1 * u.ms:
                 pytest.xfail()
             assume(t.jd > 2441317.5 or t.jd2 < 0.4999999)
         raise
@@ -504,25 +526,25 @@ def test_leap_stretch_mjd(d, f):
     assert_quantity_allclose((t1 - th).to(u.s), (1 - f) * (1 * u.day + delta * u.s))
 
 
-@given(scale=sampled_from(STANDARD_TIME_SCALES),
-       jds=unreasonable_jd(),
-       delta=floats(-10000, 10000))
-@example(scale='utc',
-         jds=(0.0, 2.2204460492503136e-13),
-         delta=6.661338147750941e-13)
-@example(scale='utc',
-         jds=(2441682.5, 2.2204460492503136e-16),
-         delta=7.327471962526035e-12)
-@example(scale='utc', jds=(0.0, 5.787592627370942e-13), delta=0.0)
-@example(scale='utc', jds=(1.0, 0.25000000023283064), delta=-1.0)
-@example(scale='utc', jds=(0.0, 0.0), delta=2*2.220446049250313e-16)
-@example(scale='utc', jds=(2442778.5, 0.0), delta=-2.220446049250313e-16)
+@given(
+    scale=sampled_from(STANDARD_TIME_SCALES),
+    jds=unreasonable_jd(),
+    delta=floats(-10000, 10000),
+)
+@example(scale="utc", jds=(0.0, 2.2204460492503136e-13), delta=6.661338147750941e-13)
+@example(
+    scale="utc", jds=(2441682.5, 2.2204460492503136e-16), delta=7.327471962526035e-12
+)
+@example(scale="utc", jds=(0.0, 5.787592627370942e-13), delta=0.0)
+@example(scale="utc", jds=(1.0, 0.25000000023283064), delta=-1.0)
+@example(scale="utc", jds=(0.0, 0.0), delta=2 * 2.220446049250313e-16)
+@example(scale="utc", jds=(2442778.5, 0.0), delta=-2.220446049250313e-16)
 def test_jd_add_subtract_round_trip(scale, jds, delta):
     jd1, jd2 = jds
     minimum_for_change = np.finfo(float).eps
-    thresh = 2*dt_tiny
-    if scale == 'utc':
-        if jd1+jd2 < 1 or jd1+jd2+delta < 1:
+    thresh = 2 * dt_tiny
+    if scale == "utc":
+        if jd1 + jd2 < 1 or jd1 + jd2 + delta < 1:
             # Near-zero UTC JDs degrade accuracy; not clear why,
             # but also not so relevant, so ignoring.
             minimum_for_change = 1e-9
@@ -534,34 +556,37 @@ def test_jd_add_subtract_round_trip(scale, jds, delta):
     t = Time(jd1, jd2, scale=scale, format="jd")
     try:
         with quiet_erfa():
-            t2 = t + delta*u.day
+            t2 = t + delta * u.day
             if abs(delta) >= minimum_for_change:
                 assert t2 != t
-            t3 = t2 - delta*u.day
+            t3 = t2 - delta * u.day
             assert_almost_equal(t3, t, atol=thresh, rtol=0)
     except ErfaError:
-        assume(scale != 'utc' or 2440000 < jd1+jd2 < 2460000)
+        assume(scale != "utc" or 2440000 < jd1 + jd2 < 2460000)
         raise
 
 
-@given(scale=sampled_from(TimeDelta.SCALES),
-       jds=reasonable_jd(),
-       delta=floats(-3*tiny, 3*tiny))
-@example(scale='tai', jds=(0.0, 3.5762786865234384), delta=2.220446049250313e-16)
-@example(scale='tai', jds=(2441316.5, 0.0), delta=6.938893903907228e-17)
-@example(scale='tai', jds=(2441317.5, 0.0), delta=-6.938893903907228e-17)
-@example(scale='tai', jds=(2440001.0, 0.49999999999999994), delta=5.551115123125783e-17)
+@given(
+    scale=sampled_from(TimeDelta.SCALES),
+    jds=reasonable_jd(),
+    delta=floats(-3 * tiny, 3 * tiny),
+)
+@example(scale="tai", jds=(0.0, 3.5762786865234384), delta=2.220446049250313e-16)
+@example(scale="tai", jds=(2441316.5, 0.0), delta=6.938893903907228e-17)
+@example(scale="tai", jds=(2441317.5, 0.0), delta=-6.938893903907228e-17)
+@example(scale="tai", jds=(2440001.0, 0.49999999999999994), delta=5.551115123125783e-17)
 def test_time_argminmaxsort(scale, jds, delta):
     jd1, jd2 = jds
-    t = (Time(jd1, jd2, scale=scale, format="jd")
-         + TimeDelta([0, delta], scale=scale, format='jd'))
+    t = Time(jd1, jd2, scale=scale, format="jd") + TimeDelta(
+        [0, delta], scale=scale, format="jd"
+    )
     imin = t.argmin()
     imax = t.argmax()
     isort = t.argsort()
     # Be careful in constructing diff, for case that abs(jd2[1]-jd2[0]) ~ 1.
     # and that is compensated by jd1[1]-jd1[0] (see example above).
     diff, extra = two_sum(t.jd2[1], -t.jd2[0])
-    diff += t.jd1[1]-t.jd1[0]
+    diff += t.jd1[1] - t.jd1[0]
     diff += extra
     if diff < 0:  # item 1 smaller
         assert delta < 0
@@ -575,19 +600,20 @@ def test_time_argminmaxsort(scale, jds, delta):
 
 
 @given(sampled_from(STANDARD_TIME_SCALES), unreasonable_jd(), unreasonable_jd())
-@example(scale='utc',
-         jds_a=(2455000.0, 0.0),
-         jds_b=(2443144.5, 0.5000462962962965))
-@example(scale='utc',
-         jds_a=(2459003.0, 0.267502885949074),
-         jds_b=(2454657.001045462, 0.49895453779026877))
+@example(scale="utc", jds_a=(2455000.0, 0.0), jds_b=(2443144.5, 0.5000462962962965))
+@example(
+    scale="utc",
+    jds_a=(2459003.0, 0.267502885949074),
+    jds_b=(2454657.001045462, 0.49895453779026877),
+)
 def test_timedelta_full_precision(scale, jds_a, jds_b):
     jd1_a, jd2_a = jds_a
     jd1_b, jd2_b = jds_b
-    assume(scale != 'utc'
-           or (2440000 < jd1_a+jd2_a < 2460000
-               and 2440000 < jd1_b+jd2_b < 2460000))
-    if scale == 'utc':
+    assume(
+        scale != "utc"
+        or (2440000 < jd1_a + jd2_a < 2460000 and 2440000 < jd1_b + jd2_b < 2460000)
+    )
+    if scale == "utc":
         # UTC subtraction implies a scale change, so possible rounding errors.
         tiny = 2 * dt_tiny
     else:
@@ -598,17 +624,24 @@ def test_timedelta_full_precision(scale, jds_a, jds_b):
     dt = t_b - t_a
     assert dt != (t_b + tiny) - t_a
     with quiet_erfa():
-        assert_almost_equal(t_b-dt/2, t_a+dt/2, atol=2*dt_tiny, rtol=0,
-                            label="midpoint")
-        assert_almost_equal(t_b+dt, t_a+2*dt, atol=2*dt_tiny, rtol=0, label="up")
-        assert_almost_equal(t_b-2*dt, t_a-dt, atol=2*dt_tiny, rtol=0, label="down")
+        assert_almost_equal(
+            t_b - dt / 2, t_a + dt / 2, atol=2 * dt_tiny, rtol=0, label="midpoint"
+        )
+        assert_almost_equal(
+            t_b + dt, t_a + 2 * dt, atol=2 * dt_tiny, rtol=0, label="up"
+        )
+        assert_almost_equal(
+            t_b - 2 * dt, t_a - dt, atol=2 * dt_tiny, rtol=0, label="down"
+        )
 
 
-@given(scale=sampled_from(STANDARD_TIME_SCALES),
-       jds_a=unreasonable_jd(),
-       jds_b=unreasonable_jd(),
-       x=integers(1, 100),
-       y=integers(1, 100))
+@given(
+    scale=sampled_from(STANDARD_TIME_SCALES),
+    jds_a=unreasonable_jd(),
+    jds_b=unreasonable_jd(),
+    x=integers(1, 100),
+    y=integers(1, 100),
+)
 def test_timedelta_full_precision_arithmetic(scale, jds_a, jds_b, x, y):
     jd1_a, jd2_a = jds_a
     jd1_b, jd2_b = jds_b
@@ -617,27 +650,33 @@ def test_timedelta_full_precision_arithmetic(scale, jds_a, jds_b, x, y):
     with quiet_erfa():
         try:
             dt = t_b - t_a
-            dt_x = x*dt/(x+y)
-            dt_y = y*dt/(x+y)
-            assert_almost_equal(dt_x + dt_y, dt, atol=(x+y)*dt_tiny, rtol=0)
+            dt_x = x * dt / (x + y)
+            dt_y = y * dt / (x + y)
+            assert_almost_equal(dt_x + dt_y, dt, atol=(x + y) * dt_tiny, rtol=0)
         except ErfaError:
-            assume(scale != 'utc'
-                   or (2440000 < jd1_a+jd2_a < 2460000
-                       and 2440000 < jd1_b+jd2_b < 2460000))
+            assume(
+                scale != "utc"
+                or (
+                    2440000 < jd1_a + jd2_a < 2460000
+                    and 2440000 < jd1_b + jd2_b < 2460000
+                )
+            )
             raise
 
 
-@given(scale1=sampled_from(STANDARD_TIME_SCALES),
-       scale2=sampled_from(STANDARD_TIME_SCALES),
-       jds_a=reasonable_jd(),
-       jds_b=reasonable_jd())
+@given(
+    scale1=sampled_from(STANDARD_TIME_SCALES),
+    scale2=sampled_from(STANDARD_TIME_SCALES),
+    jds_a=reasonable_jd(),
+    jds_b=reasonable_jd(),
+)
 def test_timedelta_conversion(scale1, scale2, jds_a, jds_b):
     jd1_a, jd2_a = jds_a
     jd1_b, jd2_b = jds_b
     # not translation invariant so can't convert TimeDelta
-    assume('utc' not in [scale1, scale2])
+    assume("utc" not in [scale1, scale2])
     # Conversions a problem but within UT1 it should work
-    assume(('ut1' not in [scale1, scale2]) or scale1 == scale2)
+    assume(("ut1" not in [scale1, scale2]) or scale1 == scale2)
     t_a = Time(jd1_a, jd2_a, scale=scale1, format="jd")
     t_b = Time(jd1_b, jd2_b, scale=scale2, format="jd")
     with quiet_erfa():
@@ -645,59 +684,68 @@ def test_timedelta_conversion(scale1, scale2, jds_a, jds_b):
         t_a_2 = getattr(t_a, scale2)
         t_b_2 = getattr(t_b, scale2)
         dt_2 = getattr(dt, scale2)
-        assert_almost_equal(t_b_2 - t_a_2, dt_2, atol=dt_tiny, rtol=0,
-                            label="converted")
+        assert_almost_equal(
+            t_b_2 - t_a_2, dt_2, atol=dt_tiny, rtol=0, label="converted"
+        )
         # Implicit conversion
-        assert_almost_equal(t_b_2 - t_a_2, dt, atol=dt_tiny, rtol=0,
-                            label="not converted")
+        assert_almost_equal(
+            t_b_2 - t_a_2, dt, atol=dt_tiny, rtol=0, label="not converted"
+        )
 
 
 # UTC disagrees when there are leap seconds
-_utc_bad = [(pytest.param(s, marks=pytest.mark.xfail) if s == 'utc' else s)
-            for s in STANDARD_TIME_SCALES]
+_utc_bad = [
+    (pytest.param(s, marks=pytest.mark.xfail) if s == "utc" else s)
+    for s in STANDARD_TIME_SCALES
+]
 
 
 @given(datetimes(), datetimes())  # datetimes have microsecond resolution
-@example(dt1=datetime(1235, 1, 1, 0, 0),
-         dt2=datetime(9950, 1, 1, 0, 0, 0, 890773))
+@example(dt1=datetime(1235, 1, 1, 0, 0), dt2=datetime(9950, 1, 1, 0, 0, 0, 890773))
 @pytest.mark.parametrize("scale", _utc_bad)
 def test_datetime_difference_agrees_with_timedelta(scale, dt1, dt2):
     t1 = Time(dt1, scale=scale)
     t2 = Time(dt2, scale=scale)
-    assert_almost_equal(t2-t1,
-                        TimeDelta(dt2-dt1,
-                                  scale=None if scale == 'utc' else scale),
-                        atol=2*u.us)
+    assert_almost_equal(
+        t2 - t1,
+        TimeDelta(dt2 - dt1, scale=None if scale == "utc" else scale),
+        atol=2 * u.us,
+    )
 
 
-@given(days=integers(-3000*365, 3000*365),
-       microseconds=integers(0, 24*60*60*1000000))
+@given(
+    days=integers(-3000 * 365, 3000 * 365),
+    microseconds=integers(0, 24 * 60 * 60 * 1000000),
+)
 @pytest.mark.parametrize("scale", _utc_bad)
 def test_datetime_to_timedelta(scale, days, microseconds):
     td = timedelta(days=days, microseconds=microseconds)
-    assert (TimeDelta(td, scale=scale)
-            == TimeDelta(days, microseconds/(86400*1e6), scale=scale, format="jd"))
+    assert TimeDelta(td, scale=scale) == TimeDelta(
+        days, microseconds / (86400 * 1e6), scale=scale, format="jd"
+    )
 
 
-@given(days=integers(-3000*365, 3000*365),
-       microseconds=integers(0, 24*60*60*1000000))
+@given(
+    days=integers(-3000 * 365, 3000 * 365),
+    microseconds=integers(0, 24 * 60 * 60 * 1000000),
+)
 @pytest.mark.parametrize("scale", _utc_bad)
 def test_datetime_timedelta_roundtrip(scale, days, microseconds):
     td = timedelta(days=days, microseconds=microseconds)
     assert td == TimeDelta(td, scale=scale).value
 
 
-@given(days=integers(-3000*365, 3000*365), day_frac=floats(0, 1))
+@given(days=integers(-3000 * 365, 3000 * 365), day_frac=floats(0, 1))
 @example(days=262144, day_frac=2.314815006343452e-11)
 @example(days=1048576, day_frac=1.157407503171726e-10)
 @pytest.mark.parametrize("scale", _utc_bad)
 def test_timedelta_datetime_roundtrip(scale, days, day_frac):
     td = TimeDelta(days, day_frac, format="jd", scale=scale)
     td.format = "datetime"
-    assert_almost_equal(td, TimeDelta(td.value, scale=scale), atol=2*u.us)
+    assert_almost_equal(td, TimeDelta(td.value, scale=scale), atol=2 * u.us)
 
 
-@given(integers(-3000*365, 3000*365), floats(0, 1))
+@given(integers(-3000 * 365, 3000 * 365), floats(0, 1))
 @example(days=262144, day_frac=2.314815006343452e-11)
 @pytest.mark.parametrize("scale", _utc_bad)
 def test_timedelta_from_parts(scale, days, day_frac):
@@ -713,21 +761,21 @@ def test_datetime_difference_agrees_with_timedelta_no_hypothesis():
     dt2 = datetime(9950, 1, 1, 0, 0, 0, 890773)
     t1 = Time(dt1, scale=scale)
     t2 = Time(dt2, scale=scale)
-    assert abs((t2-t1) - TimeDelta(dt2-dt1, scale=scale)) < 1*u.us
+    assert abs((t2 - t1) - TimeDelta(dt2 - dt1, scale=scale)) < 1 * u.us
 
 
 # datetimes have microsecond resolution
 @given(datetimes(), timedeltas())
-@example(dt=datetime(2000, 1, 1, 0, 0),
-         td=timedelta(days=-397683, microseconds=2))
-@example(dt=datetime(2179, 1, 1, 0, 0),
-         td=timedelta(days=-795365, microseconds=53))
-@example(dt=datetime(2000, 1, 1, 0, 0),
-         td=timedelta(days=1590729, microseconds=10))
-@example(dt=datetime(4357, 1, 1, 0, 0),
-         td=timedelta(days=-1590729, microseconds=107770))
-@example(dt=datetime(4357, 1, 1, 0, 0, 0, 29),
-         td=timedelta(days=-1590729, microseconds=746292))
+@example(dt=datetime(2000, 1, 1, 0, 0), td=timedelta(days=-397683, microseconds=2))
+@example(dt=datetime(2179, 1, 1, 0, 0), td=timedelta(days=-795365, microseconds=53))
+@example(dt=datetime(2000, 1, 1, 0, 0), td=timedelta(days=1590729, microseconds=10))
+@example(
+    dt=datetime(4357, 1, 1, 0, 0), td=timedelta(days=-1590729, microseconds=107770)
+)
+@example(
+    dt=datetime(4357, 1, 1, 0, 0, 0, 29),
+    td=timedelta(days=-1590729, microseconds=746292),
+)
 @pytest.mark.parametrize("scale", _utc_bad)
 def test_datetime_timedelta_sum(scale, dt, td):
     try:
@@ -735,40 +783,44 @@ def test_datetime_timedelta_sum(scale, dt, td):
     except OverflowError:
         assume(False)
     dt_a = Time(dt, scale=scale)
-    td_a = TimeDelta(td, scale=None if scale == 'utc' else scale)
-    assert_almost_equal(dt_a+td_a, Time(dt+td, scale=scale), atol=2*u.us)
+    td_a = TimeDelta(td, scale=None if scale == "utc" else scale)
+    assert_almost_equal(dt_a + td_a, Time(dt + td, scale=scale), atol=2 * u.us)
 
 
-@given(jds=reasonable_jd(),
-       lat1=floats(-90, 90),
-       lat2=floats(-90, 90),
-       lon=floats(-180, 180))
+@given(
+    jds=reasonable_jd(),
+    lat1=floats(-90, 90),
+    lat2=floats(-90, 90),
+    lon=floats(-180, 180),
+)
 @pytest.mark.parametrize("kind", ["apparent", "mean"])
 def test_sidereal_lat_independent(iers_b, kind, jds, lat1, lat2, lon):
     jd1, jd2 = jds
     t1 = Time(jd1, jd2, scale="ut1", format="jd", location=(lon, lat1))
     t2 = Time(jd1, jd2, scale="ut1", format="jd", location=(lon, lat2))
     try:
-        assert_almost_equal(t1.sidereal_time(kind),
-                            t2.sidereal_time(kind),
-                            atol=1*u.uas)
+        assert_almost_equal(
+            t1.sidereal_time(kind), t2.sidereal_time(kind), atol=1 * u.uas
+        )
     except iers.IERSRangeError:
         assume(False)
 
 
-@given(jds=reasonable_jd(),
-       lat=floats(-90, 90),
-       lon=floats(-180, 180),
-       lon_delta=floats(-360, 360))
+@given(
+    jds=reasonable_jd(),
+    lat=floats(-90, 90),
+    lon=floats(-180, 180),
+    lon_delta=floats(-360, 360),
+)
 @pytest.mark.parametrize("kind", ["apparent", "mean"])
 def test_sidereal_lon_independent(iers_b, kind, jds, lat, lon, lon_delta):
     jd1, jd2 = jds
     t1 = Time(jd1, jd2, scale="ut1", format="jd", location=(lon, lat))
-    t2 = Time(jd1, jd2, scale="ut1", format="jd", location=(lon+lon_delta, lat))
+    t2 = Time(jd1, jd2, scale="ut1", format="jd", location=(lon + lon_delta, lat))
     try:
-        diff = t1.sidereal_time(kind) + lon_delta*u.degree - t2.sidereal_time(kind)
+        diff = t1.sidereal_time(kind) + lon_delta * u.degree - t2.sidereal_time(kind)
     except iers.IERSRangeError:
         assume(False)
     else:
         expected_degrees = (diff.to_value(u.degree) + 180) % 360
-        assert_almost_equal(expected_degrees, 180, atol=1/(60*60*1000))
+        assert_almost_equal(expected_degrees, 180, atol=1 / (60 * 60 * 1000))

--- a/astropy/time/tests/test_quantity_interaction.py
+++ b/astropy/time/tests/test_quantity_interaction.py
@@ -8,8 +8,9 @@ from astropy import units as u
 from astropy.table import Column
 from astropy.time import Time, TimeDelta
 
-allclose_sec = functools.partial(np.allclose, rtol=2. ** -52,
-                                 atol=2. ** -52 * 24 * 3600)  # 20 ps atol
+allclose_sec = functools.partial(
+    np.allclose, rtol=2.0**-52, atol=2.0**-52 * 24 * 3600
+)  # 20 ps atol
 
 
 class TestTimeQuantity:
@@ -18,76 +19,75 @@ class TestTimeQuantity:
     def test_valid_quantity_input(self):
         """Test Time formats that are allowed to take quantity input."""
         q = 2450000.125 * u.day
-        t1 = Time(q, format='jd', scale='utc')
+        t1 = Time(q, format="jd", scale="utc")
         assert t1.value == q.value
         q2 = q.to(u.second)
-        t2 = Time(q2, format='jd', scale='utc')
+        t2 = Time(q2, format="jd", scale="utc")
         assert t2.value == q.value == q2.to_value(u.day)
         q3 = q - 2400000.5 * u.day
-        t3 = Time(q3, format='mjd', scale='utc')
+        t3 = Time(q3, format="mjd", scale="utc")
         assert t3.value == q3.value
         # test we can deal with two quantity arguments, with different units
-        qs = 24. * 36. * u.second
-        t4 = Time(q3, qs, format='mjd', scale='utc')
+        qs = 24.0 * 36.0 * u.second
+        t4 = Time(q3, qs, format="mjd", scale="utc")
         assert t4.value == (q3 + qs).to_value(u.day)
 
-        qy = 1990. * u.yr
-        ty1 = Time(qy, format='jyear', scale='utc')
+        qy = 1990.0 * u.yr
+        ty1 = Time(qy, format="jyear", scale="utc")
         assert ty1.value == qy.value
-        ty2 = Time(qy.to(u.day), format='jyear', scale='utc')
+        ty2 = Time(qy.to(u.day), format="jyear", scale="utc")
         assert ty2.value == qy.value
-        qy2 = 10. * u.yr
-        tcxc = Time(qy2, format='cxcsec')
+        qy2 = 10.0 * u.yr
+        tcxc = Time(qy2, format="cxcsec")
         assert tcxc.value == qy2.to_value(u.second)
-        tgps = Time(qy2, format='gps')
+        tgps = Time(qy2, format="gps")
         assert tgps.value == qy2.to_value(u.second)
-        tunix = Time(qy2, format='unix')
+        tunix = Time(qy2, format="unix")
         assert tunix.value == qy2.to_value(u.second)
-        qd = 2000. * 365. * u.day
-        tplt = Time(qd, format='plot_date', scale='utc')
+        qd = 2000.0 * 365.0 * u.day
+        tplt = Time(qd, format="plot_date", scale="utc")
         assert tplt.value == qd.value
 
     def test_invalid_quantity_input(self):
         with pytest.raises(u.UnitsError):
-            Time(2450000. * u.m, format='jd', scale='utc')
+            Time(2450000.0 * u.m, format="jd", scale="utc")
 
         with pytest.raises(u.UnitsError):
-            Time(2450000. * u.dimensionless_unscaled, format='jd', scale='utc')
+            Time(2450000.0 * u.dimensionless_unscaled, format="jd", scale="utc")
 
     def test_column_with_and_without_units(self):
         """Ensure a Column without a unit is treated as an array [#3648]"""
-        a = np.arange(50000., 50010.)
-        ta = Time(a, format='mjd')
-        c1 = Column(np.arange(50000., 50010.), name='mjd')
-        tc1 = Time(c1, format='mjd')
+        a = np.arange(50000.0, 50010.0)
+        ta = Time(a, format="mjd")
+        c1 = Column(np.arange(50000.0, 50010.0), name="mjd")
+        tc1 = Time(c1, format="mjd")
         assert np.all(ta == tc1)
-        c2 = Column(np.arange(50000., 50010.), name='mjd', unit='day')
-        tc2 = Time(c2, format='mjd')
+        c2 = Column(np.arange(50000.0, 50010.0), name="mjd", unit="day")
+        tc2 = Time(c2, format="mjd")
         assert np.all(ta == tc2)
-        c3 = Column(np.arange(50000., 50010.), name='mjd', unit='m')
+        c3 = Column(np.arange(50000.0, 50010.0), name="mjd", unit="m")
         with pytest.raises(u.UnitsError):
-            Time(c3, format='mjd')
+            Time(c3, format="mjd")
 
     def test_no_quantity_input_allowed(self):
         """Time formats that are not allowed to take Quantity input."""
-        qy = 1990. * u.yr
-        for fmt in ('iso', 'yday', 'datetime', 'byear',
-                    'byear_str', 'jyear_str'):
+        qy = 1990.0 * u.yr
+        for fmt in ("iso", "yday", "datetime", "byear", "byear_str", "jyear_str"):
             with pytest.raises(ValueError):
-                Time(qy, format=fmt, scale='utc')
+                Time(qy, format=fmt, scale="utc")
 
     def test_valid_quantity_operations(self):
         """Check that adding a time-valued quantity to a Time gives a Time"""
-        t0 = Time(100000., format='cxcsec')
-        q1 = 10. * u.second
+        t0 = Time(100000.0, format="cxcsec")
+        q1 = 10.0 * u.second
         t1 = t0 + q1
         assert isinstance(t1, Time)
         assert t1.value == t0.value + q1.to_value(u.second)
-        q2 = 1. * u.day
+        q2 = 1.0 * u.day
         t2 = t0 - q2
         assert allclose_sec(t2.value, t0.value - q2.to_value(u.second))
         # check broadcasting
-        q3 = np.arange(15.).reshape(3, 5) * u.hour
+        q3 = np.arange(15.0).reshape(3, 5) * u.hour
         t3 = t0 - q3
         assert t3.shape == q3.shape
         assert allclose_sec(t3.value, t0.value - q3.to_value(u.second))
@@ -96,9 +96,9 @@ class TestTimeQuantity:
         """Check that comparisons of Time with quantities does not work
         (even for time-like, since we cannot compare Time to TimeDelta)"""
         with pytest.raises(TypeError):
-            Time(100000., format='cxcsec') > 10. * u.m
+            Time(100000.0, format="cxcsec") > 10.0 * u.m
         with pytest.raises(TypeError):
-            Time(100000., format='cxcsec') > 10. * u.second
+            Time(100000.0, format="cxcsec") > 10.0 * u.second
 
 
 class TestTimeDeltaQuantity:
@@ -107,69 +107,71 @@ class TestTimeDeltaQuantity:
     def test_valid_quantity_input(self):
         """Test that TimeDelta can take quantity input."""
         q = 500.25 * u.day
-        dt1 = TimeDelta(q, format='jd')
+        dt1 = TimeDelta(q, format="jd")
         assert dt1.value == q.value
-        dt2 = TimeDelta(q, format='sec')
+        dt2 = TimeDelta(q, format="sec")
         assert dt2.value == q.to_value(u.second)
         dt3 = TimeDelta(q)
         assert dt3.value == q.value
 
     def test_invalid_quantity_input(self):
         with pytest.raises(u.UnitsError):
-            TimeDelta(2450000. * u.m, format='jd')
+            TimeDelta(2450000.0 * u.m, format="jd")
 
         with pytest.raises(u.UnitsError):
-            Time(2450000. * u.dimensionless_unscaled, format='jd', scale='utc')
+            Time(2450000.0 * u.dimensionless_unscaled, format="jd", scale="utc")
 
         with pytest.raises(TypeError):
-            TimeDelta(100, format='sec') > 10. * u.m
+            TimeDelta(100, format="sec") > 10.0 * u.m
 
     def test_quantity_output(self):
         q = 500.25 * u.day
         dt = TimeDelta(q)
         assert dt.to(u.day) == q
         assert dt.to_value(u.day) == q.value
-        assert dt.to_value('day') == q.value
+        assert dt.to_value("day") == q.value
         assert dt.to(u.second).value == q.to_value(u.second)
         assert dt.to_value(u.second) == q.to_value(u.second)
-        assert dt.to_value('s') == q.to_value(u.second)
+        assert dt.to_value("s") == q.to_value(u.second)
         # Following goes through "format", but should be the same.
-        assert dt.to_value('sec') == q.to_value(u.second)
+        assert dt.to_value("sec") == q.to_value(u.second)
 
     def test_quantity_output_errors(self):
-        dt = TimeDelta(250., format='sec')
+        dt = TimeDelta(250.0, format="sec")
         with pytest.raises(u.UnitsError):
             dt.to(u.m)
         with pytest.raises(u.UnitsError):
             dt.to_value(u.m)
         with pytest.raises(u.UnitsError):
             dt.to_value(unit=u.m)
-        with pytest.raises(ValueError, match=("not one of the known formats.*"
-                                              "failed to parse as a unit")):
-            dt.to_value('parrot')
+        with pytest.raises(
+            ValueError,
+            match="not one of the known formats.*failed to parse as a unit",
+        ):
+            dt.to_value("parrot")
         with pytest.raises(TypeError):
-            dt.to_value('sec', unit=u.s)
+            dt.to_value("sec", unit=u.s)
         with pytest.raises(TypeError):
             # TODO: would be nice to make this work!
-            dt.to_value(u.s, subfmt='str')
+            dt.to_value(u.s, subfmt="str")
 
     def test_valid_quantity_operations1(self):
         """Check adding/substracting/comparing a time-valued quantity works
         with a TimeDelta.  Addition/subtraction should give TimeDelta"""
-        t0 = TimeDelta(106400., format='sec')
-        q1 = 10. * u.second
+        t0 = TimeDelta(106400.0, format="sec")
+        q1 = 10.0 * u.second
         t1 = t0 + q1
         assert isinstance(t1, TimeDelta)
         assert t1.value == t0.value + q1.to_value(u.second)
-        q2 = 1. * u.day
+        q2 = 1.0 * u.day
         t2 = t0 - q2
         assert isinstance(t2, TimeDelta)
         assert allclose_sec(t2.value, t0.value - q2.to_value(u.second))
         # now comparisons
         assert t0 > q1
-        assert t0 < 1. * u.yr
+        assert t0 < 1.0 * u.yr
         # and broadcasting
-        q3 = np.arange(12.).reshape(4, 3) * u.hour
+        q3 = np.arange(12.0).reshape(4, 3) * u.hour
         t3 = t0 + q3
         assert isinstance(t3, TimeDelta)
         assert t3.shape == q3.shape
@@ -177,31 +179,31 @@ class TestTimeDeltaQuantity:
 
     def test_valid_quantity_operations2(self):
         """Check that TimeDelta is treated as a quantity where possible."""
-        t0 = TimeDelta(100000., format='sec')
-        f = 1. / t0
+        t0 = TimeDelta(100000.0, format="sec")
+        f = 1.0 / t0
         assert isinstance(f, u.Quantity)
-        assert f.unit == 1. / u.day
-        g = 10. * u.m / u.second**2
+        assert f.unit == 1.0 / u.day
+        g = 10.0 * u.m / u.second**2
         v = t0 * g
         assert isinstance(v, u.Quantity)
         assert u.allclose(v, t0.sec * g.value * u.m / u.second)
         q = np.log10(t0 / u.second)
         assert isinstance(q, u.Quantity)
         assert q.value == np.log10(t0.sec)
-        s = 1. * u.m
+        s = 1.0 * u.m
         v = s / t0
         assert isinstance(v, u.Quantity)
-        assert u.allclose(v, 1. / t0.sec * u.m / u.s)
-        t = 1. * u.s
+        assert u.allclose(v, 1.0 / t0.sec * u.m / u.s)
+        t = 1.0 * u.s
         t2 = t0 * t
         assert isinstance(t2, u.Quantity)
-        assert u.allclose(t2, t0.sec * u.s ** 2)
+        assert u.allclose(t2, t0.sec * u.s**2)
         t3 = [1] / t0
         assert isinstance(t3, u.Quantity)
         assert u.allclose(t3, 1 / (t0.sec * u.s))
         # broadcasting
-        t1 = TimeDelta(np.arange(100000., 100012.).reshape(6, 2), format='sec')
-        f = np.array([1., 2.]) * u.cycle * u.Hz
+        t1 = TimeDelta(np.arange(100000.0, 100012.0).reshape(6, 2), format="sec")
+        f = np.array([1.0, 2.0]) * u.cycle * u.Hz
         phase = f * t1
         assert isinstance(phase, u.Quantity)
         assert phase.shape == t1.shape
@@ -215,59 +217,59 @@ class TestTimeDeltaQuantity:
 
     def test_valid_quantity_operations3(self):
         """Test a TimeDelta remains one if possible."""
-        t0 = TimeDelta(10., format='jd')
-        q = 10. * u.one
+        t0 = TimeDelta(10.0, format="jd")
+        q = 10.0 * u.one
         t1 = q * t0
         assert isinstance(t1, TimeDelta)
-        assert t1 == TimeDelta(100., format='jd')
+        assert t1 == TimeDelta(100.0, format="jd")
         t2 = t0 * q
         assert isinstance(t2, TimeDelta)
-        assert t2 == TimeDelta(100., format='jd')
+        assert t2 == TimeDelta(100.0, format="jd")
         t3 = t0 / q
         assert isinstance(t3, TimeDelta)
-        assert t3 == TimeDelta(1., format='jd')
-        q2 = 1. * u.percent
+        assert t3 == TimeDelta(1.0, format="jd")
+        q2 = 1.0 * u.percent
         t4 = t0 * q2
         assert isinstance(t4, TimeDelta)
-        assert abs(t4 - TimeDelta(0.1, format='jd')) < 1. * u.ns
-        q3 = 1. * u.hr / (36. * u.s)
+        assert abs(t4 - TimeDelta(0.1, format="jd")) < 1.0 * u.ns
+        q3 = 1.0 * u.hr / (36.0 * u.s)
         t5 = q3 * t0
         assert isinstance(t4, TimeDelta)
-        assert abs(t5 - TimeDelta(1000., format='jd')) < 1. * u.ns
+        assert abs(t5 - TimeDelta(1000.0, format="jd")) < 1.0 * u.ns
         # Test multiplication with a unit.
         t6 = t0 * u.one
         assert isinstance(t6, TimeDelta)
-        assert t6 == TimeDelta(10., format='jd')
+        assert t6 == TimeDelta(10.0, format="jd")
         t7 = u.one * t0
         assert isinstance(t7, TimeDelta)
-        assert t7 == TimeDelta(10., format='jd')
-        t8 = t0 * ''
+        assert t7 == TimeDelta(10.0, format="jd")
+        t8 = t0 * ""
         assert isinstance(t8, TimeDelta)
-        assert t8 == TimeDelta(10., format='jd')
-        t9 = '' * t0
+        assert t8 == TimeDelta(10.0, format="jd")
+        t9 = "" * t0
         assert isinstance(t9, TimeDelta)
-        assert t9 == TimeDelta(10., format='jd')
+        assert t9 == TimeDelta(10.0, format="jd")
         t10 = t0 / u.one
         assert isinstance(t10, TimeDelta)
-        assert t6 == TimeDelta(10., format='jd')
-        t11 = t0 / ''
+        assert t6 == TimeDelta(10.0, format="jd")
+        t11 = t0 / ""
         assert isinstance(t11, TimeDelta)
-        assert t11 == TimeDelta(10., format='jd')
+        assert t11 == TimeDelta(10.0, format="jd")
         t12 = t0 / [1]
         assert isinstance(t12, TimeDelta)
-        assert t12 == TimeDelta(10., format='jd')
+        assert t12 == TimeDelta(10.0, format="jd")
         t13 = [1] * t0
         assert isinstance(t13, TimeDelta)
-        assert t13 == TimeDelta(10., format='jd')
+        assert t13 == TimeDelta(10.0, format="jd")
 
     def test_invalid_quantity_operations(self):
         """Check comparisons of TimeDelta with non-time quantities fails."""
         with pytest.raises(TypeError):
-            TimeDelta(100000., format='sec') > 10. * u.m
+            TimeDelta(100000.0, format="sec") > 10.0 * u.m
 
     def test_invalid_quantity_operations2(self):
         """Check that operations with non-time/quantity fail."""
-        td = TimeDelta(100000., format='sec')
+        td = TimeDelta(100000.0, format="sec")
         with pytest.raises(TypeError):
             td * object()
         with pytest.raises(TypeError):
@@ -275,53 +277,58 @@ class TestTimeDeltaQuantity:
 
     def test_invalid_quantity_broadcast(self):
         """Check broadcasting rules in interactions with Quantity."""
-        t0 = TimeDelta(np.arange(12.).reshape(4, 3), format='sec')
+        t0 = TimeDelta(np.arange(12.0).reshape(4, 3), format="sec")
         with pytest.raises(ValueError):
-            t0 + np.arange(4.) * u.s
+            t0 + np.arange(4.0) * u.s
 
 
 class TestDeltaAttributes:
     def test_delta_ut1_utc(self):
-        t = Time('2010-01-01 00:00:00', format='iso', scale='utc', precision=6)
+        t = Time("2010-01-01 00:00:00", format="iso", scale="utc", precision=6)
         t.delta_ut1_utc = 0.3 * u.s
-        assert t.ut1.iso == '2010-01-01 00:00:00.300000'
-        t.delta_ut1_utc = 0.4 / 60. * u.minute
-        assert t.ut1.iso == '2010-01-01 00:00:00.400000'
+        assert t.ut1.iso == "2010-01-01 00:00:00.300000"
+        t.delta_ut1_utc = 0.4 / 60.0 * u.minute
+        assert t.ut1.iso == "2010-01-01 00:00:00.400000"
         with pytest.raises(u.UnitsError):
             t.delta_ut1_utc = 0.4 * u.m
         # Also check that a TimeDelta works.
-        t.delta_ut1_utc = TimeDelta(0.3, format='sec')
-        assert t.ut1.iso == '2010-01-01 00:00:00.300000'
-        t.delta_ut1_utc = TimeDelta(0.5 / 24. / 3600., format='jd')
-        assert t.ut1.iso == '2010-01-01 00:00:00.500000'
+        t.delta_ut1_utc = TimeDelta(0.3, format="sec")
+        assert t.ut1.iso == "2010-01-01 00:00:00.300000"
+        t.delta_ut1_utc = TimeDelta(0.5 / 24.0 / 3600.0, format="jd")
+        assert t.ut1.iso == "2010-01-01 00:00:00.500000"
 
     def test_delta_tdb_tt(self):
-        t = Time('2010-01-01 00:00:00', format='iso', scale='tt', precision=6)
-        t.delta_tdb_tt = 20. * u.second
-        assert t.tdb.iso == '2010-01-01 00:00:20.000000'
-        t.delta_tdb_tt = 30. / 60. * u.minute
-        assert t.tdb.iso == '2010-01-01 00:00:30.000000'
+        t = Time("2010-01-01 00:00:00", format="iso", scale="tt", precision=6)
+        t.delta_tdb_tt = 20.0 * u.second
+        assert t.tdb.iso == "2010-01-01 00:00:20.000000"
+        t.delta_tdb_tt = 30.0 / 60.0 * u.minute
+        assert t.tdb.iso == "2010-01-01 00:00:30.000000"
         with pytest.raises(u.UnitsError):
             t.delta_tdb_tt = 0.4 * u.m
         # Also check that a TimeDelta works.
-        t.delta_tdb_tt = TimeDelta(40., format='sec')
-        assert t.tdb.iso == '2010-01-01 00:00:40.000000'
-        t.delta_tdb_tt = TimeDelta(50. / 24. / 3600., format='jd')
-        assert t.tdb.iso == '2010-01-01 00:00:50.000000'
+        t.delta_tdb_tt = TimeDelta(40.0, format="sec")
+        assert t.tdb.iso == "2010-01-01 00:00:40.000000"
+        t.delta_tdb_tt = TimeDelta(50.0 / 24.0 / 3600.0, format="jd")
+        assert t.tdb.iso == "2010-01-01 00:00:50.000000"
 
 
-@pytest.mark.parametrize('q1, q2', ((5e8 * u.s, None),
-                                    (5e17 * u.ns, None),
-                                    (4e8 * u.s, 1e17 * u.ns),
-                                    (4e14 * u.us, 1e17 * u.ns)))
+@pytest.mark.parametrize(
+    "q1, q2",
+    (
+        (5e8 * u.s, None),
+        (5e17 * u.ns, None),
+        (4e8 * u.s, 1e17 * u.ns),
+        (4e14 * u.us, 1e17 * u.ns),
+    ),
+)
 def test_quantity_conversion_rounding(q1, q2):
     """Check that no rounding errors are incurred by unit conversion.
 
     This occurred before as quantities in seconds were converted to days
     before trying to split them into two-part doubles.  See gh-7622.
     """
-    t = Time('2001-01-01T00:00:00.', scale='tai')
-    expected = Time('2016-11-05T00:53:20.', scale='tai')
+    t = Time("2001-01-01T00:00:00.", scale="tai")
+    expected = Time("2016-11-05T00:53:20.", scale="tai")
     if q2 is None:
         t0 = t + q1
     else:
@@ -330,6 +337,6 @@ def test_quantity_conversion_rounding(q1, q2):
     dt1 = TimeDelta(q1, q2)
     t1 = t + dt1
     assert abs(t1 - expected) < 20 * u.ps
-    dt2 = TimeDelta(q1, q2, format='sec')
+    dt2 = TimeDelta(q1, q2, format="sec")
     t2 = t + dt2
     assert abs(t2 - expected) < 20 * u.ps

--- a/astropy/time/tests/test_sidereal.py
+++ b/astropy/time/tests/test_sidereal.py
@@ -13,13 +13,13 @@ from astropy.utils import iers
 
 allclose_hours = functools.partial(np.allclose, rtol=1e-15, atol=3e-8)
 # 0.1 ms atol; IERS-B files change at that level.
-within_1_second = functools.partial(np.allclose, rtol=1., atol=1. / 3600.)
-within_2_seconds = functools.partial(np.allclose, rtol=1., atol=2. / 3600.)
+within_1_second = functools.partial(np.allclose, rtol=1.0, atol=1.0 / 3600.0)
+within_2_seconds = functools.partial(np.allclose, rtol=1.0, atol=2.0 / 3600.0)
 
 
 def test_doc_string_contains_models():
     """The doc string is formatted; this ensures this remains working."""
-    for kind in ('mean', 'apparent'):
+    for kind in ("mean", "apparent"):
         for model in SIDEREAL_TIME_MODELS[kind]:
             assert model in Time.sidereal_time.__doc__
 
@@ -29,49 +29,60 @@ class TestERFATestCases:
 
     def setup_class(cls):
         # Sidereal time tests use the following JD inputs.
-        cls.time_ut1 = Time(2400000.5, 53736.0, scale='ut1', format='jd')
-        cls.time_tt = Time(2400000.5, 53736.0, scale='tt', format='jd')
+        cls.time_ut1 = Time(2400000.5, 53736.0, scale="ut1", format="jd")
+        cls.time_tt = Time(2400000.5, 53736.0, scale="tt", format="jd")
         # but tt!=ut1 at these dates, unlike what is assumed, so we cannot
         # reproduce this exactly. Now it does not really matter,
         # but may as well fake this (and avoid IERS table lookup here)
-        cls.time_ut1.delta_ut1_utc = 0.
-        cls.time_ut1.delta_ut1_utc = 24 * 3600 * (
-            (cls.time_ut1.tt.jd1 - cls.time_tt.jd1)
-            + (cls.time_ut1.tt.jd2 - cls.time_tt.jd2))
+        cls.time_ut1.delta_ut1_utc = 0.0
+        cls.time_ut1.delta_ut1_utc = (
+            24
+            * 3600
+            * (
+                (cls.time_ut1.tt.jd1 - cls.time_tt.jd1)
+                + (cls.time_ut1.tt.jd2 - cls.time_tt.jd2)
+            )
+        )
 
     def test_setup(self):
-        assert np.allclose((self.time_ut1.tt.jd1 - self.time_tt.jd1)
-                           + (self.time_ut1.tt.jd2 - self.time_tt.jd2),
-                           0., atol=1.e-14)
+        assert np.allclose(
+            (self.time_ut1.tt.jd1 - self.time_tt.jd1)
+            + (self.time_ut1.tt.jd2 - self.time_tt.jd2),
+            0.0,
+            atol=1.0e-14,
+        )
 
-    @pytest.mark.parametrize('erfa_test_input',
-                             ((1.754174972210740592, 1e-12, "eraGmst00"),
-                              (1.754174971870091203, 1e-12, "eraGmst06"),
-                              (1.754174981860675096, 1e-12, "eraGmst82"),
-                              (1.754166138018281369, 1e-12, "eraGst00a"),
-                              (1.754166136510680589, 1e-12, "eraGst00b"),
-                              (1.754166137675019159, 1e-12, "eraGst06a"),
-                              (1.754166136020645203, 1e-12, "eraGst94")))
+    @pytest.mark.parametrize(
+        "erfa_test_input",
+        (
+            (1.754174972210740592, 1e-12, "eraGmst00"),
+            (1.754174971870091203, 1e-12, "eraGmst06"),
+            (1.754174981860675096, 1e-12, "eraGmst82"),
+            (1.754166138018281369, 1e-12, "eraGst00a"),
+            (1.754166136510680589, 1e-12, "eraGst00b"),
+            (1.754166137675019159, 1e-12, "eraGst06a"),
+            (1.754166136020645203, 1e-12, "eraGst94"),
+        ),
+    )
     def test_iau_models(self, erfa_test_input):
         result, precision, name = erfa_test_input
-        if name[4] == 'm':
-            kind = 'mean'
+        if name[4] == "m":
+            kind = "mean"
             model_name = f"IAU{20 if name[7] == '0' else 19:2d}{name[7:]:s}"
         else:
-            kind = 'apparent'
+            kind = "apparent"
             model_name = f"IAU{20 if name[6] == '0' else 19:2d}{name[6:].upper():s}"
 
         assert kind in SIDEREAL_TIME_MODELS.keys()
         assert model_name in SIDEREAL_TIME_MODELS[kind]
 
-        gst = self.time_ut1.sidereal_time(kind, 'greenwich', model_name)
-        assert np.allclose(gst.to_value('radian'), result,
-                           rtol=1., atol=precision)
+        gst = self.time_ut1.sidereal_time(kind, "greenwich", model_name)
+        assert np.allclose(gst.to_value("radian"), result, rtol=1.0, atol=precision)
 
     def test_era(self):
         # Separate since it does not use the same time.
-        time_ut1 = Time(2400000.5, 54388.0, format='jd', scale='ut1')
-        era = time_ut1.earth_rotation_angle('tio')
+        time_ut1 = Time(2400000.5, 54388.0, format="jd", scale="ut1")
+        era = time_ut1.earth_rotation_angle("tio")
         expected = 0.4022837240028158102
         assert np.abs(era.to_value(u.radian) - expected) < 1e-12
 
@@ -86,36 +97,53 @@ class TestST:
         cls.orig_auto_download = iers.conf.auto_download
         iers.conf.auto_download = False
 
-        cls.t1 = Time(['2012-06-30 12:00:00', '2012-06-30 23:59:59',
-                       '2012-06-30 23:59:60', '2012-07-01 00:00:00',
-                       '2012-07-01 12:00:00'], scale='utc')
-        cls.t2 = Time(cls.t1, location=('120d', '10d'))
+        cls.t1 = Time(
+            [
+                "2012-06-30 12:00:00",
+                "2012-06-30 23:59:59",
+                "2012-06-30 23:59:60",
+                "2012-07-01 00:00:00",
+                "2012-07-01 12:00:00",
+            ],
+            scale="utc",
+        )
+        cls.t2 = Time(cls.t1, location=("120d", "10d"))
 
     @classmethod
     def teardown_class(cls):
         iers.conf.auto_download = cls.orig_auto_download
 
     def test_gmst(self):
-        """Compare Greenwich Mean Sidereal Time with what was found earlier
-        """
-        gmst_compare = np.array([6.5968497894730564, 18.629426164144697,
-                                 18.629704702452862, 18.629983240761003,
-                                 6.6628381828899643])
-        gmst = self.t1.sidereal_time('mean', 'greenwich')
+        """Compare Greenwich Mean Sidereal Time with what was found earlier"""
+        gmst_compare = np.array(
+            [
+                6.5968497894730564,
+                18.629426164144697,
+                18.629704702452862,
+                18.629983240761003,
+                6.6628381828899643,
+            ]
+        )
+        gmst = self.t1.sidereal_time("mean", "greenwich")
         assert allclose_hours(gmst.value, gmst_compare)
 
     def test_gst(self):
-        """Compare Greenwich Apparent Sidereal Time with what was found earlier
-        """
-        gst_compare = np.array([6.5971168570494854, 18.629694220878296,
-                                18.62997275921186, 18.630251297545389,
-                                6.6631074284018244])
-        gst = self.t1.sidereal_time('apparent', 'greenwich')
+        """Compare Greenwich Apparent Sidereal Time with what was found earlier"""
+        gst_compare = np.array(
+            [
+                6.5971168570494854,
+                18.629694220878296,
+                18.62997275921186,
+                18.630251297545389,
+                6.6631074284018244,
+            ]
+        )
+        gst = self.t1.sidereal_time("apparent", "greenwich")
         assert allclose_hours(gst.value, gst_compare)
 
     def test_era(self):
         """Comare ERA relative to erfa.era00 test case."""
-        t = Time(2400000.5, 54388.0, format='jd', location=(0, 0), scale='ut1')
+        t = Time(2400000.5, 54388.0, format="jd", location=(0, 0), scale="ut1")
         era = t.earth_rotation_angle()
         expected = 0.4022837240028158102 * u.radian
         # Without the TIO locator/polar motion, this should be close already.
@@ -128,7 +156,7 @@ class TestST:
         expected1 = expected + (np.arctan2(r[0, 1], r[0, 0]) << u.radian)
         assert np.abs(era - expected1) < 1e-12 * u.radian
         # Now try at a longitude different from 0.
-        t2 = Time(2400000.5, 54388.0, format='jd', location=(45, 0), scale='ut1')
+        t2 = Time(2400000.5, 54388.0, format="jd", location=(45, 0), scale="ut1")
         era2 = t2.earth_rotation_angle()
         r2 = erfa.rz(np.deg2rad(45), r)
         expected2 = expected + (np.arctan2(r2[0, 1], r2[0, 0]) << u.radian)
@@ -136,71 +164,94 @@ class TestST:
 
     def test_gmst_gst_close(self):
         """Check that Mean and Apparent are within a few seconds."""
-        gmst = self.t1.sidereal_time('mean', 'greenwich')
-        gst = self.t1.sidereal_time('apparent', 'greenwich')
+        gmst = self.t1.sidereal_time("mean", "greenwich")
+        gst = self.t1.sidereal_time("apparent", "greenwich")
         assert within_2_seconds(gst.value, gmst.value)
 
     def test_gmst_era_close(self):
         """Check that mean sidereal time and earth rotation angle are close."""
-        gmst = self.t1.sidereal_time('mean', 'greenwich')
-        era = self.t1.earth_rotation_angle('tio')
+        gmst = self.t1.sidereal_time("mean", "greenwich")
+        era = self.t1.earth_rotation_angle("tio")
         assert within_2_seconds(era.value, gmst.value)
 
     def test_gmst_independent_of_self_location(self):
         """Check that Greenwich time does not depend on self.location"""
-        gmst1 = self.t1.sidereal_time('mean', 'greenwich')
-        gmst2 = self.t2.sidereal_time('mean', 'greenwich')
+        gmst1 = self.t1.sidereal_time("mean", "greenwich")
+        gmst2 = self.t2.sidereal_time("mean", "greenwich")
         assert allclose_hours(gmst1.value, gmst2.value)
 
     def test_gmst_vs_lmst(self):
         """Check that Greenwich and local sidereal time differ."""
-        gmst = self.t1.sidereal_time('mean', 'greenwich')
-        lmst = self.t1.sidereal_time('mean', 0)
+        gmst = self.t1.sidereal_time("mean", "greenwich")
+        lmst = self.t1.sidereal_time("mean", 0)
         assert allclose_hours(lmst.value, gmst.value)
-        assert np.all(np.abs(lmst-gmst) > 1e-10 * u.hourangle)
+        assert np.all(np.abs(lmst - gmst) > 1e-10 * u.hourangle)
 
-    @pytest.mark.parametrize('kind', ('mean', 'apparent'))
+    @pytest.mark.parametrize("kind", ("mean", "apparent"))
     def test_lst(self, kind):
         """Compare Local Sidereal Time with what was found earlier,
         as well as with what is expected from GMST
         """
         lst_compare = {
-            'mean': np.array([14.596849789473058, 2.629426164144693,
-                              2.6297047024528588, 2.6299832407610033,
-                              14.662838182889967]),
-            'apparent': np.array([14.597116857049487, 2.6296942208782959,
-                                  2.6299727592118565, 2.6302512975453887,
-                                  14.663107428401826])}
+            "mean": np.array(
+                [
+                    14.596849789473058,
+                    2.629426164144693,
+                    2.6297047024528588,
+                    2.6299832407610033,
+                    14.662838182889967,
+                ]
+            ),
+            "apparent": np.array(
+                [
+                    14.597116857049487,
+                    2.6296942208782959,
+                    2.6299727592118565,
+                    2.6302512975453887,
+                    14.663107428401826,
+                ]
+            ),
+        }
 
-        gmst2 = self.t2.sidereal_time(kind, 'greenwich')
+        gmst2 = self.t2.sidereal_time(kind, "greenwich")
         lmst2 = self.t2.sidereal_time(kind)
         assert allclose_hours(lmst2.value, lst_compare[kind])
-        assert allclose_hours((lmst2 - gmst2).wrap_at('12h').value,
-                              self.t2.location.lon.to_value('hourangle'))
+        assert allclose_hours(
+            (lmst2 - gmst2).wrap_at("12h").value,
+            self.t2.location.lon.to_value("hourangle"),
+        )
         # check it also works when one gives longitude explicitly
         lmst1 = self.t1.sidereal_time(kind, self.t2.location.lon)
         assert allclose_hours(lmst1.value, lst_compare[kind])
 
     def test_lst_string_longitude(self):
-        lmst1 = self.t1.sidereal_time('mean', longitude='120d')
-        lmst2 = self.t2.sidereal_time('mean')
+        lmst1 = self.t1.sidereal_time("mean", longitude="120d")
+        lmst2 = self.t2.sidereal_time("mean")
         assert allclose_hours(lmst1.value, lmst2.value)
 
     def test_lst_needs_location(self):
         with pytest.raises(ValueError):
-            self.t1.sidereal_time('mean')
+            self.t1.sidereal_time("mean")
         with pytest.raises(ValueError):
-            self.t1.sidereal_time('mean', None)
+            self.t1.sidereal_time("mean", None)
 
     def test_lera(self):
-        lera_compare = np.array([14.586176631122177, 2.618751847545134,
-                                 2.6190303858265067, 2.619308924107852,
-                                 14.652162695594276])
-        gera2 = self.t2.earth_rotation_angle('tio')
+        lera_compare = np.array(
+            [
+                14.586176631122177,
+                2.618751847545134,
+                2.6190303858265067,
+                2.619308924107852,
+                14.652162695594276,
+            ]
+        )
+        gera2 = self.t2.earth_rotation_angle("tio")
         lera2 = self.t2.earth_rotation_angle()
         assert allclose_hours(lera2.value, lera_compare)
-        assert allclose_hours((lera2 - gera2).wrap_at('12h').value,
-                              self.t2.location.lon.to_value('hourangle'))
+        assert allclose_hours(
+            (lera2 - gera2).wrap_at("12h").value,
+            self.t2.location.lon.to_value("hourangle"),
+        )
         # Check it also works when one gives location explicitly.
         # This also verifies input of a location generally.
         lera1 = self.t1.earth_rotation_angle(self.t2.location)
@@ -215,20 +266,20 @@ class TestModelInterpretation:
         cls.orig_auto_download = iers.conf.auto_download
         iers.conf.auto_download = False
 
-        cls.t = Time(['2012-06-30 12:00:00'], scale='utc',
-                     location=('120d', '10d'))
+        cls.t = Time(["2012-06-30 12:00:00"], scale="utc", location=("120d", "10d"))
 
     @classmethod
     def teardown_class(cls):
         iers.conf.auto_download = cls.orig_auto_download
 
-    @pytest.mark.parametrize('kind', ('mean', 'apparent'))
+    @pytest.mark.parametrize("kind", ("mean", "apparent"))
     def test_model_uniqueness(self, kind):
         """Check models give different answers, yet are close."""
         for model1, model2 in itertools.combinations(
-                SIDEREAL_TIME_MODELS[kind].keys(), 2):
-            gst1 = self.t.sidereal_time(kind, 'greenwich', model1)
-            gst2 = self.t.sidereal_time(kind, 'greenwich', model2)
+            SIDEREAL_TIME_MODELS[kind].keys(), 2
+        ):
+            gst1 = self.t.sidereal_time(kind, "greenwich", model1)
+            gst2 = self.t.sidereal_time(kind, "greenwich", model2)
             assert np.all(gst1.value != gst2.value)
             assert within_1_second(gst1.value, gst2.value)
             lst1 = self.t.sidereal_time(kind, None, model1)
@@ -236,16 +287,17 @@ class TestModelInterpretation:
             assert np.all(lst1.value != lst2.value)
             assert within_1_second(lst1.value, lst2.value)
 
-    @pytest.mark.parametrize(('kind', 'other'), (('mean', 'apparent'),
-                                                 ('apparent', 'mean')))
+    @pytest.mark.parametrize(
+        ("kind", "other"), (("mean", "apparent"), ("apparent", "mean"))
+    )
     def test_wrong_models_raise_exceptions(self, kind, other):
-
         with pytest.raises(ValueError):
-            self.t.sidereal_time(kind, 'greenwich', 'nonsense')
+            self.t.sidereal_time(kind, "greenwich", "nonsense")
 
-        for model in (set(SIDEREAL_TIME_MODELS[other].keys())
-                      - set(SIDEREAL_TIME_MODELS[kind].keys())):
+        for model in set(SIDEREAL_TIME_MODELS[other].keys()) - set(
+            SIDEREAL_TIME_MODELS[kind].keys()
+        ):
             with pytest.raises(ValueError):
-                self.t.sidereal_time(kind, 'greenwich', model)
+                self.t.sidereal_time(kind, "greenwich", model)
             with pytest.raises(ValueError):
                 self.t.sidereal_time(kind, None, model)

--- a/astropy/time/tests/test_update_leap_seconds.py
+++ b/astropy/time/tests/test_update_leap_seconds.py
@@ -23,23 +23,23 @@ class TestUpdateLeapSeconds:
 
     def test_auto_update_leap_seconds(self):
         # Sanity check.
-        assert erfa.dat(2018, 1, 1, 0.) == 37.0
+        assert erfa.dat(2018, 1, 1, 0.0) == 37.0
         # Set expired leap seconds
-        expired = self.erfa_ls[self.erfa_ls['year'] < 2017]
-        expired.update_erfa_leap_seconds(initialize_erfa='empty')
+        expired = self.erfa_ls[self.erfa_ls["year"] < 2017]
+        expired.update_erfa_leap_seconds(initialize_erfa="empty")
         # Check the 2017 leap second is indeed missing.
-        assert erfa.dat(2018, 1, 1, 0.) == 36.0
+        assert erfa.dat(2018, 1, 1, 0.0) == 36.0
 
         # Update with missing leap seconds.
         n_update = update_leap_seconds([iers.IERS_LEAP_SECOND_FILE])
         assert n_update >= 1
         assert erfa.leap_seconds.expires == self.built_in.expires
-        assert erfa.dat(2018, 1, 1, 0.) == 37.0
+        assert erfa.dat(2018, 1, 1, 0.0) == 37.0
 
         # Doing it again does not change anything
         n_update2 = update_leap_seconds([iers.IERS_LEAP_SECOND_FILE])
         assert n_update2 == 0
-        assert erfa.dat(2018, 1, 1, 0.) == 37.0
+        assert erfa.dat(2018, 1, 1, 0.0) == 37.0
 
     @pytest.mark.remote_data
     def test_never_expired_if_connected(self):
@@ -48,51 +48,56 @@ class TestUpdateLeapSeconds:
 
     @pytest.mark.remote_data
     def test_auto_update_always_good(self):
-        self.erfa_ls.update_erfa_leap_seconds(initialize_erfa='only')
+        self.erfa_ls.update_erfa_leap_seconds(initialize_erfa="only")
         update_leap_seconds()
         assert not erfa.leap_seconds.expired
         assert erfa.leap_seconds.expires > self.good_enough
 
     def test_auto_update_bad_file(self):
-        with pytest.warns(AstropyWarning, match='FileNotFound'):
-            update_leap_seconds(['nonsense'])
+        with pytest.warns(AstropyWarning, match="FileNotFound"):
+            update_leap_seconds(["nonsense"])
 
     def test_auto_update_corrupt_file(self, tmp_path):
-        bad_file = str(tmp_path / 'no_expiration')
+        bad_file = str(tmp_path / "no_expiration")
         with open(iers.IERS_LEAP_SECOND_FILE) as fh:
-
             lines = fh.readlines()
-        with open(bad_file, 'w') as fh:
-            fh.write('\n'.join([line for line in lines
-                                if not line.startswith('#')]))
+        with open(bad_file, "w") as fh:
+            fh.write("\n".join([line for line in lines if not line.startswith("#")]))
 
-        with pytest.warns(AstropyWarning,
-                          match='ValueError.*did not find expiration'):
+        with pytest.warns(AstropyWarning, match="ValueError.*did not find expiration"):
             update_leap_seconds([bad_file])
 
     def test_auto_update_expired_file(self, tmp_path):
         # Set up expired ERFA leap seconds.
-        expired = self.erfa_ls[self.erfa_ls['year'] < 2017]
-        expired.update_erfa_leap_seconds(initialize_erfa='empty')
+        expired = self.erfa_ls[self.erfa_ls["year"] < 2017]
+        expired.update_erfa_leap_seconds(initialize_erfa="empty")
         # Create similarly expired file.
-        expired_file = str(tmp_path / 'expired.dat')
-        with open(expired_file, 'w') as fh:
-            fh.write('\n'.join(['# File expires on 28 June 2010']
-                               + [str(item) for item in expired]))
+        expired_file = str(tmp_path / "expired.dat")
+        with open(expired_file, "w") as fh:
+            fh.write(
+                "\n".join(
+                    ["# File expires on 28 June 2010"] + [str(item) for item in expired]
+                )
+            )
 
         with pytest.warns(iers.IERSStaleWarning):
-            update_leap_seconds(['erfa', expired_file])
+            update_leap_seconds(["erfa", expired_file])
 
     def test_init_thread_safety(self, monkeypatch):
         # Set up expired ERFA leap seconds.
-        expired = self.erfa_ls[self.erfa_ls['year'] < 2017]
-        expired.update_erfa_leap_seconds(initialize_erfa='empty')
+        expired = self.erfa_ls[self.erfa_ls["year"] < 2017]
+        expired.update_erfa_leap_seconds(initialize_erfa="empty")
         # Force re-initialization, even if another test already did it
-        monkeypatch.setattr(astropy.time.core, '_LEAP_SECONDS_CHECK',
-                            astropy.time.core._LeapSecondsCheck.NOT_STARTED)
+        monkeypatch.setattr(
+            astropy.time.core,
+            "_LEAP_SECONDS_CHECK",
+            astropy.time.core._LeapSecondsCheck.NOT_STARTED,
+        )
         workers = 4
         with ThreadPoolExecutor(max_workers=workers) as executor:
-            futures = [executor.submit(lambda: str(Time('2019-01-01 00:00:00.000').tai))
-                       for i in range(workers)]
+            futures = [
+                executor.submit(lambda: str(Time("2019-01-01 00:00:00.000").tai))
+                for i in range(workers)
+            ]
             results = [future.result() for future in futures]
-            assert results == ['2019-01-01 00:00:37.000'] * workers
+            assert results == ["2019-01-01 00:00:37.000"] * workers

--- a/astropy/time/tests/test_ut1.py
+++ b/astropy/time/tests/test_ut1.py
@@ -32,7 +32,7 @@ def do_ut1_prediction_tst(iers_type):
     with iers.earth_orientation_table.set(iers_type.open()):
         delta2, status2 = tnow.get_delta_ut1_utc(return_status=True)
         assert status2 == status
-        assert delta2.to_value('s') == delta_ut1_utc
+        assert delta2.to_value("s") == delta_ut1_utc
 
         tnow_ut1 = tnow.ut1
         assert tnow_ut1._delta_ut1_utc == delta_ut1_utc
@@ -51,16 +51,27 @@ class TestTimeUT1Remote:
         iers_conf.auto_download = False
 
     def test_utc_to_ut1(self):
-        "Test conversion of UTC to UT1, making sure to include a leap second"""
-        t = Time(['2012-06-30 12:00:00', '2012-06-30 23:59:59',
-                  '2012-06-30 23:59:60', '2012-07-01 00:00:00',
-                  '2012-07-01 12:00:00'], scale='utc')
+        "Test conversion of UTC to UT1, making sure to include a leap second"
+        t = Time(
+            [
+                "2012-06-30 12:00:00",
+                "2012-06-30 23:59:59",
+                "2012-06-30 23:59:60",
+                "2012-07-01 00:00:00",
+                "2012-07-01 12:00:00",
+            ],
+            scale="utc",
+        )
         t_ut1_jd = t.ut1.jd
-        t_comp = np.array([2456108.9999932079,
-                           2456109.4999816339,
-                           2456109.4999932083,
-                           2456109.5000047823,
-                           2456110.0000047833])
+        t_comp = np.array(
+            [
+                2456108.9999932079,
+                2456109.4999816339,
+                2456109.4999932083,
+                2456109.5000047823,
+                2456110.0000047833,
+            ]
+        )
         assert allclose_jd(t_ut1_jd, t_comp)
         t_back = t.ut1.utc
         assert allclose_jd(t.jd, t_back.jd)
@@ -79,16 +90,27 @@ class TestTimeUT1:
     def test_ut1_to_utc(self):
         """Also test the reverse, around the leap second
         (round-trip test closes #2077)"""
-        with iers_conf.set_temp('auto_download', False):
-            t = Time(['2012-06-30 12:00:00', '2012-06-30 23:59:59',
-                      '2012-07-01 00:00:00', '2012-07-01 00:00:01',
-                      '2012-07-01 12:00:00'], scale='ut1')
+        with iers_conf.set_temp("auto_download", False):
+            t = Time(
+                [
+                    "2012-06-30 12:00:00",
+                    "2012-06-30 23:59:59",
+                    "2012-07-01 00:00:00",
+                    "2012-07-01 00:00:01",
+                    "2012-07-01 12:00:00",
+                ],
+                scale="ut1",
+            )
             t_utc_jd = t.utc.jd
-            t_comp = np.array([2456109.0000010049,
-                               2456109.4999836441,
-                               2456109.4999952177,
-                               2456109.5000067917,
-                               2456109.9999952167])
+            t_comp = np.array(
+                [
+                    2456109.0000010049,
+                    2456109.4999836441,
+                    2456109.4999952177,
+                    2456109.5000067917,
+                    2456109.9999952167,
+                ]
+            )
             assert allclose_jd(t_utc_jd, t_comp)
             t_back = t.utc.ut1
             assert allclose_jd(t.jd, t_back.jd)
@@ -97,19 +119,20 @@ class TestTimeUT1:
         """Testing for a zero-length Time object from UTC to UT1
         when an empty array is passed"""
         from astropy import units as u
-        with iers_conf.set_temp('auto_download', False):
-            t = Time(['2012-06-30 12:00:00']) + np.arange(24) * u.hour
+
+        with iers_conf.set_temp("auto_download", False):
+            t = Time(["2012-06-30 12:00:00"]) + np.arange(24) * u.hour
             t_empty = t[[]].ut1
             assert isinstance(t_empty, Time)
-            assert t_empty.scale == 'ut1'
+            assert t_empty.scale == "ut1"
             assert t_empty.size == 0
 
     def test_delta_ut1_utc(self):
         """Accessing delta_ut1_utc should try to get it from IERS
         (closes #1924 partially)"""
-        with iers_conf.set_temp('auto_download', False):
-            t = Time('2012-06-30 12:00:00', scale='utc')
-            assert not hasattr(t, '_delta_ut1_utc')
+        with iers_conf.set_temp("auto_download", False):
+            t = Time("2012-06-30 12:00:00", scale="utc")
+            assert not hasattr(t, "_delta_ut1_utc")
             # accessing delta_ut1_utc calculates it
             assert allclose_sec(t.delta_ut1_utc, -0.58682110003124965)
             # and keeps it around
@@ -117,7 +140,7 @@ class TestTimeUT1:
 
 
 class TestTimeUT1SpecificIERSTable:
-    @pytest.mark.skipif(not HAS_IERS_A, reason='requires IERS_A')
+    @pytest.mark.skipif(not HAS_IERS_A, reason="requires IERS_A")
     def test_ut1_iers_A(self):
         do_ut1_prediction_tst(iers.IERS_A)
 

--- a/astropy/time/time_helper/function_helpers.py
+++ b/astropy/time/time_helper/function_helpers.py
@@ -17,14 +17,19 @@ custom_functions = FunctionAssigner(CUSTOM_FUNCTIONS)
 @custom_functions(helps={np.linspace})
 def linspace(tstart, tstop, *args, **kwargs):
     from astropy.time import Time
+
     if isinstance(tstart, Time):
         if not isinstance(tstop, Time):
             return NotImplemented
 
-    if kwargs.get('retstep'):
-        offsets, step = np.linspace(np.zeros(tstart.shape), np.ones(tstop.shape), *args, **kwargs)
+    if kwargs.get("retstep"):
+        offsets, step = np.linspace(
+            np.zeros(tstart.shape), np.ones(tstop.shape), *args, **kwargs
+        )
         tdelta = tstop - tstart
         return tstart + tdelta * offsets, tdelta * step
     else:
-        offsets = np.linspace(np.zeros(tstart.shape), np.ones(tstop.shape), *args, **kwargs)
+        offsets = np.linspace(
+            np.zeros(tstart.shape), np.ones(tstop.shape), *args, **kwargs
+        )
         return tstart + (tstop - tstart) * offsets

--- a/astropy/time/utils.py
+++ b/astropy/time/utils.py
@@ -66,8 +66,9 @@ def day_frac(val1, val2, factor=None, divisor=None):
     # particular care for the case that frac=0.5 and check>0 or frac=-0.5 and check<0,
     # since in that case if check is large enough, rounding was done the wrong way.
     frac, check = two_sum(sum12 - day, err12)
-    excess = np.where(frac * np.sign(check) != 0.5, np.round(frac),
-                      np.round(frac+2*check))
+    excess = np.where(
+        frac * np.sign(check) != 0.5, np.round(frac), np.round(frac + 2 * check)
+    )
     day += excess
     frac = sum12 - day
     frac += err12
@@ -105,16 +106,16 @@ def quantity_day_frac(val1, val2=None):
     except Exception:
         # Not a simple scaling, so cannot do the full-precision one.
         # But at least try normal conversion, since equivalencies may be set.
-        return val1.to_value(u.day), 0.
+        return val1.to_value(u.day), 0.0
 
-    if factor == 1.:
-        return day_frac(val1.value, 0.)
+    if factor == 1.0:
+        return day_frac(val1.value, 0.0)
 
     if factor > 1:
-        return day_frac(val1.value, 0., factor=factor)
+        return day_frac(val1.value, 0.0, factor=factor)
     else:
         divisor = u.day.to(val1.unit)
-        return day_frac(val1.value, 0., divisor=divisor)
+        return day_frac(val1.value, 0.0, divisor=divisor)
 
 
 def two_sum(a, b):
@@ -178,7 +179,7 @@ def split(a):
     http://www.cs.berkeley.edu/~jrs/papers/robustr.pdf
 
     """
-    c = 134217729. * a  # 2**27+1.
+    c = 134217729.0 * a  # 2**27+1.
     abig = c - a
     ah = c - abig
     al = a - ah
@@ -190,7 +191,7 @@ _enough_decimal_places = 34  # to represent two doubles
 
 def longdouble_to_twoval(val1, val2=None):
     if val2 is None:
-        val2 = val1.dtype.type(0.)
+        val2 = val1.dtype.type(0.0)
     else:
         best_type = np.result_type(val1.dtype, val2.dtype)
         val1 = val1.astype(best_type, copy=False)
@@ -212,7 +213,7 @@ def decimal_to_twoval1(val1, val2=None):
 
 
 def bytes_to_twoval1(val1, val2=None):
-    return decimal_to_twoval1(val1.decode('ascii'))
+    return decimal_to_twoval1(val1.decode("ascii"))
 
 
 def twoval_to_longdouble(val1, val2):
@@ -226,23 +227,23 @@ def twoval_to_decimal1(val1, val2):
 
 
 def twoval_to_string1(val1, val2, fmt):
-    if val2 == 0.:
+    if val2 == 0.0:
         # For some formats, only a single float is really used.
         # For those, let numpy take care of correct number of digits.
         return str(val1)
 
-    result = format(twoval_to_decimal1(val1, val2), fmt).strip('0')
-    if result[-1] == '.':
-        result += '0'
+    result = format(twoval_to_decimal1(val1, val2), fmt).strip("0")
+    if result[-1] == ".":
+        result += "0"
     return result
 
 
 def twoval_to_bytes1(val1, val2, fmt):
-    return twoval_to_string1(val1, val2, fmt).encode('ascii')
+    return twoval_to_string1(val1, val2, fmt).encode("ascii")
 
 
 decimal_to_twoval = np.vectorize(decimal_to_twoval1)
 bytes_to_twoval = np.vectorize(bytes_to_twoval1)
 twoval_to_decimal = np.vectorize(twoval_to_decimal1)
-twoval_to_string = np.vectorize(twoval_to_string1, excluded='fmt')
-twoval_to_bytes = np.vectorize(twoval_to_bytes1, excluded='fmt')
+twoval_to_string = np.vectorize(twoval_to_string1, excluded="fmt")
+twoval_to_bytes = np.vectorize(twoval_to_bytes1, excluded="fmt")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,6 @@ force-exclude = '''
     | astropy/stats
     | astropy/table
     | astropy/tests
-    | astropy/time
     | astropy/timeseries
     | astropy/uncertainty
     | astropy/units


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

Apply `black` to `astropy.time` according to the process laid out by [APE 20](https://github.com/astropy/astropy-APEs/blob/main/APE20.rst).

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
