### PR TITLE
Update expected list of observatory sites in coordinates docs

### DIFF
--- a/docs/coordinates/index.rst
+++ b/docs/coordinates/index.rst
@@ -338,7 +338,7 @@ To see the list of site names available, use
 :func:`~astropy.coordinates.EarthLocation.get_site_names`::
 
     >>> EarthLocation.get_site_names()  # doctest: +REMOTE_DATA
-    ['ALMA', 'ATST', 'Anglo-Australian Observatory', ...]
+    ['ALMA', 'AO', 'ARCA', 'ASKAP', 'ATST', 'Anderson Mesa', ...]
 
 For arbitrary Earth addresses (e.g., not observatory sites), use the
 :func:`~astropy.coordinates.EarthLocation.of_address` classmethod to retrieve


### PR DESCRIPTION
### Description
This is fixing a doctest in `coordinates` that broke with additions to the observatory site list from astropy/astropy-data#49, astropy/astropy-data#121 and astropy/astropy-data#124.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
