### PR TITLE
Manual backport of PR 14140 to v5.0.x (Unpin sphinx alternative)

### DIFF
--- a/astropy/coordinates/angles.py
+++ b/astropy/coordinates/angles.py
@@ -34,8 +34,8 @@ class Angle(u.SpecificTypeQuantity):
     :class:`~astropy.coordinates.Angle`.
 
     The input parser is flexible and supports a variety of formats.
-    The examples below illustrate common ways of initializing an `Angle`
-    object. First some imports::
+    The examples below illustrate common ways of initializing an
+    `~astropy.coordinates.Angle` object. First some imports::
 
       >>> from astropy.coordinates import Angle
       >>> from astropy import units as u
@@ -81,7 +81,7 @@ class Angle(u.SpecificTypeQuantity):
 
     Parameters
     ----------
-    angle : `~numpy.array`, scalar, `~astropy.units.Quantity`, :class:`~astropy.coordinates.Angle`
+    angle : `~numpy.array`, scalar, `~astropy.units.Quantity`, `~astropy.coordinates.Angle`
         The angle value. If a tuple, will be interpreted as ``(h, m,
         s)`` or ``(d, m, s)`` depending on ``unit``. If a string, it
         will be interpreted following the rules described above.

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -209,12 +209,10 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
     Unless overridden via `frame_specific_representation_info`, velocity name
     defaults are:
 
-      * ``pm_{lon}_cos{lat}``, ``pm_{lat}`` for `SphericalCosLatDifferential`
-        proper motion components
-      * ``pm_{lon}``, ``pm_{lat}`` for `SphericalDifferential` proper motion
-        components
+      * ``pm_{lon}_cos{lat}``, ``pm_{lat}`` for `~astropy.coordinates.SphericalCosLatDifferential` velocity components
+      * ``pm_{lon}``, ``pm_{lat}`` for `~astropy.coordinates.SphericalDifferential` velocity components
       * ``radial_velocity`` for any ``d_distance`` component
-      * ``v_{x,y,z}`` for `CartesianDifferential` velocity components
+      * ``v_{x,y,z}`` for `~astropy.coordinates.CartesianDifferential` velocity components
 
     where ``{lon}`` and ``{lat}`` are the frame names of the angular components.
     """
@@ -978,7 +976,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
 
         Returns
         -------
-        frameobj : `BaseCoordinateFrame` subclass instance
+        frameobj : `~astropy.coordinates.BaseCoordinateFrame` subclass instance
             Replica of this object, but possibly with new frame attributes.
         """
         return self._replicate(self.data, copy=copy, **kwargs)
@@ -1006,7 +1004,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
 
         Returns
         -------
-        frameobj : `BaseCoordinateFrame` subclass instance
+        frameobj : `~astropy.coordinates.BaseCoordinateFrame` subclass instance
             Replica of this object, but without data and possibly with new frame
             attributes.
         """
@@ -1028,7 +1026,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
 
         Returns
         -------
-        frameobj : `BaseCoordinateFrame` subclass instance
+        frameobj : `~astropy.coordinates.BaseCoordinateFrame` subclass instance
             A new object in *this* frame, with the same frame attributes as
             this one, but with the ``data`` as the coordinate data.
 
@@ -1247,7 +1245,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
 
         Parameters
         ----------
-        new_frame : coordinate-like or `BaseCoordinateFrame` subclass instance
+        new_frame : coordinate-like or `~astropy.coordinates.BaseCoordinateFrame` subclass instance
             The frame to transform this coordinate frame into.
             The frame class option is deprecated.
 
@@ -1314,7 +1312,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
 
         Parameters
         ----------
-        new_frame : `BaseCoordinateFrame` subclass or instance
+        new_frame : `~astropy.coordinates.BaseCoordinateFrame` subclass or instance
             The proposed frame to transform into.
 
         Returns
@@ -1459,7 +1457,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
         Raises
         ------
         TypeError
-            If ``other`` isn't a `BaseCoordinateFrame` or subclass.
+            If ``other`` isn't a `~astropy.coordinates.BaseCoordinateFrame` or subclass.
         """
         if self.__class__ == other.__class__:
             for frame_attr_name in self.get_frame_attr_names():
@@ -1947,7 +1945,8 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
     def sphericalcoslat(self):
         """
         Shorthand for a spherical representation of the positional data and a
-        `SphericalCosLatDifferential` for the velocity data in this object.
+        `~astropy.coordinates.SphericalCosLatDifferential` for the velocity
+        data in this object.
         """
 
         # TODO: if representations are updated to use a full transform graph,
