### PR TITLE
Modified `astropy.units.Quantity.__array_ufunc__()` to return `NotImplemented` if the inputs are incompatible

### DIFF
--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -633,53 +633,70 @@ class Quantity(np.ndarray):
 
         Returns
         -------
-        result : `~astropy.units.Quantity`
+        result : `~astropy.units.Quantity` or `NotImplemented`
             Results of the ufunc, with the unit set properly.
         """
         # Determine required conversion functions -- to bring the unit of the
         # input to that expected (e.g., radian for np.sin), or to get
         # consistent units between two inputs (e.g., in np.add) --
         # and the unit of the result (or tuple of units for nout > 1).
-        converters, unit = converters_and_unit(function, method, *inputs)
+        try:
+            converters, unit = converters_and_unit(function, method, *inputs)
 
-        out = kwargs.get("out", None)
-        # Avoid loop back by turning any Quantity output into array views.
-        if out is not None:
-            # If pre-allocated output is used, check it is suitable.
-            # This also returns array view, to ensure we don't loop back.
-            if function.nout == 1:
-                out = out[0]
-            out_array = check_output(out, unit, inputs, function=function)
-            # Ensure output argument remains a tuple.
-            kwargs["out"] = (out_array,) if function.nout == 1 else out_array
+            out = kwargs.get("out", None)
+            # Avoid loop back by turning any Quantity output into array views.
+            if out is not None:
+                # If pre-allocated output is used, check it is suitable.
+                # This also returns array view, to ensure we don't loop back.
+                if function.nout == 1:
+                    out = out[0]
+                out_array = check_output(out, unit, inputs, function=function)
+                # Ensure output argument remains a tuple.
+                kwargs["out"] = (out_array,) if function.nout == 1 else out_array
 
-        if method == "reduce" and "initial" in kwargs and unit is not None:
-            # Special-case for initial argument for reductions like
-            # np.add.reduce.  This should be converted to the output unit as
-            # well, which is typically the same as the input unit (but can
-            # in principle be different: unitless for np.equal, radian
-            # for np.arctan2, though those are not necessarily useful!)
-            kwargs["initial"] = self._to_own_unit(
-                kwargs["initial"], check_precision=False, unit=unit
+            if method == "reduce" and "initial" in kwargs and unit is not None:
+                # Special-case for initial argument for reductions like
+                # np.add.reduce.  This should be converted to the output unit as
+                # well, which is typically the same as the input unit (but can
+                # in principle be different: unitless for np.equal, radian
+                # for np.arctan2, though those are not necessarily useful!)
+                kwargs["initial"] = self._to_own_unit(
+                    kwargs["initial"], check_precision=False, unit=unit
+                )
+
+            # Same for inputs, but here also convert if necessary.
+            arrays = []
+            for input_, converter in zip(inputs, converters):
+                input_ = getattr(input_, "value", input_)
+                arrays.append(converter(input_) if converter else input_)
+
+            # Call our superclass's __array_ufunc__
+            result = super().__array_ufunc__(function, method, *arrays, **kwargs)
+            # If unit is None, a plain array is expected (e.g., comparisons), which
+            # means we're done.
+            # We're also done if the result was None (for method 'at') or
+            # NotImplemented, which can happen if other inputs/outputs override
+            # __array_ufunc__; hopefully, they can then deal with us.
+            if unit is None or result is None or result is NotImplemented:
+                return result
+
+            return self._result_as_quantity(result, unit, out)
+
+        except (TypeError, ValueError) as e:
+            out_normalized = kwargs.get("out", tuple())
+            inputs_and_outputs = inputs + out_normalized
+            ignored_ufunc = (
+                None,
+                np.ndarray.__array_ufunc__,
+                type(self).__array_ufunc__,
             )
-
-        # Same for inputs, but here also convert if necessary.
-        arrays = []
-        for input_, converter in zip(inputs, converters):
-            input_ = getattr(input_, "value", input_)
-            arrays.append(converter(input_) if converter else input_)
-
-        # Call our superclass's __array_ufunc__
-        result = super().__array_ufunc__(function, method, *arrays, **kwargs)
-        # If unit is None, a plain array is expected (e.g., comparisons), which
-        # means we're done.
-        # We're also done if the result was None (for method 'at') or
-        # NotImplemented, which can happen if other inputs/outputs override
-        # __array_ufunc__; hopefully, they can then deal with us.
-        if unit is None or result is None or result is NotImplemented:
-            return result
-
-        return self._result_as_quantity(result, unit, out)
+            if not all(
+                getattr(type(io), "__array_ufunc__", None) in ignored_ufunc
+                for io in inputs_and_outputs
+            ):
+                return NotImplemented
+            else:
+                raise e
 
     def _result_as_quantity(self, result, unit, out):
         """Turn result into a quantity with the given unit.

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -505,11 +505,10 @@ class TestQuantityOperations:
 
     def test_non_number_type(self):
         q1 = u.Quantity(11.412, unit=u.meter)
-        with pytest.raises(TypeError) as exc:
+        with pytest.raises(
+            TypeError, match=r"Unsupported operand type\(s\) for ufunc .*"
+        ):
             q1 + {"a": 1}
-        assert exc.value.args[0].startswith(
-            "Unsupported operand type(s) for ufunc add:"
-        )
 
         with pytest.raises(TypeError):
             q1 + u.meter

