### PR TITLE
Deprecate passing coord_wrap as bare number

### DIFF
--- a/astropy/visualization/wcsaxes/coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/coordinate_helpers.py
@@ -207,6 +207,15 @@ class CoordinateHelper:
 
         self.coord_type = coord_type
 
+        if coord_wrap is not None:
+            if not isinstance(coord_wrap, u.Quantity):
+                warnings.warn(
+                    "Passing 'coord_wrap' as a number is deprecated. Use a Quantity with units convertible to angular degrees instead.",
+                    AstropyDeprecationWarning,
+                )
+            else:
+                coord_wrap = coord_wrap.to_value(u.deg)
+
         if coord_type == "longitude" and coord_wrap is None:
             self.coord_wrap = 360
         elif coord_type != "longitude" and coord_wrap is not None:

--- a/astropy/visualization/wcsaxes/coordinate_range.py
+++ b/astropy/visualization/wcsaxes/coordinate_range.py
@@ -37,7 +37,7 @@ def find_coordinate_range(transform, extent, coord_types, coord_units, coord_wra
         ``'scalar'`` value.
     coord_units : list of `astropy.units.Unit`
         The units for each coordinate.
-    coord_wraps : list of float
+    coord_wraps : list of `astropy.units.Quantity`
         The wrap angles for longitudes.
     """
     # Sample coordinates on a NX x NY grid.
@@ -118,8 +118,8 @@ def find_coordinate_range(transform, extent, coord_types, coord_units, coord_wra
         x_range = xw_max - xw_min
         if coord_type == "longitude":
             if x_range > 300.0:
-                xw_min = coord_wraps[coord_index] - 360
-                xw_max = coord_wraps[coord_index] - np.spacing(360.0)
+                xw_min = coord_wraps[coord_index].to_value(u.deg) - 360
+                xw_max = coord_wraps[coord_index].to_value(u.deg) - np.spacing(360.0)
             elif xw_min < 0.0:
                 xw_min = max(-180.0, xw_min - 0.1 * x_range)
                 xw_max = min(+180.0, xw_max + 0.1 * x_range)

--- a/astropy/visualization/wcsaxes/tests/test_images.py
+++ b/astropy/visualization/wcsaxes/tests/test_images.py
@@ -646,7 +646,7 @@ class TestBasic(BaseImageTests):
 
         ax.imshow(np.zeros([1024, 1024]), origin="lower")
 
-        ax.coords[0].set_coord_type("longitude", coord_wrap=180)
+        ax.coords[0].set_coord_type("longitude", coord_wrap=180 * u.deg)
         ax.coords[1].set_coord_type("latitude")
 
         ax.coords[0].set_major_formatter("s.s")

--- a/astropy/visualization/wcsaxes/tests/test_misc.py
+++ b/astropy/visualization/wcsaxes/tests/test_misc.py
@@ -404,11 +404,11 @@ def test_invalid_slices_errors(ignore_matplotlibrc):
 EXPECTED_REPR_1 = """
 <CoordinatesMap with 3 world coordinates:
 
-  index            aliases                type   unit wrap format_unit visible
-  ----- ------------------------------ --------- ---- ---- ----------- -------
-      0                   distmod dist    scalar      None                  no
-      1 pos.galactic.lon glon-car glon longitude  deg  360         deg     yes
-      2 pos.galactic.lat glat-car glat  latitude  deg None         deg     yes
+  index            aliases                type   ...    wrap   format_unit visible
+  ----- ------------------------------ --------- ... --------- ----------- -------
+      0                   distmod dist    scalar ...      None                  no
+      1 pos.galactic.lon glon-car glon longitude ... 360.0 deg         deg     yes
+      2 pos.galactic.lat glat-car glat  latitude ...      None         deg     yes
 
 >
  """.strip()
@@ -416,11 +416,11 @@ EXPECTED_REPR_1 = """
 EXPECTED_REPR_2 = """
 <CoordinatesMap with 3 world coordinates:
 
-  index            aliases                type   unit wrap format_unit visible
-  ----- ------------------------------ --------- ---- ---- ----------- -------
-      0                   distmod dist    scalar      None                 yes
-      1 pos.galactic.lon glon-car glon longitude  deg  360         deg     yes
-      2 pos.galactic.lat glat-car glat  latitude  deg None         deg     yes
+  index            aliases                type   ...    wrap   format_unit visible
+  ----- ------------------------------ --------- ... --------- ----------- -------
+      0                   distmod dist    scalar ...      None                 yes
+      1 pos.galactic.lon glon-car glon longitude ... 360.0 deg         deg     yes
+      2 pos.galactic.lat glat-car glat  latitude ...      None         deg     yes
 
 >
  """.strip()

--- a/astropy/visualization/wcsaxes/tests/test_transform_coord_meta.py
+++ b/astropy/visualization/wcsaxes/tests/test_transform_coord_meta.py
@@ -75,7 +75,7 @@ class TestTransformCoordMeta(BaseImageTests):
 
         coord_meta = {}
         coord_meta["type"] = ("longitude", "latitude")
-        coord_meta["wrap"] = (360.0, None)
+        coord_meta["wrap"] = (360.0 * u.deg, None)
         coord_meta["unit"] = (u.deg, u.deg)
         coord_meta["name"] = "lon", "lat"
 
@@ -126,7 +126,7 @@ class TestTransformCoordMeta(BaseImageTests):
 
         coord_meta = {}
         coord_meta["type"] = ("longitude", "latitude")
-        coord_meta["wrap"] = (360.0, None)
+        coord_meta["wrap"] = (360.0 * u.deg, None)
         coord_meta["unit"] = (u.deg, u.deg)
         coord_meta["name"] = "lon", "lat"
         fig = plt.figure(figsize=(4, 4))

--- a/astropy/visualization/wcsaxes/tests/test_wcsapi.py
+++ b/astropy/visualization/wcsaxes/tests/test_wcsapi.py
@@ -179,7 +179,7 @@ def test_coord_type_from_ctype(cube_wcs):
 
     assert coord_meta["type"] == ["longitude", "latitude"]
     assert coord_meta["format_unit"] == [u.arcsec, u.arcsec]
-    assert coord_meta["wrap"] == [180.0, None]
+    assert coord_meta["wrap"] == [180.0 * u.deg, None]
 
     _, coord_meta = transform_coord_meta_from_wcs(
         wcs, RectangularFrame, slices=("y", "x")
@@ -205,7 +205,7 @@ def test_coord_type_from_ctype(cube_wcs):
 
     assert coord_meta["type"] == ["longitude", "latitude"]
     assert coord_meta["format_unit"] == [u.deg, u.deg]
-    assert coord_meta["wrap"] == [180.0, None]
+    assert coord_meta["wrap"] == [180.0 * u.deg, None]
 
     wcs = WCS(naxis=2)
     wcs.wcs.ctype = ["CRLN-TAN", "CRLT-TAN"]
@@ -218,7 +218,7 @@ def test_coord_type_from_ctype(cube_wcs):
 
     assert coord_meta["type"] == ["longitude", "latitude"]
     assert coord_meta["format_unit"] == [u.deg, u.deg]
-    assert coord_meta["wrap"] == [360.0, None]
+    assert coord_meta["wrap"] == [360.0 * u.deg, None]
 
     wcs = WCS(naxis=2)
     wcs.wcs.ctype = ["RA---TAN", "DEC--TAN"]
@@ -373,7 +373,7 @@ def test_sliced_ND_input(wcs_4d, sub_wcs, wcs_slice, plt_close):
             ("custom:pos.helioprojective.lon", "hpln-tan", "hpln"),
         ]
         assert coord_meta["type"] == ["scalar", "latitude", "longitude"]
-        assert coord_meta["wrap"] == [None, None, 180.0]
+        assert coord_meta["wrap"] == [None, None, 180.0 * u.deg]
         assert coord_meta["unit"] == [u.Unit("min"), u.Unit("deg"), u.Unit("deg")]
         assert coord_meta["visible"] == [False, True, True]
         assert coord_meta["format_unit"] == [

--- a/astropy/visualization/wcsaxes/wcsapi.py
+++ b/astropy/visualization/wcsaxes/wcsapi.py
@@ -63,21 +63,21 @@ def transform_coord_meta_from_wcs(wcs, frame_class, slices=None):
             axis_type_split = axis_type.split(".")
 
             if "pos.helioprojective.lon" in axis_type:
-                coord_wrap = 180.0
+                coord_wrap = 180.0 * u.deg
                 format_unit = u.arcsec
                 coord_type = "longitude"
             elif "pos.helioprojective.lat" in axis_type:
                 format_unit = u.arcsec
                 coord_type = "latitude"
             elif "pos.heliographic.stonyhurst.lon" in axis_type:
-                coord_wrap = 180.0
+                coord_wrap = 180.0 * u.deg
                 format_unit = u.deg
                 coord_type = "longitude"
             elif "pos.heliographic.stonyhurst.lat" in axis_type:
                 format_unit = u.deg
                 coord_type = "latitude"
             elif "pos.heliographic.carrington.lon" in axis_type:
-                coord_wrap = 360.0
+                coord_wrap = 360.0 * u.deg
                 format_unit = u.deg
                 coord_type = "longitude"
             elif "pos.heliographic.carrington.lat" in axis_type:

--- a/docs/changes/visualization/14050.api.rst
+++ b/docs/changes/visualization/14050.api.rst
@@ -1,0 +1,2 @@
+Passing a bare number as the ``coord_wrap`` argument to ``CoordinateHelper.set_coord_type`` is deprecated.
+Pass a ``Quantity`` with units equivalent to angular degrees instead.

--- a/docs/changes/visualization/14050.api.rst
+++ b/docs/changes/visualization/14050.api.rst
@@ -1,2 +1,4 @@
 Passing a bare number as the ``coord_wrap`` argument to ``CoordinateHelper.set_coord_type`` is deprecated.
 Pass a ``Quantity`` with units equivalent to angular degrees instead.
+
+The ``.coord_wrap`` attribute of ``CoordinateHelper`` is now a ``Quantity`` instead of a bare number.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This PR deprecates passing `coord_wrap` as a bare number. Still needs a changelog. Fixes https://github.com/astropy/astropy/issues/8868

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
