### PR TITLE
Apply `black` to `astropy.tests`

### DIFF
--- a/astropy/tests/command.py
+++ b/astropy/tests/command.py
@@ -377,18 +377,14 @@ class AstropyTest(Command, metaclass=FixRemoteDataOption):
             tmp.write(coveragerc_content.encode("utf-8"))
 
         cmd_pre = (
-            "import coverage; "
-            'cov = coverage.coverage(data_file=r"{}", config_file=r"{}"); '
-            "cov.start();".format(
-                os.path.abspath(".coverage"), os.path.abspath(tmp_coveragerc)
-            )
+            "import coverage; cov ="
+            f' coverage.coverage(data_file=r"{os.path.abspath(".coverage")}",'
+            f' config_file=r"{os.path.abspath(tmp_coveragerc)}"); cov.start();'
         )
         cmd_post = (
-            "cov.stop(); "
-            "from astropy.tests.helper import _save_coverage; "
-            '_save_coverage(cov, result, r"{}", r"{}");'.format(
-                os.path.abspath("."), os.path.abspath(self.testing_path)
-            )
+            "cov.stop(); from astropy.tests.helper import _save_coverage;"
+            f' _save_coverage(cov, result, r"{os.path.abspath(".")}",'
+            f' r"{os.path.abspath(self.testing_path)}");'
         )
 
         return cmd_pre, cmd_post

--- a/astropy/tests/command.py
+++ b/astropy/tests/command.py
@@ -19,12 +19,12 @@ from astropy.logger import log
 
 @contextmanager
 def _suppress_stdout():
-    '''
+    """
     A context manager to temporarily disable stdout.
 
     Used later when installing a temporary copy of astropy to avoid a
     very verbose output.
-    '''
+    """
     with open(os.devnull, "w") as devnull:
         old_stdout = sys.stdout
         sys.stdout = devnull
@@ -42,83 +42,106 @@ class FixRemoteDataOption(type):
     enable all remote tests. With this metaclass, we can modify sys.argv
     before setuptools try to parse the command-line options.
     """
+
     def __init__(cls, name, bases, dct):
-
         try:
-            idx = sys.argv.index('--remote-data')
+            idx = sys.argv.index("--remote-data")
         except ValueError:
             pass
         else:
-            sys.argv[idx] = '--remote-data=any'
+            sys.argv[idx] = "--remote-data=any"
 
         try:
-            idx = sys.argv.index('-R')
+            idx = sys.argv.index("-R")
         except ValueError:
             pass
         else:
-            sys.argv[idx] = '-R=any'
+            sys.argv[idx] = "-R=any"
 
         return super().__init__(name, bases, dct)
 
 
 class AstropyTest(Command, metaclass=FixRemoteDataOption):
-    description = 'Run the tests for this package'
+    description = "Run the tests for this package"
 
     user_options = [
-        ('package=', 'P',
-         "The name of a specific package to test, e.g. 'io.fits' or 'utils'. "
-         "Accepts comma separated string to specify multiple packages. "
-         "If nothing is specified, all default tests are run."),
-        ('test-path=', 't',
-         'Specify a test location by path.  If a relative path to a  .py file, '
-         'it is relative to the built package, so e.g., a  leading "astropy/" '
-         'is necessary.  If a relative  path to a .rst file, it is relative to '
-         'the directory *below* the --docs-path directory, so a leading '
-         '"docs/" is usually necessary.  May also be an absolute path.'),
-        ('verbose-results', 'V',
-         'Turn on verbose output from pytest.'),
-        ('plugins=', 'p',
-         'Plugins to enable when running pytest.'),
-        ('pastebin=', 'b',
-         "Enable pytest pastebin output. Either 'all' or 'failed'."),
-        ('args=', 'a',
-         'Additional arguments to be passed to pytest.'),
-        ('remote-data=', 'R', 'Run tests that download remote data. Should be '
-         'one of none/astropy/any (defaults to none).'),
-        ('pep8', '8',
-         'Enable PEP8 checking and disable regular tests. '
-         'Requires the pytest-pep8 plugin.'),
-        ('pdb', 'd',
-         'Start the interactive Python debugger on errors.'),
-        ('coverage', 'c',
-         'Create a coverage report. Requires the coverage package.'),
-        ('open-files', 'o', 'Fail if any tests leave files open.  Requires the '
-         'psutil package.'),
-        ('parallel=', 'j',
-         'Run the tests in parallel on the specified number of '
-         'CPUs.  If "auto", all the cores on the machine will be '
-         'used.  Requires the pytest-xdist plugin.'),
-        ('docs-path=', None,
-         'The path to the documentation .rst files.  If not provided, and '
-         'the current directory contains a directory called "docs", that '
-         'will be used.'),
-        ('skip-docs', None,
-         "Don't test the documentation .rst files."),
-        ('repeat=', None,
-         'How many times to repeat each test (can be used to check for '
-         'sporadic failures).'),
-        ('temp-root=', None,
-         'The root directory in which to create the temporary testing files. '
-         'If unspecified the system default is used (e.g. /tmp) as explained '
-         'in the documentation for tempfile.mkstemp.'),
-        ('verbose-install', None,
-         'Turn on terminal output from the installation of astropy in a '
-         'temporary folder.'),
-        ('readonly', None,
-         'Make the temporary installation being tested read-only.')
+        (
+            "package=",
+            "P",
+            "The name of a specific package to test, e.g. 'io.fits' or 'utils'. "
+            "Accepts comma separated string to specify multiple packages. "
+            "If nothing is specified, all default tests are run.",
+        ),
+        (
+            "test-path=",
+            "t",
+            "Specify a test location by path.  If a relative path to a  .py file, "
+            'it is relative to the built package, so e.g., a  leading "astropy/" '
+            "is necessary.  If a relative  path to a .rst file, it is relative to "
+            "the directory *below* the --docs-path directory, so a leading "
+            '"docs/" is usually necessary.  May also be an absolute path.',
+        ),
+        ("verbose-results", "V", "Turn on verbose output from pytest."),
+        ("plugins=", "p", "Plugins to enable when running pytest."),
+        ("pastebin=", "b", "Enable pytest pastebin output. Either 'all' or 'failed'."),
+        ("args=", "a", "Additional arguments to be passed to pytest."),
+        (
+            "remote-data=",
+            "R",
+            "Run tests that download remote data. Should be "
+            "one of none/astropy/any (defaults to none).",
+        ),
+        (
+            "pep8",
+            "8",
+            "Enable PEP8 checking and disable regular tests. "
+            "Requires the pytest-pep8 plugin.",
+        ),
+        ("pdb", "d", "Start the interactive Python debugger on errors."),
+        ("coverage", "c", "Create a coverage report. Requires the coverage package."),
+        (
+            "open-files",
+            "o",
+            "Fail if any tests leave files open.  Requires the psutil package.",
+        ),
+        (
+            "parallel=",
+            "j",
+            "Run the tests in parallel on the specified number of "
+            'CPUs.  If "auto", all the cores on the machine will be '
+            "used.  Requires the pytest-xdist plugin.",
+        ),
+        (
+            "docs-path=",
+            None,
+            "The path to the documentation .rst files.  If not provided, and "
+            'the current directory contains a directory called "docs", that '
+            "will be used.",
+        ),
+        ("skip-docs", None, "Don't test the documentation .rst files."),
+        (
+            "repeat=",
+            None,
+            "How many times to repeat each test (can be used to check for "
+            "sporadic failures).",
+        ),
+        (
+            "temp-root=",
+            None,
+            "The root directory in which to create the temporary testing files. "
+            "If unspecified the system default is used (e.g. /tmp) as explained "
+            "in the documentation for tempfile.mkstemp.",
+        ),
+        (
+            "verbose-install",
+            None,
+            "Turn on terminal output from the installation of astropy in a "
+            "temporary folder.",
+        ),
+        ("readonly", None, "Make the temporary installation being tested read-only."),
     ]
 
-    package_name = ''
+    package_name = ""
 
     def initialize_options(self):
         self.package = None
@@ -127,7 +150,7 @@ class AstropyTest(Command, metaclass=FixRemoteDataOption):
         self.plugins = None
         self.pastebin = None
         self.args = None
-        self.remote_data = 'none'
+        self.remote_data = "none"
         self.pep8 = False
         self.pdb = False
         self.coverage = False
