### PR TITLE
Fix ITRS frame earth_location attribute to work correctly for topocentric frames.

### DIFF
--- a/astropy/coordinates/builtin_frames/itrs.py
+++ b/astropy/coordinates/builtin_frames/itrs.py
@@ -77,7 +77,8 @@ class ITRS(BaseCoordinateFrame):
         """
         from astropy.coordinates.earth import EarthLocation
 
-        cart = self.represent_as(CartesianRepresentation)
+        cart = self.represent_as(CartesianRepresentation).without_differentials()
+        cart += self.location.get_itrs().cartesian
         return EarthLocation(x=cart.x, y=cart.y, z=cart.z)
 
 

--- a/astropy/coordinates/builtin_frames/itrs.py
+++ b/astropy/coordinates/builtin_frames/itrs.py
@@ -77,9 +77,12 @@ class ITRS(BaseCoordinateFrame):
         """
         from astropy.coordinates.earth import EarthLocation
 
-        cart = self.represent_as(CartesianRepresentation).without_differentials()
-        cart += self.location.get_itrs(self.obstime).cartesian
-        return EarthLocation(x=cart.x, y=cart.y, z=cart.z)
+        cart = self.represent_as(CartesianRepresentation)
+        return EarthLocation(
+            x=cart.x + self.location.x,
+            y=cart.y + self.location.y,
+            z=cart.z + self.location.z,
+        )
 
 
 # Self-transform is in intermediate_rotation_transforms.py with all the other

--- a/astropy/coordinates/builtin_frames/itrs.py
+++ b/astropy/coordinates/builtin_frames/itrs.py
@@ -78,7 +78,7 @@ class ITRS(BaseCoordinateFrame):
         from astropy.coordinates.earth import EarthLocation
 
         cart = self.represent_as(CartesianRepresentation).without_differentials()
-        cart += self.location.get_itrs().cartesian
+        cart += self.location.get_itrs(self.obstime).cartesian
         return EarthLocation(x=cart.x, y=cart.y, z=cart.z)
 
 

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -818,6 +818,26 @@ def test_hadec_attributes():
     assert_allclose(sr.lon, -1 * u.hourangle)
 
 
+def test_itrs_earth_location():
+    loc = EarthLocation(lat=0 * u.deg, lon=0 * u.deg, height=0 * u.m)
+    sat = EarthLocation(
+        lat=-24.6609379 * u.deg, lon=160.34199789 * u.deg, height=420.17927591 * u.km
+    )
+
+    itrs_geo = sat.get_itrs()
+    eloc = itrs_geo.earth_location
+    assert_allclose(sat.lon, eloc.lon)
+    assert_allclose(sat.lat, eloc.lat)
+    assert_allclose(sat.height, eloc.height)
+
+    topo_itrs_repr = itrs_geo.cartesian - loc.get_itrs().cartesian
+    itrs_topo = ITRS(topo_itrs_repr, location=loc)
+    eloc = itrs_topo.earth_location
+    assert_allclose(sat.lon, eloc.lon)
+    assert_allclose(sat.lat, eloc.lat)
+    assert_allclose(sat.height, eloc.height)
+
+
 def test_representation():
     """
     Test the getter and setter properties for `representation`

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -837,6 +837,14 @@ def test_itrs_earth_location():
     assert_allclose(sat.lat, eloc.lat)
     assert_allclose(sat.height, eloc.height)
 
+    obstime = Time("J2010")  # Anything different from default
+    topo_itrs_repr2 = sat.get_itrs(obstime).cartesian - loc.get_itrs(obstime).cartesian
+    itrs_topo2 = ITRS(topo_itrs_repr2, location=loc, obstime=obstime)
+    eloc2 = itrs_topo2.earth_location
+    assert_allclose(sat.lon, eloc2.lon)
+    assert_allclose(sat.lat, eloc2.lat)
+    assert_allclose(sat.height, eloc2.height)
+
 
 def test_representation():
     """

--- a/docs/changes/coordinates/14180.bugfix.rst
+++ b/docs/changes/coordinates/14180.bugfix.rst
@@ -1,0 +1,1 @@
+Fix to ITRS frame ``earth_location`` attribute to give the correct result for a topocentric frame.


### PR DESCRIPTION

<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

As @maxnoe pointed out here https://github.com/astropy/astropy/issues/14173#issuecomment-1351564230, the ITRS frame `earth_location` attribute currently returns an incorrect result for a topocentric frame. This PR will fix that. Perhaps this could be backported to 5.2?

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
