### PR TITLE
Add use of `|` and `|=` operators to `Table`

### DIFF
--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -2242,6 +2242,21 @@ class Table:
             self._first_colname = next(iter(self.columns))
             return len(self.columns[self._first_colname])
 
+    def __or__(self, other):
+        if isinstance(other, Table):
+            updated_table = self.copy()
+            updated_table.update(other)
+            return updated_table
+        else:
+            return NotImplemented
+
+    def __ior__(self, other):
+        try:
+            self.update(other)
+            return self
+        except TypeError:
+            return NotImplemented
+
     def index_column(self, name):
         """
         Return the positional index of column ``name``.
@@ -3331,7 +3346,9 @@ class Table:
         The argument ``other`` must be a |Table|, or something that can be used
         to initialize a table. Columns from (possibly converted) ``other`` are
         added to this table. In case of matching column names the column from
-        this table is replaced with the one from ``other``.
+        this table is replaced with the one from ``other``. If ``other`` is a
+        |Table| instance then ``|=`` is available as alternate syntax for in-place
+        update and ``|`` can be used merge data to a new table.
 
         Parameters
         ----------

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -2455,6 +2455,42 @@ class TestUpdate:
         assert np.all(t2["c"] == self.c)
         assert np.all(t2["d"] == self.d)
 
+    def test_merge_operator(self):
+        self._setup()
+        t1 = Table([self.a, self.b])
+        t2 = Table([self.b, self.c])
+        with pytest.raises(TypeError):
+            _ = 1 | t1
+        with pytest.raises(TypeError):
+            _ = t1 | 1
+
+        t1_copy = t1.copy(True)
+        t3 = t1 | t2
+        assert t1.colnames == ["a", "b"]  # t1 should remain unchanged
+        assert np.all(t1["a"] == self.a)
+        assert np.all(t1["b"] == self.b)
+
+        t1_copy.update(t2)
+        assert t3.colnames == ["a", "b", "c"]
+        assert np.all(t3["a"] == t1_copy["a"])
+        assert np.all(t3["b"] == t1_copy["b"])
+        assert np.all(t3["c"] == t1_copy["c"])
+
+    def test_update_operator(self):
+        self._setup()
+        t1 = Table([self.a, self.b])
+        t2 = Table([self.b, self.c])
+        with pytest.raises(ValueError):
+            t1 |= 1
+
+        t1_copy = t1.copy(True)
+        t1 |= t2
+        t1_copy.update(t2)
+        assert t1.colnames == ["a", "b", "c"]
+        assert np.all(t1["a"] == t1_copy["a"])
+        assert np.all(t1["b"] == t1_copy["b"])
+        assert np.all(t1["c"] == t1_copy["c"])
+
 
 def test_table_meta_copy():
     """

--- a/docs/changes/table/14187.feature.rst
+++ b/docs/changes/table/14187.feature.rst
@@ -1,0 +1,2 @@
+``Table`` and ``QTable`` can now use the ``|`` and ``|=`` operators for
+dictionary-style merge and update.

--- a/docs/table/modify_table.rst
+++ b/docs/table/modify_table.rst
@@ -155,7 +155,7 @@ the table and replaces existing ones::
 
   >>> t1 = Table({'name': ['foo', 'bar'], 'val': [0., 0.]}, meta={'n': 2})
   >>> t2 = Table({'val': [1., 2.], 'val2': [10., 10.]}, meta={'id': 0})
-  >>> t1.update(t2)
+  >>> t1 |= t2
   >>> t1
   <Table length=2>
   name   val     val2
@@ -164,14 +164,45 @@ the table and replaces existing ones::
    foo     1.0    10.0
    bar     2.0    10.0
 
-:meth:`~astropy.table.Table.update` also takes care of silently :ref:`merging_metadata`::
+When using ``|=``, the other object does not need to be a |Table|, it can be
+anything that can be used for :ref:`construct_table` with a compatible number
+of rows::
 
