### PR TITLE
Make ``__all__`` reflect public (and not) API

### DIFF
--- a/astropy/cosmology/__init__.py
+++ b/astropy/cosmology/__init__.py
@@ -8,27 +8,57 @@ detailed usage examples and references.
 
 """
 
-from . import core, flrw, funcs, parameter, units, utils
+from . import units
 
 from . import io  # needed before 'realizations'  # isort: split
 from . import realizations
-from .core import *
-from .flrw import *
-from .funcs import *
-from .parameter import *
+from .core import Cosmology, CosmologyError, FlatCosmologyMixin
+from .flrw.base import FLRW, FlatFLRWMixin
+from .flrw.lambdacdm import FlatLambdaCDM, LambdaCDM
+from .flrw.w0cdm import FlatwCDM, wCDM
+from .flrw.w0wacdm import Flatw0waCDM, w0waCDM
+from .flrw.w0wzcdm import Flatw0wzCDM, w0wzCDM
+from .flrw.wpwazpcdm import FlatwpwaCDM, wpwaCDM
+from .funcs import cosmology_equal, z_at_value
+from .parameter import Parameter
 from .realizations import available, default_cosmology
-from .utils import *
 
-__all__ = (
-    core.__all__
-    + flrw.__all__  # cosmology classes
-    + realizations.__all__  # instances thereof
-    + ["units"]
-    # utils
-    + funcs.__all__
-    + parameter.__all__
-    + utils.__all__
-)
+__all__ = [
+    "Cosmology",
+    "FlatCosmologyMixin",
+    "Parameter",
+    "CosmologyError",
+    # FLRW
+    "FLRW",
+    "FlatFLRWMixin",
+    "LambdaCDM",
+    "FlatLambdaCDM",
+    "wCDM",
+    "FlatwCDM",
+    "w0waCDM",
+    "Flatw0waCDM",
+    "w0wzCDM",
+    "Flatw0wzCDM",
+    "wpwaCDM",
+    "FlatwpwaCDM",
+    # realizations
+    "available",
+    "default_cosmology",
+    "WMAP1",  # In `__getattr__`
+    "WMAP3",  # In `__getattr__`
+    "WMAP5",  # In `__getattr__`
+    "WMAP7",  # In `__getattr__`
+    "WMAP9",  # In `__getattr__`
+    "Planck13",  # In `__getattr__`
+    "Planck15",  # In `__getattr__`
+    "Planck18",  # In `__getattr__`
+    # funcs
+    "z_at_value",
+    "cosmology_equal",
+    # public modules
+    "realizations",
+    "units",
+]
 
 
 def __getattr__(name):
@@ -48,4 +78,4 @@ def __getattr__(name):
 
 def __dir__():
     """Directory, including lazily-imported objects."""
-    return __all__
+    return sorted(__all__ + list(available))

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:  # pragma: no cover
 # Many of these adapted from Hogg 1999, astro-ph/9905116
 # and Linder 2003, PRL 90, 91301
 
-__all__ = ["Cosmology", "CosmologyError", "FlatCosmologyMixin"]
+__all__ = []  # No public API -- see cosmology/__init__.pys
 
 __doctest_requires__ = {}  # needed until __getattr__ removed
 

--- a/astropy/cosmology/flrw/__init__.py
+++ b/astropy/cosmology/flrw/__init__.py
@@ -1,42 +1,30 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Astropy FLRW classes."""
 
-from . import base, lambdacdm, w0cdm, w0wacdm, w0wzcdm, wpwazpcdm
-from .base import *
-from .lambdacdm import *
-from .w0cdm import *
-from .w0wacdm import *
-from .w0wzcdm import *
-from .wpwazpcdm import *
-
-__all__ = (
-    base.__all__
-    + lambdacdm.__all__
-    + w0cdm.__all__
-    + w0wacdm.__all__
-    + wpwazpcdm.__all__
-    + w0wzcdm.__all__
-)
+__all__ = []  # No public API -- see cosmology/__init__.py
 
 
 def __getattr__(attr):
     """Lazy import deprecated private API."""
