### PR TITLE
Truncate exception message from `Latitude._validate_angles` to readable size

### DIFF
--- a/astropy/coordinates/angles/core.py
+++ b/astropy/coordinates/angles/core.py
@@ -616,15 +616,16 @@ class Latitude(Angle):
             angles_view = angles_view[np.newaxis]
 
         if np.any(np.abs(angles_view) > limit):
-            if np.size(angles) < 5:
-                info = f"got {angles.to(u.degree)}"
-            else:
-                invalid_angles = np.logical_or(angles.value < -limit, angles.value > limit)
-                idx = np.where(invalid_angles)[0]
-                if len(idx) < 5:
-                    info = f"found {angles[idx].to(u.degree)}"
+            with np.printoptions(precision=2):
+                if np.size(angles) < 9:
+                    info = f"got {angles.to(u.degree)}"
                 else:
-                    info = f"found {angles[idx[0]].to(u.degree)} [{idx[0]}], ..."
+                    invalid_angles = np.logical_or(angles.value < -limit, angles.value > limit)
+                    idx = np.where(invalid_angles)[0]
+                    if len(idx) < 9:
+                        info = f"found {angles[idx].to(u.degree)}"
+                    else:
+                        info = f"found {angles[idx[0]].to(u.degree):.2f} [{idx[0]}], ..."
             raise ValueError("Latitude angle(s) must be within -90 deg <= angle <= "
                              f"90 deg, {info}")
 

--- a/astropy/coordinates/angles/core.py
+++ b/astropy/coordinates/angles/core.py
@@ -617,12 +617,16 @@ class Latitude(Angle):
 
         if np.any(np.abs(angles_view) > limit):
             if np.size(angles) < 5:
-                raise ValueError("Latitude angle(s) must be within -90 deg <= angle "
-                                     f"<= 90 deg, got {angles.to(u.degree)}")
+                raise ValueError(
+                    "Latitude angle(s) must be within -90 deg <= angle "
+                    f"<= 90 deg, got {angles.to(u.degree)}"
+                )
             else:
-                raise ValueError("Latitude angle(s) must be within -90 deg <= angle "
-                                 f"<= 90 deg, got {angles.min().to(u.degree)} <= "
-                                 f"angle <= {angles.max().to(u.degree)}")
+                raise ValueError(
+                    "Latitude angle(s) must be within -90 deg <= angle "
+                    f"<= 90 deg, got {angles.min().to(u.degree)} <= "
+                    f"angle <= {angles.max().to(u.degree)}"
+                )
 
     def __setitem__(self, item, value):
         # Forbid assigning a Long to a Lat.

--- a/astropy/coordinates/angles/core.py
+++ b/astropy/coordinates/angles/core.py
@@ -616,18 +616,13 @@ class Latitude(Angle):
             angles_view = angles_view[np.newaxis]
 
         if np.any(np.abs(angles_view) > limit):
-            with np.printoptions(precision=2):
-                if np.size(angles) < 9:
-                    info = f"got {angles.to(u.degree)}"
-                else:
-                    invalid_angles = np.logical_or(angles.value < -limit, angles.value > limit)
-                    idx = np.where(invalid_angles)[0]
-                    if len(idx) < 9:
-                        info = f"found {angles[idx].to(u.degree)}"
-                    else:
-                        info = f"found {angles[idx[0]].to(u.degree):.2f} [{idx[0]}], ..."
-            raise ValueError("Latitude angle(s) must be within -90 deg <= angle <= "
-                             f"90 deg, {info}")
+            if np.size(angles) < 5:
+                raise ValueError("Latitude angle(s) must be within -90 deg <= angle "
+                                     f"<= 90 deg, got {angles.to(u.degree)}")
+            else:
+                raise ValueError("Latitude angle(s) must be within -90 deg <= angle "
+                                 f"<= 90 deg, got {angles.min().to(u.degree)} <= "
+                                 f"angle <= {angles.max().to(u.degree)}")
 
     def __setitem__(self, item, value):
         # Forbid assigning a Long to a Lat.

--- a/astropy/coordinates/angles/core.py
+++ b/astropy/coordinates/angles/core.py
@@ -616,10 +616,17 @@ class Latitude(Angle):
             angles_view = angles_view[np.newaxis]
 
         if np.any(np.abs(angles_view) > limit):
-            raise ValueError(
-                "Latitude angle(s) must be within -90 deg <= angle <= 90 deg, "
-                f"got {angles.to(u.degree)}"
-            )
+            if np.size(angles) < 5:
+                info = f"got {angles.to(u.degree)}"
+            else:
+                invalid_angles = np.logical_or(angles.value < -limit, angles.value > limit)
+                idx = np.where(invalid_angles)[0]
+                if len(idx) < 5:
+                    info = f"found {angles[idx].to(u.degree)}"
+                else:
+                    info = f"found {angles[idx[0]].to(u.degree)} [{idx[0]}], ..."
+            raise ValueError("Latitude angle(s) must be within -90 deg <= angle <= "
+                             f"90 deg, {info}")
 
     def __setitem__(self, item, value):
         # Forbid assigning a Long to a Lat.

--- a/astropy/coordinates/tests/test_angles.py
+++ b/astropy/coordinates/tests/test_angles.py
@@ -759,7 +759,7 @@ def test_lon_as_lat():
     with pytest.raises(
         TypeError, match="A Latitude angle cannot be created from a Longitude angle"
     ):
