### PR TITLE
Apply `black` to `astropy.config`

### DIFF
--- a/astropy/config/configuration.py
+++ b/astropy/config/configuration.py
@@ -330,8 +330,10 @@ class ConfigItem:
         try:
             value = self._validate_val(value)
         except validate.ValidateError as e:
-            msg = "Provided value for configuration item {0} not valid: {1}"
-            raise TypeError(msg.format(self.name, e.args[0]))
+            raise TypeError(
+                f"Provided value for configuration item {self.name} not valid:"
+                f" {e.args[0]}"
+            )
 
         sec = get_config(self.module, rootname=self.rootname)
 
@@ -395,32 +397,22 @@ class ConfigItem:
         return baseobj.get(self.name)
 
     def __repr__(self):
-        out = "<{}: name={!r} value={!r} at 0x{:x}>".format(
-            self.__class__.__name__, self.name, self(), id(self)
+        return (
+            f"<{self.__class__.__name__}: name={self.name!r} value={self()!r} at"
+            f" 0x{id(self):x}>"
         )
-        return out
 
     def __str__(self):
-        out = "\n".join(
+        return "\n".join(
             (
-                "{0}: {1}",
-                "  cfgtype={2!r}",
-                "  defaultvalue={3!r}",
-                "  description={4!r}",
-                "  module={5}",
-                "  value={6!r}",
+                f"{self.__class__.__name__}: {self.name}",
+                f"  cfgtype={self.cfgtype!r}",
+                f"  defaultvalue={self.defaultvalue!r}",
+                f"  description={self.description!r}",
+                f"  module={self.module}",
+                f"  value={self()!r}",
             )
         )
-        out = out.format(
-            self.__class__.__name__,
-            self.name,
-            self.cfgtype,
-            self.defaultvalue,
-            self.description,
-            self.module,
-            self(),
-        )
-        return out
 
     def __call__(self):
         """Returns the value of this ``ConfigItem``
@@ -463,14 +455,10 @@ class ConfigItem:
                 else:
                     new_module = ""
                 warn(
-                    "Config parameter '{}' {} of the file '{}' "
-                    "is deprecated. Use '{}' {} instead.".format(
-                        name,
-                        section_name(module),
-                        get_config_filename(filename, rootname=self.rootname),
-                        self.name,
-                        section_name(new_module),
-                    ),
+                    f"Config parameter '{name}' {section_name(module)} of the file"
+                    f" '{get_config_filename(filename, rootname=self.rootname)}' is"
+                    f" deprecated. Use '{self.name}'"
+                    f" {section_name(new_module)} instead.",
                     AstropyDeprecationWarning,
                 )
                 options.append((sec[name], module, name))
@@ -482,13 +470,11 @@ class ConfigItem:
         if len(options) > 1:
             filename, sec = self.module.split(".", 1)
             warn(
-                "Config parameter '{}' {} of the file '{}' is "
-                "given by more than one alias ({}). Using the first.".format(
-                    self.name,
-                    section_name(sec),
-                    get_config_filename(filename, rootname=self.rootname),
-                    ", ".join([".".join(x[1:3]) for x in options if x[1] is not None]),
-                ),
+                f"Config parameter '{self.name}' {section_name(sec)} of the file"
+                f" '{get_config_filename(filename, rootname=self.rootname)}' is given"
+                " by more than one alias"
+                f" ({', '.join(['.'.join(x[1:3]) for x in options if x[1] is not None])})."
+                " Using the first.",
                 AstropyDeprecationWarning,
             )
 
@@ -497,7 +483,7 @@ class ConfigItem:
         try:
             return self._validate_val(val)
         except validate.ValidateError as e:
-            raise TypeError("Configuration value not valid:" + e.args[0])
+            raise TypeError(f"Configuration value not valid: {e.args[0]}")
 
     def _validate_val(self, val):
         """Validates the provided value based on cfgtype and returns the
@@ -840,10 +826,10 @@ def update_default_config(pkg, default_cfg_dir_or_fn, version=None, rootname="as
             # changes, display a warning.
             if not identical and not doupdate:
                 warn(
-                    "The configuration options in {} {} may have changed, "
+                    f"The configuration options in {pkg} {version} may have changed, "
                     "your configuration file was not updated in order to "
                     "preserve local changes.  A new configuration template "
-                    "has been saved to '{}'.".format(pkg, version, template_path),
+                    f"has been saved to '{template_path}'.",
                     ConfigurationChangedWarning,
                 )
 

--- a/astropy/config/configuration.py
+++ b/astropy/config/configuration.py
@@ -28,13 +28,20 @@ from astropy.utils.introspection import resolve_name
 
 from .paths import get_config_dir
 
-__all__ = ('InvalidConfigurationItemWarning', 'ConfigurationMissingWarning',
-           'get_config', 'reload_config', 'ConfigNamespace', 'ConfigItem',
-           'generate_config', 'create_config_file')
+__all__ = (
+    "InvalidConfigurationItemWarning",
+    "ConfigurationMissingWarning",
+    "get_config",
+    "reload_config",
+    "ConfigNamespace",
+    "ConfigItem",
+    "generate_config",
+    "create_config_file",
+)
 
 
 class InvalidConfigurationItemWarning(AstropyWarning):
-    """ A Warning that is issued when the configuration value specified in the
+    """A Warning that is issued when the configuration value specified in the
     astropy configuration file does not match the type expected for that
     configuration value.
     """
@@ -42,9 +49,9 @@ class InvalidConfigurationItemWarning(AstropyWarning):
 
 # This was raised with Astropy < 4.3 when the configuration file was not found.
 # It is kept for compatibility and should be removed at some point.
-@deprecated('5.0')
+@deprecated("5.0")
 class ConfigurationMissingWarning(AstropyWarning):
-    """ A Warning that is issued when the configuration directory cannot be
+    """A Warning that is issued when the configuration directory cannot be
     accessed (usually due to a permissions problem). If this warning appears,
     configuration items will be set to their defaults rather than read from the
     configuration file, and no configuration will persist across sessions.
@@ -53,14 +60,14 @@ class ConfigurationMissingWarning(AstropyWarning):
 
 # these are not in __all__ because it's not intended that a user ever see them
 class ConfigurationDefaultMissingError(ValueError):
-    """ An exception that is raised when the configuration defaults (which
+    """An exception that is raised when the configuration defaults (which
     should be generated at build-time) are missing.
     """
 
 
 # this is used in astropy/__init__.py
 class ConfigurationDefaultMissingWarning(AstropyWarning):
-    """ A warning that is issued when the configuration defaults (which
+    """A warning that is issued when the configuration defaults (which
     should be generated at build-time) are missing.
     """
 
@@ -99,6 +106,7 @@ class ConfigNamespace(metaclass=_ConfigNamespaceMeta):
                 aliases=['astropy.utils.console.USE_COLOR'])
         conf = Conf()
     """
+
     def __iter__(self):
         for key, val in self.__class__.__dict__.items():
             if isinstance(val, ConfigItem):
@@ -242,20 +250,21 @@ class ConfigItem:
     ``configspec`` file of ``configobj``.
     """
 
-    rootname = 'astropy'
+    rootname = "astropy"
     """
     Rootname sets the base path for all config files.
     """
 
-    def __init__(self, defaultvalue='', description=None, cfgtype=None,
-                 module=None, aliases=None):
+    def __init__(
+        self, defaultvalue="", description=None, cfgtype=None, module=None, aliases=None
+    ):
         from astropy.utils import isiterable
 
         if module is None:
             module = find_current_module(2)
             if module is None:
-                msg1 = 'Cannot automatically determine get_config module, '
-                msg2 = 'because it is not called from inside a valid module'
+                msg1 = "Cannot automatically determine get_config module, "
+                msg2 = "because it is not called from inside a valid module"
                 raise RuntimeError(msg1 + msg2)
             else:
                 module = module.__name__
@@ -266,20 +275,19 @@ class ConfigItem:
 
         # now determine cfgtype if it is not given
         if cfgtype is None:
-            if (isiterable(defaultvalue) and not
-                    isinstance(defaultvalue, str)):
+            if isiterable(defaultvalue) and not isinstance(defaultvalue, str):
                 # it is an options list
                 dvstr = [str(v) for v in defaultvalue]
-                cfgtype = 'option(' + ', '.join(dvstr) + ')'
+                cfgtype = "option(" + ", ".join(dvstr) + ")"
                 defaultvalue = dvstr[0]
             elif isinstance(defaultvalue, bool):
-                cfgtype = 'boolean'
+                cfgtype = "boolean"
             elif isinstance(defaultvalue, int):
-                cfgtype = 'integer'
+                cfgtype = "integer"
             elif isinstance(defaultvalue, float):
-                cfgtype = 'float'
+                cfgtype = "float"
             elif isinstance(defaultvalue, str):
-                cfgtype = 'string'
+                cfgtype = "string"
                 defaultvalue = str(defaultvalue)
 
         self.cfgtype = cfgtype
@@ -322,7 +330,7 @@ class ConfigItem:
         try:
             value = self._validate_val(value)
         except validate.ValidateError as e:
-            msg = 'Provided value for configuration item {0} not valid: {1}'
+            msg = "Provided value for configuration item {0} not valid: {1}"
             raise TypeError(msg.format(self.name, e.args[0]))
 
         sec = get_config(self.module, rootname=self.rootname)
@@ -358,7 +366,7 @@ class ConfigItem:
             self.set(initval)
 
     def reload(self):
-        """ Reloads the value of this ``ConfigItem`` from the relevant
+        """Reloads the value of this ``ConfigItem`` from the relevant
         configuration file.
 
         Returns
@@ -387,24 +395,35 @@ class ConfigItem:
         return baseobj.get(self.name)
 
     def __repr__(self):
-        out = '<{}: name={!r} value={!r} at 0x{:x}>'.format(
-            self.__class__.__name__, self.name, self(), id(self))
+        out = "<{}: name={!r} value={!r} at 0x{:x}>".format(
+            self.__class__.__name__, self.name, self(), id(self)
+        )
         return out
 
     def __str__(self):
-        out = '\n'.join(('{0}: {1}',
-                         '  cfgtype={2!r}',
-                         '  defaultvalue={3!r}',
-                         '  description={4!r}',
-                         '  module={5}',
-                         '  value={6!r}'))
-        out = out.format(self.__class__.__name__, self.name, self.cfgtype,
-                         self.defaultvalue, self.description, self.module,
-                         self())
+        out = "\n".join(
+            (
+                "{0}: {1}",
+                "  cfgtype={2!r}",
+                "  defaultvalue={3!r}",
+                "  description={4!r}",
+                "  module={5}",
+                "  value={6!r}",
+            )
+        )
+        out = out.format(
+            self.__class__.__name__,
+            self.name,
+            self.cfgtype,
+            self.defaultvalue,
+            self.description,
+            self.module,
+            self(),
+        )
         return out
 
     def __call__(self):
-        """ Returns the value of this ``ConfigItem``
+        """Returns the value of this ``ConfigItem``
 
         Returns
         -------
@@ -418,11 +437,12 @@ class ConfigItem:
             If the configuration value as stored is not this item's type.
 
         """
+
         def section_name(section):
-            if section == '':
-                return 'at the top-level'
+            if section == "":
+                return "at the top-level"
             else:
-                return f'in section [{section}]'
+                return f"in section [{section}]"
 
         options = []
         sec = get_config(self.module, rootname=self.rootname)
@@ -430,25 +450,29 @@ class ConfigItem:
             options.append((sec[self.name], self.module, self.name))
 
         for alias in self.aliases:
-            module, name = alias.rsplit('.', 1)
+            module, name = alias.rsplit(".", 1)
             sec = get_config(module, rootname=self.rootname)
-            if '.' in module:
-                filename, module = module.split('.', 1)
+            if "." in module:
+                filename, module = module.split(".", 1)
             else:
                 filename = module
-                module = ''
+                module = ""
             if name in sec:
-                if '.' in self.module:
-                    new_module = self.module.split('.', 1)[1]
+                if "." in self.module:
+                    new_module = self.module.split(".", 1)[1]
                 else:
-                    new_module = ''
+                    new_module = ""
                 warn(
                     "Config parameter '{}' {} of the file '{}' "
                     "is deprecated. Use '{}' {} instead.".format(
-                        name, section_name(module), get_config_filename(filename,
-                                                                        rootname=self.rootname),
-                        self.name, section_name(new_module)),
-                    AstropyDeprecationWarning)
+                        name,
+                        section_name(module),
+                        get_config_filename(filename, rootname=self.rootname),
+                        self.name,
+                        section_name(new_module),
+                    ),
+                    AstropyDeprecationWarning,
+                )
                 options.append((sec[name], module, name))
 
         if len(options) == 0:
@@ -456,25 +480,27 @@ class ConfigItem:
             options.append((self.defaultvalue, None, None))
 
         if len(options) > 1:
-            filename, sec = self.module.split('.', 1)
+            filename, sec = self.module.split(".", 1)
             warn(
                 "Config parameter '{}' {} of the file '{}' is "
                 "given by more than one alias ({}). Using the first.".format(
-                    self.name, section_name(sec), get_config_filename(filename,
-                                                                      rootname=self.rootname),
-                    ', '.join([
-                        '.'.join(x[1:3]) for x in options if x[1] is not None])),
-                AstropyDeprecationWarning)
+                    self.name,
+                    section_name(sec),
+                    get_config_filename(filename, rootname=self.rootname),
+                    ", ".join([".".join(x[1:3]) for x in options if x[1] is not None]),
+                ),
+                AstropyDeprecationWarning,
+            )
 
         val = options[0][0]
 
         try:
             return self._validate_val(val)
         except validate.ValidateError as e:
