### PR TITLE
Deprecate getting/setting pix on WCSAxes Spine

### DIFF
--- a/astropy/visualization/wcsaxes/frame.py
+++ b/astropy/visualization/wcsaxes/frame.py
@@ -148,10 +148,8 @@ class SpineXAligned(Spine):
     def data(self, value):
         self._data = value
         if value is None:
-            self._data = None
             self._world = None
         else:
-            self._data = value
             with np.errstate(invalid="ignore"):
                 self._world = self.transform.transform(self._data[:, 0:1])
             self._update_normal()

--- a/astropy/visualization/wcsaxes/frame.py
+++ b/astropy/visualization/wcsaxes/frame.py
@@ -397,6 +397,12 @@ class EllipticalFrame(BaseFrame):
         over which spines are drawn.
         """
         axis = "c"
-        x, y = self[axis].pixel[:, 0], self[axis].pixel[:, 1]
-        line = Line2D(x, y, linewidth=self._linewidth, color=self._color, zorder=1000)
+        pixel = self[axis]._get_pixel()
+        line = Line2D(
+            pixel[:, 0],
+            pixel[:, 1],
+            linewidth=self._linewidth,
+            color=self._color,
+            zorder=1000,
+        )
         line.draw(renderer)

--- a/astropy/visualization/wcsaxes/frame.py
+++ b/astropy/visualization/wcsaxes/frame.py
@@ -2,12 +2,15 @@
 
 
 import abc
+import warnings
 from collections import OrderedDict
 
 import numpy as np
 from matplotlib import rcParams
 from matplotlib.lines import Line2D, Path
 from matplotlib.patches import PathPatch
+
+from astropy.utils.exceptions import AstropyDeprecationWarning
 
 __all__ = [
     "RectangularFrame1D",
@@ -43,7 +46,6 @@ class Spine:
         self.data_func = data_func
 
         self._data = None
-        self._pixel = None
         self._world = None
 
     @property
@@ -56,28 +58,36 @@ class Spine:
     def data(self, value):
         self._data = value
         if value is None:
-            self._pixel = None
+            self._data = None
             self._world = None
         else:
-            self._pixel = self.parent_axes.transData.transform(self._data)
             with np.errstate(invalid="ignore"):
                 self._world = self.transform.transform(self._data)
             self._update_normal()
 
+    def _get_pixel(self):
+        return self.parent_axes.transData.transform(self._data)
+
     @property
     def pixel(self):
-        return self._pixel
+        warnings.warn(
+            "Pixel coordinates cannot be accurately calculated unless "
+            "Matplotlib is currently drawing a figure, so the .pixel "
+            "attribute is deprecated and will be removed in a future "
+            "astropy release.",
+            AstropyDeprecationWarning,
+        )
+        return self._get_pixel()
 
     @pixel.setter
     def pixel(self, value):
-        self._pixel = value
-        if value is None:
-            self._data = None
-            self._world = None
-        else:
-            self._data = self.parent_axes.transData.inverted().transform(self._data)
-            self._world = self.transform.transform(self._data)
-            self._update_normal()
+        warnings.warn(
+            "Manually setting pixel values of a Spine can lead to incorrect results "
+            "as these can only be accurately calculated when Matplotlib is drawing "
+            "a figure. As such the .pixel setter now does nothing, is deprecated, "
+            "and will be removed in a future astropy release.",
+            AstropyDeprecationWarning,
+        )
 
     @property
     def world(self):
@@ -95,16 +105,18 @@ class Spine:
             self._update_normal()
 
     def _update_normal(self):
+        pixel = self._get_pixel()
         # Find angle normal to border and inwards, in display coordinate
-        dx = self.pixel[1:, 0] - self.pixel[:-1, 0]
-        dy = self.pixel[1:, 1] - self.pixel[:-1, 1]
+        dx = pixel[1:, 0] - pixel[:-1, 0]
+        dy = pixel[1:, 1] - pixel[:-1, 1]
         self.normal_angle = np.degrees(np.arctan2(dx, -dy))
 
     def _halfway_x_y_angle(self):
         """
         Return the x, y, normal_angle values halfway along the spine.
         """
-        x_disp, y_disp = self.pixel[:, 0], self.pixel[:, 1]
+        pixel = self._get_pixel()
+        x_disp, y_disp = pixel[:, 0], pixel[:, 1]
         # Get distance along the path
         d = np.hstack(
             [0.0, np.cumsum(np.sqrt(np.diff(x_disp) ** 2 + np.diff(y_disp) ** 2))]
@@ -136,27 +148,12 @@ class SpineXAligned(Spine):
     def data(self, value):
         self._data = value
         if value is None:
-            self._pixel = None
-            self._world = None
-        else:
-            self._pixel = self.parent_axes.transData.transform(self._data)
-            with np.errstate(invalid="ignore"):
-                self._world = self.transform.transform(self._data[:, 0:1])
-            self._update_normal()
-
-    @property
-    def pixel(self):
-        return self._pixel
-
-    @pixel.setter
-    def pixel(self, value):
-        self._pixel = value
-        if value is None:
             self._data = None
             self._world = None
         else:
-            self._data = self.parent_axes.transData.inverted().transform(self._data)
-            self._world = self.transform.transform(self._data[:, 0:1])
+            self._data = value
+            with np.errstate(invalid="ignore"):
+                self._world = self.transform.transform(self._data[:, 0:1])
             self._update_normal()
 
 
@@ -219,8 +216,9 @@ class BaseFrame(OrderedDict, metaclass=abc.ABCMeta):
         )
 
     def draw(self, renderer):
-        for axis in self.spine_names:
-            x, y = self[axis].pixel[:, 0], self[axis].pixel[:, 1]
+        for axis in self:
+            pixel = self[axis]._get_pixel()
+            x, y = pixel[:, 0], pixel[:, 1]
             line = Line2D(
                 x, y, linewidth=self._linewidth, color=self._color, zorder=1000
             )

--- a/astropy/visualization/wcsaxes/frame.py
+++ b/astropy/visualization/wcsaxes/frame.py
@@ -58,7 +58,6 @@ class Spine:
     def data(self, value):
         self._data = value
         if value is None:
-            self._data = None
             self._world = None
         else:
             with np.errstate(invalid="ignore"):

--- a/docs/changes/visualization/13989.api.rst
+++ b/docs/changes/visualization/13989.api.rst
@@ -1,0 +1,5 @@
+The pixel attribute of ``astropy.visualization.wcsaxes.frame.Spine`` is deprecated
+and will be removed in a future astropy version.
+Because it is (in general) not possible to correctly calculate pixel
+coordinates before Matplotlib is drawing a figure, instead set the world or data
+coordinates of the ``Spine`` using the appropriate setters.

--- a/docs/changes/visualization/13989.bugfix.rst
+++ b/docs/changes/visualization/13989.bugfix.rst
@@ -1,0 +1,3 @@
+The location of a ``astropy.visualization.wcsaxes.frame.Spine`` in a plot is now
+correctly calculated when the DPI of a figure changes between a WCSAxes being
+created and the figure being drawn.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
(this is a revival of https://github.com/astropy/astropy/pull/12621)

When using Matplotlib, it is generally only safe to calculate pixel coordinates of artists at draw time, as that is when the figure DPI is set in stone. Calculating the pixel coordinates before drawing can lead to issues like https://github.com/astropy/astropy/issues/12568.

This PR fixes this issue for `WCSAxes` `Spine`s by ensuring that pixel calculations are done at draw time. It also deprecates getting and setting pixel coordinates.

<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to partly address https://github.com/astropy/astropy/issues/12568. Before that issue can be fully resolved I think there is also a fix required on the Matplotlib side.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

With the sample code given in https://github.com/astropy/astropy/issues/12568, this improves the resulting plot from this (on current main):
![grid-False](https://user-images.githubusercontent.com/6197628/200173923-1912b10f-28ec-4d5e-bbbf-93ce6fad4db4.png)

to this:
![grid-False-new](https://user-images.githubusercontent.com/6197628/200173927-8ac5215d-129d-495e-b0fa-cfcd73bd19b1.png)



### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
