### PR TITLE
Raise ValueError in Quantity.__bool__ instead of issuing DeprecationWarning

### DIFF
--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -19,7 +19,7 @@ import numpy as np
 from astropy import config as _config
 from astropy.utils.compat import NUMPY_LT_1_22
 from astropy.utils.data_info import ParentDtypeInfo
-from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyWarning
+from astropy.utils.exceptions import AstropyWarning
 from astropy.utils.misc import isiterable
 
 from .core import (
@@ -1320,15 +1320,13 @@ class Quantity(np.ndarray):
     # __contains__ is OK
 
     def __bool__(self):
-        """Quantities should always be treated as non-False; there is too much
-        potential for ambiguity otherwise.
+        """This method raises ValueError, since truthiness of quantities is ambiguous,
+        especially for logarithmic units and temperatures. Use explicit comparisons.
         """
-        warnings.warn(
-            "The truth value of a Quantity is ambiguous. "
-            "In the future this will raise a ValueError.",
-            AstropyDeprecationWarning,
+        raise ValueError(
+            f"{type(self).__name__} truthiness is ambiguous, especially for logarithmic units"
+            " and temperatures. Use explicit comparisons."
         )
-        return True
 
     def __len__(self):
         if self.isscalar:

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -14,7 +14,7 @@ from numpy.testing import assert_allclose, assert_array_almost_equal, assert_arr
 from astropy import units as u
 from astropy.units.quantity import _UNIT_NOT_INITIALISED
 from astropy.utils import isiterable, minversion
-from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyWarning
+from astropy.utils.exceptions import AstropyWarning
 
 """ The Quantity class will represent a number + unit + uncertainty """
 
@@ -587,15 +587,8 @@ class TestQuantityOperations:
         assert not 1.0 * u.cm == 1.0
         assert 1.0 * u.cm != 1.0
 
-        # comparison with zero should raise a deprecation warning
         for quantity in (1.0 * u.cm, 1.0 * u.dimensionless_unscaled):
-            with pytest.warns(
-                AstropyDeprecationWarning,
-                match=(
-                    "The truth value of a Quantity is ambiguous. "
-                    "In the future this will raise a ValueError."
-                ),
-            ):
+            with pytest.raises(ValueError, match="ambiguous"):
                 bool(quantity)
 
     def test_numeric_converters(self):

--- a/docs/changes/units/14124.api.rst
+++ b/docs/changes/units/14124.api.rst
@@ -1,0 +1,5 @@
+The conversion of ``astropy.units.Quantity`` to ``bool``
+that was deprecated since astropy 3.0 now raises a ``ValueError``.
+This affects statements like ``if quantity``.
+Use explicit comparisons like ``if quantity.value != 0``
+or ``if quantity is not None`` instead.


### PR DESCRIPTION


<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request converts the deprecation warning in `Quantity.__bool__` into the promised `ValueError`. The deprecation warning was raised since astropy 3.0 more than 5 years ago.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