-        lat = Latitude(lon)
+        Latitude(lon)
 
     with pytest.raises(
         TypeError, match="A Longitude angle cannot be assigned to a Latitude angle"
@@ -866,7 +866,7 @@ def test_lat_as_lon():
     with pytest.raises(
         TypeError, match="A Longitude angle cannot be created from a Latitude angle"
     ):
-        lon = Longitude(lat)
+        Longitude(lat)
 
     with pytest.raises(
         TypeError, match="A Latitude angle cannot be assigned to a Longitude angle"

--- a/astropy/coordinates/tests/test_angles.py
+++ b/astropy/coordinates/tests/test_angles.py
@@ -698,9 +698,9 @@ def test_latitude():
 
     lim_exc = r"Latitude angle\(s\) must be within -90 deg <= angle <= 90 deg, got"
     with pytest.raises(ValueError, match=rf"{lim_exc} \[91. 89.\] deg"):
-        Latitude(['91d', '89d'])
+        Latitude(["91d", "89d"])
     with pytest.raises(ValueError, match=f"{lim_exc} -91.0 deg"):
-        Latitude('-91d')
+        Latitude("-91d")
 
     lat = Latitude(["90d", "89d"])
     # check that one can get items
@@ -721,7 +721,7 @@ def test_latitude():
 
     # Check error message for long-ish input arrays (#13994).
     with pytest.raises(
-            ValueError, match=rf"{lim_exc} -143.239\d* deg <= angle <= 171.887\d* deg"
+        ValueError, match=rf"{lim_exc} -143.239\d* deg <= angle <= 171.887\d* deg"
     ):
         lat = Latitude([0, 1, 2, 3, -2.5, -1, -0.5] * u.radian)
 
@@ -729,7 +729,7 @@ def test_latitude():
 def test_latitude_manipulation():
     """Test value manipulation operations on Latitude angles."""
 
-    lat = Latitude(['90d', '-29d'])
+    lat = Latitude(["90d", "-29d"])
     # conserve type on unit change (closes #1423)
     angle = lat.to("radian")
     assert type(angle) is Latitude
@@ -755,16 +755,16 @@ def test_latitude_manipulation():
 def test_lon_as_lat():
     """Test validation when trying to interoperate with longitudes."""
 
-    lon = Longitude(10, 'deg')
+    lon = Longitude(10, "deg")
     with pytest.raises(
-            TypeError, match="A Latitude angle cannot be created from a Longitude angle"
+        TypeError, match="A Latitude angle cannot be created from a Longitude angle"
     ):
         lat = Latitude(lon)
 
     with pytest.raises(
-            TypeError, match="A Longitude angle cannot be assigned to a Latitude angle"
+        TypeError, match="A Longitude angle cannot be assigned to a Latitude angle"
     ):
-        lat = Latitude([20], 'deg')
+        lat = Latitude([20], "deg")
         lat[0] = lon
 
     # Check we can work around the Lat vs Long checks by casting explicitly to Angle.
@@ -772,7 +772,7 @@ def test_lon_as_lat():
     assert lat.value == 10.0
 
     # Check setitem.
-    lat = Latitude([20], 'deg')
+    lat = Latitude([20], "deg")
     lat[0] = Angle(lon)
     assert lat.value[0] == 10.0
 
@@ -861,17 +861,17 @@ def test_longitude():
 def test_lat_as_lon():
     """Test validation when trying to interoperate with latitudes."""
 
-    lat = Latitude(10, 'deg')
+    lat = Latitude(10, "deg")
     # Test errors when trying to interoperate with latitudes.
     with pytest.raises(
-            TypeError, match="A Longitude angle cannot be created from a Latitude angle"
+        TypeError, match="A Longitude angle cannot be created from a Latitude angle"
     ):
         lon = Longitude(lat)
 
     with pytest.raises(
-            TypeError, match="A Latitude angle cannot be assigned to a Longitude angle"
+        TypeError, match="A Latitude angle cannot be assigned to a Longitude angle"
     ):
-        lon = Longitude([20], 'deg')
+        lon = Longitude([20], "deg")
         lon[0] = lat
 
     # Check we can work around the Lat vs Long checks by casting explicitly to Angle.
@@ -879,7 +879,7 @@ def test_lat_as_lon():
     assert lon.value == 10.0
 
     # Check setitem.
-    lon = Longitude([20], 'deg')
+    lon = Longitude([20], "deg")
     lon[0] = Angle(lat)
     assert lon.value[0] == 10.0
 
@@ -1209,8 +1209,11 @@ def test_latitude_out_of_limits(value, dtype):
     Test that values slightly larger than pi/2 are rejected for different dtypes.
     Test cases for issue #13708
     """
-    with pytest.raises(ValueError, match=r"Latitude angle\(s\) must be within -90 deg "
-                       r"<= angle <= 90 deg, got -?90.001\d* deg"):
+    with pytest.raises(
+        ValueError,
+        match=r"Latitude angle\(s\) must be within -90 deg "
+        r"<= angle <= 90 deg, got -?90.001\d* deg",
+    ):
         Latitude(value, u.rad, dtype=dtype)
 
 

--- a/docs/changes/coordinates/13997.bugfix.rst
+++ b/docs/changes/coordinates/13997.bugfix.rst
@@ -1,0 +1,2 @@
+Keep ``Latitude`` from printing long input arrays in their entirety when failing
+limits check in ``_validate_angles``, indicating their range instead.


### PR DESCRIPTION
### Description
This pull request is to fix #13994

The input validator for setting a `Latitude` angle, on finding values outside the permitted [-90 deg, 90 deg] range, currently prints the entire input vector (as formatted by numpy, i.e. up to 1000 elements with default `np.set_printoptions` settings) to the error message.

This approach limits the number of printed values to 4 by only printing the out-of-range values, or just the first element of them with its position.

To discuss:
1. Test needed?
2. Is the "value deg [index]" syntax sensibly understandable (especially compared to "[lat0, lat1, lat3] deg")?
3. Should the second case rather also print the indices of the out-of-range elements?

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