@@ -150,8 +173,8 @@ class AstropyTest(Command, metaclass=FixRemoteDataOption):
         Build a Python script to run the tests.
         """
 
-        cmd_pre = ''  # Commands to run before the test function
-        cmd_post = ''  # Commands to run after the test function
+        cmd_pre = ""  # Commands to run before the test function
+        cmd_post = ""  # Commands to run after the test function
 
         if self.coverage:
             pre, post = self._generate_coverage_commands()
@@ -160,25 +183,27 @@ class AstropyTest(Command, metaclass=FixRemoteDataOption):
 
         set_flag = "import builtins; builtins._ASTROPY_TEST_ = True"
 
-        cmd = ('{cmd_pre}{0}; import {1.package_name}, sys; result = ('
-               '{1.package_name}.test('
-               'package={1.package!r}, '
-               'test_path={1.test_path!r}, '
-               'args={1.args!r}, '
-               'plugins={1.plugins!r}, '
-               'verbose={1.verbose_results!r}, '
-               'pastebin={1.pastebin!r}, '
-               'remote_data={1.remote_data!r}, '
-               'pep8={1.pep8!r}, '
-               'pdb={1.pdb!r}, '
-               'open_files={1.open_files!r}, '
-               'parallel={1.parallel!r}, '
-               'docs_path={1.docs_path!r}, '
-               'skip_docs={1.skip_docs!r}, '
-               'add_local_eggs_to_path=True, '  # see _build_temp_install below
-               'repeat={1.repeat!r})); '
-               '{cmd_post}'
-               'sys.exit(result)')
+        cmd = (  # see _build_temp_install below
+            "{cmd_pre}{0}; import {1.package_name}, sys; result = ("
+            "{1.package_name}.test("
+            "package={1.package!r}, "
+            "test_path={1.test_path!r}, "
+            "args={1.args!r}, "
+            "plugins={1.plugins!r}, "
+            "verbose={1.verbose_results!r}, "
+            "pastebin={1.pastebin!r}, "
+            "remote_data={1.remote_data!r}, "
+            "pep8={1.pep8!r}, "
+            "pdb={1.pdb!r}, "
+            "open_files={1.open_files!r}, "
+            "parallel={1.parallel!r}, "
+            "docs_path={1.docs_path!r}, "
+            "skip_docs={1.skip_docs!r}, "
+            "add_local_eggs_to_path=True, "
+            "repeat={1.repeat!r})); "
+            "{cmd_post}"
+            "sys.exit(result)"
+        )
         return cmd.format(set_flag, self, cmd_pre=cmd_pre, cmd_post=cmd_post)
 
     def run(self):
@@ -192,7 +217,9 @@ class AstropyTest(Command, metaclass=FixRemoteDataOption):
 
         # Ensure there is a doc path
         if self.docs_path is None:
-            cfg_docs_dir = self.distribution.get_option_dict('build_docs').get('source_dir', None)
+            cfg_docs_dir = self.distribution.get_option_dict("build_docs").get(
+                "source_dir", None
+            )
 
             # Some affiliated packages use this.
             # See astropy/package-template#157
@@ -200,8 +227,8 @@ class AstropyTest(Command, metaclass=FixRemoteDataOption):
                 self.docs_path = os.path.abspath(cfg_docs_dir[1])
 
             # fall back on a default path of "docs"
-            elif os.path.exists('docs'):  # pragma: no cover
-                self.docs_path = os.path.abspath('docs')
+            elif os.path.exists("docs"):  # pragma: no cover
+                self.docs_path = os.path.abspath("docs")
 
         # Build a testing install of the package
         self._build_temp_install()
@@ -217,13 +244,13 @@ class AstropyTest(Command, metaclass=FixRemoteDataOption):
         # tests_requires or install_requires. We then pass the
         # add_local_eggs_to_path=True option to package.test() to make sure the
         # eggs get included in the path.
-        if os.path.exists('.eggs'):
-            shutil.copytree('.eggs', os.path.join(self.testing_path, '.eggs'))
+        if os.path.exists(".eggs"):
+            shutil.copytree(".eggs", os.path.join(self.testing_path, ".eggs"))
 
         # This option exists so that we can make sure that the tests don't
         # write to an installed location.
         if self.readonly:
-            log.info('changing permissions of temporary installation to read-only')
+            log.info("changing permissions of temporary installation to read-only")
             self._change_permissions_testing_path(writable=False)
 
         # Run everything in a try: finally: so that the tmp dir gets deleted.
@@ -236,8 +263,8 @@ class AstropyTest(Command, metaclass=FixRemoteDataOption):
             # easiest way to set up a new environment
 
             testproc = subprocess.Popen(
-                [sys.executable, '-c', cmd],
-                cwd=self.testing_path, close_fds=False)
+                [sys.executable, "-c", cmd], cwd=self.testing_path, close_fds=False
+            )
             retcode = testproc.wait()
         except KeyboardInterrupt:
             import signal
@@ -267,39 +294,41 @@ class AstropyTest(Command, metaclass=FixRemoteDataOption):
         # dereference that link, because pytest is very sensitive to relative
         # paths...
 
-        tmp_dir = tempfile.mkdtemp(prefix=self.package_name + '-test-',
-                                   dir=self.temp_root)
+        tmp_dir = tempfile.mkdtemp(
+            prefix=self.package_name + "-test-", dir=self.temp_root
+        )
         self.tmp_dir = os.path.realpath(tmp_dir)
 
-        log.info(f'installing to temporary directory: {self.tmp_dir}')
+        log.info(f"installing to temporary directory: {self.tmp_dir}")
 
         # We now install the package to the temporary directory. We do this
         # rather than build and copy because this will ensure that e.g. entry
         # points work.
-        self.reinitialize_command('install')
-        install_cmd = self.distribution.get_command_obj('install')
+        self.reinitialize_command("install")
+        install_cmd = self.distribution.get_command_obj("install")
         install_cmd.prefix = self.tmp_dir
         if self.verbose_install:
-            self.run_command('install')
+            self.run_command("install")
         else:
             with _suppress_stdout():
-                self.run_command('install')
+                self.run_command("install")
 
         # We now get the path to the site-packages directory that was created
         # inside self.tmp_dir
-        install_cmd = self.get_finalized_command('install')
+        install_cmd = self.get_finalized_command("install")
         self.testing_path = install_cmd.install_lib
 
         # Ideally, docs_path is set properly in run(), but if it is still
         # not set here, do not pretend it is, otherwise bad things happen.
         # See astropy/package-template#157
         if self.docs_path is not None:
-            new_docs_path = os.path.join(self.testing_path,
-                                         os.path.basename(self.docs_path))
+            new_docs_path = os.path.join(
+                self.testing_path, os.path.basename(self.docs_path)
+            )
             shutil.copytree(self.docs_path, new_docs_path)
             self.docs_path = new_docs_path
 
-        shutil.copy('setup.cfg', self.testing_path)
+        shutil.copy("setup.cfg", self.testing_path)
 
     def _change_permissions_testing_path(self, writable=False):
         if writable:
@@ -318,41 +347,48 @@ class AstropyTest(Command, metaclass=FixRemoteDataOption):
         generated
         """
         if self.parallel != 0:
-            raise ValueError(
-                "--coverage can not be used with --parallel")
+            raise ValueError("--coverage can not be used with --parallel")
 
         try:
             import coverage  # noqa: F401
         except ImportError:
             raise ImportError(
-                "--coverage requires that the coverage package is "
-                "installed.")
+                "--coverage requires that the coverage package is installed."
+            )
 
         # Don't use get_pkg_data_filename here, because it
         # requires importing astropy.config and thus screwing
         # up coverage results for those packages.
         coveragerc = os.path.join(
-            self.testing_path, self.package_name.replace('.', '/'),
-            'tests', 'coveragerc')
+            self.testing_path,
+            self.package_name.replace(".", "/"),
+            "tests",
+            "coveragerc",
+        )
 
         with open(coveragerc) as fd:
             coveragerc_content = fd.read()
 
         coveragerc_content = coveragerc_content.replace(
-            "{packagename}", self.package_name.replace('.', '/'))
-        tmp_coveragerc = os.path.join(self.tmp_dir, 'coveragerc')
-        with open(tmp_coveragerc, 'wb') as tmp:
-            tmp.write(coveragerc_content.encode('utf-8'))
+            "{packagename}", self.package_name.replace(".", "/")
+        )
+        tmp_coveragerc = os.path.join(self.tmp_dir, "coveragerc")
+        with open(tmp_coveragerc, "wb") as tmp:
+            tmp.write(coveragerc_content.encode("utf-8"))
 
         cmd_pre = (
-            'import coverage; '
+            "import coverage; "
             'cov = coverage.coverage(data_file=r"{}", config_file=r"{}"); '
-            'cov.start();'.format(
-                os.path.abspath(".coverage"), os.path.abspath(tmp_coveragerc)))
+            "cov.start();".format(
+                os.path.abspath(".coverage"), os.path.abspath(tmp_coveragerc)
+            )
+        )
         cmd_post = (
-            'cov.stop(); '
-            'from astropy.tests.helper import _save_coverage; '
+            "cov.stop(); "
+            "from astropy.tests.helper import _save_coverage; "
             '_save_coverage(cov, result, r"{}", r"{}");'.format(
-                os.path.abspath('.'), os.path.abspath(self.testing_path)))
+                os.path.abspath("."), os.path.abspath(self.testing_path)
+            )
+        )
 
         return cmd_pre, cmd_post

--- a/astropy/tests/figures/helpers.py
+++ b/astropy/tests/figures/helpers.py
@@ -20,19 +20,19 @@ def figure_test(*args, **kwargs):
     # the matplotlib version embedded since this changes for every developer
     # version.
 
-    tolerance = kwargs.pop('tolerance', 0)
-    style = kwargs.pop('style', {})
-    savefig_kwargs = kwargs.pop('savefig_kwargs', {})
-    savefig_kwargs['metadata'] = {'Software': None}
+    tolerance = kwargs.pop("tolerance", 0)
+    style = kwargs.pop("style", {})
+    savefig_kwargs = kwargs.pop("savefig_kwargs", {})
+    savefig_kwargs["metadata"] = {"Software": None}
 
     def decorator(test_function):
-
         @pytest.mark.remote_data
-        @pytest.mark.mpl_image_compare(tolerance=tolerance,
-                                       style=style,
-                                       savefig_kwargs=savefig_kwargs,
-                                       **kwargs)
-        @pytest.mark.skipif(not HAS_PYTEST_MPL, reason='pytest-mpl is required for the figure tests')
+        @pytest.mark.mpl_image_compare(
+            tolerance=tolerance, style=style, savefig_kwargs=savefig_kwargs, **kwargs
+        )
+        @pytest.mark.skipif(
+            not HAS_PYTEST_MPL, reason="pytest-mpl is required for the figure tests"
+        )
         @wraps(test_function)
         def test_wrapper(*args, **kwargs):
             return test_function(*args, **kwargs)

