### PR TITLE
Switch to using math.comb in Polynomial models. Deprecate modeling.utils.comb

### DIFF
--- a/astropy/modeling/polynomial.py
+++ b/astropy/modeling/polynomial.py
@@ -4,6 +4,8 @@ This module contains models representing polynomials and polynomial series.
 
 """
 # pylint: disable=invalid-name
+from math import comb
+
 import numpy as np
 
 from astropy.utils import check_broadcast, indent
@@ -11,7 +13,7 @@ from astropy.utils import check_broadcast, indent
 from .core import FittableModel, Model
 from .functional_models import Shift
 from .parameters import Parameter
-from .utils import _validate_domain_window, comb, poly_map_domain
+from .utils import _validate_domain_window, poly_map_domain
 
 __all__ = [
     "Chebyshev1D",

--- a/astropy/modeling/utils.py
+++ b/astropy/modeling/utils.py
@@ -215,6 +215,7 @@ def _validate_domain_window(value):
     return value
 
 
+@deprecated("5.3", alternative="math.comb")
 def comb(N, k):
     """
     The number of combinations of N things taken k at a time.

--- a/docs/changes/modeling/14038.api.rst
+++ b/docs/changes/modeling/14038.api.rst
@@ -1,0 +1,2 @@
+Deprecated ``astropy.modeling.utils.comb()`` function in favor of ``comb()``
+from ``math`` standard library.


### PR DESCRIPTION
### Description
`Polynomial._order` is computed using [`astropy.modeling.utils.comb()`](https://github.com/astropy/astropy/blob/cffe98aaff7a5ffe442934ecdf20b209606db0db/astropy/modeling/utils.py#L218-L235) function which returns floating point numbers, making `_order` - the number of terms in a polynomial and naturally an integer number - a floating point number.

Instead of converting floating point numbers to integers, I propose that `astropy.modeling.utils.comb()` simply performs integer/exact computations.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