-  >>> t1.meta
+  >>> t1 = Table({'name': ['foo', 'bar'], 'val': [0., 0.]}, meta={'n': 2})
+  >>> d = dict({'val': [1., 2.], 'val2': [10., 10.]})
+  >>> t1 |= d
+  >>> t1
+  <Table length=2>
+  name   val     val2
+  str3 float64 float64
+  ---- ------- -------
+   foo     1.0    10.0
+   bar     2.0    10.0
+
+It is also possible to use the ``|`` operator to merge multiple |Table| instances
+into a new table::
+
+  >>> from astropy.table import QTable
+  >>> t1 = Table({'name': ['foo', 'bar'], 'val': [0., 0.]}, meta={'n': 2})
+  >>> t2 = QTable({'val': [1., 2.], 'val2': [10., 10.]}, meta={'id': 0})
+  >>> t3 = t1 | t2  # Create a new table as result of update
+  >>> t3
+  <Table length=2>
+  name   val     val2
+  str3 float64 float64
+  ---- ------- -------
+   foo     1.0    10.0
+   bar     2.0    10.0
+
+``|`` and ``|=`` also take care of silently :ref:`merging_metadata`::
+
+  >>> t3.meta
   {'n': 2, 'id': 0}
 
-The input of :meth:`~astropy.table.Table.update` does not have to be a |Table|,
-it can be anything that can be used for :ref:`construct_table` with a
-compatible number of rows.
+The columns in the updated |Table| are going to be copies of the originals. If
+you need them to be references you can use the
+:meth:`~astropy.table.Table.update` method with ``copy=False``, see :ref:`copy_versus_reference`
+for details.
 
 **Rename columns**
 

--- a/docs/whatsnew/5.3.rst
+++ b/docs/whatsnew/5.3.rst
@@ -12,7 +12,7 @@ the 5.2 release.
 
 In particular, this release includes:
 
-.. * :ref:`whatsnew-5.3-example`
+.. * :ref:`whatsnew-5.3-table-union-operators`
 
 In addition to these major changes, Astropy v5.3 includes a large number of
 smaller improvements and bug fixes, which are described in the :ref:`changelog`.
@@ -37,6 +37,41 @@ respectively.
     >>> cosmo.comoving_distance(0.5)  # doctest: +SKIP
     <Quantity 1982.66012926 Mpc>
 
+.. _whatsnew-5.3-table-union-operators:
+
+New union operators for |Table|
+===============================
+
+We have added support for dictionary-style merge (``|``) and update (``|=``)
+of columns in the |Table| class. This follows the  behavior for ``dict`` defined
+in `PEP 584 <https://peps.python.org/pep-0584/>`_. ``|=`` works the same way as
+:meth:`~astropy.table.Table.update` and updates the table in place. ``|``
+return the updated table::
+
+	>>> from astropy.table import Table, QTable
+	>>> t1 = Table({'a': ['foo', 'bar'], 'b': [0., 0.]})
+	>>> t2 = QTable({'b': [1., 2.], 'c': [7., 11.]})
+	>>> t3 = t1 | t2  # Create new table which merges columns from t1 and t2
+	>>> t3
+	<Table length=2>
+	a      b       c
+	str3 float64 float64
+	---- ------- -------
+	foo     1.0     7.0
+	bar     2.0    11.0
+
+	>>> t2 |= t1  # Update t2 columns in-place with t1 columns
+	>>> t2
+	<QTable length=2>
+	   b       c     a
+	float64 float64 str3
+	------- ------- ----
+	    0.0     7.0  foo
+	    0.0    11.0  bar
+
+When using ``|=``, the other object does not need to be a |Table|, it can be
+anything that can be used for :ref:`construct_table` with a compatible number
+of rows.
 
 Full change log
 ===============


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

Since Python 3.9, dictionaries support using the `|` and `|=` operators to merge and update dictionaries in a similar way to how `Table.update()` works. The goal of this pull request is to enable the use of `|` and `|=` operators for merge and update in place for Tables. No real new functionality is added, everything builds on the existing `.update` method. This PR only enables the operators. 

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