--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -23,9 +23,13 @@ from astropy.utils.exceptions import (
 # For backward-compatibility with affiliated packages
 from .runner import TestRunner  # noqa: F401
 
-__all__ = ['assert_follows_unicode_guidelines',
-           'assert_quantity_allclose', 'check_pickling_recovery',
-           'pickle_protocol', 'generic_recursive_equality_test']
+__all__ = [
+    "assert_follows_unicode_guidelines",
+    "assert_quantity_allclose",
+    "check_pickling_recovery",
+    "pickle_protocol",
+    "generic_recursive_equality_test",
+]
 
 
 def _save_coverage(cov, result, rootdir, testing_path):
@@ -55,20 +59,19 @@ def _save_coverage(cov, result, rootdir, testing_path):
 
     for key in list(lines.keys()):
         new_path = os.path.relpath(
-            os.path.realpath(key),
-            os.path.realpath(testing_path))
-        new_path = os.path.abspath(
-            os.path.join(rootdir, new_path))
+            os.path.realpath(key), os.path.realpath(testing_path)
+        )
+        new_path = os.path.abspath(os.path.join(rootdir, new_path))
         lines[new_path] = lines.pop(key)
 
-    color_print('Saving coverage data in .coverage...', 'green')
+    color_print("Saving coverage data in .coverage...", "green")
     cov.save()
 
-    color_print('Saving HTML coverage report in htmlcov...', 'green')
-    cov.html_report(directory=os.path.join(rootdir, 'htmlcov'))
+    color_print("Saving HTML coverage report in htmlcov...", "green")
+    cov.html_report(directory=os.path.join(rootdir, "htmlcov"))
 
 
-@deprecated('5.1', alternative='pytest.raises')
+@deprecated("5.1", alternative="pytest.raises")
 class raises:
     """
     A decorator to mark that a test should raise a given exception.
@@ -96,6 +99,7 @@ class raises:
         @functools.wraps(func)
         def run_raises_test(*args, **kwargs):
             pytest.raises(self._exc, func, *args, **kwargs)
+
         return run_raises_test
 
     def __enter__(self):
@@ -110,41 +114,53 @@ class raises:
 _deprecations_as_exceptions = False
 _include_astropy_deprecations = True
 _modules_to_ignore_on_import = {
-    r'compiler',  # A deprecated stdlib module used by pytest
-    r'scipy',
-    r'pygments',
-    r'ipykernel',
-    r'IPython',   # deprecation warnings for async and await
-    r'setuptools'}
+    r"compiler",  # A deprecated stdlib module used by pytest
+    r"scipy",
+    r"pygments",
+    r"ipykernel",
+    r"IPython",  # deprecation warnings for async and await
+    r"setuptools",
+}
 _warnings_to_ignore_entire_module = set()
 _warnings_to_ignore_by_pyver = {
     None: {  # Python version agnostic
         # https://github.com/astropy/astropy/pull/7372
-        (r"Importing from numpy\.testing\.decorators is deprecated, "
-         r"import from numpy\.testing instead\.", DeprecationWarning),
+        (
+            r"Importing from numpy\.testing\.decorators is deprecated, "
+            r"import from numpy\.testing instead\.",
+            DeprecationWarning,
+        ),
         # inspect raises this slightly different warning on Python 3.7.
         # Keeping it since e.g. lxml as of 3.8.0 is still calling getargspec()
-        (r"inspect\.getargspec\(\) is deprecated, use "
-         r"inspect\.signature\(\) or inspect\.getfullargspec\(\)",
-         DeprecationWarning),
+        (
+            r"inspect\.getargspec\(\) is deprecated, use "
+            r"inspect\.signature\(\) or inspect\.getfullargspec\(\)",
+            DeprecationWarning,
+        ),
         # https://github.com/astropy/pytest-doctestplus/issues/29
         (r"split\(\) requires a non-empty pattern match", FutureWarning),
         # Package resolution warning that we can do nothing about
-        (r"can't resolve package from __spec__ or __package__, "
-         r"falling back on __name__ and __path__", ImportWarning)},
+        (
+            r"can't resolve package from __spec__ or __package__, "
+            r"falling back on __name__ and __path__",
+            ImportWarning,
+        ),
+    },
     (3, 7): {
         # Deprecation warning for collections.abc, fixed in Astropy but still
         # used in lxml, and maybe others
-        (r"Using or importing the ABCs from 'collections'",
-         DeprecationWarning)}
+        (r"Using or importing the ABCs from 'collections'", DeprecationWarning)
+    },
 }
 
 
-@deprecated('5.1', alternative='https://docs.pytest.org/en/stable/warnings.html')
-def enable_deprecations_as_exceptions(include_astropy_deprecations=True,
-                                      modules_to_ignore_on_import=[],
-                                      warnings_to_ignore_entire_module=[],
-                                      warnings_to_ignore_by_pyver={}):
+@deprecated("5.1", alternative="https://docs.pytest.org/en/stable/warnings.html")
+def enable_deprecations_as_exceptions(
+    include_astropy_deprecations=True,
+    modules_to_ignore_on_import=[],
+    warnings_to_ignore_entire_module=[],
+    warnings_to_ignore_by_pyver={},
+):
     """
     Turn on the feature that turns deprecations into exceptions.
 
