### PR TITLE
Document coords attribute of WCSAxes

### DIFF
--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -100,6 +100,11 @@ class WCSAxes(Axes):
         The class for the frame, which should be a subclass of
         :class:`~astropy.visualization.wcsaxes.frame.BaseFrame`. The default is to use a
         :class:`~astropy.visualization.wcsaxes.frame.RectangularFrame`
+
+    Attributes
+    ----------
+    coords : :class:`~astropy.visualization.wcsaxes.CoordinatesMap`
+        Container for coordinate information.
     """
 
     def __init__(


### PR DESCRIPTION
Does what it says in the title - since the `.coords` attribute is used in at least one example (https://docs.astropy.org/en/stable/visualization/wcsaxes/custom_frames.html#frame-properties), it seems worth documenting here.