### PR TITLE
Demonstrate that we don't need pytest-openfiles any more

### DIFF
--- a/astropy/tests/test_unclosed.py
+++ b/astropy/tests/test_unclosed.py
@@ -1,0 +1,48 @@
+"""
+This file is an experiment to compare ResourceWarnings with pytest-openfiles
+"""
+import pytest
+
+
+def test_closed_file(tmp_path):
+    with open(tmp_path / "test1", "w") as fobj:
+        pass
+
+
+def test_unclosed_file(tmp_path):
+    open(tmp_path / "test2", "w")
+
+
+def test_evil_unclosed_file(tmp_path):
+    fobj = open(tmp_path / "test3", "w")
+    fobj = None
+
+
+@pytest.fixture
+def unclosed_fixture(tmp_path):
+    return open(tmp_path / "test4", "w")
+
+
+@pytest.fixture
+def closed_fixture(tmp_path):
+    fobj = open(tmp_path / "test5", "w")
+    yield fobj
+    fobj.close()
+
+
+@pytest.fixture
+def closed_fixture_context(tmp_path):
+    with open(tmp_path / "test6", "w") as fobj:
+        yield fobj
+
+
+def test_closed_fixture(closed_fixture):
+    pass
+
+
+def test_unclosed_fixture(unclosed_fixture):
+    pass
+
+
+def test_closed_fixture_context(closed_fixture_context):
+    pass


### PR DESCRIPTION
I ran into a pytest-openfiles bug https://github.com/astropy/pytest-openfiles/issues/32 and it seems like we should just stop using it because pytest throws a `ResourceWarning` now which our [default warnings filter](https://github.com/astropy/astropy/blob/main/setup.cfg#L134) converts into an exception.

This PR adds some tests which leave open files hanging (and some which don't), my hypothesis is that all the CI jobs will fail and not just the one which uses `pytest-openfiles`, if this is the case we can remove openfiles because it is redundant.

Secondary hypothesis: More tests will fail on the pytest-openfiles build because of astropy/pytest-openfiles#32 that will fail on the other builds, but these fails are actually incorrect and shouldn't fail because the files are closed in the fixture teardown which happens *after* pytest-openfiles checks to see if the files are closed.