### PR TITLE
[FIX] _transform_plot_args was converting to degrees instead of coord_unit

### DIFF
--- a/astropy/tests/figures/py39-test-image-mpl322-cov.json
+++ b/astropy/tests/figures/py39-test-image-mpl322-cov.json
@@ -49,5 +49,6 @@
   "astropy.visualization.wcsaxes.tests.test_transform_coord_meta.TestTransformCoordMeta.test_coords_overlay": "382af290d2231d93a6a529e581e07a76912be48ad974abe4a7021eda15f37ba2",
   "astropy.visualization.wcsaxes.tests.test_transform_coord_meta.TestTransformCoordMeta.test_coords_overlay_auto_coord_meta": "069adb197b6c078e5354c10dec96808cd8a61ab50e079ee8806a388a6a5be3a0",
   "astropy.visualization.wcsaxes.tests.test_transform_coord_meta.TestTransformCoordMeta.test_direct_init": "f1916439fdc8be04568545db6169687f3ea8af4692ad7a9bede5a39eb5562896",
-  "astropy.visualization.wcsaxes.tests.test_wcsapi.test_wcsapi_5d_with_names": "1db4eb1d01da87647c19dde5bd115555f65d3b2d1036a82c41020b938c22bb7f"
+  "astropy.visualization.wcsaxes.tests.test_wcsapi.test_wcsapi_5d_with_names": "1db4eb1d01da87647c19dde5bd115555f65d3b2d1036a82c41020b938c22bb7f",
+  "astropy.visualization.wcsaxes.tests.test_wcsapi.test_wcsapi_2d_celestial_arcsec": "d2a991a19d26b139bb53812a1fe861cf21a29f1ebe0b894e96f6fcd60dc63fd6"
 }

--- a/astropy/tests/figures/py39-test-image-mpldev-cov.json
+++ b/astropy/tests/figures/py39-test-image-mpldev-cov.json
@@ -49,5 +49,6 @@
   "astropy.visualization.wcsaxes.tests.test_transform_coord_meta.TestTransformCoordMeta.test_coords_overlay": "0a87473ff8e5b5610f4adac1518c608afcd2178b25584fb42f77bcc594c4f47a",
   "astropy.visualization.wcsaxes.tests.test_transform_coord_meta.TestTransformCoordMeta.test_coords_overlay_auto_coord_meta": "4ab8cade790f7ab36c620cb136e076a14eccf1dac7109a3d4d5601cebc46ac8a",
   "astropy.visualization.wcsaxes.tests.test_transform_coord_meta.TestTransformCoordMeta.test_direct_init": "1f24c5243bfdf0f30e88afc4f2f5d66db85954cea50a2910af94975ff8765b45",
-  "astropy.visualization.wcsaxes.tests.test_wcsapi.test_wcsapi_5d_with_names": "d2dd2f7efef595a5819906c3f4f77f68d70d29efca5851d19528aecb0e3f8035"
+  "astropy.visualization.wcsaxes.tests.test_wcsapi.test_wcsapi_5d_with_names": "d2dd2f7efef595a5819906c3f4f77f68d70d29efca5851d19528aecb0e3f8035",
+  "astropy.visualization.wcsaxes.tests.test_wcsapi.test_wcsapi_2d_celestial_arcsec": "645d52dd264a02cf70fb85408f698930863f09f633eab37f0d8d06495a43e3cc"
 }

--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -9,7 +9,6 @@ from matplotlib.artist import Artist
 from matplotlib.axes import Axes, subplot_class_factory
 from matplotlib.transforms import Affine2D, Bbox, Transform
 
-import astropy.units as u
 from astropy.coordinates import BaseCoordinateFrame, SkyCoord
 from astropy.utils import minversion
 from astropy.utils.compat.optional_deps import HAS_PIL
@@ -304,9 +303,9 @@ class WCSAxes(Axes):
             plot_data = []
             for coord in self.coords:
                 if coord.coord_type == "longitude":
-                    plot_data.append(frame0.spherical.lon.to_value(u.deg))
+                    plot_data.append(frame0.spherical.lon.to_value(coord.coord_unit))
                 elif coord.coord_type == "latitude":