-    base_attrs = (
-        "H0units_to_invs",
-        "a_B_c2",
-        "critdens_const",
-        "kB_evK",
-        "radian_in_arcmin",
-        "radian_in_arcsec",
-        "sec_to_Gyr",
-    )
+    base_attrs = {
+        "H0units_to_invs": "_H0units_to_invs",
+        "a_B_c2": "_a_B_c2",
+        "critdens_const": "_critdens_const",
+        "kB_evK": "_kB_evK",
+        "radian_in_arcmin": "_radian_in_arcmin",
+        "radian_in_arcsec": "_radian_in_arcsec",
+        "sec_to_Gyr": "_sec_to_Gyr",
+        "quad": "quad",
+    }
+    lambdacdm_attrs = {
+        "ellipkinc": "ellipkinc",
+        "hyp2f1": "hyp2f1",
+    }
 
-    if attr in base_attrs + ("quad",) + ("ellipkinc", "hyp2f1"):
+    if attr in base_attrs or attr in lambdacdm_attrs:
         import warnings
 
         from astropy.utils.exceptions import AstropyDeprecationWarning
-
-        from . import base, lambdacdm
 
         msg = (
             f"`astropy.cosmology.flrw.{attr}` is a private variable (since "
@@ -45,10 +33,12 @@ def __getattr__(attr):
         warnings.warn(msg, AstropyDeprecationWarning)
 
         if attr in base_attrs:
-            return getattr(base, "_" + attr)
-        elif attr == "quad":
-            return getattr(base, attr)
-        elif attr in ("ellipkinc", "hyp2f1"):
-            return getattr(lambdacdm, attr)
+            from . import base
+
+            return getattr(base, base_attrs[attr])
+        elif attr in lambdacdm_attrs:
+            from . import lambdacdm
+
+            return getattr(lambdacdm, lambdacdm_attrs[attr])
 
     raise AttributeError(f"module {__name__!r} has no attribute {attr!r}.")

--- a/astropy/cosmology/flrw/base.py
+++ b/astropy/cosmology/flrw/base.py
@@ -33,7 +33,7 @@ else:
         raise ModuleNotFoundError("No module named 'scipy.integrate'")
 
 
-__all__ = ["FLRW", "FlatFLRWMixin"]
+__all__ = []  # No public API -- see cosmology/__init__.py
 
 __doctest_requires__ = {"*": ["scipy"]}
 

--- a/astropy/cosmology/flrw/lambdacdm.py
+++ b/astropy/cosmology/flrw/lambdacdm.py
@@ -25,7 +25,7 @@ else:
         raise ModuleNotFoundError("No module named 'scipy.special'")
 
 
-__all__ = ["LambdaCDM", "FlatLambdaCDM"]
+__all__ = []  # No public API -- see cosmology/__init__.py
 
 __doctest_requires__ = {"*": ["scipy"]}
 

--- a/astropy/cosmology/flrw/w0cdm.py
+++ b/astropy/cosmology/flrw/w0cdm.py
@@ -10,7 +10,7 @@ from astropy.cosmology.utils import aszarr
 from . import scalar_inv_efuncs
 from .base import FLRW, FlatFLRWMixin
 
-__all__ = ["wCDM", "FlatwCDM"]
+__all__ = []  # No public API -- see cosmology/__init__.py
 
 __doctest_requires__ = {"*": ["scipy"]}
 

--- a/astropy/cosmology/flrw/w0wacdm.py
+++ b/astropy/cosmology/flrw/w0wacdm.py
@@ -9,7 +9,7 @@ from astropy.cosmology.utils import aszarr
 from . import scalar_inv_efuncs
 from .base import FLRW, FlatFLRWMixin
 
-__all__ = ["w0waCDM", "Flatw0waCDM"]
+__all__ = []  # No public API -- see cosmology/__init__.py
 
 __doctest_requires__ = {"*": ["scipy"]}
 

--- a/astropy/cosmology/flrw/w0wzcdm.py
+++ b/astropy/cosmology/flrw/w0wzcdm.py
@@ -9,7 +9,7 @@ from astropy.cosmology.utils import aszarr
 from . import scalar_inv_efuncs
 from .base import FLRW, FlatFLRWMixin
 
-__all__ = ["w0wzCDM", "Flatw0wzCDM"]
+__all__ = []  # No public API -- see cosmology/__init__.py
 
 __doctest_requires__ = {"*": ["scipy"]}
 

--- a/astropy/cosmology/funcs/__init__.py
+++ b/astropy/cosmology/funcs/__init__.py
@@ -7,4 +7,4 @@ from .comparison import cosmology_equal
 # _z_at_scalar_value is imported for backwards compatibility
 from .optimize import _z_at_scalar_value, z_at_value
 
-__all__ = ["z_at_value", "cosmology_equal"]
+__all__ = []  # No public API -- see cosmology/__init__.py

--- a/astropy/cosmology/funcs/tests/test_funcs.py
+++ b/astropy/cosmology/funcs/tests/test_funcs.py
@@ -8,7 +8,17 @@ import numpy as np
 import pytest
 
 from astropy import units as u
-from astropy.cosmology import core, flrw
+from astropy.cosmology import (
+    FlatLambdaCDM,
+    Flatw0waCDM,
+    FlatwCDM,
+    LambdaCDM,
+    core,
+    w0waCDM,
+    w0wzCDM,
+    wCDM,
+    wpwaCDM,
+)
 from astropy.cosmology.funcs import _z_at_scalar_value, z_at_value
 from astropy.cosmology.realizations import (
     WMAP1,
@@ -352,14 +362,14 @@ def test_z_at_value_unconverged(method):
         WMAP5,
         WMAP7,
         WMAP9,
-        flrw.LambdaCDM,
-        flrw.FlatLambdaCDM,
-        flrw.wpwaCDM,
-        flrw.w0wzCDM,
-        flrw.wCDM,
-        flrw.FlatwCDM,
-        flrw.w0waCDM,
-        flrw.Flatw0waCDM,
+        LambdaCDM,
+        FlatLambdaCDM,
+        wpwaCDM,
+        w0wzCDM,
+        wCDM,
+        FlatwCDM,
+        w0waCDM,
+        Flatw0waCDM,
     ],
 )
 def test_z_at_value_roundtrip(cosmo):

