### PR TITLE
Allow RST header rows to be specified via header_rows argument

### DIFF
--- a/astropy/io/ascii/rst.py
+++ b/astropy/io/ascii/rst.py
@@ -27,7 +27,6 @@ class SimpleRSTHeader(FixedWidthHeader):
 
 
 class SimpleRSTData(FixedWidthData):
-    start_line = 3
     end_line = -1
     splitter_class = FixedWidthTwoLineDataSplitter
 
@@ -39,12 +38,29 @@ class RST(FixedWidth):
 
     Example::
 
-        ==== ===== ======
-        Col1  Col2  Col3
-        ==== ===== ======
-          1    2.3  Hello
-          2    4.5  Worlds
-        ==== ===== ======
+      >>> from astropy.table import QTable
+      >>> import astropy.units as u
+      >>> import sys
+      >>> tbl = QTable({"wave": [350, 950] * u.nm, "response": [0.7, 1.2] * u.count})
+      >>> tbl.write(sys.stdout,  format="ascii.rst")
+      ===== ========
+       wave response
+      ===== ========
+      350.0      0.7
+      950.0      1.2
+      ===== ========
+
+    Like other fixed-width formats, when writing a table you can provide ``header_rows``
+    to specify a list of table rows to output as the header.  For example::
+
+      >>> tbl.write(sys.stdout,  format="ascii.rst", header_rows=['name', 'unit'])
+      ===== ========
+       wave response
+         nm       ct
+      ===== ========
+      350.0      0.7
+      950.0      1.2
+      ===== ========
 
     Currently there is no support for reading tables which utilize continuation lines,
     or for ones which define column spans through the use of an additional
@@ -57,10 +73,15 @@ class RST(FixedWidth):
     data_class = SimpleRSTData
     header_class = SimpleRSTHeader
 
-    def __init__(self):
-        super().__init__(delimiter_pad=None, bookend=False)
+    def __init__(self, header_rows=None):
+        super().__init__(delimiter_pad=None, bookend=False, header_rows=header_rows)
 
     def write(self, lines):
         lines = super().write(lines)
-        lines = [lines[1]] + lines + [lines[1]]
+        idx = len(self.header.header_rows)
+        lines = [lines[idx]] + lines + [lines[idx]]
         return lines
+
+    def read(self, table):
+        self.data.start_line = 2 + len(self.header.header_rows)
+        return super().read(table)

--- a/astropy/io/ascii/tests/test_rst.py
+++ b/astropy/io/ascii/tests/test_rst.py
@@ -2,7 +2,10 @@
 
 from io import StringIO
 
+import astropy.units as u
+import numpy as np
 from astropy.io import ascii
+from astropy.table import QTable
 
 from .common import assert_almost_equal, assert_equal
 
@@ -185,3 +188,28 @@ Col1      Col2 Col3 Col4
 ==== ========= ==== ====
 """,
     )
+
+
+def test_rst_with_header_rows():
+    """Round-trip a table with header_rows specified"""
+    lines = [
+        "======= ======== ====",
+        "   wave response ints",
+        "     nm       ct     ",
+        "float64  float32 int8",
+        "======= ======== ====",
+        "  350.0      1.0    1",
+        "  950.0      2.0    2",
+        "======= ======== ====",
+    ]
+    tbl = QTable.read(lines, format="ascii.rst", header_rows=["name", "unit", "dtype"])
+    assert tbl['wave'].unit == u.nm
+    assert tbl['response'].unit == u.ct
+    assert tbl['wave'].dtype == np.float64
+    assert tbl['response'].dtype == np.float32
+    assert tbl['ints'].dtype == np.int8
+
+    out = StringIO()
+    tbl.write(out, format="ascii.rst", header_rows=["name", "unit", "dtype"])
+    assert out.getvalue().splitlines() == lines
+

--- a/docs/changes/io.ascii/14182.feature.rst
+++ b/docs/changes/io.ascii/14182.feature.rst
@@ -1,0 +1,4 @@
+Add ability to read and write an RST (reStructuredText) ASCII table that
+includes additional header rows specifying any or all of the column dtype, unit,
+format, and description. This is available via the new ``header_rows`` keyword
+argument.

--- a/docs/io/ascii/fixed_width_gallery.rst
+++ b/docs/io/ascii/fixed_width_gallery.rst
@@ -463,9 +463,9 @@ Fixed Width Two Line
 Custom Header Rows
 ==================
 
-The ``fixed_width`` and ``fixed_width_two_line`` formats normally include a
-single initial row with the column names in the header.  However, it is possible
-to customize the column attributes which appear as header rows. The available
+The ``fixed_width``, ``fixed_width_two_line``, and ``rst`` formats normally include a
+single row with the column names in the header.  However, for these formats you can
+customize the column attributes which appear as header rows. The available
 column attributes are ``name``, ``dtype``, ``format``, ``description`` and
 ``unit``.  This is done by listing the desired the header rows using the
 ``header_rows`` keyword argument.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to add support for header rows in RestructuredText output.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #14181

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
