### PR TITLE
Add pre-commit hook for codespell

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,6 +64,14 @@ repos:
     hooks:
       - id: yesqa
 
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.2.2
+    hooks:
+      - id: codespell
+        args: ["--write-changes"]
+        additional_dependencies:
+          - tomli
+
   - repo: https://github.com/pycqa/isort
     rev: v5.11.3
     hooks:

--- a/docs/changes/13985.other.rst
+++ b/docs/changes/13985.other.rst
@@ -1,0 +1,1 @@
+Added a pre-commit configuration for codespell.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -338,7 +338,7 @@ try:
             "astropy": None,
             "matplotlib": "https://matplotlib.org/stable/",
             # The stable numpy search js isn't loadable at the moment (2022-12-07)
-            # It seems to be valid js but it's not valid json so sphinx wont load it.
+            # It seems to be valid js but it's not valid json so sphinx won't load it.
             "numpy": "https://numpy.org/devdocs/",
         },
         "abort_on_example_error": True,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -267,9 +267,9 @@ force-exclude = '''
         report_on_fail = true
 
 [tool.codespell]
-skip = "*.dat,*.fits,*.hdr,*.xml,*egg*,*extern,.git,.tox,_build,fitshdr.htest_groups.py,venv,_*.c,wcs.h,lin.h,tab.h,spc.h,cython*"
+skip = "*.dat,*.fits,*.hdr,*.xml,*egg*,*extern/*,.git,.tox,_build,fitshdr.htest_groups.py,venv,_*.c,wcs.h,lin.h,tab.h,spc.h,cython*"
 # The following list of words for codespell to ignore may contain some
-# mispellings that should be revisited and fixed in the future.
+# misspellings that should be revisited and fixed in the future.
 ignore-words-list = """
     ans,
     clen,


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description

This PR adds a pre-commit hook for [codespell](https://github.com/codespell-project/codespell).  Instead of searching for words that are not found in a dictionary, it looks for words that are in a dictionary of common misspellings. Hence, it gives very few false positives.

It will provide error messages like: 

```
astropy/wcs/utils.py:947: transfomations ==> transformations
```

The codespell configuration in `pyproject.toml` is the place to list false positives and files/directories not to check.  

An additional possibility would be to create a `tox` environment for codespell (discussed in #13814), which is the approach that we took for PlasmaPy.  

Closes #13814.  This will need to be merged after #13982.

<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->


<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