--- a/astropy/cosmology/parameter.py
+++ b/astropy/cosmology/parameter.py
@@ -5,7 +5,7 @@ import copy
 import astropy.units as u
 from astropy.utils.decorators import deprecated_attribute, deprecated_renamed_argument
 
-__all__ = ["Parameter"]
+__all__ = []  # No public API -- see cosmology/__init__.py
 
 
 class Parameter:

--- a/astropy/cosmology/realizations.py
+++ b/astropy/cosmology/realizations.py
@@ -18,7 +18,8 @@ _COSMOLOGY_DATA_DIR = pathlib.Path(
 available = tuple(sorted(p.stem for p in _COSMOLOGY_DATA_DIR.glob("*.ecsv")))
 
 
-__all__ = ["available", "default_cosmology"] + list(available)
+__all__ = ["available", "default_cosmology"]
+
 
 __doctest_requires__ = {"*": ["scipy"]}
 
@@ -51,7 +52,7 @@ def __getattr__(name):
 
 def __dir__():
     """Directory, including lazily-imported objects."""
-    return __all__
+    return sorted(__all__ + list(available))
 
 
 #########################################################################

--- a/astropy/cosmology/tests/test_realizations.py
+++ b/astropy/cosmology/tests/test_realizations.py
@@ -25,9 +25,9 @@ def test_realizations_in_toplevel_dir():
 
 def test_realizations_in_realizations_dir():
     """Test the realizations are in ``dir`` of :mod:`astropy.cosmology.realizations`."""
-    d = dir(realizations)
+    d = dir(c)
 
-    assert set(d) == set(realizations.__all__)
+    assert set(d) == set(parameters.__all__ + list(parameters.available))
     for n in parameters.available:
         assert n in d
 

--- a/docs/changes/cosmology/14239.api.rst
+++ b/docs/changes/cosmology/14239.api.rst
@@ -1,0 +1,4 @@
+``__all__`` is now the definitive source of what is (and isn't) public API. Currently
+the top-level namespace (``cosmology.``), ``cosmology.parameters``,
+``cosmology.realizations``, and ``cosmology.units`` contain the public API. Other
+modules are considered private API.


### PR DESCRIPTION
Focus on the top-level namespace. Now ``__all__`` is the definition what is and isn't public API.

PEP8 (https://peps.python.org/pep-0008/#public-and-internal-interfaces) says every module should have an `__all__`, even if it's empty!


TODO:
- [ ] Should ``flrw.__all__`` have stuff, as in should ``cosmology.flrw.FlatLambdaCDM`` be public, or just ``cosmology.FlatLambdaCDM``?
- [x] Changelog? I suppose under the assumption that ``__all__`` has always been the definition of public API and this module was just untidy, there should be a changelog.

Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>


### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
