### PR TITLE
Add support for degrees Celsius to FITS format

### DIFF
--- a/astropy/units/format/fits.py
+++ b/astropy/units/format/fits.py
@@ -28,7 +28,12 @@ class Fits(generic.Generic):
     def _generate_unit_names():
         from astropy import units as u
 
-        names = {}
+        # add some units up-front for which we don't want to use prefixes
+        # and that have different names from the astropy default.
+        names = {
+            "Celsius": u.deg_C,
+            "deg C": u.deg_C,
+        }
         deprecated_names = set()
         bases = [
             "m", "g", "s", "rad", "sr", "K", "A", "mol", "cd",

--- a/astropy/units/si.py
+++ b/astropy/units/si.py
@@ -252,7 +252,7 @@ def_unit(
     ["deg_C", "Celsius"],
     namespace=_ns,
     doc="Degrees Celsius",
-    format={"latex": r"{}^{\circ}C", "unicode": "°C"},
+    format={"latex": r"{}^{\circ}C", "unicode": "°C", "fits": "Celsius"},
 )
 
 

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -788,3 +788,13 @@ def test_parse_error_message_for_output_only_format(format_):
 def test_unknown_parser():
     with pytest.raises(ValueError, match=r"Unknown.*unicode'\] for output only"):
         u.Unit("m", format="foo")
+
+
+def test_celsius_fits():
+    assert u.Unit("Celsius", format="fits") == u.deg_C
+    assert u.Unit("deg C", format="fits") == u.deg_C
+
+    # check that compounds do what we expect: what do we expect?
+    assert u.Unit("deg C kg-1", format="fits") == u.C * u.deg / u.kg
+    assert u.Unit("Celsius kg-1", format="fits") == u.deg_C / u.kg
+    assert u.deg_C.to_string("fits") == "Celsius"

--- a/docs/changes/units/14042.feature.rst
+++ b/docs/changes/units/14042.feature.rst
@@ -1,0 +1,7 @@
+Add support for degrees Celsius for FITS. Parsing "Celsius" and "deg C" is now
+supported and astropy will output "Celsius" into FITS.
+
+Note that "deg C" is only provided for compatibility with existing FITS files,
+as it does not conform to the normal unit standard, where this should be read
+as "degree * Coulomb". Indeed, compound units like "deg C kg-1" will still be
+parsed as "Coulomb degree per kilogram".


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->


<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #14033 

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
