### PR TITLE
Remove use of pytest-openfiles

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -60,9 +60,6 @@ jobs:
         - name: Python 3.10 with minimal dependencies and full coverage
           linux: py310-test-cov
 
-        # NOTE: In the build below we also check that tests do not open and
-        # leave open any files. This has a performance impact on running the
-        # tests, hence why it is not enabled by default.
         - name: Python 3.9 with all optional dependencies
           linux: py39-test-alldeps-fitsio
           libraries:

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -71,7 +71,7 @@ jobs:
               - tzdata
               - libcfitsio-dev
           toxargs: -v --develop
-          posargs: --open-files --run-slow
+          posargs: --run-slow
 
         - name: Python 3.8 with oldest supported version of all dependencies
           linux: py38-test-oldestdeps-alldeps-cov-clocale

--- a/astropy/io/fits/tests/test_connect.py
+++ b/astropy/io/fits/tests/test_connect.py
@@ -296,7 +296,7 @@ class TestSingleTable:
         t2 = Table.read(filename, memmap=False)
         t3 = Table.read(filename, memmap=True)
         assert equal_data(t2, t3)
-        # To avoid issues with --open-files, we need to remove references to
+        # To avoid issues with open files, we need to remove references to
         # data that uses memory mapping and force the garbage collection
         del t1, t2, t3
         gc.collect()
@@ -311,7 +311,7 @@ class TestSingleTable:
         assert t2["b"].dtype.kind == "U"
         assert t3["b"].dtype.kind == "S"
         assert equal_data(t2, t3)
-        # To avoid issues with --open-files, we need to remove references to
+        # To avoid issues with open files, we need to remove references to
         # data that uses memory mapping and force the garbage collection
         del t1, t2, t3
         gc.collect()

--- a/astropy/io/fits/tests/test_core.py
+++ b/astropy/io/fits/tests/test_core.py
@@ -1056,7 +1056,6 @@ class TestFileFunctions(FitsTestCase):
             mmap.mmap = old_mmap
             _File.__dict__["_mmap_available"]._cache.clear()
 
-    @pytest.mark.openfiles_ignore
     def test_mmap_allocate_error(self):
         """
         Regression test for https://github.com/astropy/astropy/issues/1380

--- a/astropy/io/misc/tests/test_hdf5.py
+++ b/astropy/io/misc/tests/test_hdf5.py
@@ -633,7 +633,7 @@ def test_read_h5py_objects(tmp_path):
     t4 = Table.read(f["the_table"])
     assert np.all(t4["a"] == [1, 2, 3])
 
-    f.close()  # don't raise an error in 'test --open-files'
+    f.close()  # don't leave the file open
 
 
 @pytest.mark.skipif(not HAS_H5PY, reason="requires h5py")

--- a/astropy/tests/command.py
+++ b/astropy/tests/command.py
@@ -100,11 +100,6 @@ class AstropyTest(Command, metaclass=FixRemoteDataOption):
         ("pdb", "d", "Start the interactive Python debugger on errors."),
         ("coverage", "c", "Create a coverage report. Requires the coverage package."),
         (
-            "open-files",
-            "o",
-            "Fail if any tests leave files open.  Requires the psutil package.",
-        ),
-        (
             "parallel=",
             "j",
             "Run the tests in parallel on the specified number of "
@@ -154,7 +149,6 @@ class AstropyTest(Command, metaclass=FixRemoteDataOption):
         self.pep8 = False
         self.pdb = False
         self.coverage = False
-        self.open_files = False
         self.parallel = 0
         self.docs_path = None
         self.skip_docs = False
@@ -194,7 +188,6 @@ class AstropyTest(Command, metaclass=FixRemoteDataOption):
             "remote_data={1.remote_data!r}, "
             "pep8={1.pep8!r}, "
             "pdb={1.pdb!r}, "
-            "open_files={1.open_files!r}, "
             "parallel={1.parallel!r}, "
             "docs_path={1.docs_path!r}, "
             "skip_docs={1.skip_docs!r}, "

--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -184,8 +184,7 @@ class TestRunnerBase:
 
     @classmethod
     def _has_test_dependencies(cls):  # pragma: no cover
-        # Using the test runner will not work without these dependencies, but
-        # pytest-openfiles is optional, so it's not listed here.
+        # Using the test runner will not work without these dependencies.
         for module in cls._required_dependencies:
             spec = find_spec(module)
             # Checking loader accounts for packages that were uninstalled

--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -516,35 +516,6 @@ class TestRunner(TestRunnerBase):
             return ["--pdb"]
         return []
 
-    @keyword()
-    def open_files(self, open_files, kwargs):
-        """
-        open_files : bool, optional
-            Fail when any tests leave files open.  Off by default, because
-            this adds extra run time to the test suite.  Requires the
-            ``psutil`` package.
-        """
-        if open_files:
-            if kwargs["parallel"] != 0:
-                raise SystemError(
-                    "open file detection may not be used in conjunction with "
-                    "parallel testing."
-                )
-
-            try:
-                import psutil  # noqa: F401
-            except ImportError:
-                raise SystemError(
-                    "open file detection requested, but psutil package "
-                    "is not installed."
-                )
-
-            return ["--open-files"]
-
-            print("Checking for unclosed files")
-
-        return []
-
     @keyword(0)
     def parallel(self, parallel, kwargs):
         """