@@ -1958,8 +1957,9 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
     def velocity(self):
         """
         Shorthand for retrieving the Cartesian space-motion as a
-        `CartesianDifferential` object. This is equivalent to calling
-        ``self.cartesian.differentials['s']``.
+        `~astropy.coordinates.CartesianDifferential` object.
+
+        This is equivalent to calling ``self.cartesian.differentials['s']``.
         """
         if "s" not in self.data.differentials:
             raise ValueError(

--- a/astropy/coordinates/builtin_frames/__init__.py
+++ b/astropy/coordinates/builtin_frames/__init__.py
@@ -60,7 +60,8 @@ from .lsr import LSR, GalacticLSR, LSRK, LSRD
 from astropy.coordinates.baseframe import frame_transform_graph
 
 # we define an __all__ because otherwise the transformation modules
-# get included
+# get included.  Note that the order here determines the order in the
+# documentation of the built-in frames (see make_transform_graphs_docs).
 __all__ = [
     "ICRS",
     "FK5",
@@ -68,7 +69,6 @@ __all__ = [
     "FK4NoETerms",
     "Galactic",
     "Galactocentric",
-    "galactocentric_frame_defaults",
     "Supergalactic",
     "AltAz",
     "HADec",
@@ -85,17 +85,36 @@ __all__ = [
     "GeocentricTrueEcliptic",
     "BarycentricTrueEcliptic",
     "HeliocentricTrueEcliptic",
-    "SkyOffsetFrame",
-    "GalacticLSR",
+    "HeliocentricEclipticIAU76",
+    "CustomBarycentricEcliptic",
     "LSR",
     "LSRK",
     "LSRD",
+    "GalacticLSR",
+    "SkyOffsetFrame",
     "BaseEclipticFrame",
     "BaseRADecFrame",
+    "galactocentric_frame_defaults",
     "make_transform_graph_docs",
-    "HeliocentricEclipticIAU76",
-    "CustomBarycentricEcliptic",
 ]
+
+
+def _get_doc_header(cls):
+    """Get the first line of a docstring.
+
+    Skips possible empty first lines, and then combine following text until
+    the first period or a fully empty line.
+    """
+    out = []
+    for line in cls.__doc__.splitlines():
+        if line:
+            parts = line.split(".")
+            out.append(parts[0].strip())
+            if len(parts) > 1:
+                break
+        elif out:
+            break
+    return " ".join(out) + "."
 
 
 def make_transform_graph_docs(transform_graph):
@@ -106,7 +125,7 @@ def make_transform_graph_docs(transform_graph):
 
     Parameters
     ----------
-    transform_graph : `~.coordinates.TransformGraph`
+    transform_graph : `~astropy.coordinates.TransformGraph`
 
     Returns
     -------
@@ -116,11 +135,16 @@ def make_transform_graph_docs(transform_graph):
     """
     from textwrap import dedent
 
-    coosys = [transform_graph.lookup_name(item) for item in transform_graph.get_names()]
+    coosys = {
+        (cls := transform_graph.lookup_name(item)).__name__: cls
+        for item in transform_graph.get_names()
+    }
 
     # currently, all of the priorities are set to 1, so we don't need to show
     #   then in the transform graph.
-    graphstr = transform_graph.to_dot_graph(addnodes=coosys, priorities=False)
+    graphstr = transform_graph.to_dot_graph(
+        addnodes=list(coosys.values()), priorities=False
+    )
 
     docstr = """
     The diagram below shows all of the built in coordinate systems,
@@ -168,7 +192,23 @@ def make_transform_graph_docs(transform_graph):
     """
     docstr = docstr + dedent(graph_legend)
 
-    return docstr
+    # Add table with built-in frame classes.
+    template = """
+       * - `~astropy.coordinates.{}`
+         - {}
+    """
+    table = """
+    Built-in Frame Classes
+    ^^^^^^^^^^^^^^^^^^^^^^
+    .. list-table::
+       :widths: 20 80
+    """ + "".join(
+        template.format(name, _get_doc_header(coosys[name]))
+        for name in __all__
+        if name in coosys
+    )
+
+    return docstr + dedent(table)
 
 
 _transform_graph_docs = make_transform_graph_docs(frame_transform_graph)

--- a/astropy/coordinates/builtin_frames/galactocentric.py
+++ b/astropy/coordinates/builtin_frames/galactocentric.py
@@ -62,14 +62,15 @@ class _StateProxy(MappingView):
 
 
 class galactocentric_frame_defaults(ScienceState):
-    """This class controls the global setting of default values for the frame
-    attributes in the `~astropy.coordinates.Galactocentric` frame, which may be
-    updated in future versions of ``astropy``. Note that when using
-    `~astropy.coordinates.Galactocentric`, changing values here will not affect
-    any attributes that are set explicitly by passing values in to the
-    `~astropy.coordinates.Galactocentric` initializer. Modifying these defaults
-    will only affect the frame attribute values when using the frame as, e.g.,
-    ``Galactocentric`` or ``Galactocentric()`` with no explicit arguments.
+    """Global setting of default values for the frame attributes in the `~astropy.coordinates.Galactocentric` frame.
+
+    These constancts may be updated in future versions of ``astropy``. Note
+    that when using `~astropy.coordinates.Galactocentric`, changing values
+    here will not affect any attributes that are set explicitly by passing
+    values in to the `~astropy.coordinates.Galactocentric`
+    initializer. Modifying these defaults will only affect the frame attribute
+    values when using the frame as, e.g., ``Galactocentric`` or
+    ``Galactocentric()`` with no explicit arguments.
 
     This class controls the parameter settings by specifying a string name,
     with the following pre-specified options:
@@ -93,8 +94,8 @@ class galactocentric_frame_defaults(ScienceState):
     parameter uncertainties.
 
     The preferred method for getting a parameter set and metadata, by name, is
-    :meth:`~galactocentric_frame_defaults.get_from_registry` since
-    it ensures the immutability of the registry.
+    :meth:`~astropy.coordinates.galactocentric_frame_defaults.get_from_registry`
+    since it ensures the immutability of the registry.
 
     See :ref:`astropy:astropy-coordinates-galactocentric-defaults` for more
     information.
@@ -372,11 +373,11 @@ doc_components = """
 doc_footer = """
     Other parameters
     ----------------
-    galcen_coord : `ICRS`, optional, keyword-only
+    galcen_coord : `~astropy.coordinates.ICRS`, optional, keyword-only
         The ICRS coordinates of the Galactic center.
     galcen_distance : `~astropy.units.Quantity`, optional, keyword-only
         The distance from the sun to the Galactic center.
-    galcen_v_sun : `~astropy.coordinates.representation.CartesianDifferential`, `~astropy.units.Quantity` ['speed'], optional, keyword-only
+    galcen_v_sun : `~astropy.coordinates.CartesianDifferential`, `~astropy.units.Quantity` ['speed'], optional, keyword-only
         The velocity of the sun *in the Galactocentric frame* as Cartesian
         velocity components.
     z_sun : `~astropy.units.Quantity` ['length'], optional, keyword-only
@@ -515,11 +516,12 @@ class Galactocentric(BaseCoordinateFrame):
 
     @classmethod
     def get_roll0(cls):
-        """
-        The additional roll angle (about the final x axis) necessary to align
-        the final z axis to match the Galactic yz-plane.  Setting the ``roll``
-        frame attribute to  -this method's return value removes this rotation,
-        allowing the use of the `Galactocentric` frame in more general contexts.
+        """The additional roll angle (about the final x axis) necessary to align the
+        final z axis to match the Galactic yz-plane.  Setting the ``roll``
+        frame attribute to -this method's return value removes this rotation,
+        allowing the use of the `~astropy.coordinates.Galactocentric` frame
+        in more general contexts.
+
         """
         # note that the actual value is defined at the module level.  We make at
         # a property here because this module isn't actually part of the public

--- a/astropy/coordinates/builtin_frames/lsr.py
+++ b/astropy/coordinates/builtin_frames/lsr.py
@@ -30,7 +30,7 @@ __all__ = ["LSR", "GalacticLSR", "LSRK", "LSRD"]
 doc_footer_lsr = """
     Other parameters
     ----------------
-    v_bary : `~astropy.coordinates.representation.CartesianDifferential`
+    v_bary : `~astropy.coordinates.CartesianDifferential`
         The velocity of the solar system barycenter with respect to the LSR, in
         Galactic cartesian velocity components.
 """
@@ -40,16 +40,16 @@ doc_footer_lsr = """
 class LSR(BaseRADecFrame):
     r"""A coordinate or frame in the Local Standard of Rest (LSR).
 
-    This coordinate frame is axis-aligned and co-spatial with `ICRS`, but has
-    a velocity offset relative to the solar system barycenter to remove the
-    peculiar motion of the sun relative to the LSR. Roughly, the LSR is the mean
-    velocity of the stars in the solar neighborhood, but the precise definition
-    of which depends on the study. As defined in Schönrich et al. (2010):
-    "The LSR is the rest frame at the location of the Sun of a star that would
-    be on a circular orbit in the gravitational potential one would obtain by
-    azimuthally averaging away non-axisymmetric features in the actual Galactic
-    potential." No such orbit truly exists, but it is still a commonly used
-    velocity frame.
+    This coordinate frame is axis-aligned and co-spatial with
+    `~astropy.coordinates.ICRS`, but has a velocity offset relative to the
+    solar system barycenter to remove the peculiar motion of the sun relative
+    to the LSR. Roughly, the LSR is the mean velocity of the stars in the solar
+    neighborhood, but the precise definition of which depends on the study. As
+    defined in Schönrich et al. (2010): "The LSR is the rest frame at the
+    location of the Sun of a star that would be on a circular orbit in the
+    gravitational potential one would obtain by azimuthally averaging away
+    non-axisymmetric features in the actual Galactic potential." No such orbit
+    truly exists, but it is still a commonly used velocity frame.
 
     We use default values from Schönrich et al. (2010) for the barycentric
     velocity relative to the LSR, which is defined in Galactic (right-handed)
@@ -59,6 +59,7 @@ class LSR(BaseRADecFrame):
     velocity of the solar system barycenter with respect to the LSR.
 
     The frame attributes are listed under **Other Parameters**.
+
     """
 
     # frame attributes:
@@ -113,18 +114,18 @@ doc_components_gal = """
 @format_doc(base_doc, components=doc_components_gal, footer=doc_footer_lsr)
 class GalacticLSR(BaseCoordinateFrame):
     r"""A coordinate or frame in the Local Standard of Rest (LSR), axis-aligned
-    to the `Galactic` frame.
+    to the Galactic frame.
 
-    This coordinate frame is axis-aligned and co-spatial with `ICRS`, but has
-    a velocity offset relative to the solar system barycenter to remove the
-    peculiar motion of the sun relative to the LSR. Roughly, the LSR is the mean
-    velocity of the stars in the solar neighborhood, but the precise definition
-    of which depends on the study. As defined in Schönrich et al. (2010):
-    "The LSR is the rest frame at the location of the Sun of a star that would
-    be on a circular orbit in the gravitational potential one would obtain by
-    azimuthally averaging away non-axisymmetric features in the actual Galactic
-    potential." No such orbit truly exists, but it is still a commonly used
-    velocity frame.
+    This coordinate frame is axis-aligned and co-spatial with
+    `~astropy.coordinates.ICRS`, but has a velocity offset relative to the
+    solar system barycenter to remove the peculiar motion of the sun relative
+    to the LSR. Roughly, the LSR is the mean velocity of the stars in the solar
+    neighborhood, but the precise definition of which depends on the study. As
+    defined in Schönrich et al. (2010): "The LSR is the rest frame at the
+    location of the Sun of a star that would be on a circular orbit in the
+    gravitational potential one would obtain by azimuthally averaging away
+    non-axisymmetric features in the actual Galactic potential." No such orbit
+    truly exists, but it is still a commonly used velocity frame.
 
     We use default values from Schönrich et al. (2010) for the barycentric
     velocity relative to the LSR, which is defined in Galactic (right-handed)
@@ -134,6 +135,7 @@ class GalacticLSR(BaseCoordinateFrame):
     velocity of the solar system barycenter with respect to the LSR.
 
     The frame attributes are listed under **Other Parameters**.
+
     """
 
     frame_specific_representation_info = {
@@ -177,8 +179,7 @@ def galacticlsr_to_galactic(lsr_coord, galactic_frame):
 
 
 class LSRK(BaseRADecFrame):
-    r"""
-    A coordinate or frame in the Kinematic Local Standard of Rest (LSR).
+    r"""A coordinate or frame in the Kinematic Local Standard of Rest (LSR).
 
     This frame is defined as having a velocity of 20 km/s towards RA=270 Dec=30
     (B1900) relative to the solar system Barycenter. This is defined in:
@@ -186,9 +187,11 @@ class LSRK(BaseRADecFrame):
         Gordon 1975, Methods of Experimental Physics: Volume 12:
         Astrophysics, Part C: Radio Observations - Section 6.1.5.
 
-    This coordinate frame is axis-aligned and co-spatial with `ICRS`, but has
-    a velocity offset relative to the solar system barycenter to remove the
-    peculiar motion of the sun relative to the LSRK.
+    This coordinate frame is axis-aligned and co-spatial with
+    `~astropy.coordinates.ICRS`, but has a velocity offset relative to the
+    solar system barycenter to remove the peculiar motion of the sun relative
+    to the LSRK.
+
     """
 
 
@@ -232,8 +235,7 @@ def lsrk_to_icrs(lsr_coord, icrs_frame):
 
 
 class LSRD(BaseRADecFrame):
-    r"""
-    A coordinate or frame in the Dynamical Local Standard of Rest (LSRD)
+    r"""A coordinate or frame in the Dynamical Local Standard of Rest (LSRD)
 
     This frame is defined as a velocity of U=9 km/s, V=12 km/s,
     and W=7 km/s in Galactic coordinates or 16.552945 km/s
@@ -242,9 +244,11 @@ class LSRD(BaseRADecFrame):
        Delhaye 1965, Solar Motion and Velocity Distribution of
        Common Stars.
 
-    This coordinate frame is axis-aligned and co-spatial with `ICRS`, but has
-    a velocity offset relative to the solar system barycenter to remove the
-    peculiar motion of the sun relative to the LSRD.
+    This coordinate frame is axis-aligned and co-spatial with
+    `~astropy.coordinates.ICRS`, but has a velocity offset relative to the
+    solar system barycenter to remove the peculiar motion of the sun relative
+    to the LSRD.
+
     """
 
 

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -143,7 +143,7 @@ class BaseRepresentationOrDifferentialInfo(MixinInfo):
 
         Returns
         -------
-        col : `BaseRepresentation` or `BaseDifferential` subclass instance
+        col : `~astropy.coordinates.BaseRepresentation` or `~astropy.coordinates.BaseDifferential` subclass instance
             Empty instance of this class consistent with ``cols``
 
         """
@@ -314,12 +314,12 @@ class BaseRepresentationOrDifferential(ShapedLikeNDArray):
 
         Parameters
         ----------
-        other : `CartesianRepresentation`
+        other : `~astropy.coordinates.CartesianRepresentation`
             The representation to turn into this class
 
         Returns
         -------
-        representation : `BaseRepresentation` subclass instance
+        representation : `~astropy.coordinates.BaseRepresentation` subclass instance
             A new representation of this class's type.
         """
         # Note: the above docstring gets overridden for differentials.
@@ -347,7 +347,7 @@ class BaseRepresentationOrDifferential(ShapedLikeNDArray):
 
         Returns
         -------
-        cartrepr : `CartesianRepresentation`
+        cartrepr : `~astropy.coordinates.CartesianRepresentation`
             The representation in Cartesian form.
         """
         # Note: the above docstring gets overridden for differentials.
@@ -842,7 +842,7 @@ class BaseRepresentation(BaseRepresentationOrDifferential):
 
         Returns
         -------
-        unit_vectors : dict of `CartesianRepresentation`
+        unit_vectors : dict of `~astropy.coordinates.CartesianRepresentation`
             The keys are the component names.
         """
         raise NotImplementedError(f"{type(self)} has not implemented unit vectors")
@@ -1334,11 +1334,11 @@ class CartesianRepresentation(BaseRepresentation):
         The axis along which the coordinates are stored when a single array is
         provided rather than distinct ``x``, ``y``, and ``z`` (default: 0).
 
-    differentials : dict, `CartesianDifferential`, optional
+    differentials : dict, `~astropy.coordinates.CartesianDifferential`, optional
         Any differential classes that should be associated with this
         representation. The input must either be a single
-        `CartesianDifferential` instance, or a dictionary of
-        `CartesianDifferential` s with keys set to a string representation of
+        `~astropy.coordinates.CartesianDifferential` instance, or a dictionary of
+        `~astropy.coordinates.CartesianDifferential` s with keys set to a string representation of
         the SI unit with which the differential (derivative) is taken. For
         example, for a velocity differential on a positional representation, the
         key would be ``'s'`` for seconds, indicating that the derivative is a
@@ -1747,9 +1747,9 @@ class UnitSphericalRepresentation(BaseRepresentation):
 
         Returns
         -------
-        `UnitSphericalRepresentation` or `SphericalRepresentation`
+        `~astropy.coordinates.UnitSphericalRepresentation` or `~astropy.coordinates.SphericalRepresentation`
             If ``matrix`` is O(3) -- :math:`M \dot M^T = I` -- like a rotation,
-            then the result is a `UnitSphericalRepresentation`.
+            then the result is a `~astropy.coordinates.UnitSphericalRepresentation`.
             All other matrices will change the distance, so the dimensional
             representation is used instead.
 
@@ -2250,10 +2250,10 @@ class PhysicsSphericalRepresentation(BaseRepresentation):
         passed to the :class:`~astropy.coordinates.Distance` class, otherwise
         it is passed to the :class:`~astropy.units.Quantity` class.
 
-    differentials : dict, `PhysicsSphericalDifferential`, optional
+    differentials : dict, `~astropy.coordinates.PhysicsSphericalDifferential`, optional
         Any differential classes that should be associated with this
         representation. The input must either be a single
-        `PhysicsSphericalDifferential` instance, or a dictionary of of
+        `~astropy.coordinates.PhysicsSphericalDifferential` instance, or a dictionary of of
         differential instances with keys set to a string representation of the
         SI unit with which the differential (derivative) is taken. For example,
         for a velocity differential on a positional representation, the key
@@ -2472,10 +2472,10 @@ class CylindricalRepresentation(BaseRepresentation):
     z : `~astropy.units.Quantity`
         The z coordinate(s) of the point(s)
 
-    differentials : dict, `CylindricalDifferential`, optional
+    differentials : dict, `~astropy.coordinates.CylindricalDifferential`, optional
         Any differential classes that should be associated with this
         representation. The input must either be a single
-        `CylindricalDifferential` instance, or a dictionary of of differential
+        `~astropy.coordinates.CylindricalDifferential` instance, or a dictionary of of differential
         instances with keys set to a string representation of the SI unit with
         which the differential (derivative) is taken. For example, for a
         velocity differential on a positional representation, the key would be
@@ -2707,7 +2707,7 @@ class BaseDifferential(BaseRepresentationOrDifferential):
 
         Returns
         -------
-        unit_vectors : dict of `CartesianRepresentation`
+        unit_vectors : dict of `~astropy.coordinates.CartesianRepresentation`
             In the directions of the coordinates of base.
         scale_factors : dict of `~astropy.units.Quantity`
             Scale factors for each of the coordinates
@@ -2730,7 +2730,7 @@ class BaseDifferential(BaseRepresentationOrDifferential):
 
         Returns
         -------
-        `CartesianDifferential`
+        `~astropy.coordinates.CartesianDifferential`
             This object, converted.
 
         """
@@ -2752,14 +2752,14 @@ class BaseDifferential(BaseRepresentationOrDifferential):
         ----------
         other
             The object to convert into this differential.
-        base : `BaseRepresentation`
+        base : `~astropy.coordinates.BaseRepresentation`
             The points for which the differentials are to be converted: each of
             the components is multiplied by its unit vectors and scale factors.
             Will be converted to ``cls.base_representation`` if needed.
 
         Returns
         -------
-        `BaseDifferential` subclass instance
+        `~astropy.coordinates.BaseDifferential` subclass instance
             A new differential object that is this class' type.
         """
         base = base.represent_as(cls.base_representation)
@@ -3296,7 +3296,7 @@ class BaseSphericalCosLatDifferential(BaseDifferential):
 
         Returns
         -------
-        unit_vectors : dict of `CartesianRepresentation`
+        unit_vectors : dict of `~astropy.coordinates.CartesianRepresentation`
             In the directions of the coordinates of base.
         scale_factors : dict of `~astropy.units.Quantity`
             Scale factors for each of the coordinates.  The scale factor for

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -135,7 +135,7 @@ class SkyCoordInfo(MixinInfo):
 
         Returns
         -------
-        skycoord : SkyCoord (or subclass)
+        skycoord : |SkyCoord| (or subclass)
             Instance of this class consistent with ``skycoords``
 
         """
@@ -171,7 +171,7 @@ class SkyCoord(ShapedLikeNDArray):
     """High-level object providing a flexible interface for celestial coordinate
     representation, manipulation, and transformation between systems.
 
-    The `SkyCoord` class accepts a wide variety of inputs for initialization. At
+    The |SkyCoord| class accepts a wide variety of inputs for initialization. At
     a minimum these must provide one or more celestial coordinate values with
     unambiguous units.  Inputs may be scalars or lists/tuples/arrays, yielding
     scalar or array coordinates (can be checked via ``SkyCoord.isscalar``).
@@ -192,7 +192,7 @@ class SkyCoord(ShapedLikeNDArray):
 
     Examples
     --------
-    The examples below illustrate common ways of initializing a `SkyCoord`
+    The examples below illustrate common ways of initializing a |SkyCoord|
     object.  For a complete description of the allowed syntax see the
     full coordinates documentation.  First some imports::
 
@@ -234,16 +234,14 @@ class SkyCoord(ShapedLikeNDArray):
       >>> c = SkyCoord(ra=1*u.deg, dec=2*u.deg, pm_ra_cosdec=2*u.mas/u.yr, pm_dec=1*u.mas/u.yr)
 
     As shown, the frame can be a `~astropy.coordinates.BaseCoordinateFrame`
-    class or the corresponding string alias.  The frame classes that are built in
-    to astropy are `ICRS`, `FK5`, `FK4`, `FK4NoETerms`, and `Galactic`.
-    The string aliases are simply lower-case versions of the class name, and
-    allow for creating a `SkyCoord` object and transforming frames without
-    explicitly importing the frame classes.
+    class or the corresponding string alias -- lower-case versions of the
+    class name that allow for creating a |SkyCoord| object and transforming
+    frames without explicitly importing the frame classes.
 
     Parameters
     ----------
     frame : `~astropy.coordinates.BaseCoordinateFrame` class or string, optional
-        Type of coordinate frame this `SkyCoord` should represent. Defaults to
+        Type of coordinate frame this |SkyCoord| should represent. Defaults to
         to ICRS if not given or given as None.
     unit : `~astropy.units.Unit`, string, or tuple of :class:`~astropy.units.Unit` or str, optional
         Units for supplied coordinate values.
@@ -268,17 +266,17 @@ class SkyCoord(ShapedLikeNDArray):
 
         ra, dec : angle-like, optional
             RA and Dec for frames where ``ra`` and ``dec`` are keys in the
-            frame's ``representation_component_names``, including `ICRS`,
-            `FK5`, `FK4`, and `FK4NoETerms`.
+            frame's ``representation_component_names``, including ``ICRS``,
+            ``FK5``, ``FK4``, and ``FK4NoETerms``.
         pm_ra_cosdec, pm_dec  : `~astropy.units.Quantity` ['angular speed'], optional
             Proper motion components, in angle per time units.
         l, b : angle-like, optional
             Galactic ``l`` and ``b`` for for frames where ``l`` and ``b`` are
             keys in the frame's ``representation_component_names``, including
-            the `Galactic` frame.
+            the ``Galactic`` frame.
         pm_l_cosb, pm_b : `~astropy.units.Quantity` ['angular speed'], optional
-            Proper motion components in the `Galactic` frame, in angle per time
-            units.
+            Proper motion components in the `~astropy.coordinates.Galactic` frame,
+            in angle per time units.
         x, y, z : float or `~astropy.units.Quantity` ['length'], optional
             Cartesian coordinates values
         u, v, w : float or `~astropy.units.Quantity` ['length'], optional
@@ -511,7 +509,7 @@ class SkyCoord(ShapedLikeNDArray):
         return a new Frame object.
 
         The values to be inserted must conform to the rules for in-place setting
-        of ``SkyCoord`` objects.
+        of |SkyCoord| objects.
 
         The API signature matches the ``np.insert`` API, but is more limited.
         The specification of insert index ``obj`` must be a single integer,
@@ -628,14 +626,14 @@ class SkyCoord(ShapedLikeNDArray):
         value in the destination frame.
 
         Note that in either case, any explicitly set attributes on the source
-        `SkyCoord` that are not part of the destination frame's definition are
-        kept (stored on the resulting `SkyCoord`), and thus one can round-trip
+        |SkyCoord| that are not part of the destination frame's definition are
+        kept (stored on the resulting |SkyCoord|), and thus one can round-trip
         (e.g., from FK4 to ICRS to FK4 without losing obstime).
 
         Parameters
         ----------
-        frame : str, `BaseCoordinateFrame` class or instance, or `SkyCoord` instance
-            The frame to transform this coordinate into.  If a `SkyCoord`, the
+        frame : str, `~astropy.coordinates.BaseCoordinateFrame` class or instance, or |SkyCoord| instance
+            The frame to transform this coordinate into.  If a |SkyCoord|, the
             underlying frame is extracted, and all other information ignored.
         merge_attributes : bool, optional
             Whether the default attributes in the destination frame are allowed
@@ -644,7 +642,7 @@ class SkyCoord(ShapedLikeNDArray):
 
         Returns
         -------
-        coord : `SkyCoord`
+        coord : |SkyCoord|
             A new object with this coordinate represented in the `frame` frame.
 
         Raises
@@ -743,7 +741,7 @@ class SkyCoord(ShapedLikeNDArray):
 
         Returns
         -------
-        new_coord : `SkyCoord`
+        new_coord : |SkyCoord|
             A new coordinate object with the evolved location of this coordinate
             at the new time.  ``obstime`` will be set on this object to the new
             time only if ``self`` also has ``obstime``.
@@ -1121,7 +1119,7 @@ class SkyCoord(ShapedLikeNDArray):
         object.
 
         To be the same frame, two objects must be the same frame class and have
-        the same frame attributes. For two `SkyCoord` objects, *all* of the
+        the same frame attributes. For two |SkyCoord| objects, *all* of the
         frame attributes have to match, not just those relevant for the object's
         frame.
 
@@ -1138,7 +1136,8 @@ class SkyCoord(ShapedLikeNDArray):
         Raises
         ------
         TypeError
-            If ``other`` isn't a `SkyCoord` or a `BaseCoordinateFrame` or subclass.
+            If ``other`` isn't a |SkyCoord| or a subclass of
+            `~astropy.coordinates.BaseCoordinateFrame`.
         """
         if isinstance(other, BaseCoordinateFrame):
             return self.frame.is_equivalent_frame(other)
@@ -1556,7 +1555,7 @@ class SkyCoord(ShapedLikeNDArray):
         ----------
         searcharoundcoords : coordinate-like
             The coordinates to search around to try to find matching points in
-            this `SkyCoord`. This should be an object with array coordinates,
+            this |SkyCoord|. This should be an object with array coordinates,
             not a scalar coordinate object.
         seplimit : `~astropy.units.Quantity` ['angle']
             The on-sky separation to search within.
@@ -1616,7 +1615,7 @@ class SkyCoord(ShapedLikeNDArray):
         ----------
         searcharoundcoords : `~astropy.coordinates.SkyCoord` or `~astropy.coordinates.BaseCoordinateFrame`
             The coordinates to search around to try to find matching points in
-            this `SkyCoord`. This should be an object with array coordinates,
+            this |SkyCoord|. This should be an object with array coordinates,
             not a scalar coordinate object.
         distlimit : `~astropy.units.Quantity` ['length']
             The physical radius to search within.
@@ -1662,11 +1661,11 @@ class SkyCoord(ShapedLikeNDArray):
     def position_angle(self, other):
         """
         Computes the on-sky position angle (East of North) between this
-        `SkyCoord` and another.
+        SkyCoord and another.
 
         Parameters
         ----------
-        other : `SkyCoord`
+        other : |SkyCoord|
             The other coordinate to compute the position angle to.  It is
             treated as the "head" of the vector of the position angle.
 
@@ -1708,26 +1707,28 @@ class SkyCoord(ShapedLikeNDArray):
 
     def skyoffset_frame(self, rotation=None):
         """
-        Returns the sky offset frame with this `SkyCoord` at the origin.
+        Returns the sky offset frame with this SkyCoord at the origin.
 
-        Returns
-        -------
-        astrframe : `~astropy.coordinates.SkyOffsetFrame`
-            A sky offset frame of the same type as this `SkyCoord` (e.g., if
-            this object has an ICRS coordinate, the resulting frame is
-            SkyOffsetICRS, with the origin set to this object)
+        Parameters
+        ----------
         rotation : angle-like
             The final rotation of the frame about the ``origin``. The sign of
             the rotation is the left-hand rule. That is, an object at a
             particular position angle in the un-rotated system will be sent to
             the positive latitude (z) direction in the final frame.
+
+        Returns
+        -------
+        astrframe : `~astropy.coordinates.SkyOffsetFrame`
+            A sky offset frame of the same type as this |SkyCoord| (e.g., if
+            this object has an ICRS coordinate, the resulting frame is
+            SkyOffsetICRS, with the origin set to this object)
         """
         return SkyOffsetFrame(origin=self, rotation=rotation)
 
     def get_constellation(self, short_name=False, constellation_list="iau"):
         """
-        Determines the constellation(s) of the coordinates this `SkyCoord`
-        contains.
+        Determines the constellation(s) of the coordinates this SkyCoord contains.
 
         Parameters
         ----------
@@ -1742,7 +1743,7 @@ class SkyCoord(ShapedLikeNDArray):
         -------
         constellation : str or string array
             If this is a scalar coordinate, returns the name of the
-            constellation.  If it is an array `SkyCoord`, it returns an array of
+            constellation.  If it is an array |SkyCoord|, it returns an array of
             names.
 
         Notes
@@ -1802,8 +1803,7 @@ class SkyCoord(ShapedLikeNDArray):
     @classmethod
     def from_pixel(cls, xp, yp, wcs, origin=0, mode="all"):
         """
-        Create a new `SkyCoord` from pixel coordinates using an
-        `~astropy.wcs.WCS` object.
+        Create a new SkyCoord from pixel coordinates using a World Coordinate System.
 
         Parameters
         ----------
@@ -1885,18 +1885,18 @@ class SkyCoord(ShapedLikeNDArray):
             'heliocentric'.
         obstime : `~astropy.time.Time` or None, optional
             The time at which to compute the correction.  If `None`, the
-            ``obstime`` frame attribute on the `SkyCoord` will be used.
+            ``obstime`` frame attribute on the |SkyCoord| will be used.
         location : `~astropy.coordinates.EarthLocation` or None, optional
             The observer location at which to compute the correction.  If
             `None`, the  ``location`` frame attribute on the passed-in
             ``obstime`` will be used, and if that is None, the ``location``
-            frame attribute on the `SkyCoord` will be used.
+            frame attribute on the |SkyCoord| will be used.
 
         Raises
         ------
         ValueError
             If either ``obstime`` or ``location`` are passed in (not ``None``)
-            when the frame attribute is already set on this `SkyCoord`.
+            when the frame attribute is already set on this |SkyCoord|.
         TypeError
             If ``obstime`` or ``location`` aren't provided, either as arguments
             or as frame attributes.
@@ -2095,7 +2095,7 @@ class SkyCoord(ShapedLikeNDArray):
     @classmethod
     def guess_from_table(cls, table, **coord_kwargs):
         r"""
-        A convenience method to create and return a new `SkyCoord` from the data
+        A convenience method to create and return a new SkyCoord from the data
         in an astropy Table.
 
         This method matches table columns that start with the case-insensitive
@@ -2128,7 +2128,7 @@ class SkyCoord(ShapedLikeNDArray):
         Returns
         -------
         newsc : `~astropy.coordinates.SkyCoord` or subclass
-            The new `SkyCoord` (or subclass) object.
+            The new instance.
 
         Raises
         ------

--- a/astropy/coordinates/transformations.py
+++ b/astropy/coordinates/transformations.py
@@ -48,7 +48,7 @@ __all__ = [
 def frame_attrs_from_set(frame_set):
     """
     A `dict` of all the attributes of all frame classes in this
-    `TransformGraph`.
+    `~astropy.coordinates.TransformGraph`.
 
     Broken out of the class so this can be called on a temporary frame set to
     validate new additions to the transform graph before actually adding them.
@@ -64,7 +64,7 @@ def frame_attrs_from_set(frame_set):
 def frame_comps_from_set(frame_set):
     """
     A `set` of all component names every defined within any frame class in
-    this `TransformGraph`.
+    this `~astropy.coordinates.TransformGraph`.
 
     Broken out of the class so this can be called on a temporary frame set to
     validate new additions to the transform graph before actually adding them.
@@ -106,7 +106,7 @@ class TransformGraph:
     @property
     def frame_set(self):
         """
-        A `set` of all the frame classes present in this `TransformGraph`.
+        A `set` of all the frame classes present in this TransformGraph.
         """
         if self._cached_frame_set is None:
             self._cached_frame_set = set()
@@ -120,8 +120,7 @@ class TransformGraph:
     @property
     def frame_attributes(self):
         """
-        A `dict` of all the attributes of all frame classes in this
-        `TransformGraph`.
+        A `dict` of all the attributes of all frame classes in this TransformGraph.
         """
         if self._cached_frame_attributes is None:
             self._cached_frame_attributes = frame_attrs_from_set(self.frame_set)
@@ -132,7 +131,7 @@ class TransformGraph:
     def frame_component_names(self):
         """
         A `set` of all component names every defined within any frame class in
-        this `TransformGraph`.
+        this TransformGraph.
         """
         if self._cached_component_names is None:
             self._cached_component_names = frame_comps_from_set(self.frame_set)
@@ -154,8 +153,7 @@ class TransformGraph:
         self._composite_cache = {}
 
     def add_transform(self, fromsys, tosys, transform):
-        """
-        Add a new coordinate transformation to the graph.
+        """Add a new coordinate transformation to the graph.
 
         Parameters
         ----------
@@ -163,16 +161,17 @@ class TransformGraph:
             The coordinate frame class to start from.
         tosys : class
             The coordinate frame class to transform into.
-        transform : `CoordinateTransform`
-            The transformation object. Typically a `CoordinateTransform` object,
-            although it may be some other callable that is called with the same
-            signature.
+        transform : `~astropy.coordinates.CoordinateTransform`
+            The transformation object. Typically a
+            `~astropy.coordinates.CoordinateTransform` object, although it may
+            be some other callable that is called with the same signature.
 
         Raises
         ------
         TypeError
             If ``fromsys`` or ``tosys`` are not classes or ``transform`` is
             not callable.
+
         """
 
         if not inspect.isclass(fromsys):
@@ -397,8 +396,7 @@ class TransformGraph:
         return result[tosys]
 
     def get_transform(self, fromsys, tosys):
-        """
-        Generates and returns the `CompositeTransform` for a transformation
+        """Generates and returns the CompositeTransform for a transformation
         between two coordinate systems.
 
         Parameters
@@ -410,18 +408,19 @@ class TransformGraph:
 
         Returns
         -------
-        trans : `CompositeTransform` or None
+        trans : `~astropy.coordinates.CompositeTransform` or None
             If there is a path from ``fromsys`` to ``tosys``, this is a
             transform object for that path.   If no path could be found, this is
             `None`.
 
         Notes
         -----
-        This function always returns a `CompositeTransform`, because
-        `CompositeTransform` is slightly more adaptable in the way it can be
-        called than other transform classes. Specifically, it takes care of
-        intermediate steps of transformations in a way that is consistent with
-        1-hop transformations.
+
+        A `~astropy.coordinates.CompositeTransform` is always returned, because
+        `~astropy.coordinates.CompositeTransform` is slightly more adaptable in
+        the way it can be called than other transform classes. Specifically, it
+        takes care of intermediate steps of transformations in a way that is
+        consistent with 1-hop transformations.
 
         """
         if not inspect.isclass(fromsys):
@@ -617,7 +616,8 @@ class TransformGraph:
         Returns
         -------
         nxgraph : ``networkx.Graph``
-            This `TransformGraph` as a `networkx.Graph <https://networkx.github.io/documentation/stable/reference/classes/graph.html>`_.
+            This `~astropy.coordinates.TransformGraph` as a
+            `networkx.Graph <https://networkx.github.io/documentation/stable/reference/classes/graph.html>`_.
         """
         import networkx as nx
 
@@ -643,8 +643,7 @@ class TransformGraph:
         return nxgraph
 
     def transform(self, transcls, fromsys, tosys, priority=1, **kwargs):
-        """
-        A function decorator for defining transformations.
+        """A function decorator for defining transformations.
 
         .. note::
             If decorating a static method of a class, ``@staticmethod``
@@ -674,10 +673,11 @@ class TransformGraph:
         Notes
         -----
         This decorator assumes the first argument of the ``transcls``
-        initializer accepts a callable, and that the second and third
-        are ``fromsys`` and ``tosys``. If this is not true, you should just
-        initialize the class manually and use `add_transform` instead of
-        using this decorator.
+        initializer accepts a callable, and that the second and third are
+        ``fromsys`` and ``tosys``. If this is not true, you should just
+        initialize the class manually and use
+        `~astropy.coordinates.TransformGraph.add_transform` instead of this
+        decorator.
 
         Examples
         --------
@@ -716,11 +716,11 @@ class TransformGraph:
 
         The created transform internally calls the existing transforms.  If all of the
         transforms are affine, the merged transform is
-        `~astropy.coordinates.transformations.DynamicMatrixTransform` (if there are no
-        origin shifts) or `~astropy.coordinates.transformations.AffineTransform`
+        `~astropy.coordinates.DynamicMatrixTransform` (if there are no
+        origin shifts) or `~astropy.coordinates.AffineTransform`
         (otherwise).  If at least one of the transforms is not affine, the merged
         transform is
-        `~astropy.coordinates.transformations.FunctionTransformWithFiniteDifference`.
+        `~astropy.coordinates.FunctionTransformWithFiniteDifference`.
 
         This method is primarily useful for defining loopback transformations
         (i.e., where ``fromsys`` and the final ``tosys`` are the same).
@@ -782,7 +782,7 @@ class TransformGraph:
         For each transformation in this transformation graph that has the attribute
         ``finite_difference_dt``, that attribute is set to the provided value.  The only standard
         transformation with this attribute is
-        `~astropy.coordinates.transformations.FunctionTransformWithFiniteDifference`.
+        `~astropy.coordinates.FunctionTransformWithFiniteDifference`.
 
         Parameters
         ----------
@@ -825,7 +825,7 @@ class CoordinateTransform(metaclass=ABCMeta):
     priority : float or int
         The priority if this transform when finding the shortest
         coordinate transform path - large numbers are lower priorities.
-    register_graph : `TransformGraph` or None
+    register_graph : `~astropy.coordinates.TransformGraph` or None
         A graph to register this transformation with on creation, or
         `None` to leave it unregistered.
     """
@@ -864,7 +864,7 @@ class CoordinateTransform(metaclass=ABCMeta):
 
         Parameters
         ----------
-        graph : `TransformGraph` object
+        graph : `~astropy.coordinates.TransformGraph` object
             The graph to register this transformation with.
         """
         graph.add_transform(self.fromsys, self.tosys, self)
@@ -905,7 +905,7 @@ class CoordinateTransform(metaclass=ABCMeta):
 
         Returns
         -------
-        tocoord : `BaseCoordinateFrame` subclass instance
+        tocoord : `~astropy.coordinates.BaseCoordinateFrame` subclass instance
             The new coordinate after the transform has been applied.
         """
 
@@ -929,7 +929,7 @@ class FunctionTransform(CoordinateTransform):
     priority : float or int
         The priority if this transform when finding the shortest
         coordinate transform path - large numbers are lower priorities.
-    register_graph : `TransformGraph` or None
+    register_graph : `~astropy.coordinates.TransformGraph` or None
         A graph to register this transformation with on creation, or
         `None` to leave it unregistered.
 
@@ -980,12 +980,13 @@ class FunctionTransform(CoordinateTransform):
 
 
 class FunctionTransformWithFiniteDifference(FunctionTransform):
-    r"""
-    A coordinate transformation that works like a `FunctionTransform`, but
-    computes velocity shifts based on the finite-difference relative to one of
-    the frame attributes.  Note that the transform function should *not* change
-    the differential at all in this case, as any differentials will be
-    overridden.
+    r"""Transormation based on functions using finite difference for velocities.
+
+    A coordinate transformation that works like a
+    `~astropy.coordinates.FunctionTransform`, but computes velocity shifts
+    based on the finite-difference relative to one of the frame attributes.
+    Note that the transform function should *not* change the differential at
+    all in this case, as any differentials will be overridden.
 
     When a differential is in the from coordinate, the finite difference
     calculation has two components. The first part is simple the existing
@@ -1016,7 +1017,7 @@ class FunctionTransformWithFiniteDifference(FunctionTransform):
         behavior).
 
     All other parameters are identical to the initializer for
-    `FunctionTransform`.
+    `~astropy.coordinates.FunctionTransform`.
 
     """
 
@@ -1160,13 +1161,15 @@ class BaseAffineTransform(CoordinateTransform):
     """Base class for common functionality between the ``AffineTransform``-type
     subclasses.
 
-    This base class is needed because ``AffineTransform`` and the matrix
-    transform classes share the ``__call__()`` method, but differ in how they
-    generate the affine parameters.  ``StaticMatrixTransform`` passes in a
-    matrix stored as a class attribute, and both of the matrix transforms pass
-    in ``None`` for the offset. Hence, user subclasses would likely want to
-    subclass this (rather than ``AffineTransform``) if they want to provide
+    This base class is needed because `~astropy.coordinates.AffineTransform`
+    and the matrix transform classes share the ``__call__()`` method, but
+    differ in how they generate the affine parameters.
+    `~astropy.coordinates.StaticMatrixTransform` passes in a matrix stored as a
+    class attribute, and both of the matrix transforms pass in ``None`` for the
+    offset. Hence, user subclasses would likely want to subclass this (rather
+    than `~astropy.coordinates.AffineTransform`) if they want to provide
     alternative transformations using this machinery.
+
     """
 
     def _apply_transform(self, fromcoord, matrix, offset):
@@ -1367,7 +1370,7 @@ class AffineTransform(BaseAffineTransform):
     A coordinate transformation specified as a function that yields a 3 x 3
     cartesian transformation matrix and a tuple of displacement vectors.
 
-    See `~astropy.coordinates.builtin_frames.galactocentric.Galactocentric` for
+    See `~astropy.coordinates.Galactocentric` for
     an example.
 
     Parameters
@@ -1386,7 +1389,7 @@ class AffineTransform(BaseAffineTransform):
     priority : float or int
         The priority if this transform when finding the shortest
         coordinate transform path - large numbers are lower priorities.
-    register_graph : `TransformGraph` or None
+    register_graph : `~astropy.coordinates.TransformGraph` or None
         A graph to register this transformation with on creation, or
         `None` to leave it unregistered.
 
@@ -1432,7 +1435,7 @@ class StaticMatrixTransform(BaseAffineTransform):
     priority : float or int
         The priority if this transform when finding the shortest
         coordinate transform path - large numbers are lower priorities.
-    register_graph : `TransformGraph` or None
+    register_graph : `~astropy.coordinates.TransformGraph` or None
         A graph to register this transformation with on creation, or
         `None` to leave it unregistered.
 
@@ -1480,7 +1483,7 @@ class DynamicMatrixTransform(BaseAffineTransform):
     priority : float or int
         The priority if this transform when finding the shortest
         coordinate transform path - large numbers are lower priorities.
-    register_graph : `TransformGraph` or None
+    register_graph : `~astropy.coordinates.TransformGraph` or None
         A graph to register this transformation with on creation, or
         `None` to leave it unregistered.
 
@@ -1516,7 +1519,7 @@ class CompositeTransform(CoordinateTransform):
 
     Parameters
     ----------
-    transforms : sequence of `CoordinateTransform` object
+    transforms : sequence of `~astropy.coordinates.CoordinateTransform` object
         The sequence of transformations to apply.
     fromsys : class
         The coordinate frame class to start from.
@@ -1525,12 +1528,13 @@ class CompositeTransform(CoordinateTransform):
     priority : float or int
         The priority if this transform when finding the shortest
         coordinate transform path - large numbers are lower priorities.
-    register_graph : `TransformGraph` or None
+    register_graph : `~astropy.coordinates.TransformGraph` or None
         A graph to register this transformation with on creation, or
         `None` to leave it unregistered.
     collapse_static_mats : bool
-        If `True`, consecutive `StaticMatrixTransform` will be collapsed into a
-        single transformation to speed up the calculation.
+        If `True`, consecutive `~astropy.coordinates.StaticMatrixTransform`
+        will be collapsed into a single transformation to speed up the
+        calculation.
 
     """
 
@@ -1554,7 +1558,7 @@ class CompositeTransform(CoordinateTransform):
 
     def _combine_statics(self, transforms):
         """
-        Combines together sequences of `StaticMatrixTransform`s into a single
+        Combines together sequences of StaticMatrixTransform's into a single
         transform and returns it.
         """
         newtrans = []
@@ -1603,11 +1607,11 @@ class CompositeTransform(CoordinateTransform):
 
         The returned transform internally calls the constituent transforms.  If all of
         the transforms are affine, the merged transform is
-        `~astropy.coordinates.transformations.DynamicMatrixTransform` (if there are no
-        origin shifts) or `~astropy.coordinates.transformations.AffineTransform`
+        `~astropy.coordinates.DynamicMatrixTransform` (if there are no
+        origin shifts) or `~astropy.coordinates.AffineTransform`
         (otherwise).  If at least one of the transforms is not affine, the merged
         transform is
-        `~astropy.coordinates.transformations.FunctionTransformWithFiniteDifference`.
+        `~astropy.coordinates.FunctionTransformWithFiniteDifference`.
         """
         # Create a list of the transforms including flattening any constituent CompositeTransform
         transforms = [

--- a/astropy/units/function/core.py
+++ b/astropy/units/function/core.py
@@ -238,7 +238,7 @@ class FunctionUnitBase(metaclass=ABCMeta):
 
         Parameters
         ----------
-        other : `~astropy.units.Unit`, `~astropy.units.function.FunctionUnitBase`, or str
+        other : `~astropy.units.Unit`, `~astropy.units.FunctionUnitBase`, or str
             The unit to convert to.
 
         value : int, float, or scalar array-like, optional
@@ -480,8 +480,8 @@ class FunctionQuantity(Quantity):
         converted to the function unit, after, if necessary, converting it to
         the physical unit inferred from ``unit``.
 
-    unit : str, `~astropy.units.UnitBase`, or `~astropy.units.function.FunctionUnitBase`, optional
-        For an `~astropy.units.function.FunctionUnitBase` instance, the
+    unit : str, `~astropy.units.UnitBase`, or `~astropy.units.FunctionUnitBase`, optional
+        For an `~astropy.units.FunctionUnitBase` instance, the
         physical unit will be taken from it; for other input, it will be
         inferred from ``value``. By default, ``unit`` is set by the subclass.
 
@@ -518,12 +518,12 @@ class FunctionQuantity(Quantity):
     TypeError
         If the value provided is not a Python numeric type.
     TypeError
-        If the unit provided is not a `~astropy.units.function.FunctionUnitBase`
+        If the unit provided is not a `~astropy.units.FunctionUnitBase`
         or `~astropy.units.Unit` object, or a parseable string unit.
     """
 
     _unit_class = None
-    """Default `~astropy.units.function.FunctionUnitBase` subclass.
+    """Default `~astropy.units.FunctionUnitBase` subclass.
 
     This should be overridden by subclasses.
     """

--- a/astropy/units/function/core.py
+++ b/astropy/units/function/core.py
@@ -593,7 +593,7 @@ class FunctionQuantity(Quantity):
         return self.__class__(self.physical.cgs)
 
     def decompose(self, bases=[]):
-        """Generate a new `FunctionQuantity` with the physical unit decomposed.
+        """Generate a new instance with the physical unit decomposed.
 
         For details, see `~astropy.units.Quantity.decompose`.
         """

--- a/astropy/units/function/logarithmic.py
+++ b/astropy/units/function/logarithmic.py
@@ -36,7 +36,8 @@ class LogUnit(FunctionUnitBase):
     """Logarithmic unit containing a physical one
 
     Usually, logarithmic units are instantiated via specific subclasses
-    such `MagUnit`, `DecibelUnit`, and `DexUnit`.
+    such `~astropy.units.MagUnit`, `~astropy.units.DecibelUnit`, and
+    `~astropy.units.DexUnit`.
 
     Parameters
     ----------

--- a/astropy/units/function/logarithmic.py
+++ b/astropy/units/function/logarithmic.py
@@ -217,8 +217,8 @@ class LogQuantity(FunctionQuantity):
         it will converted to the logarithmic unit, after, if necessary,
         converting it to the physical unit inferred from ``unit``.
 
-    unit : str, `~astropy.units.UnitBase`, or `~astropy.units.function.FunctionUnitBase`, optional
-        For an `~astropy.units.function.FunctionUnitBase` instance, the
+    unit : str, `~astropy.units.UnitBase`, or `~astropy.units.FunctionUnitBase`, optional
+        For an `~astropy.units.FunctionUnitBase` instance, the
         physical unit will be taken from it; for other input, it will be
         inferred from ``value``. By default, ``unit`` is set by the subclass.
 
@@ -237,7 +237,7 @@ class LogQuantity(FunctionQuantity):
 
     Examples
     --------
-    Typically, use is made of an `~astropy.units.function.FunctionQuantity`
+    Typically, use is made of an `~astropy.units.FunctionQuantity`
     subclass, as in::
 
         >>> import astropy.units as u

--- a/astropy/wcs/utils.py
+++ b/astropy/wcs/utils.py
@@ -218,8 +218,8 @@ def wcs_to_celestial_frame(wcs):
 
     Returns
     -------
-    frame : :class:`~astropy.coordinates.baseframe.BaseCoordinateFrame` subclass instance
-        An instance of a :class:`~astropy.coordinates.baseframe.BaseCoordinateFrame`
+    frame : :class:`~astropy.coordinates.BaseCoordinateFrame` subclass instance
+        An instance of a :class:`~astropy.coordinates.BaseCoordinateFrame`
         subclass instance that best matches the specified WCS.
 
     Notes
@@ -254,8 +254,8 @@ def celestial_frame_to_wcs(frame, projection="TAN"):
 
     Parameters
     ----------
-    frame : :class:`~astropy.coordinates.baseframe.BaseCoordinateFrame` subclass instance
-        An instance of a :class:`~astropy.coordinates.baseframe.BaseCoordinateFrame`
+    frame : :class:`~astropy.coordinates.BaseCoordinateFrame` subclass instance
+        An instance of a :class:`~astropy.coordinates.BaseCoordinateFrame`
         subclass instance for which to find the WCS
     projection : str
         Projection code to use in ctype, if applicable
@@ -297,7 +297,7 @@ def celestial_frame_to_wcs(frame, projection="TAN"):
 
     To extend this function to frames not defined in astropy.coordinates, you
     can write your own function which should take a
-    :class:`~astropy.coordinates.baseframe.BaseCoordinateFrame` subclass
+    :class:`~astropy.coordinates.BaseCoordinateFrame` subclass
     instance and a projection (given as a string) and should return either a WCS
     instance, or `None` if the WCS could not be determined. You can register
     this function temporarily with::
@@ -1228,7 +1228,7 @@ def fit_wcs_from_points(
 
 def obsgeo_to_frame(obsgeo, obstime):
     """
-    Convert a WCS obsgeo property into an `~.builtin_frames.ITRS` coordinate frame.
+    Convert a WCS obsgeo property into an ITRS coordinate frame.
 
     Parameters
     ----------
@@ -1238,12 +1238,12 @@ def obsgeo_to_frame(obsgeo, obstime):
 
     obstime : time-like
         The time associated with the coordinate, will be passed to
-        `~.builtin_frames.ITRS` as the obstime keyword.
+        `~astropy.coordinates.ITRS` as the obstime keyword.
 
     Returns
     -------
-    `~.builtin_frames.ITRS`
-        An `~.builtin_frames.ITRS` coordinate frame
+    ~astropy.coordinates.ITRS
+        An `~astropy.coordinates.ITRS` coordinate frame
         representing the coordinates.
 
     Notes

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -220,6 +220,8 @@ numpydoc_xref_aliases.update(
 # Add from sphinx-astropy 1) glossary aliases 2) physical types.
 numpydoc_xref_aliases.update(numpydoc_xref_astropy_aliases)
 
+# Turn off table of contents entries for functions and classes
+toc_object_entries = False
 
 # -- Project information ------------------------------------------------------
 
@@ -351,7 +353,9 @@ try:
         "reference_url": {
             "astropy": None,
             "matplotlib": "https://matplotlib.org/stable/",
-            "numpy": "https://numpy.org/doc/stable/",
+            # The stable numpy search js isn't loadable at the moment (2022-12-07)
+            # It seems to be valid js but it's not valid json so sphinx wont load it.
+            "numpy": "https://numpy.org/devdocs/",
         },
         "abort_on_example_error": True,
     }

--- a/docs/coordinates/index.rst
+++ b/docs/coordinates/index.rst
@@ -550,12 +550,10 @@ coordinate systems implemented here include:
     the True Equator Mean Equinox (TEME) coordinate frame.
 
 
-Built-in Frame Classes
-======================
+Built-in Frames and Transformations
+===================================
 
-.. automodapi:: astropy.coordinates.builtin_frames
-    :skip: make_transform_graph_docs
-    :no-inheritance-diagram:
+.. automodule:: astropy.coordinates.builtin_frames
 
 
 .. _astropy-coordinates-api:

--- a/docs/coordinates/matchsep.rst
+++ b/docs/coordinates/matchsep.rst
@@ -135,7 +135,7 @@ offset location::
 -------------------
 
 To extend the concept of spherical offsets, `~astropy.coordinates` has
-a frame class :class:`~astropy.coordinates.builtin_frames.skyoffset.SkyOffsetFrame`
+a frame class :class:`~astropy.coordinates.SkyOffsetFrame`
 which creates distinct frames that are centered on a specific point.
 These are known as "sky offset frames," as they are a convenient way to create
 a frame centered on an arbitrary position on the sky suitable for computing
@@ -198,7 +198,7 @@ frame aligned with standard ICRA RA/Dec, but on M31::
 .. note::
 
     Currently, distance information in the ``origin`` of a
-    :class:`~astropy.coordinates.builtin_frames.skyoffset.SkyOffsetFrame` is not
+    :class:`~astropy.coordinates.SkyOffsetFrame` is not
     used to compute any part of the transform. The ``origin`` is only used for
     on-sky rotation. This may change in the future, however.
 

--- a/docs/units/index.rst
+++ b/docs/units/index.rst
@@ -254,7 +254,7 @@ Reference/API
 
 .. automodapi:: astropy.units.equivalencies
 
-.. automodapi:: astropy.units.function
+.. automodapi:: astropy.units.function.core
 
 .. automodapi:: astropy.units.function.logarithmic
    :include-all-objects:

--- a/docs/units/logarithmic_units.rst
+++ b/docs/units/logarithmic_units.rst
@@ -37,10 +37,10 @@ To create a logarithmic quantity::
 
 Above, we make use of the fact that the units ``mag``, ``dex``, and
 ``dB`` are special in that, when used as functions, they return a
-:class:`~astropy.units.logarithmic.LogUnit` instance
-(:class:`~astropy.units.logarithmic.MagUnit`,
-:class:`~astropy.units.logarithmic.DexUnit`, and
-:class:`~astropy.units.logarithmic.DecibelUnit`,
+:class:`~astropy.units.LogUnit` instance
+(:class:`~astropy.units.MagUnit`,
+:class:`~astropy.units.DexUnit`, and
+:class:`~astropy.units.DecibelUnit`,
 respectively). The same happens as required when strings are parsed
 by :class:`~astropy.units.Unit`.
 

--- a/docs/units/logarithmic_units.rst
+++ b/docs/units/logarithmic_units.rst
@@ -37,10 +37,10 @@ To create a logarithmic quantity::
 
 Above, we make use of the fact that the units ``mag``, ``dex``, and
 ``dB`` are special in that, when used as functions, they return a
-:class:`~astropy.units.function.logarithmic.LogUnit` instance
-(:class:`~astropy.units.function.logarithmic.MagUnit`,
-:class:`~astropy.units.function.logarithmic.DexUnit`, and
-:class:`~astropy.units.function.logarithmic.DecibelUnit`,
+:class:`~astropy.units.logarithmic.LogUnit` instance
+(:class:`~astropy.units.logarithmic.MagUnit`,
+:class:`~astropy.units.logarithmic.DexUnit`, and
+:class:`~astropy.units.logarithmic.DecibelUnit`,
 respectively). The same happens as required when strings are parsed
 by :class:`~astropy.units.Unit`.
 
@@ -49,7 +49,7 @@ by :class:`~astropy.units.Unit`.
 As for normal |Quantity| objects, you can access the value with the
 `~astropy.units.Quantity.value` attribute. In addition, you can convert to a
 |Quantity| with the physical unit using the
-`~astropy.units.function.FunctionQuantity.physical` attribute::
+`~astropy.units.FunctionQuantity.physical` attribute::
 
     >>> logg = 5. * u.dex(u.cm / u.s**2)
     >>> logg.value
@@ -76,8 +76,8 @@ To convert a logarithmic quantity to a different unit::
     >>> logg.to('dex(m/s2)')  # doctest: +FLOAT_CMP
     <Dex 3. dex(m / s2)>
 
-For convenience, the :attr:`~astropy.units.function.FunctionQuantity.si` and
-:attr:`~astropy.units.function.FunctionQuantity.cgs` attributes can be used to
+For convenience, the :attr:`~astropy.units.FunctionQuantity.si` and
+:attr:`~astropy.units.FunctionQuantity.cgs` attributes can be used to
 convert the |Quantity| to base `SI
 <https://www.bipm.org/documents/20126/41483022/SI-Brochure-9-EN.pdf>`_ or `CGS
 <https://en.wikipedia.org/wiki/Centimetre-gram-second_system_of_units>`_
@@ -258,7 +258,7 @@ to work::
 
     This is implemented by having a list of supported ufuncs in
     ``units/function/core.py`` and by explicitly disabling some array methods in
-    :class:`~astropy.units.function.FunctionQuantity`.  If you believe a
+    :class:`~astropy.units.FunctionQuantity`.  If you believe a
     function or method is incorrectly treated, please `let us know
     <http://www.astropy.org/contribute.html>`_.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -94,14 +94,14 @@ all =
     pytest>=7.0
     typing_extensions>=3.10.0.1
 docs =
-    sphinx<4
+    sphinx
     sphinx-astropy>=1.6
     pytest>=7.0
     scipy>=1.3
     matplotlib>=3.1,!=3.4.0,!=3.5.2
     towncrier<22.12.0
     sphinx-changelog>=1.2.0
-    Jinja2<3.1
+    Jinja2>=3.0
 
 [options.package_data]
 * = data/*, data/*/*, data/*/*/*, data/*/*/*/*, data/*/*/*/*/*, data/*/*/*/*/*/*


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to manually backport #14140 to v5.0.x

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
