### PR TITLE
Replace numpy.ctypeslib with cython

### DIFF
--- a/astropy/convolution/_convolve.pyx
+++ b/astropy/convolution/_convolve.pyx
@@ -3,6 +3,7 @@
 cimport numpy as np
 from libcpp cimport bool
 
+
 cdef extern from "src/convolve.h":
     void convolveNd_c(np.float64_t * const result,
             const np.float64_t * const f,

--- a/astropy/convolution/_convolve.pyx
+++ b/astropy/convolution/_convolve.pyx
@@ -1,0 +1,34 @@
+# cython: language_level=3
+
+cimport numpy as np
+from libcpp cimport bool
+
+cdef extern from "src/convolve.h":
+    void convolveNd_c(np.float64_t * const result,
+            const np.float64_t * const f,
+            const unsigned n_dim,
+            const size_t * const image_shape,
+            const np.float64_t * const g,
+            const size_t * const kernel_shape,
+            const bool nan_interpolate,
+            const bool embed_result_within_padded_region,
+            const unsigned n_threads) nogil
+
+
+def _convolveNd_c(np.ndarray result,
+                  np.ndarray array_to_convolve,
+                  np.ndarray kernel,
+                  bool nan_interpolate,
+                  bool embed_result_within_padded_region,
+                  int n_threads):
+    convolveNd_c(
+        <np.float64_t*>np.PyArray_DATA(result),
+        <np.float64_t*>np.PyArray_DATA(array_to_convolve),
+        array_to_convolve.ndim,
+        <size_t*>array_to_convolve.shape,
+        <np.float64_t*>np.PyArray_DATA(kernel),
+        <size_t*>kernel.shape,
+        nan_interpolate,
+        embed_result_within_padded_region,
+        n_threads,
+    )

--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -1,12 +1,10 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import ctypes
-import os
 import warnings
 from functools import partial
 
 import numpy as np
-from numpy.ctypeslib import load_library, ndpointer
 
 from astropy import units as u
 from astropy.modeling.convolution import Convolution
@@ -15,42 +13,9 @@ from astropy.nddata import support_nddata
 from astropy.utils.console import human_file_size
 from astropy.utils.exceptions import AstropyUserWarning
 
+from ._convolve import _convolveNd_c
 from .core import MAX_NORMALIZATION, Kernel, Kernel1D, Kernel2D
 from .utils import KernelSizeError, has_even_axis, raise_even_kernel_exception
-
-LIBRARY_PATH = os.path.dirname(__file__)
-
-try:
-    with warnings.catch_warnings():
-        # numpy.distutils is deprecated since numpy 1.23
-        # see https://github.com/astropy/astropy/issues/12865
-        warnings.simplefilter("ignore", DeprecationWarning)
-        _convolve = load_library("_convolve", LIBRARY_PATH)
-except Exception:
-    raise ImportError("Convolution C extension is missing. Try re-building astropy.")
-
-# The GIL is automatically released by default when calling functions imported
-# from libraries loaded by ctypes.cdll.LoadLibrary(<path>)
-
-# Declare prototypes
-# Boundary None
-_convolveNd_c = _convolve.convolveNd_c
-_convolveNd_c.restype = None
-_convolveNd_c.argtypes = [
-    ndpointer(ctypes.c_double, flags={"C_CONTIGUOUS", "WRITEABLE"}),  # return array
-    ndpointer(ctypes.c_double, flags="C_CONTIGUOUS"),  # input array
-    ctypes.c_uint,  # N dim
-    # size array for input and result unless
-    # embed_result_within_padded_region is False,
-    # in which case the result array is assumed to be
-    # input.shape - 2*(kernel.shape//2). Note: integer division.
-    ndpointer(ctypes.c_size_t, flags="C_CONTIGUOUS"),
-    ndpointer(ctypes.c_double, flags="C_CONTIGUOUS"),  # kernel array
-    ndpointer(ctypes.c_size_t, flags="C_CONTIGUOUS"),  # size array for kernel
-    ctypes.c_bool,  # nan_interpolate
-    ctypes.c_bool,  # embed_result_within_padded_region
-    ctypes.c_uint,  # n_threads
-]
 
 # np.unique([scipy.fft.next_fast_len(i, real=True) for i in range(10000)])
 # fmt: off
@@ -447,10 +412,7 @@ def convolve(
     _convolveNd_c(
         result,
         array_to_convolve,
-        array_to_convolve.ndim,
-        np.array(array_to_convolve.shape, dtype=ctypes.c_size_t, order="C"),
         kernel_internal,
-        np.array(kernel_shape, dtype=ctypes.c_size_t, order="C"),
         nan_interpolate,
         embed_result_within_padded_region,
         n_threads,

--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-import ctypes
 import warnings
 from functools import partial
 

--- a/astropy/convolution/setup_package.py
+++ b/astropy/convolution/setup_package.py
@@ -8,10 +8,6 @@ from setuptools import Extension
 
 C_CONVOLVE_PKGDIR = os.path.relpath(os.path.dirname(__file__))
 
-SRC_FILES = [
-    os.path.join(C_CONVOLVE_PKGDIR, filename) for filename in ["src/convolve.c"]
-]
-
 extra_compile_args = ["-UNDEBUG"]
 if not sys.platform.startswith("win"):
     extra_compile_args.append("-fPIC")
@@ -20,12 +16,14 @@ if not sys.platform.startswith("win"):
 def get_extensions():
     # Add '-Rpass-missed=.*' to ``extra_compile_args`` when compiling with clang
     # to report missed optimizations
+    sources = [
+        os.path.join(C_CONVOLVE_PKGDIR, "_convolve.pyx"),
+        os.path.join(C_CONVOLVE_PKGDIR, "src", "convolve.c"),
+    ]
     _convolve_ext = Extension(
         name="astropy.convolution._convolve",
-        sources=SRC_FILES,
         extra_compile_args=extra_compile_args,
         include_dirs=[numpy.get_include()],
-        language="c",
+        sources=sources,
     )
-
     return [_convolve_ext]

--- a/astropy/convolution/src/convolve.c
+++ b/astropy/convolution/src/convolve.c
@@ -33,15 +33,6 @@
 
 #include "convolve.h"
 
-// Distutils on Windows automatically exports ``PyInit__convolve``,
-// create dummy to prevent linker complaining about missing symbol.
-#if defined(_MSC_VER)
-void PyInit__convolve(void)
-{
-    return;
-}
-#endif
-
 #ifdef _OPENMP
 #include <omp.h>
 #endif

--- a/astropy/convolution/src/convolve.h
+++ b/astropy/convolution/src/convolve.h
@@ -34,12 +34,6 @@ typedef size_t omp_iter_var;
 #define LIB_CONVOLVE_EXPORT // nothing
 #endif
 
-// Distutils on Windows will automatically exports ``PyInit_lib_convolve``,
-// create dummy to prevent linker complaining about missing symbol.
-#if defined(_MSC_VER)
-void PyInit__convolve(void);
-#endif
-
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #define NO_IMPORT_ARRAY
 #include "numpy/ndarrayobject.h"

--- a/astropy/convolution/src/convolve.h
+++ b/astropy/convolution/src/convolve.h
@@ -1,6 +1,7 @@
 #ifndef CONVOLVE_INCLUDE
 #define CONVOLVE_INCLUDE
 
+#include <stdbool.h>
 #include <stddef.h>
 
 // Forcibly disable OpenMP support at the src level

--- a/docs/changes/convolution/14035.bugfix.rst
+++ b/docs/changes/convolution/14035.bugfix.rst
@@ -1,0 +1,3 @@
+Fix import error with setuptools v65.6.0 by replacing
+``numpy.ctypeslib.load_library`` with Cython to load the C convolution
+extension.


### PR DESCRIPTION
This is one way to fix #14025, removing our dependency to `numpy.ctypeslib` which itself relies on `numpy.distutils`

<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address ...

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
