### PR TITLE
replace all `..` imports

### DIFF
--- a/astropy/coordinates/builtin_frames/cirs_observed_transforms.py
+++ b/astropy/coordinates/builtin_frames/cirs_observed_transforms.py
@@ -8,13 +8,13 @@ import numpy as np
 
 from astropy import units as u
 from astropy.coordinates.baseframe import frame_transform_graph
+from astropy.coordinates.erfa_astrom import erfa_astrom
 from astropy.coordinates.representation import (
     SphericalRepresentation,
     UnitSphericalRepresentation,
 )
 from astropy.coordinates.transformations import FunctionTransformWithFiniteDifference
 
-from ..erfa_astrom import erfa_astrom
 from .altaz import AltAz
 from .cirs import CIRS
 from .hadec import HADec

--- a/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
@@ -8,6 +8,7 @@ import numpy as np
 
 from astropy import units as u
 from astropy.coordinates.baseframe import frame_transform_graph
+from astropy.coordinates.erfa_astrom import erfa_astrom
 from astropy.coordinates.representation import (
     CartesianRepresentation,
     SphericalRepresentation,
@@ -18,7 +19,6 @@ from astropy.coordinates.transformations import (
     FunctionTransformWithFiniteDifference,
 )
 
-from ..erfa_astrom import erfa_astrom
 from .cirs import CIRS
 from .gcrs import GCRS
 from .hcrs import HCRS

--- a/astropy/coordinates/builtin_frames/icrs_observed_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_observed_transforms.py
@@ -7,6 +7,7 @@ import erfa
 from astropy import units as u
 from astropy.coordinates.baseframe import frame_transform_graph
 from astropy.coordinates.builtin_frames.utils import atciqz, aticq
+from astropy.coordinates.erfa_astrom import erfa_astrom
 from astropy.coordinates.representation import (
     CartesianRepresentation,
     SphericalRepresentation,
@@ -14,7 +15,6 @@ from astropy.coordinates.representation import (
 )
 from astropy.coordinates.transformations import FunctionTransformWithFiniteDifference
 
-from ..erfa_astrom import erfa_astrom
 from .altaz import AltAz
 from .hadec import HADec
 from .icrs import ICRS

--- a/astropy/coordinates/builtin_frames/utils.py
+++ b/astropy/coordinates/builtin_frames/utils.py
@@ -11,11 +11,10 @@ import numpy as np
 
 from astropy import units as u
 from astropy.coordinates.earth import EarthLocation
+from astropy.coordinates.representation import CartesianDifferential
 from astropy.time import Time
 from astropy.utils import iers
 from astropy.utils.exceptions import AstropyWarning
-
-from ..representation import CartesianDifferential
 
 # We use tt as the time scale for this equinoxes, primarily because it is the
 # convention for J2000 (it is unclear if there is any "right answer" for B1950)

--- a/astropy/io/ascii/cparser.pyx
+++ b/astropy/io/ascii/cparser.pyx
@@ -23,8 +23,9 @@ from cpython.buffer cimport (
 )
 from libc cimport stdio
 
-from ...utils.data import get_readable_fileobj
-from ...utils.exceptions import AstropyWarning
+from astropy.utils.data import get_readable_fileobj
+from astropy.utils.exceptions import AstropyWarning
+
 from . import core
 
 
@@ -979,7 +980,7 @@ cdef class FastWriter:
                   fill_exclude_names=None,
                   fast_writer=True):
 
-        from ...table import pprint  # Here to avoid circular import
+        from astropy.table import pprint  # Here to avoid circular import
 
         if fast_writer is True:
             fast_writer = {}

--- a/astropy/units/format/generic.py
+++ b/astropy/units/format/generic.py
@@ -205,7 +205,7 @@ class Generic(Base):
             structured_unit : subunit COMMA
                             | subunit COMMA subunit
             """
-            from ..structured import StructuredUnit
+            from astropy.units.structured import StructuredUnit
 
             inputs = (p[1],) if len(p) == 3 else (p[1], p[3])
             units = ()

--- a/astropy/units/format/utils.py
+++ b/astropy/units/format/utils.py
@@ -7,9 +7,8 @@ Utilities shared by the different formats.
 
 import warnings
 
+from astropy.units.utils import maybe_simple_fraction
 from astropy.utils.misc import did_you_mean
-
-from ..utils import maybe_simple_fraction
 
 
 def get_grouped_by_powers(bases, powers):

--- a/astropy/wcs/utils.py
+++ b/astropy/wcs/utils.py
@@ -946,7 +946,7 @@ def _sip_fit(params, lon, lat, u, v, w_obj, order, coeff_names):
         WCS object
     """
 
-    from ..modeling.models import SIP  # here to avoid circular import
+    from astropy.modeling.models import SIP  # here to avoid circular import
 
     # unpack params
     crpix = params[0:2]


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

### Description

Fixes #14021 

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
