### PR TITLE
Add doc mention of datetime and leap seconds

### DIFF
--- a/docs/time/index.rst
+++ b/docs/time/index.rst
@@ -1213,13 +1213,13 @@ datetime   :class:`~astropy.time.TimeDeltaDatetime`
 =========  ===================================================
 
 .. warning:: The ``datetime`` format does *not* support instants of time that
-             are leap seconds. This is a 
+             are leap seconds. This is a
              `limitation of the Python standard library datetime object <https://github.com/python/cpython/issues/67762>`_
              not a limitation of Astropy's |Time|. If the upstream datetime
              object is updated to support leap seconds Astropy can follow it,
-             but until then ``t.datetime`` will raise an exception if ``t`` is 
-             a leap second. See 
-             `astropy issue #14112 <https://github.com/astropy/astropy/issues/14112>`_ 
+             but until then ``t.datetime`` will raise an exception if ``t`` is
+             a leap second. See
+             `astropy issue #14112 <https://github.com/astropy/astropy/issues/14112>`_
              for more details.
 
 Examples

--- a/docs/time/index.rst
+++ b/docs/time/index.rst
@@ -1212,6 +1212,16 @@ jd         :class:`~astropy.time.TimeDeltaJD`
 datetime   :class:`~astropy.time.TimeDeltaDatetime`
 =========  ===================================================
 
+.. warning:: The ``datetime`` format does *not* support instants of time that
+             are leap seconds. This is a 
+             `limitation of the Python standard library datetime object <https://github.com/python/cpython/issues/67762>`_
+             not a limitation of Astropy's |Time|. If the upstream datetime
+             object is updated to support leap seconds Astropy can follow it,
+             but until then ``t.datetime`` will raise an exception if ``t`` is 
+             a leap second. See 
+             `astropy issue #14112 <https://github.com/astropy/astropy/issues/14112>`_ 
+             for more details.
+
 Examples
 ^^^^^^^^
 


### PR DESCRIPTION
This PR adds some explanation of why datetime formatting fails for leap seconds - more context for this is in #14112. 

This seemed the most logical spot in the time docs to me, but I can put it somewhere else if there are alternative thoughts where to put it.

Note I did *not* add anything here about the "erfa succeeds when you input a leap second, but with a warning", as I'm not sure we really need to mention that part explicitly in the docs.  But @maxnoe might think otherwise, in which case I can add it.

cc @mhvk @maxnoe @CorentinLouis @taldcroft as interested parties from #14112. 



### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