@@ -194,7 +210,7 @@ def enable_deprecations_as_exceptions(include_astropy_deprecations=True,
             _warnings_to_ignore_by_pyver[key] = set(val)
 
 
-@deprecated('5.1', alternative='https://docs.pytest.org/en/stable/warnings.html')
+@deprecated("5.1", alternative="https://docs.pytest.org/en/stable/warnings.html")
 def treat_deprecations_as_exceptions():
     """
     Turn all DeprecationWarnings (which indicate deprecated uses of
@@ -220,7 +236,7 @@ def treat_deprecations_as_exceptions():
     warnings.resetwarnings()
 
     # Hide the next couple of DeprecationWarnings
-    warnings.simplefilter('ignore', DeprecationWarning)
+    warnings.simplefilter("ignore", DeprecationWarning)
     # Here's the wrinkle: a couple of our third-party dependencies
     # (pytest and scipy) are still using deprecated features
     # themselves, and we'd like to ignore those.  Fortunately, those
@@ -239,8 +255,7 @@ def treat_deprecations_as_exceptions():
 
     # Only turn astropy deprecation warnings into exceptions if requested
     if _include_astropy_deprecations:
-        _all_warns += [AstropyDeprecationWarning,
-                       AstropyPendingDeprecationWarning]
+        _all_warns += [AstropyDeprecationWarning, AstropyPendingDeprecationWarning]
 
     for w in _all_warns:
         warnings.filterwarnings("error", ".*", w)
@@ -249,7 +264,7 @@ def treat_deprecations_as_exceptions():
     # not just on import, for use of Astropy affiliated packages.
     for m in _warnings_to_ignore_entire_module:
         for w in _all_warns:
-            warnings.filterwarnings('ignore', category=w, module=m)
+            warnings.filterwarnings("ignore", category=w, module=m)
 
     # This ignores only specified warnings by Python version, if applicable.
     for v in _warnings_to_ignore_by_pyver:
@@ -258,7 +273,7 @@ def treat_deprecations_as_exceptions():
                 warnings.filterwarnings("ignore", s[0], s[1])
 
 
-@deprecated('5.1', alternative='pytest.warns')
+@deprecated("5.1", alternative="pytest.warns")
 class catch_warnings(warnings.catch_warnings):
     """
     A high-powered version of warnings.catch_warnings to use for testing
@@ -289,18 +304,18 @@ class catch_warnings(warnings.catch_warnings):
         warning_list = super().__enter__()
         treat_deprecations_as_exceptions()
         if len(self.classes) == 0:
-            warnings.simplefilter('always')
+            warnings.simplefilter("always")
         else:
-            warnings.simplefilter('ignore')
+            warnings.simplefilter("ignore")
             for cls in self.classes:
-                warnings.simplefilter('always', cls)
+                warnings.simplefilter("always", cls)
         return warning_list
 
     def __exit__(self, type, value, traceback):
         treat_deprecations_as_exceptions()
 
 
-@deprecated('5.1', alternative='pytest.mark.filterwarnings')
+@deprecated("5.1", alternative="pytest.mark.filterwarnings")
 class ignore_warnings(catch_warnings):
     """
     This can be used either as a context manager or function decorator to
@@ -333,14 +348,13 @@ class ignore_warnings(catch_warnings):
         retval = super().__enter__()
         if self.category is not None:
             for category in self.category:
-                warnings.simplefilter('ignore', category)
+                warnings.simplefilter("ignore", category)
         else:
-            warnings.simplefilter('ignore')
+            warnings.simplefilter("ignore")
         return retval
 
 
-def assert_follows_unicode_guidelines(
-        x, roundtrip=None):
+def assert_follows_unicode_guidelines(x, roundtrip=None):
     """
     Test that an object follows our Unicode policy.  See
     "Unicode guidelines" in the coding guidelines.
@@ -358,39 +372,39 @@ def assert_follows_unicode_guidelines(
     """
     from astropy import conf
 
-    with conf.set_temp('unicode_output', False):
+    with conf.set_temp("unicode_output", False):
         bytes_x = bytes(x)
         unicode_x = str(x)
         repr_x = repr(x)
 
         assert isinstance(bytes_x, bytes)
-        bytes_x.decode('ascii')
+        bytes_x.decode("ascii")
         assert isinstance(unicode_x, str)
-        unicode_x.encode('ascii')
+        unicode_x.encode("ascii")
         assert isinstance(repr_x, str)
         if isinstance(repr_x, bytes):
-            repr_x.decode('ascii')
+            repr_x.decode("ascii")
         else:
-            repr_x.encode('ascii')
+            repr_x.encode("ascii")
 
         if roundtrip is not None:
             assert x.__class__(bytes_x) == x
             assert x.__class__(unicode_x) == x
             assert eval(repr_x, roundtrip) == x
 
-    with conf.set_temp('unicode_output', True):
+    with conf.set_temp("unicode_output", True):
         bytes_x = bytes(x)
         unicode_x = str(x)
         repr_x = repr(x)
 
         assert isinstance(bytes_x, bytes)
-        bytes_x.decode('ascii')
+        bytes_x.decode("ascii")
         assert isinstance(unicode_x, str)
         assert isinstance(repr_x, str)
         if isinstance(repr_x, bytes):
-            repr_x.decode('ascii')
+            repr_x.decode("ascii")
         else:
-            repr_x.encode('ascii')
+            repr_x.encode("ascii")
 
         if roundtrip is not None:
             assert x.__class__(bytes_x) == x
@@ -413,14 +427,14 @@ def generic_recursive_equality_test(a, b, class_history):
     check if the attributes of the attributes are equal.
     """
     if PYTHON_LT_3_11:
-        dict_a = a.__getstate__() if hasattr(a, '__getstate__') else a.__dict__
+        dict_a = a.__getstate__() if hasattr(a, "__getstate__") else a.__dict__
     else:
         # NOTE: The call may need to be adapted if other objects implementing a __getstate__
         # with required argument(s) are passed to this function.
         # For a class with `__slots__` the default state is not a `dict`;
         # with neither `__dict__` nor `__slots__` it is `None`.
         state = a.__getstate__(a) if inspect.isclass(a) else a.__getstate__()
-        dict_a = state if isinstance(state, dict) else getattr(a, '__dict__', dict())
+        dict_a = state if isinstance(state, dict) else getattr(a, "__dict__", dict())
     dict_b = b.__dict__
     for key in dict_a:
         assert key in dict_b, f"Did not pickle {key}"
@@ -431,21 +445,21 @@ def generic_recursive_equality_test(a, b, class_history):
             # object.__eq__, which is equivalent to checking that two
             # instances are the same.  This will generally not be true
             # after pickling.
-            eq = (dict_a[key] == dict_b[key])
-            if '__iter__' in dir(eq):
-                eq = (False not in eq)
+            eq = dict_a[key] == dict_b[key]
+            if "__iter__" in dir(eq):
+                eq = False not in eq
             assert eq, f"Value of {key} changed by pickling"
 
-        if hasattr(dict_a[key], '__dict__'):
+        if hasattr(dict_a[key], "__dict__"):
             if dict_a[key].__class__ in class_history:
                 # attempt to prevent infinite recursion
                 pass
             else:
                 new_class_history = [dict_a[key].__class__]
                 new_class_history.extend(class_history)
-                generic_recursive_equality_test(dict_a[key],
-                                                dict_b[key],
-                                                new_class_history)
+                generic_recursive_equality_test(
+                    dict_a[key], dict_b[key], new_class_history
+                )
 
 
 def check_pickling_recovery(original, protocol):
@@ -456,12 +470,10 @@ def check_pickling_recovery(original, protocol):
     f = pickle.dumps(original, protocol=protocol)
     unpickled = pickle.loads(f)
     class_history = [original.__class__]
-    generic_recursive_equality_test(original, unpickled,
-                                    class_history)
+    generic_recursive_equality_test(original, unpickled, class_history)
 
 
-def assert_quantity_allclose(actual, desired, rtol=1.e-7, atol=None,
-                             **kwargs):
+def assert_quantity_allclose(actual, desired, rtol=1.0e-7, atol=None, **kwargs):
     """
     Raise an assertion if two objects are not equal up to desired tolerance.
 
@@ -471,5 +483,7 @@ def assert_quantity_allclose(actual, desired, rtol=1.e-7, atol=None,
     import numpy as np
 
     from astropy.units.quantity import _unquantify_allclose_arguments
-    np.testing.assert_allclose(*_unquantify_allclose_arguments(
-        actual, desired, rtol, atol), **kwargs)
+
+    np.testing.assert_allclose(
+        *_unquantify_allclose_arguments(actual, desired, rtol, atol), **kwargs
+    )

--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -478,10 +478,10 @@ class TestRunner(TestRunnerBase):
         elif remote_data not in ("none", "astropy", "any"):
             warnings.warn(
                 "The remote_data option should be one of "
-                "none/astropy/any (found {}). For backward-compatibility, "
+                f"none/astropy/any (found {remote_data}). For backward-compatibility, "
                 "assuming 'any', but you should change the option to be "
                 "one of the supported ones to avoid issues in "
-                "future.".format(remote_data),
+                "future.",
                 AstropyDeprecationWarning,
             )
             remote_data = "any"

--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -16,7 +16,7 @@ from astropy.config.paths import set_temp_cache, set_temp_config
 from astropy.utils import find_current_module
 from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyWarning
 
-__all__ = ['TestRunner', 'TestRunnerBase', 'keyword']
+__all__ = ["TestRunner", "TestRunnerBase", "keyword"]
 
 
 class keyword:
@@ -100,7 +100,7 @@ class TestRunnerBase:
         functions = inspect.getmembers(cls, predicate=inspect.isfunction)
 
         # Filter out anything that's not got the name 'keyword'
-        keywords = filter(lambda func: func[1].__name__ == 'keyword', functions)
+        keywords = filter(lambda func: func[1].__name__ == "keyword", functions)
         # Sort all keywords based on the priority flag.
         sorted_keywords = sorted(keywords, key=lambda x: x[1]._priority, reverse=True)
 
@@ -125,9 +125,9 @@ class TestRunnerBase:
             # Construct the default kwargs dict and docstring
             cls.keywords[name] = func._default_value
             if func.__doc__:
-                doc_keywords += ' '*8
+                doc_keywords += " " * 8
                 doc_keywords += func.__doc__.strip()
-                doc_keywords += '\n\n'
+                doc_keywords += "\n\n"
 
         cls.run_tests.__doc__ = cls.RUN_TESTS_DOCSTRING.format(keywords=doc_keywords)
 
@@ -146,7 +146,9 @@ class TestRunnerBase:
 
             # Allow disabling of options in a subclass
             if result is NotImplemented:
-                raise TypeError(f"run_tests() got an unexpected keyword argument {keyword}")
+                raise TypeError(
+                    f"run_tests() got an unexpected keyword argument {keyword}"
+                )
 
             # keyword methods must return a list
             if not isinstance(result, list):
@@ -156,8 +158,7 @@ class TestRunnerBase:
 
         return args
 
-    RUN_TESTS_DOCSTRING = \
-        """
+    RUN_TESTS_DOCSTRING = """
         Run the tests for the package.
 
         This method builds arguments for and then calls ``pytest.main``.
@@ -168,12 +169,18 @@ class TestRunnerBase:
 
         """
 
-    _required_dependencies = ['pytest', 'pytest_remotedata', 'pytest_doctestplus', 'pytest_astropy_header']
+    _required_dependencies = [
+        "pytest",
+        "pytest_remotedata",
+        "pytest_doctestplus",
+        "pytest_astropy_header",
+    ]
     _missing_dependancy_error = (
         "Test dependencies are missing: {module}. You should install the "
         "'pytest-astropy' package (you may need to update the package if you "
         "have a previous version installed, e.g., "
-        "'pip install pytest-astropy --upgrade' or the equivalent with conda).")
+        "'pip install pytest-astropy --upgrade' or the equivalent with conda)."
+    )
 
     @classmethod
     def _has_test_dependencies(cls):  # pragma: no cover
@@ -183,8 +190,7 @@ class TestRunnerBase:
             spec = find_spec(module)
             # Checking loader accounts for packages that were uninstalled
             if spec is None or spec.loader is None:
-                raise RuntimeError(
-                    cls._missing_dependancy_error.format(module=module))
+                raise RuntimeError(cls._missing_dependancy_error.format(module=module))
 
     def run_tests(self, **kwargs):
         # The following option will include eggs inside a .eggs folder in
@@ -192,10 +198,9 @@ class TestRunnerBase:
         # running pytest, test dependencies installed via e.g.
         # tests_requires are available here. This is not an advertised option
         # since it is only for internal use
-        if kwargs.pop('add_local_eggs_to_path', False):
-
+        if kwargs.pop("add_local_eggs_to_path", False):
             # Add each egg to sys.path individually
-            for egg in glob.glob(os.path.join('.eggs', '*.egg')):
+            for egg in glob.glob(os.path.join(".eggs", "*.egg")):
                 sys.path.insert(0, egg)
 
         self._has_test_dependencies()  # pragma: no cover
@@ -211,14 +216,16 @@ class TestRunnerBase:
         passed_kwargs = set(kwargs.keys())
         if not passed_kwargs.issubset(allowed_kwargs):
             wrong_kwargs = list(passed_kwargs.difference(allowed_kwargs))
-            raise TypeError(f"run_tests() got an unexpected keyword argument {wrong_kwargs[0]}")
+            raise TypeError(
+                f"run_tests() got an unexpected keyword argument {wrong_kwargs[0]}"
+            )
 
         args = self._generate_args(**kwargs)
 
-        if kwargs.get('plugins', None) is not None:
-            plugins = kwargs.pop('plugins')
-        elif self.keywords.get('plugins', None) is not None:
-            plugins = self.keywords['plugins']
+        if kwargs.get("plugins", None) is not None:
+            plugins = kwargs.pop("plugins")
+        elif self.keywords.get("plugins", None) is not None:
+            plugins = self.keywords["plugins"]
         else:
             plugins = []
 
@@ -229,8 +236,8 @@ class TestRunnerBase:
         # to do it here - but at the same time the code here doesn't work when
         # running tests in parallel mode because this uses subprocesses which
         # don't know about the temporary config/cache.
-        astropy_config = tempfile.mkdtemp('astropy_config')
-        astropy_cache = tempfile.mkdtemp('astropy_cache')
+        astropy_config = tempfile.mkdtemp("astropy_config")
+        astropy_cache = tempfile.mkdtemp("astropy_cache")
 
         # Have to use nested with statements for cross-Python support
         # Note, using these context managers here is superfluous if the
@@ -254,7 +261,7 @@ class TestRunnerBase:
 
         runner = cls(path)
 
-        @wraps(runner.run_tests, ('__doc__',))
+        @wraps(runner.run_tests, ("__doc__",))
         def test(**kwargs):
             return runner.run_tests(**kwargs)
 
@@ -268,7 +275,7 @@ class TestRunnerBase:
         # used to determine the signature to display in help() which is
         # not useful in this case.  We don't really care in this case if the
         # function was wrapped either
-        if hasattr(test, '__wrapped__'):
+        if hasattr(test, "__wrapped__"):
             del test.__wrapped__
 
         test.__test__ = False
@@ -308,10 +315,9 @@ class TestRunner(TestRunnerBase):
 
         paths = []
         for package in packages:
-            path = os.path.join(
-                base_path, package.replace('.', os.path.sep))
+            path = os.path.join(base_path, package.replace(".", os.path.sep))
             if not os.path.isdir(path):
-                info = {'name': package, 'path': path}
+                info = {"name": package, "path": path}
                 if error is not None:
                     raise ValueError(error.format(**info))
                 if warning is not None:
@@ -329,7 +335,8 @@ class TestRunner(TestRunnerBase):
                 "The coverage option is ignored on run_tests, since it "
                 "can not be made to work in that context.  Use "
                 "'python setup.py test --coverage' instead.",
-                AstropyWarning)
+                AstropyWarning,
+            )
 
         return []
 