--- a/astropy/visualization/scripts/tests/test_fits2bitmap.py
+++ b/astropy/visualization/scripts/tests/test_fits2bitmap.py
@@ -18,19 +18,16 @@ class TestFits2Bitmap:
         self.filename = "test.fits"
         self.array = np.arange(16384).reshape((128, 128))
 
-    @pytest.mark.openfiles_ignore
     def test_function(self, tmp_path):
         filename = tmp_path / self.filename
         fits.writeto(filename, self.array)
         fits2bitmap(filename)
 
-    @pytest.mark.openfiles_ignore
     def test_script(self, tmp_path):
         filename = str(tmp_path / self.filename)
         fits.writeto(filename, self.array)
         main([filename, "-e", "0"])
 
-    @pytest.mark.openfiles_ignore
     def test_exten_num(self, tmp_path):
         filename = str(tmp_path / self.filename)
         hdu1 = fits.PrimaryHDU()
@@ -39,7 +36,6 @@ class TestFits2Bitmap:
         hdulist.writeto(filename)
         main([filename, "-e", "1"])
 
-    @pytest.mark.openfiles_ignore
     def test_exten_name(self, tmp_path):
         filename = str(tmp_path / self.filename)
         hdu1 = fits.PrimaryHDU()
@@ -56,7 +52,6 @@ class TestFits2Bitmap:
         fits.writeto(filename, self.array)
         main([filename, "-e", "0"])
 
