### PR TITLE
Ensure all units references are to top-level

### DIFF
--- a/astropy/units/function/core.py
+++ b/astropy/units/function/core.py
@@ -230,7 +230,7 @@ class FunctionUnitBase(metaclass=ABCMeta):
 
         Parameters
         ----------
-        other : `~astropy.units.Unit`, `~astropy.units.function.FunctionUnitBase`, or str
+        other : `~astropy.units.Unit`, `~astropy.units.FunctionUnitBase`, or str
             The unit to convert to.
 
         value : int, float, or scalar array-like, optional
@@ -467,8 +467,8 @@ class FunctionQuantity(Quantity):
         converted to the function unit, after, if necessary, converting it to
         the physical unit inferred from ``unit``.
 
-    unit : str, `~astropy.units.UnitBase`, or `~astropy.units.function.FunctionUnitBase`, optional
-        For an `~astropy.units.function.FunctionUnitBase` instance, the
+    unit : str, `~astropy.units.UnitBase`, or `~astropy.units.FunctionUnitBase`, optional
+        For an `~astropy.units.FunctionUnitBase` instance, the
         physical unit will be taken from it; for other input, it will be
         inferred from ``value``. By default, ``unit`` is set by the subclass.
 
@@ -505,12 +505,12 @@ class FunctionQuantity(Quantity):
     TypeError
         If the value provided is not a Python numeric type.
     TypeError
-        If the unit provided is not a `~astropy.units.function.FunctionUnitBase`
+        If the unit provided is not a `~astropy.units.FunctionUnitBase`
         or `~astropy.units.Unit` object, or a parseable string unit.
     """
 
     _unit_class = None
-    """Default `~astropy.units.function.FunctionUnitBase` subclass.
+    """Default `~astropy.units.FunctionUnitBase` subclass.
 
     This should be overridden by subclasses.
     """

--- a/astropy/units/function/logarithmic.py
+++ b/astropy/units/function/logarithmic.py
@@ -209,7 +209,7 @@ class LogQuantity(FunctionQuantity):
 
     Parameters
     ----------
-    value : number, `~astropy.units.Quantity`, `~astropy.units.function.logarithmic.LogQuantity`, or sequence of quantity-like.
+    value : number, `~astropy.units.Quantity`, `~astropy.units.LogQuantity`, or sequence of quantity-like.
         The numerical value of the logarithmic quantity. If a number or
         a `~astropy.units.Quantity` with a logarithmic unit, it will be
         converted to ``unit`` and the physical unit will be inferred from
@@ -217,8 +217,8 @@ class LogQuantity(FunctionQuantity):
         it will converted to the logarithmic unit, after, if necessary,
         converting it to the physical unit inferred from ``unit``.
 
-    unit : str, `~astropy.units.UnitBase`, or `~astropy.units.function.FunctionUnitBase`, optional
-        For an `~astropy.units.function.FunctionUnitBase` instance, the
+    unit : str, `~astropy.units.UnitBase`, or `~astropy.units.FunctionUnitBase`, optional
+        For an `~astropy.units.FunctionUnitBase` instance, the
         physical unit will be taken from it; for other input, it will be
         inferred from ``value``. By default, ``unit`` is set by the subclass.
 
@@ -237,7 +237,7 @@ class LogQuantity(FunctionQuantity):
 
     Examples
     --------
-    Typically, use is made of an `~astropy.units.function.FunctionQuantity`
+    Typically, use is made of an `~astropy.units.FunctionQuantity`
     subclass, as in::
 
         >>> import astropy.units as u

--- a/docs/units/logarithmic_units.rst
+++ b/docs/units/logarithmic_units.rst
@@ -37,10 +37,10 @@ To create a logarithmic quantity::
 
 Above, we make use of the fact that the units ``mag``, ``dex``, and
 ``dB`` are special in that, when used as functions, they return a
-:class:`~astropy.units.function.logarithmic.LogUnit` instance
-(:class:`~astropy.units.function.logarithmic.MagUnit`,
-:class:`~astropy.units.function.logarithmic.DexUnit`, and
-:class:`~astropy.units.function.logarithmic.DecibelUnit`,
+:class:`~astropy.units.LogUnit` instance
+(:class:`~astropy.units.MagUnit`,
+:class:`~astropy.units.DexUnit`, and
+:class:`~astropy.units.DecibelUnit`,
 respectively). The same happens as required when strings are parsed
 by :class:`~astropy.units.Unit`.
 
@@ -49,7 +49,7 @@ by :class:`~astropy.units.Unit`.
 As for normal |Quantity| objects, you can access the value with the
 `~astropy.units.Quantity.value` attribute. In addition, you can convert to a
 |Quantity| with the physical unit using the
-`~astropy.units.function.FunctionQuantity.physical` attribute::
+`~astropy.units.FunctionQuantity.physical` attribute::
 
     >>> logg = 5. * u.dex(u.cm / u.s**2)
     >>> logg.value
@@ -76,8 +76,8 @@ To convert a logarithmic quantity to a different unit::
     >>> logg.to('dex(m/s2)')  # doctest: +FLOAT_CMP
     <Dex 3. dex(m / s2)>
 
-For convenience, the :attr:`~astropy.units.function.FunctionQuantity.si` and
-:attr:`~astropy.units.function.FunctionQuantity.cgs` attributes can be used to
+For convenience, the :attr:`~astropy.units.FunctionQuantity.si` and
+:attr:`~astropy.units.FunctionQuantity.cgs` attributes can be used to
 convert the |Quantity| to base `SI
 <https://www.bipm.org/documents/20126/41483022/SI-Brochure-9-EN.pdf>`_ or `CGS
 <https://en.wikipedia.org/wiki/Centimetre-gram-second_system_of_units>`_
@@ -258,7 +258,7 @@ to work::
 
     This is implemented by having a list of supported ufuncs in
     ``units/function/core.py`` and by explicitly disabling some array methods in
-    :class:`~astropy.units.function.FunctionQuantity`.  If you believe a
+    :class:`~astropy.units.FunctionQuantity`.  If you believe a
     function or method is incorrectly treated, please `let us know
     <http://www.astropy.org/contribute.html>`_.
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address recent failures on readthedocs (e.g., in #13977), after #14140 was merged. Oddly, that passed, even though some of the references now are wrong. This corrects it.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
