### PR TITLE
Only propagate info if the quantity stays effectively the same

### DIFF
--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -397,6 +397,16 @@ class TestQuantityOperations:
         assert new_quantity.value == 171.3
         assert new_quantity.unit == u.meter
 
+        # Multiple with a unit.
+        new_quantity = self.q1 * u.s
+        assert new_quantity.value == 11.42
+        assert new_quantity.unit == u.Unit("m s")
+
+        # Reverse multiple with a unit.
+        new_quantity = u.s * self.q1
+        assert new_quantity.value == 11.42
+        assert new_quantity.unit == u.Unit("m s")
+
     def test_division(self):
         # Take units from left object, q1
         new_quantity = self.q1 / self.q2
@@ -423,6 +433,16 @@ class TestQuantityOperations:
         new_quantity = 11.42 / self.q1
         assert new_quantity.value == 1.0
         assert new_quantity.unit == u.Unit("1/m")
+
+        # Divide by a unit.
+        new_quantity = self.q1 / u.s
+        assert new_quantity.value == 11.42
+        assert new_quantity.unit == u.Unit("m/s")
+
+        # Divide into a unit.
+        new_quantity = u.s / self.q1
+        assert new_quantity.value == 1 / 11.42
+        assert new_quantity.unit == u.Unit("s/m")
 
     def test_commutativity(self):
         """Regression test for issue #587."""

--- a/astropy/units/tests/test_quantity_info.py
+++ b/astropy/units/tests/test_quantity_info.py
@@ -1,0 +1,121 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""Test the propagation of info on Quantity during operations."""
+
+import copy
+
+import numpy as np
+
+from astropy import units as u
+
+
+def assert_info_equal(a, b, ignore=set()):
+    a_info = a.info
+    b_info = b.info
+    for attr in (a_info.attr_names | b_info.attr_names) - ignore:
+        if attr == "unit":
+            assert a_info.unit.is_equivalent(b_info.unit)
+        else:
+            assert getattr(a_info, attr, None) == getattr(b_info, attr, None)
+
+
+def assert_no_info(a):
+    assert "info" not in a.__dict__
+
+
+class TestQuantityInfo:
+    @classmethod
+    def setup_class(self):
+        self.q = u.Quantity(np.arange(1.0, 5.0), "m/s")
+        self.q.info.name = "v"
+        self.q.info.description = "air speed of a african swallow"
+
+    def test_copy(self):
+        q_copy1 = self.q.copy()
+        assert_info_equal(q_copy1, self.q)
+        q_copy2 = copy.copy(self.q)
+        assert_info_equal(q_copy2, self.q)
+        q_copy3 = copy.deepcopy(self.q)
+        assert_info_equal(q_copy3, self.q)
+
+    def test_slice(self):
+        q_slice = self.q[1:3]
+        assert_info_equal(q_slice, self.q)
+        q_take = self.q.take([0, 1])
+        assert_info_equal(q_take, self.q)
+
+    def test_item(self):
+        # Scalars do not get info set (like for Column); TODO: is this OK?
+        q1 = self.q[1]
+        assert_no_info(q1)
+        q_item = self.q.item(1)
+        assert_no_info(q_item)
+
+    def test_iter(self):
+        # Scalars do not get info set.
+        for q in self.q:
+            assert_no_info(q)
+        for q in iter(self.q):
+            assert_no_info(q)
+
+    def test_change_to_equivalent_unit(self):
+        q1 = self.q.to(u.km / u.hr)
+        assert_info_equal(q1, self.q)
+        q2 = self.q.si
+        assert_info_equal(q2, self.q)
+        q3 = self.q.cgs
+        assert_info_equal(q3, self.q)
+        q4 = self.q.decompose()
+        assert_info_equal(q4, self.q)
+
+    def test_reshape(self):
+        q = self.q.reshape(-1, 1, 2)
+        assert_info_equal(q, self.q)
+        q2 = q.squeeze()
+        assert_info_equal(q2, self.q)
+
+    def test_insert(self):
+        q = self.q.copy()
+        q.insert(1, 1 * u.cm / u.hr)
+        assert_info_equal(q, self.q)
+
+    def test_unary_op(self):
+        q = -self.q
+        assert_no_info(q)
+
+    def test_binary_op(self):
+        q = self.q + self.q
+        assert_no_info(q)
+
+    def test_unit_change(self):
+        q = self.q * u.s
+        assert_no_info(q)
+        q2 = u.s / self.q
+        assert_no_info(q)
+
+    def test_inplace_unit_change(self):
+        # Not sure if it is logical to keep info here!
+        q = self.q.copy()
+        q *= u.s
+        assert_info_equal(q, self.q, ignore={"unit"})
+
+
+class TestStructuredQuantity:
+    @classmethod
+    def setup_class(self):
+        value = np.array([(1.0, 2.0), (3.0, 4.0)], dtype=[("p", "f8"), ("v", "f8")])
+        self.q = u.Quantity(value, "m, m/s")
+        self.q.info.name = "pv"
+        self.q.info.description = "Location and speed"
+
+    def test_keying(self):
+        q_p = self.q["p"]
+        assert_no_info(q_p)
+
+    def test_slicing(self):
+        q = self.q[:1]
+        assert_info_equal(q, self.q)
+
+    def test_item(self):
+        # Scalars do not get info set.
+        q = self.q[1]
+        assert_no_info(q)

--- a/docs/changes/units/14253.api.rst
+++ b/docs/changes/units/14253.api.rst
@@ -1,0 +1,4 @@
+Operations on ``Quantity`` in tables are sped up by only copying ``info`` when
+it makes sense (i.e., when the object can still logically be thought of as the
+same, such as in unit changes or slicing). ``info`` is no longer copied if a
+``Quantity`` is part of an operation.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address the fact that `info` gets copied from one quantity to another even when it makes little sense (such as in operations on quantities), slowing things done needlessly and possibly leading to confusion.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #5047, #14248

Also addresses https://github.com/astropy/astropy/issues/14244#issuecomment-1369524044

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
