### PR TITLE
ENH nddata: collapse operations on NDDataArray, improved Masked Quantity support

### DIFF
--- a/astropy/nddata/compat.py
+++ b/astropy/nddata/compat.py
@@ -170,7 +170,9 @@ class NDDataArray(NDArithmeticMixin, NDSlicingMixin, NDIOMixin, NDData):
         if (value is not None) and (value is not np.ma.nomask):
             mask = np.array(value, dtype=np.bool_, copy=False)
             if mask.shape != self.data.shape:
-                raise ValueError("dimensions of mask do not match data")
+                raise ValueError(
+                    f"dimensions of mask {mask.shape} and data {self.data.shape} do not match"
+                )
             else:
                 self._mask = mask
         else:

--- a/astropy/nddata/mixins/ndarithmetic.py
+++ b/astropy/nddata/mixins/ndarithmetic.py
@@ -172,7 +172,7 @@ class NDArithmeticMixin:
         handle_meta=None,
         uncertainty_correlation=0,
         compare_wcs="first_found",
-        ignore_masked_data=False,
+        operation_ignores_mask=False,
         axis=None,
         **kwds,
     ):
@@ -208,7 +208,7 @@ class NDArithmeticMixin:
         uncertainty_correlation : ``Number`` or `~numpy.ndarray`, optional
             see :meth:`NDArithmeticMixin.add`
 
-        ignore_masked_data : bool, optional
+        operation_ignores_mask : bool, optional
             When True, masked values will be excluded from operations;
             otherwise the operation will be performed on all values,
             including masked ones.
@@ -266,7 +266,7 @@ class NDArithmeticMixin:
         if use_masked_arith:
             # if we're *including* masked values in the operation,
             # use the astropy Masked module:
-            if not ignore_masked_data:
+            if not operation_ignores_mask:
                 # call the numpy operation on a Masked NDDataArray
                 # representation of the nddata, with units when available:
                 if self.unit is not None and not hasattr(self.data, "unit"):

--- a/astropy/nddata/mixins/ndarithmetic.py
+++ b/astropy/nddata/mixins/ndarithmetic.py
@@ -369,7 +369,7 @@ class NDArithmeticMixin:
         elif operand is not None:
             result = operation(self.data << self.unit, operand.data << operand.unit)
         else:
-            result = operation(self.data << self.unit, axis=kwds["axis"])
+            result = operation(self.data, axis=kwds["axis"])
 
         return result
 

--- a/astropy/nddata/mixins/ndarithmetic.py
+++ b/astropy/nddata/mixins/ndarithmetic.py
@@ -291,6 +291,10 @@ class NDArithmeticMixin:
                 operation, operand, axis=axis, **kwds2["data"]
             )
 
+        # preserve original units
+        if not hasattr(result, "unit") and hasattr(self, "unit"):
+            kwargs["unit"] = self.unit
+
         # Determine the other properties
         if propagate_uncertainties is None:
             kwargs["uncertainty"] = None

--- a/astropy/nddata/mixins/ndarithmetic.py
+++ b/astropy/nddata/mixins/ndarithmetic.py
@@ -297,10 +297,12 @@ class NDArithmeticMixin:
                 AstropyUserWarning,
             )
 
-        if hasattr(result, "mask"):
-            # if astropy.utils.masked is being used, we can use
-            # the mask attribute directly:
-            kwargs["mask"] = result.mask
+        if handle_mask is None:
+            pass
+        elif hasattr(result, "mask"):
+            # if astropy.utils.masked is being used, the constructor
+            # will pick up the mask from the Masked object:
+            kwargs["mask"] = None
         elif handle_mask in ["ff", "first_found"]:
             if self.mask is None:
                 kwargs["mask"] = deepcopy(operand.mask)
@@ -612,7 +614,7 @@ class NDArithmeticMixin:
     @sharedmethod
     def min(self, **kwargs):
         # use the provided propagate_uncertainties if available, otherwise default is False:
-        propagate_uncertainties = kwargs.pop("propagate_uncertainties", False)
+        propagate_uncertainties = kwargs.pop("propagate_uncertainties", None)
         return self._prepare_then_do_arithmetic(
             np.min, propagate_uncertainties=propagate_uncertainties, **kwargs
         )
@@ -620,7 +622,7 @@ class NDArithmeticMixin:
     @sharedmethod
     def max(self, **kwargs):
         # use the provided propagate_uncertainties if available, otherwise default is False:
-        propagate_uncertainties = kwargs.pop("propagate_uncertainties", False)
+        propagate_uncertainties = kwargs.pop("propagate_uncertainties", None)
         return self._prepare_then_do_arithmetic(
             np.max, propagate_uncertainties=propagate_uncertainties, **kwargs
         )

--- a/astropy/nddata/mixins/tests/test_ndarithmetic.py
+++ b/astropy/nddata/mixins/tests/test_ndarithmetic.py
@@ -1297,3 +1297,16 @@ def test_psf_warning():
         ndd2.add(ndd1)
     with pytest.warns(AstropyUserWarning, match="Not setting psf attribute during add"):
         ndd1.add(ndd1)
