### PR TITLE
Add ``refresh_cache`` option to ``EarthLocation`` methods

### DIFF
--- a/astropy/coordinates/errors.py
+++ b/astropy/coordinates/errors.py
@@ -193,6 +193,8 @@ class UnknownSiteException(KeyError):
     def __init__(self, site, attribute, close_names=None):
         message = (
             f"Site '{site}' not in database. Use {attribute} to see available sites."
+            f" If '{site}' exists in the online astropy-data repository, use the"
+            " 'refresh_cache=True' option to download the latest version."
         )
         if close_names:
             message += " Did you mean one of: '{}'?'".format("', '".join(close_names))

--- a/docs/changes/coordinates/13993.feature.rst
+++ b/docs/changes/coordinates/13993.feature.rst
@@ -1,0 +1,3 @@
+Add optional parameter ``refresh_cache`` to ``EarthLocation.of_site()`` and
+``EarthLocation.get_site_names()`` to force the download of the latest site
+registry.

--- a/docs/coordinates/index.rst
+++ b/docs/coordinates/index.rst
@@ -325,7 +325,7 @@ use this option if you do not need sub-arcsecond accuracy for your coordinates::
 
 For sites (primarily observatories) on the Earth, `astropy.coordinates` provides
 a quick way to get an |EarthLocation| - the
-:func:`~astropy.coordinates.EarthLocation.of_site` classmethod:
+:meth:`~astropy.coordinates.EarthLocation.of_site` classmethod:
 
 .. doctest-remote-data::
 
@@ -335,13 +335,26 @@ a quick way to get an |EarthLocation| - the
     <EarthLocation (-1463969.30185172, -5166673.34223433, 3434985.71204565) m>
 
 To see the list of site names available, use
-:func:`~astropy.coordinates.EarthLocation.get_site_names`::
+:meth:`~astropy.coordinates.EarthLocation.get_site_names`::
 
     >>> EarthLocation.get_site_names()  # doctest: +REMOTE_DATA
     ['ALMA', 'AO', 'ARCA', ...]
 
+Both :meth:`~astropy.coordinates.EarthLocation.of_site` and
+:meth:`~astropy.coordinates.EarthLocation.get_site_names`,
+`astropy.coordinates` attempt to access the site registry from the
+`astropy-data repository <https://github.com/astropy/astropy-data>`_ and will
+save the registry in the user's local cache (see :ref:`utils-data`).  If
+there is no local cache and Internet connection is not available, a built-in
+list (consisting of only the Greenwich Royal Observatory as an example case) is
+loaded. The cached version of the site registry is not updated automatically,
+but the latest version may be downloaded using the ``refresh_cache=True``
+option of these methods. If you would like a site to be added to the registry,
+issue a pull request to the `astropy-data repository
+<https://github.com/astropy/astropy-data>`_.
+
 For arbitrary Earth addresses (e.g., not observatory sites), use the
-:func:`~astropy.coordinates.EarthLocation.of_address` classmethod to retrieve
+:meth:`~astropy.coordinates.EarthLocation.of_address` classmethod to retrieve
 the latitude and longitude. This works with fully specified addresses, location
 names, city names, etc:
 
@@ -367,9 +380,9 @@ longitude and latitude, but only with the Google queries::
     geocoding API...
 
 .. note::
-    :func:`~astropy.coordinates.SkyCoord.from_name`,
-    :func:`~astropy.coordinates.EarthLocation.of_site`, and
-    :func:`~astropy.coordinates.EarthLocation.of_address` are designed for
+    :meth:`~astropy.coordinates.SkyCoord.from_name`,
+    :meth:`~astropy.coordinates.EarthLocation.of_site`, and
+    :meth:`~astropy.coordinates.EarthLocation.of_address` are designed for
     convenience, not accuracy. If you need accurate coordinates for an
     object you should find the appropriate reference and input the coordinates
     manually, or use more specialized functionality like that in the `astroquery

--- a/docs/whatsnew/5.3.rst
+++ b/docs/whatsnew/5.3.rst
@@ -18,6 +18,7 @@ In particular, this release includes:
 .. * :ref:`whatsnew-5.3-compressed-fits-nocompress`
 .. * :ref:`whatsnew-5.3-unit-formats-fraction`
 .. * :ref:`whatsnew-5.3-nddata-collapse-arbitrary-axes`
+.. * :ref:`whatsnew-5.3-coordinates-refresh-site-registry`
 
 In addition to these major changes, Astropy v5.3 includes a large number of
 smaller improvements and bug fixes, which are described in the :ref:`changelog`.
@@ -180,6 +181,22 @@ we can take the sum of ND masked quantities along the ``1`` axis like so::
     (NDDataArray([6., 9.], unit='m'),
      array([ True, False]),
      StdDevUncertainty([1.41421356, 1.73205081]))
+
+.. _whatsnew-5.3-coordinates-refresh-site-registry:
+
+Refresh cached observatory site registry for |EarthLocation| methods
+====================================================================
+
+The |EarthLocation| convenience methods
+:meth:`~astropy.coordinates.EarthLocation.of_site` and
+:meth:`~astropy.coordinates.EarthLocation.get_site_names` use the observatory
+site registry from the
+`astropy-data repository <https://github.com/astropy/astropy-data>`_ to
+return site data by name.  Usually, the site registry is cached on the
+user's computer for quick access.  The online version of the registry,
+however, is updated from time to time to include new locations.  The user
+may refresh their locally cached site registry by passing the new
+``refresh_cache=True`` option to these two functions.
 
 Full change log
 ===============


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

Add the new option ``refresh_cache`` option to ``EarthLocation.of_site()`` and ``EarthLocation.get_site_names()`` which is then passed along to the ``force_download`` option of ``EarthLocation._get_site_registry()``.  This last method already had the ``force_download`` option; this PR simply adds a user-facing option to the public methods.


<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
