### PR TITLE
TST: No OpenAstronomy template for daily cron, display CI value

### DIFF
--- a/.github/workflows/ci_cron_daily.yml
+++ b/.github/workflows/ci_cron_daily.yml
@@ -33,22 +33,40 @@ permissions:
 
 jobs:
   tests:
+    runs-on: ${{ matrix.os }}
     if: (github.repository == 'astropy/astropy' && (github.event_name == 'schedule' || github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'Extra CI')))
-    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
-    with:
-      submodules: false
-      coverage: codecov
-      toxdeps: "'tox<4'"
-      libraries: |
-        apt:
-          - language-pack-de
-          - tzdata
-      envs: |
-        - name: Bundling with pyinstaller
-          linux: pyinstaller
-          python-version: 3.8
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
 
-        - name: Python 3.10 with all optional dependencies and pre-releases
-          linux: py310-test-alldeps-predeps
-          toxargs: -v
-          toxposargs: --remote-data=any
+          - name: Bundling with pyinstaller
+            os: ubuntu-latest
+            python: 3.8
+            toxenv: pyinstaller
+
+          - name: Python 3.10 with all optional dependencies and pre-releases
+            os: ubuntu-latest
+            python: '3.10'
+            toxenv: py310-test-alldeps-predeps
+            toxargs: -v
+            toxposargs: --remote-data=any
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python }}
+    - name: Install language-pack-de and tzdata
+      if: ${{ matrix.os == 'ubuntu-latest' }}
+      run: |
+        sudo apt-get update
+        sudo apt-get install language-pack-de tzdata
+    - name: Install Python dependencies
+      run: python -m pip install "tox<4"
+    - name: Run tests
+      run: tox ${{ matrix.toxargs}} -e ${{ matrix.toxenv}} -- ${{ matrix.toxposargs}}

--- a/conftest.py
+++ b/conftest.py
@@ -31,6 +31,7 @@ def pytest_configure(config):
 def pytest_report_header(config):
     # This gets added after the pytest-astropy-header output.
     return (
+        f'CI: {os.environ.get("CI", "undefined")}\n'
         f'ARCH_ON_CI: {os.environ.get("ARCH_ON_CI", "undefined")}\n'
         f'IS_CRON: {os.environ.get("IS_CRON", "undefined")}\n'
     )


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to make it possible to pass environment variables properly to daily cron job and to properly trigger remote data for daily cron with alldeps combo. To this end, unfortunately, we cannot use the OpenAstronomy template. The template never made it to v5.2.x or earlier, so there is no need to backport.

We will also display the value of CI in the pytest header.

xref https://github.com/astropy/astropy/pull/14123

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
