### PR TITLE
Add support for array-type columns (fixed size and variable) to io.misc.parquet

### DIFF
--- a/astropy/io/misc/parquet.py
+++ b/astropy/io/misc/parquet.py
@@ -8,7 +8,6 @@ available as readers/writers in `astropy.table`.  See
 
 import os
 import warnings
-from math import prod
 
 import numpy as np
 
@@ -327,13 +326,13 @@ def write_table_parquet(table, output, overwrite=False):
 
     Notes
     -----
-    Tables written with array columns (fixed-size or variable-length) are not
-    able to be read with pandas.
+    Tables written with array columns (fixed-size or variable-length) cannot
+    be read with pandas.
 
     Raises
     ------
     ValueError
-        Ff one of the columns has a mixed-type variable-length array, or
+        If one of the columns has a mixed-type variable-length array, or
         if it is a zero-length table and any of the columns are variable-length
         arrays.
     """
@@ -390,7 +389,7 @@ def write_table_parquet(table, output, overwrite=False):
             # is an array of fixed-length elements.
             arrow_type = pa.list_(
                 value_type=pa.from_numpy_dtype(dt.subdtype[0].type),
-                list_size=prod(dt.shape),
+                list_size=np.prod(dt.shape),
             )
         else:
             # This is a standard column.

--- a/astropy/io/misc/parquet.py
+++ b/astropy/io/misc/parquet.py
@@ -200,7 +200,7 @@ def read_table_parquet(
 
         if isinstance(t, pa.FixedSizeListType):
             value_type = t.value_type
-            shape = (t.list_size, )
+            shape = (t.list_size,)
         elif isinstance(t, pa.ListType):
             value_type = t.value_type
         else:
@@ -337,13 +337,17 @@ def write_table_parquet(table, output, overwrite=False):
                 # We check that we have a homogeneous list of types here.
                 for row in encode_table[name]:
                     if row.dtype != obj_dtype:
-                        raise ValueError(f"Cannot serialize mixed-type column ({name}) with parquet.")
+                        raise ValueError(
+                            f"Cannot serialize mixed-type column ({name}) with parquet."
+                        )
                 arrow_type = pa.list_(
                     pa.from_numpy_dtype(obj_dtype.type),
                 )
             else:
-                raise ValueError("Cannot serialize zero-length table "
-                                 f"with object column ({name}) with parquet.")
+                raise ValueError(
+                    "Cannot serialize zero-length table "
+                    f"with object column ({name}) with parquet."
+                )
         elif len(dt.shape) > 0:
             arrow_type = pa.list_(
                 pa.from_numpy_dtype(dt.subdtype[0].type),

--- a/astropy/io/misc/tests/test_parquet.py
+++ b/astropy/io/misc/tests/test_parquet.py
@@ -62,9 +62,20 @@ def _default_array_values(dtype):
 
 def _default_var_length_array_values(dtype):
     values = _default_values(dtype)
-    return [[values[0], ],
-            [values[0], values[1], ],
-            [values[0], values[1], values[2], ]]
+    return [
+        [
+            values[0],
+        ],
+        [
+            values[0],
+            values[1],
+        ],
+        [
+            values[0],
+            values[1],
+            values[2],
+        ],
+    ]
 
 
 def test_read_write_simple(tmp_path):
@@ -238,8 +249,7 @@ def test_preserve_single_var_length_array_dtypes(tmp_path, dtype):
     values = _default_var_length_array_values(dtype)
 
     t1 = Table()
-    data = np.array([np.array(val, dtype=dtype)
-                     for val in values], dtype=np.object_)
+    data = np.array([np.array(val, dtype=dtype) for val in values], dtype=np.object_)
     t1.add_column(Column(name="a", data=data))
     t1.write(test_file)
 
@@ -262,7 +272,9 @@ def test_preserve_all_dtypes(tmp_path):
         t1.add_column(Column(name=str(dtype), data=np.array(values, dtype=dtype)))
 
         arr_values = _default_array_values(dtype)
-        t1.add_column(Column(name=str(dtype) + "_arr", data=np.array(arr_values, dtype=dtype)))
+        t1.add_column(
+            Column(name=str(dtype) + "_arr", data=np.array(arr_values, dtype=dtype))
+        )
 
     t1.write(test_file)
 
@@ -293,8 +305,9 @@ def test_preserve_all_var_length_dtypes(tmp_path):
 
     for dtype in ALL_DTYPES:
         varr_values = _default_var_length_array_values(dtype)
-        data = np.array([np.array(val, dtype=dtype)
-                         for val in varr_values], dtype=np.object_)
+        data = np.array(
+            [np.array(val, dtype=dtype) for val in varr_values], dtype=np.object_
+        )
         t1.add_column(Column(name=str(dtype) + "_varr", data=data))
 
     t1.write(test_file)
@@ -321,7 +334,9 @@ def test_write_empty_tables(tmp_path):
         t1.add_column(Column(name=str(dtype), data=np.array(values, dtype=dtype)))
 
         arr_values = _default_array_values(dtype)
-        t1.add_column(Column(name=str(dtype) + "_arr", data=np.array(arr_values, dtype=dtype)))
+        t1.add_column(
+            Column(name=str(dtype) + "_arr", data=np.array(arr_values, dtype=dtype))
+        )
 
     data = np.zeros(0, dtype=t1.dtype)
     t2 = Table(data=data)
@@ -337,8 +352,9 @@ def test_write_empty_tables(tmp_path):
     t4 = Table()
     for dtype in ALL_DTYPES:
         varr_values = _default_var_length_array_values(dtype)
-        data = np.array([np.array(val, dtype=dtype)
-                         for val in varr_values], dtype=np.object_)
+        data = np.array(
+            [np.array(val, dtype=dtype) for val in varr_values], dtype=np.object_
+        )
         t4.add_column(Column(name=str(dtype) + "_varr", data=data))
 
     data = np.zeros(0, dtype=t4.dtype)
@@ -355,8 +371,10 @@ def test_heterogeneous_var_array_table(tmp_path):
     t1 = Table()
 
     data = np.array(
-        [np.array([0, 1, 2], dtype=np.int32),
-         np.array([0, 1, 2, 3, 4], dtype=np.float64)],
+        [
+            np.array([0, 1, 2], dtype=np.int32),
+            np.array([0, 1, 2, 3, 4], dtype=np.float64),
+        ],
         dtype=np.object_,
     )
     t1.add_column(Column(name="a", data=data))

--- a/astropy/io/misc/tests/test_parquet.py
+++ b/astropy/io/misc/tests/test_parquet.py
@@ -347,6 +347,24 @@ def test_write_empty_tables(tmp_path):
         t5.write(test_file2)
 
 
+def test_heterogeneous_var_array_table(tmp_path):
+    """Test exception when trying to serialize a mixed-type variable-length column."""
+
+    test_file = tmp_path / "test.parquet"
+
+    t1 = Table()
+
+    data = np.array(
+        [np.array([0, 1, 2], dtype=np.int32),
+         np.array([0, 1, 2, 3, 4], dtype=np.float64)],
+        dtype=np.object_,
+    )
+    t1.add_column(Column(name="a", data=data))
+
+    with pytest.raises(ValueError) as err:
+        t1.write(test_file)
+
+
 def test_preserve_meta(tmp_path):
     """Test that writing/reading preserves metadata."""
 

--- a/astropy/io/misc/tests/test_parquet.py
+++ b/astropy/io/misc/tests/test_parquet.py
@@ -338,6 +338,7 @@ def test_write_empty_tables(tmp_path):
             Column(name=str(dtype) + "_arr", data=np.array(arr_values, dtype=dtype))
         )
 
+    # Write an empty table with values and arrays, and confirm it works.
     data = np.zeros(0, dtype=t1.dtype)
     t2 = Table(data=data)
 
@@ -357,9 +358,12 @@ def test_write_empty_tables(tmp_path):
         )
         t4.add_column(Column(name=str(dtype) + "_varr", data=data))
 
+    # Write an empty table with variable-length arrays, and confirm this
+    # raises an exception. (The datatype of an np.object_ type column
+    # cannot be inferred from an empty table.)
     data = np.zeros(0, dtype=t4.dtype)
     t5 = Table(data=data)
-    with pytest.raises(ValueError) as err:
+    with pytest.raises(ValueError, match="Cannot serialize zero-length table") as err:
         t5.write(test_file2)
 
 
@@ -379,7 +383,7 @@ def test_heterogeneous_var_array_table(tmp_path):
     )
     t1.add_column(Column(name="a", data=data))
 
-    with pytest.raises(ValueError) as err:
+    with pytest.raises(ValueError, match="Cannot serialize mixed-type column") as err:
         t1.write(test_file)
 
 

--- a/astropy/io/misc/tests/test_parquet.py
+++ b/astropy/io/misc/tests/test_parquet.py
@@ -247,6 +247,11 @@ def test_preserve_all_dtypes(tmp_path):
         assert t2[str(dtype)].dtype == dtype
         assert np.all(t2[str(dtype) + "_arr"].shape == np.array(arr_values).shape)
 
+    # Test just reading the schema
+    schema2 = Table.read(test_file, schema_only=True)
+    assert len(schema2) == 0
+    assert schema2.dtype == t2.dtype
+
 
 def test_preserve_meta(tmp_path):
     """Test that writing/reading preserves metadata."""

--- a/astropy/io/misc/tests/test_parquet.py
+++ b/astropy/io/misc/tests/test_parquet.py
@@ -284,6 +284,31 @@ def test_preserve_all_dtypes(tmp_path):
     assert schema2.dtype == t2.dtype
 
 
+def test_preserve_all_var_length_dtypes(tmp_path):
+    """Test that round-tripping preserves a table with all the var length datatypes."""
+
+    test_file = tmp_path / "test.parquet"
+
+    t1 = Table()
+
+    for dtype in ALL_DTYPES:
+        varr_values = _default_var_length_array_values(dtype)
+        data = np.array([np.array(val, dtype=dtype)
+                         for val in varr_values], dtype=np.object_)
+        t1.add_column(Column(name=str(dtype) + "_varr", data=data))
+
+    t1.write(test_file)
+
+    t2 = Table.read(test_file)
+
+    for dtype in ALL_DTYPES:
+        varr_values = _default_var_length_array_values(dtype)
+        colname = str(dtype) + "_varr"
+        for row1, row2 in zip(t1[colname], t2[colname]):
+            assert np.all(row1 == row2)
+            assert row1.dtype == row2.dtype
+
+
 def test_preserve_meta(tmp_path):
     """Test that writing/reading preserves metadata."""
 

--- a/astropy/io/misc/tests/test_parquet.py
+++ b/astropy/io/misc/tests/test_parquet.py
@@ -60,6 +60,13 @@ def _default_array_values(dtype):
     return [values for i in range(3)]
 
 
+def _default_var_length_array_values(dtype):
+    values = _default_values(dtype)
+    return [[values[0], ],
+            [values[0], values[1], ],
+            [values[0], values[1], values[2], ]]
+
+
 def test_read_write_simple(tmp_path):
     """Test writing/reading a simple parquet file."""
     test_file = tmp_path / "test.parquet"
@@ -217,6 +224,30 @@ def test_preserve_single_array_dtypes(tmp_path, dtype):
     assert np.all(t2["a"] == t1["a"])
     assert np.all(t2["a"].shape == np.array(values).shape)
     assert t2["a"].dtype == dtype
+
+
+@pytest.mark.parametrize("dtype", ALL_DTYPES)
+def test_preserve_single_var_length_array_dtypes(tmp_path, dtype):
+    """
+    Test that round-tripping a single variable length array column preserves
+    datatypes.
+    """
+
+    test_file = tmp_path / "test.parquet"
+
+    values = _default_var_length_array_values(dtype)
+
+    t1 = Table()
+    data = np.array([np.array(val, dtype=dtype)
+                     for val in values], dtype=np.object_)
+    t1.add_column(Column(name="a", data=data))
+    t1.write(test_file)
+
+    t2 = Table.read(test_file)
+
+    for row1, row2 in zip(t1["a"], t2["a"]):
+        assert np.all(row1 == row2)
+        assert row1.dtype == row2.dtype
 
 
 def test_preserve_all_dtypes(tmp_path):

--- a/astropy/io/misc/tests/test_parquet.py
+++ b/astropy/io/misc/tests/test_parquet.py
@@ -55,6 +55,11 @@ def _default_values(dtype):
         return [1, 2, 3]
 
 
+def _default_array_values(dtype):
+    values = _default_values(dtype)
+    return [values for i in range(4)]
+
+
 def test_read_write_simple(tmp_path):
     """Test writing/reading a simple parquet file."""
     test_file = tmp_path / "test.parquet"
@@ -192,6 +197,25 @@ def test_preserve_single_dtypes(tmp_path, dtype):
     t2 = Table.read(test_file)
 
     assert np.all(t2["a"] == values)
+    assert t2["a"].dtype == dtype
+
+
+@pytest.mark.parametrize("dtype", ALL_DTYPES)
+def test_preserve_single_array_dtypes(tmp_path, dtype):
+    """Test that round-tripping a single array column preserves datatypes."""
+
+    test_file = tmp_path / "test.parquet"
+
+    values = _default_array_values(dtype)
+
+    t1 = Table()
+    t1.add_column(Column(name="a", data=np.array(values, dtype=dtype)))
+    t1.write(test_file)
+
+    t2 = Table.read(test_file)
+
+    assert np.all(t2["a"] == t1["a"])
+    assert np.all(t2["a"].shape == np.array(values).shape)
     assert t2["a"].dtype == dtype
 
 

--- a/astropy/io/misc/tests/test_parquet.py
+++ b/astropy/io/misc/tests/test_parquet.py
@@ -57,7 +57,7 @@ def _default_values(dtype):
 
 def _default_array_values(dtype):
     values = _default_values(dtype)
-    return [values for i in range(4)]
+    return [values for i in range(3)]
 
 
 def test_read_write_simple(tmp_path):
@@ -230,6 +230,9 @@ def test_preserve_all_dtypes(tmp_path):
         values = _default_values(dtype)
         t1.add_column(Column(name=str(dtype), data=np.array(values, dtype=dtype)))
 
+        arr_values = _default_array_values(dtype)
+        t1.add_column(Column(name=str(dtype) + "_arr", data=np.array(arr_values, dtype=dtype)))
+
     t1.write(test_file)
 
     t2 = Table.read(test_file)
@@ -238,6 +241,11 @@ def test_preserve_all_dtypes(tmp_path):
         values = _default_values(dtype)
         assert np.all(t2[str(dtype)] == values)
         assert t2[str(dtype)].dtype == dtype
+
+        arr_values = _default_array_values(dtype)
+        assert np.all(t2[str(dtype) + "_arr"] == values)
+        assert t2[str(dtype)].dtype == dtype
+        assert np.all(t2[str(dtype) + "_arr"].shape == np.array(arr_values).shape)
 
 
 def test_preserve_meta(tmp_path):

--- a/astropy/io/misc/tests/test_parquet.py
+++ b/astropy/io/misc/tests/test_parquet.py
@@ -309,6 +309,44 @@ def test_preserve_all_var_length_dtypes(tmp_path):
             assert row1.dtype == row2.dtype
 
 
+def test_write_empty_tables(tmp_path):
+    """Test that we can save an empty table with var length datatypes."""
+
+    test_file = tmp_path / "test.parquet"
+
+    t1 = Table()
+
+    for dtype in ALL_DTYPES:
+        values = _default_values(dtype)
+        t1.add_column(Column(name=str(dtype), data=np.array(values, dtype=dtype)))
+
+        arr_values = _default_array_values(dtype)
+        t1.add_column(Column(name=str(dtype) + "_arr", data=np.array(arr_values, dtype=dtype)))
+
+    data = np.zeros(0, dtype=t1.dtype)
+    t2 = Table(data=data)
+
+    t2.write(test_file)
+
+    t3 = Table.read(test_file)
+
+    assert t3.dtype == t2.dtype
+
+    test_file2 = tmp_path / "test2.parquet"
+
+    t4 = Table()
+    for dtype in ALL_DTYPES:
+        varr_values = _default_var_length_array_values(dtype)
+        data = np.array([np.array(val, dtype=dtype)
+                         for val in varr_values], dtype=np.object_)
+        t4.add_column(Column(name=str(dtype) + "_varr", data=data))
+
+    data = np.zeros(0, dtype=t4.dtype)
+    t5 = Table(data=data)
+    with pytest.raises(ValueError) as err:
+        t5.write(test_file2)
+
+
 def test_preserve_meta(tmp_path):
     """Test that writing/reading preserves metadata."""
 

--- a/docs/changes/io.misc/14237.feature.rst
+++ b/docs/changes/io.misc/14237.feature.rst
@@ -1,0 +1,1 @@
+Add support for writing/reading fixed-size and variable-length array columns to the parquet formatter.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This PR adds a few features to the parquet writer/reader.  In particular, it
* Optimizes file reading to reduce memory copying.
* Adds support for columns with array types.
* Adds support for columns with variable length arrays (issue #14000).

At the moment I only added support for 1D array columns (e.g. dtype `(np.int64, (5, ))`) and not multi-dimensional array columns (e.g dtype `(np.int64, (5, 4, ))`).  This functionality could be added by making a special metadata column (e.g. `table::multidim::{name}`) and raveling on write and reshaping on read if the maintainers think this would be useful (it would make the code slightly more complex).

The variable length array support does work in the tests, though I don't know how performant it is.  Prior to working on this I didn't even know astropy tables handled variable length array columns (this does not seem to be documented; only the fits support for variable length columns is documented that I could find).

Note that tables with array columns (pyarrow `list` types) cannot be read with pandas, because pandas does not support array columns.  But that's a pandas limitation, not an astropy or arrow or parquet limitation.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #14000

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
