### PR TITLE
Enabled the `equal_nan` keyword argument for `np.array_equal()` when the arguments are `astropy.units.Quantity` instances.

### DIFF
--- a/astropy/units/quantity_helper/function_helpers.py
+++ b/astropy/units/quantity_helper/function_helpers.py
@@ -562,9 +562,9 @@ def close(a, b, rtol=1e-05, atol=1e-08, *args, **kwargs):
 
 
 @function_helper
-def array_equal(a1, a2):
+def array_equal(a1, a2, equal_nan=False):
     args, unit = _quantities2arrays(a1, a2)
-    return args, {}, None, None
+    return args, dict(equal_nan=equal_nan), None, None
 
 
 @function_helper

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -924,6 +924,14 @@ class TestReductionLikeFunctions(InvariantUnitTestSetup):
         q3 = q1.value * u.cm
         assert not np.array_equal(q1, q3)
 
+    @pytest.mark.parametrize("equal_nan", [False, True])
+    def test_array_equal_nan(self, equal_nan):
+        q1 = np.linspace(0, 1, num=11) * u.m
+        q1[0] = np.nan
+        q2 = q1.to(u.cm)
+        result = np.array_equal(q1, q2, equal_nan=equal_nan)
+        assert result == equal_nan
+
     @needs_array_function
     def test_array_equiv(self):
         q1 = np.array([[0.0, 1.0, 2.0]] * 3) * u.m

--- a/docs/changes/units/14135.feature.rst
+++ b/docs/changes/units/14135.feature.rst
@@ -1,0 +1,2 @@
+Enabled the ``equal_nan`` keyword argument for ``np.array_equal()`` when the
+arguments are ``astropy.units.Quantity`` instances.


### PR DESCRIPTION
The `equal_nan` keyword argument was added in Numpy 1.19. This PR just adds it to our overload of `np.array_equal`.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
