### PR TITLE
Allow zero WCSAxes ticks

### DIFF
--- a/astropy/tests/figures/py39-test-image-mpl334-cov.json
+++ b/astropy/tests/figures/py39-test-image-mpl334-cov.json
@@ -21,6 +21,7 @@
   "astropy.visualization.wcsaxes.tests.test_images.TestBasic.test_changed_axis_units": "056ec7123c67fa7ee6269bec47641bfe4932630a79d02029e71164b522fadacd",
   "astropy.visualization.wcsaxes.tests.test_images.TestBasic.test_minor_ticks": "5224f8fa725901ff74a4558987ceaae0363f98894d2c6a12d8c557db500ff7fe",
   "astropy.visualization.wcsaxes.tests.test_images.TestBasic.test_ticks_labels": "f4944296c37a6e8ea9d30126709da3567a25908c1665e8cad10e894dd87cd54d",
+  "astropy.visualization.wcsaxes.tests.test_images.TestBasic.test_no_ticks": "14c20201942f1db9796db8747ffcdec77254d79a9ae7dc45ce668ebf07c6de8e",
   "astropy.visualization.wcsaxes.tests.test_images.TestBasic.test_rcparams": "1af0c66ba343df4f03efc18e707f5b0c2a54dbce7351e0f9024154937a30b371",
   "astropy.visualization.wcsaxes.tests.test_images.TestBasic.test_tick_angles": "475f028bd48a51fe9dfc07fe3d58e63e629511fffeb3a4db27a26f6427b4256b",
   "astropy.visualization.wcsaxes.tests.test_images.TestBasic.test_tick_angles_non_square_axes": "3a3a15f71e7303368bd7cebb70c6fd1f9d6710edf8af2ceb68642c64c74492a2",

--- a/astropy/tests/figures/py39-test-image-mpldev-cov.json
+++ b/astropy/tests/figures/py39-test-image-mpldev-cov.json
@@ -21,6 +21,7 @@
   "astropy.visualization.wcsaxes.tests.test_images.TestBasic.test_changed_axis_units": "056ec7123c67fa7ee6269bec47641bfe4932630a79d02029e71164b522fadacd",
   "astropy.visualization.wcsaxes.tests.test_images.TestBasic.test_minor_ticks": "5224f8fa725901ff74a4558987ceaae0363f98894d2c6a12d8c557db500ff7fe",
   "astropy.visualization.wcsaxes.tests.test_images.TestBasic.test_ticks_labels": "f4944296c37a6e8ea9d30126709da3567a25908c1665e8cad10e894dd87cd54d",
+  "astropy.visualization.wcsaxes.tests.test_images.TestBasic.test_no_ticks": "14c20201942f1db9796db8747ffcdec77254d79a9ae7dc45ce668ebf07c6de8e",
   "astropy.visualization.wcsaxes.tests.test_images.TestBasic.test_rcparams": "1af0c66ba343df4f03efc18e707f5b0c2a54dbce7351e0f9024154937a30b371",
   "astropy.visualization.wcsaxes.tests.test_images.TestBasic.test_tick_angles": "11ef218080920301ada1ef9cea558599ca110ba49e3dc4e9dc547c013b87fcc7",
   "astropy.visualization.wcsaxes.tests.test_images.TestBasic.test_tick_angles_non_square_axes": "2ffe1157db233bc80e0eda08a30b916cc56a8ff0a7f34c3a0a1b1037695fe1a5",

--- a/astropy/visualization/wcsaxes/coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/coordinate_helpers.py
@@ -957,6 +957,8 @@ class CoordinateHelper:
         tick_world_coordinates_values = tick_world_coordinates.to_value(self.coord_unit)
 
         n_coord = len(tick_world_coordinates_values)
+        if n_coord == 0:
+            return
 
         from . import conf
 

--- a/astropy/visualization/wcsaxes/formatter_locator.py
+++ b/astropy/visualization/wcsaxes/formatter_locator.py
@@ -155,6 +155,11 @@ class BaseFormatterLocator:
 class AngleFormatterLocator(BaseFormatterLocator):
     """
     A joint formatter/locator.
+
+    Parameters
+    ----------
+    number : int, optional
+        Number of ticks.
     """
 
     def __init__(
@@ -347,6 +352,9 @@ class AngleFormatterLocator(BaseFormatterLocator):
             if self.spacing is not None:
                 # spacing was manually specified
                 spacing_value = self.spacing.to_value(self._unit)
+
+            elif self.number == 0:
+                return [] * self._unit, np.nan * self._unit
 
             elif self.number is not None:
                 # number of ticks was specified, work out optimal spacing

--- a/astropy/visualization/wcsaxes/tests/test_images.py
+++ b/astropy/visualization/wcsaxes/tests/test_images.py
@@ -487,6 +487,18 @@ class TestBasic(BaseImageTests):
         return fig
 
     @figure_test
+    def test_no_ticks(self):
+        # Check that setting no ticks works
+        fig = plt.figure(figsize=(6, 6))
+        ax = fig.add_axes(
+            [0.1, 0.1, 0.8, 0.8], projection=WCS(self.msx_header), aspect="equal"
+        )
+        ax.set_xlim(-0.5, 148.5)
+        ax.set_ylim(-0.5, 148.5)
+        ax.coords[0].set_ticks(number=0)
+        return fig
+
+    @figure_test
     def test_rcparams(self):
         # Test custom rcParams
 

--- a/astropy/visualization/wcsaxes/tests/test_images.py
+++ b/astropy/visualization/wcsaxes/tests/test_images.py
@@ -496,6 +496,7 @@ class TestBasic(BaseImageTests):
         ax.set_xlim(-0.5, 148.5)
         ax.set_ylim(-0.5, 148.5)
         ax.coords[0].set_ticks(number=0)
+        ax.coords[0].grid(True)
         return fig
 
     @figure_test

--- a/docs/changes/visualization/14160.bugfix.rst
+++ b/docs/changes/visualization/14160.bugfix.rst
@@ -1,0 +1,1 @@
+``CoordinateHelper.set_ticks()`` now accepts ``nticks=0``. Previously it errored.

--- a/docs/changes/visualization/14160.bugfix.rst
+++ b/docs/changes/visualization/14160.bugfix.rst
@@ -1,1 +1,1 @@
-``CoordinateHelper.set_ticks()`` now accepts ``nticks=0``. Previously it errored.
+``CoordinateHelper.set_ticks()`` now accepts ``number=0``. Previously it errored.


### PR DESCRIPTION
Fixes https://github.com/astropy/astropy/issues/14159

<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address ...

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
