### PR TITLE
Numpy dev 1.25 bugfixes

### DIFF
--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -27,6 +27,7 @@ from astropy.table import (
 )
 from astropy.tests.helper import assert_follows_unicode_guidelines
 from astropy.time import Time, TimeDelta
+from astropy.utils.compat import NUMPY_LT_1_25
 from astropy.utils.compat.optional_deps import HAS_PANDAS
 from astropy.utils.data import get_pkg_data_filename
 from astropy.utils.exceptions import AstropyUserWarning
@@ -1568,12 +1569,21 @@ def test_values_equal_part1():
         # Shape mismatch
         t3.values_equal(t1)
 
-    with pytest.raises(ValueError, match="unable to compare column c"):
-        # Type mismatch in column c causes FutureWarning
-        t1.values_equal(2)
+    if NUMPY_LT_1_25:
+        with pytest.raises(ValueError, match="unable to compare column c"):
+            # Type mismatch in column c causes FutureWarning
+            t1.values_equal(2)
 
-    with pytest.raises(ValueError, match="unable to compare column c"):
-        t1.values_equal([1, 2])
+        with pytest.raises(ValueError, match="unable to compare column c"):
+            t1.values_equal([1, 2])
+    else:
+        eq = t2.values_equal(2)
+        for col in eq.colnames:
+            assert np.all(eq[col] == [False, True])
+
+        eq = t2.values_equal([1, 2])
+        for col in eq.colnames:
+            assert np.all(eq[col] == [True, True])
 
     eq = t2.values_equal(t2)
     for col in eq.colnames:

--- a/astropy/utils/compat/numpycompat.py
+++ b/astropy/utils/compat/numpycompat.py
@@ -14,6 +14,7 @@ __all__ = [
     "NUMPY_LT_1_22_1",
     "NUMPY_LT_1_23",
     "NUMPY_LT_1_24",
+    "NUMPY_LT_1_25",
 ]
 
 # TODO: It might also be nice to have aliases to these named for specific
@@ -23,4 +24,5 @@ NUMPY_LT_1_21_1 = not minversion(np, "1.21.1")
 NUMPY_LT_1_22 = not minversion(np, "1.22")
 NUMPY_LT_1_22_1 = not minversion(np, "1.22.1")
 NUMPY_LT_1_23 = not minversion(np, "1.23")
-NUMPY_LT_1_24 = not minversion(np, "1.24dev0")
+NUMPY_LT_1_24 = not minversion(np, "1.24")
+NUMPY_LT_1_25 = not minversion(np, "1.25.0.dev0+151")

--- a/astropy/utils/masked/tests/test_function_helpers.py
+++ b/astropy/utils/masked/tests/test_function_helpers.py
@@ -19,7 +19,7 @@ import pytest
 from numpy.testing import assert_array_equal
 
 from astropy.units.tests.test_quantity_non_ufuncs import get_wrapped_functions
-from astropy.utils.compat import NUMPY_LT_1_23, NUMPY_LT_1_24
+from astropy.utils.compat import NUMPY_LT_1_23, NUMPY_LT_1_24, NUMPY_LT_1_25
 from astropy.utils.masked import Masked, MaskedNDArray
 from astropy.utils.masked.function_helpers import (
     APPLY_TO_BOTH_FUNCTIONS,
@@ -897,7 +897,7 @@ class TestPartitionLikeFunctions:
         assert_array_equal(o.filled(np.nan), expected)
         assert_array_equal(o.mask, np.isnan(expected))
         # Also check that we can give an output MaskedArray.
-        if kwargs.get("keepdims", False):
+        if NUMPY_LT_1_25 and kwargs.get("keepdims", False):
             # numpy bug gh-22714 prevents using out with keepdims=True.
             # This is fixed in numpy 1.25.
             return


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address changes in numpy that have not yet percolated to nightly but will cause tests to fail. Both in fact are improvements that also make astropy just a little better.

See https://github.com/numpy/numpy/pull/22707 and https://github.com/numpy/numpy/pull/22721

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes an issue that @pllim would surely have raised if I hadn't been ahead of the game for once!

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
