### PR TITLE
chore: Set permissions for GitHub actions (was PR 13397)

### DIFF
--- a/.github/workflows/ci_cron_daily.yml
+++ b/.github/workflows/ci_cron_daily.yml
@@ -28,6 +28,9 @@ env:
   ARCH_ON_CI: "normal"
   IS_CRON: "true"
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     if: (github.repository == 'astropy/astropy' && (github.event_name == 'schedule' || github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'Extra CI')))

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -16,8 +16,15 @@ on:
     # run every Wednesday at 6am UTC
     - cron: '0 6 * * 3'
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
+    permissions:
+      actions: read  # for github/codeql-action/init to get workflow details
+      contents: read  # for actions/checkout to fetch code
+      security-events: write  # for github/codeql-action/autobuild to send a status report
     name: Analyze
     runs-on: ubuntu-latest
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,10 +8,15 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
 
   test_wheel_building:
     # This ensures that a couple of targets work fine in pull requests and pushes
+    permissions:
+      contents: none
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish.yml@v1
     if: (github.event_name == 'push' || github.event_name == 'pull_request')
     with:
@@ -25,6 +30,8 @@ jobs:
   build_and_publish:
     # This does the actual wheel building and publishing as part of the cron job
     # or if triggered manually via the workflow dispatch, or for a tag.
+    permissions:
+      contents: none
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish.yml@v1
     if: (github.repository == 'astropy/astropy' && ( startsWith(github.ref, 'refs/tags/v') || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'Build all wheels')))
     with:

--- a/.github/workflows/update_iers.yml
+++ b/.github/workflows/update_iers.yml
@@ -5,8 +5,14 @@ on:
     - cron: '0 0 1 * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   update-iers:
+    permissions:
+      contents: write  # for peter-evans/create-pull-request to create branch
+      pull-requests: write  # for peter-evans/create-pull-request to create a PR
     name: Auto-update IERS tables
     runs-on: ubuntu-latest
     if: github.repository == 'astropy/astropy'


### PR DESCRIPTION
#13397 was getting stale but the author disabled push by maintainer to keep it alive, so here it is.

## Original post

Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>

## TODO

As discussed in infrastructure tag-up 2022-08-11 , we can push this forward with the following steps:

- [x] @WilliamJamieson will try the same permissions for the publish workflow over at asdf-astropy and see if anything breaks.
- [x] If nothing breaks, we can merge this PR as-is and monitor the logs.
- [ ] Open a follow-up issue to revisit permissions for the remaining workflows that do not use `pull_request`.
