### PR TITLE
Fix memory policy warning in io.fits

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -154,8 +154,6 @@ filterwarnings =
     # Ignore a warning we emit about not supporting the parallel
     # reading option for now, can be removed once the issue is fixed
     ignore:parallel reading does not currently work, so falling back to serial
-    # numpy configurable allocator now wants memory policy set
-    ignore:Trying to dealloc data, but a memory policy is not set.
     # Ignore deprecation warning for asdf in astropy
     ignore:ASDF functionality for astropy is being moved.*:astropy.utils.exceptions.AstropyDeprecationWarning:astropy.io.misc.asdf.types
     ignore:ASDF functionality for astropy is being moved.*:astropy.utils.exceptions.AstropyDeprecationWarning:astropy.io.misc.asdf.tags.coordinates.frames

--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,7 @@ pypi_filter = https://raw.githubusercontent.com/astropy/ci-helpers/main/pip_pinn
 passenv = HOME WINDIR LC_ALL LC_CTYPE CC CI IS_CRON ARCH_ON_CI
 
 setenv =
+    NUMPY_WARN_IF_NO_MEM_POLICY = 1
     # For coverage, we need to pass extra options to the C compiler
     cov: CFLAGS = --coverage -fno-inline-functions -O0
     image: MPLFLAGS = -m "mpl_image_compare" --mpl --mpl-generate-summary=html --mpl-results-path={toxinidir}/results --mpl-hash-library={toxinidir}/astropy/tests/figures/{envname}.json --mpl-baseline-path=https://raw.githubusercontent.com/astropy/astropy-figure-tests/astropy-main/figures/{envname}/ --remote-data -W ignore::DeprecationWarning


### PR DESCRIPTION
Fix https://github.com/astropy/astropy/issues/12324 : Fix the warnings emitted by Numpy when transferring
ownership by setting ``NPY_ARRAY_OWNDATA``:

    RuntimeWarning: Trying to dealloc data, but a memory policy is not
    set.  If you take ownership of the data, you must set a base owning
    the data (e.g. a PyCapsule).

The warning was added in [1], and is now visible only when setting the
NUMPY_WARN_IF_NO_MEM_POLICY environment variable [2]. For more details
and a fix see [3].

[1] https://github.com/numpy/numpy/pull/17582
[2] https://github.com/numpy/numpy/pull/20200
[3] https://github.com/numpy/numpy/blob/main/doc/source/reference/c-api/data_memory.rst#what-happens-when-deallocating-if-there-is-no-policy-set