### PR TITLE
Deprecate the `humlicek2` method for `Voigt1D`

### DIFF
--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -2,10 +2,13 @@
 
 """Mathematical models."""
 # pylint: disable=line-too-long, too-many-lines, too-many-arguments, invalid-name
+import warnings
+
 import numpy as np
 
 from astropy import units as u
 from astropy.units import Quantity, UnitsError
+from astropy.utils.exceptions import AstropyDeprecationWarning
 
 from .core import Fittable1DModel, Fittable2DModel
 from .parameters import InputParameterError, Parameter
@@ -1719,14 +1722,22 @@ class Voigt1D(Fittable1DModel):
         amplitude_L=amplitude_L.default,
         fwhm_L=fwhm_L.default,
         fwhm_G=fwhm_G.default,
-        method="humlicek2",
+        method=None,
         **kwargs,
     ):
+        if method is None:
+            method = "wofz"
+
         if str(method).lower() in ("wofz", "scipy"):
             from scipy.special import wofz
 
             self._faddeeva = wofz
         elif str(method).lower() == "humlicek2":
+            warnings.warn(
+                f"{method} has been depricated in favor of the `wofz` method which requires scipy",
+                AstropyDeprecationWarning,
+            )
+
             self._faddeeva = self._hum2zpf16c
         else:
             raise ValueError(

--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -1763,10 +1763,11 @@ class Voigt1D(Fittable1DModel):
         ):
             return self._last_w
 
-        if isinstance(z, u.Quantity):
-            z = z.to_value(u.dimensionless_unscaled)
-        self._last_w = self._faddeeva(z)
-        self._last_z = z
+        self._last_z = (
+            z.to_value(u.dimensionless_unscaled) if isinstance(z, u.Quantity) else z
+        )
+        self._last_w = self._faddeeva(self._last_z)
+
         return self._last_w
 
     def evaluate(self, x, x_0, amplitude_L, fwhm_L, fwhm_G):

--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -8,6 +8,7 @@ import numpy as np
 
 from astropy import units as u
 from astropy.units import Quantity, UnitsError
+from astropy.utils.compat.optional_deps import HAS_SCIPY
 from astropy.utils.exceptions import AstropyDeprecationWarning
 
 from .core import Fittable1DModel, Fittable2DModel
@@ -1726,7 +1727,10 @@ class Voigt1D(Fittable1DModel):
         **kwargs,
     ):
         if method is None:
-            method = "wofz"
+            if HAS_SCIPY:
+                method = "wofz"
+            else:
+                method = "humlicek2"
 
         if str(method).lower() in ("wofz", "scipy"):
             from scipy.special import wofz
@@ -1734,7 +1738,7 @@ class Voigt1D(Fittable1DModel):
             self._faddeeva = wofz
         elif str(method).lower() == "humlicek2":
             warnings.warn(
-                f"{method} has been depricated in favor of the `wofz` method which requires scipy",
+                f"{method} has been depricated in favor of the `wofz` method which requires `scipy`",
                 AstropyDeprecationWarning,
             )
 

--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -1726,6 +1726,14 @@ class Voigt1D(Fittable1DModel):
         method=None,
         **kwargs,
     ):
+        if str(method).lower() == "humlicek2" and HAS_SCIPY:
+            warnings.warn(
+                f"{method} has been deprecated since Astropy 5.3 and will be removed in a future version.\n"
+                "It is recommended to always use the `~scipy.special.wofz` implementation "
+                "when `scipy` is installed.",
+                AstropyDeprecationWarning,
+            )
+
         if method is None:
             if HAS_SCIPY:
                 method = "wofz"
@@ -1737,12 +1745,6 @@ class Voigt1D(Fittable1DModel):
 
             self._faddeeva = wofz
         elif str(method).lower() == "humlicek2":
