### PR TITLE
Bug fixes in io.votable.validator.validator.make_validation_report (#14099)

### DIFF
--- a/astropy/io/votable/validator/main.py
+++ b/astropy/io/votable/validator/main.py
@@ -124,8 +124,10 @@ def make_validation_report(
         with Spinner("Loading URLs", "green") as s:
             urls = get_urls(destdir, s)
     else:
+        urls = [url.encode() for url in urls if isinstance(url, str)]
+
         color_print("Marking URLs", "green")
-        for url in ProgressBar.iterate(urls):
+        for url in ProgressBar(urls):
             with result.Result(url, root=destdir) as r:
                 r["expected"] = type
 

--- a/docs/changes/io.votable/14102.bugfix.rst
+++ b/docs/changes/io.votable/14102.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed two bugs in validator.validator.make_validation_report:
+- ProgressBar iterator was not called correctly.
+- make_validation_report now handles input string urls correctly.


### PR DESCRIPTION
### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->


This pull request is to address a bug in `io.votable.validator.validator.make_validation_report` that fails with basic usage. It fixes #14099.

- Calling `make_validation_report` fails because ProgressBar has no iterate method. To fix it,`ProgressBar.iterate(urls)` is replaced with `ProgressBar(urls)` to initiate the iterator.
- `make_validation_report` fails when a `urls` is a list of `str`. The fix is to encode `url` if it is a `str` in io/votable/validator/result.py

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