@@ -346,12 +353,12 @@ class TestRunner(TestRunnerBase):
         if package is None:
             self.package_path = [self.base_path]
         else:
-            error_message = ('package to test is not found: {name} '
-                             '(at path {path}).')
-            self.package_path = self.packages_path(package, self.base_path,
-                                                   error=error_message)
+            error_message = "package to test is not found: {name} (at path {path})."
+            self.package_path = self.packages_path(
+                package, self.base_path, error=error_message
+            )
 
-        if not kwargs['test_path']:
+        if not kwargs["test_path"]:
             return self.package_path
 
         return []
@@ -366,34 +373,38 @@ class TestRunner(TestRunnerBase):
         """
         all_args = []
         # Ensure that the package kwarg has been run.
-        self.package(kwargs['package'], kwargs)
+        self.package(kwargs["package"], kwargs)
         if test_path:
             base, ext = os.path.splitext(test_path)
 
-            if ext in ('.rst', ''):
-                if kwargs['docs_path'] is None:
+            if ext in (".rst", ""):
+                if kwargs["docs_path"] is None:
                     # This shouldn't happen from "python setup.py test"
                     raise ValueError(
-                        "Can not test .rst files without a docs_path "
-                        "specified.")
+                        "Can not test .rst files without a docs_path specified."
+                    )
 
-                abs_docs_path = os.path.abspath(kwargs['docs_path'])
+                abs_docs_path = os.path.abspath(kwargs["docs_path"])
                 abs_test_path = os.path.abspath(
-                    os.path.join(abs_docs_path, os.pardir, test_path))
+                    os.path.join(abs_docs_path, os.pardir, test_path)
+                )
 
                 common = os.path.commonprefix((abs_docs_path, abs_test_path))
 
                 if os.path.exists(abs_test_path) and common == abs_docs_path:
                     # Turn on the doctest_rst plugin
-                    all_args.append('--doctest-rst')
+                    all_args.append("--doctest-rst")
                     test_path = abs_test_path
 
             # Check that the extensions are in the path and not at the end to
             # support specifying the name of the test, i.e.
             # test_quantity.py::test_unit
-            if not (os.path.isdir(test_path) or ('.py' in test_path or '.rst' in test_path)):
-                raise ValueError("Test path must be a directory or a path to "
-                                 "a .py or .rst file")
+            if not (
+                os.path.isdir(test_path) or (".py" in test_path or ".rst" in test_path)
+            ):
+                raise ValueError(
+                    "Test path must be a directory or a path to a .py or .rst file"
+                )
 
             return all_args + [test_path]
 
@@ -407,7 +418,7 @@ class TestRunner(TestRunnerBase):
             keyword argument.
         """
         if args:
-            return shlex.split(args, posix=not sys.platform.startswith('win'))
+            return shlex.split(args, posix=not sys.platform.startswith("win"))
 
         return []
 
@@ -430,7 +441,7 @@ class TestRunner(TestRunnerBase):
             True is the same as specifying ``-v`` in ``args``.
         """
         if verbose:
-            return ['-v']
+            return ["-v"]
 
         return []
 
@@ -443,14 +454,14 @@ class TestRunner(TestRunnerBase):
             for all tests.
         """
         if pastebin is not None:
-            if pastebin in ['failed', 'all']:
-                return [f'--pastebin={pastebin}']
+            if pastebin in ["failed", "all"]:
+                return [f"--pastebin={pastebin}"]
             else:
                 raise ValueError("pastebin should be 'failed' or 'all'")
 
         return []
 
-    @keyword(default_value='none')
+    @keyword(default_value="none")
     def remote_data(self, remote_data, kwargs):
         """
         remote_data : {'none', 'astropy', 'any'}, optional
@@ -461,19 +472,21 @@ class TestRunner(TestRunnerBase):
         """
 
         if remote_data is True:
-            remote_data = 'any'
+            remote_data = "any"
         elif remote_data is False:
-            remote_data = 'none'
-        elif remote_data not in ('none', 'astropy', 'any'):
-            warnings.warn("The remote_data option should be one of "
-                          "none/astropy/any (found {}). For backward-compatibility, "
-                          "assuming 'any', but you should change the option to be "
-                          "one of the supported ones to avoid issues in "
-                          "future.".format(remote_data),
-                          AstropyDeprecationWarning)
-            remote_data = 'any'
+            remote_data = "none"
+        elif remote_data not in ("none", "astropy", "any"):
+            warnings.warn(
+                "The remote_data option should be one of "
+                "none/astropy/any (found {}). For backward-compatibility, "
+                "assuming 'any', but you should change the option to be "
+                "one of the supported ones to avoid issues in "
+                "future.".format(remote_data),
+                AstropyDeprecationWarning,
+            )
+            remote_data = "any"
 
-        return [f'--remote-data={remote_data}']
+        return [f"--remote-data={remote_data}"]
 
     @keyword()
     def pep8(self, pep8, kwargs):
@@ -486,10 +499,12 @@ class TestRunner(TestRunnerBase):
             try:
                 import pytest_pep8  # noqa: F401
             except ImportError:
-                raise ImportError('PEP8 checking requires pytest-pep8 plugin: '
-                                  'https://pypi.org/project/pytest-pep8')
+                raise ImportError(
+                    "PEP8 checking requires pytest-pep8 plugin: "
+                    "https://pypi.org/project/pytest-pep8"
+                )
             else:
-                return ['--pep8', '-k', 'pep8']
+                return ["--pep8", "-k", "pep8"]
 
         return []
 
@@ -501,7 +516,7 @@ class TestRunner(TestRunnerBase):
             specifying ``--pdb`` in ``args``.
         """
         if pdb:
-            return ['--pdb']
+            return ["--pdb"]
         return []
 
     @keyword()
@@ -513,19 +528,21 @@ class TestRunner(TestRunnerBase):
             ``psutil`` package.
         """
         if open_files:
-            if kwargs['parallel'] != 0:
+            if kwargs["parallel"] != 0:
                 raise SystemError(
                     "open file detection may not be used in conjunction with "
-                    "parallel testing.")
+                    "parallel testing."
+                )
 
             try:
                 import psutil  # noqa: F401
             except ImportError:
                 raise SystemError(
                     "open file detection requested, but psutil package "
-                    "is not installed.")
+                    "is not installed."
+                )
 
-            return ['--open-files']
+            return ["--open-files"]
 
             print("Checking for unclosed files")
 
@@ -544,9 +561,10 @@ class TestRunner(TestRunnerBase):
                 from xdist import plugin  # noqa: F401
             except ImportError:
                 raise SystemError(
-                    "running tests in parallel requires the pytest-xdist package")
+                    "running tests in parallel requires the pytest-xdist package"
+                )
 
-            return ['-n', str(parallel)]
+            return ["-n", str(parallel)]
 
         return []
 
@@ -558,17 +576,20 @@ class TestRunner(TestRunnerBase):
         """
 
         paths = []
-        if docs_path is not None and not kwargs['skip_docs']:
-            if kwargs['package'] is not None:
-                warning_message = ("Can not test .rst docs for {name}, since "
-                                   "docs path ({path}) does not exist.")
-                paths = self.packages_path(kwargs['package'], docs_path,
-                                           warning=warning_message)
-            elif not kwargs['test_path']:
-                paths = [docs_path, ]
+        if docs_path is not None and not kwargs["skip_docs"]:
+            if kwargs["package"] is not None:
+                warning_message = (
+                    "Can not test .rst docs for {name}, since "
+                    "docs path ({path}) does not exist."
+                )
+                paths = self.packages_path(
+                    kwargs["package"], docs_path, warning=warning_message
+                )
+            elif not kwargs["test_path"]:
+                paths = [docs_path]
 
-            if len(paths) and not kwargs['test_path']:
-                paths.append('--doctest-rst')
+            if len(paths) and not kwargs["test_path"]:
+                paths.append("--doctest-rst")
 
         return paths
 
@@ -589,13 +610,12 @@ class TestRunner(TestRunnerBase):
             useful for diagnosing sporadic failures.
         """
         if repeat:
-            return [f'--repeat={repeat}']
+            return [f"--repeat={repeat}"]
 
         return []
 
     # Override run_tests for astropy-specific fixes
     def run_tests(self, **kwargs):
-
         # This prevents cyclical import problems that make it
         # impossible to test packages that define Table types on their
         # own.

--- a/astropy/tests/test_logger.py
+++ b/astropy/tests/test_logger.py
@@ -25,7 +25,6 @@ except NameError:
 
 
 def setup_function(function):
-
     # Reset modules to default
     importlib.reload(warnings)
     importlib.reload(sys)
@@ -50,26 +49,28 @@ teardown_module = setup_function
 def test_warnings_logging_disable_no_enable():
     with pytest.raises(LoggingError) as e:
         log.disable_warnings_logging()
-    assert e.value.args[0] == 'Warnings logging has not been enabled'
+    assert e.value.args[0] == "Warnings logging has not been enabled"
 
 
 def test_warnings_logging_enable_twice():
     log.enable_warnings_logging()
     with pytest.raises(LoggingError) as e:
         log.enable_warnings_logging()
-    assert e.value.args[0] == 'Warnings logging has already been enabled'
+    assert e.value.args[0] == "Warnings logging has already been enabled"
 
 
 def test_warnings_logging_overridden():
     log.enable_warnings_logging()
     warnings.showwarning = lambda: None
-    with pytest.raises(LoggingError, match=r'Cannot disable warnings logging: '
-                       r'warnings\.showwarning was not set by this logger, or has been overridden'):
+    with pytest.raises(
+        LoggingError,
+        match=r"Cannot disable warnings logging: "
+        r"warnings\.showwarning was not set by this logger, or has been overridden",
+    ):
         log.disable_warnings_logging()
 
 
 def test_warnings_logging():
-
     # Without warnings logging
     with pytest.warns(AstropyUserWarning, match="This is a warning") as warn_list:
         with log.log_to_list() as log_list:
@@ -85,13 +86,14 @@ def test_warnings_logging():
         log.disable_warnings_logging()
     assert len(log_list) == 1
     assert len(warn_list) == 0
-    assert log_list[0].levelname == 'WARNING'
-    assert log_list[0].message.startswith('This is a warning')
-    assert log_list[0].origin == 'astropy.tests.test_logger'
+    assert log_list[0].levelname == "WARNING"
+    assert log_list[0].message.startswith("This is a warning")
+    assert log_list[0].origin == "astropy.tests.test_logger"
 
     # With warnings logging (differentiate between Astropy and non-Astropy)
-    with pytest.warns(UserWarning, match="This is another warning, not "
-                      "from Astropy") as warn_list:
+    with pytest.warns(
+        UserWarning, match="This is another warning, not from Astropy"
+    ) as warn_list:
         log.enable_warnings_logging()
         with log.log_to_list() as log_list:
             warnings.warn("This is a warning", AstropyUserWarning)
@@ -99,9 +101,9 @@ def test_warnings_logging():
         log.disable_warnings_logging()
     assert len(log_list) == 1
     assert len(warn_list) == 1
-    assert log_list[0].levelname == 'WARNING'
-    assert log_list[0].message.startswith('This is a warning')
-    assert log_list[0].origin == 'astropy.tests.test_logger'
+    assert log_list[0].levelname == "WARNING"
+    assert log_list[0].message.startswith("This is a warning")
+    assert log_list[0].origin == "astropy.tests.test_logger"
 
     # Without warnings logging
     with pytest.warns(AstropyUserWarning, match="This is a warning") as warn_list:
@@ -123,9 +125,11 @@ def test_warnings_logging_with_custom_class():
         log.disable_warnings_logging()
     assert len(log_list) == 1
     assert len(warn_list) == 0
-    assert log_list[0].levelname == 'WARNING'
-    assert log_list[0].message.startswith('CustomAstropyWarningClass: This is a warning')
-    assert log_list[0].origin == 'astropy.tests.test_logger'
+    assert log_list[0].levelname == "WARNING"
+    assert log_list[0].message.startswith(
+        "CustomAstropyWarningClass: This is a warning"
+    )
+    assert log_list[0].origin == "astropy.tests.test_logger"
 
 
 def test_warning_logging_with_io_votable_warning():
@@ -134,15 +138,16 @@ def test_warning_logging_with_io_votable_warning():
     with warnings.catch_warnings(record=True) as warn_list:
         log.enable_warnings_logging()
         with log.log_to_list() as log_list:
-            vo_warn(W02, ('a', 'b'))
+            vo_warn(W02, ("a", "b"))
         log.disable_warnings_logging()
     assert len(log_list) == 1
     assert len(warn_list) == 0
-    assert log_list[0].levelname == 'WARNING'
-    x = log_list[0].message.startswith("W02: ?:?:?: W02: a attribute 'b' is "
-                                       "invalid.  Must be a standard XML id")
+    assert log_list[0].levelname == "WARNING"
+    x = log_list[0].message.startswith(
+        "W02: ?:?:?: W02: a attribute 'b' is invalid.  Must be a standard XML id"
+    )
     assert x
-    assert log_list[0].origin == 'astropy.tests.test_logger'
+    assert log_list[0].origin == "astropy.tests.test_logger"
 
 
 def test_import_error_in_warning_logging():
@@ -155,44 +160,53 @@ def test_import_error_in_warning_logging():
 
     class FakeModule:
         def __getattr__(self, attr):
-            raise ImportError('_showwarning should ignore any exceptions '
-                              'here')
+            raise ImportError("_showwarning should ignore any exceptions here")
 
     log.enable_warnings_logging()
 
-    sys.modules['<test fake module>'] = FakeModule()
+    sys.modules["<test fake module>"] = FakeModule()
     try:
-        warnings.showwarning(AstropyWarning('Regression test for #2671'),
-                             AstropyWarning, '<this is only a test>', 1)
+        warnings.showwarning(
+            AstropyWarning("Regression test for #2671"),
+            AstropyWarning,
+            "<this is only a test>",
+            1,
+        )
     finally:
-        del sys.modules['<test fake module>']
+        del sys.modules["<test fake module>"]
 
 
 def test_exception_logging_disable_no_enable():
     with pytest.raises(LoggingError) as e:
         log.disable_exception_logging()
-    assert e.value.args[0] == 'Exception logging has not been enabled'
+    assert e.value.args[0] == "Exception logging has not been enabled"
 
 
 def test_exception_logging_enable_twice():
     log.enable_exception_logging()
     with pytest.raises(LoggingError) as e:
         log.enable_exception_logging()
-    assert e.value.args[0] == 'Exception logging has already been enabled'
+    assert e.value.args[0] == "Exception logging has already been enabled"
 
 
-@pytest.mark.skipif(ip is not None, reason="Cannot override exception handler in IPython")
+@pytest.mark.skipif(
+    ip is not None, reason="Cannot override exception handler in IPython"
+)
 def test_exception_logging_overridden():
     log.enable_exception_logging()
     sys.excepthook = lambda etype, evalue, tb: None
-    with pytest.raises(LoggingError, match='Cannot disable exception logging: '
-                       'sys.excepthook was not set by this logger, or has been overridden'):
+    with pytest.raises(
+        LoggingError,
+        match=(
+            "Cannot disable exception logging: "
+            "sys.excepthook was not set by this logger, or has been overridden"
+        ),
+    ):
         log.disable_exception_logging()
 
 
 @pytest.mark.xfail("ip is not None")
 def test_exception_logging():
-
     # Without exception logging
     try:
         with log.log_to_list() as log_list:
@@ -215,9 +229,9 @@ def test_exception_logging():
     else:
         assert False  # exception should have been raised
     assert len(log_list) == 1
-    assert log_list[0].levelname == 'ERROR'
-    assert log_list[0].message.startswith('Exception: This is an Exception')
-    assert log_list[0].origin == 'astropy.tests.test_logger'
+    assert log_list[0].levelname == "ERROR"
+    assert log_list[0].message.startswith("Exception: This is an Exception")
+    assert log_list[0].origin == "astropy.tests.test_logger"
 
     # Without exception logging
     log.disable_exception_logging()
@@ -243,18 +257,20 @@ def test_exception_logging_origin():
     try:
         log.enable_exception_logging()
         with log.log_to_list() as log_list:
-            lst.append('foo')
+            lst.append("foo")
     except TypeError as exc:
         sys.excepthook(*sys.exc_info())
         assert exc.args[0].startswith(
-            "homogeneous list must contain only objects of type ")
+            "homogeneous list must contain only objects of type "
+        )
     else:
         assert False
     assert len(log_list) == 1
-    assert log_list[0].levelname == 'ERROR'
+    assert log_list[0].levelname == "ERROR"
     assert log_list[0].message.startswith(
-        "TypeError: homogeneous list must contain only objects of type ")
-    assert log_list[0].origin == 'astropy.utils.collections'
+        "TypeError: homogeneous list must contain only objects of type "
+    )
+    assert log_list[0].origin == "astropy.utils.collections"
 
 
 @pytest.mark.skip(reason="Infinite recursion on Python 3.5+, probably a real issue")
@@ -276,14 +292,13 @@ def test_exception_logging_argless_exception():
     else:
         assert False  # exception should have been raised
     assert len(log_list) == 1
-    assert log_list[0].levelname == 'ERROR'
-    assert log_list[0].message == 'Exception [astropy.tests.test_logger]'
-    assert log_list[0].origin == 'astropy.tests.test_logger'
+    assert log_list[0].levelname == "ERROR"
+    assert log_list[0].message == "Exception [astropy.tests.test_logger]"
+    assert log_list[0].origin == "astropy.tests.test_logger"
 
 
-@pytest.mark.parametrize(('level'), [None, 'DEBUG', 'INFO', 'WARN', 'ERROR'])
+@pytest.mark.parametrize("level", [None, "DEBUG", "INFO", "WARN", "ERROR"])
 def test_log_to_list(level):