-            warnings.warn(
-                f"{method} has been deprecated since Astropy 5.3 and will be removed in a future version.\n"
-                "It is recommended to always use the `wofz` method which requires `scipy`.",
-                AstropyDeprecationWarning,
-            )
-
             self._faddeeva = self._hum2zpf16c
         else:
             raise ValueError(

--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -1738,7 +1738,8 @@ class Voigt1D(Fittable1DModel):
             self._faddeeva = wofz
         elif str(method).lower() == "humlicek2":
             warnings.warn(
-                f"{method} has been depricated in favor of the `wofz` method which requires `scipy`",
+                f"{method} has been deprecated since Astropy 5.3 and will be removed in a future version.\n"
+                "It is recommended to always use the `wofz` method which requires `scipy`.",
                 AstropyDeprecationWarning,
             )
 

--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -1763,6 +1763,8 @@ class Voigt1D(Fittable1DModel):
         ):
             return self._last_w
 
+        if isinstance(z, u.Quantity):
+            z = z.to_value(u.dimensionless_unscaled)
         self._last_w = self._faddeeva(z)
         self._last_z = z
         return self._last_w

--- a/astropy/modeling/tests/test_functional_models.py
+++ b/astropy/modeling/tests/test_functional_models.py
@@ -527,6 +527,15 @@ def test_Voigt1D_hum2(doppler):
     assert_allclose(dvda_h, dvda_w, rtol=1e-9, atol=1e-7 * (1 + 30 / doppler))
 
 
+def test_Voigt1D_default_method():
+    """Test Voigt1D default method"""
+    voi = models.Voigt1D()
+    if HAS_SCIPY:
+        assert voi.method == "wofz"
+    else:
+        assert voi.method == "humlicek2"
+
+
 @pytest.mark.skipif(not HAS_SCIPY, reason="requires scipy")
 @pytest.mark.parametrize("fitter", fitters)
 def test_KingProjectedAnalytic1D_fit(fitter):

--- a/astropy/modeling/tests/test_functional_models.py
+++ b/astropy/modeling/tests/test_functional_models.py
@@ -485,7 +485,7 @@ def test_Voigt1D_norm(algorithm):
 
     if algorithm == "humlicek2":
         with pytest.warns(
-            AstropyDeprecationWarning, match=r".* has been depricated .*"
+            AstropyDeprecationWarning, match=r"humlicek2 has been deprecated since .*"
         ):
             voi = voigt(algorithm)
     else:
@@ -500,7 +500,7 @@ def test_Voigt1D_norm(algorithm):
 
 @pytest.mark.skipif(not HAS_SCIPY, reason="requires scipy")
 @pytest.mark.parametrize("doppler", (1.0e-3, 1.0e-2, 0.1, 0.5, 1.0, 2.5, 5.0, 10))
-@pytest.mark.filterwarnings(r"ignore:.*has been depricated.*")
+@pytest.mark.filterwarnings(r"ignore:humlicek2 has been deprecated since .*")
 def test_Voigt1D_hum2(doppler):
     """
     Verify accuracy of Voigt profile in Humlicek approximation to Faddeeva.cc (SciPy).
@@ -527,13 +527,23 @@ def test_Voigt1D_hum2(doppler):
     assert_allclose(dvda_h, dvda_w, rtol=1e-9, atol=1e-7 * (1 + 30 / doppler))
 
 
-def test_Voigt1D_default_method():
+@pytest.mark.filterwarnings(r"ignore:humlicek2 has been deprecated since .*")
+def test_Voigt1D_method():
     """Test Voigt1D default method"""
+    voi = models.Voigt1D(method="wofz")
+    assert voi.method == "wofz"
+
+    voi = models.Voigt1D(method="scipy")
+    assert voi.method == "wofz"
+
+    voi = models.Voigt1D(method="humlicek2")
+    assert voi.method == "_hum2zpf16c"
+
     voi = models.Voigt1D()
     if HAS_SCIPY:
         assert voi.method == "wofz"
     else:
-        assert voi.method == "humlicek2"
+        assert voi.method == "_hum2zpf16c"
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason="requires scipy")

--- a/astropy/modeling/tests/test_functional_models.py
+++ b/astropy/modeling/tests/test_functional_models.py
@@ -530,17 +530,18 @@ def test_Voigt1D_hum2(doppler):
 @pytest.mark.filterwarnings(r"ignore:humlicek2 has been deprecated since .*")
 def test_Voigt1D_method():
     """Test Voigt1D default method"""
-    voi = models.Voigt1D(method="wofz")
-    assert voi.method == "wofz"
-
-    voi = models.Voigt1D(method="scipy")
-    assert voi.method == "wofz"
 
     voi = models.Voigt1D(method="humlicek2")
     assert voi.method == "_hum2zpf16c"
 
     voi = models.Voigt1D()
     if HAS_SCIPY:
+        assert voi.method == "wofz"
+
+        voi = models.Voigt1D(method="wofz")
+        assert voi.method == "wofz"
+
+        voi = models.Voigt1D(method="scipy")
         assert voi.method == "wofz"
     else:
         assert voi.method == "_hum2zpf16c"

--- a/astropy/modeling/tests/test_models.py
+++ b/astropy/modeling/tests/test_models.py
@@ -390,6 +390,7 @@ class Fittable2DModelTester:
             )
 
 
+@pytest.mark.filterwarnings(r"ignore:humlicek2 has been deprecated since .*")
 class Fittable1DModelTester:
     """
     Test class for all one dimensional parametric models.