-            raise TypeError('Configuration value not valid:' + e.args[0])
+            raise TypeError("Configuration value not valid:" + e.args[0])
 
     def _validate_val(self, val):
-        """ Validates the provided value based on cfgtype and returns the
+        """Validates the provided value based on cfgtype and returns the
         type-cast value
 
         throws the underlying configobj exception if it fails
@@ -508,7 +534,7 @@ _override_config_file = None
 
 
 def get_config(packageormod=None, reload=False, rootname=None):
-    """ Gets the configuration object or section associated with a particular
+    """Gets the configuration object or section associated with a particular
     package or module.
 
     Parameters
@@ -544,8 +570,8 @@ def get_config(packageormod=None, reload=False, rootname=None):
     if packageormod is None:
         packageormod = find_current_module(2)
         if packageormod is None:
-            msg1 = 'Cannot automatically determine get_config module, '
-            msg2 = 'because it is not called from inside a valid module'
+            msg1 = "Cannot automatically determine get_config module, "
+            msg2 = "because it is not called from inside a valid module"
             raise RuntimeError(msg1 + msg2)
         else:
             packageormod = packageormod.__name__
@@ -555,15 +581,15 @@ def get_config(packageormod=None, reload=False, rootname=None):
     else:
         _autopkg = False
 