--- a/astropy/units/tests/test_quantity_ufuncs.py
+++ b/astropy/units/tests/test_quantity_ufuncs.py
@@ -2,6 +2,7 @@
 # returns quantities with the right units, or raises exceptions.
 
 import concurrent.futures
+import dataclasses
 import warnings
 from collections import namedtuple
 
@@ -1292,6 +1293,125 @@ class TestUfuncOuter:
         check13_greater_outer = np.greater.outer(check1, check3)
         assert type(s13_greater_outer) is np.ndarray
         assert np.all(s13_greater_outer == check13_greater_outer)
+
+
+@dataclasses.dataclass
+class DuckQuantity1:
+    data: u.Quantity
+
+
+@dataclasses.dataclass
+class DuckQuantity2(DuckQuantity1):
+    @property
+    def unit(self) -> u.UnitBase:
+        return self.data.unit
+
+
+@dataclasses.dataclass(eq=False)
+class DuckQuantity3(DuckQuantity2):
+    def __array_ufunc__(self, function, method, *inputs, **kwargs):
+
+        inputs = [inp.data if isinstance(inp, type(self)) else inp for inp in inputs]
+
+        if "out" in kwargs:
+            out = kwargs["out"]
+        else:
+            out = None
+
+        kwargs_copy = {}
+        for k in kwargs:
+            kwarg = kwargs[k]
+            if isinstance(kwarg, type(self)):
+                kwargs_copy[k] = kwarg.data
+            elif isinstance(kwarg, (list, tuple)):
+                kwargs_copy[k] = type(kwarg)(
+                    item.data if isinstance(item, type(self)) else item
+                    for item in kwarg
+                )
+            else:
+                kwargs_copy[k] = kwarg
+        kwargs = kwargs_copy
+
+        for inp in inputs:
+            if isinstance(inp, np.ndarray):
+                result = inp.__array_ufunc__(function, method, *inputs, **kwargs)
+                if result is not NotImplemented:
+                    if out is None:
+                        return type(self)(result)
+                    else:
+                        if function.nout == 1:
+                            return out[0]
+                        else:
+                            return out
+
+        return NotImplemented
+
+
+class TestUfuncReturnsNotImplemented:
+    @pytest.mark.parametrize("ufunc", (np.negative, np.abs))
+    class TestUnaryUfuncs:
+        @pytest.mark.parametrize(
+            "duck_quantity",
+            [DuckQuantity1(1 * u.mm), DuckQuantity2(1 * u.mm)],
+        )
+        def test_basic(self, ufunc, duck_quantity):
+            with pytest.raises(TypeError, match="bad operand type for .*"):
+                ufunc(duck_quantity)
+
+        @pytest.mark.parametrize(
+            "duck_quantity", [DuckQuantity3(1 * u.mm), DuckQuantity3([1, 2] * u.mm)]
+        )
+        @pytest.mark.parametrize("out", [None, "empty"])
+        def test_full(self, ufunc, duck_quantity, out):
+            out_expected = out
+            if out == "empty":
+                out = type(duck_quantity)(np.empty_like(ufunc(duck_quantity.data)))
+                out_expected = np.empty_like(ufunc(duck_quantity.data))
+
+            result = ufunc(duck_quantity, out=out)
+            if out is not None:
+                assert result is out
+
+            result_expected = ufunc(duck_quantity.data, out=out_expected)
+            assert np.all(result.data == result_expected)
+
+    @pytest.mark.parametrize("ufunc", (np.add, np.multiply, np.less))
+    @pytest.mark.parametrize("quantity", (1 * u.m, [1, 2] * u.m))
+    class TestBinaryUfuncs:
+        @pytest.mark.parametrize(
+            "duck_quantity",
+            [DuckQuantity1(1 * u.mm), DuckQuantity2(1 * u.mm)],
+        )
+        def test_basic(self, ufunc, quantity, duck_quantity):
+            with pytest.raises(
+                (TypeError, ValueError),
+                match=(
+                    r"(Unsupported operand type\(s\) for ufunc .*)|"
+                    r"(unsupported operand type\(s\) for .*)|"
+                    r"(Value not scalar compatible or convertible to an int, float, or complex array)"
+                ),
+            ):
+                ufunc(quantity, duck_quantity)
+
+        @pytest.mark.parametrize(
+            "duck_quantity",
+            [DuckQuantity3(1 * u.mm), DuckQuantity3([1, 2] * u.mm)],
+        )
+        @pytest.mark.parametrize("out", [None, "empty"])
+        def test_full(self, ufunc, quantity, duck_quantity, out):
+            out_expected = out
+            if out == "empty":
+                out = type(duck_quantity)(
+                    np.empty_like(ufunc(quantity, duck_quantity.data))
+                )
+                out_expected = np.empty_like(ufunc(quantity, duck_quantity.data))
+
+            result = ufunc(quantity, duck_quantity, out=out)
+            if out is not None:
+                assert result is out
+
+            result_expected = ufunc(quantity, duck_quantity.data, out=out_expected)
+            assert np.all(result.data == result_expected)
 
 
 if HAS_SCIPY:

--- a/docs/changes/units/13977.bugfix.rst
+++ b/docs/changes/units/13977.bugfix.rst
@@ -1,0 +1,1 @@
+Modified ``astropy.units.Quantity.__array_ufunc__()`` to return ``NotImplemented`` instead of raising a ``ValueError`` if the inputs are incompatible.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address the current behavior of `astropy.units.Quantity.__array_ufunc__()`, which raises a `ValueError` instead of returning `NotImplemented` if the inputs are incompatible.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #13976

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
