### PR TITLE
Fix WCSAxes sometimes emitting RuntimeWarning with NumPy 1.24

### DIFF
--- a/astropy/visualization/wcsaxes/coordinate_range.py
+++ b/astropy/visualization/wcsaxes/coordinate_range.py
@@ -71,7 +71,7 @@ def find_coordinate_range(transform, extent, coord_types, coord_units, coord_wra
                 reset = np.abs(wjump) > 180.0
             if np.any(reset):
                 wjump = wjump + np.sign(wjump) * 180.0
-                wjump = 360.0 * (wjump / 360.0).astype(int)
+                wjump = 360.0 * np.trunc(wjump / 360.0)
                 xw[0, 1:][reset] -= wjump[reset]
 
             # Now iron out coordinates along all columns, starting with first row.
@@ -80,7 +80,7 @@ def find_coordinate_range(transform, extent, coord_types, coord_units, coord_wra
                 reset = np.abs(wjump) > 180.0
             if np.any(reset):
                 wjump = wjump + np.sign(wjump) * 180.0
-                wjump = 360.0 * (wjump / 360.0).astype(int)
+                wjump = 360.0 * np.trunc(wjump / 360.0)
                 xw[1:][reset] -= wjump[reset]
 
         with warnings.catch_warnings():

--- a/docs/changes/visualization/14211.bugfix.rst
+++ b/docs/changes/visualization/14211.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed WCSAxes sometimes triggering a NumPy RuntimeWarning when determining the coordinate range of an axes.
+Fixed WCSAxes sometimes triggering a NumPy RuntimeWarning when determining the coordinate range of the axes.

--- a/docs/changes/visualization/14211.bugfix.rst
+++ b/docs/changes/visualization/14211.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed WCSAxes sometimes triggering a NumPy RuntimeWarning when determining the coordinate range of an axes.


### PR DESCRIPTION
As of NumPy 1.24 (specifically, numpy/numpy#21437), casting a NaN to an integer produces a `RuntimeWarning`.  `astropy.visualization.wcsaxes.coordinate_range.find_coordinate_range()` uses `.astype(int)` to truncate an array to integers, but the array can have NaNs because it is the result of a transformation to world coordinates.  Not only does that produce a `RuntimeWarning`, the resulting array has garbage integers where the NaNs were, which is silly because the array is immediately turned back into a float array.

This PR replaces those uses with `np.trunc()`.