### PR TITLE
DOC: Clarify CI and pre-commit usage

### DIFF
--- a/docs/development/workflow/development_workflow.rst
+++ b/docs/development/workflow/development_workflow.rst
@@ -161,8 +161,7 @@ when you make a git commit using our provided `pre-commit hook <https://pre-comm
 for git, for more information see
 `git hooks <https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks#_git_hooks>`_.
 We encourage you to setup and use these hooks to ensure that your code always meets
-our coding style standards. This can be done by installing ``pre-commit`` in the root
-of your astropy repository by running::
+our coding style standards. The easiest way to do this is by installing ``pre-commit``::
 
     pip install pre-commit
 
@@ -170,7 +169,8 @@ Or if you prefer `conda`_::
 
     conda install pre-commit
 
-Followed by::
+This next command needs be done by installing ``pre-commit`` in the **root**
+of your astropy repository by running::
 
     pre-commit install
 
@@ -193,6 +193,10 @@ If you do not want to use ``pre-commit`` as part of your git workflow, you can
 still run the checks manually (see, :ref:`code-style`) using::
 
   tox -e codestyle
+
+Or this will run whether you did ``pre-commit install`` or not::
+
+  pre-commit run
 
 Again, this will automatically apply the necessary changes to your code if possible.
 
@@ -501,6 +505,7 @@ it into Astropy:
    the maintainers know that your work is not ready for a full review nor to be
    merged yet. In addition, if your commits are not ready for CI testing, you
    should also use ``[ci skip]`` or ``[skip ci]`` directive in your commit message.
+   For usage of pre-commit hooks and directives, see :ref:`pre-commit` and :ref:`pre-commit_bot`.
 
 .. _revise and push:
 

--- a/docs/development/workflow/maintainer_workflow.rst
+++ b/docs/development/workflow/maintainer_workflow.rst
@@ -130,6 +130,10 @@ One can control the bot by making comments on the pull request:
 .. note::
   These comments must appear in the comment on a single line by themselves.
 
+.. note::
+  If you wish to run the pre-commit check first in CI without running Actions,
+  use ``[skip actions]`` or ``[actions skip]`` in your commit message.
+
 .. _milestones-and-labels:
 
 ===========================


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to clarify 2 things that came up in dev telecon:

1. Emphasize a little more that "pre-commit install" should happen inside source checkout.
2. Tip on how to run only pre-commit bot without running CI in Actions. Also see https://docs.github.com/en/actions/managing-workflow-runs/skipping-workflow-runs

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
