### PR TITLE
Fix image test environment in devdocs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,6 @@ v
 
 .tmp
 pip-wheel-metadata
+
+# Files generated if figure tests are run
+results

--- a/docs/development/testguide.rst
+++ b/docs/development/testguide.rst
@@ -775,7 +775,7 @@ hashes and images.
 
 To run the Astropy tests with the image comparison, use e.g.::
 
-    tox -e py39-test-image-mpl311
+    tox -e py39-test-image-mpl311-cov
 
 However, note that the output can be sensitive to the operating system and
 specific version of libraries such as freetype. In general, using tox will


### PR DESCRIPTION
This is another manifestation of https://github.com/astropy/astropy/issues/14052 - for figures tests to pass the environment with `cov` on the end needs to be specificed.

Also .gitignore all the generated images when the tests are run.