### PR TITLE
Fix test for multidimensional VLA. Reverse dim tuple.

### DIFF
--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -3276,20 +3276,21 @@ class TestVLATables(FitsTestCase):
         See https://github.com/astropy/astropy/issues/12860
         and https://github.com/astropy/astropy/issues/7810
         """
-        a = np.arange(5).reshape((5, 1))
-        b = np.arange(7).reshape((7, 1))
+
+        a = np.arange(5)
+        b = np.arange(7)
         array = np.array([a, b], dtype=object)
-        col = fits.Column(name="test", format="PD(7)", dim="(1,7)", array=array)
+        col = fits.Column(name="test", format="PD(7)", dim="(7,1)", array=array)
         fits.BinTableHDU.from_columns([col]).writeto(self.temp("test.fits"))
 
         with fits.open(self.temp("test.fits")) as hdus:
+            print(hdus[1].data["test"][0])
             assert hdus[1].columns.formats == ["PD(7)"]
-            np.array_equal(
-                hdus[1].data["test"],
-                [
-                    np.array([[0.0, 1.0, 2.0, 3.0, 4.0]]),
-                    np.array([[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0]]),
-                ],
+            assert np.array_equal(
+                hdus[1].data["test"][0], np.array([[0.0, 1.0, 2.0, 3.0, 4.0]])
+            )
+            assert np.array_equal(
+                hdus[1].data["test"][1], np.array([[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0]])
             )
 
         a = np.arange(10).reshape((5, 2))
@@ -3300,24 +3301,23 @@ class TestVLATables(FitsTestCase):
 
         with fits.open(self.temp("test2.fits")) as hdus:
             assert hdus[1].columns.formats == ["PD(14)"]
-            np.array_equal(
-                hdus[1].data["test"],
-                [
-                    np.array(
-                        [[0.0, 1.0], [2.0, 3.0], [4.0, 5.0], [6.0, 7.0], [8.0, 9.0]]
-                    ),
-                    np.array(
-                        [
-                            [0.0, 1.0],
-                            [2.0, 3.0],
-                            [4.0, 5.0],
-                            [6.0, 7.0],
-                            [8.0, 9.0],
-                            [10.0, 11.0],
-                            [12.0, 13.0],
-                        ]
-                    ),
-                ],
+            assert np.array_equal(
+                hdus[1].data["test"][0],
+                np.array([[0.0, 1.0], [2.0, 3.0], [4.0, 5.0], [6.0, 7.0], [8.0, 9.0]]),
+            )
+            assert np.array_equal(
+                hdus[1].data["test"][1],
+                np.array(
+                    [
+                        [0.0, 1.0],
+                        [2.0, 3.0],
+                        [4.0, 5.0],
+                        [6.0, 7.0],
+                        [8.0, 9.0],
+                        [10.0, 11.0],
+                        [12.0, 13.0],
+                    ]
+                ),
             )
 
         a = np.arange(3).reshape((1, 3))
@@ -3328,12 +3328,9 @@ class TestVLATables(FitsTestCase):
 
         with fits.open(self.temp("test3.fits")) as hdus:
             assert hdus[1].columns.formats == ["PD(6)"]
-            np.array_equal(
-                hdus[1].data["test"],
-                [
-                    np.array([[0.0, 1.0, 2.0]]),
-                    np.array([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]),
-                ],
+            assert np.array_equal(hdus[1].data["test"][0], np.array([[0.0, 1.0, 2.0]]))
+            assert np.array_equal(
+                hdus[1].data["test"][1], np.array([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]])
             )
 
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to fix the bad test in #13417.
Also improving the test pointed out that some multidimensional VLA are not covered by the actual implementation. 
The current workaround is probably not the best one. :(

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
