### PR TITLE
Performance improvements for WCSAxes grids

### DIFF
--- a/astropy/visualization/wcsaxes/coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/coordinate_helpers.py
@@ -708,6 +708,8 @@ class CoordinateHelper:
 
                 pixel0 = spine.data
                 world0 = spine.world[:, self.coord_index]
+                if np.isnan(world0).all():
+                    continue
                 axes0 = transData.transform(pixel0)
 
                 # Advance 2 pixels in figure coordinates

--- a/astropy/visualization/wcsaxes/coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/coordinate_helpers.py
@@ -708,8 +708,6 @@ class CoordinateHelper:
 
                 pixel0 = spine.data
                 world0 = spine.world[:, self.coord_index]
-                with np.errstate(invalid="ignore"):
-                    world0 = self.transform.transform(pixel0)[:, self.coord_index]
                 axes0 = transData.transform(pixel0)
 
                 # Advance 2 pixels in figure coordinates

--- a/docs/changes/visualization/14164.bugfix.rst
+++ b/docs/changes/visualization/14164.bugfix.rst
@@ -1,0 +1,1 @@
+Improved the performance of drawing WCSAxes grids by skipping some unnecessary computations.


### PR DESCRIPTION
Improves the performance of `astropy.visualization.wcsaxes.coordinate_helpers.CoordinateHelper._update_ticks()`:

- Each spine already has its world coordinates calculated as part of the setter for `.data`, so a redundant computation can be removed
- If the world coordinates of a spine are all NaNs (i.e., the spine is outside of the whole coordinate grid), there can't be any ticks, so we can skip all of the computations to figure out tick orientations