### PR TITLE
Catch changed URLError message from `ftp_open`

### DIFF
--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -1284,7 +1284,8 @@ def _download_file_from_source(
             )
         except urllib.error.URLError as e:
             # e.reason might not be a string, e.g. socket.gaierror
-            if str(e.reason).startswith("ftp error: error_perm"):
+            # URLError changed to report original exception in Python 3.10, 3.11 (bpo-43564)
+            if str(e.reason).lstrip("ftp error: ").startswith(("error_perm", "5")):
                 ftp_tls = True
             else:
                 raise

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -2138,8 +2138,10 @@ def test_clear_download_cache_variants(temp_cache, valid_urls):
     assert not is_url_in_cache(u)
 
 
-@pytest.mark.skipif(CI and os.environ.get("IS_CRON", "false") == "false",
-                    reason="Flaky/too much external traffic for regular CI")
+@pytest.mark.skipif(
+    CI and os.environ.get("IS_CRON", "false") == "false",
+    reason="Flaky/too much external traffic for regular CI",
+)
 @pytest.mark.remote_data
 def test_ftp_tls_auto(temp_cache):
     """Test that download automatically enables TLS/SSL when required"""

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -59,7 +59,7 @@ from astropy.utils.data import (
 )
 from astropy.utils.exceptions import AstropyWarning
 
-CI = os.environ.get("CI", False) == "true"
+CI = os.environ.get("CI", "false") == "true"
 TESTURL = "http://www.astropy.org"
 TESTURL2 = "http://www.astropy.org/about.html"
 TESTURL_SSL = "https://www.astropy.org"
@@ -2138,10 +2138,13 @@ def test_clear_download_cache_variants(temp_cache, valid_urls):
     assert not is_url_in_cache(u)
 
 
-@pytest.mark.skipif("CI", reason="Flaky on CI")
+@pytest.mark.skipif(CI and os.environ.get("IS_CRON", "false") == "false",
+                    reason="Flaky/too much external traffic for regular CI")
 @pytest.mark.remote_data
 def test_ftp_tls_auto(temp_cache):
-    url = "ftp://anonymous:mail%40astropy.org@gdc.cddis.eosdis.nasa.gov/pub/products/iers/finals2000A.all"  # noqa: E501
+    """Test that download automatically enables TLS/SSL when required"""
+
+    url = "ftp://anonymous:mail%40astropy.org@gdc.cddis.eosdis.nasa.gov/pub/products/iers/finals2000A.daily"  # noqa: E501
     download_file(url)
 
 

--- a/docs/changes/utils/14092.bugfix.rst
+++ b/docs/changes/utils/14092.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed an incompatibility with latest Python 3.1x versions that kept
+``astropy.utils.data.download_file`` from switching to TLS+FTP mode.


### PR DESCRIPTION
### Description
This pull request is to address a change in raising exceptions in `ftp_open` in latest Pythons to handle them in `_download_file_from_source`.

Fixes #14091

This is using the more general check discussed there to catch any permission (type 5NN) exceptions.
In released Python 3.11.0 the exception has been changed to 
`raise URLError(f'ftp error: {exp}') from exp`
vs. 
`raise URLError(exp) from exp`
in 3.10.8, 3.12a2 and main, so that may change again in the next 3.11 release – catching all 3 versions here.
Also giving `test_ftp_tls_auto` a new try here.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.