+
+
+def test_raise_method_not_supported():
+    ndd1 = NDDataArithmetic(np.zeros(3), uncertainty=StdDevUncertainty(np.zeros(3)))
+    ndd2 = NDDataArithmetic(np.ones(3), uncertainty=StdDevUncertainty(np.ones(3)))
+    result = np.zeros(3)
+    correlation = 0
+    # no error should be raised for supported operations:
+    ndd1.uncertainty.propagate(np.add, ndd2, result, correlation)
+
+    # raise error for unsupported propagation operations:
+    with pytest.raises(ValueError):
+        ndd1.uncertainty.propagate(np.mod, ndd2, result, correlation)

--- a/astropy/nddata/nduncertainty.py
+++ b/astropy/nddata/nduncertainty.py
@@ -56,22 +56,12 @@ def _unravel_preserved_axes(arr, collapsed_arr, preserve_axes):
 
 
 def from_variance_for_mean(x, axis):
-    if not hasattr(x, "mask"):
-        if axis is None:
-            # do operation on all dimensions:
-            denom = np.prod(x.shape)
-        elif hasattr(axis, "__len__"):
-            denom = np.prod([x.shape[i] for i in axis])
-        else:
-            denom = x.shape[axis]
-        return np.sqrt(np.sum(x, axis)) / denom
+    if axis is None:
+        # do operation on all dimensions:
+        denom = np.ma.count(x)
     else:
-        if axis is None:
-            # do operation on all dimensions:
-            denom = np.ma.count(x)
-        else:
-            denom = np.ma.count(x, axis)
-        return np.sqrt(np.ma.sum(x, axis)) / denom
+        denom = np.ma.count(x, axis)
+    return np.sqrt(np.ma.sum(x, axis)) / denom
 
 
 # mapping from collapsing operations to the complementary methods used for `from_variance`

--- a/astropy/nddata/nduncertainty.py
+++ b/astropy/nddata/nduncertainty.py
@@ -20,6 +20,64 @@ __all__ = [
     "InverseVariance",
 ]
 
+# mapping from collapsing operations to the complementary methods used for `to_variance`
+collapse_to_variance_mapping = {
+    np.sum: np.square,
+    np.mean: np.square,
+    np.median: None,
+}
+
+
+def _move_preserved_axes_first(arr, preserve_axes):
+    # When collapsing an ND array and preserving M axes, move the
+    # preserved axes to the first M axes of the output. For example,
+    # if arr.shape == (6, 5, 4, 3, 2) and we're preserving axes (1, 2),
+    # then the output should have shape (20, 6, 3, 2). Axes 1 and 2 have
+    # shape 5 and 4, so we take their product and put them both in the zeroth
+    # axis.
+    zeroth_axis_after_reshape = np.prod(np.array(arr.shape)[list(preserve_axes)])
+    collapse_axes = [i for i in range(arr.ndim) if i not in preserve_axes]
+    return arr.reshape(
+        [zeroth_axis_after_reshape] + np.array(arr.shape)[collapse_axes].tolist()
+    )
+
+
+def _unravel_preserved_axes(arr, collapsed_arr, preserve_axes):
+    # After reshaping an array with _move_preserved_axes_first and collapsing
+    # the result, convert the reshaped first axis back into the shape of each
+    # of the original preserved axes.
+    # For example, if arr.shape == (6, 5, 4, 3, 2) and we're preserving axes (1, 2),
+    # then the output of _move_preserved_axes_first should have shape (20, 6, 3, 2).
+    # This method unravels the first axis in the output *after* a collapse, so the
+    # output with shape (20,) becomes shape (5, 4).
+    if collapsed_arr.ndim != len(preserve_axes):
+        arr_shape = np.array(arr.shape)
+        return collapsed_arr.reshape(arr_shape[np.asarray(preserve_axes)])
+    return collapsed_arr
+
+
+def from_variance_for_mean(x, axis):
+    # when computing the error on a mean along one or more axes,
+    # normalize the root-mean-square of stddev uncertainties by
+    # sqrt(N) along each axis, which is equivalent to assuming
+    # uncertainties are Gaussian and uncorrelated.
+    if axis is None:
+        # do operation on all dimensions:
+        denom = np.prod(x.shape) ** 0.5
+    elif hasattr(axis, "__len__"):
+        denom = np.prod([x.shape[i] for i in axis]) ** 0.5
+    else:
+        denom = x.shape[axis] ** 0.5
+    return np.sqrt(np.sum(x, axis)) / denom
+
+
+# mapping from collapsing operations to the complementary methods used for `from_variance`
+collapse_from_variance_mapping = {
+    np.sum: lambda x, axis: np.sqrt(np.sum(x, axis)),
+    np.mean: from_variance_for_mean,
+    np.median: None,
+}
+
 
 class IncompatibleUncertaintiesException(Exception):
     """This exception should be used to indicate cases in which uncertainties
@@ -214,12 +272,16 @@ class NDUncertainty(metaclass=ABCMeta):
         # with empty parent (Value=None)
         if value is not None:
             parent_unit = self.parent_nddata.unit
-            if self.unit is None:
-                if parent_unit is None:
-                    self.unit = None
-                else:
-                    # Set the uncertainty's unit to the appropriate value
-                    self.unit = self._data_unit_to_uncertainty_unit(parent_unit)
+            # this will get the unit for masked quantity input:
+            parent_data_unit = getattr(self.parent_nddata.data, "unit", None)
+            if parent_unit is None and parent_data_unit is None:
+                self.unit = None
+            elif self.unit is None and parent_unit is not None:
+                # Set the uncertainty's unit to the appropriate value
+                self.unit = self._data_unit_to_uncertainty_unit(parent_unit)
+            elif parent_data_unit is not None:
+                # if the parent_nddata object has a unit, use it:
+                self.unit = self._data_unit_to_uncertainty_unit(parent_data_unit)
             else:
                 # Check that units of uncertainty are compatible with those of
                 # the parent. If they are, no need to change units of the
@@ -275,7 +337,7 @@ class NDUncertainty(metaclass=ABCMeta):
         """Normal slicing on the array, keep the unit and return a reference."""
         return self.__class__(self.array[item], unit=self.unit, copy=False)
 
-    def propagate(self, operation, other_nddata, result_data, correlation):
+    def propagate(self, operation, other_nddata, result_data, correlation, axis=None):
         """Calculate the resulting uncertainty given an operation on the data.
 
         .. versionadded:: 1.2