-    @pytest.mark.openfiles_ignore
     def test_orientation(self, tmp_path):
         """
         Regression test to check the image vertical orientation/origin.

--- a/docs/common_links.txt
+++ b/docs/common_links.txt
@@ -148,7 +148,6 @@
 .. _pytest: https://pytest.org/en/latest/index.html
 .. _pytest-astropy: https://github.com/astropy/pytest-astropy
 .. _pytest-doctestplus: https://github.com/astropy/pytest-doctestplus
-.. _pytest-openfiles: https://github.com/astropy/pytest-openfiles
 .. _pytest-remotedata: https://github.com/astropy/pytest-remotedata
 
 .. fsspec

--- a/docs/development/testguide.rst
+++ b/docs/development/testguide.rst
@@ -209,28 +209,6 @@ Astropy Test Function
 Test-running options
 ====================
 
-.. _open-files:
-
-Testing for open files
-----------------------
-
-Using the :ref:`openfiles-plugin` plugin (which is installed automatically
-when installing pytest-astropy),  we can test whether any of the unit tests
-inadvertently leave any files open.  Since this greatly slows down the time it
-takes to run the tests, it is turned off by default.
-
-To use it from the commandline, do::
-
-    pytest --open-files
-
-To use it from Python, do::
-
-    >>> import astropy
-    >>> astropy.test(open_files=True)
-
-For more information on the ``pytest-openfiles`` plugin see
-:ref:`openfiles-plugin`
-
 Test coverage reports
 ---------------------
 
@@ -1119,20 +1097,3 @@ The Astropy test runner enables both of these options by default. When running
 the test suite directly from ``pytest`` (instead of through the Astropy test
 runner), it is necessary to explicitly provide these options when they are
 needed.
-
-.. _openfiles-plugin:
-
-pytest-openfiles
-================
-
-The `pytest-openfiles`_ plugin allows for the detection of open I/O resources
-at the end of unit tests. This plugin adds the ``--open-files`` option to the
-``pytest`` command (which is also exposed through the Astropy test runner).
-
-When running tests with ``--open-files``, if a file is opened during the course
-of a unit test but that file  not closed before the test finishes, the test
-will fail. This is particularly useful for testing code that manipulates file
-handles or other I/O resources. It allows developers to ensure that this kind
-of code properly cleans up I/O resources when they are no longer needed.
-
-Also see :ref:`open-files`.

--- a/docs/development/testguide.rst
+++ b/docs/development/testguide.rst
@@ -209,6 +209,16 @@ Astropy Test Function
 Test-running options
 ====================
 
+.. _open-files:
+
+Testing for open files
+----------------------
+
+There is a configuration inside the ``setup.cfg`` file that converts all
+unhandled warnings to errors during a test run. As a result, any open file(s)
+that throw ``ResourceWarning`` (except the specific ones already ignored)
+would fail the affected test(s).
+
 Test coverage reports
 ---------------------
 
@@ -218,7 +228,7 @@ automatically when installing pytest-astropy) by using e.g.::
 
     pytest --cov astropy --cov-report html
 
-There is some configuration inside the ``setup.cfg`` file that
+There is some configuration inside the ``pyproject.toml`` file that
 defines files to omit as well as lines to exclude.
 
 Running tests in parallel

--- a/setup.cfg
+++ b/setup.cfg
@@ -125,7 +125,6 @@ norecursedirs =
 astropy_header = true
 doctest_plus = enabled
 text_file_format = rst
-open_files_ignore = "astropy.log" "/etc/hosts" "*.ttf"
 remote_data_strict = true
 addopts = --color=yes --doctest-rst
 xfail_strict = true

--- a/tox.ini
+++ b/tox.ini
@@ -83,9 +83,6 @@ deps =
     # ipython did not pin traitlets, so we have to
     oldestdeps: traitlets<4.1
 
-    # pytest-openfiles pinned because of https://github.com/astropy/astropy/issues/10160 (takes too long)
-    alldeps: pytest-openfiles==0.4.0
-
     # The devdeps factor is intended to be used to install the latest developer version
     # or nightly wheel of key dependencies.
     # Do not install asdf-astropy so we can test astropy.io.misc.asdf until we remove it.
@@ -100,7 +97,6 @@ deps =
     devinfra: git+https://github.com/astropy/extension-helpers.git
     devinfra: git+https://github.com/astropy/pytest-doctestplus.git
     devinfra: git+https://github.com/astropy/pytest-remotedata.git
-    devinfra: git+https://github.com/astropy/pytest-openfiles.git
     devinfra: git+https://github.com/astropy/pytest-astropy-header.git
     devinfra: git+https://github.com/astropy/pytest-arraydiff.git
     devinfra: git+https://github.com/astropy/pytest-filter-subpackage.git
@@ -183,7 +179,6 @@ commands =
                 --collect-submodules=py \
                 --hidden-import pytest \
                 --hidden-import pytest_astropy.plugin \
-                --hidden-import pytest_openfiles.plugin \
                 --hidden-import pytest_remotedata.plugin \
                 --hidden-import pytest_doctestplus.plugin \
                 --hidden-import pytest_mpl.plugin


### PR DESCRIPTION
As demonstrated in #14040 we no longer need to use `pytest-openfiles` to fail the test build if files are left open. This PR purges any mention of it from basically everywhere. I split the test runner changes into a different commit because we might not want to break that if it's still in use downstream somewhere?

Close #14040 