@@ -687,6 +688,7 @@ def test_ScaleModel():
     assert_equal(m([1, 2], model_set_axis=False), [[42, 84], [43, 86]])
 
 
+@pytest.mark.filterwarnings(r"ignore:humlicek2 has been deprecated since .*")
 def test_voigt_model():
     """
     Currently just tests that the model peaks at its origin.
@@ -1061,6 +1063,7 @@ def test_parameter_inheritance():
     assert b.f.fixed == True  # noqa: E712
 
 
+@pytest.mark.filterwarnings(r"ignore:humlicek2 has been deprecated since .*")
 def test_parameter_description():
     model = models.Gaussian1D(1.5, 2.5, 3.5)
     assert model.amplitude._description == "Amplitude (peak value) of the Gaussian"

--- a/astropy/modeling/tests/test_models_quantities.py
+++ b/astropy/modeling/tests/test_models_quantities.py
@@ -562,6 +562,7 @@ NON_FINITE_TRF_MODELS = [
     PowerLaw1D,
     ExponentialCutoffPowerLaw1D,
     BrokenPowerLaw1D,
+    Voigt1D,
 ]
 
 # These models will fail the LMLSQFitter fitting test due to non-finite
@@ -574,6 +575,7 @@ NON_FINITE_LM_MODELS = [
     Schechter1D,
     ExponentialCutoffPowerLaw1D,
     BrokenPowerLaw1D,
+    Voigt1D,
 ]
 
 # These models will fail the DogBoxLSQFitter fitting test due to non-finite

--- a/docs/changes/modeling/14013.api.rst
+++ b/docs/changes/modeling/14013.api.rst
@@ -1,3 +1,3 @@
 Deprecate the ``humlicek2`` method for `~astropy.modeling.functional_models.Voigt1D` in favor
-of using the ``wolz`` method provided by `scipy.special.wofz` whenever `scipy` is
-installed.
+of using the ``wofz`` method using the `scipy.special.wofz` implementation of the
+Fadeeva function whenever `scipy` is installed.

--- a/docs/changes/modeling/14013.api.rst
+++ b/docs/changes/modeling/14013.api.rst
@@ -1,0 +1,3 @@
+Deprecate the ``humlicek2`` method for `~astropy.modeling.functional_models.Voigt1D` in favor
+of using the ``wolz`` method provided by `scipy.special.wofz` whenever `scipy` is
+installed.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

As part of the discussion in this thread: https://github.com/astropy/astropy/pull/13960#discussion_r1021250845 I determined that the `wofz` method is an overall better method than the `humlicek2` method for a few reasons:

1. `wofz` is more accurate.
2. `wofz` implemented by `scipy` so the code is more widely used and tested.
3. According to the discussion here: https://github.com/astropy/astropy/pull/11177#issuecomment-748305490 it is almost as fast as `humlicek2` in most cases and faster in some.

The better accuracy for little to no performance hit means at the very least, it is a better default choice than `humlicek2`. The downside is that it requires `scipy` which many other `astropy.modeling.models` require, and is required for using `astropy.modeling.fitting` using this model.

This PR is an attempt to move this discussion from #13960 into a forum specific to this issue.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