-
     orig_level = log.level
 
     try:
@@ -303,49 +318,47 @@ def test_log_to_list(level):
         level = conf.log_level
 
     # Check list length
-    if level == 'DEBUG':
+    if level == "DEBUG":
         assert len(log_list) == 4
-    elif level == 'INFO':
+    elif level == "INFO":
         assert len(log_list) == 3
-    elif level == 'WARN':
+    elif level == "WARN":
         assert len(log_list) == 2
-    elif level == 'ERROR':
+    elif level == "ERROR":
         assert len(log_list) == 1
 
     # Check list content
 
-    assert log_list[0].levelname == 'ERROR'
-    assert log_list[0].message.startswith('Error message')
-    assert log_list[0].origin == 'astropy.tests.test_logger'
+    assert log_list[0].levelname == "ERROR"
+    assert log_list[0].message.startswith("Error message")
+    assert log_list[0].origin == "astropy.tests.test_logger"
 
     if len(log_list) >= 2:
-        assert log_list[1].levelname == 'WARNING'
-        assert log_list[1].message.startswith('Warning message')
-        assert log_list[1].origin == 'astropy.tests.test_logger'
+        assert log_list[1].levelname == "WARNING"
+        assert log_list[1].message.startswith("Warning message")
+        assert log_list[1].origin == "astropy.tests.test_logger"
 
     if len(log_list) >= 3:
-        assert log_list[2].levelname == 'INFO'
-        assert log_list[2].message.startswith('Information message')
-        assert log_list[2].origin == 'astropy.tests.test_logger'
+        assert log_list[2].levelname == "INFO"
+        assert log_list[2].message.startswith("Information message")
+        assert log_list[2].origin == "astropy.tests.test_logger"
 
     if len(log_list) >= 4:
-        assert log_list[3].levelname == 'DEBUG'
-        assert log_list[3].message.startswith('Debug message')
-        assert log_list[3].origin == 'astropy.tests.test_logger'
+        assert log_list[3].levelname == "DEBUG"
+        assert log_list[3].message.startswith("Debug message")
+        assert log_list[3].origin == "astropy.tests.test_logger"
 
 
 def test_log_to_list_level():
-
-    with log.log_to_list(filter_level='ERROR') as log_list:
+    with log.log_to_list(filter_level="ERROR") as log_list:
         log.error("Error message")
         log.warning("Warning message")
 
-    assert len(log_list) == 1 and log_list[0].levelname == 'ERROR'
+    assert len(log_list) == 1 and log_list[0].levelname == "ERROR"
 
 
 def test_log_to_list_origin1():
-
-    with log.log_to_list(filter_origin='astropy.tests') as log_list:
+    with log.log_to_list(filter_origin="astropy.tests") as log_list:
         log.error("Error message")
         log.warning("Warning message")
 
@@ -353,19 +366,17 @@ def test_log_to_list_origin1():
 
 
 def test_log_to_list_origin2():
-
-    with log.log_to_list(filter_origin='astropy.wcs') as log_list:
+    with log.log_to_list(filter_origin="astropy.wcs") as log_list:
         log.error("Error message")
         log.warning("Warning message")
 
     assert len(log_list) == 0
 
 
-@pytest.mark.parametrize(('level'), [None, 'DEBUG', 'INFO', 'WARN', 'ERROR'])
+@pytest.mark.parametrize("level", [None, "DEBUG", "INFO", "WARN", "ERROR"])
 def test_log_to_file(tmp_path, level):
-
-    local_path = tmp_path / 'test.log'
-    log_file = local_path.open('wb')
+    local_path = tmp_path / "test.log"
+    log_file = local_path.open("wb")
     log_path = str(local_path.resolve())
     orig_level = log.level
 
@@ -383,7 +394,7 @@ def test_log_to_file(tmp_path, level):
     finally:
         log.setLevel(orig_level)
 
-    log_file = local_path.open('rb')
+    log_file = local_path.open("rb")
     log_entries = log_file.readlines()
     log_file.close()
 
@@ -392,67 +403,76 @@ def test_log_to_file(tmp_path, level):
         level = conf.log_level
 
     # Check list length
-    if level == 'DEBUG':
+    if level == "DEBUG":
         assert len(log_entries) == 4
-    elif level == 'INFO':
+    elif level == "INFO":
         assert len(log_entries) == 3
-    elif level == 'WARN':
+    elif level == "WARN":
         assert len(log_entries) == 2
-    elif level == 'ERROR':
+    elif level == "ERROR":
         assert len(log_entries) == 1
 
     # Check list content
 
     assert eval(log_entries[0].strip())[-3:] == (
-        'astropy.tests.test_logger', 'ERROR', 'Error message')
+        "astropy.tests.test_logger",
+        "ERROR",
+        "Error message",
+    )
 
     if len(log_entries) >= 2:
         assert eval(log_entries[1].strip())[-3:] == (
-            'astropy.tests.test_logger', 'WARNING', 'Warning message')
+            "astropy.tests.test_logger",
+            "WARNING",
+            "Warning message",
+        )
 
     if len(log_entries) >= 3:
         assert eval(log_entries[2].strip())[-3:] == (
-            'astropy.tests.test_logger', 'INFO', 'Information message')
+            "astropy.tests.test_logger",
+            "INFO",
+            "Information message",
+        )
 
     if len(log_entries) >= 4:
         assert eval(log_entries[3].strip())[-3:] == (
-            'astropy.tests.test_logger', 'DEBUG', 'Debug message')
+            "astropy.tests.test_logger",
+            "DEBUG",
+            "Debug message",
+        )
 
 
 def test_log_to_file_level(tmp_path):
-
-    local_path = tmp_path / 'test.log'
-    log_file = local_path.open('wb')
+    local_path = tmp_path / "test.log"
+    log_file = local_path.open("wb")
     log_path = str(local_path.resolve())
 
-    with log.log_to_file(log_path, filter_level='ERROR'):
+    with log.log_to_file(log_path, filter_level="ERROR"):
         log.error("Error message")
         log.warning("Warning message")
 
     log_file.close()
 
-    log_file = local_path.open('rb')
+    log_file = local_path.open("rb")
     log_entries = log_file.readlines()
     log_file.close()
 
     assert len(log_entries) == 1
-    assert eval(log_entries[0].strip())[-2:] == (
-        'ERROR', 'Error message')
+    assert eval(log_entries[0].strip())[-2:] == ("ERROR", "Error message")
 
 
 def test_log_to_file_origin1(tmp_path):
-
-    local_path = tmp_path / 'test.log'
-    log_file = local_path.open('wb')
+    local_path = tmp_path / "test.log"
+    log_file = local_path.open("wb")
     log_path = str(local_path.resolve())
 
-    with log.log_to_file(log_path, filter_origin='astropy.tests'):
+    with log.log_to_file(log_path, filter_origin="astropy.tests"):
         log.error("Error message")
         log.warning("Warning message")
 
     log_file.close()
 
-    log_file = local_path.open('rb')
+    log_file = local_path.open("rb")
     log_entries = log_file.readlines()
     log_file.close()
 
@@ -460,28 +480,26 @@ def test_log_to_file_origin1(tmp_path):
 
 
 def test_log_to_file_origin2(tmp_path):
-
-    local_path = tmp_path / 'test.log'
-    log_file = local_path.open('wb')
+    local_path = tmp_path / "test.log"
+    log_file = local_path.open("wb")
     log_path = str(local_path.resolve())
 
-    with log.log_to_file(log_path, filter_origin='astropy.wcs'):
+    with log.log_to_file(log_path, filter_origin="astropy.wcs"):
         log.error("Error message")
         log.warning("Warning message")
 
     log_file.close()
 
-    log_file = local_path.open('rb')
+    log_file = local_path.open("rb")
     log_entries = log_file.readlines()
     log_file.close()
 
     assert len(log_entries) == 0
 
 
-@pytest.mark.parametrize(('encoding'), ['', 'utf-8', 'cp1252'])
+@pytest.mark.parametrize("encoding", ["", "utf-8", "cp1252"])
 def test_log_to_file_encoding(tmp_path, encoding):
-
-    local_path = tmp_path / 'test.log'
+    local_path = tmp_path / "test.log"
     log_path = str(local_path.resolve())
 
     orig_encoding = conf.log_file_encoding

--- a/astropy/tests/test_logger.py
+++ b/astropy/tests/test_logger.py
@@ -47,16 +47,16 @@ teardown_module = setup_function
 
 
 def test_warnings_logging_disable_no_enable():
-    with pytest.raises(LoggingError) as e:
+    with pytest.raises(LoggingError, match=r"Warnings logging has not been enabled"):
         log.disable_warnings_logging()
-    assert e.value.args[0] == "Warnings logging has not been enabled"
 
 
 def test_warnings_logging_enable_twice():
     log.enable_warnings_logging()
-    with pytest.raises(LoggingError) as e:
+    with pytest.raises(
+        LoggingError, match=r"Warnings logging has already been enabled"
+    ):
         log.enable_warnings_logging()
-    assert e.value.args[0] == "Warnings logging has already been enabled"
 
 
 def test_warnings_logging_overridden():
@@ -177,16 +177,16 @@ def test_import_error_in_warning_logging():
 
 
 def test_exception_logging_disable_no_enable():
-    with pytest.raises(LoggingError) as e:
+    with pytest.raises(LoggingError, match=r"Exception logging has not been enabled"):
         log.disable_exception_logging()
