### PR TITLE
Make sure the main CI runs on release branches

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
     - main
+    - 'v*'
     tags:
     - '*'
   pull_request:


### PR DESCRIPTION
The main CI workflow isn't running on v5.2.x currently.

It looks like v5.0.x was manually patched to make it run but we should fix this properly in main as done here and backported to v5.2.x.