### PR TITLE
Add links to make physical types more discoverable

### DIFF
--- a/astropy/units/physical.py
+++ b/astropy/units/physical.py
@@ -210,6 +210,8 @@ class PhysicalType:
     `~astropy.units.core.UnitBase.physical_type` attribute of units.
     This class is not intended to be instantiated directly in user code.
 
+    For a list of physical types, see `astropy.units.physical`.
+
     Parameters
     ----------
     unit : `~astropy.units.Unit`
@@ -450,6 +452,10 @@ def def_physical_type(unit, name):
     ValueError
         If a physical type name is already in use for another unit, or
         if attempting to name a unit as ``"unknown"``.
+
+    Notes
+    -----
+    For a list of physical types, see `astropy.units.physical`.
     """
     physical_type_id = unit._get_physical_type_id()
     physical_type_names = _standardize_physical_type_names(name)
@@ -505,6 +511,10 @@ def get_physical_type(obj):
     -------
     `~astropy.units.PhysicalType`
         A representation of the physical type(s) of the unit.
+
+    Notes
+    -----
+    For a list of physical types, see `astropy.units.physical`.
 
     Examples
     --------

--- a/docs/units/physical_types.rst
+++ b/docs/units/physical_types.rst
@@ -8,6 +8,8 @@ compatible units. For example, the physical type *mass* corresponds to
 physical quantities with units that can be converted to kilograms.
 Physical types are represented as instances of the |PhysicalType| class.
 
+For a list of physical types, see `astropy.units.physical`.
+
 Accessing Physical Types
 ========================
 


### PR DESCRIPTION
### Description

The purpose of this PR is to add a few links from functions/attributes related to physical types to documentation for the `astropy.units.physical` module, which lists out the contents of that module including physical types. Since my usual strategy for finding the listing of physical types has been to do a search for "absement", this should make the listing of physical types more discoverable.

I'll probably add a few more links (i.e. in `UnitBase.physical_type` and the notebook section on physical types), and I also need to make sure that I'm linking to the correct location in the docs. 

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.