### PR TITLE
Manual backport of PR 14211 to v5.0.x (Fix WCSAxes sometimes emitting RuntimeWarning with NumPy 1.24)

### DIFF
--- a/astropy/visualization/wcsaxes/coordinate_range.py
+++ b/astropy/visualization/wcsaxes/coordinate_range.py
@@ -71,7 +71,7 @@ def find_coordinate_range(transform, extent, coord_types, coord_units, coord_wra
                 reset = np.abs(wjump) > 180.0
             if np.any(reset):
                 wjump = wjump + np.sign(wjump) * 180.0
-                wjump = 360.0 * (wjump / 360.0).astype(int)
+                wjump = 360.0 * np.trunc(wjump / 360.0)
                 xw[0, 1:][reset] -= wjump[reset]
 
             # Now iron out coordinates along all columns, starting with first row.
@@ -80,7 +80,7 @@ def find_coordinate_range(transform, extent, coord_types, coord_units, coord_wra
                 reset = np.abs(wjump) > 180.0
             if np.any(reset):
                 wjump = wjump + np.sign(wjump) * 180.0
-                wjump = 360.0 * (wjump / 360.0).astype(int)
+                wjump = 360.0 * np.trunc(wjump / 360.0)
                 xw[1:][reset] -= wjump[reset]
 
         with warnings.catch_warnings():

--- a/astropy/visualization/wcsaxes/tests/test_misc.py
+++ b/astropy/visualization/wcsaxes/tests/test_misc.py
@@ -548,3 +548,36 @@ def test_multiple_draws_grid_contours(tmpdir):
     ax.grid(color="black", grid_type="contours")
     fig.savefig(tmpdir / "plot.png")
     fig.savefig(tmpdir / "plot.png")
+
+
+def test_get_coord_range_nan_regression():
+    # Test to make sure there is no internal casting of NaN to integers
+    # NumPy 1.24 raises a RuntimeWarning if a NaN is cast to an integer
+
+    wcs = WCS(TARGET_HEADER)
+    wcs.wcs.crval[0] = 0  # Re-position the longitude wrap to the middle
+    ax = plt.subplot(1, 1, 1, projection=wcs)
+
+    # Set the Y limits within valid latitudes/declinations
+    ax.set_ylim(300, 500)
+
+    # Set the X limits within valid longitudes/RAs, so the world coordinates have no NaNs
+    ax.set_xlim(300, 700)
+    assert np.allclose(
+        ax.coords.get_coord_range(),
+        np.array(
+            [
+                (-123.5219272110385, 122.49684897692201),
+                (-44.02289164685554, 44.80732766607591),
+            ]
+        ),
+    )
+
+    # Extend the X limits to include invalid longitudes/RAs, so the world coordinates have NaNs
+    ax.set_xlim(0, 700)
+    assert np.allclose(
+        ax.coords.get_coord_range(),
+        np.array(
+            [(-131.3193386797236, 180.0), (-44.02289164685554, 44.80732766607591)]
+        ),
+    )

--- a/docs/changes/visualization/14211.bugfix.rst
+++ b/docs/changes/visualization/14211.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed WCSAxes sometimes triggering a NumPy RuntimeWarning when determining the coordinate range of the axes.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to manually backport #14211 to v5.0.x branch.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
