### PR TITLE
DOC: Remove CASA, fix VO ref links

### DIFF
--- a/astropy/io/votable/exceptions.py
+++ b/astropy/io/votable/exceptions.py
@@ -318,7 +318,7 @@ class W02(VOTableSpecWarning):
 
     **References**: `1.1
     <http://www.ivoa.net/documents/VOTable/20040811/REC-VOTable-1.1-20040811.html#sec:name>`__,
-    `XML Names <http://www.w3.org/TR/REC-xml/#NT-Name>`__
+    `XML Names <https://www.w3.org/TR/xml-names/>`__
     """
 
     message_template = "{} attribute '{}' is invalid.  Must be a standard XML id"

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -379,41 +379,7 @@ The C libraries currently bundled with ``astropy`` include:
 - `expat <https://libexpat.github.io/>`_ see ``cextern/expat/README`` for the
   bundled version. To use the system version, set ``ASTROPY_USE_SYSTEM_EXPAT=1``.
 
-
-Installing ``astropy`` into CASA
---------------------------------
-
-If you want to be able to use ``astropy`` inside `CASA
-<https://casa.nrao.edu/>`_, the easiest way is to do so from inside CASA.
-
-First, we need to make sure `pip <https://pip.pypa.io>`__ is
-installed. Start up CASA as normal, and then type::
-
-    CASA <2>: from setuptools.command import easy_install
-
-    CASA <3>: easy_install.main(['--user', 'pip'])
-
-Now, quit CASA and re-open it, then type the following to install ``astropy``::
-
-    CASA <2>: import subprocess, sys
-
-    CASA <3>: subprocess.check_call([sys.executable, '-m', 'pip', 'install', '--user', 'astropy'])
-
-Then close CASA again and open it, and you should be able to import ``astropy``::
-
-    CASA <2>: import astropy
-
-Any ``astropy`` affiliated package can be installed the same way (e.g. the
-`spectral-cube <https://spectral-cube.readthedocs.io>`_ or other
-packages that may be useful for radio astronomy).
-
-.. note:: The above instructions have not been tested on all systems.
-   We know of a few examples that do work, but that is not a guarantee
-   that this will work on all systems. If you install ``astropy`` and begin to
-   encounter issues with CASA, please look at the `known CASA issues
-   <https://github.com/astropy/astropy/issues?q=+label%3ACASA-Installation+>`_
-   and if you do not encounter your issue there, please post a new one.
-
+.. _install_astropy_nightly:
 
 Installing pre-built Development Versions of ``astropy``
 --------------------------------------------------------

--- a/docs/io/votable/references.txt
+++ b/docs/io/votable/references.txt
@@ -6,7 +6,7 @@
 .. _FIELDref: http://www.ivoa.net/documents/REC/VOTable/VOTable-20040811.html#ToC31
 .. _FITS: https://fits.gsfc.nasa.gov/fits_documentation.html
 .. _GROUP: http://www.ivoa.net/documents/REC/VOTable/VOTable-20040811.html#ToC31
-.. _ID: http://www.w3.org/TR/REC-xml/#id
+.. _ID: https://www.w3.org/TR/xml-id/
 .. _INFO: http://www.ivoa.net/documents/VOTable/20040811/REC-VOTable-1.1-20040811.html#ToC19
 .. _LINK: http://www.ivoa.net/documents/REC/VOTable/VOTable-20040811.html#ToC22
 .. _multidimensional arrays: http://www.ivoa.net/documents/REC/VOTable/VOTable-20040811.html#ToC12


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to remove CASA from installation page and fix broken links in VO docs.

Fixes #14151

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
