### PR TITLE
Only specify image test envs that work in tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 envlist =
     py{38,39,310,311,dev}-test{,-recdeps,-alldeps,-oldestdeps,-devdeps,-devinfra,-predeps,-numpy120,-numpy121,-numpy122,-numpy123,-mpl311}{,-cov}{,-clocale}
+    # Only these two exact tox environments have corresponding figure hash files.
     py39-test-image-mpl311-cov
     py39-test-image-mpldev-cov
     build_docs

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,8 @@
 [tox]
 envlist =
-    py{38,39,310,311,dev}-test{,-image,-recdeps,-alldeps,-oldestdeps,-devdeps,-devinfra,-predeps,-numpy120,-numpy121,-numpy122,-numpy123,-mpl311}{,-cov}{,-clocale}
+    py{38,39,310,311,dev}-test{,-recdeps,-alldeps,-oldestdeps,-devdeps,-devinfra,-predeps,-numpy120,-numpy121,-numpy122,-numpy123,-mpl311}{,-cov}{,-clocale}
+    py39-test-image-mpl311-cov
+    py39-test-image-mpldev-cov
     build_docs
     linkcheck
     codestyle


### PR DESCRIPTION
Because these are the only two environments that have figure test hash files, they are the only two environments that will work for running the figure tests. Fixes https://github.com/astropy/astropy/issues/14052.