### PR TITLE
Enable `fsspec` remote tests

### DIFF
--- a/astropy/io/fits/tests/test_fsspec.py
+++ b/astropy/io/fits/tests/test_fsspec.py
@@ -1,6 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Can `astropy.io.fits.open` access (remote) data using the fsspec package?
 """
+import os
+
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose, assert_array_equal
@@ -108,6 +110,11 @@ class TestFsspecRemote:
                 assert "partially read" in repr(hdul)
                 assert "partially read" in str(hdul)
 
+    @pytest.mark.skipif(
+        os.environ.get("CI", "false") == "true"
+        and os.environ.get("IS_CRON", "false") != "true",
+        reason="S3 downloads may become too expensive",
+    )
     @pytest.mark.skipif(not HAS_S3FS, reason="requires s3fs")
     def test_fsspec_s3(self):
         """Can we use fsspec to open a FITS file in a public Amazon S3 bucket?"""

--- a/docs/io/fits/usage/cloud.rst
+++ b/docs/io/fits/usage/cloud.rst
@@ -102,7 +102,7 @@ prefix ``s3://`` (Amazon S3 Storage) or ``gs://`` (Google Cloud Storage),
 `open` will automatically default to ``use_fsspec=True`` for convenience.
 For example:
 
-.. doctest-requires:: fsspec
+.. doctest-requires:: s3fs
 
     >>> # Download a small 10-by-20 pixel cutout from a FITS file stored in Amazon S3
     >>> with fits.open(s3_uri, fsspec_kwargs={"anon": True}) as hdul:  # doctest: +REMOTE_DATA
@@ -175,7 +175,7 @@ We also know that the radius of the galaxy is approximately 5 arcseconds::
 Given this sky position and radius, we can use `~astropy.nddata.Cutout2D`
 in combination with ``use_fsspec=True`` and ``.section`` as follows:
 
-.. doctest-requires:: fsspec
+.. doctest-requires:: s3fs
 
     >>> from astropy.nddata import Cutout2D
     >>> from astropy.wcs import WCS

--- a/setup.cfg
+++ b/setup.cfg
@@ -69,7 +69,7 @@ test_all =  # Required for testing, plus packages used by particular tests.
     ipython>=4.2
     coverage[toml]
     fsspec[http]>=2022.8.2
-    s3fs
+    s3fs>=2022.8.2
     skyfield>=1.20
     sgp4>=2.3
     pooch
@@ -153,6 +153,8 @@ filterwarnings =
     ignore:the imp module is deprecated:DeprecationWarning
     # toolz internal deprecation warning https://github.com/pytoolz/toolz/issues/500
     ignore:The toolz\.compatibility module is no longer needed:DeprecationWarning
+    # Triggered by botocore (s3fs dependency)
+    ignore:'cgi' is deprecated and slated for removal in Python 3.13:DeprecationWarning
     # Ignore a warning we emit about not supporting the parallel
     # reading option for now, can be removed once the issue is fixed
     ignore:parallel reading does not currently work, so falling back to serial

--- a/setup.cfg
+++ b/setup.cfg
@@ -68,8 +68,6 @@ test_all =  # Required for testing, plus packages used by particular tests.
     objgraph
     ipython>=4.2
     coverage[toml]
-    fsspec[http]>=2022.8.2
-    s3fs>=2022.8.2
     skyfield>=1.20
     sgp4>=2.3
     pooch

--- a/setup.cfg
+++ b/setup.cfg
@@ -69,6 +69,7 @@ test_all =  # Required for testing, plus packages used by particular tests.
     ipython>=4.2
     coverage[toml]
     fsspec[http]>=2022.8.2
+    s3fs
     skyfield>=1.20
     sgp4>=2.3
     pooch

--- a/setup.cfg
+++ b/setup.cfg
@@ -68,6 +68,7 @@ test_all =  # Required for testing, plus packages used by particular tests.
     objgraph
     ipython>=4.2
     coverage[toml]
+    fsspec[http]>=2022.8.2
     skyfield>=1.20
     sgp4>=2.3
     pooch


### PR DESCRIPTION
### Description
On running the full `io.fits` tests with remote data enabled and `fsspec` dependencies installed, `test_ignore_sigint` fails on raising the expected warnings if `test_fsspec_http` was run previously:
```python
    @ignore_sigint
    def test():
>       with pytest.warns(UserWarning) as w:
E       Failed: DID NOT WARN. No warnings of type (<class 'UserWarning'>,) were emitted. The list of emitted warnings is: [].

/opt/lib/python3.10/site-packages/astropy/io/fits/tests/test_util.py:27: Failed
```
This has only been observed in some macOS 12 environments so far, but as `test_fsspec_http` is not currently run in any CI environment, would have been missed.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
