### PR TITLE
Only call sys.getrefcount when it is available

### DIFF
--- a/astropy/io/fits/file.py
+++ b/astropy/io/fits/file.py
@@ -476,8 +476,12 @@ class _File:
 
         This will close the mmap if there are no arrays referencing it.
         """
-
-        if self._mmap is not None and sys.getrefcount(self._mmap) == 2 + refcount_delta:
+        # sys.getrefcount is CPython specific and not on PyPy.
+        if (
+            self._mmap is not None
+            and hasattr(sys, "getrefcount")
+            and sys.getrefcount(self._mmap) == 2 + refcount_delta
+        ):
             self._mmap.close()
             self._mmap = None
 

--- a/astropy/io/fits/hdu/base.py
+++ b/astropy/io/fits/hdu/base.py
@@ -184,8 +184,12 @@ class _BaseHDU:
             # Don't do anything if the class has already explicitly
             # set the deleter for its data property
             def data(self):
-                # The deleter
-                if self._file is not None and self._data_loaded:
+                # The deleter. sys.getrefcount is CPython specific and not on PyPy.
+                if (
+                    self._file is not None
+                    and self._data_loaded
+                    and hasattr(sys, "getrefcount")
+                ):
                     data_refcount = sys.getrefcount(self.data)
                     # Manually delete *now* so that FITS_rec.__del__
                     # cleanup can happen if applicable

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -2556,7 +2556,12 @@ class Table:
         refcount = None
         old_col = None
 
-        if "refcount" in warns and name in self.colnames:
+        # sys.getrefcount is CPython specific and not on PyPy.
+        if (
+            "refcount" in warns
+            and name in self.colnames
+            and hasattr(sys, "getrefcount")
+        ):
             refcount = sys.getrefcount(self[name])
 
         if name in self.colnames:
@@ -2586,7 +2591,8 @@ class Table:
             except AttributeError:
                 pass
 
-        if "refcount" in warns:
+        # sys.getrefcount is CPython specific and not on PyPy.
+        if "refcount" in warns and hasattr(sys, "getrefcount"):
             # Did reference count change?
             new_refcount = sys.getrefcount(self[name])
             if refcount != new_refcount:


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

Only call sys.getrefcount when it is available. It exists for CPython but not for PyPy.

xref https://github.com/conda-forge/pysynphot-feedstock/pull/7

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #13978

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
