### PR TITLE
Adding a votable.get_infos_by_name method.

### DIFF
--- a/astropy/io/votable/tests/vo_test.py
+++ b/astropy/io/votable/tests/vo_test.py
@@ -1060,3 +1060,20 @@ def test_timesys_errors():
     assert "E23: Invalid timeorigin attribute 'bad-origin'" in outstr
     assert "E22: ID attribute is required for all TIMESYS elements" in outstr
     assert "W48: Unknown attribute 'refposition_mispelled' on TIMESYS" in outstr
+
+
+def test_get_infos_by_name():
+    vot = parse(
+        io.BytesIO(
+            b"""
+        <VOTABLE xmlns="http://www.ivoa.net/xml/VOTable/v1.3"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.4">
+          <RESOURCE type="results">
+            <INFO name="creator-name" value="Cannon, A."/>
+            <INFO name="creator-name" value="Fleming, W."/>
+          </RESOURCE>
+        </VOTABLE>"""
+        )
+    )
+    infos = vot.get_infos_by_name("creator-name")
+    assert [i.value for i in infos] == ["Cannon, A.", "Fleming, W."]

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -4173,6 +4173,14 @@ class VOTableFile(Element, _IDProperty, _DescriptionProperty):
         "ID", True, "iter_info", "INFO", """Looks up a INFO element by the given ID."""
     )
 
+    get_infos_by_name = _lookup_by_attr_factory(
+        "name",
+        False,
+        "iter_info",
+        "INFO",
+        """Returns all INFO children with the given name.""",
+    )
+
     def set_all_tables_format(self, format):
         """
         Set the output storage format of all tables in the file.

--- a/docs/changes/io.votable/14212.feature.rst
+++ b/docs/changes/io.votable/14212.feature.rst
@@ -1,0 +1,2 @@
+Added a method ``get_infos_by_name`` to make it easier to implement
+DALI-compliant protocols


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request adds a get_infos_by_name method to VOTable objects, quite in line with the existing get_info_by_id.  It would be great if astropy had this because named infos play an important role in VO protocols based on DALI (cf.  https://ivoa.net/documents/DALI/) with names such as standardID, QUERY_STATUS, citation, and more to come as part of an initiative from the IVOA data curation IG, https://github.com/gilleslandais/ivoa-dcp-data-origin.

I have noted that quite a few tests fail, both locally on my machine and on the github CI; however, none of these failures seem related to this particular change.  Kindly let me know if I got that wrong.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.