-    assert e.value.args[0] == "Exception logging has not been enabled"
 
 
 def test_exception_logging_enable_twice():
     log.enable_exception_logging()
-    with pytest.raises(LoggingError) as e:
+    with pytest.raises(
+        LoggingError, match=r"Exception logging has already been enabled"
+    ):
         log.enable_exception_logging()
-    assert e.value.args[0] == "Exception logging has already been enabled"
 
 
 @pytest.mark.skipif(

--- a/astropy/tests/tests/test_imports.py
+++ b/astropy/tests/tests/test_imports.py
@@ -8,6 +8,7 @@ def test_imports():
     This just imports all modules in astropy, making sure they don't have any
     dependencies that sneak through
     """
+
     def onerror(name):
         # We should raise any legitimate error that occurred, but not
         # any warnings which happen to be caught because of our pytest
@@ -17,15 +18,17 @@ def test_imports():
         except Warning:
             pass
 
-    for imper, nm, ispkg in pkgutil.walk_packages(['astropy'], 'astropy.',
-                                                  onerror=onerror):
+    for imper, nm, ispkg in pkgutil.walk_packages(
+        ["astropy"], "astropy.", onerror=onerror
+    ):
         imper.find_spec(nm)
 
 
 def test_toplevel_namespace():
     import astropy
+
     d = dir(astropy)
-    assert 'os' not in d
-    assert 'log' in d
-    assert 'test' in d
-    assert 'sys' not in d
+    assert "os" not in d
+    assert "log" in d
+    assert "test" in d
+    assert "sys" not in d

--- a/astropy/tests/tests/test_quantity_helpers.py
+++ b/astropy/tests/tests/test_quantity_helpers.py
@@ -5,7 +5,6 @@ from astropy.tests.helper import assert_quantity_allclose
 
 
 def test_assert_quantity_allclose():
-
     assert_quantity_allclose([1, 2], [1, 2])
 
     assert_quantity_allclose([1, 2] * u.m, [100, 200] * u.cm)
@@ -21,19 +20,29 @@ def test_assert_quantity_allclose():
 
     with pytest.raises(u.UnitsError) as exc:
         assert_quantity_allclose([1, 2] * u.m, [100, 200])
-    assert exc.value.args[0] == "Units for 'desired' () and 'actual' (m) are not convertible"
+    assert (
+        exc.value.args[0]
+        == "Units for 'desired' () and 'actual' (m) are not convertible"
+    )
 
     with pytest.raises(u.UnitsError) as exc:
         assert_quantity_allclose([1, 2], [100, 200] * u.cm)
-    assert exc.value.args[0] == "Units for 'desired' (cm) and 'actual' () are not convertible"
+    assert (
+        exc.value.args[0]
+        == "Units for 'desired' (cm) and 'actual' () are not convertible"
+    )
 
     with pytest.raises(u.UnitsError) as exc:
         assert_quantity_allclose([1, 2] * u.m, [100, 200] * u.cm, atol=0.3)
-    assert exc.value.args[0] == "Units for 'atol' () and 'actual' (m) are not convertible"
+    assert (
+        exc.value.args[0] == "Units for 'atol' () and 'actual' (m) are not convertible"
+    )
 
     with pytest.raises(u.UnitsError) as exc:
         assert_quantity_allclose([1, 2], [1, 2], atol=0.3 * u.m)
-    assert exc.value.args[0] == "Units for 'atol' (m) and 'actual' () are not convertible"
+    assert (
+        exc.value.args[0] == "Units for 'atol' (m) and 'actual' () are not convertible"
+    )
 
     with pytest.raises(u.UnitsError) as exc:
         assert_quantity_allclose([1, 2], [1, 2], rtol=0.3 * u.m)

--- a/astropy/tests/tests/test_quantity_helpers.py
+++ b/astropy/tests/tests/test_quantity_helpers.py
@@ -11,39 +11,35 @@ def test_assert_quantity_allclose():
 
     assert_quantity_allclose([1, 2] * u.m, [101, 201] * u.cm, atol=2 * u.cm)
 
-    with pytest.raises(AssertionError) as exc:
+    with pytest.raises(AssertionError, match=r"\nNot equal to tolerance"):
         assert_quantity_allclose([1, 2] * u.m, [90, 200] * u.cm)
-    assert exc.value.args[0].startswith("\nNot equal to tolerance")
 
     with pytest.raises(AssertionError):
         assert_quantity_allclose([1, 2] * u.m, [101, 201] * u.cm, atol=0.5 * u.cm)
 
-    with pytest.raises(u.UnitsError) as exc:
+    with pytest.raises(
+        u.UnitsError,
+        match=r"Units for 'desired' \(\) and 'actual' \(m\) are not convertible",
+    ):
         assert_quantity_allclose([1, 2] * u.m, [100, 200])
-    assert (
-        exc.value.args[0]
-        == "Units for 'desired' () and 'actual' (m) are not convertible"
-    )
 
-    with pytest.raises(u.UnitsError) as exc:
+    with pytest.raises(
+        u.UnitsError,
+        match=r"Units for 'desired' \(cm\) and 'actual' \(\) are not convertible",
+    ):
         assert_quantity_allclose([1, 2], [100, 200] * u.cm)
-    assert (
-        exc.value.args[0]
-        == "Units for 'desired' (cm) and 'actual' () are not convertible"
-    )
 
-    with pytest.raises(u.UnitsError) as exc:
+    with pytest.raises(
+        u.UnitsError,
+        match=r"Units for 'atol' \(\) and 'actual' \(m\) are not convertible",
+    ):
         assert_quantity_allclose([1, 2] * u.m, [100, 200] * u.cm, atol=0.3)
-    assert (
-        exc.value.args[0] == "Units for 'atol' () and 'actual' (m) are not convertible"
-    )
 
-    with pytest.raises(u.UnitsError) as exc:
+    with pytest.raises(
+        u.UnitsError,
+        match=r"Units for 'atol' \(m\) and 'actual' \(\) are not convertible",
+    ):
         assert_quantity_allclose([1, 2], [1, 2], atol=0.3 * u.m)
-    assert (
-        exc.value.args[0] == "Units for 'atol' (m) and 'actual' () are not convertible"
-    )
 
-    with pytest.raises(u.UnitsError) as exc:
+    with pytest.raises(u.UnitsError, match=r"'rtol' should be dimensionless"):
         assert_quantity_allclose([1, 2], [1, 2], rtol=0.3 * u.m)
-    assert exc.value.args[0] == "'rtol' should be dimensionless"

--- a/astropy/tests/tests/test_run_tests.py
+++ b/astropy/tests/tests/test_run_tests.py
@@ -8,14 +8,14 @@ from astropy import test as run_tests
 # run_tests should raise ValueError when asked to run on a module it can't find
 def test_module_not_found():
     with pytest.raises(ValueError):
-        run_tests(package='fake.module')
+        run_tests(package="fake.module")
 
 
 # run_tests should raise ValueError when passed an invalid pastebin= option
 def test_pastebin_keyword():
     with pytest.raises(ValueError):
-        run_tests(pastebin='not_an_option')
+        run_tests(pastebin="not_an_option")
 
 
 def test_unicode_literal_conversion():
-    assert isinstance('ångström', str)
+    assert isinstance("ångström", str)

--- a/astropy/tests/tests/test_runner.py
+++ b/astropy/tests/tests/test_runner.py
@@ -14,26 +14,26 @@ def test_disable_kwarg():
         def remote_data(self, remote_data, kwargs):
             return NotImplemented
 
-    r = no_remote_data('.')
+    r = no_remote_data(".")
     with pytest.raises(TypeError):
-        r.run_tests(remote_data='bob')
+        r.run_tests(remote_data="bob")
 
 
 def test_wrong_kwarg():
-    r = _TestRunner('.')
+    r = _TestRunner(".")
     with pytest.raises(TypeError):
-        r.run_tests(spam='eggs')
+        r.run_tests(spam="eggs")
 
 
 def test_invalid_kwarg():
     class bad_return(_TestRunnerBase):
         @keyword()
         def remote_data(self, remote_data, kwargs):
-            return 'bob'
+            return "bob"
 
-    r = bad_return('.')
+    r = bad_return(".")
     with pytest.raises(TypeError):
-        r.run_tests(remote_data='bob')
+        r.run_tests(remote_data="bob")
 
 
 def test_new_kwarg():
@@ -42,11 +42,11 @@ def test_new_kwarg():
         def spam(self, spam, kwargs):
             return [spam]
 
-    r = Spam('.')
+    r = Spam(".")
 
-    args = r._generate_args(spam='spam')
+    args = r._generate_args(spam="spam")
 
-    assert ['spam'] == args
+    assert ["spam"] == args
 
 
 def test_priority():
@@ -59,11 +59,11 @@ def test_priority():
         def eggs(self, eggs, kwargs):
             return [eggs]
 
-    r = Spam('.')
+    r = Spam(".")
 
-    args = r._generate_args(spam='spam', eggs='eggs')
+    args = r._generate_args(spam="spam", eggs="eggs")
 
-    assert ['eggs', 'spam'] == args
+    assert ["eggs", "spam"] == args
 
 
 def test_docs():
@@ -82,6 +82,6 @@ def test_docs():
             """
             return [eggs]
 
-    r = Spam('.')
+    r = Spam(".")
     assert "eggs" in r.run_tests.__doc__
     assert "Spam Spam Spam" in r.run_tests.__doc__

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,6 @@ force-exclude = '''
     | astropy/io/tests
     | astropy/modeling
     | astropy/table
-    | astropy/tests
     | astropy/units
     | astropy/visualization
   )/


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

Apply `black` to `astropy.tests` according to the process laid out by [APE 20](https://github.com/astropy/astropy-APEs/blob/main/APE20.rst).

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
