### PR TITLE
Misc tests to increase WCSAxes coverage

### DIFF
--- a/astropy/visualization/wcsaxes/tests/test_misc.py
+++ b/astropy/visualization/wcsaxes/tests/test_misc.py
@@ -601,3 +601,41 @@ def test_get_coord_range_nan_regression():
             [(-131.3193386797236, 180.0), (-44.02289164685554, 44.80732766607591)]
         ),
     )
+
+
+def test_imshow_error():
+    fig = plt.figure()
+    ax = fig.add_subplot(1, 1, 1, projection=WCS())
+    with pytest.raises(ValueError, match="Cannot use images with origin='upper"):
+        ax.imshow(np.ones(100).reshape(10, 10), origin="upper")
+
+
+def test_label_setting():
+    fig = plt.figure()
+    ax = fig.add_subplot(1, 1, 1, projection=WCS())
+    # Check both xlabel and label kwargs work
+    ax.set_xlabel(xlabel="label")
+    ax.set_xlabel(label="label")
+    # Check no label errors:
+    with pytest.raises(
+        TypeError, match=r"set_xlabel\(\) missing 1 required positional argument"
+    ):
+        ax.set_xlabel()
+
+    # Check both xlabel and label kwargs work
+    ax.set_ylabel(ylabel="label")
+    ax.set_ylabel(label="label")
+    # Check no label errors:
+    with pytest.raises(
+        TypeError, match=r"set_ylabel\(\) missing 1 required positional argument"
+    ):
+        ax.set_ylabel()
+
+
+def test_invisible_bbox():
+    fig = plt.figure()
+    ax = fig.add_subplot(1, 1, 1, projection=WCS())
+
+    assert ax.get_tightbbox(fig.canvas.get_renderer()) is not None
+    ax.set_visible(False)
+    assert ax.get_tightbbox(fig.canvas.get_renderer()) is None


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
This PR adds some miscellaneous tests that bump WCSAxes code coverage.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