@@ -297,6 +359,9 @@ class NDUncertainty(metaclass=ABCMeta):
             The correlation (rho) is defined between the uncertainties in
             sigma_AB = sigma_A * sigma_B * rho. A value of ``0`` means
             uncorrelated operands.
+
+        axis : int or tuple of ints, optional
+            Axis over which to perform a collapsing operation.
 
         Returns
         -------
@@ -328,19 +393,27 @@ class NDUncertainty(metaclass=ABCMeta):
                     "".format(self.__class__.__name__)
                 )
 
-        # Get the other uncertainty (and convert it to a matching one)
-        other_uncert = self._convert_uncertainty(other_nddata.uncertainty)
+        if other_nddata is not None:
+            # Get the other uncertainty (and convert it to a matching one)
+            other_uncert = self._convert_uncertainty(other_nddata.uncertainty)
 
-        if operation.__name__ == "add":
-            result = self._propagate_add(other_uncert, result_data, correlation)
-        elif operation.__name__ == "subtract":
-            result = self._propagate_subtract(other_uncert, result_data, correlation)
-        elif operation.__name__ == "multiply":
-            result = self._propagate_multiply(other_uncert, result_data, correlation)
-        elif operation.__name__ in ["true_divide", "divide"]:
-            result = self._propagate_divide(other_uncert, result_data, correlation)
+            if operation.__name__ == "add":
+                result = self._propagate_add(other_uncert, result_data, correlation)
+            elif operation.__name__ == "subtract":
+                result = self._propagate_subtract(
+                    other_uncert, result_data, correlation
+                )
+            elif operation.__name__ == "multiply":
+                result = self._propagate_multiply(
+                    other_uncert, result_data, correlation
+                )
+            elif operation.__name__ in ["true_divide", "divide"]:
+                result = self._propagate_divide(other_uncert, result_data, correlation)
+            else:
+                raise ValueError(f"unsupported operation: {operation.__name__}")
         else:
-            raise ValueError("unsupported operation")
+            # assume this is a collapsing operation:
+            result = self._propagate_collapse(operation, axis)
 
         return self.__class__(result, copy=False)
 