-    packageormodspl = packageormod.split('.')
+    packageormodspl = packageormod.split(".")
     pkgname = packageormodspl[0]
-    secname = '.'.join(packageormodspl[1:])
+    secname = ".".join(packageormodspl[1:])
 
     if rootname is None:
         if _autopkg:
             rootname = pkgname
         else:
-            rootname = 'astropy'  # so we don't break affiliated packages
+            rootname = "astropy"  # so we don't break affiliated packages
 
     cobj = _cfgobjs.get(pkgname, None)
 
@@ -574,7 +600,7 @@ def get_config(packageormod=None, reload=False, rootname=None):
             if _override_config_file is not None:
                 cfgfn = _override_config_file
             else:
-                cfgfn = path.join(get_config_dir(rootname=rootname), pkgname + '.cfg')
+                cfgfn = path.join(get_config_dir(rootname=rootname), pkgname + ".cfg")
             cobj = configobj.ConfigObj(cfgfn, interpolation=False)
         except OSError:
             # This can happen when HOME is not set
@@ -592,7 +618,7 @@ def get_config(packageormod=None, reload=False, rootname=None):
         return cobj
 
 
-def generate_config(pkgname='astropy', filename=None, verbose=False):
+def generate_config(pkgname="astropy", filename=None, verbose=False):
     """Generates a configuration file, from the list of `ConfigItem`
     objects for each subpackage.
 
@@ -615,30 +641,30 @@ def generate_config(pkgname='astropy', filename=None, verbose=False):
 
     package = importlib.import_module(pkgname)
     with verbosity(), warnings.catch_warnings():
-        warnings.simplefilter('ignore', category=filter_warnings)
-        for mod in pkgutil.walk_packages(path=package.__path__,
-                                         prefix=package.__name__ + '.'):
-
-            if (mod.module_finder.path.endswith(('test', 'tests')) or
-                    mod.name.endswith('setup_package')):
+        warnings.simplefilter("ignore", category=filter_warnings)
+        for mod in pkgutil.walk_packages(
+            path=package.__path__, prefix=package.__name__ + "."
+        ):
+            if mod.module_finder.path.endswith(("test", "tests")) or mod.name.endswith(
+                "setup_package"
+            ):
                 # Skip test and setup_package modules
                 continue
-            if mod.name.split('.')[-1].startswith('_'):
+            if mod.name.split(".")[-1].startswith("_"):
                 # Skip private modules
                 continue
 
             with contextlib.suppress(ImportError):
                 importlib.import_module(mod.name)
 
-    wrapper = TextWrapper(initial_indent="## ", subsequent_indent='## ',
-                          width=78)
+    wrapper = TextWrapper(initial_indent="## ", subsequent_indent="## ", width=78)
 
     if filename is None:
         filename = get_config_filename(pkgname)
 
     with contextlib.ExitStack() as stack:
         if isinstance(filename, (str, os.PathLike)):
-            fp = stack.enter_context(open(filename, 'w'))
+            fp = stack.enter_context(open(filename, "w"))
         else:
             # assume it's a file object, or io.StringIO
             fp = filename
@@ -652,7 +678,7 @@ def generate_config(pkgname='astropy', filename=None, verbose=False):
 
             # Skip modules for other packages, e.g. astropy modules that
             # would be imported when running the function for astroquery.
-            if mod.split('.')[0] != pkgname:
+            if mod.split(".")[0] != pkgname:
                 continue
 
             # Check that modules are not processed twice, which can happen
@@ -668,24 +694,27 @@ def generate_config(pkgname='astropy', filename=None, verbose=False):
                     # If this is the first item of the module, we print the
                     # module name, but not if this is the root package...
                     if item.module != pkgname:
-                        modname = item.module.replace(f'{pkgname}.', '')
+                        modname = item.module.replace(f"{pkgname}.", "")
                         fp.write(f"[{modname}]\n\n")
                     print_module = False
 
-                fp.write(wrapper.fill(item.description) + '\n')
+                fp.write(wrapper.fill(item.description) + "\n")
                 if isinstance(item.defaultvalue, (tuple, list)):
                     if len(item.defaultvalue) == 0:
-                        fp.write(f'# {item.name} = ,\n\n')
+                        fp.write(f"# {item.name} = ,\n\n")
                     elif len(item.defaultvalue) == 1:
-                        fp.write(f'# {item.name} = {item.defaultvalue[0]},\n\n')
+                        fp.write(f"# {item.name} = {item.defaultvalue[0]},\n\n")
                     else:
-                        fp.write(f'# {item.name} = {",".join(map(str, item.defaultvalue))}\n\n')
+                        fp.write(
+                            f"# {item.name} ="
+                            f' {",".join(map(str, item.defaultvalue))}\n\n'
+                        )
                 else:
-                    fp.write(f'# {item.name} = {item.defaultvalue}\n\n')
+                    fp.write(f"# {item.name} = {item.defaultvalue}\n\n")
 
 
 def reload_config(packageormod=None, rootname=None):
-    """ Reloads configuration settings from a configuration file for the root
+    """Reloads configuration settings from a configuration file for the root
     package of the requested package/module.
 
     This overwrites any changes that may have been made in `ConfigItem`
@@ -725,8 +754,8 @@ def is_unedited_config_file(content, template_content=None):
 # packages that may use it (e.g. astroquery). It should be removed at some
 # point.
 # this is not in __all__ because it's not intended that a user uses it
-@deprecated('5.0')
-def update_default_config(pkg, default_cfg_dir_or_fn, version=None, rootname='astropy'):
+@deprecated("5.0")
+def update_default_config(pkg, default_cfg_dir_or_fn, version=None, rootname="astropy"):
     """
     Checks if the configuration file for the specified package exists,
     and if not, copy over the default configuration.  If the