-                    plot_data.append(frame0.spherical.lat.to_value(u.deg))
+                    plot_data.append(frame0.spherical.lat.to_value(coord.coord_unit))
                 else:
                     raise NotImplementedError(
                         "Coordinates cannot be plotted with this "

--- a/astropy/visualization/wcsaxes/tests/test_wcsapi.py
+++ b/astropy/visualization/wcsaxes/tests/test_wcsapi.py
@@ -539,3 +539,67 @@ def test_wcsapi_5d_with_names(plt_close):
     ax.set_xlim(-0.5, 148.5)
     ax.set_ylim(-0.5, 148.5)
     return fig
+
+
+
+class LowLevelWCSCelestial2D(BaseLowLevelWCS):
+
+    # APE 14 WCS that has celestial coordinates that are deliberately not in degrees
+
+    @property
+    def pixel_n_dim(self):
+        return 2
+
+    @property
+    def world_n_dim(self):
+        return 2
+
+    @property
+    def world_axis_physical_types(self):
+        return [
+            "pos.eq.ra",
+            "pos.eq.dec",
+        ]
+
+    @property
+    def world_axis_units(self):
+        return ["arcsec", "arcsec"]
+
+    @property
+    def world_axis_names(self):
+        return ["RA", "DEC"]
+
+    # Since the units are in arcsec, we can just go for an identity transform
+    # where 1 pixel = 1" since this is not completely unrealistic
+
+    def pixel_to_world_values(self, *pixel_arrays):
+        return pixel_arrays
+
+    def world_to_pixel_values(self, *world_arrays):
+        return world_arrays
+
+    @property
+    def world_axis_object_components(self):
+        return [
+            ("celestial", 0, "spherical.lon.arcsec"),
+            ("celestial", 1, "spherical.lat.arcsec"),
+        ]
+
+    @property
+    def world_axis_object_classes(self):
+        return {
+            "celestial": (SkyCoord, (), {"unit": "arcsec"}),
+        }
+
+
+@figure_test
+def test_wcsapi_2d_celestial_arcsec(plt_close):
+    # Regression test for plot_coord/scatter_coord with celestial WCS that is not in degrees
+    fig = plt.figure(figsize=(6, 6))
+    ax = fig.add_axes([0.15, 0.1, 0.8, 0.8], projection=LowLevelWCSCelestial2D())
+    ax.set_xlim(-0.5, 200.5)
+    ax.set_ylim(-0.5, 200.5)
+    ax.coords[0].set_format_unit('arcsec')
+    ax.plot_coord(SkyCoord([50, 150], [100, 100], unit='arcsec'), 'ro')
+    ax.scatter_coord(SkyCoord([100, 100], [50, 150], unit='arcsec'), color='green', s=50)
+    return fig

--- a/astropy/visualization/wcsaxes/tests/test_wcsapi.py
+++ b/astropy/visualization/wcsaxes/tests/test_wcsapi.py
@@ -541,9 +541,7 @@ def test_wcsapi_5d_with_names(plt_close):
     return fig
 
 
-
 class LowLevelWCSCelestial2D(BaseLowLevelWCS):
-
     # APE 14 WCS that has celestial coordinates that are deliberately not in degrees
 
     @property
@@ -599,7 +597,9 @@ def test_wcsapi_2d_celestial_arcsec(plt_close):
     ax = fig.add_axes([0.15, 0.1, 0.8, 0.8], projection=LowLevelWCSCelestial2D())
     ax.set_xlim(-0.5, 200.5)
     ax.set_ylim(-0.5, 200.5)
-    ax.coords[0].set_format_unit('arcsec')
-    ax.plot_coord(SkyCoord([50, 150], [100, 100], unit='arcsec'), 'ro')
-    ax.scatter_coord(SkyCoord([100, 100], [50, 150], unit='arcsec'), color='green', s=50)
+    ax.coords[0].set_format_unit("arcsec")
+    ax.plot_coord(SkyCoord([50, 150], [100, 100], unit="arcsec"), "ro")
+    ax.scatter_coord(
+        SkyCoord([100, 100], [50, 150], unit="arcsec"), color="green", s=50
+    )
     return fig

--- a/docs/changes/visualization/14251.bugfix.rst
+++ b/docs/changes/visualization/14251.bugfix.rst
@@ -1,0 +1,1 @@
+``WCSAxes.plot_coord`` and ``plot_scatter`` now work correctly for APE 14 compliant WCSes where the units are not always converted to degrees.


### PR DESCRIPTION
Discovered this when trying to plot a coordinate using a gWCS. 

I am unsure how to unit test this.