### PR TITLE
In samp : add a warning if notify_all did not find receiver

### DIFF
--- a/astropy/samp/hub.py
+++ b/astropy/samp/hub.py
@@ -1093,6 +1093,11 @@ class SAMPHubServer:
                             target=self._notify,
                             args=(sender_private_key, _recipient_id, message),
                         )
+        if not recipient_ids:
+            warnings.warn(
+                "No client was able to receive this message",
+                SAMPWarning,
+            )
 
         return recipient_ids
 

--- a/astropy/samp/tests/test_client.py
+++ b/astropy/samp/tests/test_client.py
@@ -3,7 +3,7 @@
 import pytest
 
 # By default, tests should not use the internet.
-from astropy.samp import conf
+from astropy.samp import conf, SAMPProxyError
 from astropy.samp.client import SAMPClient
 from astropy.samp.hub import SAMPHubServer
 from astropy.samp.hub_proxy import SAMPHubProxy
@@ -36,6 +36,16 @@ def samp_hub(request):
     my_hub = SAMPHubServer()
     my_hub.start()
     request.addfinalizer(my_hub.stop)
+
+
+def test_SAMPIntegratedClient_notify_all(samp_hub):
+    """Test that SAMP returns a warning if no receiver got the message."""
+    client = SAMPIntegratedClient()
+    client.connect()
+    message = {"samp.mtype": "coverage.load.moc.fits"}
+    with pytest.raises(SAMPProxyError):
+        client.notify_all(message)
+    client.disconnect()
 
 
 def test_reconnect(samp_hub):

--- a/astropy/samp/tests/test_client.py
+++ b/astropy/samp/tests/test_client.py
@@ -3,7 +3,7 @@
 import pytest
 
 # By default, tests should not use the internet.
-from astropy.samp import conf, SAMPProxyError
+from astropy.samp import SAMPWarning, conf
 from astropy.samp.client import SAMPClient
 from astropy.samp.hub import SAMPHubServer
 from astropy.samp.hub_proxy import SAMPHubProxy
@@ -43,7 +43,7 @@ def test_SAMPIntegratedClient_notify_all(samp_hub):
     client = SAMPIntegratedClient()
     client.connect()
     message = {"samp.mtype": "coverage.load.moc.fits"}
-    with pytest.raises(SAMPProxyError):
+    with pytest.warns(SAMPWarning):
         client.notify_all(message)
     client.disconnect()
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

Adds a warning in the function _notify_all_ in samp module if no client was able to catch the message
I think it might just be useful 

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