@@ -760,7 +789,7 @@ def update_default_config(pkg, default_cfg_dir_or_fn, version=None, rootname='as
     """
 
     if path.isdir(default_cfg_dir_or_fn):
-        default_cfgfn = path.join(default_cfg_dir_or_fn, pkg + '.cfg')
+        default_cfgfn = path.join(default_cfg_dir_or_fn, pkg + ".cfg")
     else:
         default_cfgfn = default_cfg_dir_or_fn
 
@@ -772,39 +801,39 @@ def update_default_config(pkg, default_cfg_dir_or_fn, version=None, rootname='as
 
     cfgfn = get_config(pkg, rootname=rootname).filename
 
-    with open(default_cfgfn, encoding='latin-1') as fr:
+    with open(default_cfgfn, encoding="latin-1") as fr:
         template_content = fr.read()
 
     doupdate = False
     if cfgfn is not None:
         if path.exists(cfgfn):
-            with open(cfgfn, encoding='latin-1') as fd:
+            with open(cfgfn, encoding="latin-1") as fd:
                 content = fd.read()
 
-            identical = (content == template_content)
+            identical = content == template_content
 
             if not identical:
-                doupdate = is_unedited_config_file(
-                    content, template_content)
+                doupdate = is_unedited_config_file(content, template_content)
         elif path.exists(path.dirname(cfgfn)):
             doupdate = True
             identical = False
 
     if version is None:
-        version = resolve_name(pkg, '__version__')
+        version = resolve_name(pkg, "__version__")
 
     # Don't install template files for dev versions, or we'll end up
     # spamming `~/.astropy/config`.
-    if version and 'dev' not in version and cfgfn is not None:
+    if version and "dev" not in version and cfgfn is not None:
         template_path = path.join(
-            get_config_dir(rootname=rootname), f'{pkg}.{version}.cfg')
+            get_config_dir(rootname=rootname), f"{pkg}.{version}.cfg"
+        )
         needs_template = not path.exists(template_path)
     else:
         needs_template = False
 
     if doupdate or needs_template:
         if needs_template:
-            with open(template_path, 'w', encoding='latin-1') as fw:
+            with open(template_path, "w", encoding="latin-1") as fw:
                 fw.write(template_content)
             # If we just installed a new template file and we can't
             # update the main configuration file because it has user
@@ -814,19 +843,19 @@ def update_default_config(pkg, default_cfg_dir_or_fn, version=None, rootname='as
                     "The configuration options in {} {} may have changed, "
                     "your configuration file was not updated in order to "
                     "preserve local changes.  A new configuration template "
-                    "has been saved to '{}'.".format(
-                        pkg, version, template_path),
-                    ConfigurationChangedWarning)
+                    "has been saved to '{}'.".format(pkg, version, template_path),
+                    ConfigurationChangedWarning,
+                )
 
         if doupdate and not identical:
-            with open(cfgfn, 'w', encoding='latin-1') as fw:
+            with open(cfgfn, "w", encoding="latin-1") as fw:
                 fw.write(template_content)
             return True
 
     return False
 
 
-def create_config_file(pkg, rootname='astropy', overwrite=False):
+def create_config_file(pkg, rootname="astropy", overwrite=False):
     """
     Create the default configuration file for the specified package.
     If the file already exists, it is updated only if it has not been
@@ -863,20 +892,21 @@ def create_config_file(pkg, rootname='astropy', overwrite=False):
 
     # if the file already exists, check that it has not been modified
     if cfgfn is not None and path.exists(cfgfn):
-        with open(cfgfn, encoding='latin-1') as fd:
+        with open(cfgfn, encoding="latin-1") as fd:
             content = fd.read()
 
         doupdate = is_unedited_config_file(content, template_content)
 
     if doupdate or overwrite:
-        with open(cfgfn, 'w', encoding='latin-1') as fw:
+        with open(cfgfn, "w", encoding="latin-1") as fw:
             fw.write(template_content)
-        log.info('The configuration file has been successfully written '
-                 f'to {cfgfn}')
+        log.info(f"The configuration file has been successfully written to {cfgfn}")
         return True
     elif not doupdate:
-        log.warning('The configuration file already exists and seems to '
-                    'have been customized, so it has not been updated. '
-                    'Use overwrite=True if you really want to update it.')
+        log.warning(
+            "The configuration file already exists and seems to "
+            "have been customized, so it has not been updated. "
+            "Use overwrite=True if you really want to update it."
+        )
 
     return False

--- a/astropy/config/paths.py
+++ b/astropy/config/paths.py
@@ -304,8 +304,9 @@ def _find_or_create_root_dir(dirnm, linkto, pkgname="astropy"):
                 if not os.path.isdir(innerdir):
                     raise
         elif not os.path.isdir(innerdir):
-            msg = "Intended {0} {1} directory {1} is actually a file."
-            raise OSError(msg.format(pkgname, dirnm, maindir))
+            raise OSError(
+                f"Intended {pkgname} {dirnm} directory {maindir} is actually a file."
+            )
 
         try:
             os.mkdir(maindir)
@@ -321,7 +322,8 @@ def _find_or_create_root_dir(dirnm, linkto, pkgname="astropy"):
             os.symlink(maindir, linkto)
 
     elif not os.path.isdir(maindir):
-        msg = "Intended {0} {1} directory {1} is actually a file."
-        raise OSError(msg.format(pkgname, dirnm, maindir))
+        raise OSError(
+            f"Intended {pkgname} {dirnm} directory {maindir} is actually a file."
+        )
 
     return os.path.abspath(maindir)

--- a/astropy/config/paths.py
+++ b/astropy/config/paths.py
@@ -8,8 +8,7 @@ import shutil
 import sys
 from functools import wraps
 
-__all__ = ['get_config_dir', 'get_cache_dir', 'set_temp_config',
-           'set_temp_cache']
+__all__ = ["get_config_dir", "get_cache_dir", "set_temp_config", "set_temp_cache"]
 
 
 def _find_home():
@@ -24,54 +23,60 @@ def _find_home():
         directories.
     """
     try:
-        homedir = os.path.expanduser('~')
+        homedir = os.path.expanduser("~")
     except Exception:
         # Linux, Unix, AIX, OS X
-        if os.name == 'posix':
-            if 'HOME' in os.environ:
-                homedir = os.environ['HOME']
+        if os.name == "posix":
+            if "HOME" in os.environ:
+                homedir = os.environ["HOME"]
             else:
-                raise OSError('Could not find unix home directory to search for '
-                              'astropy config dir')
-        elif os.name == 'nt':  # This is for all modern Windows (NT or after)
-            if 'MSYSTEM' in os.environ and os.environ.get('HOME'):
+                raise OSError(
+                    "Could not find unix home directory to search for "
+                    "astropy config dir"
+                )
+        elif os.name == "nt":  # This is for all modern Windows (NT or after)
+            if "MSYSTEM" in os.environ and os.environ.get("HOME"):
                 # Likely using an msys shell; use whatever it is using for its
                 # $HOME directory
-                homedir = os.environ['HOME']
+                homedir = os.environ["HOME"]
             # See if there's a local home
-            elif 'HOMEDRIVE' in os.environ and 'HOMEPATH' in os.environ:
-                homedir = os.path.join(os.environ['HOMEDRIVE'],
-                                       os.environ['HOMEPATH'])
+            elif "HOMEDRIVE" in os.environ and "HOMEPATH" in os.environ:
+                homedir = os.path.join(os.environ["HOMEDRIVE"], os.environ["HOMEPATH"])
             # Maybe a user profile?
-            elif 'USERPROFILE' in os.environ:
-                homedir = os.path.join(os.environ['USERPROFILE'])
+            elif "USERPROFILE" in os.environ:
+                homedir = os.path.join(os.environ["USERPROFILE"])
             else:
                 try:
                     import winreg as wreg
-                    shell_folders = r'Software\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders'  # noqa: E501
+
+                    shell_folders = r"Software\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders"  # noqa: E501
                     key = wreg.OpenKey(wreg.HKEY_CURRENT_USER, shell_folders)
 
-                    homedir = wreg.QueryValueEx(key, 'Personal')[0]
+                    homedir = wreg.QueryValueEx(key, "Personal")[0]
                     key.Close()
                 except Exception:
                     # As a final possible resort, see if HOME is present
-                    if 'HOME' in os.environ:
-                        homedir = os.environ['HOME']
+                    if "HOME" in os.environ:
+                        homedir = os.environ["HOME"]
                     else:
-                        raise OSError('Could not find windows home directory to '
-                                      'search for astropy config dir')
+                        raise OSError(
+                            "Could not find windows home directory to "
+                            "search for astropy config dir"
+                        )
         else:
             # for other platforms, try HOME, although it probably isn't there
-            if 'HOME' in os.environ:
-                homedir = os.environ['HOME']
+            if "HOME" in os.environ:
+                homedir = os.environ["HOME"]
             else:
-                raise OSError('Could not find a home directory to search for '
-                              'astropy config dir - are you on an unsupported '
-                              'platform?')
+                raise OSError(
+                    "Could not find a home directory to search for "
+                    "astropy config dir - are you on an unsupported "
+                    "platform?"
+                )
     return homedir
 
 
-def get_config_dir(rootname='astropy'):
+def get_config_dir(rootname="astropy"):
     """
     Determines the package configuration directory name and creates the
     directory if it doesn't exist.
@@ -107,7 +112,7 @@ def get_config_dir(rootname='astropy'):
         return os.path.abspath(config_path)
 
     # first look for XDG_CONFIG_HOME
-    xch = os.environ.get('XDG_CONFIG_HOME')
+    xch = os.environ.get("XDG_CONFIG_HOME")
 
     if xch is not None and os.path.exists(xch):
         xchpth = os.path.join(xch, rootname)
@@ -116,7 +121,7 @@ def get_config_dir(rootname='astropy'):
                 return os.path.abspath(xchpth)
             else:
                 linkto = xchpth
-    return os.path.abspath(_find_or_create_root_dir('config', linkto, rootname))
+    return os.path.abspath(_find_or_create_root_dir("config", linkto, rootname))
 
 
 def get_cache_dir(rootname="astropy"):
@@ -155,7 +160,7 @@ def get_cache_dir(rootname="astropy"):
         return os.path.abspath(cache_path)
 
     # first look for XDG_CACHE_HOME
-    xch = os.environ.get('XDG_CACHE_HOME')
+    xch = os.environ.get("XDG_CACHE_HOME")
 
     if xch is not None and os.path.exists(xch):
         xchpth = os.path.join(xch, rootname)
@@ -165,7 +170,7 @@ def get_cache_dir(rootname="astropy"):
             else:
                 linkto = xchpth
 
-    return os.path.abspath(_find_or_create_root_dir('cache', linkto, rootname))
+    return os.path.abspath(_find_or_create_root_dir("cache", linkto, rootname))
 
 
 class _SetTempPath:
@@ -183,7 +188,7 @@ class _SetTempPath:
     def __enter__(self):
         self.__class__._temp_path = self._path
         try:
-            return self._default_path_getter('astropy')
+            return self._default_path_getter("astropy")
         except Exception:
             self.__class__._temp_path = self._prev_path
             raise
@@ -240,12 +245,14 @@ class set_temp_config(_SetTempPath):
         # may have been set programmatically rather than be stored in the
         # config file (e.g., iers.conf.auto_download=False for our tests).
         from .configuration import _cfgobjs
+
         self._cfgobjs_copy = _cfgobjs.copy()
         _cfgobjs.clear()
         return super().__enter__()
 
     def __exit__(self, *args):
         from .configuration import _cfgobjs
+
         _cfgobjs.clear()
         _cfgobjs.update(self._cfgobjs_copy)
         del self._cfgobjs_copy
@@ -284,9 +291,9 @@ class set_temp_cache(_SetTempPath):
     _default_path_getter = staticmethod(get_cache_dir)
 
 
-def _find_or_create_root_dir(dirnm, linkto, pkgname='astropy'):
-    innerdir = os.path.join(_find_home(), f'.{pkgname}')
-    maindir = os.path.join(_find_home(), f'.{pkgname}', dirnm)
+def _find_or_create_root_dir(dirnm, linkto, pkgname="astropy"):
+    innerdir = os.path.join(_find_home(), f".{pkgname}")
+    maindir = os.path.join(_find_home(), f".{pkgname}", dirnm)
 
     if not os.path.exists(maindir):
         # first create .astropy dir if needed
@@ -297,7 +304,7 @@ def _find_or_create_root_dir(dirnm, linkto, pkgname='astropy'):
                 if not os.path.isdir(innerdir):
                     raise
         elif not os.path.isdir(innerdir):
-            msg = 'Intended {0} {1} directory {1} is actually a file.'
+            msg = "Intended {0} {1} directory {1} is actually a file."
             raise OSError(msg.format(pkgname, dirnm, maindir))
 
         try:
@@ -306,13 +313,15 @@ def _find_or_create_root_dir(dirnm, linkto, pkgname='astropy'):
             if not os.path.isdir(maindir):
                 raise
 
-        if (not sys.platform.startswith('win') and
-            linkto is not None and
-                not os.path.exists(linkto)):
+        if (
+            not sys.platform.startswith("win")
+            and linkto is not None
+            and not os.path.exists(linkto)
+        ):
             os.symlink(maindir, linkto)
 
     elif not os.path.isdir(maindir):
-        msg = 'Intended {0} {1} directory {1} is actually a file.'
+        msg = "Intended {0} {1} directory {1} is actually a file."
         raise OSError(msg.format(pkgname, dirnm, maindir))
 
     return os.path.abspath(maindir)

--- a/astropy/config/tests/test_configs.py
+++ b/astropy/config/tests/test_configs.py
@@ -25,20 +25,20 @@ def teardown_module():
 
 
 def test_paths():
-    assert 'astropy' in paths.get_config_dir()
-    assert 'astropy' in paths.get_cache_dir()
+    assert "astropy" in paths.get_config_dir()
+    assert "astropy" in paths.get_cache_dir()
 
-    assert 'testpkg' in paths.get_config_dir(rootname='testpkg')
-    assert 'testpkg' in paths.get_cache_dir(rootname='testpkg')
+    assert "testpkg" in paths.get_config_dir(rootname="testpkg")
+    assert "testpkg" in paths.get_cache_dir(rootname="testpkg")
 
 
 def test_set_temp_config(tmp_path, monkeypatch):
     # Check that we start in an understood state.
     assert configuration._cfgobjs == OLD_CONFIG
     # Temporarily remove any temporary overrides of the configuration dir.
-    monkeypatch.setattr(paths.set_temp_config, '_temp_path', None)
+    monkeypatch.setattr(paths.set_temp_config, "_temp_path", None)
 
-    orig_config_dir = paths.get_config_dir(rootname='astropy')
+    orig_config_dir = paths.get_config_dir(rootname="astropy")
     (temp_config_dir := tmp_path / "config").mkdir()
     temp_astropy_config = temp_config_dir / "astropy"
 
@@ -49,7 +49,7 @@ def test_set_temp_config(tmp_path, monkeypatch):
 
         # Test temporary restoration of original default
         with paths.set_temp_config() as d:
-            assert d == orig_config_dir == paths.get_config_dir(rootname='astropy')
+            assert d == orig_config_dir == paths.get_config_dir(rootname="astropy")
 
     test_func()
 
@@ -63,9 +63,9 @@ def test_set_temp_config(tmp_path, monkeypatch):
 
 
 def test_set_temp_cache(tmp_path, monkeypatch):
-    monkeypatch.setattr(paths.set_temp_cache, '_temp_path', None)
+    monkeypatch.setattr(paths.set_temp_cache, "_temp_path", None)
 
-    orig_cache_dir = paths.get_cache_dir(rootname='astropy')
+    orig_cache_dir = paths.get_cache_dir(rootname="astropy")
     (temp_cache_dir := tmp_path / "cache").mkdir()
     temp_astropy_cache = temp_cache_dir / "astropy"
 
@@ -76,7 +76,7 @@ def test_set_temp_cache(tmp_path, monkeypatch):
 
         # Test temporary restoration of original default
         with paths.set_temp_cache() as d:
-            assert d == orig_cache_dir == paths.get_cache_dir(rootname='astropy')
+            assert d == orig_cache_dir == paths.get_cache_dir(rootname="astropy")
 
     test_func()
 
@@ -99,67 +99,68 @@ def test_set_temp_cache_resets_on_exception(tmp_path):
 def test_config_file():
     from astropy.config.configuration import get_config, reload_config
 
-    apycfg = get_config('astropy')
-    assert apycfg.filename.endswith('astropy.cfg')
+    apycfg = get_config("astropy")
+    assert apycfg.filename.endswith("astropy.cfg")
 
-    cfgsec = get_config('astropy.config')
+    cfgsec = get_config("astropy.config")
     assert cfgsec.depth == 1
-    assert cfgsec.name == 'config'
-    assert cfgsec.parent.filename.endswith('astropy.cfg')
+    assert cfgsec.name == "config"
+    assert cfgsec.parent.filename.endswith("astropy.cfg")
 
     # try with a different package name, still inside astropy config dir:
-    testcfg = get_config('testpkg', rootname='astropy')
+    testcfg = get_config("testpkg", rootname="astropy")
     parts = os.path.normpath(testcfg.filename).split(os.sep)
-    assert '.astropy' in parts or 'astropy' in parts
-    assert parts[-1] == 'testpkg.cfg'
-    configuration._cfgobjs['testpkg'] = None  # HACK
+    assert ".astropy" in parts or "astropy" in parts
+    assert parts[-1] == "testpkg.cfg"
+    configuration._cfgobjs["testpkg"] = None  # HACK
 
     # try with a different package name, no specified root name (should
     #   default to astropy):
-    testcfg = get_config('testpkg')
+    testcfg = get_config("testpkg")
     parts = os.path.normpath(testcfg.filename).split(os.sep)
-    assert '.astropy' in parts or 'astropy' in parts
-    assert parts[-1] == 'testpkg.cfg'
-    configuration._cfgobjs['testpkg'] = None  # HACK
+    assert ".astropy" in parts or "astropy" in parts
+    assert parts[-1] == "testpkg.cfg"
+    configuration._cfgobjs["testpkg"] = None  # HACK
 
     # try with a different package name, specified root name:
-    testcfg = get_config('testpkg', rootname='testpkg')
+    testcfg = get_config("testpkg", rootname="testpkg")
     parts = os.path.normpath(testcfg.filename).split(os.sep)
-    assert '.testpkg' in parts or 'testpkg' in parts
-    assert parts[-1] == 'testpkg.cfg'
-    configuration._cfgobjs['testpkg'] = None  # HACK
+    assert ".testpkg" in parts or "testpkg" in parts
+    assert parts[-1] == "testpkg.cfg"
+    configuration._cfgobjs["testpkg"] = None  # HACK
 
     # try with a subpackage with specified root name:
-    testcfg_sec = get_config('testpkg.somemodule', rootname='testpkg')
+    testcfg_sec = get_config("testpkg.somemodule", rootname="testpkg")
     parts = os.path.normpath(testcfg_sec.parent.filename).split(os.sep)
-    assert '.testpkg' in parts or 'testpkg' in parts
-    assert parts[-1] == 'testpkg.cfg'
-    configuration._cfgobjs['testpkg'] = None  # HACK
+    assert ".testpkg" in parts or "testpkg" in parts
+    assert parts[-1] == "testpkg.cfg"
+    configuration._cfgobjs["testpkg"] = None  # HACK
 
-    reload_config('astropy')
+    reload_config("astropy")
 
 
 def check_config(conf):
     # test that the output contains some lines that we expect
-    assert '# unicode_output = False' in conf
-    assert '[io.fits]' in conf
-    assert '[table]' in conf
-    assert '# replace_warnings = ,' in conf
-    assert '[table.jsviewer]' in conf
-    assert '# css_urls = https://cdn.datatables.net/1.10.12/css/jquery.dataTables.css,' in conf
-    assert '[visualization.wcsaxes]' in conf
-    assert '## Whether to log exceptions before raising them.' in conf
-    assert '# log_exceptions = False' in conf
+    assert "# unicode_output = False" in conf
+    assert "[io.fits]" in conf
+    assert "[table]" in conf
+    assert "# replace_warnings = ," in conf
+    assert "[table.jsviewer]" in conf
+    assert "# css_urls = https://cdn.datatables.net/1.10.12/css/jquery.dataTables.css," in conf  # fmt: skip
+    assert "[visualization.wcsaxes]" in conf
+    assert "## Whether to log exceptions before raising them." in conf
+    assert "# log_exceptions = False" in conf
 
 
 def test_generate_config(tmp_path):
     from astropy.config.configuration import generate_config
+
     out = io.StringIO()
-    generate_config('astropy', out)
+    generate_config("astropy", out)
     conf = out.getvalue()
 
-    outfile = tmp_path / 'astropy.cfg'
-    generate_config('astropy', outfile)
+    outfile = tmp_path / "astropy.cfg"
+    generate_config("astropy", outfile)
     with open(outfile) as fp:
         conf2 = fp.read()
 
@@ -172,11 +173,12 @@ def test_generate_config2(tmp_path):
 
     with set_temp_config(tmp_path):
         from astropy.config.configuration import generate_config
-        generate_config('astropy')
 
-    assert os.path.exists(tmp_path / 'astropy' / 'astropy.cfg')
+        generate_config("astropy")
 
-    with open(tmp_path / 'astropy' / 'astropy.cfg') as fp:
+    assert os.path.exists(tmp_path / "astropy" / "astropy.cfg")
+
+    with open(tmp_path / "astropy" / "astropy.cfg") as fp:
         conf = fp.read()
 
     check_config(conf)
@@ -184,90 +186,94 @@ def test_generate_config2(tmp_path):
 
 def test_create_config_file(tmp_path, caplog):
     with set_temp_config(tmp_path):
-        create_config_file('astropy')
+        create_config_file("astropy")
 
     # check that the config file has been created
-    assert ('The configuration file has been successfully written'
-            in caplog.records[0].message)
-    assert os.path.exists(tmp_path / 'astropy' / 'astropy.cfg')
+    assert (
+        "The configuration file has been successfully written"
+        in caplog.records[0].message
+    )
+    assert os.path.exists(tmp_path / "astropy" / "astropy.cfg")
 
-    with open(tmp_path / 'astropy' / 'astropy.cfg') as fp:
+    with open(tmp_path / "astropy" / "astropy.cfg") as fp:
         conf = fp.read()
     check_config(conf)
 
     caplog.clear()
 
     # now modify the config file
-    conf = conf.replace('# unicode_output = False', 'unicode_output = True')
-    with open(tmp_path / 'astropy' / 'astropy.cfg', mode='w') as fp:
+    conf = conf.replace("# unicode_output = False", "unicode_output = True")
+    with open(tmp_path / "astropy" / "astropy.cfg", mode="w") as fp:
         fp.write(conf)
 
     with set_temp_config(tmp_path):
-        create_config_file('astropy')
+        create_config_file("astropy")
 
     # check that the config file has not been overwritten since it was modified
-    assert ('The configuration file already exists and seems to have been '
-            'customized' in caplog.records[0].message)
+    assert (
+        "The configuration file already exists and seems to have been customized"
+        in caplog.records[0].message
+    )
 
     caplog.clear()
 
     with set_temp_config(tmp_path):
-        create_config_file('astropy', overwrite=True)
+        create_config_file("astropy", overwrite=True)
 
     # check that the config file has been overwritten
-    assert ('The configuration file has been successfully written'
-            in caplog.records[0].message)
+    assert (
+        "The configuration file has been successfully written"
+        in caplog.records[0].message
+    )
 
 
 def test_configitem():
-
     from astropy.config.configuration import ConfigItem, ConfigNamespace, get_config
 
-    ci = ConfigItem(34, 'this is a Description')
+    ci = ConfigItem(34, "this is a Description")
 
     class Conf(ConfigNamespace):
         tstnm = ci
 
     conf = Conf()
 
-    assert ci.module == 'astropy.config.tests.test_configs'
+    assert ci.module == "astropy.config.tests.test_configs"
     assert ci() == 34
-    assert ci.description == 'this is a Description'
+    assert ci.description == "this is a Description"
 
     assert conf.tstnm == 34
 
     sec = get_config(ci.module)
-    assert sec['tstnm'] == 34
+    assert sec["tstnm"] == 34
 
-    ci.description = 'updated Descr'
+    ci.description = "updated Descr"
     ci.set(32)
     assert ci() == 32
 
     # It's useful to go back to the default to allow other test functions to
     # call this one and still be in the default configuration.
-    ci.description = 'this is a Description'
+    ci.description = "this is a Description"
     ci.set(34)
     assert ci() == 34
 
     # Test iterator for one-item namespace
     result = [x for x in conf]
-    assert result == ['tstnm']
+    assert result == ["tstnm"]
     result = [x for x in conf.keys()]
-    assert result == ['tstnm']
+    assert result == ["tstnm"]
     result = [x for x in conf.values()]
     assert result == [ci]
     result = [x for x in conf.items()]
-    assert result == [('tstnm', ci)]
+    assert result == [("tstnm", ci)]
 
 
 def test_configitem_types():
-
     from astropy.config.configuration import ConfigItem, ConfigNamespace
 
     ci1 = ConfigItem(34)
     ci2 = ConfigItem(34.3)
     ci3 = ConfigItem(True)
-    ci4 = ConfigItem('astring')
+    ci4 = ConfigItem("astring")
 
     class Conf(ConfigNamespace):
         tstnm1 = ci1
@@ -286,26 +292,30 @@ def test_configitem_types():
         conf.tstnm1 = 34.3
     conf.tstnm2 = 12  # this would should succeed as up-casting
     with pytest.raises(TypeError):
-        conf.tstnm3 = 'fasd'
+        conf.tstnm3 = "fasd"
     with pytest.raises(TypeError):
         conf.tstnm4 = 546.245
 
     # Test iterator for multi-item namespace. Assume ordered by insertion order.
     item_names = [x for x in conf]
-    assert item_names == ['tstnm1', 'tstnm2', 'tstnm3', 'tstnm4']
+    assert item_names == ["tstnm1", "tstnm2", "tstnm3", "tstnm4"]
     result = [x for x in conf.keys()]
     assert result == item_names
     result = [x for x in conf.values()]
     assert result == [ci1, ci2, ci3, ci4]
     result = [x for x in conf.items()]
-    assert result == [('tstnm1', ci1), ('tstnm2', ci2), ('tstnm3', ci3), ('tstnm4', ci4)]
+    assert result == [
+        ("tstnm1", ci1),
+        ("tstnm2", ci2),
+        ("tstnm3", ci3),
+        ("tstnm4", ci4),
+    ]
 
 
 def test_configitem_options(tmp_path):
-
     from astropy.config.configuration import ConfigItem, ConfigNamespace, get_config
 
-    cio = ConfigItem(['op1', 'op2', 'op3'])
+    cio = ConfigItem(["op1", "op2", "op3"])
 
     class Conf(ConfigNamespace):
         tstnmo = cio
@@ -313,13 +323,13 @@ def test_configitem_options(tmp_path):
     sec = get_config(cio.module)
 
     assert isinstance(cio(), str)
-    assert cio() == 'op1'
-    assert sec['tstnmo'] == 'op1'
+    assert cio() == "op1"
+    assert sec["tstnmo"] == "op1"
 
-    cio.set('op2')
+    cio.set("op2")
     with pytest.raises(TypeError):
-        cio.set('op5')
-    assert sec['tstnmo'] == 'op2'
+        cio.set("op5")
+    assert sec["tstnmo"] == "op2"
 
     # now try saving
     apycfg = sec
@@ -331,7 +341,7 @@ def test_configitem_options(tmp_path):
     with open(f, encoding="utf-8") as fd:
         lns = [x.strip() for x in fd.readlines()]
 
-    assert 'tstnmo = op2' in lns
+    assert "tstnmo = op2" in lns
 
 
 def test_config_noastropy_fallback(monkeypatch):
@@ -341,22 +351,23 @@ def test_config_noastropy_fallback(monkeypatch):
     """
 
     # make sure the config directory is not searched
-    monkeypatch.setenv('XDG_CONFIG_HOME', 'foo')
-    monkeypatch.delenv('XDG_CONFIG_HOME')
-    monkeypatch.setattr(paths.set_temp_config, '_temp_path', None)
+    monkeypatch.setenv("XDG_CONFIG_HOME", "foo")
+    monkeypatch.delenv("XDG_CONFIG_HOME")
+    monkeypatch.setattr(paths.set_temp_config, "_temp_path", None)
 
     # make sure the _find_or_create_root_dir function fails as though the
     # astropy dir could not be accessed
     def osraiser(dirnm, linkto, pkgname=None):
         raise OSError
-    monkeypatch.setattr(paths, '_find_or_create_root_dir', osraiser)
+
+    monkeypatch.setattr(paths, "_find_or_create_root_dir", osraiser)
 
     # also have to make sure the stored configuration objects are cleared
-    monkeypatch.setattr(configuration, '_cfgobjs', {})
+    monkeypatch.setattr(configuration, "_cfgobjs", {})
 
     with pytest.raises(OSError):
         # make sure the config dir search fails
-        paths.get_config_dir(rootname='astropy')
+        paths.get_config_dir(rootname="astropy")
 
     # now run the basic tests, and make sure the warning about no astropy
     # is present
@@ -364,28 +375,27 @@ def test_config_noastropy_fallback(monkeypatch):
 
 
 def test_configitem_setters():
-
     from astropy.config.configuration import ConfigItem, ConfigNamespace
 
     class Conf(ConfigNamespace):
-        tstnm12 = ConfigItem(42, 'this is another Description')
+        tstnm12 = ConfigItem(42, "this is another Description")
 
     conf = Conf()
 
     assert conf.tstnm12 == 42
-    with conf.set_temp('tstnm12', 45):
+    with conf.set_temp("tstnm12", 45):
         assert conf.tstnm12 == 45
     assert conf.tstnm12 == 42
 
     conf.tstnm12 = 43
     assert conf.tstnm12 == 43
 
-    with conf.set_temp('tstnm12', 46):
+    with conf.set_temp("tstnm12", 46):
         assert conf.tstnm12 == 46
 
     # Make sure it is reset even with Exception
     try:
-        with conf.set_temp('tstnm12', 47):
+        with conf.set_temp("tstnm12", 47):
             raise Exception
     except Exception:
         pass
@@ -397,28 +407,28 @@ def test_empty_config_file():
     from astropy.config.configuration import is_unedited_config_file
 
     def get_content(fn):
-        with open(get_pkg_data_filename(fn), encoding='latin-1') as fd:
+        with open(get_pkg_data_filename(fn), encoding="latin-1") as fd:
             return fd.read()
 
-    content = get_content('data/empty.cfg')
+    content = get_content("data/empty.cfg")
     assert is_unedited_config_file(content)
 
-    content = get_content('data/not_empty.cfg')
+    content = get_content("data/not_empty.cfg")
     assert not is_unedited_config_file(content)
 
 
 class TestAliasRead:
-
     def setup_class(self):
-        configuration._override_config_file = get_pkg_data_filename('data/alias.cfg')
+        configuration._override_config_file = get_pkg_data_filename("data/alias.cfg")
 
     def test_alias_read(self):
         from astropy.utils.data import conf
 
         with pytest.warns(
-                AstropyDeprecationWarning,
-                match=r"Config parameter 'name_resolve_timeout' in section "
-                      r"\[coordinates.name_resolve\].*") as w:
+            AstropyDeprecationWarning,
+            match=r"Config parameter 'name_resolve_timeout' in section "
+            r"\[coordinates.name_resolve\].*",
+        ) as w:
             conf.reload()
             assert conf.remote_timeout == 42
 
@@ -432,10 +442,9 @@ class TestAliasRead:
 
 
 def test_configitem_unicode():
-
     from astropy.config.configuration import ConfigItem, ConfigNamespace, get_config
 
-    cio = ConfigItem('ასტრონომიის')
+    cio = ConfigItem("ასტრონომიის")
 
     class Conf(ConfigNamespace):
         tstunicode = cio
@@ -443,8 +452,8 @@ def test_configitem_unicode():
     sec = get_config(cio.module)
 
     assert isinstance(cio(), str)
-    assert cio() == 'ასტრონომიის'
-    assert sec['tstunicode'] == 'ასტრონომიის'
+    assert cio() == "ასტრონომიის"
+    assert sec["tstunicode"] == "ასტრონომიის"
 
 
 def test_warning_move_to_top_level():
@@ -452,7 +461,7 @@ def test_warning_move_to_top_level():
     # file works.  See #2514
     from astropy import conf
 
-    configuration._override_config_file = get_pkg_data_filename('data/deprecated.cfg')
+    configuration._override_config_file = get_pkg_data_filename("data/deprecated.cfg")
 
     try:
         with pytest.warns(AstropyDeprecationWarning) as w:
@@ -470,21 +479,18 @@ def test_no_home():
     # subprocess and try to import astropy.
 
     test_path = os.path.dirname(__file__)
-    astropy_path = os.path.abspath(
-        os.path.join(test_path, '..', '..', '..'))
+    astropy_path = os.path.abspath(os.path.join(test_path, "..", "..", ".."))
 
     env = os.environ.copy()
     paths = [astropy_path]
-    if env.get('PYTHONPATH'):
-        paths.append(env.get('PYTHONPATH'))
-    env['PYTHONPATH'] = os.pathsep.join(paths)
+    if env.get("PYTHONPATH"):
+        paths.append(env.get("PYTHONPATH"))
+    env["PYTHONPATH"] = os.pathsep.join(paths)
 
-    for val in ['HOME', 'XDG_CONFIG_HOME']:
+    for val in ["HOME", "XDG_CONFIG_HOME"]:
         if val in env:
             del env[val]
 
-    retcode = subprocess.check_call(
-        [sys.executable, '-c', 'import astropy'],
-        env=env)
+    retcode = subprocess.check_call([sys.executable, "-c", "import astropy"], env=env)
 
     assert retcode == 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,6 @@ force-exclude = '''
     | examples
     | astropy/_dev
     | astropy/_erfa
-    | astropy/config
     | astropy/constants
     | astropy/convolution
     | astropy/coordinates


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

Apply `black` to `astropy.config` according to the process laid out by [APE 20](https://github.com/astropy/astropy-APEs/blob/main/APE20.rst).

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Resolves #13946

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