@@ -483,6 +556,109 @@ class _VariancePropagationMixin:
     propagation for variance-like uncertainties (standard deviation and inverse
     variance).
     """
+
+    def _propagate_collapse(self, numpy_op, axis=None):
+        """
+        Error propagation for collapse operations on variance or
+        variance-like uncertainties. Uncertainties are calculated using the
+        formulae for variance but can be used for uncertainty convertible to
+        a variance.
+
+        Parameters
+        ----------
+        numpy_op : function
+            Numpy operation like `np.sum` or `np.max` to use in the collapse
+
+        subtract : bool, optional
+            If ``True``, propagate for subtraction, otherwise propagate for
+            addition.
+
+        axis : tuple, optional
+            Axis on which to compute collapsing operations.
+        """
+        try:
+            result_unit_sq = self.parent_nddata.unit**2
+        except (AttributeError, TypeError):
+            result_unit_sq = None
+
+        if self.array is not None:
+            # Formula: sigma**2 = dA
+
+            if numpy_op in [np.min, np.max]:
+                # Find the indices of the min/max in parent data along each axis,
+                # return the uncertainty at the corresponding entry:
+                return self._get_err_at_extremum(numpy_op, axis=axis)
+
+            # np.sum and np.mean operations use similar pattern
+            # to `_propagate_add_sub`, for example:
+            else:
+                # lookup the mapping for to_variance and from_variance for this
+                # numpy operation:
+                to_variance = collapse_to_variance_mapping[numpy_op]
+                from_variance = collapse_from_variance_mapping[numpy_op]
+
+                if (
+                    self.unit is not None
+                    and to_variance(self.unit) != self.parent_nddata.unit**2
+                ):
+                    # If the uncertainty has a different unit than the result we
+                    # need to convert it to the results unit.
+                    this = to_variance(self.array << self.unit).to(result_unit_sq).value
+                else:
+                    this = to_variance(self.array)
+
+                return from_variance(this, axis=axis)
+
+    def _get_err_at_extremum(self, extremum, axis):
+        """
+        Return the value of the ``uncertainty`` array at the indices
+        which satisfy the ``extremum`` function applied to the ``measurement`` array,
+        where we expect ``extremum`` to be np.argmax or np.argmin, and
+        we expect a two-dimensional output.
+
+        Assumes the ``measurement`` and ``uncertainty`` array dimensions
+        are ordered such that the zeroth dimension is the one to preserve.
+        For example, if you start with array with shape (a, b, c), this
+        function applies the ``extremum`` function to the last two dimensions,
+        with shapes b and c.
+
+        This operation is difficult to cast in a vectorized way. Here
+        we implement it with a list comprehension, which is likely not the
+        most performant solution.
+        """
+        if axis is not None and not hasattr(axis, "__len__"):
+            # this is a single axis:
+            axis = [axis]
+
+        if extremum is np.min:
+            arg_extremum = np.ma.argmin
+        elif extremum is np.max:
+            arg_extremum = np.ma.argmax
+
+        all_axes = np.arange(self.array.ndim)
+
+        if axis is None:
+            # collapse over all dimensions
+            ind = arg_extremum(np.asanyarray(self.parent_nddata).ravel())
+            return self.array.ravel()[ind]
+
+        # collapse an ND array over arbitrary dimensions:
+        preserve_axes = [ax for ax in all_axes if ax not in axis]
+        meas = np.ma.masked_array(
+            _move_preserved_axes_first(self.parent_nddata.data, preserve_axes),
+            _move_preserved_axes_first(self.parent_nddata.mask, preserve_axes),
+        )
+        err = _move_preserved_axes_first(self.array, preserve_axes)
+
+        result = np.array(
+            [e[np.unravel_index(arg_extremum(m), m.shape)] for m, e in zip(meas, err)]
+        )
+
+        return _unravel_preserved_axes(
+            self.parent_nddata.data,
+            result,
+            preserve_axes,
+        )
 
     def _propagate_add_sub(
         self,
@@ -816,6 +992,10 @@ class StdDevUncertainty(_VariancePropagationMixin, NDUncertainty):
             to_variance=np.square,
             from_variance=np.sqrt,
         )
+
+    def _propagate_collapse(self, numpy_operation, axis):
+        # defer to _VariancePropagationMixin
+        return super()._propagate_collapse(numpy_operation, axis=axis)
 
     def _data_unit_to_uncertainty_unit(self, value):
         return value

--- a/astropy/nddata/tests/test_nddata.py
+++ b/astropy/nddata/tests/test_nddata.py
@@ -194,6 +194,11 @@ def test_nddata_init_data_quantity(data):
         quantity.value[1] = 5
         assert ndd.data[1] != quantity.value[1]
 
+    # provide a quantity and override the unit
+    ndd_unit = NDData(data * u.erg, unit=u.J)
+    assert ndd_unit.unit == u.J
+    np.testing.assert_allclose((ndd_unit.data * ndd_unit.unit).to_value(u.erg), data)
+
 
 def test_nddata_init_data_masked_quantity():
     a = np.array([2, 3])

--- a/astropy/nddata/tests/test_nddata.py
+++ b/astropy/nddata/tests/test_nddata.py
@@ -602,9 +602,9 @@ collapse_units = [None, u.Jy]
 collapse_propagate = [True, False]
 collapse_data_shapes = [
     # 3D example:
-    # (4, 3, 2),
+    (4, 3, 2),
     # 5D example
-    (6, 5, 4, 3, 2)
+    (6, 5, 4, 3, 2),
 ]
 collapse_masks = list(
     chain.from_iterable(
@@ -620,27 +620,21 @@ collapse_masks = list(
         for collapse_data_shape in collapse_data_shapes
     )
 )
+
+# the following provides pytest.mark.parametrize with every
+# permutation of (1) the units, (2) propagating/not propagating
+# uncertainties, and (3) the data shapes of different ndim.
 permute = len(collapse_masks) * len(collapse_propagate) * len(collapse_units)
 collapse_units = permute // len(collapse_units) * collapse_units
 collapse_propagate = permute // len(collapse_propagate) * collapse_propagate
 collapse_masks = permute // len(collapse_masks) * collapse_masks
 
 
-# The filtered warning below is given when "invalid value
-# encountered in divide", and can be removed when this div by zero
-# errors are prevented in the Masked implementation of `mean`.
-@pytest.mark.filterwarnings("ignore::RuntimeWarning")
 @pytest.mark.parametrize(
     "mask, unit, propagate_uncertainties",
-    [
-        (mask, unit, propagate_uncertainties)
-        for mask, unit, propagate_uncertainties in zip(
-            collapse_masks, collapse_units, collapse_propagate
-        )
-    ],
+    list(zip(collapse_masks, collapse_units, collapse_propagate)),
 )
 def test_collapse(mask, unit, propagate_uncertainties):
-
     # unique set of combinations of each of the N-1 axes for an N-D cube:
     axes_permutations = {tuple(axes[:2]) for axes in permutations(range(mask.ndim))}
 

--- a/astropy/nddata/tests/test_nddata.py
+++ b/astropy/nddata/tests/test_nddata.py
@@ -643,10 +643,10 @@ collapse_ignore_masked = permute // len(collapse_ignore_masked) * collapse_ignor
 
 
 @pytest.mark.parametrize(
-    "mask, unit, propagate_uncertainties, ignore_masked_data",
+    "mask, unit, propagate_uncertainties, operation_ignores_mask",
     zip(collapse_masks, collapse_units, collapse_propagate, collapse_ignore_masked),
 )
-def test_collapse(mask, unit, propagate_uncertainties, ignore_masked_data):
+def test_collapse(mask, unit, propagate_uncertainties, operation_ignores_mask):
     # unique set of combinations of each of the N-1 axes for an N-D cube:
     axes_permutations = {tuple(axes[:2]) for axes in permutations(range(mask.ndim))}
 
@@ -681,7 +681,7 @@ def test_collapse(mask, unit, propagate_uncertainties, ignore_masked_data):
             nddata_method = getattr(ndarr, method)(
                 axis=axes,
                 propagate_uncertainties=propagate_uncertainties,
-                ignore_masked_data=ignore_masked_data,
+                operation_ignores_mask=operation_ignores_mask,
             )
             astropy_unmasked = astropy_method.base[~astropy_method.mask]
             nddata_unmasked = nddata_method.data[~nddata_method.mask]
@@ -692,7 +692,7 @@ def test_collapse(mask, unit, propagate_uncertainties, ignore_masked_data):
             # check if the numpy and astropy.utils.masked results agree when
             # the result is not fully masked:
             if len(astropy_unmasked) > 0:
-                if not ignore_masked_data:
+                if not operation_ignores_mask:
                     # compare with astropy
                     assert np.all(np.equal(astropy_unmasked, nddata_unmasked))
                     assert np.all(np.equal(astropy_method.mask, nddata_method.mask))

--- a/astropy/nddata/tests/test_nduncertainty.py
+++ b/astropy/nddata/tests/test_nduncertainty.py
@@ -18,6 +18,8 @@ from astropy.nddata.nduncertainty import (
     StdDevUncertainty,
     UnknownUncertainty,
     VarianceUncertainty,
+    _move_preserved_axes_first,
+    _unravel_preserved_axes,
 )
 
 # Regarding setter tests:
@@ -399,3 +401,29 @@ def test_self_conversion_via_variance_not_supported(UncertClass):
     start_uncert = UncertClass(uncert)
     with pytest.raises(TypeError):
         final_uncert = start_uncert.represent_as(UncertClass)
+
+
+def test_reshape_ndarray_methods():
+    shape = (6, 5, 4, 3, 2)
+    preserve_axes = (1, 2)
+    arr = np.arange(np.prod(shape)).reshape(shape)
+    reshaped_arr = _move_preserved_axes_first(arr, preserve_axes)
+    new_shape = reshaped_arr.shape
+
+    # first entry will be product of two preserved axes:
+    assert new_shape[0] == np.prod(np.array(shape)[np.array(preserve_axes)])
+
+    # remaining entries unchanged:
+    shape_unchanged_axes = np.array(shape)[
+        np.array([i for i in range(len(shape)) if i not in preserve_axes])
+    ]
+    assert np.all(np.equal(new_shape[1:], shape_unchanged_axes))
+
+    # now confirm that after collapsing along first axis, what's left
+    # can be unraveled to the shape of the preserved axes:
+    summed = np.sum(reshaped_arr, axis=tuple(range(1, len(shape) - 1)))
+    assert summed.shape[0] == new_shape[0]
+
+    unravelled = _unravel_preserved_axes(arr, summed, preserve_axes)
+    shape_preserved = np.array(shape)[np.array(preserve_axes)]
+    assert np.all(np.equal(unravelled.shape, shape_preserved))

--- a/docs/changes/nddata/14175.feature.rst
+++ b/docs/changes/nddata/14175.feature.rst
@@ -1,0 +1,3 @@
+``astropy.nddata.NDDataArray`` now has collapsing methods like ``sum``,
+``mean``, ``min``, and ``max`` which operate along any axes, and better
+support for ``astropy.utils.Masked`` objects.

--- a/docs/nddata/mixins/ndarithmetic.rst
+++ b/docs/nddata/mixins/ndarithmetic.rst
@@ -103,7 +103,7 @@ Adding two `~astropy.nddata.NDData` objects with the same unit works::
 
     >>> ndd = ndd1.add(ndd2)
     >>> ndd.data  # doctest: +FLOAT_CMP
-    array([101., 152., 203.,  54., 505.])
+    array([101., 152., 203., 54., 505.])
     >>> ndd.unit
     Unit("m")
 
@@ -126,7 +126,7 @@ not be decomposed during division::
 
     >>> ndd = ndd2.divide(ndd1)
     >>> ndd.data  # doctest: +FLOAT_CMP
-    array([100.        ,  75.        ,  66.66666667,  12.5       , 100.        ])
+    array([100. , 75. , 66.66666667, 12.5 , 100. ])
     >>> ndd.unit
     Unit("lyr / pc")
 

--- a/docs/nddata/nddata.rst
+++ b/docs/nddata/nddata.rst
@@ -495,8 +495,8 @@ Converting the ``data`` and ``unit`` to a Quantity::
     >>> quantity  # doctest: +FLOAT_CMP
     <Quantity [1., 2., 3., 4.] m>
 
-`~astropy.utils.masked.core.MaskedQuantity`
--------------------------------------------
+`MaskedQuantity`
+----------------
 
 Converting the ``data``, ``unit``, and ``mask`` to a ``MaskedQuantity``::
 

--- a/docs/nddata/nddata.rst
+++ b/docs/nddata/nddata.rst
@@ -495,8 +495,8 @@ Converting the ``data`` and ``unit`` to a Quantity::
     >>> quantity  # doctest: +FLOAT_CMP
     <Quantity [1., 2., 3., 4.] m>
 
-`MaskedQuantity`
-----------------
+MaskedQuantity
+--------------
 
 Converting the ``data``, ``unit``, and ``mask`` to a ``MaskedQuantity``::
 

--- a/docs/nddata/nddata.rst
+++ b/docs/nddata/nddata.rst
@@ -447,6 +447,21 @@ behavior with::
     >>> print(min_axis_1.uncertainty)  # doctest: +FLOAT_CMP
     StdDevUncertainty([1, 1])
 
+Finally, in some cases it may be useful to do perform a collapse
+operation only on the unmasked values, and only return a masked
+result when all of the input values are masked. If we refer back to
+the first example in this section, we see that the underlying
+``data`` attribute has been summed over all values, including
+masked ones::
+
+    >>> sum_axis_1  # doctest: +FLOAT_CMP
+    NDDataArray([6., 9.], unit='m')
+
+where the first data element is masked. We can instead get the sum
+for only unmasked values with the ``ignore_masked_data`` option::
+
+    >>> nddata.sum(axis=1, ignore_masked_data=True)
+    NDDataArray([5, 9])
 
 ..
   EXAMPLE END

--- a/docs/nddata/nddata.rst
+++ b/docs/nddata/nddata.rst
@@ -128,7 +128,7 @@ explicit parameter will be used and an info message will be issued::
     >>> ndd6 = NDData(quantity, unit='m')
     INFO: overwriting Quantity's current unit with specified unit. [astropy.nddata.nddata]
     >>> ndd6.data  # doctest: +FLOAT_CMP
-    array([1., 1., 1.])
+    array([0.01, 0.01, 0.01])
     >>> ndd6.unit
     Unit("m")
 

--- a/docs/nddata/nddata.rst
+++ b/docs/nddata/nddata.rst
@@ -461,7 +461,7 @@ where the first data element is masked. We can instead get the sum
 for only unmasked values with the ``operation_ignores_mask`` option::
 
     >>> nddata.sum(axis=1, operation_ignores_mask=True)
-    NDDataArray([5, 9])
+    NDDataArray([5, 9], unit='m')
 
 ..
   EXAMPLE END

--- a/docs/nddata/nddata.rst
+++ b/docs/nddata/nddata.rst
@@ -363,6 +363,94 @@ copies during initialization by setting the ``copy`` parameter to ``True``::
 ..
   EXAMPLE END
 
+
+Collapsing an NDData object along one or more axes
+==================================================
+
+..
+  EXAMPLE START
+  Collapsing an NDData object along one or more axes
+
+A common operation on an `~numpy.ndarray` is to take the sum, mean,
+maximum, or minimum along one or more axes, reducing the dimensions
+of the output. These four operations are implemented on
+`~astropy.nddata.NDData` with appropriate propagation of uncertainties,
+masks, and units.
+
+For example, let's work on the the following ``data`` with a mask, unit, and
+(uniform) uncertainty::
+
+    >>> import numpy as np
+    >>> import astropy.units as u
+    >>> from astropy.nddata import NDDataArray, StdDevUncertainty
+    >>>
+    >>> data = [
+    ...     [1, 2, 3],
+    ...     [2, 3, 4]
+    ... ]
+    >>> mask = [
+    ...     [True, False, False],
+    ...     [False, False, False]
+    ... ]
+    >>> uncertainty = StdDevUncertainty(np.ones_like(data))
+    >>> nddata = NDDataArray(data=data, uncertainty=uncertainty, mask=mask, unit='m')
+
+The sum along axis ``1`` gives one result per row::
+
+    >>> sum_axis_1 = nddata.sum(axis=1)  # this is a new NDDataArray
+    >>> print(np.asanyarray(sum_axis_1))  # this converts data to a numpy masked array. doctest: +FLOAT_CMP
+    [-- 9.0]
+    >>> print(sum_axis_1.uncertainty)  # doctest: +FLOAT_CMP
+    StdDevUncertainty([1.41421356, 1.73205081])
+
+The result has one masked value derived from the logical OR of the original mask
+along ``axis=1``. The uncertainties are the square-root of the sum of the squares
+of the input uncertainties. Since the original uncertainties were all unity, the
+result is the square root of the number of unmasked data entries,
+:math:`[\sqrt{2},\,\sqrt{3}]`.
+
+We can similarly take the mean along ``axis=1``::
+
+    >>> mean_axis_1 = nddata.mean(axis=1)
+    >>> print(np.asanyarray(mean_axis_1))  # doctest: +FLOAT_CMP
+    [2.5 3.0]
+    >>> print(mean_axis_1.uncertainty)  # doctest: +FLOAT_CMP
+    StdDevUncertainty([0.70710678, 0.57735027])
+
+The result is the mean of the values where ``mask==False``, and in this example,
+the result would only have ``mask==True`` if an entire row was masked. Since the
+uncertainties were given as `~astropy.nddata.StdDevUncertainty`, the propagated
+uncertainties decrease proportional to the number of unmasked measurements in each
+row, following :math:`[2^{-1/2},\,3^{-1/2}]`.
+
+There's no single, correct way of defining the uncertainties associated
+with the ``min`` or ``max`` of a set of measurements, so
+`~astropy.nddata.NDData` resists the temptation to guess, and returns
+the minimum data value along the axis/axes, and the propagated mask, but
+no uncertainties::
+
+    >>> min_axis_1 = nddata.min(axis=1)
+    >>> print(np.asanyarray(min_axis_1))  # doctest: +FLOAT_CMP
+    [2.0 2.0]
+    >>> print(min_axis_1.uncertainty)
+    None
+
+For some use cases, it may be helpful to return the uncertainty
+at the same index as the minimum/maximum ``data`` value, so that
+the original ``data`` retains its uncertainty. You can get this
+behavior with::
+
+    >>> min_axis_1 = nddata.min(axis=1, propagate_uncertainties=True)
+
+    >>> print(np.asanyarray(min_axis_1))  # doctest: +FLOAT_CMP
+    [2.0 2.0]
+    >>> print(min_axis_1.uncertainty)  # doctest: +FLOAT_CMP
+    StdDevUncertainty([1, 1])
+
+
+..
+  EXAMPLE END
+
 Converting NDData to Other Classes
 ==================================
 
@@ -407,6 +495,12 @@ Converting the ``data`` and ``unit`` to a Quantity::
     >>> quantity  # doctest: +FLOAT_CMP
     <Quantity [1., 2., 3., 4.] m>
 
-.. note::
-    Ideally, you would construct masked quantities, but these are not properly
-    supported: many operations on them fail.
+`~astropy.utils.masked.core.MaskedQuantity`
+-------------------------------------------
+
+Converting the ``data``, ``unit``, and ``mask`` to a ``MaskedQuantity``::
+
+    >>> from astropy.utils.masked import Masked
+    >>> Masked(u.Quantity(ndd.data, ndd.unit), ndd.mask)  # doctest: +FLOAT_CMP
+    <MaskedQuantity [——, 2., 3., ——] m>
+

--- a/docs/nddata/nddata.rst
+++ b/docs/nddata/nddata.rst
@@ -458,9 +458,9 @@ masked ones::
     NDDataArray([6., 9.], unit='m')
 
 where the first data element is masked. We can instead get the sum
-for only unmasked values with the ``ignore_masked_data`` option::
+for only unmasked values with the ``operation_ignores_mask`` option::
 
-    >>> nddata.sum(axis=1, ignore_masked_data=True)
+    >>> nddata.sum(axis=1, operation_ignores_mask=True)
     NDDataArray([5, 9])
 
 ..

--- a/docs/nddata/subclassing.rst
+++ b/docs/nddata/subclassing.rst
@@ -275,8 +275,8 @@ To change the default value of an existing parameter for arithmetic methods::
 
     >>> ndd1 = NDDDiffAritDefaults(1, mask=False)
     >>> ndd2 = NDDDiffAritDefaults(1, mask=True)
-    >>> ndd1.add(ndd2).mask is None  # it will be None
-    True
+    >>> # No mask handling logic will return no mask:
+    >>> ndd1.add(ndd2).mask
 
     >>> # But giving other values is still possible:
     >>> ndd1.add(ndd2, handle_mask=np.logical_or).mask

--- a/docs/whatsnew/5.3.rst
+++ b/docs/whatsnew/5.3.rst
@@ -147,6 +147,34 @@ readable results when printing quantities, table headers and cells, etc.
 For ``'latex'`` the default remains ``fraction='display'``, for an
 unchanged experience with IPython notebook.
 
+Support for collapse operations on arbitrary axes in ``nddata``
+===============================================================
+
+
+Take the sum, mean, maximum, or minimum along one or more axes,
+reducing the dimensions of the output, on `~astropy.nddata.NDData` objects
+with appropriate propagation of uncertainties, masks, and units. For example,
+we can take the sum of ND masked quantities along the ``1`` axis like so::
+
+    >>> import numpy as np
+    >>> import astropy.units as u
+    >>> from astropy.nddata import NDDataArray, StdDevUncertainty
+    >>>
+    >>> data = [
+    ...     [1, 2, 3],
+    ...     [2, 3, 4]
+    ... ]
+    >>> mask = [
+    ...     [True, False, False],
+    ...     [False, False, False]
+    ... ]
+    >>> uncertainty = StdDevUncertainty(np.ones_like(data))
+    >>> nddata = NDDataArray(data=data, uncertainty=uncertainty, mask=mask, unit='m')
+    >>> nddata.sum(axis=1), sum_axis_1.mask, sum_axis_1.uncertainty
+    (NDDataArray([6., 9.], unit='m'),
+     array([ True, False]),
+     StdDevUncertainty([1.41421356, 1.73205081]))
+
 Full change log
 ===============
 

--- a/docs/whatsnew/5.3.rst
+++ b/docs/whatsnew/5.3.rst
@@ -170,7 +170,8 @@ we can take the sum of ND masked quantities along the ``1`` axis like so::
     ... ]
     >>> uncertainty = StdDevUncertainty(np.ones_like(data))
     >>> nddata = NDDataArray(data=data, uncertainty=uncertainty, mask=mask, unit='m')
-    >>> nddata.sum(axis=1), sum_axis_1.mask, sum_axis_1.uncertainty
+    >>> sum_axis_1 = nddata.sum(axis=1)
+    >>> sum_axis_1, sum_axis_1.mask, sum_axis_1.uncertainty
     (NDDataArray([6., 9.], unit='m'),
      array([ True, False]),
      StdDevUncertainty([1.41421356, 1.73205081]))

--- a/docs/whatsnew/5.3.rst
+++ b/docs/whatsnew/5.3.rst
@@ -12,8 +12,12 @@ the 5.2 release.
 
 In particular, this release includes:
 
+.. * :ref:`whatsnew-5.3-cosmology`
 .. * :ref:`whatsnew-5.3-table-union-operators`
+.. * :ref:`whatsnew-5.3-compressed-fits`
+.. * :ref:`whatsnew-5.3-compressed-fits-nocompress`
 .. * :ref:`whatsnew-5.3-unit-formats-fraction`
+.. * :ref:`whatsnew-5.3-nddata-collapse-arbitrary-axes`
 
 In addition to these major changes, Astropy v5.3 includes a large number of
 smaller improvements and bug fixes, which are described in the :ref:`changelog`.
@@ -147,9 +151,10 @@ readable results when printing quantities, table headers and cells, etc.
 For ``'latex'`` the default remains ``fraction='display'``, for an
 unchanged experience with IPython notebook.
 
+.. _whatsnew-5.3-nddata-collapse-arbitrary-axes:
+
 Support for collapse operations on arbitrary axes in ``nddata``
 ===============================================================
-
 
 Take the sum, mean, maximum, or minimum along one or more axes,
 reducing the dimensions of the output, on `~astropy.nddata.NDData` objects


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

The nddata module ([docs](https://docs.astropy.org/en/stable/nddata/index.html)) supports arithmetic between `NDDataArray` objects with propagation of units, masking and uncertainties. The currently supported arithmetic operations include addition, subtraction, multiplication and division. 

A set of unsupported operations would "collapse" `NDDataArray`s along specified axes. For a concrete example, imagine the `NDDataArray` named `cube` represents a spectral cube from an IFU with a spectral dimension (axis=0) and two spatial dimensions (axes 1 and 2). It may be useful to collapse the cube to a single spectrum by taking the maximum the spatial dimensions at each wavelength, which might be represented with a numpy-like syntax like with `collapsed_spectrum = cube.max(axis=(1, 2))`. In the case of `min`/`max`, we expect the uncertainties in `collapsed_spectrum` to be the uncertainties at each maximum flux in the spatial dimension. If instead we took the mean with `cube.mean(axis=(1, 2))`, we would propagate uncertainties along the collapsed axes. The mask should also be propagated so that only unmasked values are included in the collapse operation.

This type of generic collapse operation is something we need over in [jdaviz](https://github.com/spacetelescope/jdaviz/), where we currently rely on glue to collapse our spectral cubes *after* they have been converted to glue `Data` objects. Since we don't anticipate unit/mask/error propagation to be added to glue `Data` objects, we're hoping to implement this functionality in astropy, and then offer jdaviz users the option to propagate units/masks/errors via the astropy methods.

This PR is a first-draft implementation of `sum`, `mean`, `min`, and `max` methods for `NDDataArray`, which accept an integer or a tuple of ints for the `axis` argument. As of opening this draft PR, I have implemented the collapse arithmetic for the data and uncertainties, and I'm now working on correctly applying the masks. I'm putting up this unfinished PR to collect comments and discussion while I put together docs and tests. Comments welcome and needed!

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.

## See additional to-do items at https://github.com/astropy/astropy/pull/14175#issuecomment-1428117828