### PR TITLE
TST: Do not use scipy to get ascent.dat

### DIFF
--- a/astropy/io/fits/tests/test_image.py
+++ b/astropy/io/fits/tests/test_image.py
@@ -11,8 +11,7 @@ from numpy.testing import assert_equal
 
 from astropy.io import fits
 from astropy.io.fits.hdu.compressed import DITHER_SEED_CHECKSUM, SUBTRACTIVE_DITHER_1
-from astropy.utils.compat.optional_deps import HAS_SCIPY
-from astropy.utils.data import get_pkg_data_filename
+from astropy.utils.data import get_pkg_data_filename, download_file
 from astropy.utils.exceptions import AstropyUserWarning
 
 from .conftest import FitsTestCase
@@ -1178,7 +1177,6 @@ class TestCompressedImage(FitsTestCase):
             assert fd[1].header["NAXIS2"] == chdu.header["NAXIS2"]
             assert fd[1].header["BITPIX"] == chdu.header["BITPIX"]
 
-    @pytest.mark.skipif(not HAS_SCIPY, reason="requires scipy")
     @pytest.mark.remote_data
     def test_comp_image_quantize_level(self):
         """
@@ -1187,19 +1185,14 @@ class TestCompressedImage(FitsTestCase):
         Test that quantize_level is used.
 
         """
-        import scipy
+        import pickle
 
-        from astropy.utils import minversion
-
-        SCIPY_LT_1_10 = not minversion(scipy, "1.10dev0")
         np.random.seed(42)
 
-        if SCIPY_LT_1_10:
-            import scipy.misc  # No lazy loading for SCIPY_LT_1_9
-
-            scipy_data = scipy.misc.ascent()
-        else:
-            scipy_data = scipy.datasets.ascent()
+        # Basically what scipy.datasets.ascent() does.
+        fname = download_file('https://github.com/scipy/dataset-ascent/blob/main/ascent.dat?raw=true')
+        with open(fname, 'rb') as f:
+            scipy_data = np.array(pickle.load(f))
 
         data = scipy_data + np.random.randn(512, 512) * 10
 

--- a/astropy/io/fits/tests/test_image.py
+++ b/astropy/io/fits/tests/test_image.py
@@ -11,7 +11,7 @@ from numpy.testing import assert_equal
 
 from astropy.io import fits
 from astropy.io.fits.hdu.compressed import DITHER_SEED_CHECKSUM, SUBTRACTIVE_DITHER_1
-from astropy.utils.data import get_pkg_data_filename, download_file
+from astropy.utils.data import download_file, get_pkg_data_filename
 from astropy.utils.exceptions import AstropyUserWarning
 
 from .conftest import FitsTestCase
@@ -1190,8 +1190,10 @@ class TestCompressedImage(FitsTestCase):
         np.random.seed(42)
 
         # Basically what scipy.datasets.ascent() does.
-        fname = download_file('https://github.com/scipy/dataset-ascent/blob/main/ascent.dat?raw=true')
-        with open(fname, 'rb') as f:
+        fname = download_file(
+            "https://github.com/scipy/dataset-ascent/blob/main/ascent.dat?raw=true"
+        )
+        with open(fname, "rb") as f:
             scipy_data = np.array(pickle.load(f))
 
         data = scipy_data + np.random.randn(512, 512) * 10

--- a/setup.cfg
+++ b/setup.cfg
@@ -70,7 +70,6 @@ test_all =  # Required for testing, plus packages used by particular tests.
     coverage[toml]
     skyfield>=1.20
     sgp4>=2.3
-    pooch
 recommended =
     scipy>=1.5
     matplotlib>=3.1,!=3.4.0,!=3.5.2


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to hopefully fix #14205 by completely working around https://github.com/scipy/dataset-ascent/issues/4 because I never heard back and it is just one file for one test.

Pro: This test no longer needs scipy to be installed to run. Also can get rid of pooch.

Con: There must be a reason why scipy got so fancy with their dataset control? Am I introducing a security risk here?

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
