### PR TITLE
Fix D202 - NoBlankLineAfterFunction 

### DIFF
--- a/astropy/config/configuration.py
+++ b/astropy/config/configuration.py
@@ -552,7 +552,6 @@ def get_config(packageormod=None, reload=False, rootname=None):
         If ``packageormod`` is `None`, but the package this item is created
         from cannot be determined.
     """
-
     if packageormod is None:
         packageormod = find_current_module(2)
         if packageormod is None:
@@ -773,7 +772,6 @@ def update_default_config(pkg, default_cfg_dir_or_fn, version=None, rootname="as
         If the version number of the package could not determined.
 
     """
-
     if path.isdir(default_cfg_dir_or_fn):
         default_cfgfn = path.join(default_cfg_dir_or_fn, pkg + ".cfg")
     else:
@@ -862,7 +860,6 @@ def create_config_file(pkg, rootname="astropy", overwrite=False):
         If the profile was updated, `True`, otherwise `False`.
 
     """
-
     # local import to prevent using the logger before it is configured
     from astropy.logger import log
 

--- a/astropy/config/paths.py
+++ b/astropy/config/paths.py
@@ -99,7 +99,6 @@ def get_config_dir(rootname="astropy"):
         The absolute path to the configuration directory.
 
     """
-
     # symlink will be set to this if the directory is created
     linkto = None
 
@@ -147,7 +146,6 @@ def get_cache_dir(rootname="astropy"):
         The absolute path to the cache directory.
 
     """
-
     # symlink will be set to this if the directory is created
     linkto = None
 

--- a/astropy/conftest.py
+++ b/astropy/conftest.py
@@ -125,7 +125,6 @@ def pytest_unconfigure(config):
 
 def pytest_terminal_summary(terminalreporter):
     """Output a warning to IPython users in case any tests failed."""
-
     try:
         get_ipython()
     except NameError:

--- a/astropy/constants/constant.py
+++ b/astropy/constants/constant.py
@@ -195,31 +195,26 @@ class Constant(Quantity, metaclass=ConstantMeta):
         """A typical ASCII text abbreviation of the constant, also generally
         the same as the Python variable used for this constant.
         """
-
         return self._abbrev
 
     @property
     def name(self):
         """The full name of the constant."""
-
         return self._name
 
     @lazyproperty
     def _unit(self):
         """The unit(s) in which this constant is defined."""
-
         return Unit(self._unit_string)
 
     @property
     def uncertainty(self):
         """The known absolute uncertainty in this constant's value."""
-
         return self._uncertainty
 
     @property
     def reference(self):
         """The source used for the value of this constant."""
-
         return self._reference
 
     @property
@@ -228,7 +223,6 @@ class Constant(Quantity, metaclass=ConstantMeta):
         `None` so long as the constant's units can be directly converted
         between systems).
         """
-
         return self._system
 
     def _instance_or_super(self, key):
@@ -244,7 +238,6 @@ class Constant(Quantity, metaclass=ConstantMeta):
         """If the Constant is defined in the SI system return that instance of
         the constant, else convert to a Quantity in the appropriate SI units.
         """
-
         return self._instance_or_super("si")
 
     @property
@@ -252,7 +245,6 @@ class Constant(Quantity, metaclass=ConstantMeta):
         """If the Constant is defined in the CGS system return that instance of
         the constant, else convert to a Quantity in the appropriate CGS units.
         """
-
         return self._instance_or_super("cgs")
 
     def __array_finalize__(self, obj):
@@ -278,7 +270,6 @@ class EMConstant(Constant):
         """Overridden for EMConstant to raise a `TypeError`
         emphasizing that there are multiple EM extensions to CGS.
         """
-
         raise TypeError(
             "Cannot convert EM constants to cgs because there "
             "are different systems for E.M constants within the "

--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -54,7 +54,6 @@ def _next_fast_lengths(shape):
     Calculated directly with `scipy.fft.next_fast_len`, if available; otherwise
     looked up from list and scaled by powers of 10, if necessary.
     """
-
     try:
         import scipy.fft
 
@@ -214,7 +213,6 @@ def convolve(
     For masked arrays, masked values are treated as NaNs.  The convolution
     is always done at ``numpy.float`` precision.
     """
-
     if boundary not in BOUNDARY_OPTIONS:
         raise ValueError(f"Invalid boundary option: must be one of {BOUNDARY_OPTIONS}")
 
@@ -979,7 +977,6 @@ def interpolate_replace_nans(array, kernel, convolve=convolve, **kwargs):
         A copy of the original array with NaN pixels replaced with their
         interpolated counterparts
     """
-
     if not np.any(np.isnan(array)):
         return array.copy()
 
@@ -1023,7 +1020,6 @@ def convolve_models(model, kernel, mode="convolve_fft", **kwargs):
     default : `~astropy.modeling.core.CompoundModel`
         Convolved model
     """
-
     if mode == "convolve_fft":
         operator = SPECIAL_OPERATORS.add(
             "convolve_fft", partial(convolve_fft, **kwargs)
@@ -1065,7 +1061,6 @@ def convolve_models_fft(model, kernel, bounding_box, resolution, cache=True, **k
     default : `~astropy.modeling.core.CompoundModel`
         Convolved model
     """
-
     operator = SPECIAL_OPERATORS.add("convolve_fft", partial(convolve_fft, **kwargs))
 
     return Convolution(operator, model, kernel, bounding_box, resolution, cache)

--- a/astropy/convolution/core.py
+++ b/astropy/convolution/core.py
@@ -98,7 +98,6 @@ class Kernel:
                 * 'peak'
                     Kernel is normalized such that its peak = 1.
         """
-
         if mode == "integral":
             normalization = self._array.sum()
         elif mode == "peak":

--- a/astropy/coordinates/angle_formats.py
+++ b/astropy/coordinates/angle_formats.py
@@ -466,7 +466,6 @@ def hms_to_hours(h, m, s=None):
     """
     Convert hour, minute, second to a float hour value.
     """
-
     check_hms_ranges(h, m, s)
 
     # determine sign
@@ -498,7 +497,6 @@ def hms_to_degrees(h, m, s):
     """
     Convert hour, minute, second to a float degrees value.
     """
-
     return hms_to_hours(h, m, s) * 15.0
 
 
@@ -506,7 +504,6 @@ def hms_to_radians(h, m, s):
     """
     Convert hour, minute, second to a float radians value.
     """
-
     return u.degree.to(u.radian, hms_to_degrees(h, m, s))
 
 
@@ -515,7 +512,6 @@ def hms_to_dms(h, m, s):
     Convert degrees, arcminutes, arcseconds to an ``(hour, minute, second)``
     tuple.
     """
-
     return degrees_to_dms(hms_to_degrees(h, m, s))
 
 
@@ -532,7 +528,6 @@ def hours_to_radians(h):
     """
     Convert an angle in Hours to Radians.
     """
-
     return u.hourangle.to(u.radian, h)
 
 
@@ -541,7 +536,6 @@ def hours_to_hms(h):
     Convert an floating-point hour value into an ``(hour, minute,
     second)`` tuple.
     """
-
     sign = np.copysign(1.0, h)
 
     (hf, h) = np.modf(np.abs(h))  # (degree fraction, degree)
@@ -569,7 +563,6 @@ def radians_to_hms(r):
     """
     Convert an angle in Radians to an ``(hour, minute, second)`` tuple.
     """
-
     hours = radians_to_hours(r)
     return hours_to_hms(hours)
 
@@ -579,7 +572,6 @@ def radians_to_dms(r):
     Convert an angle in Radians to an ``(degree, arcminute,
     arcsecond)`` tuple.
     """
-
     degrees = u.radian.to(u.degree, r)
     return degrees_to_dms(degrees)
 
@@ -592,7 +584,6 @@ def sexagesimal_to_string(values, precision=None, pad=False, sep=(":",), fields=
     See `hours_to_string` and `degrees_to_string` for a higher-level
     interface to this functionality.
     """
-
     # Check to see if values[0] is negative, using np.copysign to handle -0
     sign = np.copysign(1.0, values[0])
     # If the coordinates are negative, we need to take the absolute values.

--- a/astropy/coordinates/angle_utilities.py
+++ b/astropy/coordinates/angle_utilities.py
@@ -51,7 +51,6 @@ def angular_separation(lon1, lat1, lon2, lat2):
 
     .. [1] https://en.wikipedia.org/wiki/Great-circle_distance
     """
-
     sdlon = np.sin(lon2 - lon1)
     cdlon = np.cos(lon2 - lon1)
     slat1 = np.sin(lat1)
@@ -201,7 +200,6 @@ def uniform_spherical_random_surface(size=1):
     rep : `~astropy.coordinates.UnitSphericalRepresentation`
         The random points.
     """
-
     rng = np.random  # can maybe switch to this being an input later - see #11628
 
     lon = rng.uniform(0, _TWOPI, size) * u.rad

--- a/astropy/coordinates/attributes.py
+++ b/astropy/coordinates/attributes.py
@@ -175,7 +175,6 @@ class TimeAttribute(Attribute):
         ValueError
             If the input is not valid for this attribute.
         """
-
         from astropy.time import Time
 
         if value is None:
@@ -240,7 +239,6 @@ class CartesianRepresentationAttribute(Attribute):
         ValueError
             If the input is not valid for this attribute.
         """
-
         if (
             isinstance(value, list)
             and len(value) == 3
@@ -329,7 +327,6 @@ class QuantityAttribute(Attribute):
         ValueError
             If the input is not valid for this attribute.
         """
-
         if value is None:
             return None, False
 
@@ -396,7 +393,6 @@ class EarthLocationAttribute(Attribute):
         ValueError
             If the input is not valid for this attribute.
         """
-
         if value is None:
             return None, False
         elif isinstance(value, EarthLocation):
@@ -520,7 +516,6 @@ class DifferentialAttribute(Attribute):
         ValueError
             If the input is not valid for this attribute.
         """
-
         if value is None:
             return None, False
 

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -42,7 +42,6 @@ def _get_repr_cls(value):
     """
     Return a valid representation class from ``value`` or raise exception.
     """
-
     if value in r.REPRESENTATION_CLASSES:
         value = r.REPRESENTATION_CLASSES[value]
     elif not isinstance(value, type) or not issubclass(value, r.BaseRepresentation):
@@ -60,7 +59,6 @@ def _get_diff_cls(value):
     As originally created, this is only used in the SkyCoord initializer, so if
     that is refactored, this function my no longer be necessary.
     """
-
     if value in r.DIFFERENTIAL_CLASSES:
         value = r.DIFFERENTIAL_CLASSES[value]
     elif not isinstance(value, type) or not issubclass(value, r.BaseDifferential):
@@ -1090,7 +1088,6 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
         <SkyCoord (ICRS): (x, y, z) [dimensionless]
             (1., 0., 0.)>
         """
-
         # For backwards compatibility (because in_frame_units used to be the
         # 2nd argument), we check to see if `new_differential` is a boolean. If
         # it is, we ignore the value of `new_differential` and warn about the
@@ -1485,7 +1482,6 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
 
     def _data_repr(self):
         """Returns a string representation of the coordinate data."""
-
         if not self.has_data:
             return ""
 
@@ -1729,7 +1725,6 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
         TODO: We should handle dynamic representation transforms here (e.g.,
         `.cylindrical`) instead of defining properties as below.
         """
-
         # attr == '_representation' is likely from the hasattr() test in the
         # representation property which is used for
         # self.representation_component_names.
@@ -1871,7 +1866,6 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
         ValueError
             If this or the other coordinate do not have distances.
         """
-
         from .distances import Distance
 
         if issubclass(self.data.__class__, r.UnitSphericalRepresentation):
@@ -1908,7 +1902,6 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
         Shorthand for a cartesian representation of the coordinates in this
         object.
         """
-
         # TODO: if representations are updated to use a full transform graph,
         #       the representation aliases should not be hard-coded like this
         return self.represent_as("cartesian", in_frame_units=True)
@@ -1919,7 +1912,6 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
         Shorthand for a cylindrical representation of the coordinates in this
         object.
         """
-
         # TODO: if representations are updated to use a full transform graph,
         #       the representation aliases should not be hard-coded like this
         return self.represent_as("cylindrical", in_frame_units=True)
@@ -1930,7 +1922,6 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
         Shorthand for a spherical representation of the coordinates in this
         object.
         """
-
         # TODO: if representations are updated to use a full transform graph,
         #       the representation aliases should not be hard-coded like this
         return self.represent_as("spherical", in_frame_units=True)
@@ -1942,7 +1933,6 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
         `~astropy.coordinates.SphericalCosLatDifferential` for the velocity
         data in this object.
         """
-
         # TODO: if representations are updated to use a full transform graph,
         #       the representation aliases should not be hard-coded like this
         return self.represent_as("spherical", "sphericalcoslat", in_frame_units=True)

--- a/astropy/coordinates/builtin_frames/icrs_fk5_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_fk5_transforms.py
@@ -14,7 +14,6 @@ def _icrs_to_fk5_matrix():
     B-matrix from USNO circular 179.  Used by the ICRS->FK5 transformation
     functions.
     """
-
     eta0 = -19.9 / 3600000.0
     xi0 = 9.1 / 3600000.0
     da0 = -22.9 / 3600000.0

--- a/astropy/coordinates/builtin_frames/skyoffset.py
+++ b/astropy/coordinates/builtin_frames/skyoffset.py
@@ -38,7 +38,6 @@ def make_skyoffset_cls(framecls):
     just that class, as well as ensuring that only one example of such a class
     actually gets created in any given python session.
     """
-
     if framecls in _skyoffset_cache:
         return _skyoffset_cache[framecls]
 
@@ -62,7 +61,6 @@ def make_skyoffset_cls(framecls):
     )
     def skyoffset_to_skyoffset(from_skyoffset_coord, to_skyoffset_frame):
         """Transform between two skyoffset frames."""
-
         # This transform goes through the parent frames on each side.
         # from_frame -> from_frame.origin -> to_frame.origin -> to_frame
         tmp_from = from_skyoffset_coord.transform_to(from_skyoffset_coord.origin)
@@ -74,7 +72,6 @@ def make_skyoffset_cls(framecls):
     )
     def reference_to_skyoffset(reference_frame, skyoffset_frame):
         """Convert a reference coordinate to an sky offset frame."""
-
         # Define rotation matrices along the position angle vector, and
         # relative to the origin.
         origin = skyoffset_frame.origin.spherical
@@ -89,7 +86,6 @@ def make_skyoffset_cls(framecls):
     )
     def skyoffset_to_reference(skyoffset_coord, reference_frame):
         """Convert an sky offset frame coordinate to the reference frame."""
-
         # use the forward transform, but just invert it
         R = reference_to_skyoffset(reference_frame, skyoffset_coord)
         # transpose is the inverse because R is a rotation matrix

--- a/astropy/coordinates/earth.py
+++ b/astropy/coordinates/earth.py
@@ -437,7 +437,6 @@ class EarthLocation(u.Quantity):
         .. [4] https://developers.google.com/maps/documentation/geocoding/get-api-key
 
         """
-
         use_google = google_api_key is not None
 
         # Fail fast if invalid options are passed:

--- a/astropy/coordinates/name_resolve.py
+++ b/astropy/coordinates/name_resolve.py
@@ -81,7 +81,6 @@ def _parse_response(resp_data):
     dec : str
         The string Declination parsed from the HTTP response.
     """
-
     pattr = re.compile(r"%J\s*([0-9\.]+)\s*([\+\-\.0-9]+)")
     matched = pattr.search(resp_data)
 
@@ -131,7 +130,6 @@ def get_icrs_coordinates(name, parse=False, cache=False):
         The object's coordinates in the ICRS frame.
 
     """
-
     # if requested, first try extract coordinates embedded in the object name.
     # Do this first since it may be much faster than doing the sesame query
     if parse:

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -147,7 +147,6 @@ class BaseRepresentationOrDifferentialInfo(MixinInfo):
             Empty instance of this class consistent with ``cols``
 
         """
-
         # Get merged info attributes like shape, dtype, format, description, etc.
         attrs = self.merge_cols_attributes(
             reps, metadata_conflicts, name, ("meta", "description")
@@ -720,7 +719,6 @@ class BaseRepresentation(BaseRepresentationOrDifferential):
         Note that this does *not* set the differentials on
         ``self._differentials``, but rather leaves that for the caller.
         """
-
         # Now handle the actual validation of any specified differential classes
         if differentials is None:
             differentials = dict()
@@ -992,7 +990,6 @@ class BaseRepresentation(BaseRepresentationOrDifferential):
             A shallow copy of this representation, without any differentials.
             If no differentials were present, no copy is made.
         """
-
         if not self._differentials:
             return self
 
@@ -2106,7 +2103,6 @@ class SphericalRepresentation(BaseRepresentation):
         Converts spherical polar coordinates to 3D rectangular cartesian
         coordinates.
         """
-
         # We need to convert Distance to Quantity to allow negative values.
         if isinstance(self.distance, Distance):
             d = self.distance.view(u.Quantity)
@@ -2316,7 +2312,6 @@ class PhysicsSphericalRepresentation(BaseRepresentation):
         Converts spherical polar coordinates to 3D rectangular cartesian
         coordinates.
         """
-
         # We need to convert Distance to Quantity to allow negative values.
         if isinstance(self.r, Distance):
             d = self.r.view(u.Quantity)
@@ -2335,7 +2330,6 @@ class PhysicsSphericalRepresentation(BaseRepresentation):
         Converts 3D rectangular cartesian coordinates to spherical polar
         coordinates.
         """
-
         s = np.hypot(cart.x, cart.y)
         r = np.hypot(s, cart.z)
 
@@ -2492,7 +2486,6 @@ class CylindricalRepresentation(BaseRepresentation):
         Converts 3D rectangular cartesian coordinates to cylindrical polar
         coordinates.
         """
-
         rho = np.hypot(cart.x, cart.y)
         phi = np.arctan2(cart.y, cart.x)
         z = cart.z
@@ -2567,7 +2560,6 @@ class BaseDifferential(BaseRepresentationOrDifferential):
         For these, the components are those of the base representation prefixed
         by 'd_', and the class is `~astropy.units.Quantity`.
         """
-
         # Don't do anything for base helper classes.
         if cls.__name__ in (
             "BaseDifferential",
@@ -2621,7 +2613,6 @@ class BaseDifferential(BaseRepresentationOrDifferential):
         derivative by removing the representation unit from the component units
         of this differential.
         """
-
         # This check is just a last resort so we don't return a strange unit key
         # from accidentally passing in the wrong base.
         self._check_base(base)

--- a/astropy/coordinates/sites.py
+++ b/astropy/coordinates/sites.py
@@ -139,7 +139,6 @@ def get_downloaded_sites(jsonurl=None):
     """
     Load observatory database from data.astropy.org and parse into a SiteRegistry.
     """
-
     # we explicitly set the encoding because the default is to leave it set by
     # the users' locale, which may fail if it's not matched to the sites.json
     if jsonurl is None:

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -381,7 +381,6 @@ class SkyCoord(ShapedLikeNDArray):
         equivalent, extra frame attributes are equivalent, and that the
         representation data are exactly equal.
         """
-
         if isinstance(value, BaseCoordinateFrame):
             if value._data is None:
                 raise ValueError("Can only compare SkyCoord to Frame with data")
@@ -1005,7 +1004,6 @@ class SkyCoord(ShapedLikeNDArray):
         **kwargs
             Keyword args passed to :meth:`~astropy.coordinates.Angle.to_string`.
         """
-
         sph_coord = self.frame.represent_as(SphericalRepresentation)
 
         styles = {
@@ -1833,7 +1831,6 @@ class SkyCoord(ShapedLikeNDArray):
         response : bool
             True means the WCS footprint contains the coordinate, False means it does not.
         """
-
         if image is not None:
             ymax, xmax = image.shape
         else:
@@ -2204,7 +2201,6 @@ class SkyCoord(ShapedLikeNDArray):
         coord : SkyCoord
             Instance of the SkyCoord class.
         """
-
         from .name_resolve import get_icrs_coordinates
 
         icrs_coord = get_icrs_coordinates(name, parse, cache=cache)

--- a/astropy/coordinates/sky_coordinate_parsers.py
+++ b/astropy/coordinates/sky_coordinate_parsers.py
@@ -42,7 +42,6 @@ def _get_frame_class(frame):
     Get a frame class from the input `frame`, which could be a frame name
     string, or frame class.
     """
-
     if isinstance(frame, str):
         frame_names = frame_transform_graph.get_names()
         if frame not in frame_names:
@@ -693,7 +692,6 @@ def _parse_ra_dec(coord_str):
     coord : str or list of str
         Parsed coordinate values.
     """
-
     if isinstance(coord_str, str):
         coord1 = coord_str.split()
     else:

--- a/astropy/coordinates/solar_system.py
+++ b/astropy/coordinates/solar_system.py
@@ -531,7 +531,6 @@ def get_moon(time, location=None, ephemeris=None):
 
     {_EPHEMERIS_NOTE}
     """
-
     return get_body("moon", time, location=location, ephemeris=ephemeris)
 
 

--- a/astropy/coordinates/spectral_coordinate.py
+++ b/astropy/coordinates/spectral_coordinate.py
@@ -49,7 +49,6 @@ def _apply_relativistic_doppler_shift(scoord, velocity):
     Positive velocities are assumed to redshift the spectral quantity,
     while negative velocities blueshift the spectral quantity.
     """
-
     # NOTE: we deliberately don't keep sub-classes of SpectralQuantity intact
     # since we can't guarantee that their metadata would be correct/consistent.
     squantity = scoord.view(SpectralQuantity)
@@ -86,7 +85,6 @@ def update_differentials_to_match(
     the frame of the original coordinate, otherwise it will be in the frame of
     the velocity reference.
     """
-
     if not velocity_reference.data.differentials:
         raise ValueError("Reference frame has no velocities")
 
@@ -265,7 +263,6 @@ class SpectralCoord(SpectralQuantity):
             The name of the object being validated (e.g. 'target' or 'observer'),
             which is then used in error messages.
         """
-
         if coord is None:
             return
 
@@ -357,7 +354,6 @@ class SpectralCoord(SpectralQuantity):
         sc : `SpectralCoord` object
             Replica of this object
         """
-
         if isinstance(value, u.Quantity):
             if unit is not None:
                 raise ValueError(
@@ -525,7 +521,6 @@ class SpectralCoord(SpectralQuantity):
         `~astropy.units.Quantity` ['speed']
             The radial velocity of the target with respect to the observer.
         """
-
         # Convert observer and target to ICRS to avoid finite differencing
         # calculations that lack numerical precision.
         observer_icrs = observer.transform_to(ICRS())
@@ -609,7 +604,6 @@ class SpectralCoord(SpectralQuantity):
             The new coordinate object representing the spectral data
             transformed based on the observer's new velocity frame.
         """
-
         if self.observer is None or self.target is None:
             raise ValueError(
                 "This method can only be used if both observer "
@@ -699,7 +693,6 @@ class SpectralCoord(SpectralQuantity):
             to incorporate the shift. This is always a new object even if
             ``target_shift`` and ``observer_shift`` are both `None`.
         """
-
         if observer_shift is not None and (
             self.target is None or self.observer is None
         ):
@@ -773,7 +766,6 @@ class SpectralCoord(SpectralQuantity):
         """
         Transforms the spectral axis to the rest frame.
         """
-
         if self.observer is not None and self.target is not None:
             return self.with_observer_stationary_relative_to(self.target)
 

--- a/astropy/coordinates/spectral_quantity.py
+++ b/astropy/coordinates/spectral_quantity.py
@@ -176,7 +176,6 @@ class SpectralQuantity(SpecificTypeQuantity):
         .. [1] Astropy documentation: https://docs.astropy.org/en/stable/units/equivalencies.html#spectral-doppler-equivalencies
 
         """
-
         if self._doppler_convention is not None:
             raise AttributeError(
                 "doppler_convention has already been set, and cannot be changed. Use"
@@ -227,7 +226,6 @@ class SpectralQuantity(SpecificTypeQuantity):
         `SpectralQuantity`
             New spectral coordinate object with data converted to the new unit.
         """
-
         # Make sure units can be passed as strings
         unit = Unit(unit)
 

--- a/astropy/coordinates/tests/accuracy/generate_ref_ast.py
+++ b/astropy/coordinates/tests/accuracy/generate_ref_ast.py
@@ -16,7 +16,6 @@ def ref_fk4_no_e_fk4(fnout="fk4_no_e_fk4.csv"):
     Accuracy tests for the FK4 (with no E-terms of aberration) to/from FK4
     conversion, with arbitrary equinoxes and epoch of observation.
     """
-
     import starlink.Ast as Ast
 
     np.random.seed(12345)
@@ -74,7 +73,6 @@ def ref_fk4_no_e_fk5(fnout="fk4_no_e_fk5.csv"):
     Accuracy tests for the FK4 (with no E-terms of aberration) to/from FK5
     conversion, with arbitrary equinoxes and epoch of observation.
     """
-
     import starlink.Ast as Ast
 
     np.random.seed(12345)
@@ -140,7 +138,6 @@ def ref_galactic_fk4(fnout="galactic_fk4.csv"):
     Accuracy tests for the ICRS (with no E-terms of aberration) to/from FK5
     conversion, with arbitrary equinoxes and epoch of observation.
     """
-
     import starlink.Ast as Ast
 
     np.random.seed(12345)
@@ -202,7 +199,6 @@ def ref_icrs_fk5(fnout="icrs_fk5.csv"):
     Accuracy tests for the ICRS (with no E-terms of aberration) to/from FK5
     conversion, with arbitrary equinoxes and epoch of observation.
     """
-
     import starlink.Ast as Ast
 
     np.random.seed(12345)

--- a/astropy/coordinates/transformations.py
+++ b/astropy/coordinates/transformations.py
@@ -170,7 +170,6 @@ class TransformGraph:
             not callable.
 
         """
-
         if not inspect.isclass(fromsys):
             raise TypeError("fromsys must be a class")
         if not inspect.isclass(tosys):
@@ -290,7 +289,6 @@ class TransformGraph:
             priorities are not set this is the number of transforms
             needed. Is ``inf`` if there is no possible path.
         """
-
         inf = float("inf")
 
         # special-case the 0 or 1-path
@@ -454,7 +452,6 @@ class TransformGraph:
             The coordinate class corresponding to the ``name`` or `None` if
             no such class exists.
         """
-
         return self._cached_names.get(name, None)
 
     def get_names(self):
@@ -514,7 +511,6 @@ class TransformGraph:
         dotgraph : str
             A string with the DOT format graph.
         """
-
         nodes = []
         # find the node names
         for a in self._graph:

--- a/astropy/cosmology/flrw/__init__.py
+++ b/astropy/cosmology/flrw/__init__.py
@@ -21,7 +21,6 @@ __all__ = (
 
 def __getattr__(attr):
     """Lazy import deprecated private API."""
-
     base_attrs = (
         "H0units_to_invs",
         "a_B_c2",

--- a/astropy/cosmology/flrw/base.py
+++ b/astropy/cosmology/flrw/base.py
@@ -1066,7 +1066,6 @@ class FLRW(Cosmology):
         rho : `~astropy.units.Quantity`
             Critical density in g/cm^3 at each input redshift.
         """
-
         return self._critical_density0 * (self.efunc(z)) ** 2
 
     def comoving_distance(self, z):

--- a/astropy/io/ascii/cds.py
+++ b/astropy/io/ascii/cds.py
@@ -55,7 +55,6 @@ class CdsHeader(core.BaseHeader):
             List of table lines
 
         """
-
         # Read header block for the table ``self.data.table_name`` from the read
         # me file ``self.readme``.
         if self.readme and self.data.table_name:

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -555,7 +555,6 @@ def _get_line_index(line_or_func, lines):
     """Return the appropriate line index, depending on ``line_or_func`` which
     can be either a function, a positive or negative int, or None.
     """
-
     if hasattr(line_or_func, "__call__"):
         return line_or_func(lines)
     elif line_or_func:
@@ -621,7 +620,6 @@ class BaseHeader:
             List of table lines
 
         """
-
         start_line = _get_line_index(self.start_line, self.process_lines(lines))
         if start_line is None:
             # No header line so auto-generate names from n_data_cols
@@ -1006,7 +1004,6 @@ def convert_numpy(numpy_type):
         Raised by ``converter`` if the list elements could not be converted to
         the required type.
     """
-
     # Infer converter type from an instance of numpy_type.
     type_name = numpy.array([], dtype=numpy_type).dtype.name
     if "int" in type_name:
@@ -1552,7 +1549,6 @@ class BaseReader(metaclass=MetaBaseReader):
             List of strings corresponding to ASCII table
 
         """
-
         # Check column names before altering
         self.header.cols = list(table.columns.values())
         self.header.check_column_names(self.names, self.strict_names, False)
@@ -1673,7 +1669,6 @@ def _get_reader(Reader, Inputter=None, Outputter=None, **kwargs):
     for param docs.  This routine is for internal (package) use only and is useful
     because it depends only on the "core" module.
     """
-
     from .fastbasic import FastBasic
 
     if issubclass(Reader, FastBasic):  # Fast readers handle args separately
@@ -1801,7 +1796,6 @@ def _get_writer(Writer, fast_writer, **kwargs):
     routine is for internal (package) use only and is useful because it depends
     only on the "core" module.
     """
-
     from .fastbasic import FastBasic
 
     # A value of None for fill_values imply getting the default string

--- a/astropy/io/ascii/daophot.py
+++ b/astropy/io/ascii/daophot.py
@@ -165,7 +165,6 @@ class DaophotHeader(core.BaseHeader):
         col : list
             List of table Columns
         """
-
         if not self.names:
             raise core.InconsistentTableError("No column names found in DAOphot header")
 
@@ -234,7 +233,6 @@ class DaophotInputter(core.ContinuationLinesInputter):
         continued rows in a datablock.  For efficiency, depth gives the upper
         limit of lines to search.
         """
-
         # The list of apertures given in the #K APERTURES keyword may not be
         # complete!!  This happens if the string description of the aperture
         # list is longer than the field width of the #K APERTURES field.  In

--- a/astropy/io/ascii/fixedwidth.py
+++ b/astropy/io/ascii/fixedwidth.py
@@ -202,7 +202,6 @@ class FixedWidthHeader(basic.BasicHeader):
             List of ending indices.
 
         """
-
         # If column positions are already specified then just use those.
         # If neither column starts or ends are given, figure out positions
         # between delimiters. Otherwise, either the starts or the ends have

--- a/astropy/io/ascii/html.py
+++ b/astropy/io/ascii/html.py
@@ -46,7 +46,6 @@ def identify_table(soup, htmldict, numtable):
     Checks whether the given BeautifulSoup tag is the table
     the user intends to process.
     """
-
     if soup is None or soup.name != "table":
         return False  # Tag is not a <table>
 
@@ -76,7 +75,6 @@ class HTMLInputter(core.BaseInputter):
         Convert the given input into a list of SoupString rows
         for further processing.
         """
-
         try:
             from bs4 import BeautifulSoup
         except ImportError:
@@ -189,7 +187,6 @@ class HTMLHeader(core.BaseHeader):
         """
         Return the line number at which header data begins.
         """
-
         for i, line in enumerate(lines):
             if not isinstance(line, SoupString):
                 raise TypeError("HTML lines should be of type SoupString")
@@ -230,7 +227,6 @@ class HTMLData(core.BaseData):
         """
         Return the line number at which table data begins.
         """
-
         for i, line in enumerate(lines):
             if not isinstance(line, SoupString):
                 raise TypeError("HTML lines should be of type SoupString")
@@ -347,7 +343,6 @@ class HTML(core.BaseReader):
         """
         Read the ``table`` in HTML format and return a resulting ``Table``.
         """
-
         self.outputter = HTMLOutputter()
         return super().read(table)
 

--- a/astropy/io/ascii/ipac.py
+++ b/astropy/io/ascii/ipac.py
@@ -318,7 +318,6 @@ class IpacHeader(fixedwidth.FixedWidthHeader):
         This function is called from there, once the width information is
         available.
         """
-
         for vals in self.str_vals():
             lines.append(self.splitter.join(vals, widths))
         return lines

--- a/astropy/io/ascii/misc.py
+++ b/astropy/io/ascii/misc.py
@@ -80,7 +80,6 @@ def sortmore(*args, **kw):
         Out[2]: (['a', 'a', 'C', 'c', 'e', 'h', 'r', 'r', 'S', 't'],
                  [2, 4, 0, 5, 7, 1, 3, 8, 9, 6])
     """
-
     first = list(args[0])
     if not len(first):
         return args

--- a/astropy/io/ascii/qdp.py
+++ b/astropy/io/ascii/qdp.py
@@ -119,7 +119,6 @@ def _get_type_from_list_of_lines(lines, delimiter=None):
         ...
     ValueError: Inconsistent number of columns
     """
-
     types = [_line_type(line, delimiter=delimiter) for line in lines]
     current_ncol = None
     for type_ in types:
@@ -191,7 +190,6 @@ def _interpret_err_lines(err_specs, ncols, names=None):
         ...
     ValueError: Inconsistent number of input colnames
     """
-
     colnames = ["" for i in range(ncols)]
     if err_specs is None:
         serr_cols = terr_cols = []
@@ -257,7 +255,6 @@ def _get_tables_from_qdp_file(qdp_file, input_colnames=None, delimiter=None):
     list of `~astropy.table.Table`
         List containing all the tables present inside the QDP file
     """
-
     lines = _get_lines_from_file(qdp_file)
     contents, ncol = _get_type_from_list_of_lines(lines, delimiter=delimiter)
 

--- a/astropy/io/ascii/sextractor.py
+++ b/astropy/io/ascii/sextractor.py
@@ -30,7 +30,6 @@ class SExtractorHeader(core.BaseHeader):
             List of table lines
 
         """
-
         # This assumes that the columns are listed in order, one per line with a
         # header comment string of the format: "# 1 ID short description [unit]"
         # However, some may be missing and must be inferred from skipped column numbers

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -470,7 +470,6 @@ def _guess(table, read_kwargs, format, fast_reader):
     dat : `~astropy.table.Table` or None
         Output table or None if only one guess format was available
     """
-
     # Keep a trace of all failed guesses kwarg
     failed_kwargs = []
 
@@ -1014,5 +1013,4 @@ def get_read_trace():
     trace : list of dict
         Ordered list of format guesses and status
     """
-
     return copy.deepcopy(_read_trace)

--- a/astropy/io/fits/_tiled_compression/tiled_compression.py
+++ b/astropy/io/fits/_tiled_compression/tiled_compression.py
@@ -107,7 +107,6 @@ def _finalize_array(tile_buffer, *, bitpix, tile_shape, algorithm, lossless):
     and translates it into a numpy array with the correct dtype, endianness and
     shape.
     """
-
     if algorithm.startswith("GZIP"):
         # This algorithm is taken from fitsio
         # https://github.com/astropy/astropy/blob/a8cb1668d4835562b89c0d0b3448ac72ca44db63/cextern/cfitsio/lib/imcompress.c#L6345-L6388
@@ -260,7 +259,6 @@ def decompress_hdu(hdu):
     data : `numpy.ndarray`
         The decompressed data array.
     """
-
     _check_compressed_header(hdu._header)
 
     tile_shape = _tile_shape(hdu._header)
@@ -381,7 +379,6 @@ def compress_hdu(hdu):
     heap : `bytes`
         The bytes of the FITS table heap.
     """
-
     if not isinstance(hdu.data, np.ndarray):
         raise TypeError("CompImageHDU.data must be a numpy.ndarray")
 

--- a/astropy/io/fits/_tiled_compression/utils.py
+++ b/astropy/io/fits/_tiled_compression/utils.py
@@ -6,7 +6,6 @@ def _iter_array_tiles(data_shape, tile_shape):
     Given an array shape and a tile shape, iterate over the tiles in the array
     returning at each iteration the slices for the array.
     """
-
     ndim = len(data_shape)
     istart = np.zeros(ndim, dtype=int)
 

--- a/astropy/io/fits/card.py
+++ b/astropy/io/fits/card.py
@@ -284,7 +284,6 @@ class Card(_Verify):
     @property
     def value(self):
         """The value associated with the keyword stored in this card."""
-
         if self.field_specifier:
             return float(self._value)
 
@@ -406,7 +405,6 @@ class Card(_Verify):
         character FITS keyword that this RVKC is stored in.  Otherwise it is
         the card's normal keyword.
         """
-
         if self._rawkeyword is not None:
             return self._rawkeyword
         elif self.field_specifier is not None:
@@ -421,7 +419,6 @@ class Card(_Verify):
         the ``<field-specifier>: <value>`` format stored in the card in order
         to represent a RVKC.  Otherwise it is the card's normal value.
         """
-
         if self._rawvalue is not None:
             return self._rawvalue
         elif self.field_specifier is not None:
@@ -433,7 +430,6 @@ class Card(_Verify):
     @property
     def comment(self):
         """Get the comment attribute from the card image if not already set."""
-
         if self._comment is not None:
             return self._comment
         elif self._image:
@@ -494,7 +490,6 @@ class Card(_Verify):
         The field-specifier of record-valued keyword cards; always `None` on
         normal cards.
         """
-
         # Ensure that the keyword exists and has been parsed--the will set the
         # internal _field_specifier attribute if this is a RVKC.
         if self.keyword:
@@ -534,7 +529,6 @@ class Card(_Verify):
         The card "image", that is, the 80 byte character string that represents
         this card in an actual FITS header.
         """
-
         if self._image and not self._verified:
             self.verify("fix+warn")
         if self._image is None or self._modified:
@@ -549,7 +543,6 @@ class Card(_Verify):
 
         Returns `False` otherwise.
         """
-
         if not self._verified:
             # The card image has not been parsed yet; compare directly with the
             # string representation of a blank card
@@ -572,7 +565,6 @@ class Card(_Verify):
         image is longer than 80 columns, assume it contains ``CONTINUE``
         card(s).
         """
-
         card = cls()
         if isinstance(image, bytes):
             # FITS supports only ASCII, but decode as latin1 and just take all
@@ -597,7 +589,6 @@ class Card(_Verify):
         keyword : or str
             A keyword value or a ``keyword.field-specifier`` value
         """
-
         # Test first for the most common case: a standard FITS keyword provided
         # in standard all-caps
         if len(keyword) <= KEYWORD_LENGTH and cls._keywd_FSC_RE.match(keyword):
@@ -641,7 +632,6 @@ class Card(_Verify):
             self._check_if_rvkc('DP1.AXIS.1', 2)
             self._check_if_rvkc('DP1     = AXIS.1: 2')
         """
-
         if not conf.enable_record_valued_keyword_cards:
             return False
 
@@ -677,7 +667,6 @@ class Card(_Verify):
         two arguments the card has already been split between keyword and
         value+comment at the standard value indicator '= '.
         """
-
         if len(args) == 1:
             image = args[0]
             eq_idx = image.find(VALUE_INDICATOR)
@@ -712,7 +701,6 @@ class Card(_Verify):
         Sort of addendum to Card.__init__ to set the appropriate internal
         attributes if the card was determined to be a RVKC.
         """
-
         keyword_upper = keyword.upper()
         self._keyword = ".".join((keyword_upper, field_specifier))
         self._rawkeyword = keyword_upper
@@ -767,7 +755,6 @@ class Card(_Verify):
 
     def _parse_value(self):
         """Extract the keyword value from the card image."""
-
         # for commentary cards, no need to parse further
         # Likewise for invalid cards
         if self.keyword.upper() in self._commentary_keywords or self._invalid:
@@ -824,7 +811,6 @@ class Card(_Verify):
 
     def _parse_comment(self):
         """Extract the keyword value from the card image."""
-
         # for commentary cards, no need to parse further
         # likewise for invalid/unparsable cards
         if self.keyword in Card._commentary_keywords or self._invalid:
@@ -851,7 +837,6 @@ class Card(_Verify):
         """
         Split the card image between the keyword and the rest of the card.
         """
-
         if self._image is not None:
             # If we already have a card image, don't try to rebuild a new card
             # image, which self.image would do
@@ -926,7 +911,6 @@ class Card(_Verify):
 
     def _fix_value(self):
         """Fix the card image for fixable non-standard compliance."""
-
         value = None
         keyword, valuecomment = self._split()
         m = self._value_NFSC_RE.match(valuecomment)
@@ -1075,7 +1059,6 @@ class Card(_Verify):
         it does not break at the blank space between words.  So it may
         not look pretty.
         """
-
         if self.keyword in Card._commentary_keywords:
             return self._format_long_commentary_image()
 
@@ -1125,7 +1108,6 @@ class Card(_Verify):
         will render the card as multiple consecutive commentary card of the
         same type.
         """
-
         maxlen = Card.length - KEYWORD_LENGTH
         value = self._format_value()
         output = []
@@ -1257,7 +1239,6 @@ class Card(_Verify):
         long value that is stored internally as multiple concatenated card
         images.
         """
-
         ncards = len(self._image) // Card.length
 
         for idx in range(0, Card.length * ncards, Card.length):
@@ -1281,7 +1262,6 @@ def _int_or_float(s):
 
     If the string is neither a string or a float a value error is raised.
     """
-
     if isinstance(s, float):
         # Already a float so just pass through
         return s
@@ -1300,7 +1280,6 @@ def _format_value(value):
     Converts a card value to its appropriate string representation as
     defined by the FITS format.
     """
-
     # string value should occupies at least 8 columns, unless it is
     # a null string
     if isinstance(value, str):
@@ -1333,7 +1312,6 @@ def _format_value(value):
 
 def _format_float(value):
     """Format a floating number to make sure it gets the decimal point."""
-
     value_str = f"{value:.16G}"
     if "." not in value_str and "E" not in value_str:
         value_str += ".0"
@@ -1365,7 +1343,6 @@ def _format_float(value):
 
 def _pad(input):
     """Pad blank space to the input string to be multiple of 80."""
-
     _len = len(input)
     if _len == Card.length:
         return input

--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -276,7 +276,6 @@ class _BaseColumnFormat(str):
         """
         The Numpy dtype object created from the format's associated recformat.
         """
-
         return np.dtype(self.recformat)
 
     @classmethod
@@ -287,7 +286,6 @@ class _BaseColumnFormat(str):
         That is, this can convert a _ColumnFormat to an _AsciiColumnFormat
         or vice versa at least in cases where a direct translation is possible.
         """
-
         return cls.from_recformat(format.recformat)
 
 
@@ -320,13 +318,11 @@ class _ColumnFormat(_BaseColumnFormat):
     @classmethod
     def from_recformat(cls, recformat):
         """Creates a column format from a Numpy record dtype format."""
-
         return cls(_convert_format(recformat, reverse=True))
 
     @lazyproperty
     def recformat(self):
         """Returns the equivalent Numpy record format string."""
-
         return _convert_format(self)
 
     @lazyproperty
@@ -338,7 +334,6 @@ class _ColumnFormat(_BaseColumnFormat):
         type code, a is the optional part, and r is the repeat.  If repeat == 1
         (the default) it is left out of this representation.
         """
-
         if self.repeat == 1:
             repeat = ""
         else:
@@ -388,13 +383,11 @@ class _AsciiColumnFormat(_BaseColumnFormat):
     @classmethod
     def from_recformat(cls, recformat):
         """Creates a column format from a Numpy record dtype format."""
-
         return cls(_convert_ascii_format(recformat, reverse=True))
 
     @lazyproperty
     def recformat(self):
         """Returns the equivalent Numpy record format string."""
-
         return _convert_ascii_format(self)
 
     @lazyproperty
@@ -407,7 +400,6 @@ class _AsciiColumnFormat(_BaseColumnFormat):
         number of digits after the decimal place (for format codes 'E', 'F',
         and 'D' only).
         """
-
         if self.format in ("E", "F", "D"):
             return f"{self.format}{self.width}.{self.precision}"
 
@@ -551,7 +543,6 @@ class ColumnAttribute:
         Returns ``self`` so that this can be used as a decorator, as described
         in the docs for this class.
         """
-
         self._validator = func
 
         return self
@@ -658,7 +649,6 @@ class Column(NotifierMixin):
             reference position for a time coordinate column corresponding to
             ``TRPOS`` keyword
         """
-
         if format is None:
             raise ValueError("Must specify format to construct Column.")
 
@@ -749,7 +739,6 @@ class Column(NotifierMixin):
         Two columns are equal if their name and format are the same.  Other
         attributes aren't taken into account at this time.
         """
-
         # According to the FITS standard column names must be case-insensitive
         a = (self.name.lower(), self.format)
         b = (other.name.lower(), other.format)
@@ -761,7 +750,6 @@ class Column(NotifierMixin):
         name and format, and be case-insensitive with respect to the column
         name.
         """
-
         return hash((self.name.lower(), self.format))
 
     @property
@@ -776,7 +764,6 @@ class Column(NotifierMixin):
         the associated field in the table, which may no longer be the same
         array.
         """
-
         # Ideally the .array attribute never would have existed in the first
         # place, or would have been internal-only.  This is a legacy of the
         # older design from Astropy that needs to have continued support, for
@@ -963,7 +950,6 @@ class Column(NotifierMixin):
     @lazyproperty
     def ascii(self):
         """Whether this `Column` represents a column in an ASCII table."""
-
         return isinstance(self.format, _AsciiColumnFormat)
 
     @lazyproperty
@@ -986,7 +972,6 @@ class Column(NotifierMixin):
 
         TODO: There should be an abc base class for column format classes
         """
-
         # Short circuit in case we're already a _BaseColumnFormat--there is at
         # least one case in which this can happen
         if isinstance(format, _BaseColumnFormat):
@@ -1036,7 +1021,6 @@ class Column(NotifierMixin):
         values.  The second maps invalid keywords to a 2-tuple of their value,
         and a message explaining why they were found invalid.
         """
-
         valid = {}
         invalid = {}
 
@@ -1315,7 +1299,6 @@ class Column(NotifierMixin):
         the former is only valid for ASCII tables and the latter only for
         BINARY tables.
         """
-
         # If the given format string is unambiguously a Numpy dtype or one of
         # the Numpy record format type specifiers supported by Astropy then that
         # should take priority--otherwise assume it is a FITS format
@@ -1534,7 +1517,6 @@ class ColDefs(NotifierMixin):
         """Initialize from an existing ColDefs object (just copy the
         columns and convert their formats if necessary).
         """
-
         self.columns = [self._copy_column(col) for col in coldefs]
 
     def _init_from_sequence(self, columns):
@@ -1645,7 +1627,6 @@ class ColDefs(NotifierMixin):
         to help convert columns from binary format to ASCII format or vice
         versa if necessary (otherwise performs a straight copy).
         """
-
         if isinstance(column.format, self._col_format_cls):
             # This column has a FITS format compatible with this column
             # definitions class (that is ascii or binary)
@@ -1754,7 +1735,6 @@ class ColDefs(NotifierMixin):
     @lazyproperty
     def _dims(self):
         """Returns the values of the TDIMn keywords parsed into tuples."""
-
         return [col._dims for col in self.columns]
 
     def __getitem__(self, key):
@@ -1817,7 +1797,6 @@ class ColDefs(NotifierMixin):
         to update their headers, etc.  However, this also informs the table of
         the numerical index of the column that changed.
         """
-
         idx = 0
         for idx, col in enumerate(self.columns):
             if col is column:
@@ -1836,7 +1815,6 @@ class ColDefs(NotifierMixin):
         """
         Append one `Column` to the column definition.
         """
-
         if not isinstance(column, Column):
             raise AssertionError
 
@@ -1868,7 +1846,6 @@ class ColDefs(NotifierMixin):
         col_name : str or int
             The column's name or index
         """
-
         # Ask the HDU object to load the data before we modify our columns
         self._notify("load_data")
 
@@ -1909,7 +1886,6 @@ class ColDefs(NotifierMixin):
         new_value : object
             The new value for the attribute
         """
-
         setattr(self[col_name], attrib, new_value)
 
     def change_name(self, col_name, new_name):
@@ -1924,7 +1900,6 @@ class ColDefs(NotifierMixin):
         new_name : str
             The new name of the column
         """
-
         if new_name != col_name and new_name in self.names:
             raise ValueError(f"New name {new_name} already exists.")
         else:
@@ -1942,7 +1917,6 @@ class ColDefs(NotifierMixin):
         new_unit : str
             The new unit for the column
         """
-
         self.change_attrib(col_name, "unit", new_unit)
 
     def info(self, attrib="all", output=None):
@@ -1967,7 +1941,6 @@ class ColDefs(NotifierMixin):
         This function doesn't return anything by default; it just prints to
         stdout.
         """
-
         if output is None:
             output = sys.stdout
 
@@ -2032,7 +2005,6 @@ class _AsciiColDefs(ColDefs):
     @property
     def spans(self):
         """A list of the widths of each field in the table."""
-
         return self._spans
 
     @lazyproperty
@@ -2061,7 +2033,6 @@ class _AsciiColDefs(ColDefs):
         Updates the list of the start columns, the list of the widths of each
         field, and the total width of each record in the table.
         """
-
         spans = [0] * len(self.columns)
         end_col = 0  # Refers to the ASCII text column, not the table col
         for idx, col in enumerate(self.columns):
@@ -2092,7 +2063,6 @@ class _VLF(np.ndarray):
         input
             a sequence of variable-sized elements.
         """
-
         if dtype == "a":
             try:
                 # this handles ['abc'] and [['a','b','c']]
@@ -2118,7 +2088,6 @@ class _VLF(np.ndarray):
         To make sure the new item has consistent data type to avoid
         misalignment.
         """
-
         if isinstance(value, np.ndarray) and value.dtype == self.dtype:
             pass
         elif isinstance(value, chararray.chararray) and value.itemsize == 1:
@@ -2158,7 +2127,6 @@ def _get_index(names, key):
         name is a case variant of "XYZ", then field('xyz'),
         field('Xyz'), etc. will get this field.
     """
-
     if _is_int(key):
         indx = int(key)
     elif isinstance(key, str):
@@ -2197,7 +2165,6 @@ def _unwrapx(input, output, repeat):
     repeat
         number of bits
     """
-
     pow2 = np.array([128, 64, 32, 16, 8, 4, 2, 1], dtype="uint8")
     nbytes = ((repeat - 1) // 8) + 1
     for i in range(nbytes):
@@ -2222,7 +2189,6 @@ def _wrapx(input, output, repeat):
     repeat
         number of bits
     """
-
     output[...] = 0  # reset the output
     nbytes = ((repeat - 1) // 8) + 1
     unused = nbytes * 8 - repeat
@@ -2263,7 +2229,6 @@ def _makep(array, descr_output, format, nrows=None):
         number of rows to create in the column; defaults to the number of rows
         in the input array
     """
-
     # TODO: A great deal of this is redundant with FITS_rec._convert_p; see if
     # we can merge the two somehow.
 
@@ -2304,7 +2269,6 @@ def _parse_tformat(tform):
     """Parse ``TFORMn`` keyword for a binary table into a
     ``(repeat, format, option)`` tuple.
     """
-
     try:
         (repeat, format, option) = TFORMAT_RE.match(tform.strip()).groups()
     except Exception:
@@ -2327,7 +2291,6 @@ def _parse_ascii_tformat(tform, strict=False):
     precision)`` tuple (the latter is always zero unless format is one of 'E',
     'F', or 'D').
     """
-
     match = TFORMAT_ASCII_RE.match(tform.strip())
     if not match:
         raise VerifyError(f"Format {tform!r} is not recognized.")
@@ -2418,7 +2381,6 @@ def _scalar_to_format(value):
     that can represent that value.  'minimum' is defined by the order given in
     FORMATORDER.
     """
-
     # First, if value is a string, try to convert to the appropriate scalar
     # value
     for type_ in (int, float, complex):
@@ -2442,7 +2404,6 @@ def _cmp_recformats(f1, f2):
     """
     Compares two numpy recformats using the ordering given by FORMATORDER.
     """
-
     if f1[0] == "a" and f2[0] == "a":
         return cmp(int(f1[1:]), int(f2[1:]))
     else:
@@ -2454,7 +2415,6 @@ def _convert_fits2record(format):
     """
     Convert FITS format spec to record format spec.
     """
-
     repeat, dtype, option = _parse_tformat(format)
 
     if dtype in FITS2NUMPY:
@@ -2492,7 +2452,6 @@ def _convert_record2fits(format):
     """
     Convert record format spec to FITS format spec.
     """
-
     recformat, kind, dtype = _dtype_to_recformat(format)
     shape = dtype.shape
     itemsize = dtype.base.itemsize
@@ -2544,7 +2503,6 @@ def _dtype_to_recformat(dtype):
     deprecated in Numpy, but Astropy remains heavily invested in its use
     (something to try to get away from sooner rather than later).
     """
-
     if not isinstance(dtype, np.dtype):
         dtype = np.dtype(dtype)
 
@@ -2564,7 +2522,6 @@ def _convert_format(format, reverse=False):
     Convert FITS format spec to record format spec.  Do the opposite if
     reverse=True.
     """
-
     if reverse:
         return _convert_record2fits(format)
     else:
@@ -2573,7 +2530,6 @@ def _convert_format(format, reverse=False):
 
 def _convert_ascii_format(format, reverse=False):
     """Convert ASCII table format spec to record format spec."""
-
     if reverse:
         recformat, kind, dtype = _dtype_to_recformat(format)
         itemsize = dtype.itemsize
@@ -2651,7 +2607,6 @@ def _parse_tdisp_format(tdisp):
         The exponential int value from TDISPn
 
     """
-
     # Use appropriate regex for format type
     tdisp = tdisp.strip()
     fmt_key = (
@@ -2732,7 +2687,6 @@ def python_to_tdisp(format_string, logical_dtype=False):
     tdsip_string: str
         The TDISPn keyword string translated into a Python format string.
     """
-
     fmt_to_tdisp = {
         "a": "A",
         "s": "A",

--- a/astropy/io/fits/connect.py
+++ b/astropy/io/fits/connect.py
@@ -182,7 +182,6 @@ def read_table_fits(
         when using ``memmap=True`` (see above).
 
     """
-
     if isinstance(input, HDUList):
         # Parse all table objects
         tables = dict()
@@ -431,7 +430,6 @@ def write_table_fits(input, output, overwrite=False, append=False):
     append : bool
         Whether to append the table to an existing file
     """
-
     # Encode any mixin columns into standard Columns.
     input = _encode_mixins(input)
 

--- a/astropy/io/fits/convenience.py
+++ b/astropy/io/fits/convenience.py
@@ -117,7 +117,6 @@ def getheader(filename, *args, **kwargs):
     -------
     header : `Header` object
     """
-
     mode, closed = _get_file_mode(filename)
     hdulist, extidx = _getext(filename, mode, *args, **kwargs)
     try:
@@ -209,7 +208,6 @@ def getdata(filename, *args, header=None, lower=None, upper=None, view=None, **k
     IndexError
         If no data is found in searched HDUs.
     """
-
     mode, closed = _get_file_mode(filename)
 
     ext = kwargs.get("ext")
@@ -293,7 +291,6 @@ def getval(filename, keyword, *args, **kwargs):
     -------
     keyword value : str, int, or float
     """
-
     if "do_not_scale_image_data" not in kwargs:
         kwargs["do_not_scale_image_data"] = True
 
@@ -365,7 +362,6 @@ def setval(
         = True`` when opening the file so that values can be retrieved from the
         unmodified header.
     """
-
     if "do_not_scale_image_data" not in kwargs:
         kwargs["do_not_scale_image_data"] = True
 
@@ -404,7 +400,6 @@ def delval(filename, keyword, *args, **kwargs):
         = True`` when opening the file so that values can be retrieved from the
         unmodified header.
     """
-
     if "do_not_scale_image_data" not in kwargs:
         kwargs["do_not_scale_image_data"] = True
 
@@ -457,7 +452,6 @@ def writeto(
         If `True`, adds both ``DATASUM`` and ``CHECKSUM`` cards to the
         headers of all HDU's written to the file.
     """
-
     hdu = _makehdu(data, header)
     if hdu.is_image and not isinstance(hdu, PrimaryHDU):
         hdu = PrimaryHDU(data, header=header)
@@ -776,7 +770,6 @@ def update(filename, data, *args, **kwargs):
         Any additional keyword arguments to be passed to
         `astropy.io.fits.open`.
     """
-
     # The arguments to this function are a bit trickier to deal with than others
     # in this module, since the documentation has promised that the header
     # argument can be an optional positional argument.
@@ -822,7 +815,6 @@ def info(filename, output=None, **kwargs):
         `astropy.io.fits.open`.
         *Note:* This function sets ``ignore_missing_end=True`` by default.
     """
-
     mode, closed = _get_file_mode(filename, default="readonly")
     # Set the default value for the ignore_missing_end parameter
     if "ignore_missing_end" not in kwargs:
@@ -898,7 +890,6 @@ def printdiff(inputa, inputb, *args, **kwargs):
     To save the diff report to a file please use `~astropy.io.fits.FITSDiff`
     directly.
     """
-
     # Pop extension keywords
     extension = {
         key: kwargs.pop(key) for key in ["ext", "extname", "extver"] if key in kwargs
@@ -988,7 +979,6 @@ def tabledump(filename, datafile=None, cdfile=None, hfile=None, ext=1, overwrite
     `tableload` function can be used to reassemble the table from the
     three ASCII files.
     """
-
     # allow file object to already be opened in any of the valid modes
     # and leave the file in the same state (opened or closed) as when
     # the function was called
@@ -1044,7 +1034,6 @@ def tableload(datafile, cdfile, hfile=None):
     data and parameters.  The tabledump function can be used to create the
     initial ASCII files.
     """
-
     return BinTableHDU.load(datafile, cdfile, hfile, replace=True)
 
 
@@ -1059,7 +1048,6 @@ def _getext(filename, mode, *args, ext=None, extname=None, extver=None, **kwargs
     This supports several different styles of extension selection.  See the
     :func:`getdata()` documentation for the different possibilities.
     """
-
     err_msg = "Redundant/conflicting extension arguments(s): {}".format(
         {"args": args, "ext": ext, "extname": extname, "extver": extver}
     )
@@ -1170,7 +1158,6 @@ def _get_file_mode(filename, default="readonly"):
     and leave the file in the same state (opened or closed) as when
     the function was called.
     """
-
     mode = default
     closed = fileobj_closed(filename)
 

--- a/astropy/io/fits/diff.py
+++ b/astropy/io/fits/diff.py
@@ -77,7 +77,6 @@ class _BaseDiff:
         appropriate subclass of ``_BaseDiff`` for the objects being compared
         (for example, use `HeaderDiff` to compare two `Header` objects.
         """
-
         self.a = a
         self.b = b
 
@@ -92,7 +91,6 @@ class _BaseDiff:
         A ``_BaseDiff`` object acts as `True` in a boolean context if the two
         objects compared are different.  Otherwise it acts as `False`.
         """
-
         return not self.identical
 
     @classmethod
@@ -112,7 +110,6 @@ class _BaseDiff:
             >>> list(hd.ignore_keywords)
             ['*']
         """
-
         sig = signature(cls.__init__)
         # The first 3 arguments of any Diff initializer are self, a, and b.
         kwargs = {}
@@ -132,7 +129,6 @@ class _BaseDiff:
         attribute, which contains a non-empty value if and only if some
         difference was found between the two objects being compared.
         """
-
         return not any(
             getattr(self, attr) for attr in self.__dict__ if attr.startswith("diff_")
         )
@@ -163,7 +159,6 @@ class _BaseDiff:
         -------
         report : str or None
         """
-
         return_string = False
         filepath = None
 
@@ -291,7 +286,6 @@ class FITSDiff(_BaseDiff):
             Ignore all cards that are blank, i.e. they only contain
             whitespace (default: True).
         """
-
         if isinstance(a, (str, os.PathLike)):
             try:
                 a = fitsopen(a)
@@ -584,7 +578,6 @@ class HDUDiff(_BaseDiff):
             Ignore all cards that are blank, i.e. they only contain
             whitespace (default: True).
         """
-
         self.ignore_keywords = {k.upper() for k in ignore_keywords}
         self.ignore_comments = {k.upper() for k in ignore_comments}
         self.ignore_fields = {k.upper() for k in ignore_fields}
@@ -795,7 +788,6 @@ class HeaderDiff(_BaseDiff):
             Ignore all cards that are blank, i.e. they only contain
             whitespace (default: True).
         """
-
         self.ignore_keywords = {k.upper() for k in ignore_keywords}
         self.ignore_comments = {k.upper() for k in ignore_comments}
 
@@ -1081,7 +1073,6 @@ class ImageDataDiff(_BaseDiff):
 
             .. versionadded:: 2.0
         """
-
         self.numdiffs = numdiffs
         self.rtol = rtol
         self.atol = atol
@@ -1213,7 +1204,6 @@ class RawDataDiff(ImageDataDiff):
             are kept in memory or output.  If a negative value is given, then
             numdiffs is treated as unlimited (default: 10).
         """
-
         self.diff_dimensions = ()
         self.diff_bytes = []
 
@@ -1351,7 +1341,6 @@ class TableDataDiff(_BaseDiff):
 
             .. versionadded:: 2.0
         """
-
         self.ignore_fields = set(ignore_fields)
         self.numdiffs = numdiffs
         self.rtol = rtol
@@ -1601,7 +1590,6 @@ def report_diff_keyword_attr(fileobj, attr, diffs, keyword, ind=0):
     Write a diff between two header keyword values or comments to the specified
     file-like object.
     """
-
     if keyword in diffs:
         vals = diffs[keyword]
         for idx, val in enumerate(vals):

--- a/astropy/io/fits/file.py
+++ b/astropy/io/fits/file.py
@@ -293,7 +293,6 @@ class _File:
         Usually it's best not to use the `size` argument with this method, but
         it's provided for compatibility.
         """
-
         if not hasattr(self._file, "read"):
             raise EOFError
 
@@ -417,7 +416,6 @@ class _File:
         Also like file.write(), a flush() or close() may be needed before
         the file on disk reflects the data written.
         """
-
         if self.simulateonly:
             return
         if hasattr(self._file, "write"):
@@ -456,7 +454,6 @@ class _File:
         """
         Close the 'physical' FITS file.
         """
-
         if hasattr(self._file, "close"):
             self._file.close()
 
@@ -491,7 +488,6 @@ class _File:
         _File object state and is only meant for use within the ``_open_*``
         internal methods.
         """
-
         # The file will be overwritten...
         if (self.file_like and hasattr(fileobj, "len") and fileobj.len > 0) or (
             os.path.exists(self.name) and os.path.getsize(self.name) != 0
@@ -545,7 +541,6 @@ class _File:
 
     def _open_fileobj(self, fileobj, mode, overwrite):
         """Open a FITS file from a file object (including compressed files)."""
-
         closed = fileobj_closed(fileobj)
         # FIXME: this variable was unused, check if it was useful
         # fmode = fileobj_mode(fileobj) or IO_FITS_MODES[mode]
@@ -581,7 +576,6 @@ class _File:
         """Open a FITS file from a file-like object, i.e. one that has
         read and/or write methods.
         """
-
         self.file_like = True
         self._file = fileobj
 
@@ -624,7 +618,6 @@ class _File:
 
     def _open_filename(self, filename, mode, overwrite):
         """Open a FITS file from a filename string."""
-
         if mode == "ostream":
             self._overwrite_existing(overwrite, None, True)
 
@@ -655,7 +648,6 @@ class _File:
         If mmap.flush is found not to work, ``self.memmap = False`` is
         set and a warning is issued.
         """
-
         tmpfd, tmpname = tempfile.mkstemp()
         try:
             # Windows does not allow mappings on empty files
@@ -694,7 +686,6 @@ class _File:
         a file.  Allows reading only for now by extracting the file to a
         tempfile.
         """
-
         if mode in ("update", "append"):
             raise OSError("Writing to zipped fits files is not currently supported")
 

--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -58,7 +58,6 @@ class FITS_record:
             The ending column in the row associated with this object.
             Used for subsetting the columns of the `FITS_rec` object.
         """
-
         self.array = input
         self.row = row
         if base:
@@ -110,7 +109,6 @@ class FITS_record:
         """
         Display a single row.
         """
-
         outlist = []
         for idx in range(len(self)):
             outlist.append(repr(self[idx]))
@@ -120,14 +118,12 @@ class FITS_record:
         """
         Get the field data of the record.
         """
-
         return self.__getitem__(field)
 
     def setfield(self, field, value):
         """
         Set the field data of the record.
         """
-
         self.__setitem__(field, value)
 
     @lazyproperty
@@ -167,7 +163,6 @@ class FITS_rec(np.recarray):
         """
         Construct a FITS record array from a recarray.
         """
-
         # input should be a record array
         if input.dtype.subdtype is None:
             self = np.recarray.__new__(
@@ -202,7 +197,6 @@ class FITS_rec(np.recarray):
         functionality but then add in a tuple of FITS_rec-specific
         values that get used in __setstate__.
         """
-
         reconst_func, reconst_func_args, state = super().__reduce__()
 
         # Define FITS_rec-specific attrs that get added to state
@@ -274,7 +268,6 @@ class FITS_rec(np.recarray):
 
     def _init(self):
         """Initializes internal attributes specific to FITS-isms."""
-
         self._nfields = 0
         self._converted = {}
         self._heapoffset = 0
@@ -317,7 +310,6 @@ class FITS_rec(np.recarray):
             `False`, copy the data from input, undefined cells will still
             be filled with zeros/blanks.
         """
-
         if not isinstance(columns, ColDefs):
             columns = ColDefs(columns)
 
@@ -600,7 +592,6 @@ class FITS_rec(np.recarray):
         copy of all those attributes so that the two arrays truly do not share
         any data.
         """
-
         new = super().copy(order=order)
 
         new.__dict__ = copy.deepcopy(self.__dict__)
@@ -609,7 +600,6 @@ class FITS_rec(np.recarray):
     @property
     def columns(self):
         """A user-visible accessor for the coldefs."""
-
         return self._coldefs
 
     @property
@@ -661,7 +651,6 @@ class FITS_rec(np.recarray):
     @property
     def names(self):
         """List of column names."""
-
         if self.dtype.fields:
             return list(self.dtype.names)
         elif getattr(self, "_coldefs", None) is not None:
@@ -672,7 +661,6 @@ class FITS_rec(np.recarray):
     @property
     def formats(self):
         """List of column FITS formats."""
-
         if getattr(self, "_coldefs", None) is not None:
             return self._coldefs.formats
 
@@ -687,7 +675,6 @@ class FITS_rec(np.recarray):
 
         Currently for internal use only.
         """
-
         if _has_unicode_fields(self):
             total_itemsize = 0
             for field in self.dtype.fields.values():
@@ -704,7 +691,6 @@ class FITS_rec(np.recarray):
         """
         A view of a `Column`'s data as an array.
         """
-
         # NOTE: The *column* index may not be the same as the field index in
         # the recarray, if the column is a phantom column
         column = self.columns[key]
@@ -758,7 +744,6 @@ class FITS_rec(np.recarray):
         This results in a reference cycle that cannot be broken since
         ndarrays do not participate in cyclic garbage collection.
         """
-
         base = field
         while True:
             self_base = self
@@ -786,7 +771,6 @@ class FITS_rec(np.recarray):
         Dispatches column attribute change notifications to individual methods
         for each attribute ``_update_column_<attr>``
         """
-
         method_name = f"_update_column_{attr}"
         if hasattr(self, method_name):
             # Right now this is so we can be lazy and not implement updaters
@@ -795,7 +779,6 @@ class FITS_rec(np.recarray):
 
     def _update_column_name(self, column, idx, old_name, name):
         """Update the dtype field names when a column name is changed."""
-
         dtype = self.dtype
         # Updating the names on the dtype should suffice
         dtype.names = dtype.names[:idx] + (name,) + dtype.names[idx + 1 :]
@@ -804,7 +787,6 @@ class FITS_rec(np.recarray):
         """Convert a raw table column to a bit array as specified by the
         FITS X format.
         """
-
         dummy = np.zeros(self.shape + (recformat.repeat,), dtype=np.bool_)
         _unwrapx(field, dummy, recformat.repeat)
         return dummy
@@ -813,7 +795,6 @@ class FITS_rec(np.recarray):
         """Convert a raw table column of FITS P or Q format descriptors
         to a VLA column with the array data returned from the heap.
         """
-
         if column.dim:
             vla_shape = tuple(
                 reversed(tuple(map(int, column.dim.strip("()").split(","))))
@@ -869,7 +850,6 @@ class FITS_rec(np.recarray):
         Special handling for ASCII table columns to convert columns containing
         numeric types to actual numeric arrays from the string representation.
         """
-
         format = column.format
         recformat = getattr(format, "recformat", ASCII2NUMPY[format[0]])
         # if the string = TNULL, return ASCIITNULL
@@ -911,7 +891,6 @@ class FITS_rec(np.recarray):
         This may not perform any conversion at all if it's not necessary, in
         which case the original column array is returned.
         """
-
         if isinstance(recformat, _FormatX):
             # special handling for the X format
             return self._convert_x(field, recformat)
@@ -1054,7 +1033,6 @@ class FITS_rec(np.recarray):
 
         This is returned as a numpy byte array.
         """
-
         if self._heapsize:
             raw_data = self._get_raw_data().view(np.ubyte)
             heap_end = self._heapoffset + self._heapsize
@@ -1078,7 +1056,6 @@ class FITS_rec(np.recarray):
         May return ``None`` if no array resembling the "raw data" according to
         the stated criteria can be found.
         """
-
         raw_data_bytes = self.nbytes + self._heapsize
         base = self
         while hasattr(base, "base") and base.base is not None:
@@ -1095,7 +1072,6 @@ class FITS_rec(np.recarray):
 
     def _get_scale_factors(self, column):
         """Get all the scaling flags and factors for one column."""
-
         # TODO: Maybe this should be a method/property on Column?  Or maybe
         # it's not really needed at all...
         _str = column.format.format == "A"
@@ -1131,7 +1107,6 @@ class FITS_rec(np.recarray):
         the heap.  Currently this is only used as an optimization for
         CompImageHDU that does its own handling of the heap.
         """
-
         # Running total for the new heap size
         heapsize = 0
 
@@ -1290,7 +1265,6 @@ class FITS_rec(np.recarray):
         the ``output_field`` is the character array representing the ASCII
         output that will be written.
         """
-
         starts = self._coldefs.starts[:]
         spans = self._coldefs.spans
         format = self._coldefs[col_idx].format
@@ -1370,7 +1344,6 @@ def _get_recarray_field(array, key):
     This incorporates the legacy functionality of returning string arrays as
     Numeric-style chararray objects.
     """
-
     # Numpy >= 1.10.dev recarray no longer returns chararrays for strings
     # This is currently needed for backwards-compatibility and for
     # automatic truncation of trailing whitespace
@@ -1400,7 +1373,6 @@ def _ascii_encode(inarray, out=None):
     just a `UnicodeEncodeError` with an additional attribute for the index of
     the item that couldn't be encoded.
     """
-
     out_dtype = np.dtype((f"S{inarray.dtype.itemsize // 4}", inarray.dtype.shape))
     if out is not None:
         out = out.view(out_dtype)
@@ -1425,6 +1397,5 @@ def _has_unicode_fields(array):
     """
     Returns True if any fields in a structured array have Unicode dtype.
     """
-
     dtypes = (d[0] for d in array.dtype.fields.values())
     return any(d.kind == "U" for d in dtypes)

--- a/astropy/io/fits/fitstime.py
+++ b/astropy/io/fits/fitstime.py
@@ -97,7 +97,6 @@ def _verify_global_info(global_info):
     global_info : dict
         Global time reference frame information.
     """
-
     # Translate FITS deprecated scale into astropy scale, or else just convert
     # to lower case for further checks.
     global_info["scale"] = FITS_DEPRECATED_SCALES.get(
@@ -212,7 +211,6 @@ def _verify_column_info(column_info, global_info):
     column_info : dict
         Column-specific time reference frame override information.
     """
-
     scale = column_info.get("TCTYP", None)
     unit = column_info.get("TCUNI", None)
     location = column_info.get("TRPOS", None)
@@ -320,7 +318,6 @@ def _get_info_if_time_column(col, global_info):
     This is only applicable to the special-case where a column has the
     name 'TIME' and a time unit.
     """
-
     # Column with TTYPEn = 'TIME' and lacking any TC*n or time
     # specific keywords will be controlled by the global keywords.
     if col.info.name.upper() == "TIME" and col.info.unit in FITS_TIME_UNIT:
@@ -410,7 +407,6 @@ def _convert_time_column(col, column_info):
     column_info : dict
         Column-specific time reference frame override information.
     """
-
     # The code might fail while attempting to read FITS files not written by astropy.
     try:
         # ISO-8601 is the only string representation of time in FITS
@@ -497,7 +493,6 @@ def fits_to_time(hdr, table):
     hdr : `~astropy.io.fits.header.Header`
         Modified FITS Header (time metadata removed)
     """
-
     # Set defaults for global time scale, reference, etc.
     global_info = {"TIMESYS": "UTC", "TREFPOS": "TOPOCENTER"}
 

--- a/astropy/io/fits/hdu/base.py
+++ b/astropy/io/fits/hdu/base.py
@@ -97,7 +97,6 @@ def _hdu_class_from_header(cls, header):
     Used primarily by _BaseHDU._readfrom_internal and _BaseHDU._from_data to
     find an appropriate HDU class to use based on values in the header.
     """
-
     klass = cls  # By default, if no subclasses are defined
     if header:
         for c in reversed(list(itersubclasses(cls))):
@@ -326,7 +325,6 @@ class _BaseHDU:
             `BinTableHDU`.  Any unrecognized keyword arguments are simply
             ignored.
         """
-
         return cls._readfrom_internal(
             data, checksum=checksum, ignore_missing_end=ignore_missing_end, **kwargs
         )
@@ -353,7 +351,6 @@ class _BaseHDU:
             Do not issue an exception when opening a file that is missing an
             ``END`` card in the last header.
         """
-
         # TODO: Figure out a way to make it possible for the _File
         # constructor to be a noop if the argument is already a _File
         if not isinstance(fileobj, _File):
@@ -396,7 +393,6 @@ class _BaseHDU:
             When `True` adds both ``DATASUM`` and ``CHECKSUM`` cards
             to the header of the HDU when written to the file.
         """
-
         from .hdulist import HDUList
 
         hdulist = HDUList([self])
@@ -422,7 +418,6 @@ class _BaseHDU:
         For some special cases, supports using a header that was already
         created, and just using the input data for the actual array data.
         """
-
         hdu_buffer = None
         hdu_fileobj = None
         header_offset = 0
@@ -544,7 +539,6 @@ class _BaseHDU:
         Return raw array from either the HDU's memory buffer or underlying
         file.
         """
-
         if isinstance(shape, int):
             shape = (shape,)
 
@@ -570,7 +564,6 @@ class _BaseHDU:
         If the data is signed int 8, unsigned int 16, 32, or 64,
         add BSCALE/BZERO cards to header.
         """
-
         if self._has_data and self._standard and _is_pseudo_integer(self.data.dtype):
             # CompImageHDUs need TFIELDS immediately after GCOUNT,
             # so BSCALE has to go after TFIELDS if it exists.
@@ -590,7 +583,6 @@ class _BaseHDU:
         and ``datasum_keyword`` arguments--see for example ``CompImageHDU``
         for an example of why this might need to be overridden).
         """
-
         # If the data is loaded it isn't necessarily 'modified', but we have no
         # way of knowing for sure
         modified = self._header._modified or self._data_loaded
@@ -685,7 +677,6 @@ class _BaseHDU:
 
         Should return the size in bytes of the data written.
         """
-
         fileobj.writearray(self.data)
         return self.data.size * self.data.itemsize
 
@@ -826,7 +817,6 @@ class _CorruptedHDU(_BaseHDU):
         """
         Returns the size (in bytes) of the HDU's data part.
         """
-
         # Note: On compressed files this might report a negative size; but the
         # file is corrupt anyways so I'm not too worried about it.
         if self._buffer is not None:
@@ -864,7 +854,6 @@ class _NonstandardHDU(_BaseHDU, _Verify):
         Matches any HDU that has the 'SIMPLE' keyword but is not a standard
         Primary or Groups HDU.
         """
-
         # The SIMPLE keyword must be in the first card
         card = header.cards[0]
 
@@ -883,7 +872,6 @@ class _NonstandardHDU(_BaseHDU, _Verify):
         """
         Returns the size (in bytes) of the HDU's data part.
         """
-
         if self._buffer is not None:
             return len(self._buffer) - self._data_offset
 
@@ -895,7 +883,6 @@ class _NonstandardHDU(_BaseHDU, _Verify):
         automatically add padding, and treats the data as a string of raw bytes
         instead of an array.
         """
-
         offset = 0
         size = 0
 
@@ -922,7 +909,6 @@ class _NonstandardHDU(_BaseHDU, _Verify):
         """
         Return the file data.
         """
-
         return self._get_raw_data(self.size, "ubyte", self._data_offset)
 
     def _verify(self, option="warn"):
@@ -971,7 +957,6 @@ class _ValidHDU(_BaseHDU, _Verify):
         TODO: Maybe it would make more sense to use _NonstandardHDU in this
         case?  Not sure...
         """
-
         return first(header.keys()) not in ("SIMPLE", "XTENSION")
 
     @property
@@ -986,7 +971,6 @@ class _ValidHDU(_BaseHDU, _Verify):
         Calculates and returns the number of bytes that this HDU will write to
         a file.
         """
-
         f = _File()
         # TODO: Fix this once new HDU writing API is settled on
         return self._writeheader(f)[1] + self._writedata(f)[1]
@@ -1018,7 +1002,6 @@ class _ValidHDU(_BaseHDU, _Verify):
             datSpan    Data size including padding
             ========== ================================================
         """
-
         if hasattr(self, "_file") and self._file:
             return {
                 "file": self._file,
@@ -1034,7 +1017,6 @@ class _ValidHDU(_BaseHDU, _Verify):
         """
         Make a copy of the HDU, both header and data are copied.
         """
-
         if self.data is not None:
             data = self.data.copy()
         else:
@@ -1175,7 +1157,6 @@ class _ValidHDU(_BaseHDU, _Verify):
         when created.  Also check the card's value by using the ``test``
         argument.
         """
-
         errs = errlist
         fix = None
 
@@ -1286,7 +1267,6 @@ class _ValidHDU(_BaseHDU, _Verify):
         value in the card to remain consistent.  This will enable the
         generation of a ``CHECKSUM`` card with a consistent value.
         """
-
         cs = self._calculate_datasum()
 
         if when is None:
@@ -1331,7 +1311,6 @@ class _ValidHDU(_BaseHDU, _Verify):
         comments for both cards and enable the generation of a ``CHECKSUM``
         card with a consistent value.
         """
-
         if not override_datasum:
             # Calculate and add the data checksum to the header.
             data_cs = self.add_datasum(when, datasum_keyword=datasum_keyword)
@@ -1363,7 +1342,6 @@ class _ValidHDU(_BaseHDU, _Verify):
             - 1 - success
             - 2 - no ``DATASUM`` keyword present
         """
-
         if "DATASUM" in self._header:
             datasum = self._calculate_datasum()
             if datasum == int(self._header["DATASUM"]):
@@ -1386,7 +1364,6 @@ class _ValidHDU(_BaseHDU, _Verify):
             - 1 - success
             - 2 - no ``CHECKSUM`` keyword present
         """
-
         if "CHECKSUM" in self._header:
             if "DATASUM" in self._header:
                 datasum = self._calculate_datasum()
@@ -1406,7 +1383,6 @@ class _ValidHDU(_BaseHDU, _Verify):
         Verify the checksum/datasum values if the cards exist in the header.
         Simply displays warnings if either the checksum or datasum don't match.
         """
-
         if "CHECKSUM" in self._header:
             self._checksum = self._header["CHECKSUM"]
             self._checksum_valid = self.verify_checksum()
@@ -1436,14 +1412,12 @@ class _ValidHDU(_BaseHDU, _Verify):
 
         Ex.: 2007-05-30T19:05:11
         """
-
         return datetime.datetime.now().isoformat()[:19]
 
     def _calculate_datasum(self):
         """
         Calculate the value for the ``DATASUM`` card in the HDU.
         """
-
         if not self._data_loaded:
             # This is the case where the data has not been read from the file
             # yet.  We find the data in the file, read it, and calculate the
@@ -1464,7 +1438,6 @@ class _ValidHDU(_BaseHDU, _Verify):
         """
         Calculate the value of the ``CHECKSUM`` card in the HDU.
         """
-
         old_checksum = self._header[checksum_keyword]
         self._header[checksum_keyword] = "0" * 16
 
@@ -1498,7 +1471,6 @@ class _ValidHDU(_BaseHDU, _Verify):
         -------
         ones complement checksum
         """
-
         blocklen = 2880
         sum32 = np.uint32(sum32)
         for i in range(0, len(data), blocklen):
@@ -1516,7 +1488,6 @@ class _ValidHDU(_BaseHDU, _Verify):
         Historically,  this code *was* called with larger blocks and for that
         reason still needs to be for backward compatibility.
         """
-
         u8 = np.uint32(8)
         u16 = np.uint32(16)
         uFFFF = np.uint32(0xFFFF)
@@ -1574,7 +1545,6 @@ class _ValidHDU(_BaseHDU, _Verify):
         """
         Encode a single byte.
         """
-
         quotient = byte // 4 + ord("0")
         remainder = byte % 4
 
@@ -1607,7 +1577,6 @@ class _ValidHDU(_BaseHDU, _Verify):
         -------
         ascii encoded checksum
         """
-
         value = np.uint32(value)
 
         asc = np.zeros((16,), dtype="byte")
@@ -1642,7 +1611,6 @@ class ExtensionHDU(_ValidHDU):
         extension HDU type should be used for a specific extension, or
         NonstandardExtHDU should be used.
         """
-
         raise NotImplementedError
 
     def writeto(self, name, output_verify="exception", overwrite=False, checksum=False):
@@ -1651,7 +1619,6 @@ class ExtensionHDU(_ValidHDU):
         `PrimaryHDU` are required by extension HDUs (which cannot stand on
         their own).
         """
-
         from .hdulist import HDUList
         from .image import PrimaryHDU
 
@@ -1698,7 +1665,6 @@ class NonstandardExtHDU(ExtensionHDU):
         Matches any extension HDU that is not one of the standard extension HDU
         types.
         """
-
         card = header.cards[0]
         xtension = card.value
         if isinstance(xtension, str):
@@ -1720,7 +1686,6 @@ class NonstandardExtHDU(ExtensionHDU):
         """
         Return the file data.
         """
-
         return self._get_raw_data(self.size, "ubyte", self._data_offset)
 
 

--- a/astropy/io/fits/hdu/compressed.py
+++ b/astropy/io/fits/hdu/compressed.py
@@ -399,7 +399,6 @@ class CompImageHeader(Header):
         """
         Remove all cards from the header.
         """
-
         self._table_header.clear()
         super().clear()
 
@@ -640,7 +639,6 @@ class CompImageHDU(BinTableHDU):
         This is particularly useful for software testing as it ensures that the
         same image will always use the same seed.
         """
-
         compression_type = CMTYPE_ALIASES.get(compression_type, compression_type)
 
         if data is DELAYED:
@@ -823,7 +821,6 @@ class CompImageHDU(BinTableHDU):
             range 1 to 1000 (inclusive), DITHER_SEED_CLOCK (0; default), or
             DITHER_SEED_CHECKSUM (-1)
         """
-
         # Clean up EXTNAME duplicates
         self._remove_unnecessary_default_extnames(self._header)
 
@@ -1561,7 +1558,6 @@ class CompImageHDU(BinTableHDU):
         """
         Shape of the image array--should be equivalent to ``self.data.shape``.
         """
-
         # Determine from the values read from the header
         return tuple(reversed(self._axes))
 
@@ -1755,7 +1751,6 @@ class CompImageHDU(BinTableHDU):
         """
         Compress the image data so that it may be written to a file.
         """
-
         # Check to see that the image_header matches the image data
         image_bitpix = DTYPE2BITPIX[self.data.dtype.name]
 
@@ -1834,7 +1829,6 @@ class CompImageHDU(BinTableHDU):
         bscale, bzero : int, optional
             user specified ``BSCALE`` and ``BZERO`` values.
         """
-
         if self.data is None:
             return
 
@@ -1960,7 +1954,6 @@ class CompImageHDU(BinTableHDU):
         metadata about the data that is meaningless here; another reason
         why this class maybe shouldn't inherit directly from BinTableHDU...
         """
-
         return ExtensionHDU._writeheader(self, fileobj)
 
     def _writedata(self, fileobj):
@@ -1968,7 +1961,6 @@ class CompImageHDU(BinTableHDU):
         Wrap the basic ``_writedata`` method to restore the ``.data``
         attribute to the uncompressed image data in the case of an exception.
         """
-
         try:
             return super()._writedata(fileobj)
         finally:
@@ -1999,7 +1991,6 @@ class CompImageHDU(BinTableHDU):
         the BITPIX value in the header, and possibly on the BSCALE value as
         well.  Returns None if there should not be any change.
         """
-
         bitpix = self._orig_bitpix
         # Handle possible conversion to uints if enabled
         if self._uint and self._orig_bscale == 1:

--- a/astropy/io/fits/hdu/groups.py
+++ b/astropy/io/fits/hdu/groups.py
@@ -39,7 +39,6 @@ class Group(FITS_record):
         """
         Get the group parameter value.
         """
-
         if _is_int(parname):
             result = self.array[self.row][parname]
         else:
@@ -59,7 +58,6 @@ class Group(FITS_record):
         """
         Set the group parameter value.
         """
-
         # TODO: It would be nice if, instead of requiring a multi-part value to
         # be an array, there were an *option* to automatically split the value
         # into multiple columns if it doesn't already fit in the array data
@@ -137,7 +135,6 @@ class GroupData(FITS_rec):
         parbzeros : sequence of int
             list of bzeros for the parameters
         """
-
         if not isinstance(input, FITS_rec):
             if pardata is None:
                 npars = 0
@@ -243,7 +240,6 @@ class GroupData(FITS_rec):
         The raw group data represented as a multi-dimensional `numpy.ndarray`
         array.
         """
-
         # The last column in the coldefs is the data portion of the group
         return self.field(self._coldefs.names[-1])
 
@@ -255,7 +251,6 @@ class GroupData(FITS_rec):
         """
         Get the group parameter values.
         """
-
         if _is_int(parname):
             result = self.field(parname)
         else:
@@ -311,7 +306,6 @@ class GroupsHDU(PrimaryHDU, _TableLikeHDU):
         The data of a random group FITS file will be like a binary table's
         data.
         """
-
         if self._axes == [0]:
             return
 
@@ -324,7 +318,6 @@ class GroupsHDU(PrimaryHDU, _TableLikeHDU):
     @lazyproperty
     def parnames(self):
         """The names of the group parameters as described by the header."""
-
         pcount = self._header["PCOUNT"]
         # The FITS standard doesn't really say what to do if a parname is
         # missing, so for now just assume that won't happen
@@ -394,7 +387,6 @@ class GroupsHDU(PrimaryHDU, _TableLikeHDU):
         """
         Returns the size (in bytes) of the HDU's data part.
         """
-
         size = 0
         naxis = self._header.get("NAXIS", 0)
 
@@ -482,7 +474,6 @@ class GroupsHDU(PrimaryHDU, _TableLikeHDU):
         TODO: Might be nice to store some indication of the data's byte order
         as an attribute or function so that we don't have to do this.
         """
-
         size = 0
 
         if self.data is not None:
@@ -546,7 +537,6 @@ class GroupsHDU(PrimaryHDU, _TableLikeHDU):
         """
         Calculate the value for the ``DATASUM`` card in the HDU.
         """
-
         if self._has_data:
             # We have the data to be used.
 
@@ -611,7 +601,6 @@ def _par_indices(names):
     Given a list of objects, returns a mapping of objects in that list to the
     index or indices at which that object was found in the list.
     """
-
     unique = {}
     for idx, name in enumerate(names):
         # Case insensitive
@@ -629,7 +618,6 @@ def _unique_parnames(names):
     of parnames with duplicates prepended by one or more underscores to make
     them unique.  This is also case insensitive.
     """
-
     upper_names = set()
     unique_names = []
 

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -190,7 +190,6 @@ def fitsopen(
         `HDUList` containing all of the header data units in the file.
 
     """
-
     from astropy.io.fits import conf
 
     if memmap is None:
@@ -246,7 +245,6 @@ class HDUList(list, _Verify):
             or a bytes object containing the contents of the FITS
             file.
         """
-
         if isinstance(file, bytes):
             self._data = file
             self._file = None
@@ -333,7 +331,6 @@ class HDUList(list, _Verify):
         """
         Get an HDU from the `HDUList`, indexed by number or name.
         """
-
         # If the key is a slice we need to make sure the necessary HDUs
         # have been loaded before passing the slice on to super.
         if isinstance(key, slice):
@@ -412,7 +409,6 @@ class HDUList(list, _Verify):
         """
         Set an HDU to the `HDUList`, indexed by number or name.
         """
-
         _key = self._positive_index_of(key)
         if isinstance(hdu, (slice, list)):
             if _is_int(_key):
@@ -436,7 +432,6 @@ class HDUList(list, _Verify):
         """
         Delete an HDU from the `HDUList`, indexed by number or name.
         """
-
         if isinstance(key, slice):
             end_index = len(self)
         else:
@@ -478,7 +473,6 @@ class HDUList(list, _Verify):
         be used directly.  Use :func:`open` instead (and see its
         documentation for details of the parameters accepted by this method).
         """
-
         return cls._readfrom(
             fileobj=fileobj,
             mode=mode,
@@ -519,7 +513,6 @@ class HDUList(list, _Verify):
         hdul : HDUList
             An :class:`HDUList` object representing the in-memory FITS file.
         """
-
         try:
             # Test that the given object supports the buffer interface by
             # ensuring an ndarray can be created from it
@@ -574,7 +567,6 @@ class HDUList(list, _Verify):
             ========== ========================================================
 
         """
-
         if self._file is not None:
             output = self[index].fileinfo()
 
@@ -618,7 +610,6 @@ class HDUList(list, _Verify):
             A shallow copy of this `HDUList` object.
 
         """
-
         return self[:]
 
     # Syntactic sugar for `__copy__()` magic method
@@ -653,7 +644,6 @@ class HDUList(list, _Verify):
             The HDU object at position indicated by ``index`` or having name
             and version specified by ``index``.
         """
-
         # Make sure that HDUs are loaded before attempting to pop
         self.readall()
         list_index = self.index_of(index)
@@ -671,7 +661,6 @@ class HDUList(list, _Verify):
         hdu : BaseHDU
             The HDU object to insert
         """
-
         if not isinstance(hdu, _BaseHDU):
             raise ValueError(f"{hdu} is not an HDU.")
 
@@ -733,7 +722,6 @@ class HDUList(list, _Verify):
         hdu : BaseHDU
             HDU to add to the `HDUList`.
         """
-
         if not isinstance(hdu, _BaseHDU):
             raise ValueError("HDUList can only append an HDU.")
 
@@ -807,7 +795,6 @@ class HDUList(list, _Verify):
             found in the ``HDUList``.
 
         """
-
         if _is_int(key):
             return key
         elif isinstance(key, tuple):
@@ -858,7 +845,6 @@ class HDUList(list, _Verify):
         all HDUs.  Therefore using negative indices on HDULists is inherently
         inefficient.
         """
-
         index = self.index_of(key)
 
         if index >= 0:
@@ -894,7 +880,6 @@ class HDUList(list, _Verify):
         verbose : bool
             When `True`, print verbose messages
         """
-
         if self._file.mode not in ("append", "update", "ostream"):
             warnings.warn(
                 f"Flush for '{self._file.mode}' mode is not supported.",
@@ -954,7 +939,6 @@ class HDUList(list, _Verify):
         Make sure that if the primary header needs the keyword ``EXTEND`` that
         it has it and it is correct.
         """
-
         if not len(self):
             return
 
@@ -1009,7 +993,6 @@ class HDUList(list, _Verify):
             When `True` adds both ``DATASUM`` and ``CHECKSUM`` cards
             to the headers of all HDU's written to the file.
         """
-
         if len(self) == 0:
             warnings.warn("There is nothing to write.", AstropyUserWarning)
             return
@@ -1063,7 +1046,6 @@ class HDUList(list, _Verify):
         closed : bool
             When `True`, close the underlying file object.
         """
-
         try:
             if (
                 self._file
@@ -1093,7 +1075,6 @@ class HDUList(list, _Verify):
             output to a file and instead returns a list of tuples representing
             the HDU info.  Writes to ``sys.stdout`` by default.
         """
-
         if output is None:
             output = sys.stdout
 
@@ -1163,7 +1144,6 @@ class HDUList(list, _Verify):
         HDUList.fromstring, both of which wrap this method, as their
         implementations are largely the same.
         """
-
         if fileobj is not None:
             if not isinstance(fileobj, _File):
                 # instantiate a FITS file object (ffo)
@@ -1265,7 +1245,6 @@ class HDUList(list, _Verify):
         reading HDUs until the operation succeeds or there are no
         more HDUs to read.
         """
-
         while True:
             try:
                 return func(*args, **kwargs)
@@ -1282,7 +1261,6 @@ class HDUList(list, _Verify):
 
         Returns True if a new HDU was loaded, or False otherwise.
         """
-
         if self._read_all:
             return False
 
@@ -1419,7 +1397,6 @@ class HDUList(list, _Verify):
 
     def _flush_update(self):
         """Implements flushing changes to a file in update mode."""
-
         for hdu in self:
             # Need to all _prewriteto() for each HDU first to determine if
             # resizing will be necessary
@@ -1449,7 +1426,6 @@ class HDUList(list, _Verify):
         Implements flushing changes in update mode when parts of one or more HDU
         need to be resized.
         """
-
         old_name = self._file.name
         old_memmap = self._file.memmap
         name = _tmp_name(old_name)
@@ -1569,7 +1545,6 @@ class HDUList(list, _Verify):
 
         Side effect of setting the objects _resize attribute.
         """
-
         if not self._resize:
             # determine if any of the HDU is resized
             for hdu in self:

--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -179,7 +179,6 @@ class _ImageBaseHDU(_ValidHDU):
         _ImageBaseHDU is sort of an abstract class for HDUs containing image
         data (as opposed to table data) and should never be used directly.
         """
-
         raise NotImplementedError
 
     @property
@@ -211,7 +210,6 @@ class _ImageBaseHDU(_ValidHDU):
         :ref:`astropy:data-sections` section of the documentation for
         more details.
         """
-
         return Section(self)
 
     @property
@@ -219,7 +217,6 @@ class _ImageBaseHDU(_ValidHDU):
         """
         Shape of the image array--should be equivalent to ``self.data.shape``.
         """
-
         # Determine from the values read from the header
         return tuple(reversed(self._axes))
 
@@ -247,7 +244,6 @@ class _ImageBaseHDU(_ValidHDU):
         attribute returns the data scaled to its physical values unless the
         file was opened with ``do_not_scale_image_data=True``.
         """
-
         if len(self._axes) < 1:
             return
 
@@ -330,7 +326,6 @@ class _ImageBaseHDU(_ValidHDU):
         """
         Update the header keywords to agree with the data.
         """
-
         if not (
             self._modified
             or self._header._modified
@@ -399,7 +394,6 @@ class _ImageBaseHDU(_ValidHDU):
         """
         Delete BSCALE/BZERO from header if necessary.
         """
-
         # Note that _dtype_for_bitpix determines the dtype based on the
         # "original" values of bitpix, bscale, and bzero, stored in
         # self._orig_bitpix, etc. It contains the logic for determining which
@@ -479,7 +473,6 @@ class _ImageBaseHDU(_ValidHDU):
         bscale, bzero : int, optional
             User-specified ``BSCALE`` and ``BZERO`` values
         """
-
         # Disable blank support for now
         self._scale_internal(
             type=type, option=option, bscale=bscale, bzero=bzero, blank=None
@@ -502,7 +495,6 @@ class _ImageBaseHDU(_ValidHDU):
         conversion of floats to ints without specifying a BLANK if there are
         NaN/inf values).
         """
-
         if self.data is None:
             return
 
@@ -767,7 +759,6 @@ class _ImageBaseHDU(_ValidHDU):
         the BITPIX value in the header, and possibly on the BSCALE value as
         well.  Returns None if there should not be any change.
         """
-
         bitpix = self._orig_bitpix
         # Handle possible conversion to uints if enabled
         if self._uint and self._orig_bscale == 1:
@@ -796,7 +787,6 @@ class _ImageBaseHDU(_ValidHDU):
         since we can't do NaNs with integers, anyway, i.e. the user is
         responsible for managing blanks.
         """
-
         dtype = self._dtype_for_bitpix()
         # bool(dtype) is always False--have to explicitly compare to None; this
         # caused a fair amount of hair loss
@@ -817,7 +807,6 @@ class _ImageBaseHDU(_ValidHDU):
         factors to it.  Normally this is used for the entire image, but it
         supports alternate offset/shape for Section support.
         """
-
         code = BITPIX2DTYPE[self._orig_bitpix]
 
         raw_data = self._get_raw_data(shape, code, offset)
@@ -890,7 +879,6 @@ class _ImageBaseHDU(_ValidHDU):
         """
         Summarize the HDU: name, dimensions, and formats.
         """
-
         class_name = self.__class__.__name__
 
         # if data is touched, use data info.
@@ -926,7 +914,6 @@ class _ImageBaseHDU(_ValidHDU):
         """
         Calculate the value for the ``DATASUM`` card in the HDU.
         """
-
         if self._has_data:
             # We have the data to be used.
             d = self.data
@@ -1135,7 +1122,6 @@ class PrimaryHDU(_ImageBaseHDU):
             rescaled unless scale_back is explicitly set to `False`.
             (default: None)
         """
-
         super().__init__(
             data=data,
             header=header,
@@ -1248,7 +1234,6 @@ class ImageHDU(_ImageBaseHDU, ExtensionHDU):
             card of the ``header`` or 1.
             (default: None)
         """
-
         # This __init__ currently does nothing differently from the base class,
         # and is only explicitly defined for the docstring.
 
@@ -1274,7 +1259,6 @@ class ImageHDU(_ImageBaseHDU, ExtensionHDU):
         """
         ImageHDU verify method.
         """
-
         errs = super()._verify(option=option)
         naxis = self._header.get("NAXIS", 0)
         # PCOUNT must == 0, GCOUNT must == 1; the former is verified in

--- a/astropy/io/fits/hdu/nonstandard.py
+++ b/astropy/io/fits/hdu/nonstandard.py
@@ -51,7 +51,6 @@ class FitsHDU(NonstandardExtHDU):
         compress : bool, optional
             Gzip compress the FITS file
         """
-
         with HDUList.fromfile(filename) as hdulist:
             return cls.fromhdulist(hdulist, compress=compress)
 
@@ -67,7 +66,6 @@ class FitsHDU(NonstandardExtHDU):
         compress : bool, optional
             Gzip compress the FITS file
         """
-
         fileobj = bs = io.BytesIO()
         if compress:
             if hasattr(hdulist, "_file"):

--- a/astropy/io/fits/hdu/streaming.py
+++ b/astropy/io/fits/hdu/streaming.py
@@ -61,7 +61,6 @@ class StreamingHDU:
         be modified to an image extension header and appended to the
         end of the file.
         """
-
         if isinstance(name, gzip.GzipFile):
             raise TypeError("StreamingHDU not supported for GzipFile objects.")
 
@@ -165,7 +164,6 @@ class StreamingHDU:
         dtype of the input data does not match what is expected by the header,
         a `TypeError` exception is raised.
         """
-
         size = self._ffo.tell() - self._data_offset
 
         if self.writecomplete or size + data.nbytes > self._size:
@@ -200,7 +198,6 @@ class StreamingHDU:
         """
         Return the size (in bytes) of the data portion of the HDU.
         """
-
         size = 0
         naxis = self._header.get("NAXIS", 0)
 
@@ -227,5 +224,4 @@ class StreamingHDU:
         """
         Close the physical FITS file.
         """
-
         self._ffo.close()

--- a/astropy/io/fits/hdu/table.py
+++ b/astropy/io/fits/hdu/table.py
@@ -76,7 +76,6 @@ class _TableLikeHDU(_ValidHDU):
         This is even more abstract than _TableBaseHDU which is specifically for
         the standard ASCII and Binary Table types.
         """
-
         raise NotImplementedError
 
     @classmethod
@@ -138,7 +137,6 @@ class _TableLikeHDU(_ValidHDU):
         Any additional keyword arguments accepted by the HDU class's
         ``__init__`` may also be passed in as keyword arguments.
         """
-
         coldefs = cls._columns_type(columns)
         data = FITS_rec.from_columns(
             coldefs, nrows=nrows, fill=fill, character_as_bytes=character_as_bytes
@@ -154,7 +152,6 @@ class _TableLikeHDU(_ValidHDU):
         """
         The :class:`ColDefs` objects describing the columns in this table.
         """
-
         # The base class doesn't make any assumptions about where the column
         # definitions come from, so just return an empty ColDefs
         return ColDefs([])
@@ -167,12 +164,10 @@ class _TableLikeHDU(_ValidHDU):
 
         For now this is an internal-only attribute.
         """
-
         raise NotImplementedError
 
     def _get_tbdata(self):
         """Get the table data from an input HDU object."""
-
         columns = self.columns
 
         # TODO: Details related to variable length arrays need to be dealt with
@@ -422,7 +417,6 @@ class _TableBaseHDU(ExtensionHDU, _TableLikeHDU):
         the ASCII and Binary Table HDU types, which should be used instead of
         this.
         """
-
         raise NotImplementedError
 
     @lazyproperty
@@ -430,7 +424,6 @@ class _TableBaseHDU(ExtensionHDU, _TableLikeHDU):
         """
         The :class:`ColDefs` objects describing the columns in this table.
         """
-
         if self._has_data and hasattr(self.data, "_coldefs"):
             return self.data._coldefs
         return self._columns_type(self)
@@ -522,7 +515,6 @@ class _TableBaseHDU(ExtensionHDU, _TableLikeHDU):
         """
         Update header keywords to reflect recent changes of columns.
         """
-
         self._header.set("NAXIS1", self.data._raw_itemsize, after="NAXIS")
         self._header.set("NAXIS2", self.data.shape[0], after="NAXIS1")
         self._header.set("TFIELDS", len(self.columns), after="GCOUNT")
@@ -534,7 +526,6 @@ class _TableBaseHDU(ExtensionHDU, _TableLikeHDU):
         """
         Make a copy of the table HDU, both header and data are copied.
         """
-
         # touch the data, so it's defined (in the case of reading from a
         # FITS file)
         return self.__class__(data=self.data.copy(), header=self._header.copy())
@@ -572,7 +563,6 @@ class _TableBaseHDU(ExtensionHDU, _TableLikeHDU):
         """
         _TableBaseHDU verify method.
         """
-
         errs = super()._verify(option=option)
         if len(self._header) > 1:
             if not (
@@ -610,7 +600,6 @@ class _TableBaseHDU(ExtensionHDU, _TableLikeHDU):
         """
         Summarize the HDU: name, dimensions, and formats.
         """
-
         class_name = self.__class__.__name__
 
         # if data is touched, use data info.
@@ -648,7 +637,6 @@ class _TableBaseHDU(ExtensionHDU, _TableLikeHDU):
         """
         Update the header when one of the column objects is updated.
         """
-
         # base_keyword is the keyword without the index such as TDIM
         # while keyword is like TDIM1
         base_keyword = ATTRIBUTE_TO_KEYWORD[attr]
@@ -691,7 +679,6 @@ class _TableBaseHDU(ExtensionHDU, _TableLikeHDU):
         up keywords for any other columns).  The index is zero-based.
         Otherwise keywords for all columns.
         """
-
         # First collect all the table structure related keyword in the header
         # into a single list so we can then sort them by index, which will be
         # useful later for updating the header in a sensible order (since the
@@ -749,7 +736,6 @@ class _TableBaseHDU(ExtensionHDU, _TableLikeHDU):
 
     def _populate_table_keywords(self):
         """Populate the new table definition keywords from the header."""
-
         for idx, column in enumerate(self.columns):
             for keyword, attr in KEYWORD_TO_ATTRIBUTE.items():
                 val = getattr(column, attr)
@@ -842,7 +828,6 @@ class TableHDU(_TableBaseHDU):
         """
         Calculate the value for the ``DATASUM`` card in the HDU.
         """
-
         if self._has_data:
             # We have the data to be used.
             # We need to pad the data to a block length before calculating
@@ -865,7 +850,6 @@ class TableHDU(_TableBaseHDU):
         """
         `TableHDU` verify method.
         """
-
         errs = super()._verify(option=option)
         self.req_cards("PCOUNT", None, lambda v: (v == 0), 0, option, errs)
         tfields = self._header["TFIELDS"]
@@ -944,7 +928,6 @@ class BinTableHDU(_TableBaseHDU):
         """
         Calculate the value for the ``DATASUM`` card given the input data.
         """
-
         with _binary_table_byte_swap(self.data) as data:
             dout = data.view(type=np.ndarray, dtype=np.ubyte)
             csum = self._compute_checksum(dout)
@@ -976,7 +959,6 @@ class BinTableHDU(_TableBaseHDU):
         """
         Calculate the value for the ``DATASUM`` card in the HDU.
         """
-
         if self._has_data:
             # This method calculates the datasum while incorporating any
             # heap data, which is obviously not handled from the base
@@ -1152,7 +1134,6 @@ class BinTableHDU(_TableBaseHDU):
         The `load` method can be used to create a new table from the three
         plain text (ASCII) files.
         """
-
         if isinstance(datafile, path_like):
             datafile = os.path.expanduser(datafile)
         if isinstance(cdfile, path_like):
@@ -1244,7 +1225,6 @@ class BinTableHDU(_TableBaseHDU):
         parameters.  The `dump` method can be used to create the initial ASCII
         files.
         """
-
         # Process the parameter file
         if header is None:
             header = Header()
@@ -1284,7 +1264,6 @@ class BinTableHDU(_TableBaseHDU):
         Write the table data in the ASCII format read by BinTableHDU.load()
         to fileobj.
         """
-
         if not fileobj and self._file:
             root = os.path.splitext(self._file.name)[0]
             fileobj = root + ".txt"
@@ -1357,7 +1336,6 @@ class BinTableHDU(_TableBaseHDU):
         Write the column definition parameters in the ASCII format read by
         BinTableHDU.load() to fileobj.
         """
-
         close_file = False
 
         if isinstance(fileobj, str):
@@ -1384,7 +1362,6 @@ class BinTableHDU(_TableBaseHDU):
         """
         Read the table data from the ASCII file output by BinTableHDU.dump().
         """
-
         close_file = False
 
         if isinstance(fileobj, path_like):
@@ -1530,7 +1507,6 @@ class BinTableHDU(_TableBaseHDU):
         Read the table column definitions from the ASCII file output by
         BinTableHDU.dump().
         """
-
         close_file = False
 
         if isinstance(fileobj, path_like):
@@ -1570,7 +1546,6 @@ def _binary_table_byte_swap(data):
     Because a new dtype is needed to represent the byte-swapped columns, the
     new dtype is temporarily applied as well.
     """
-
     orig_dtype = data.dtype
 
     names = []

--- a/astropy/io/fits/header.py
+++ b/astropy/io/fits/header.py
@@ -289,7 +289,6 @@ class Header:
         Two Headers are equal only if they have the exact same string
         representation.
         """
-
         return str(self) == str(other)
 
     def __add__(self, other):
@@ -310,7 +309,6 @@ class Header:
         The underlying physical cards that make up this Header; it can be
         looked at, but it should not be modified directly.
         """
-
         return _CardAccessor(self)
 
     @property
@@ -328,7 +326,6 @@ class Header:
             >>> header.comments['NAXIS'] = 'Number of data axes'
 
         """
-
         return _HeaderComments(self)
 
     @property
@@ -338,7 +335,6 @@ class Header:
         it can also check each card for modifications--cards may have been
         modified directly without the header containing it otherwise knowing.
         """
-
         modified_cards = any(c._modified for c in self._cards)
         if modified_cards:
             # If any cards were modified then by definition the header was
@@ -404,7 +400,6 @@ class Header:
         `Header`
             A new `Header` instance.
         """
-
         cards = []
 
         # If the card separator contains characters that may validly appear in
@@ -503,7 +498,6 @@ class Header:
         `Header`
             A new `Header` instance.
         """
-
         close_file = False
 
         if isinstance(fileobj, path_like):
@@ -568,7 +562,6 @@ class Header:
         Returns both the entire header *string*, and the `Header` object
         returned by Header.fromstring on that string.
         """
-
         actual_block_size = _block_size(sep)
         clen = Card.length + len(sep)
 
@@ -632,7 +625,6 @@ class Header:
         This method can also returned a modified copy of the input header block
         in case an invalid end card needs to be sanitized.
         """
-
         for mo in HEADER_END_RE.finditer(block):
             # Ensure the END card was found, and it started on the
             # boundary of a new card (see ticket #142)
@@ -702,7 +694,6 @@ class Header:
         str
             A string representing a FITS header.
         """
-
         lines = []
         for card in self._cards:
             s = str(card)
@@ -751,7 +742,6 @@ class Header:
             ``OSError`` if ``False`` and the output file exists. Default is
             ``False``.
         """
-
         close_file = fileobj_closed(fileobj)
 
         if not isinstance(fileobj, _File):
@@ -788,7 +778,6 @@ class Header:
         --------
         fromfile
         """
-
         return cls.fromfile(fileobj, sep="\n", endcard=endcard, padding=False)
 
     def totextfile(self, fileobj, endcard=False, overwrite=False):
@@ -804,7 +793,6 @@ class Header:
         --------
         tofile
         """
-
         self.tofile(
             fileobj, sep="\n", endcard=endcard, padding=False, overwrite=overwrite
         )
@@ -813,7 +801,6 @@ class Header:
         """
         Remove all cards from the header.
         """
-
         self._cards = []
         self._keyword_indices = collections.defaultdict(list)
         self._rvkc_indices = collections.defaultdict(list)
@@ -838,7 +825,6 @@ class Header:
         `Header`
             A new :class:`Header` instance.
         """
-
         tmp = self.__class__(copy.copy(card) for card in self._cards)
         if strip:
             tmp.strip()
@@ -873,7 +859,6 @@ class Header:
         `Header`
             A new `Header` instance.
         """
-
         d = cls()
         if not isinstance(value, tuple):
             value = (value,)
@@ -901,7 +886,6 @@ class Header:
             The value associated with the given keyword, or the default value
             if the keyword is not in the header.
         """
-
         try:
             return self[key]
         except (KeyError, IndexError):
@@ -961,7 +945,6 @@ class Header:
             should be located in the header.
 
         """
-
         # Create a temporary card that looks like the one being set; if the
         # temporary card turns out to be a RVKC this will make it easier to
         # deal with the idiosyncrasies thereof
@@ -996,7 +979,6 @@ class Header:
 
     def items(self):
         """Like :meth:`dict.items`."""
-
         for card in self._cards:
             yield card.keyword, None if card.value == UNDEFINED else card.value
 
@@ -1005,13 +987,11 @@ class Header:
         Like :meth:`dict.keys`--iterating directly over the `Header`
         instance has the same behavior.
         """
-
         for card in self._cards:
             yield card.keyword
 
     def values(self):
         """Like :meth:`dict.values`."""
-
         for card in self._cards:
             yield None if card.value == UNDEFINED else card.value
 
@@ -1020,7 +1000,6 @@ class Header:
         Works like :meth:`list.pop` if no arguments or an index argument are
         supplied; otherwise works like :meth:`dict.pop`.
         """
-
         if len(args) > 2:
             raise TypeError(f"Header.pop expected at most 2 arguments, got {len(args)}")
 
@@ -1041,7 +1020,6 @@ class Header:
 
     def popitem(self):
         """Similar to :meth:`dict.popitem`."""
-
         try:
             k, v = next(self.items())
         except StopIteration:
@@ -1051,7 +1029,6 @@ class Header:
 
     def setdefault(self, key, default=None):
         """Similar to :meth:`dict.setdefault`."""
-
         try:
             return self[key]
         except (KeyError, IndexError):
@@ -1126,7 +1103,6 @@ class Header:
             transition a little easier.
 
         """
-
         if args:
             other = args[0]
         else:
@@ -1207,7 +1183,6 @@ class Header:
             very end of the Header.
 
         """
-
         if isinstance(card, str):
             card = Card(card)
         elif isinstance(card, tuple):
@@ -1319,7 +1294,6 @@ class Header:
             These arguments are passed to :meth:`Header.append` while appending
             new cards to the header.
         """
-
         temp = self.__class__(cards)
         if strip:
             temp.strip()
@@ -1386,7 +1360,6 @@ class Header:
             The keyword to count instances of in the header
 
         """
-
         keyword = Card.normalize_keyword(keyword)
 
         # We have to look before we leap, since otherwise _keyword_indices,
@@ -1414,7 +1387,6 @@ class Header:
             The upper bound for the index
 
         """
-
         if start is None:
             start = 0
 
@@ -1460,7 +1432,6 @@ class Header:
             If set to `True`, insert *after* the specified index or keyword,
             rather than before it.  Defaults to `False`.
         """
-
         if not isinstance(key, numbers.Integral):
             # Don't pass through ints to _cardindex because it will not take
             # kindly to indices outside the existing number of cards in the
@@ -1576,7 +1547,6 @@ class Header:
             the creation of a duplicate keyword. Otherwise a
             `ValueError` is raised.
         """
-
         oldkeyword = Card.normalize_keyword(oldkeyword)
         newkeyword = Card.normalize_keyword(newkeyword)
 
@@ -1617,7 +1587,6 @@ class Header:
         after : str or int, optional
             Same as in `Header.update`
         """
-
         self._add_commentary("HISTORY", value, before=before, after=after)
 
     def add_comment(self, value, before=None, after=None):
@@ -1635,7 +1604,6 @@ class Header:
         after : str or int, optional
             Same as in `Header.update`
         """
-
         self._add_commentary("COMMENT", value, before=before, after=after)
 
     def add_blank(self, value="", before=None, after=None):
@@ -1653,7 +1621,6 @@ class Header:
         after : str or int, optional
             Same as in `Header.update`
         """
-
         self._add_commentary("", value, before=before, after=after)
 
     def strip(self):
@@ -1663,7 +1630,6 @@ class Header:
         Strip cards like ``SIMPLE``, ``BITPIX``, etc. so the rest of
         the header can be used to reconstruct another kind of header.
         """
-
         # TODO: Previously this only deleted some cards specific to an HDU if
         # _hdutype matched that type.  But it seemed simple enough to just
         # delete all desired cards anyways, and just ignore the KeyErrors if
@@ -1733,7 +1699,6 @@ class Header:
         commentary cards.  The only other way to force creation of a duplicate
         is to use the insert(), append(), or extend() methods.
         """
-
         keyword, value, comment = card
 
         # Lookups for existing/known keywords are case-insensitive
@@ -1771,7 +1736,6 @@ class Header:
 
     def _cardindex(self, key):
         """Returns an index into the ._cards list given a valid lookup key."""
-
         # This used to just set key = (key, 0) and then go on to act as if the
         # user passed in a tuple, but it's much more common to just be given a
         # string as the key, so optimize more for that case
@@ -1837,7 +1801,6 @@ class Header:
         In a sense this is the inverse of self.index, except that it also
         supports duplicates.
         """
-
         if idx < 0:
             idx += len(self._cards)
 
@@ -1854,7 +1817,6 @@ class Header:
 
         If replace=True, move an existing card with the same keyword.
         """
-
         if before is None:
             insertionkey = after
         else:
@@ -1925,7 +1887,6 @@ class Header:
 
     def _countblanks(self):
         """Returns the number of blank cards at the end of the Header."""
-
         for idx in range(1, len(self._cards)):
             if not self._cards[-idx].is_blank:
                 return idx - 1
@@ -1940,7 +1901,6 @@ class Header:
 
     def _haswildcard(self, keyword):
         """Return `True` if the input keyword contains a wildcard pattern."""
-
         return isinstance(keyword, str) and (
             keyword.endswith("...") or "*" in keyword or "?" in keyword
         )
@@ -1954,7 +1914,6 @@ class Header:
          * '?' matches a single character
          * '...' matches 0 or more of any non-whitespace character
         """
-
         pattern = pattern.replace("*", r".*").replace("?", r".")
         pattern = pattern.replace("...", r"\S*") + "$"
         pattern_re = re.compile(pattern, re.I)
@@ -1969,7 +1928,6 @@ class Header:
         """
         Used to implement Header.__setitem__ and CardAccessor.__setitem__.
         """
-
         if isinstance(key, slice) or self._haswildcard(key):
             if isinstance(key, slice):
                 indices = range(*key.indices(len(target)))
@@ -1993,7 +1951,6 @@ class Header:
         create the multiple commentary cards needed to represent a long value
         that won't fit into a single commentary card.
         """
-
         # The maximum value in each card can be the maximum card length minus
         # the maximum key length (which can include spaces if they key length
         # less than 8
@@ -2021,7 +1978,6 @@ class Header:
         of cards of the same name (except blank card).  If there is no
         card (or blank card), append at the end.
         """
-
         if before is not None or after is not None:
             self._relativeinsert((key, value), before=before, after=after)
         else:
@@ -2157,7 +2113,6 @@ class _BasicHeader(collections.abc.Mapping):
         """The main method to parse a FITS header from a file. The parsing is
         done with the parse_header function implemented in Cython.
         """
-
         close_file = False
         if isinstance(fileobj, str):
             fileobj = open(fileobj, "rb")
@@ -2222,7 +2177,6 @@ class _CardAccessor:
         Helper for implementing __setitem__ on _CardAccessor subclasses; slices
         should always be handled in this same way.
         """
-
         if isinstance(item, slice) or self._header._haswildcard(item):
             if isinstance(item, slice):
                 indices = range(*item.indices(len(self)))
@@ -2253,7 +2207,6 @@ class _HeaderComments(_CardAccessor):
 
     def __repr__(self):
         """Returns a simple list of all keywords and their comments."""
-
         keyword_length = KEYWORD_LENGTH
         for card in self._header._cards:
             keyword_length = max(keyword_length, len(card.keyword))
@@ -2267,7 +2220,6 @@ class _HeaderComments(_CardAccessor):
         Slices and filter strings return a new _HeaderComments containing the
         returned cards.  Otherwise the comment of a single card is returned.
         """
-
         item = super().__getitem__(item)
         if isinstance(item, _HeaderComments):
             # The item key was a slice
@@ -2280,7 +2232,6 @@ class _HeaderComments(_CardAccessor):
 
         Slice/filter updates work similarly to how Header.__setitem__ works.
         """
-
         if self._header._set_slice(item, comment, self):
             return
 
@@ -2332,7 +2283,6 @@ class _HeaderCommentaryCards(_CardAccessor):
 
         Slice/filter updates work similarly to how Header.__setitem__ works.
         """
-
         if self._header._set_slice(item, value, self):
             return
 
@@ -2346,13 +2296,11 @@ def _block_size(sep):
     Determine the size of a FITS header block if a non-blank separator is used
     between cards.
     """
-
     return BLOCK_SIZE + (len(sep) * (BLOCK_SIZE // Card.length - 1))
 
 
 def _pad_length(stringlen):
     """Bytes needed to pad the input stringlen to the next FITS block."""
-
     return (BLOCK_SIZE - (stringlen % BLOCK_SIZE)) % BLOCK_SIZE
 
 

--- a/astropy/io/fits/scripts/fitscheck.py
+++ b/astropy/io/fits/scripts/fitscheck.py
@@ -199,7 +199,6 @@ def verify_checksums(filename):
 
 def verify_compliance(filename):
     """Check for FITS standard compliance."""
-
     with fits.open(filename) as hdulist:
         try:
             hdulist.verify("exception")
@@ -215,7 +214,6 @@ def update(filename):
 
     Also updates fixes standards violations if possible and requested.
     """
-
     output_verify = "silentfix" if OPTIONS.compliance else "ignore"
 
     # For unit tests we reset temporarily the warning filters. Indeed, before
@@ -239,7 +237,6 @@ def process_file(filename):
     Handle a single .fits file,  returning the count of checksum and compliance
     errors.
     """
-
     try:
         checksum_errors = verify_checksums(filename)
         if OPTIONS.compliance:
@@ -259,7 +256,6 @@ def main(args=None):
     Processes command line parameters into options and files,  then checks
     or update FITS DATASUM and CHECKSUM keywords for the specified files.
     """
-
     errors = 0
     fits_files = handle_options(args or sys.argv[1:])
     setup_logging()

--- a/astropy/io/fits/scripts/fitsheader.py
+++ b/astropy/io/fits/scripts/fitsheader.py
@@ -404,7 +404,6 @@ def print_headers_as_comparison(args):
 
 def main(args=None):
     """This is the main function called by the `fitsheader` script."""
-
     parser = argparse.ArgumentParser(
         description=DESCRIPTION, formatter_class=argparse.RawDescriptionHelpFormatter
     )

--- a/astropy/io/fits/scripts/fitsinfo.py
+++ b/astropy/io/fits/scripts/fitsinfo.py
@@ -46,7 +46,6 @@ def fitsinfo(filename):
     filename : str
         The path to a FITS file.
     """
-
     try:
         fits.info(filename)
     except OSError as e:

--- a/astropy/io/fits/tests/conftest.py
+++ b/astropy/io/fits/tests/conftest.py
@@ -101,7 +101,6 @@ class FitsTestCase:
         """Copies a backup of a test data file to the temp dir and sets its
         mode to writeable.
         """
-
         shutil.copy(
             os.path.expanduser(self.data(filename)),
             os.path.expanduser(self.temp(filename)),

--- a/astropy/io/fits/util.py
+++ b/astropy/io/fits/util.py
@@ -84,7 +84,6 @@ class NotifierMixin:
         removed from the listeners list when the listener has no other
         references to it.
         """
-
         if self._listeners is None:
             self._listeners = weakref.WeakValueDictionary()
 
@@ -95,7 +94,6 @@ class NotifierMixin:
         Removes the specified listener from the listeners list.  This relies
         on object identity (i.e. the ``is`` operator).
         """
-
         if self._listeners is None:
             return
 
@@ -111,7 +109,6 @@ class NotifierMixin:
         The notification does not by default include the object that actually
         changed (``self``), but it certainly may if required.
         """
-
         if self._listeners is None:
             return
 
@@ -133,7 +130,6 @@ class NotifierMixin:
         Exclude listeners when saving the listener's state, since they may be
         ephemeral.
         """
-
         # TODO: This hasn't come up often, but if anyone needs to pickle HDU
         # objects it will be necessary when HDU objects' states are restored to
         # re-register themselves as listeners on their new column instances.
@@ -157,7 +153,6 @@ def first(iterable):
     >>> first(a)
     1
     """
-
     return next(iter(iterable))
 
 
@@ -183,7 +178,6 @@ def itersubclasses(cls, _seen=None):
 
     From http://code.activestate.com/recipes/576949/
     """
-
     if _seen is None:
         _seen = set()
     try:
@@ -253,7 +247,6 @@ def pairwise(iterable):
 
     Ex: s -> (s0,s1), (s1,s2), (s2,s3), ....
     """
-
     a, b = itertools.tee(iterable)
     for _ in b:
         # Just a little trick to advance b without having to catch
@@ -317,7 +310,6 @@ def isreadable(f):
     Returns True if the file-like object can be read from.  This is a common-
     sense approximation of io.IOBase.readable.
     """
-
     if hasattr(f, "readable"):
         return f.readable()
 
@@ -341,7 +333,6 @@ def iswritable(f):
     Returns True if the file-like object can be written to.  This is a common-
     sense approximation of io.IOBase.writable.
     """
-
     if hasattr(f, "writable"):
         return f.writable()
 
@@ -368,7 +359,6 @@ def isfile(f):
     On Python 3 this also returns True if the given object is higher level
     wrapper on top of a FileIO object, such as a TextIOWrapper.
     """
-
     if isinstance(f, io.FileIO):
         return True
     elif hasattr(f, "buffer"):
@@ -384,7 +374,6 @@ def fileobj_name(f):
     called its name.  Otherwise f's class or type is returned.  If f is a
     string f itself is returned.
     """
-
     if isinstance(f, (str, bytes)):
         return f
     elif isinstance(f, gzip.GzipFile):
@@ -414,7 +403,6 @@ def fileobj_closed(f):
     Returns False for all other types of objects, under the assumption that
     they are file-like objects with no sense of a 'closed' state.
     """
-
     if isinstance(f, path_like):
         return True
 
@@ -433,7 +421,6 @@ def fileobj_mode(f):
     Returns the 'mode' string of a file-like object if such a thing exists.
     Otherwise returns None.
     """
-
     # Go from most to least specific--for example gzip objects have a 'mode'
     # attribute, but it's not analogous to the file.mode attribute
 
@@ -491,7 +478,6 @@ def fileobj_is_binary(f):
     Returns True if the give file or file-like object has a file open in binary
     mode.  When in doubt, returns True by default.
     """
-
     # This is kind of a hack for this to work correctly with _File objects,
     # which, for the time being, are *always* binary
     if hasattr(f, "binary"):
@@ -521,7 +507,6 @@ def fill(text, width, **kwargs):
     :func:`textwrap.wrap` does not otherwise handle well.  Also handles section
     headers.
     """
-
     paragraphs = text.split("\n\n")
 
     def maybe_fill(t):
@@ -543,7 +528,6 @@ CHUNKED_FROMFILE = None
 
 def _array_from_file(infile, dtype, count):
     """Create a numpy array from a file or a file-like object."""
-
     if isfile(infile):
         global CHUNKED_FROMFILE
         if CHUNKED_FROMFILE is None:
@@ -599,7 +583,6 @@ def _array_to_file(arr, outfile):
     If writing directly to an on-disk file this delegates directly to
     `ndarray.tofile`.  Otherwise a slower Python implementation is used.
     """
-
     try:
         seekable = outfile.seekable()
     except AttributeError:
@@ -647,7 +630,6 @@ def _array_to_file_like(arr, fileobj):
     Write a `~numpy.ndarray` to a file-like object (which is not supported by
     `numpy.ndarray.tofile`).
     """
-
     # If the array is empty, we can simply take a shortcut and return since
     # there is nothing to write.
     if len(arr) == 0:
@@ -690,7 +672,6 @@ def _write_string(f, s):
     Write a string to a file, encoding to ASCII if the file is open in binary
     mode, or decoding if the file is open in text mode.
     """
-
     # Assume if the file object doesn't have a specific mode, that the mode is
     # binary
     binmode = fileobj_is_binary(f)
@@ -709,7 +690,6 @@ def _convert_array(array, dtype):
     the same as the old dtype and both types are not numeric, a view is
     returned.  Otherwise a new array must be created.
     """
-
     if array.dtype == dtype:
         return array
     elif array.dtype.itemsize == dtype.itemsize and not (
@@ -727,7 +707,6 @@ def _pseudo_zero(dtype):
     Given a numpy dtype, finds its "zero" point, which is exactly in the
     middle of its range.
     """
-
     # special case for int8
     if dtype.kind == "i" and dtype.itemsize == 1:
         return -128
@@ -748,7 +727,6 @@ def _is_int(val):
 
 def _str_to_num(val):
     """Converts a given string to either an int or a float if necessary."""
-
     try:
         num = int(val)
     except ValueError:
@@ -764,7 +742,6 @@ def _words_group(s, width):
     which are longer than ``strlen``, then they will be split in the middle of
     the word.
     """
-
     words = []
     slen = len(s)
 
@@ -806,7 +783,6 @@ def _tmp_name(input):
     Create a temporary file name which should not already exist.  Use the
     directory of the input file as the base name of the mkstemp() output.
     """
-
     if input is not None:
         input = os.path.dirname(input)
     f, fn = tempfile.mkstemp(dir=input)
@@ -819,7 +795,6 @@ def _get_array_mmap(array):
     If the array has an mmap.mmap at base of its base chain, return the mmap
     object; otherwise return None.
     """
-
     if isinstance(array, mmap.mmap):
         return array
 
@@ -863,7 +838,6 @@ def _extract_number(value, default):
     Attempts to extract an integer number from the given value. If the
     extraction fails, the value of the 'default' argument is returned.
     """
-
     try:
         # The _str_to_num method converts the value to string/float
         # so we need to perform one additional conversion to int on top
@@ -898,7 +872,6 @@ def _rstrip_inplace(array):
     since the built-in `np.char.rstrip` in Numpy does not perform an in-place
     calculation.
     """
-
     # The following implementation convert the string to unsigned integers of
     # the right length. Trailing spaces (which are represented as 32) are then
     # converted to null characters (represented as zeros). To avoid creating

--- a/astropy/io/fits/verify.py
+++ b/astropy/io/fits/verify.py
@@ -45,7 +45,6 @@ class _Verify:
         """
         Execute the verification with selected option.
         """
-
         text = err_text
 
         if option in ["warn", "exception"]:
@@ -73,7 +72,6 @@ class _Verify:
             ``"silentfix"`` with ``"+ignore"``, ``"+warn"``, or ``"+exception"``
             (e.g. ``"fix+warn"``).  See :ref:`astropy:verify` for more info.
         """
-
         opt = option.lower()
         if opt not in VERIFY_OPTIONS:
             raise ValueError(f"Option {option!r} not recognized.")
@@ -149,7 +147,6 @@ class _ErrList(list):
         Iterate the nested structure as a list of strings with appropriate
         indentations for each level of structure.
         """
-
         element = 0
         # go through the list twice, first time print out all top level
         # messages

--- a/astropy/io/misc/hdf5.py
+++ b/astropy/io/misc/hdf5.py
@@ -81,7 +81,6 @@ def read_table_hdf5(input, path=None, character_as_bytes=True):
         If `True` then Table columns are left as bytes.
         If `False` then Table columns are converted to unicode.
     """
-
     try:
         import h5py
     except ImportError:
@@ -253,7 +252,6 @@ def write_table_hdf5(
         Additional keyword arguments are passed to
         ``h5py.File.create_dataset()`` or ``h5py.Group.create_dataset()``.
     """
-
     from astropy.table import meta
 
     try:

--- a/astropy/io/misc/parquet.py
+++ b/astropy/io/misc/parquet.py
@@ -336,7 +336,6 @@ def write_table_parquet(table, output, overwrite=False):
         if it is a zero-length table and any of the columns are variable-length
         arrays.
     """
-
     from astropy.table import meta, serialize
     from astropy.utils.data_info import serialize_context_as
 

--- a/astropy/io/misc/pickle_helpers.py
+++ b/astropy/io/misc/pickle_helpers.py
@@ -37,7 +37,6 @@ def fnunpickle(fileorname, number=0):
         from the file.
 
     """
-
     if isinstance(fileorname, str):
         f = open(fileorname, "rb")
         close = True

--- a/astropy/io/registry/core.py
+++ b/astropy/io/registry/core.py
@@ -119,7 +119,6 @@ class UnifiedInputRegistry(_UnifiedIORegistryBase):
         data_class : class
             The class of the object that the reader produces.
         """
-
         if (data_format, data_class) in self._readers:
             self._readers.pop((data_format, data_class))
         else:
@@ -299,7 +298,6 @@ class UnifiedOutputRegistry(_UnifiedIORegistryBase):
         data_class : class
             The class of the object that can be written.
         """
-
         if (data_format, data_class) in self._writers:
             self._writers.pop((data_format, data_class))
         else:

--- a/astropy/io/votable/connect.py
+++ b/astropy/io/votable/connect.py
@@ -154,7 +154,6 @@ def write_table_votable(
         (text representation), ``binary`` or ``binary2``.  Default is
         ``tabledata``.  See :ref:`astropy:votable-serialization`.
     """
-
     # Only those columns which are instances of BaseColumn or Quantity can be written
     unsupported_cols = input.columns.not_isinstance((BaseColumn, Quantity))
     if unsupported_cols:

--- a/astropy/io/votable/table.py
+++ b/astropy/io/votable/table.py
@@ -261,7 +261,6 @@ def validate(source, output=sys.stdout, xmllint=False, filename=None):
         Returns `True` if no warnings were found.  If ``output`` is
         `None`, the return value will be a string.
     """
-
     from astropy.utils.console import color_print, print_code_line
 
     return_as_str = False

--- a/astropy/io/votable/tests/table_test.py
+++ b/astropy/io/votable/tests/table_test.py
@@ -356,7 +356,6 @@ def test_validate_output_invalid():
     Issue #12603. Test that we get the correct output from votable.validate with an invalid
     votable.
     """
-
     # A votable with errors
     invalid_votable_filepath = get_pkg_data_filename("data/regression.xml")
 
@@ -378,7 +377,6 @@ def test_validate_output_valid():
     Issue #12603. Test that we get the correct output from votable.validate with a valid
     votable.
     """
-
     # A valid votable. (Example from the votable standard:
     # https://www.ivoa.net/documents/VOTable/20191021/REC-VOTable-1.4-20191021.html )
     valid_votable_filepath = get_pkg_data_filename("data/valid_votable.xml")

--- a/astropy/io/votable/tests/tree_test.py
+++ b/astropy/io/votable/tests/tree_test.py
@@ -94,7 +94,6 @@ def test_version():
     The '1.0' is curious since other checks in parse() and the version setter do not allow '1.0'.
     This test confirms that behavior for now.  A future change may remove the '1.0'.
     """
-
     # Exercise the checks in __init__
     with pytest.warns(AstropyDeprecationWarning):
         VOTableFile(version="1.0")

--- a/astropy/logger.py
+++ b/astropy/logger.py
@@ -104,7 +104,6 @@ def _init_log():
     """Initializes the Astropy log--in most circumstances this is called
     automatically when importing astropy.
     """
-
     global log
 
     orig_logger_cls = logging.getLoggerClass()
@@ -125,7 +124,6 @@ def _teardown_log():
     This involves poking some logging module internals, so much if it is 'at
     your own risk' and is allowed to pass silently if any exceptions occur.
     """
-
     global log
 
     if log.exception_logging_enabled():
@@ -498,7 +496,6 @@ class AstropyLogger(Logger):
         """
         Reset logger to its initial state.
         """
-
         # Reset any previously installed hooks
         if self.warnings_logging_enabled():
             self.disable_warnings_logging()

--- a/astropy/modeling/bounding_box.py
+++ b/astropy/modeling/bounding_box.py
@@ -234,7 +234,6 @@ class _BoundingDomain(abc.ABC):
                 the string name of the input or
                 the input index itself.
         """
-
         return get_index(self._model, key)
 
     def _get_name(self, index: int):
@@ -269,7 +268,6 @@ class _BoundingDomain(abc.ABC):
         fixed_inputs : dict
             Dictionary of inputs which have been fixed by this bounding box.
         """
-
         raise NotImplementedError("This should be implemented by a child class.")
 
     @abc.abstractmethod
@@ -332,7 +330,6 @@ class _BoundingDomain(abc.ABC):
         -------
         A full set of outputs for case that all inputs are outside domain.
         """
-
         return [
             self._base_output(input_shape, fill_value)
             for _ in range(self._model.n_outputs)
@@ -441,7 +438,6 @@ class _BoundingDomain(abc.ABC):
         with_units : bool
             whether or not a unit is required
         """
-
         if with_units:
             return getattr(valid_outputs, "unit", None)
 
@@ -544,7 +540,6 @@ class _BoundingDomain(abc.ABC):
         -------
         List containing filled in output values and units
         """
-
         if valid_outputs_unit is not None:
             return Quantity(outputs, valid_outputs_unit, copy=False, subok=True)
 
@@ -822,7 +817,6 @@ class ModelBoundingBox(_BoundingDomain):
         keep_ignored : bool
             Keep the ignored inputs of the bounding box (internal argument only)
         """
-
         new = self.copy()
 
         for _input in fixed_inputs.keys():
@@ -1076,7 +1070,6 @@ class _SelectorArgument(_BaseSelectorArgument):
         argument : int or str
             A representation of which evaluation input is being used
         """
-
         return self.index == get_index(model, argument)
 
     def named_tuple(self, model):
@@ -1241,7 +1234,6 @@ class _SelectorArguments(tuple):
         argument : int or str
             A representation of which evaluation input is being used
         """
-
         return any(selector_arg.is_argument(model, argument) for selector_arg in self)
 
     def selector_index(self, model, argument):
@@ -1256,7 +1248,6 @@ class _SelectorArguments(tuple):
         argument : int or str
             A representation of which argument is being used
         """
-
         for index, selector_arg in enumerate(self):
             if selector_arg.is_argument(model, argument):
                 return index
@@ -1277,7 +1268,6 @@ class _SelectorArguments(tuple):
         argument : int or str
             A representation of which argument is being used
         """
-
         arguments = list(self)
         kept_ignore = [arguments.pop(self.selector_index(model, argument)).index]
         kept_ignore.extend(self._kept_ignore)
@@ -1296,7 +1286,6 @@ class _SelectorArguments(tuple):
         argument : int or str
             A representation of which argument is being used
         """
-
         if self.is_argument(model, argument):
             raise ValueError(
                 f"{argument}: is a selector argument and cannot be ignored."
@@ -1614,7 +1603,6 @@ class CompoundBoundingBox(_BoundingDomain):
         fixed_inputs : dict
             Dictionary of inputs which have been fixed by this bounding box.
         """
-
         fixed_input_keys = list(fixed_inputs.keys())
         argument = fixed_input_keys.pop()
         value = fixed_inputs[argument]

--- a/astropy/modeling/convolution.py
+++ b/astropy/modeling/convolution.py
@@ -61,7 +61,6 @@ class Convolution(CompoundModel):
         """
         Clears the cached convolution.
         """
-
         self._kwargs = None
         self._convolution = None
 

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -163,7 +163,6 @@ class _ModelMeta(abc.ABCMeta):
         """
         Custom repr for Model subclasses.
         """
-
         return cls._format_cls_repr()
 
     def _repr_pretty_(cls, p, cycle):
@@ -173,7 +172,6 @@ class _ModelMeta(abc.ABCMeta):
         By default IPython "pretty prints" classes, so we need to implement
         this so that IPython displays the custom repr for Models.
         """
-
         p.text(repr(cls))
 
     def __reduce__(cls):
@@ -203,7 +201,6 @@ class _ModelMeta(abc.ABCMeta):
         This attribute is provided for symmetry with the `Model.name` attribute
         of model instances.
         """
-
         return cls.__name__
 
     @property
@@ -236,7 +233,6 @@ class _ModelMeta(abc.ABCMeta):
             >>> isinstance(r, Rotation2D)
             True
         """
-
         mod = find_current_module(2)
         if mod:
             modname = mod.__name__
@@ -290,7 +286,6 @@ class _ModelMeta(abc.ABCMeta):
         as a fixed tuple or a property or method) and wraps it in the generic
         getter/setter interface for the bounding_box attribute.
         """
-
         # TODO: Much of this is verbatim from _create_inverse_property--I feel
         # like there could be a way to generify properties that work this way,
         # but for the time being that would probably only confuse things more.
@@ -335,7 +330,6 @@ class _ModelMeta(abc.ABCMeta):
         computed in _create_bounding_box_property, so no need to duplicate that
         effort.
         """
-
         # TODO: Might be convenient if calling the bounding box also
         # automatically sets the _user_bounding_box.  So that
         #
@@ -486,7 +480,6 @@ class _ModelMeta(abc.ABCMeta):
         override the default ``__repr__`` while keeping the same basic
         formatting.
         """
-
         # For the sake of familiarity start the output with the standard class
         # __repr__
         parts = [super().__repr__()]
@@ -892,7 +885,6 @@ class Model(metaclass=_ModelMeta):
         dimensionless numbers for that input.
         Only has an effect if input_units is defined.
         """
-
         val = self._input_units_allow_dimensionless
         if isinstance(val, bool):
             return {key: val for key in self.inputs}
@@ -973,7 +965,6 @@ class Model(metaclass=_ModelMeta):
         """
         Model specific input setup that needs to occur prior to model evaluation.
         """
-
         # Broadcast inputs into common size
         inputs, broadcasted_shapes = self.prepare_inputs(*args, **kwargs)
 
@@ -1060,7 +1051,6 @@ class Model(metaclass=_ModelMeta):
         If validation succeeds, returns the total shape that will result from
         broadcasting the input arrays with each other.
         """
-
         check_model_set_axis = self._n_models > 1 and model_set_axis is not False
 
         all_shapes = []
@@ -1088,7 +1078,6 @@ class Model(metaclass=_ModelMeta):
 
         Selects and evaluates model with or without bounding_box enforcement.
         """
-
         # Evaluate the model using the prepared evaluation method either
         #   enforcing the bounding_box or not.
         bbox = self.get_bounding_box(with_bbox)
@@ -1209,13 +1198,11 @@ class Model(metaclass=_ModelMeta):
     @property
     def name(self):
         """User-provided name for this model instance."""
-
         return self._name
 
     @name.setter
     def name(self, val):
         """Assign a (new) name to this model."""
-
         self._name = val
 
     @property
@@ -1228,7 +1215,6 @@ class Model(metaclass=_ModelMeta):
         See the documentation on :ref:`astropy:modeling-model-sets`
         for more details.
         """
-
         return self._model_set_axis
 
     @property
@@ -1240,7 +1226,6 @@ class Model(metaclass=_ModelMeta):
         that parameter's values across all parameter sets, with the last axis
         associated with the parameter set.
         """
-
         return self._param_sets()
 
     @property
@@ -1250,7 +1235,6 @@ class Model(metaclass=_ModelMeta):
 
         Fittable parameters maintain this list and fitters modify it.
         """
-
         # Currently the sequence of a model's parameters must be contiguous
         # within the _parameters array (which may be a view of a larger array,
         # for example when taking a sub-expression of a compound model), so
@@ -1271,7 +1255,6 @@ class Model(metaclass=_ModelMeta):
         Assigning to this attribute updates the parameters array rather than
         replacing it.
         """
-
         if not self.param_names:
             return
 
@@ -1337,13 +1320,11 @@ class Model(metaclass=_ModelMeta):
     @property
     def eqcons(self):
         """List of parameter equality constraints."""
-
         return self._mconstraints["eqcons"]
 
     @property
     def ineqcons(self):
         """List of parameter inequality constraints."""
-
         return self._mconstraints["ineqcons"]
 
     def has_inverse(self):
@@ -1411,7 +1392,6 @@ class Model(metaclass=_ModelMeta):
         Resets the model's inverse to its default (if one exists, otherwise
         the model will have no inverse).
         """
-
         try:
             del self._user_inverse
         except AttributeError:
@@ -1484,7 +1464,6 @@ class Model(metaclass=_ModelMeta):
         use `del model.bounding_box` to restore the default bounding box,
         if one is defined for this model).
         """
-
         if self._user_bounding_box is not None:
             if self._user_bounding_box is NotImplemented:
                 raise NotImplementedError(
@@ -1516,7 +1495,6 @@ class Model(metaclass=_ModelMeta):
         """
         Assigns the bounding box limits.
         """
-
         if bounding_box is None:
             cls = None
             # We use this to explicitly set an unimplemented bounding box (as
@@ -1556,7 +1534,6 @@ class Model(metaclass=_ModelMeta):
         assigned to this model by a user, via assignment to
         ``model.bounding_box``.
         """
-
         return self._user_bounding_box is not None
 
     @property
@@ -1608,7 +1585,6 @@ class Model(metaclass=_ModelMeta):
     @property
     def separable(self):
         """A flag indicating whether a model is separable."""
-
         if self._separable is not None:
             return self._separable
         raise NotImplementedError(
@@ -1831,7 +1807,6 @@ class Model(metaclass=_ModelMeta):
         --------
         :ref:`astropy:bounding-boxes`
         """
-
         try:
             bbox = self.bounding_box
         except NotImplementedError:
@@ -2294,7 +2269,6 @@ class Model(metaclass=_ModelMeta):
         Uses a deep copy so that all model attributes, including parameter
         values, are copied as well.
         """
-
         return copy.deepcopy(self)
 
     def deepcopy(self):
@@ -2302,7 +2276,6 @@ class Model(metaclass=_ModelMeta):
         Return a deep copy of this model.
 
         """
-
         return self.copy()
 
     @sharedmethod
@@ -2479,7 +2452,6 @@ class Model(metaclass=_ModelMeta):
         Pop parameter constraint values off the keyword arguments passed to
         `Model.__init__` and store them in private instance attributes.
         """
-
         # Pop any constraints off the keyword arguments
         for constraint in self.parameter_constraints:
             values = kwargs.pop(constraint, {})
@@ -2799,7 +2771,6 @@ class Model(metaclass=_ModelMeta):
         Note: This is notably an overcomplicated device and may be removed
         entirely in the near future.
         """
-
         values = []
         shapes = []
         for name in self.param_names:
@@ -2855,7 +2826,6 @@ class Model(metaclass=_ModelMeta):
         override the default ``__repr__`` while keeping the same basic
         formatting.
         """
-
         parts = [repr(a) for a in args]
 
         parts.extend(
@@ -2884,7 +2854,6 @@ class Model(metaclass=_ModelMeta):
         override the default ``__str__`` while keeping the same basic
         formatting.
         """
-
         default_keywords = [
             ("Model", self.__class__.__name__),
             ("Name", self.name),
@@ -3302,7 +3271,6 @@ class CompoundModel(Model):
         """
         if both members of this compound model have inverses return True.
         """
-
         import warnings
 
         from astropy.utils.exceptions import AstropyDeprecationWarning
@@ -3330,7 +3298,6 @@ class CompoundModel(Model):
             All of the _pre_evaluate for each component model will be
             performed at the time that the individual model is evaluated.
         """
-
         # If equivalencies are provided, necessary to map parameters and pass
         # the leaflist as a keyword input for use by model evaluation so that
         # the compound model input names can be matched to the model input
@@ -3905,7 +3872,6 @@ class CompoundModel(Model):
         assigned to this model by a user, via assignment to
         ``model.bounding_box``.
         """
-
         return self._user_bounding_box is not None
 
     def render(self, out=None, coords=None):
@@ -3949,7 +3915,6 @@ class CompoundModel(Model):
         --------
         :ref:`astropy:bounding-boxes`
         """
-
         bbox = self.get_bounding_box()
 
         ndim = self.n_inputs
@@ -4189,7 +4154,6 @@ class CompoundModel(Model):
         Outside the mixed output units, this method is identical to the
         base method.
         """
-
         if self.op in ["*", "/"]:
             left_kwargs = kwargs.pop("_left_kwargs")
             right_kwargs = kwargs.pop("_right_kwargs")
@@ -4453,7 +4417,6 @@ def custom_model(*args, fit_deriv=None):
         >>> model(1, 1)  # doctest: +FLOAT_CMP
         0.3333333333333333
     """
-
     if len(args) == 1 and callable(args[0]):
         return _custom_model_wrapper(args[0], fit_deriv=fit_deriv)
     elif not args:
@@ -4529,7 +4492,6 @@ def _custom_model_wrapper(func, fit_deriv=None):
     When `custom_model` is used as a decorator a partial evaluation of this
     function is returned by `custom_model`.
     """
-
     if not callable(func):
         raise ModelDefinitionError(
             "func is not callable; it must be a function or other callable object"
@@ -4606,7 +4568,6 @@ def render_model(model, arr=None, coords=None):
     --------
     :ref:`astropy:bounding-boxes`
     """
-
     bbox = model.bounding_box
 
     if (coords is None) & (arr is None) & (bbox is None):

--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -376,7 +376,6 @@ class Fitter(metaclass=_FitterMeta):
         of a model.
         Fitter subclasses should implement this method.
         """
-
         raise NotImplementedError("Subclasses should implement this method.")
 
 
@@ -508,7 +507,6 @@ class LinearLSQFitter(metaclass=_FitterMeta):
         Maps domain into window for a polynomial model which has these
         attributes.
         """
-
         if y is None:
             if hasattr(model, "domain") and model.domain is None:
                 model.domain = [x.min(), x.max()]
@@ -568,7 +566,6 @@ class LinearLSQFitter(metaclass=_FitterMeta):
             a copy of the input model with parameters set by the fitter
 
         """
-
         if not model.fittable:
             raise ValueError("Model must be a subclass of FittableModel")
 
@@ -937,7 +934,6 @@ class FittingWithOutlierRemoval:
             fitting iteration (False) and which were found to be outliers or
             were masked in the input (True).
         """
-
         # For single models, the data get filtered here at each iteration and
         # then passed to the fitter, which is the historical behavior and
         # works even for fitters that don't understand masked arrays. For model
@@ -1130,7 +1126,6 @@ class _NonLinearLSQFitter(metaclass=_FitterMeta):
             [model, [weights], [input coordinates]]
 
         """
-
         model = args[0]
         weights = args[1]
         fitter_to_model_params(model, fps, self._use_min_max_bounds)
@@ -1157,7 +1152,6 @@ class _NonLinearLSQFitter(metaclass=_FitterMeta):
         Set ``cov_matrix`` and ``stds`` attributes on model with parameter
         covariance matrix returned by ``optimize.leastsq``.
         """
-
         free_param_names = [
             x
             for x in model.fixed
@@ -1177,7 +1171,6 @@ class _NonLinearLSQFitter(metaclass=_FitterMeta):
         constraints, instead of using p directly, we set the parameter list in
         this function.
         """
-
         if weights is None:
             weights = 1.0
 
@@ -1270,7 +1263,6 @@ class _NonLinearLSQFitter(metaclass=_FitterMeta):
         x, y, z : ndarrays
             x, y, and z with non-finite values filtered out.
         """
-
         MESSAGE = "Non-Finite input data has been removed by the fitter."
 
         if z is None:
@@ -1341,7 +1333,6 @@ class _NonLinearLSQFitter(metaclass=_FitterMeta):
             a copy of the input model with parameters set by the fitter
 
         """
-
         model_copy = _validate_model(model, self.supported_constraints)
         model_copy.sync_constraints = False
 
@@ -1676,7 +1667,6 @@ class SLSQPLSQFitter(Fitter):
             a copy of the input model with parameters set by the fitter
 
         """
-
         model_copy = _validate_model(model, self._opt_method.supported_constraints)
         model_copy.sync_constraints = False
         farg = _convert_input(x, y, z)
@@ -1746,7 +1736,6 @@ class SimplexLSQFitter(Fitter):
             a copy of the input model with parameters set by the fitter
 
         """
-
         model_copy = _validate_model(model, self._opt_method.supported_constraints)
         model_copy.sync_constraints = False
         farg = _convert_input(x, y, z)
@@ -1821,7 +1810,6 @@ class JointFitter(metaclass=_FitterMeta):
             args is always passed as a tuple from optimize.leastsq
 
         """
-
         lstsqargs = list(args)
         fitted = []
         fitparams = list(fps)
@@ -1877,7 +1865,6 @@ class JointFitter(metaclass=_FitterMeta):
         Fit data to these models keeping some of the parameters common to the
         two models.
         """
-
         from scipy import optimize
 
         if len(args) != reduce(lambda x, y: x + 1 + y + 1, self.modeldims):
@@ -1922,7 +1909,6 @@ class JointFitter(metaclass=_FitterMeta):
 
 def _convert_input(x, y, z=None, n_models=1, model_set_axis=0):
     """Convert inputs to float arrays."""
-
     x = np.asanyarray(x, dtype=float)
     y = np.asanyarray(y, dtype=float)
 
@@ -1992,7 +1978,6 @@ def fitter_to_model_params(model, fps, use_min_max_bounds=True):
         parameter with bounds.
         Default: True
     """
-
     _, fit_param_indices, _ = model_to_fit_params(model)
 
     has_tied = any(model.tied.values())
@@ -2064,7 +2049,6 @@ def model_to_fit_params(model):
     These may be a subset of the model parameters, if some of them are held
     constant or tied.
     """
-
     fitparam_indices = list(range(len(model.param_names)))
     model_params = model.parameters
     model_bounds = list(model.bounds.values())
@@ -2102,7 +2086,6 @@ def _model_to_fit_params(model):
 
 def _validate_constraints(supported_constraints, model):
     """Make sure model constraints are supported by the current fitter."""
-
     message = "Optimizer cannot handle {0} constraints."
 
     if any(model.fixed.values()) and "fixed" not in supported_constraints:
@@ -2128,7 +2111,6 @@ def _validate_model(model, supported_constraints):
     """
     Check that model and fitter are compatible and return a copy of the model.
     """
-
     if not model.fittable:
         raise ValueError("Model does not appear to be fittable.")
     if model.linear:
@@ -2162,7 +2144,6 @@ def populate_entry_points(entry_points):
     An explanation of entry points can be found `here
     <http://setuptools.readthedocs.io/en/latest/setuptools.html#dynamic-discovery-of-services-and-plugins>`_
     """
-
     for entry_point in entry_points:
         name = entry_point.name
         try:

--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -194,7 +194,6 @@ class Gaussian1D(Fittable1DModel):
             order='C'
         )
         """
-
         x0 = self.mean
         dx = factor * self.stddev
 
@@ -217,7 +216,6 @@ class Gaussian1D(Fittable1DModel):
         """
         Gaussian1D model function derivatives.
         """
-
         d_amplitude = np.exp(-0.5 / stddev**2 * (x - mean) ** 2)
         d_mean = amplitude * d_amplitude * (x - mean) / stddev**2
         d_stddev = amplitude * d_amplitude * (x - mean) ** 2 / stddev**3
@@ -450,7 +448,6 @@ class Gaussian2D(Fittable2DModel):
             order='C'
         )
         """
-
         a = factor * self.x_stddev
         b = factor * self.y_stddev
         dx, dy = ellipse_extent(a, b, self.theta)
@@ -463,7 +460,6 @@ class Gaussian2D(Fittable2DModel):
     @staticmethod
     def evaluate(x, y, amplitude, x_mean, y_mean, x_stddev, y_stddev, theta):
         """Two dimensional Gaussian function."""
-
         cost2 = np.cos(theta) ** 2
         sint2 = np.sin(theta) ** 2
         sin2t = np.sin(2.0 * theta)
@@ -481,7 +477,6 @@ class Gaussian2D(Fittable2DModel):
     @staticmethod
     def fit_deriv(x, y, amplitude, x_mean, y_mean, x_stddev, y_stddev, theta):
         """Two dimensional Gaussian function derivative with respect to parameters."""
-
         cost = np.cos(theta)
         sint = np.sin(theta)
         cost2 = np.cos(theta) ** 2
@@ -577,7 +572,6 @@ class Shift(Fittable1DModel):
     @property
     def inverse(self):
         """One dimensional inverse Shift model function."""
-
         inv = self.copy()
         inv.offset *= -1
 
@@ -605,7 +599,6 @@ class Shift(Fittable1DModel):
     @staticmethod
     def fit_deriv(x, *params):
         """One dimensional Shift model derivative with respect to parameter."""
-
         d_offset = np.ones_like(x)
         return [d_offset]
 
@@ -673,7 +666,6 @@ class Scale(Fittable1DModel):
     @staticmethod
     def fit_deriv(x, *params):
         """One dimensional Scale model derivative with respect to parameter."""
-
         d_factor = x
         return [d_factor]
 
@@ -722,7 +714,6 @@ class Multiply(Fittable1DModel):
     @staticmethod
     def fit_deriv(x, *params):
         """One dimensional multiply model derivative with respect to parameter."""
-
         d_factor = x
         return [d_factor]
 
@@ -753,20 +744,17 @@ class RedshiftScaleFactor(Fittable1DModel):
     @staticmethod
     def evaluate(x, z):
         """One dimensional RedshiftScaleFactor model function."""
-
         return (1 + z) * x
 
     @staticmethod
     def fit_deriv(x, z):
         """One dimensional RedshiftScaleFactor model derivative."""
-
         d_z = x
         return [d_z]
 
     @property
     def inverse(self):
         """Inverse RedshiftScaleFactor model."""
-
         inv = self.copy()
         inv.z = 1.0 / (1.0 + self.z) - 1.0
 
@@ -854,7 +842,6 @@ class Sersic1D(Fittable1DModel):
     @classmethod
     def evaluate(cls, r, amplitude, r_eff, n):
         """One dimensional Sersic profile function."""
-
         if cls._gammaincinv is None:
             from scipy.special import gammaincinv
 
@@ -970,7 +957,6 @@ class Sine1D(_Trigonometric1D):
     @staticmethod
     def fit_deriv(x, amplitude, frequency, phase):
         """One dimensional Sine model derivative."""
-
         d_amplitude = np.sin(TWOPI * frequency * x + TWOPI * phase)
         d_frequency = (
             TWOPI * x * amplitude * np.cos(TWOPI * frequency * x + TWOPI * phase)
@@ -981,7 +967,6 @@ class Sine1D(_Trigonometric1D):
     @property
     def inverse(self):
         """One dimensional inverse of Sine."""
-
         return ArcSine1D(
             amplitude=self.amplitude, frequency=self.frequency, phase=self.phase
         )
@@ -1049,7 +1034,6 @@ class Cosine1D(_Trigonometric1D):
     @staticmethod
     def fit_deriv(x, amplitude, frequency, phase):
         """One dimensional Cosine model derivative."""
-
         d_amplitude = np.cos(TWOPI * frequency * x + TWOPI * phase)
         d_frequency = -(
             TWOPI * x * amplitude * np.sin(TWOPI * frequency * x + TWOPI * phase)
@@ -1060,7 +1044,6 @@ class Cosine1D(_Trigonometric1D):
     @property
     def inverse(self):
         """One dimensional inverse of Cosine."""
-
         return ArcCosine1D(
             amplitude=self.amplitude, frequency=self.frequency, phase=self.phase
         )
@@ -1137,7 +1120,6 @@ class Tangent1D(_Trigonometric1D):
     @staticmethod
     def fit_deriv(x, amplitude, frequency, phase):
         """One dimensional Tangent model derivative."""
-
         sec = 1 / (np.cos(TWOPI * frequency * x + TWOPI * phase)) ** 2
 
         d_amplitude = np.tan(TWOPI * frequency * x + TWOPI * phase)
@@ -1148,7 +1130,6 @@ class Tangent1D(_Trigonometric1D):
     @property
     def inverse(self):
         """One dimensional inverse of Tangent."""
-
         return ArcTangent1D(
             amplitude=self.amplitude, frequency=self.frequency, phase=self.phase
         )
@@ -1158,7 +1139,6 @@ class Tangent1D(_Trigonometric1D):
         Tuple defining the default ``bounding_box`` limits,
         ``(x_low, x_high)``.
         """
-
         bbox = [
             (-1 / 4 - self.phase) / self.frequency,
             (1 / 4 - self.phase) / self.frequency,
@@ -1260,7 +1240,6 @@ class ArcSine1D(_InverseTrigonometric1D):
     @staticmethod
     def fit_deriv(x, amplitude, frequency, phase):
         """One dimensional ArcSine model derivative."""
-
         d_amplitude = -x / (
             TWOPI * frequency * amplitude**2 * np.sqrt(1 - (x / amplitude) ** 2)
         )
@@ -1273,13 +1252,11 @@ class ArcSine1D(_InverseTrigonometric1D):
         Tuple defining the default ``bounding_box`` limits,
         ``(x_low, x_high)``.
         """
-
         return -1 * self.amplitude, 1 * self.amplitude
 
     @property
     def inverse(self):
         """One dimensional inverse of ArcSine."""
-
         return Sine1D(
             amplitude=self.amplitude, frequency=self.frequency, phase=self.phase
         )
@@ -1357,7 +1334,6 @@ class ArcCosine1D(_InverseTrigonometric1D):
     @staticmethod
     def fit_deriv(x, amplitude, frequency, phase):
         """One dimensional ArcCosine model derivative."""
-
         d_amplitude = x / (
             TWOPI * frequency * amplitude**2 * np.sqrt(1 - (x / amplitude) ** 2)
         )
@@ -1370,13 +1346,11 @@ class ArcCosine1D(_InverseTrigonometric1D):
         Tuple defining the default ``bounding_box`` limits,
         ``(x_low, x_high)``.
         """
-
         return -1 * self.amplitude, 1 * self.amplitude
 
     @property
     def inverse(self):
         """One dimensional inverse of ArcCosine."""
-
         return Cosine1D(
             amplitude=self.amplitude, frequency=self.frequency, phase=self.phase
         )
@@ -1448,7 +1422,6 @@ class ArcTangent1D(_InverseTrigonometric1D):
     @staticmethod
     def fit_deriv(x, amplitude, frequency, phase):
         """One dimensional ArcTangent model derivative."""
-
         d_amplitude = -x / (
             TWOPI * frequency * amplitude**2 * (1 + (x / amplitude) ** 2)
         )
@@ -1459,7 +1432,6 @@ class ArcTangent1D(_InverseTrigonometric1D):
     @property
     def inverse(self):
         """One dimensional inverse of ArcTangent."""
-
         return Tangent1D(
             amplitude=self.amplitude, frequency=self.frequency, phase=self.phase
         )
@@ -1495,13 +1467,11 @@ class Linear1D(Fittable1DModel):
     @staticmethod
     def evaluate(x, slope, intercept):
         """One dimensional Line model function."""
-
         return slope * x + intercept
 
     @staticmethod
     def fit_deriv(x, *params):
         """One dimensional Line model derivative with respect to parameters."""
-
         d_slope = x
         d_intercept = np.ones_like(x)
         return [d_slope, d_intercept]
@@ -1555,13 +1525,11 @@ class Planar2D(Fittable2DModel):
     @staticmethod
     def evaluate(x, y, slope_x, slope_y, intercept):
         """Two dimensional Plane model function."""
-
         return slope_x * x + slope_y * y + intercept
 
     @staticmethod
     def fit_deriv(x, y, *params):
         """Two dimensional Plane model derivative with respect to parameters."""
-
         d_slope_x = x
         d_slope_y = y
         d_intercept = np.ones_like(x)
@@ -1635,13 +1603,11 @@ class Lorentz1D(Fittable1DModel):
     @staticmethod
     def evaluate(x, amplitude, x_0, fwhm):
         """One dimensional Lorentzian model function."""
-
         return amplitude * ((fwhm / 2.0) ** 2) / ((x - x_0) ** 2 + (fwhm / 2.0) ** 2)
 
     @staticmethod
     def fit_deriv(x, amplitude, x_0, fwhm):
         """One dimensional Lorentzian model derivative with respect to parameters."""
-
         d_amplitude = fwhm**2 / (fwhm**2 + (x - x_0) ** 2)
         d_x_0 = (
             amplitude * d_amplitude * (2 * x - 2 * x_0) / (fwhm**2 + (x - x_0) ** 2)
@@ -1777,7 +1743,6 @@ class Voigt1D(Fittable1DModel):
         """Call complex error (Faddeeva) function w(z) implemented by algorithm `method`;
         cache results for consecutive calls from `evaluate`, `fit_deriv`.
         """
-
         if z.shape == self._last_z.shape and np.allclose(
             z, self._last_z, rtol=1.0e-14, atol=1.0e-15
         ):
@@ -1789,7 +1754,6 @@ class Voigt1D(Fittable1DModel):
 
     def evaluate(self, x, x_0, amplitude_L, fwhm_L, fwhm_G):
         """One dimensional Voigt function scaled to Lorentz peak amplitude."""
-
         z = np.atleast_1d(2 * (x - x_0) + 1j * fwhm_L) * self.sqrt_ln2 / fwhm_G
         # The normalised Voigt profile is w.real * self.sqrt_ln2 / (self.sqrt_pi * fwhm_G) * 2 ;
         # for the legacy definition we multiply with np.pi * fwhm_L / 2 * amplitude_L
@@ -1799,7 +1763,6 @@ class Voigt1D(Fittable1DModel):
         """
         Derivative of the one dimensional Voigt function with respect to parameters.
         """
-
         s = self.sqrt_ln2 / fwhm_G
         z = np.atleast_1d(2 * (x - x_0) + 1j * fwhm_L) * s
         # V * constant from McLean implementation (== their Voigt function)
@@ -1841,7 +1804,6 @@ class Voigt1D(Fittable1DModel):
         Originally licensed under a 3-clause BSD style license - see
         https://atmos.eoc.dlr.de/tools/lbl4IR/cpfX.py
         """
-
         # Optimized (single fraction) Humlicek region I rational approximation for n=16, delta=1.35
 
         # fmt: off
@@ -1957,7 +1919,6 @@ class Const1D(Fittable1DModel):
     @staticmethod
     def evaluate(x, amplitude):
         """One dimensional Constant model function."""
-
         if amplitude.size == 1:
             # This is slightly faster than using ones_like and multiplying
             x = np.empty_like(amplitude, shape=x.shape, dtype=x.dtype)
@@ -1974,7 +1935,6 @@ class Const1D(Fittable1DModel):
     @staticmethod
     def fit_deriv(x, amplitude):
         """One dimensional Constant model derivative with respect to parameters."""
-
         d_amplitude = np.ones_like(x)
         return [d_amplitude]
 
@@ -2014,7 +1974,6 @@ class Const2D(Fittable2DModel):
     @staticmethod
     def evaluate(x, y, amplitude):
         """Two dimensional Constant model function."""
-
         if amplitude.size == 1:
             # This is slightly faster than using ones_like and multiplying
             x = np.empty_like(amplitude, shape=x.shape, dtype=x.dtype)
@@ -2122,7 +2081,6 @@ class Ellipse2D(Fittable2DModel):
     @staticmethod
     def evaluate(x, y, amplitude, x_0, y_0, a, b, theta):
         """Two dimensional Ellipse model function."""
-
         xx = x - x_0
         yy = y - y_0
         cost = np.cos(theta)
@@ -2143,7 +2101,6 @@ class Ellipse2D(Fittable2DModel):
 
         ``((y_low, y_high), (x_low, x_high))``
         """
-
         a = self.a
         b = self.b
         theta = self.theta
@@ -2214,7 +2171,6 @@ class Disk2D(Fittable2DModel):
     @staticmethod
     def evaluate(x, y, amplitude, x_0, y_0, R_0):
         """Two dimensional Disk model function."""
-
         rr = (x - x_0) ** 2 + (y - y_0) ** 2
         result = np.select([rr <= R_0**2], [amplitude])
 
@@ -2229,7 +2185,6 @@ class Disk2D(Fittable2DModel):
 
         ``((y_low, y_high), (x_low, x_high))``
         """
-
         return (
             (self.y_0 - self.R_0, self.y_0 + self.R_0),
             (self.x_0 - self.R_0, self.x_0 + self.R_0),
@@ -2338,7 +2293,6 @@ class Ring2D(Fittable2DModel):
     @staticmethod
     def evaluate(x, y, amplitude, x_0, y_0, r_in, width):
         """Two dimensional Ring model function."""
-
         rr = (x - x_0) ** 2 + (y - y_0) ** 2
         r_range = np.logical_and(rr >= r_in**2, rr <= (r_in + width) ** 2)
         result = np.select([r_range], [amplitude])
@@ -2354,7 +2308,6 @@ class Ring2D(Fittable2DModel):
 
         ``((y_low, y_high), (x_low, x_high))``
         """
-
         dr = self.r_in + self.width
 
         return ((self.y_0 - dr, self.y_0 + dr), (self.x_0 - dr, self.x_0 + dr))
@@ -2440,7 +2393,6 @@ class Box1D(Fittable1DModel):
     @staticmethod
     def evaluate(x, amplitude, x_0, width):
         """One dimensional Box model function."""
-
         inside = np.logical_and(x >= x_0 - width / 2.0, x <= x_0 + width / 2.0)
         return np.select([inside], [amplitude], 0)
 
@@ -2451,7 +2403,6 @@ class Box1D(Fittable1DModel):
 
         ``(x_low, x_high))``
         """
-
         dx = self.width / 2
 
         return (self.x_0 - dx, self.x_0 + dx)
@@ -2526,7 +2477,6 @@ class Box2D(Fittable2DModel):
     @staticmethod
     def evaluate(x, y, amplitude, x_0, y_0, x_width, y_width):
         """Two dimensional Box model function."""
-
         x_range = np.logical_and(x >= x_0 - x_width / 2.0, x <= x_0 + x_width / 2.0)
         y_range = np.logical_and(y >= y_0 - y_width / 2.0, y <= y_0 + y_width / 2.0)
 
@@ -2543,7 +2493,6 @@ class Box2D(Fittable2DModel):
 
         ``((y_low, y_high), (x_low, x_high))``
         """
-
         dx = self.x_width / 2
         dy = self.y_width / 2
 
@@ -2615,7 +2564,6 @@ class Trapezoid1D(Fittable1DModel):
     @staticmethod
     def evaluate(x, amplitude, x_0, width, slope):
         """One dimensional Trapezoid model function."""
-
         # Compute the four points where the trapezoid changes slope
         # x1 <= x2 <= x3 <= x4
         x2 = x_0 - width / 2.0
@@ -2643,7 +2591,6 @@ class Trapezoid1D(Fittable1DModel):
 
         ``(x_low, x_high))``
         """
-
         dx = self.width / 2 + self.amplitude / self.slope
 
         return (self.x_0 - dx, self.x_0 + dx)
@@ -2696,7 +2643,6 @@ class TrapezoidDisk2D(Fittable2DModel):
     @staticmethod
     def evaluate(x, y, amplitude, x_0, y_0, R_0, slope):
         """Two dimensional Trapezoid Disk model function."""
-
         r = np.sqrt((x - x_0) ** 2 + (y - y_0) ** 2)
         range_1 = r <= R_0
         range_2 = np.logical_and(r > R_0, r <= R_0 + amplitude / slope)
@@ -2715,7 +2661,6 @@ class TrapezoidDisk2D(Fittable2DModel):
 
         ``((y_low, y_high), (x_low, x_high))``
         """
-
         dr = self.R_0 + self.amplitude / self.slope
 
         return ((self.y_0 - dr, self.y_0 + dr), (self.x_0 - dr, self.x_0 + dr))
@@ -2803,7 +2748,6 @@ class RickerWavelet1D(Fittable1DModel):
     @staticmethod
     def evaluate(x, amplitude, x_0, sigma):
         """One dimensional Ricker Wavelet model function."""
-
         xx_ww = (x - x_0) ** 2 / (2 * sigma**2)
         return amplitude * (1 - 2 * xx_ww) * np.exp(-xx_ww)
 
@@ -2881,7 +2825,6 @@ class RickerWavelet2D(Fittable2DModel):
     @staticmethod
     def evaluate(x, y, amplitude, x_0, y_0, sigma):
         """Two dimensional Ricker Wavelet model function."""
-
         rr_ww = ((x - x_0) ** 2 + (y - y_0) ** 2) / (2 * sigma**2)
         return amplitude * (1 - rr_ww) * np.exp(-rr_ww)
 
@@ -2965,7 +2908,6 @@ class AiryDisk2D(Fittable2DModel):
     @classmethod
     def evaluate(cls, x, y, amplitude, x_0, y_0, radius):
         """Two dimensional Airy model function."""
-
         if cls._rz is None:
             from scipy.special import j1, jn_zeros
 
@@ -3079,13 +3021,11 @@ class Moffat1D(Fittable1DModel):
     @staticmethod
     def evaluate(x, amplitude, x_0, gamma, alpha):
         """One dimensional Moffat model function."""
-
         return amplitude * (1 + ((x - x_0) / gamma) ** 2) ** (-alpha)
 
     @staticmethod
     def fit_deriv(x, amplitude, x_0, gamma, alpha):
         """One dimensional Moffat model derivative with respect to parameters."""
-
         fac = 1 + (x - x_0) ** 2 / gamma**2
         d_A = fac ** (-alpha)
         d_x_0 = 2 * amplitude * alpha * (x - x_0) * d_A / (fac * gamma**2)
@@ -3161,14 +3101,12 @@ class Moffat2D(Fittable2DModel):
     @staticmethod
     def evaluate(x, y, amplitude, x_0, y_0, gamma, alpha):
         """Two dimensional Moffat model function."""
-
         rr_gg = ((x - x_0) ** 2 + (y - y_0) ** 2) / gamma**2
         return amplitude * (1 + rr_gg) ** (-alpha)
 
     @staticmethod
     def fit_deriv(x, y, amplitude, x_0, y_0, gamma, alpha):
         """Two dimensional Moffat model derivative with respect to parameters."""
-
         rr_gg = ((x - x_0) ** 2 + (y - y_0) ** 2) / gamma**2
         d_A = (1 + rr_gg) ** (-alpha)
         d_x_0 = 2 * amplitude * alpha * d_A * (x - x_0) / (gamma**2 * (1 + rr_gg))
@@ -3292,7 +3230,6 @@ class Sersic2D(Fittable2DModel):
     @classmethod
     def evaluate(cls, x, y, amplitude, r_eff, n, x_0, y_0, ellip, theta):
         """Two dimensional Sersic profile function."""
-
         if cls._gammaincinv is None:
             from scipy.special import gammaincinv
 
@@ -3410,7 +3347,6 @@ class KingProjectedAnalytic1D(Fittable1DModel):
         """
         Analytic King model function.
         """
-
         result = (
             amplitude
             * r_core**2
@@ -3491,7 +3427,6 @@ class KingProjectedAnalytic1D(Fittable1DModel):
 
         ``(r_low, r_high)``
         """
-
         return (0 * self.r_tide, 1 * self.r_tide)
 
     @property

--- a/astropy/modeling/mappings.py
+++ b/astropy/modeling/mappings.py
@@ -109,7 +109,6 @@ class Mapping(FittableModel):
             An inverse does no exist on mappings that drop some of its inputs
             (there is then no way to reconstruct the inputs that were dropped).
         """
-
         try:
             mapping = tuple(self.mapping.index(idx) for idx in range(self.n_inputs))
         except ValueError:
@@ -176,7 +175,6 @@ class Identity(Mapping):
 
         In this case of `Identity`, ``self.inverse is self``.
         """
-
         return self
 
 

--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -37,7 +37,6 @@ class ParameterDefinitionError(ParameterError):
 
 def _tofloat(value):
     """Convert a parameter to float or float array."""
-
     if isiterable(value):
         try:
             value = np.asanyarray(value, dtype=float)
@@ -324,7 +323,6 @@ class Parameter:
     @property
     def name(self):
         """Parameter name."""
-
         return self._name
 
     @property
@@ -377,7 +375,6 @@ class Parameter:
         model class, rather than a model instance) this is the required/
         default unit for the parameter.
         """
-
         return self._unit
 
     @unit.setter
@@ -455,13 +452,11 @@ class Parameter:
     @property
     def size(self):
         """The size of this parameter's value array."""
-
         return np.size(self.value)
 
     @property
     def std(self):
         """Standard deviation, if available from fit."""
-
         return self._std
 
     @std.setter
@@ -505,13 +500,11 @@ class Parameter:
 
         A callable which provides the relationship of the two parameters.
         """
-
         return self._tied
 
     @tied.setter
     def tied(self, value):
         """Tie a parameter."""
-
         if not callable(value) and value not in (False, None):
             raise TypeError("Tied must be a callable or set to False or None")
         self._tied = value
@@ -519,13 +512,11 @@ class Parameter:
     @property
     def bounds(self):
         """The minimum and maximum values of a parameter as a tuple."""
-
         return self._bounds
 
     @bounds.setter
     def bounds(self, value):
         """Set the minimum and maximum values of a parameter from a tuple."""
-
         _min, _max = value
         if _min is not None:
             if not isinstance(_min, (numbers.Number, Quantity)):
@@ -548,25 +539,21 @@ class Parameter:
     @property
     def min(self):
         """A value used as a lower bound when fitting a parameter."""
-
         return self.bounds[0]
 
     @min.setter
     def min(self, value):
         """Set a minimum value of a parameter."""
-
         self.bounds = (value, self.max)
 
     @property
     def max(self):
         """A value used as an upper bound when fitting a parameter."""
-
         return self.bounds[1]
 
     @max.setter
     def max(self, value):
         """Set a maximum value of a parameter."""
-
         self.bounds = (self.min, value)
 
     @property
@@ -630,7 +617,6 @@ class Parameter:
             Parameter(self.name, self.description, ...)
 
         """
-
         kwargs = locals().copy()
         del kwargs["self"]
 
@@ -688,7 +674,6 @@ class Parameter:
         a second argument then this creates a partial function using the model
         instance as the second argument.
         """
-
         if isinstance(wrapper, np.ufunc):
             if wrapper.nin != 1:
                 raise TypeError(
@@ -757,7 +742,6 @@ def param_repr_oneline(param):
     Like array_repr_oneline but works on `Parameter` objects and supports
     rendering parameters with units like quantities.
     """
-
     out = array_repr_oneline(param.value)
     if param.unit is not None:
         out = f"{out} {param.unit!s}"

--- a/astropy/modeling/polynomial.py
+++ b/astropy/modeling/polynomial.py
@@ -60,7 +60,6 @@ class PolynomialBase(FittableModel):
         can have different parameters depending on the degree of the polynomial
         and the number of dimensions, for example.
         """
-
         return self._param_names
 
 
@@ -101,14 +100,12 @@ class PolynomialModel(PolynomialBase):
     @property
     def degree(self):
         """Degree of polynomial."""
-
         return self._degree
 
     def get_num_coeff(self, ndim):
         """
         Return the number of coefficients in one parameter set.
         """
-
         if self.degree < 0:
             raise ValueError("Degree of polynomial must be positive or null")
         # deg+1 is used to account for the difference between iraf using
@@ -189,7 +186,6 @@ class _PolyDomainWindow1D(PolynomialModel):
         This method sets the ``domain`` and ``window`` attributes on 1D subclasses.
 
         """
-
         self._default_domain_window = {"domain": None, "window": (-1, 1)}
         self.window = window or (-1, 1)
         self.domain = domain
@@ -356,7 +352,6 @@ class OrthoPolynomialBase(PolynomialBase):
         numc : int
             number of coefficients
         """
-
         if self.x_degree < 0 or self.y_degree < 0:
             raise ValueError("Degree of polynomial must be positive or null")
 
@@ -439,7 +434,6 @@ class OrthoPolynomialBase(PolynomialBase):
 
         To be implemented by subclasses"
         """
-
         raise NotImplementedError("Subclasses should implement this")
 
     def evaluate(self, x, y, *coeffs):
@@ -541,7 +535,6 @@ class Chebyshev1D(_PolyDomainWindow1D):
         result : ndarray
             The Vandermonde matrix
         """
-
         x = np.array(x, dtype=float, copy=False, ndmin=1)
         v = np.empty((self.degree + 1,) + x.shape, dtype=x.dtype)
         v[0] = 1
@@ -567,7 +560,6 @@ class Chebyshev1D(_PolyDomainWindow1D):
     @staticmethod
     def clenshaw(x, coeffs):
         """Evaluates the polynomial using Clenshaw's algorithm."""
-
         if len(coeffs) == 1:
             c0 = coeffs[0]
             c1 = 0
@@ -665,7 +657,6 @@ class Hermite1D(_PolyDomainWindow1D):
         result : ndarray
             The Vandermonde matrix
         """
-
         x = np.array(x, dtype=float, copy=False, ndmin=1)
         v = np.empty((self.degree + 1,) + x.shape, dtype=x.dtype)
         v[0] = 1
@@ -790,7 +781,6 @@ class Hermite2D(OrthoPolynomialBase):
         Calculate the individual Hermite functions once and store them in a
         dictionary to be reused.
         """
-
         x_terms = self.x_degree + 1
         y_terms = self.y_degree + 1
         kfunc = {}
@@ -828,7 +818,6 @@ class Hermite2D(OrthoPolynomialBase):
         result : ndarray
             The Vandermonde matrix
         """
-
         if x.shape != y.shape:
             raise ValueError("x and y must have the same shape")
 
@@ -849,7 +838,6 @@ class Hermite2D(OrthoPolynomialBase):
         """
         Derivative of 1D Hermite series.
         """
-
         x = np.array(x, dtype=float, copy=False, ndmin=1)
         d = np.empty((deg + 1, len(x)), dtype=x.dtype)
         d[0] = x * 0 + 1
@@ -954,7 +942,6 @@ class Legendre1D(_PolyDomainWindow1D):
         result : ndarray
             The Vandermonde matrix
         """
-
         x = np.array(x, dtype=float, copy=False, ndmin=1)
         v = np.empty((self.degree + 1,) + x.shape, dtype=x.dtype)
         v[0] = 1
@@ -1074,7 +1061,6 @@ class Polynomial1D(_PolyDomainWindow1D):
         result : ndarray
             The Vandermonde matrix
         """
-
         v = np.empty((self.degree + 1,) + x.shape, dtype=float)
         v[0] = 1
         if self.degree > 0:
@@ -1256,7 +1242,6 @@ class Polynomial2D(PolynomialModel):
         result : ndarray
             The Vandermonde matrix
         """
-
         if x.ndim == 2:
             x = x.flatten()
         if y.ndim == 2:
@@ -1300,7 +1285,6 @@ class Polynomial2D(PolynomialModel):
         coeffs : array
             Coefficients in inverse lexical order.
         """
-
         alpha = self._invlex()
         r0 = coeffs[0]
         r1 = r0 * 0.0
@@ -1454,7 +1438,6 @@ class Chebyshev2D(OrthoPolynomialBase):
         Calculate the individual Chebyshev functions once and store them in a
         dictionary to be reused.
         """
-
         x_terms = self.x_degree + 1
         y_terms = self.y_degree + 1
         kfunc = {}
@@ -1492,7 +1475,6 @@ class Chebyshev2D(OrthoPolynomialBase):
         result : ndarray
             The Vandermonde matrix
         """
-
         if x.shape != y.shape:
             raise ValueError("x and y must have the same shape")
 
@@ -1513,7 +1495,6 @@ class Chebyshev2D(OrthoPolynomialBase):
         """
         Derivative of 1D Chebyshev series.
         """
-
         x = np.array(x, dtype=float, copy=False, ndmin=1)
         d = np.empty((deg + 1, len(x)), dtype=x.dtype)
         d[0] = x * 0 + 1
@@ -1613,7 +1594,6 @@ class Legendre2D(OrthoPolynomialBase):
         Calculate the individual Legendre functions once and store them in a
         dictionary to be reused.
         """
-
         x_terms = self.x_degree + 1
         y_terms = self.y_degree + 1
         kfunc = {}
@@ -1670,7 +1650,6 @@ class Legendre2D(OrthoPolynomialBase):
 
     def _legendderiv1d(self, x, deg):
         """Derivative of 1D Legendre polynomial."""
-
         x = np.array(x, dtype=float, copy=False, ndmin=1)
         d = np.empty((deg + 1,) + x.shape, dtype=x.dtype)
         d[0] = x * 0 + 1
@@ -1744,7 +1723,6 @@ class _SIP1D(PolynomialBase):
         """
         Return the number of coefficients in one param set.
         """
-
         if self.order < 2 or self.order > 9:
             raise ValueError("Degree of polynomial must be 2< deg < 9")
 

--- a/astropy/modeling/powerlaws.py
+++ b/astropy/modeling/powerlaws.py
@@ -58,7 +58,6 @@ class PowerLaw1D(Fittable1DModel):
     @staticmethod
     def fit_deriv(x, amplitude, x_0, alpha):
         """One dimensional power law derivative with respect to parameters."""
-
         xx = x / x_0
 
         d_amplitude = xx ** (-alpha)
@@ -122,7 +121,6 @@ class BrokenPowerLaw1D(Fittable1DModel):
     @staticmethod
     def evaluate(x, amplitude, x_break, alpha_1, alpha_2):
         """One dimensional broken power law model function."""
-
         alpha = np.where(x < x_break, alpha_1, alpha_2)
         xx = x / x_break
         return amplitude * xx ** (-alpha)
@@ -130,7 +128,6 @@ class BrokenPowerLaw1D(Fittable1DModel):
     @staticmethod
     def fit_deriv(x, amplitude, x_break, alpha_1, alpha_2):
         """One dimensional broken power law derivative with respect to parameters."""
-
         alpha = np.where(x < x_break, alpha_1, alpha_2)
         xx = x / x_break
 
@@ -269,7 +266,6 @@ class SmoothlyBrokenPowerLaw1D(Fittable1DModel):
     @staticmethod
     def evaluate(x, amplitude, x_break, alpha_1, alpha_2, delta):
         """One dimensional smoothly broken power law model function."""
-
         # Pre-calculate `x/x_b`
         xx = x / x_break
 
@@ -327,7 +323,6 @@ class SmoothlyBrokenPowerLaw1D(Fittable1DModel):
         """One dimensional smoothly broken power law derivative with respect
         to parameters.
         """
-
         # Pre-calculate `x_b` and `x/x_b` and `logt` (see comments in
         # SmoothlyBrokenPowerLaw1D.evaluate)
         xx = x / x_break
@@ -434,7 +429,6 @@ class ExponentialCutoffPowerLaw1D(Fittable1DModel):
     @staticmethod
     def evaluate(x, amplitude, x_0, alpha, x_cutoff):
         """One dimensional exponential cutoff power law model function."""
-
         xx = x / x_0
         return amplitude * xx ** (-alpha) * np.exp(-x / x_cutoff)
 
@@ -443,7 +437,6 @@ class ExponentialCutoffPowerLaw1D(Fittable1DModel):
         """
         One dimensional exponential cutoff power law derivative with respect to parameters.
         """
-
         xx = x / x_0
         xc = x / x_cutoff
 
@@ -506,7 +499,6 @@ class LogParabola1D(Fittable1DModel):
     @staticmethod
     def evaluate(x, amplitude, x_0, alpha, beta):
         """One dimensional log parabola model function."""
-
         xx = x / x_0
         exponent = -alpha - beta * np.log(xx)
         return amplitude * xx**exponent
@@ -514,7 +506,6 @@ class LogParabola1D(Fittable1DModel):
     @staticmethod
     def fit_deriv(x, amplitude, x_0, alpha, beta):
         """One dimensional log parabola derivative with respect to parameters."""
-
         xx = x / x_0
         log_xx = np.log(xx)
         exponent = -alpha - beta * log_xx
@@ -634,7 +625,6 @@ class Schechter1D(Fittable1DModel):
 
     def evaluate(self, mag, phi_star, m_star, alpha):
         """Schechter luminosity function model function."""
-
         factor = self._factor(mag, m_star)
 
         return 0.4 * np.log(10) * phi_star * factor ** (alpha + 1) * np.exp(-factor)

--- a/astropy/modeling/projections.py
+++ b/astropy/modeling/projections.py
@@ -1530,7 +1530,6 @@ class AffineTransformation2D(Model):
     @matrix.validator
     def matrix(self, value):
         """Validates that the input matrix is a 2x2 2D array."""
-
         if np.shape(value) != (2, 2):
             raise InputParameterError(
                 "Expected transformation matrix to be a 2x2 array"
@@ -1543,7 +1542,6 @@ class AffineTransformation2D(Model):
         either a "row" vector or a "column" vector where in the latter case the
         resultant Numpy array has ``ndim=2`` but the shape is ``(1, 2)``.
         """
-
         if not (
             (np.ndim(value) == 1 and np.shape(value) == (2,))
             or (np.ndim(value) == 2 and np.shape(value) == (1, 2))
@@ -1565,7 +1563,6 @@ class AffineTransformation2D(Model):
 
         Raises `~astropy.modeling.InputParameterError` if the transformation cannot be inverted.
         """
-
         det = np.linalg.det(self.matrix.value)
 
         if det == 0:

--- a/astropy/modeling/rotations.py
+++ b/astropy/modeling/rotations.py
@@ -506,7 +506,6 @@ class Rotation2D(Model):
     @property
     def inverse(self):
         """Inverse rotation."""
-
         return self.__class__(angle=-self.angle)
 
     @classmethod
@@ -523,7 +522,6 @@ class Rotation2D(Model):
             If float, assumed in degrees.
 
         """
-
         if x.shape != y.shape:
             raise ValueError("Expected input arrays to have the same shape")
 

--- a/astropy/modeling/separable.py
+++ b/astropy/modeling/separable.py
@@ -259,7 +259,6 @@ def _cdot(left, right):
     result : ndarray
         Result from this operation.
     """
-
     left, right = right, left
 
     def _n_inputs_outputs(input, position):

--- a/astropy/modeling/spline.py
+++ b/astropy/modeling/spline.py
@@ -67,7 +67,6 @@ class _Spline(FittableModel):
         Coefficient names generated based on the spline's degree and
         number of knots.
         """
-
         return tuple(list(self._knot_names) + list(self._coeff_names))
 
     @staticmethod
@@ -101,7 +100,6 @@ class _Spline(FittableModel):
 
     def evaluate(self, *args, **kwargs):
         """Extract the optional kwargs passed to call."""
-
         optional_inputs = kwargs
         for arg in self.optional_inputs:
             attribute = self._optional_arg(arg)
@@ -123,7 +121,6 @@ class _Spline(FittableModel):
         """
         Make model callable to model evaluation.
         """
-
         # Hack to allow an optional model argument
         kwargs = self._intercept_optional_inputs(**kwargs)
 
@@ -144,7 +141,6 @@ class _Spline(FittableModel):
         fixed : optional, bool
             If the parameter should be fixed or not
         """
-
         # Hack to allow parameters and attribute array to freely exchange values
         #   _getter forces reading value from attribute array
         #   _setter forces setting value to attribute array
@@ -324,7 +320,6 @@ class Spline1D(_Spline):
         """
         The knots vector.
         """
-
         if self._t is None:
             return np.concatenate(
                 (np.zeros(self._degree + 1), np.ones(self._degree + 1))
@@ -350,7 +345,6 @@ class Spline1D(_Spline):
         """
         The interior knots.
         """
-
         return self.t[self.degree + 1 : -(self.degree + 1)]
 
     @property
@@ -358,7 +352,6 @@ class Spline1D(_Spline):
         """
         The coefficients vector.
         """
-
         if self._c is None:
             return np.zeros(len(self.t))
         else:
@@ -382,7 +375,6 @@ class Spline1D(_Spline):
         """
         The degree of the spline polynomials.
         """
-
         return self._degree
 
     @property
@@ -394,7 +386,6 @@ class Spline1D(_Spline):
         """
         Scipy 'tck' tuple representation.
         """
-
         return (self.t, self.c, self.degree)
 
     @tck.setter
@@ -417,7 +408,6 @@ class Spline1D(_Spline):
         """
         Scipy bspline object representation.
         """
-
         from scipy.interpolate import BSpline
 
         return BSpline(*self.tck)
@@ -436,7 +426,6 @@ class Spline1D(_Spline):
         """
         Dictionary of knot parameters.
         """
-
         return [getattr(self, knot) for knot in self._knot_names]
 
     @property
@@ -453,7 +442,6 @@ class Spline1D(_Spline):
         """
         Dictionary of coefficient parameters.
         """
-
         return [getattr(self, coeff) for coeff in self._coeff_names]
 
     def _init_parameters(self):

--- a/astropy/modeling/statistic.py
+++ b/astropy/modeling/statistic.py
@@ -47,7 +47,6 @@ def leastsquare(measured_vals, updated_model, weights, *x):
     direct control.
 
     """
-
     model_vals = updated_model(*x)
 
     if np.shape(model_vals) != np.shape(measured_vals):

--- a/astropy/modeling/utils.py
+++ b/astropy/modeling/utils.py
@@ -135,7 +135,6 @@ class AliasDict(MutableMapping):
         First iterates over keys from the parent dict (if the aliased keys are
         present in the parent), followed by any keys in the local store.
         """
-
         for key, alias in self._aliases.items():
             if alias in self._parent:
                 yield key
@@ -179,7 +178,6 @@ def make_binary_operator_eval(oper, f, g):
     >>> sum_of_prod(3, 5)
     (30,)
     """
-
     return lambda inputs, params: tuple(
         oper(x, y) for x, y in zip(f(inputs, params), g(inputs, params))
     )
@@ -253,7 +251,6 @@ def combine_labels(left, right):
     However if *any* of the labels conflict, this appends '0' to the left-hand
     labels and '1' to the right-hand labels so there is no ambiguity).
     """
-
     if set(left).intersection(right):
         left = tuple(label + "0" for label in left)
         right = tuple(label + "1" for label in right)

--- a/astropy/nddata/ccddata.py
+++ b/astropy/nddata/ccddata.py
@@ -479,7 +479,6 @@ class CCDData(NDDataArray):
         This addresses that case by checking the length of the ``key`` and
         ``value`` and, if necessary, shortening the key.
         """
-
         if len(key) > 8 and len(value) > 72:
             short_name = key[:8]
             self.meta[f"HIERARCH {key.upper()}"] = (
@@ -519,7 +518,6 @@ def _generate_wcs_and_update_header(hdr):
 
     new_header, wcs
     """
-
     # Try constructing a WCS object.
     try:
         wcs = WCS(hdr)

--- a/astropy/nddata/mixins/ndarithmetic.py
+++ b/astropy/nddata/mixins/ndarithmetic.py
@@ -326,7 +326,6 @@ class NDArithmeticMixin:
             array, but if any of the operands had a unit the return is a
             Quantity.
         """
-
         # Do the calculation with or without units
         if self.unit is None and operand.unit is None:
             result = operation(self.data, operand.data)
@@ -372,7 +371,6 @@ class NDArithmeticMixin:
             subclass that ``self`` had (or ``operand`` if self had no
             uncertainty). ``None`` only if both had no uncertainty.
         """
-
         # Make sure these uncertainties are NDUncertainties so this kind of
         # propagation is possible.
         if self.uncertainty is not None and not isinstance(
@@ -451,7 +449,6 @@ class NDArithmeticMixin:
             If neither had a mask ``None`` is returned. Otherwise
             ``handle_mask`` must create (and copy) the returned mask.
         """
-
         # If only one mask is present we need not bother about any type checks
         if self.mask is None and operand.mask is None:
             return None
@@ -499,7 +496,6 @@ class NDArithmeticMixin:
         result_wcs : any type
             The ``wcs`` of the first operand is returned.
         """
-
         # ok, not really arithmetic but we need to check which wcs makes sense
         # for the result and this is an ideal place to compare the two WCS,
         # too.

--- a/astropy/nddata/utils.py
+++ b/astropy/nddata/utils.py
@@ -84,7 +84,6 @@ def overlap_slices(large_array_shape, small_array_shape, position, mode="partial
         that ``small_array[slices_small]`` extracts the region that is
         inside the large array.
     """
-
     if mode not in ["partial", "trim", "strict"]:
         raise ValueError('Mode can be only "partial", "trim", or "strict".')
     if np.isscalar(small_array_shape):
@@ -229,7 +228,6 @@ def extract_array(
            [75, 76, 77, 78, 79],
            [85, 86, 87, 88, 89]])
     """
-
     if np.isscalar(shape):
         shape = (shape,)
     if np.isscalar(position):
@@ -716,7 +714,6 @@ class Cutout2D:
             ``ax=None``.  Otherwise the output ``ax`` is the same as the
             input ``ax``.
         """
-
         import matplotlib.patches as mpatches
         import matplotlib.pyplot as plt
 

--- a/astropy/samp/client.py
+++ b/astropy/samp/client.py
@@ -413,7 +413,6 @@ class SAMPClient:
             with the MType subscribed to (see also
             :meth:`~astropy.samp.client.SAMPClient.declare_subscriptions`).
         """
-
         self.bind_receive_call(mtype, function, declare=declare, metadata=metadata)
 
         self.bind_receive_notification(

--- a/astropy/samp/hub.py
+++ b/astropy/samp/hub.py
@@ -408,7 +408,6 @@ class SAMPHubServer:
             process runs in a separated thread. `False` is usually used in a
             Python shell.
         """
-
         if self._is_running:
             raise SAMPHubError("Hub is already running")
 
@@ -443,7 +442,6 @@ class SAMPHubServer:
         """
         The hub parameters (which are written to the logfile).
         """
-
         params = {}
 
         # Keys required by standard profile
@@ -497,7 +495,6 @@ class SAMPHubServer:
         """
         Stop the current SAMP Hub instance and delete the lock file.
         """
-
         if not self._is_running:
             return
 
@@ -993,7 +990,6 @@ class SAMPHubServer:
         >>> SAMPHubServer.get_mtype_subtypes("samp.app.ping")
         ['samp.app.ping', 'samp.app.*', 'samp.*', '*']
         """
-
         subtypes = []
 
         msubs = mtype.split(".")
@@ -1308,7 +1304,6 @@ class SAMPHubServer:
         arg_params : tuple
             Any additional arguments to be passed to the SAMP method
         """
-
         if recipient_private_key is None:
             raise SAMPHubError("Invalid client ID")
 

--- a/astropy/samp/hub_proxy.py
+++ b/astropy/samp/hub_proxy.py
@@ -46,7 +46,6 @@ class SAMPHubProxy:
             The number of socket connections opened to communicate with the
             Hub.
         """
-
         self._connected = False
         self.lockfile = {}
 

--- a/astropy/samp/hub_script.py
+++ b/astropy/samp/hub_script.py
@@ -17,7 +17,6 @@ def hub_script(timeout=0):
     """
     This main function is executed by the ``samp_hub`` command line tool.
     """
-
     parser = argparse.ArgumentParser(prog="samp_hub " + __version__)
 
     parser.add_argument(

--- a/astropy/samp/integrated_client.py
+++ b/astropy/samp/integrated_client.py
@@ -299,7 +299,6 @@ class SAMPIntegratedClient:
         ...                   txt = "initialization", percent = "10",
         ...                   extra_kws = {"my.extra.info": "just an example"})
         """
-
         return self.call(recipient_id, msg_tag, self._format_easy_msg(mtype, params))
 
     def call_all(self, msg_tag, message):

--- a/astropy/samp/lockfile_helpers.py
+++ b/astropy/samp/lockfile_helpers.py
@@ -149,7 +149,6 @@ def get_running_hubs():
     running_hubs : dict
         Lock-file contents of all the currently running hubs.
     """
-
     hubs = {}
     lockfilename = ""
 
@@ -201,7 +200,6 @@ def check_running_hub(lockfilename):
     hub_params : dict
         If the hub is running this contains the parameters from the lockfile
     """
-
     is_running = False
     lockfiledict = {}
 

--- a/astropy/samp/standard_profile.py
+++ b/astropy/samp/standard_profile.py
@@ -34,7 +34,6 @@ class SAMPSimpleXMLRPCRequestHandler(SimpleXMLRPCRequestHandler):
         which are forwarded to the server's ``_dispatch`` method for
         handling.
         """
-
         # Check that the path is legal
         if not self.is_rpc_path_valid():
             self.report_404()

--- a/astropy/samp/tests/web_profile_test_helpers.py
+++ b/astropy/samp/tests/web_profile_test_helpers.py
@@ -46,7 +46,6 @@ class SAMPWebHubProxy(SAMPHubProxy):
             The number of socket connections opened to communicate with the
             Hub.
         """
-
         self._connected = False
 
         try:

--- a/astropy/samp/utils.py
+++ b/astropy/samp/utils.py
@@ -83,7 +83,6 @@ class ServerProxyPool:
 
     def shutdown(self):
         """Shut down the proxy pool by closing all active connections."""
-
         while True:
             try:
                 proxy = self._proxies.get_nowait()

--- a/astropy/stats/bayesian_blocks.py
+++ b/astropy/stats/bayesian_blocks.py
@@ -306,7 +306,6 @@ class FitnessFunc:
         If ``ncp_prior`` is not explicitly defined, compute it from ``gamma``
         or ``p0``.
         """
-
         if self.gamma is not None:
             return -np.log(self.gamma)
         elif self.p0 is not None:

--- a/astropy/stats/biweight.py
+++ b/astropy/stats/biweight.py
@@ -109,7 +109,6 @@ def biweight_location(data, c=6.0, M=None, axis=None, *, ignore_nan=False):
     >>> print(biloc)    # doctest: +FLOAT_CMP
     0.01535330525461019
     """
-
     median_func, sum_func = _stat_functions(data, ignore_nan=ignore_nan)
 
     if isinstance(data, np.ma.MaskedArray) and ignore_nan:
@@ -268,7 +267,6 @@ def biweight_scale(
     >>> print(biscl)    # doctest: +FLOAT_CMP
     1.0239311812635818
     """
-
     return np.sqrt(
         biweight_midvariance(
             data,
@@ -616,7 +614,6 @@ def biweight_midcovariance(data, c=9.0, M=None, modify_sample_size=False):
     >>> print(np.sqrt(bicov.diagonal()))  # doctest: +FLOAT_CMP
     [0.91343072 2.67519302]
     """
-
     data = np.asanyarray(data).astype(np.float64)
 
     # ensure data is 2D
@@ -742,7 +739,6 @@ def biweight_midcorrelation(x, y, c=9.0, M=None, modify_sample_size=False):
     >>> print(bicorr)  # doctest: +FLOAT_CMP
     -0.09203238319481295
     """
-
     x = np.asanyarray(x)
     y = np.asanyarray(y)
     if x.ndim != 1:

--- a/astropy/stats/circstats.py
+++ b/astropy/stats/circstats.py
@@ -155,7 +155,6 @@ def circvar(data, axis=None, weights=None):
     Precisely, Scipy circvar uses an approximation based on the limit of small
     angles which approaches the linear variance.
     """
-
     return 1.0 - _length(data, 1, 0.0, axis, weights)
 
 

--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -681,7 +681,6 @@ def poisson_conf_interval(
     array([[ 3.47894005, 16.113329533]])
 
     """
-
     if not np.isscalar(n):
         n = np.asanyarray(n)
 
@@ -794,7 +793,6 @@ def median_absolute_deviation(data, axis=None, func=None, ignore_nan=False):
     --------
     mad_std
     """
-
     if func is None:
         # Check if the array has a mask and if so use np.ma.median
         # See https://github.com/numpy/numpy/issues/7330 why using np.ma.median
@@ -907,7 +905,6 @@ def mad_std(data, axis=None, func=None, ignore_nan=False):
     --------
     biweight_midvariance, biweight_midcovariance, median_absolute_deviation
     """
-
     # NOTE: 1. / scipy.stats.norm.ppf(0.75) = 1.482602218505602
     MAD = median_absolute_deviation(data, axis=axis, func=func, ignore_nan=ignore_nan)
     return MAD * 1.482602218505602
@@ -1098,7 +1095,6 @@ def _scipy_kraft_burrows_nousek(N, B, CL):
     implementation that is slower, but can deal with arbitrarily high numbers
     since it is based on the `mpmath <http://mpmath.org/>`_ library.
     """
-
     from math import exp
 
     from scipy.integrate import quad
@@ -1438,7 +1434,6 @@ def kuiper(data, cdf=lambda x: x, args=()):
 
 
     """
-
     data = np.sort(data)
     cdfv = cdf(data, *args)
     N = len(data)

--- a/astropy/stats/histogram.py
+++ b/astropy/stats/histogram.py
@@ -138,7 +138,6 @@ def histogram(a, bins=10, range=None, weights=None, **kwargs):
     --------
     numpy.histogram
     """
-
     bins = calculate_bin_edges(a, bins=bins, range=range, weights=weights)
     # Now we call numpy's histogram with the resulting bin edges
     return np.histogram(a, bins=bins, range=range, weights=weights, **kwargs)

--- a/astropy/stats/info_theory.py
+++ b/astropy/stats/info_theory.py
@@ -114,7 +114,6 @@ def bayesian_info_criterion(log_likelihood, n_params, n_samples):
     .. [5] Liddle, A. R. How many cosmological parameters? 2008.
        <https://arxiv.org/pdf/astro-ph/0401198v3.pdf>
     """
-
     return n_params * np.log(n_samples) - 2.0 * log_likelihood
 
 
@@ -201,7 +200,6 @@ def bayesian_info_criterion_lsq(ssr, n_params, n_samples):
     .. [3] Astropy Models and Fitting
         <https://docs.astropy.org/en/stable/modeling>
     """
-
     return bayesian_info_criterion(
         -0.5 * n_samples * np.log(ssr / n_samples), n_params, n_samples
     )
@@ -404,7 +402,6 @@ def akaike_info_criterion_lsq(ssr, n_params, n_samples):
     .. [2] Origin Lab. Comparing Two Fitting Functions.
        <https://www.originlab.com/doc/Origin-Help/PostFit-CompareFitFunc>
     """
-
     return akaike_info_criterion(
         -0.5 * n_samples * np.log(ssr / n_samples), n_params, n_samples
     )

--- a/astropy/stats/jackknife.py
+++ b/astropy/stats/jackknife.py
@@ -39,7 +39,6 @@ def jackknife_resampling(data):
 
     .. [3] Jackknife resampling <https://en.wikipedia.org/wiki/Jackknife_resampling>
     """
-
     n = data.shape[0]
     if n <= 0:
         raise ValueError("data must contain at least one measurement.")

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -47,7 +47,6 @@ def _move_tuple_axes_first(array, axis):
 
 def _nanmean(array, axis=None):
     """Bottleneck nanmean function that handle tuple axis."""
-
     if isinstance(axis, tuple):
         array = _move_tuple_axes_first(array, axis=axis)
         axis = 0
@@ -60,7 +59,6 @@ def _nanmean(array, axis=None):
 
 def _nanmedian(array, axis=None):
     """Bottleneck nanmedian function that handle tuple axis."""
-
     if isinstance(axis, tuple):
         array = _move_tuple_axes_first(array, axis=axis)
         axis = 0
@@ -73,7 +71,6 @@ def _nanmedian(array, axis=None):
 
 def _nanstd(array, axis=None, ddof=0):
     """Bottleneck nanstd function that handle tuple axis."""
-
     if isinstance(axis, tuple):
         array = _move_tuple_axes_first(array, axis=axis)
         axis = 0

--- a/astropy/stats/spatial.py
+++ b/astropy/stats/spatial.py
@@ -153,7 +153,6 @@ class RipleysKEstimator:
         output : 1D array
             Ripley's K function evaluated at ``radii``.
         """
-
         return np.pi * radii * radii
 
     def Lfunction(self, data, radii, mode="none"):
@@ -161,7 +160,6 @@ class RipleysKEstimator:
         Evaluates the L function at ``radii``. For parameter description
         see ``evaluate`` method.
         """
-
         return np.sqrt(self.evaluate(data, radii, mode=mode) / np.pi)
 
     def Hfunction(self, data, radii, mode="none"):
@@ -169,7 +167,6 @@ class RipleysKEstimator:
         Evaluates the H function at ``radii``. For parameter description
         see ``evaluate`` method.
         """
-
         return self.Lfunction(data, radii, mode=mode) - radii
 
     def evaluate(self, data, radii, mode="none"):
@@ -221,7 +218,6 @@ class RipleysKEstimator:
         ripley : 1D array
             Ripley's K function estimator evaluated at ``radii``.
         """
-
         data = np.asarray(data)
 
         if not data.shape[1] == 2:

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -768,7 +768,6 @@ class BaseColumn(_ColumnGetitemShim, np.ndarray):
         """
         Format string for displaying values in this column.
         """
-
         return self._format
 
     @format.setter
@@ -1670,7 +1669,6 @@ class MaskedColumn(Column, _MaskedColumnGetitemShim, ma.MaskedArray):
         """Set fill value both in the masked column view and in the parent table
         if it exists.  Setting one or the other alone doesn't work.
         """
-
         # another ma bug workaround: If the value of fill_value for a string array is
         # requested but not yet set then it gets created as 'N/A'.  From this point onward
         # any new fill_values are truncated to 3 characters.  Note that this does not

--- a/astropy/table/groups.py
+++ b/astropy/table/groups.py
@@ -366,7 +366,6 @@ class TableGroups(BaseGroups):
         out : Table
             New table with the aggregated rows.
         """
-
         i0s = self.indices[:-1]
         out_cols = []
         parent_table = self.parent_table

--- a/astropy/table/index.py
+++ b/astropy/table/index.py
@@ -755,7 +755,6 @@ class _IndexModeContext:
         case where a copy of the indices is not needed.  See the docstring for
         ``astropy.table._column_mixins`` for more information on that.
         """
-
         if cls in self._col_subclasses:
             return self._col_subclasses[cls]
 
@@ -837,7 +836,6 @@ class TableLoc:
         """
         Retrieve Table rows indexes by value slice.
         """
-
         if isinstance(item, tuple):
             key, item = item
         else:

--- a/astropy/table/meta.py
+++ b/astropy/table/meta.py
@@ -300,7 +300,6 @@ def get_yaml_from_table(table):
     lines : list
         List of text lines with YAML header content
     """
-
     header = {"cols": list(table.columns.values())}
     if table.meta:
         header["meta"] = table.meta

--- a/astropy/table/np_utils.py
+++ b/astropy/table/np_utils.py
@@ -33,7 +33,6 @@ def get_col_name_map(
     will be present, while for the other non-key columns the value will be (col_name_0,
     None, ..) or (None, col_name_1, ..) etc.
     """
-
     col_name_map = collections.defaultdict(lambda: [None] * len(arrays))
     col_name_list = []
 
@@ -87,7 +86,6 @@ def get_descrs(arrays, col_name_map):
 
     Return a list of descrs for the output.
     """
-
     out_descrs = []
 
     for out_name, in_names in col_name_map.items():

--- a/astropy/table/operations.py
+++ b/astropy/table/operations.py
@@ -51,7 +51,6 @@ def _get_list_of_tables(tables):
     Check that tables is a Table or sequence of Tables.  Returns the
     corresponding list of Tables.
     """
-
     # Make sure we have a list of things
     if not isinstance(tables, Sequence):
         tables = [tables]
@@ -407,7 +406,6 @@ def join(
     joined_table : `~astropy.table.Table` object
         New table containing the result of the join operation.
     """
-
     # Try converting inputs to Table as needed
     if not isinstance(left, Table):
         left = Table(left)
@@ -863,7 +861,6 @@ def unique(input_table, keys=None, silent=False, keep="first"):
         1     2     3
 
     """
-
     if keep not in ("first", "last", "none"):
         raise ValueError("'keep' should be one of 'first', 'last', 'none'")
 
@@ -920,7 +917,6 @@ def get_col_name_map(
     will be present, while for the other non-key columns the value will be (col_name_0,
     None, ..) or (None, col_name_1, ..) etc.
     """
-
     col_name_map = collections.defaultdict(lambda: [None] * len(arrays))
     col_name_list = []
 
@@ -974,7 +970,6 @@ def get_descrs(arrays, col_name_map):
 
     Return a list of descrs for the output.
     """
-
     out_descrs = []
 
     for out_name, in_names in col_name_map.items():
@@ -1568,7 +1563,6 @@ def _hstack(
     stacked_table : `~astropy.table.Table` object
         New table containing the stacked data from the input tables.
     """
-
     # Store user-provided col_name_map until the end
     _col_name_map = col_name_map
 

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -1280,7 +1280,6 @@ class Table:
         col : Column, MaskedColumn, mixin-column type
             Object that can be used as a column in self
         """
-
         data_is_mixin = self._is_mixin_for_table(data)
         masked_col_cls = (
             self.ColumnClass
@@ -1402,7 +1401,6 @@ class Table:
 
     def _init_from_ndarray(self, data, names, dtype, n_cols, copy):
         """Initialize table from an ndarray structured array."""
-
         data_names = data.dtype.names or _auto_names(n_cols)
         struct = data.dtype.names is not None
         names = [name or data_names[i] for i, name in enumerate(names)]
@@ -1417,7 +1415,6 @@ class Table:
 
     def _init_from_dict(self, data, names, dtype, n_cols, copy):
         """Initialize table from a dictionary of columns."""
-
         data_list = [data[name] for name in names]
         self._init_from_list(data_list, names, dtype, n_cols, copy)
 
@@ -1431,7 +1428,6 @@ class Table:
         of the table MaskedColumn.  If not a MaskedColumn, then ensure that any
         Column-like object is a subclass of the table Column.
         """
-
         col_cls = col.__class__
 
         if self.masked:
@@ -1462,7 +1458,6 @@ class Table:
 
     def _init_from_cols(self, cols):
         """Initialize table from a list of Column or mixin objects."""
-
         lengths = {len(col) for col in cols}
         if len(lengths) > 1:
             raise ValueError(f"Inconsistent data column lengths: {lengths}")
@@ -1488,7 +1483,6 @@ class Table:
 
     def _new_from_slice(self, slice_):
         """Create a new table as a referenced slice from self."""
-
         table = self.__class__(masked=self.masked)
         if self.meta:
             table.meta = self.meta.copy()  # Shallow copy for slice
@@ -1803,7 +1797,6 @@ class Table:
         call this method while offline (and don't have a cached version of
         jquery and jquery.dataTables), you will not get the jsviewer features.
         """
-
         from IPython.display import HTML
 
         from .jsviewer import JSViewer
@@ -1885,7 +1878,6 @@ class Table:
             that if a column with this name already exists, this option will be
             ignored. Defaults to "idx".
         """
-
         import os
         import tempfile
         import webbrowser
@@ -1954,7 +1946,6 @@ class Table:
         ``astropy.conf.max_width``.
 
         """
-
         lines, outs = self.formatter._pformat_table(
             self,
             max_lines,
@@ -2000,7 +1991,6 @@ class Table:
         ``astropy.conf.max_width``.
 
         """
-
         return self.pformat(
             max_lines,
             max_width,
@@ -2861,7 +2851,6 @@ class Table:
 
         To remove several columns at the same time use remove_columns.
         """
-
         self.remove_columns([name])
 
     def remove_columns(self, names):
@@ -2924,7 +2913,6 @@ class Table:
         out_kind : str
             Output dtype.kind
         """
-
         for col in self.itercols():
             if col.dtype.kind == in_kind:
                 try:
@@ -3054,7 +3042,6 @@ class Table:
               1   3   5
               2   4   6
         """
-
         if name not in self.keys():
             raise KeyError(f"Column {name} does not exist")
 
@@ -3093,7 +3080,6 @@ class Table:
               1   3   5
               2   4   6
         """
-
         if not self._is_list_or_tuple_of_str(names):
             raise TypeError("input 'names' must be a tuple or a list of column names")
 
@@ -3711,7 +3697,6 @@ class Table:
             array([ True,  True])
 
         """
-
         if isinstance(other, Table):
             other = other.as_array()
 
@@ -4093,7 +4078,6 @@ class Table:
           2002-01-01T00:00:00.000     300.0     4.0
 
         """
-
         out = OrderedDict()
 
         names = list(dataframe.columns)

--- a/astropy/tests/command.py
+++ b/astropy/tests/command.py
@@ -172,7 +172,6 @@ class AstropyTest(Command, metaclass=FixRemoteDataOption):
         """
         Build a Python script to run the tests.
         """
-
         cmd_pre = ""  # Commands to run before the test function
         cmd_post = ""  # Commands to run after the test function
 
@@ -208,7 +207,6 @@ class AstropyTest(Command, metaclass=FixRemoteDataOption):
 
     def run(self):
         """Run the tests!"""
-
         # Install the runtime dependencies.
         if self.distribution.install_requires:
             self.distribution.fetch_build_eggs(self.distribution.install_requires)
@@ -286,7 +284,6 @@ class AstropyTest(Command, metaclass=FixRemoteDataOption):
         entry points, and also avoids creating pyc and __pycache__ directories
         inside the build directory.
         """
-
         # On OSX the default path for temp files is under /var, but in most
         # cases on OSX /var is actually a symlink to /private/var; ensure we
         # dereference that link, because pytest is very sensitive to relative

--- a/astropy/tests/figures/helpers.py
+++ b/astropy/tests/figures/helpers.py
@@ -15,7 +15,6 @@ def figure_test(*args, **kwargs):
     options used by all figure tests in astropy, and also adds the decorator
     to allow remote data to be accessed.
     """
-
     # NOTE: the savefig_kwargs option below is to avoid using PNG files with
     # the matplotlib version embedded since this changes for every developer
     # version.

--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -258,7 +258,6 @@ class TestRunnerBase:
         was called from.  This is used to implement the ``astropy.test()``
         function (or the equivalent for affiliated packages).
         """
-
         runner = cls(path)
 
         @wraps(runner.run_tests, ("__doc__",))
@@ -470,7 +469,6 @@ class TestRunner(TestRunnerBase):
             data from http://data.astropy.org (``astropy``), or all tests that
             use remote data (``any``). The default is ``none``.
         """
-
         if remote_data is True:
             remote_data = "any"
         elif remote_data is False:
@@ -574,7 +572,6 @@ class TestRunner(TestRunnerBase):
         docs_path : str, optional
             The path to the documentation .rst files.
         """
-
         paths = []
         if docs_path is not None and not kwargs["skip_docs"]:
             if kwargs["package"] is not None:

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -154,7 +154,6 @@ def _compress_array_dims(arr):
     out : array-like
         Compressed array.
     """
-
     idxs = []
     edgeitems = np.get_printoptions()["edgeitems"]
 
@@ -562,7 +561,6 @@ class TimeBase(ShapedLikeNDArray):
         If format is `None` and the input is a string-type or object array then
         guess available formats and stop when one matches.
         """
-
         if format is None and (
             val.dtype.kind in ("S", "U", "O", "M") or val.dtype.names
         ):
@@ -728,7 +726,6 @@ class TimeBase(ShapedLikeNDArray):
         This is the key routine that actually does time scale conversions.
         This is not public and not connected to the read-only scale property.
         """
-
         if scale == self.scale:
             return
         if scale not in self.SCALES:
@@ -1870,7 +1867,6 @@ class Time(TimeBase):
 
     def _make_value_equivalent(self, item, value):
         """Coerce setitem value into an equivalent Time object."""
-
         # If there is a vector location then broadcast to the Time shape
         # and then select with ``item``
         if self.location is not None and self.location.shape:
@@ -2074,7 +2070,6 @@ class Time(TimeBase):
             time in the Solar system barycentre or the Heliocentre.
             Also, the time conversion to BJD will then include the relativistic correction as well.
         """
-
         if kind.lower() not in ("barycentric", "heliocentric"):
             raise ValueError(
                 "'kind' parameter must be one of 'heliocentric' or 'barycentric'"
@@ -2241,7 +2236,6 @@ class Time(TimeBase):
         corrected for polar motion (except when ``longitude='tio'`` or ``'greenwich'``).
 
         """  # (docstring is formatted below)
-
         if kind.lower() not in SIDEREAL_TIME_MODELS:
             raise ValueError(
                 "The kind of sidereal time has to be "
@@ -2820,7 +2814,6 @@ class TimeDelta(TimeBase):
         This is the key routine that actually does time scale conversions.
         This is not public and not connected to the read-only scale property.
         """
-
         if scale == self.scale:
             return
         if scale not in self.SCALES:

--- a/astropy/timeseries/binned.py
+++ b/astropy/timeseries/binned.py
@@ -315,7 +315,6 @@ class BinnedTimeSeries(BaseTimeSeries):
             BinnedTimeSeries corresponding to the file.
 
         """
-
         try:
             # First we try the readers defined for the BinnedTimeSeries class
             return super().read(filename, format=format, *args, **kwargs)

--- a/astropy/timeseries/downsample.py
+++ b/astropy/timeseries/downsample.py
@@ -100,7 +100,6 @@ def aggregate_downsample(
     binned_time_series : :class:`~astropy.timeseries.BinnedTimeSeries`
         The downsampled time series.
     """
-
     if not isinstance(time_series, TimeSeries):
         raise TypeError("time_series should be a TimeSeries")
 

--- a/astropy/timeseries/periodograms/base.py
+++ b/astropy/timeseries/periodograms/base.py
@@ -35,7 +35,6 @@ class BasePeriodogram:
             Additional keyword arguments are passed to the initializer for this
             periodogram class.
         """
-
         if signal_column_name is None:
             raise ValueError("signal_column_name should be set to a valid column name")
 

--- a/astropy/timeseries/periodograms/bls/core.py
+++ b/astropy/timeseries/periodograms/bls/core.py
@@ -173,7 +173,6 @@ class BoxLeastSquares(BasePeriodogram):
         coarser by increasing ``frequency_factor``.
 
         """
-
         duration = self._validate_duration(duration)
         baseline = strip_units(self._trel.max() - self._trel.min())
         min_duration = strip_units(np.min(duration))
@@ -356,7 +355,6 @@ class BoxLeastSquares(BasePeriodogram):
         current _tstart value. If the times provided are relative, they are
         returned without conversion (though we still do some checks).
         """
-
         if isinstance(times, TimeDelta):
             times = times.to("day")
 
@@ -417,7 +415,6 @@ class BoxLeastSquares(BasePeriodogram):
             The model evaluated at the times ``t_model`` with units of ``y``.
 
         """
-
         period, duration = self._validate_period_and_duration(period, duration)
 
         transit_time = self._as_relative_time("transit_time", transit_time)
@@ -495,7 +492,6 @@ class BoxLeastSquares(BasePeriodogram):
                 baseline.
 
         """
-
         period, duration = self._validate_period_and_duration(period, duration)
         transit_time = self._as_relative_time("transit_time", transit_time)
 
@@ -622,7 +618,6 @@ class BoxLeastSquares(BasePeriodogram):
             ``False`` indicates and out-of-transit point.
 
         """
-
         period, duration = self._validate_period_and_duration(period, duration)
         transit_time = self._as_relative_time("transit_time", transit_time)
         t = strip_units(self._as_relative_time("t", t))
@@ -658,7 +653,6 @@ class BoxLeastSquares(BasePeriodogram):
             converted to the units of y.
 
         """
-
         # Validate shapes of inputs
         if dy is None:
             t, y = np.broadcast_arrays(t, y, subok=True)

--- a/astropy/timeseries/periodograms/lombscargle/core.py
+++ b/astropy/timeseries/periodograms/lombscargle/core.py
@@ -397,7 +397,6 @@ class LombScargle(BasePeriodogram):
         current _tstart value. If the times provided are relative, they are
         returned without conversion (though we still do some checks).
         """
-
         if isinstance(times, TimeDelta):
             times = times.to("day")
 

--- a/astropy/timeseries/sampled.py
+++ b/astropy/timeseries/sampled.py
@@ -196,7 +196,6 @@ class TimeSeries(BaseTimeSeries):
         folded_timeseries : `~astropy.timeseries.TimeSeries`
             The folded time series object with phase as the ``time`` column.
         """
-
         if not isinstance(period, Quantity) or period.unit.physical_type != "time":
             raise UnitsError("period should be a Quantity in units of time")
 

--- a/astropy/units/cds.py
+++ b/astropy/units/cds.py
@@ -27,7 +27,6 @@ _ns = globals()
 
 def _initialize_module():
     """Initialize CDS units module."""
-
     # Local imports to avoid polluting top-level namespace
     import numpy as np
 

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -757,7 +757,6 @@ class UnitBase:
             The name of a format or a formatter object.  If not
             provided, defaults to the generic format.
         """
-
         f = unit_format.get_format(format)
         return f.to_string(self)
 
@@ -1062,7 +1061,6 @@ class UnitBase:
         (which is used as a check in quantity helpers).
 
         """
-
         # First see if it is just a scaling.
         try:
             scale = self._to(other)
@@ -1499,7 +1497,6 @@ class UnitBase:
         """
         Returns a copy of the current `Unit` instance in SI units.
         """
-
         from . import si
 
         return self.to_system(si)[0]
@@ -2587,7 +2584,6 @@ def def_unit(
         The newly-defined unit, or a matching unit that was already
         defined.
     """
-
     if represents is not None:
         result = Unit(s, represents, namespace=namespace, doc=doc, format=format)
     else:

--- a/astropy/units/decorators.py
+++ b/astropy/units/decorators.py
@@ -50,7 +50,6 @@ def _validate_arg_value(
     Validates the object passed in to the wrapped function, ``arg``, with target
     unit or physical type, ``target``.
     """
-
     if len(targets) == 0:
         return
 

--- a/astropy/units/equivalencies.py
+++ b/astropy/units/equivalencies.py
@@ -351,7 +351,6 @@ def doppler_radio(rest):
     >>> radio_velocity  # doctest: +FLOAT_CMP
     <Quantity -31.209092088877583 km / s>
     """
-
     assert_is_spectral_unit(rest)
 
     ckms = _si.c.to_value("km/s")
@@ -421,7 +420,6 @@ def doppler_optical(rest):
     >>> optical_velocity  # doctest: +FLOAT_CMP
     <Quantity -31.20584348799674 km / s>
     """
-
     assert_is_spectral_unit(rest)
 
     ckms = _si.c.to_value("km/s")
@@ -499,7 +497,6 @@ def doppler_relativistic(rest):
     >>> relativistic_wavelength  # doctest: +FLOAT_CMP
     <Quantity 2.6116243681798923 mm>
     """
-
     assert_is_spectral_unit(rest)
 
     ckms = _si.c.to_value("km/s")
@@ -847,7 +844,6 @@ def pixel_scale(pixscale):
     pixscale : `~astropy.units.Quantity`
         The pixel scale either in units of <unit>/pixel or pixel/<unit>.
     """
-
     decomposed = pixscale.unit.decompose()
     dimensions = dict(zip(decomposed.bases, decomposed.powers))
     pix_power = dimensions.get(misc.pix, 0)

--- a/astropy/units/format/base.py
+++ b/astropy/units/format/base.py
@@ -28,7 +28,6 @@ class Base:
         """
         Convert a string to a unit object.
         """
-
         raise NotImplementedError(f"Can not parse with {cls.__name__} format")
 
     @classmethod
@@ -36,5 +35,4 @@ class Base:
         """
         Convert a unit object to a string.
         """
-
         raise NotImplementedError(f"Can not output in {cls.__name__} format")

--- a/astropy/units/format/cds.py
+++ b/astropy/units/format/cds.py
@@ -141,7 +141,6 @@ class CDS(Base):
         YACC grammar in the `unity library
         <https://bitbucket.org/nxg/unity/>`_.
         """
-
         tokens = cls._tokens
 
         def p_main(p):

--- a/astropy/units/format/ogip.py
+++ b/astropy/units/format/ogip.py
@@ -167,7 +167,6 @@ class OGIP(generic.Generic):
         based on the YACC grammar in the `unity library
         <https://bitbucket.org/nxg/unity/>`_.
         """
-
         tokens = cls._tokens
 
         def p_main(p):
@@ -215,7 +214,6 @@ class OGIP(generic.Generic):
                             | UNIT OPEN_PAREN complete_expression CLOSE_PAREN power numeric_power
                             | OPEN_PAREN complete_expression CLOSE_PAREN power numeric_power
             """
-
             # If we run p[1] in cls._functions, it will try and parse each
             # item in the list into a unit, which is slow. Since we know that
             # all the items in the list are strings, we can simply convert

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -217,7 +217,6 @@ class QuantityInfo(QuantityInfoBase):
             Empty instance of this class consistent with ``cols``
 
         """
-
         # Get merged info attributes like shape, dtype, format, description, etc.
         attrs = self.merge_cols_attributes(
             cols, metadata_conflicts, name, ("meta", "format", "description")
@@ -1016,7 +1015,6 @@ class Quantity(np.ndarray):
         A `~astropy.units.UnitBase` object representing the unit of this
         quantity.
         """
-
         return self._unit
 
     @property
@@ -1025,7 +1023,6 @@ class Quantity(np.ndarray):
         A list of equivalencies that will be applied by default during
         unit conversions.
         """
-
         return self._equivalencies
 
     def _recursively_apply(self, func):
@@ -1214,7 +1211,6 @@ class Quantity(np.ndarray):
     # Arithmetic operations
     def __mul__(self, other):
         """Multiplication between `Quantity` objects and other objects."""
-
         if isinstance(other, (UnitBase, str)):
             try:
                 return self._new_view(
@@ -1227,7 +1223,6 @@ class Quantity(np.ndarray):
 
     def __imul__(self, other):
         """In-place multiplication between `Quantity` objects and others."""
-
         if isinstance(other, (UnitBase, str)):
             self._set_unit(other * self.unit)
             return self
@@ -1238,12 +1233,10 @@ class Quantity(np.ndarray):
         """
         Right Multiplication between `Quantity` objects and other objects.
         """
-
         return self.__mul__(other)
 
     def __truediv__(self, other):
         """Division between `Quantity` objects and other objects."""
-
         if isinstance(other, (UnitBase, str)):
             try:
                 return self._new_view(
@@ -1256,7 +1249,6 @@ class Quantity(np.ndarray):
 
     def __itruediv__(self, other):
         """Inplace division between `Quantity` objects and other objects."""
-
         if isinstance(other, (UnitBase, str)):
             self._set_unit(self.unit / other)
             return self
@@ -1265,7 +1257,6 @@ class Quantity(np.ndarray):
 
     def __rtruediv__(self, other):
         """Right Division between `Quantity` objects and other objects."""
-
         if isinstance(other, (UnitBase, str)):
             return self._new_view(1.0 / self.value, other / self.unit, finalize=False)
 
@@ -1606,7 +1597,6 @@ class Quantity(np.ndarray):
             A new object equal to this quantity with units decomposed.
 
         """
-
         new_unit = self.unit.decompose(bases=bases)
 
         # Be careful here because self.value usually is a view of self;

--- a/astropy/units/quantity_helper/converters.py
+++ b/astropy/units/quantity_helper/converters.py
@@ -165,7 +165,6 @@ def converters_and_unit(function, method, *args):
     UnitTypeError : when the conversion to the required (or consistent) units
         is not possible.
     """
-
     # Check whether we support this ufunc, by getting the helper function
     # (defined in helpers) which returns a list of function(s) that convert the
     # input(s) to the unit required for the ufunc, as well as the unit the

--- a/astropy/units/quantity_helper/function_helpers.py
+++ b/astropy/units/quantity_helper/function_helpers.py
@@ -327,7 +327,6 @@ def _quantities2arrays(*args, unit_from_first=False):
     If unit_from_first, take the unit of the first argument regardless
     whether it actually defined a unit (e.g., dimensionless for arrays).
     """
-
     # Turn first argument into a quantity.
     q = _as_quantity(args[0])
     if len(args) == 1:

--- a/astropy/units/utils.py
+++ b/astropy/units/utils.py
@@ -25,7 +25,6 @@ def _get_first_sentence(s):
     Get the first sentence from a string and remove any carriage
     returns.
     """
-
     x = re.match(r".*?\S\.\s", s)
     if x is not None:
         s = x.group(0)
@@ -37,7 +36,6 @@ def _iter_unit_summary(namespace):
     Generates the ``(unit, doc, represents, aliases, prefixes)``
     tuple used to format the unit summary docs in `generate_unit_summary`.
     """
-
     from . import core
 
     # Get all of the units, and keep track of which ones have SI
@@ -95,7 +93,6 @@ def generate_unit_summary(namespace):
     docstring : str
         A docstring containing a summary table of the units.
     """
-
     docstring = io.StringIO()
 
     docstring.write(

--- a/astropy/utils/argparse.py
+++ b/astropy/utils/argparse.py
@@ -11,7 +11,6 @@ def directory(arg):
     `argparse.ArgumentParser.add_argument` which determines if the argument is
     an existing directory (and returns the absolute path).
     """
-
     if not isinstance(arg, str) and os.path.isdir(arg):
         raise argparse.ArgumentTypeError(
             f"{arg} is not a directory or does not exist (the directory must "
@@ -27,7 +26,6 @@ def readable_directory(arg):
     `argparse.ArgumentParser.add_argument` which determines if the argument is
     a directory that exists and is readable (and returns the absolute path).
     """
-
     arg = directory(arg)
 
     if not os.access(arg, os.R_OK):
@@ -44,7 +42,6 @@ def writeable_directory(arg):
     `argparse.ArgumentParser.add_argument` which determines if the argument is
     a directory that exists and is writeable (and returns the absolute path).
     """
-
     arg = directory(arg)
 
     if not os.access(arg, os.W_OK):

--- a/astropy/utils/codegen.py
+++ b/astropy/utils/codegen.py
@@ -47,7 +47,6 @@ def make_function_with_signature(
 
     Note, the names may only be valid Python variable names.
     """
-
     pos_args = []
     key_args = []
 

--- a/astropy/utils/console.py
+++ b/astropy/utils/console.py
@@ -111,7 +111,6 @@ def _get_stdout(stderr=False):
     logic for use in IPython on Windows to determine the correct stream to use
     (usually ``IPython.util.io.stdout`` but only if sys.stdout is a TTY).
     """
-
     if stderr:
         stream = "stderr"
     else:
@@ -172,7 +171,6 @@ def terminal_size(file=None):
     before falling back on the width and height in astropy's
     configuration.
     """
-
     if file is None:
         file = _get_stdout()
 
@@ -257,7 +255,6 @@ def _decode_preferred_encoding(s):
     is invalid, fall back first on utf-8, then on latin-1 if the message cannot
     be decoded with utf-8.
     """
-
     enc = locale.getpreferredencoding()
     try:
         try:
@@ -334,7 +331,6 @@ def color_print(*args, end="\n", **kwargs):
         The ending of the message.  Defaults to ``\\n``.  The end will
         be printed after resetting any color or font state.
     """
-
     file = kwargs.get("file", _get_stdout())
 
     write = file.write
@@ -585,7 +581,6 @@ class ProgressBar:
         """
         Update progress bar via the console or notebook accordingly.
         """
-
         # Update self.value
         if value is None:
             value = self._current_value + 1
@@ -602,7 +597,6 @@ class ProgressBar:
         Update the progress bar to the given value (out of the total
         given to the constructor).
         """
-
         if self._total == 0:
             frac = 1.0
         else:
@@ -645,7 +639,6 @@ class ProgressBar:
 
         This method is for use in the IPython notebook 2+.
         """
-
         # Create and display an empty progress bar widget,
         # if none exists.
         if not hasattr(self, "_widget"):
@@ -735,7 +728,6 @@ class ProgressBar:
             other anomalies occur with the "fork" method (the default on
             Linux).
         """
-
         if multiprocess:
             function = _mapfunc(function)
             items = list(enumerate(items))
@@ -897,7 +889,6 @@ class Spinner:
         chars : str, optional
             The character sequence to use for the spinner
         """
-
         if file is None:
             file = _get_stdout()
 
@@ -982,7 +973,6 @@ class Spinner:
             Ignored (present just for compatibility with `ProgressBar.update`).
 
         """
-
         next(self)
 
     def _silent_iterator(self):
@@ -1038,7 +1028,6 @@ class ProgressBarOrSpinner:
             member, if any), only ``msg`` will be displayed: the
             `ProgressBar` or `Spinner` will be silent.
         """
-
         if file is None:
             file = _get_stdout()
 
@@ -1101,7 +1090,6 @@ def print_code_line(line, col=None, file=None, tabwidth=8, width=70):
         truncated.  Defaults to 70 (this matches the default in the
         standard library's `textwrap` module).
     """
-
     if file is None:
         file = _get_stdout()
 

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -297,7 +297,6 @@ def get_readable_fileobj(
     -------
     file : readable file-like
     """
-
     # close_fds is a list of file handles created by this function
     # that need to be closed.  We don't want to always just close the
     # returned file handle, because it may simply be the file handle
@@ -607,7 +606,6 @@ def get_pkg_data_fileobj(data_name, package=None, encoding=None, cache=True):
     get_pkg_data_contents : returns the contents of a file or url as a bytes object
     get_pkg_data_filename : returns a local name for a file containing the data
     """
-
     datafn = get_pkg_data_path(data_name, package=package)
     if os.path.isdir(datafn):
         raise OSError(
@@ -713,7 +711,6 @@ def get_pkg_data_filename(
     get_pkg_data_contents : returns the contents of a file or url as a bytes object
     get_pkg_data_fileobj : returns a file-like object with the data
     """
-
     if remote_timeout is None:
         # use configfile default
         remote_timeout = conf.remote_timeout
@@ -820,7 +817,6 @@ def get_pkg_data_contents(data_name, package=None, encoding=None, cache=True):
     get_pkg_data_fileobj : returns a file-like object with the data
     get_pkg_data_filename : returns a local name for a file containing the data
     """
-
     with get_pkg_data_fileobj(
         data_name, package=package, encoding=encoding, cache=cache
     ) as fd:
@@ -871,7 +867,6 @@ def get_pkg_data_filenames(datadir, package=None, pattern="*"):
         ...         fcontents = f.read()
         ...
     """
-
     path = get_pkg_data_path(datadir, package=package)
     if os.path.isfile(path):
         raise OSError(
@@ -942,7 +937,6 @@ def get_pkg_data_fileobjs(datadir, package=None, pattern="*", encoding=None):
         ...     fcontents = fd.read()
         ...
     """
-
     for fn in get_pkg_data_filenames(datadir, package=package, pattern=pattern):
         with get_readable_fileobj(fn, encoding=encoding) as fd:
             yield fd

--- a/astropy/utils/decorators.py
+++ b/astropy/utils/decorators.py
@@ -85,7 +85,6 @@ def deprecated(
         Warning to be issued.
         Default is `~astropy.utils.exceptions.AstropyDeprecationWarning`.
     """
-
     method_types = (classmethod, staticmethod, types.MethodType)
 
     def deprecate_doc(old_doc, message):
@@ -117,7 +116,6 @@ def deprecated(
         Returns a wrapped function that displays ``warning_type``
         when it is called.
         """
-
         if isinstance(func, method_types):
             func_wrapper = type(func)
         else:

--- a/astropy/utils/introspection.py
+++ b/astropy/utils/introspection.py
@@ -66,7 +66,6 @@ def resolve_name(name, *additional_parts):
     `ImportError`
         If the module or named object is not found.
     """
-
     additional_parts = ".".join(additional_parts)
 
     if additional_parts:
@@ -248,7 +247,6 @@ def find_current_module(depth=1, finddiff=False):
         pkg.mod1
 
     """
-
     frm = inspect.currentframe()
     for i in range(depth):
         frm = frm.f_back
@@ -290,7 +288,6 @@ def _get_module_from_frame(frm):
     reliable in general, but more reliable than inspect.getmodule() for this
     particular case.
     """
-
     mod = inspect.getmodule(frm)
     if mod is not None:
         return mod
@@ -357,7 +354,6 @@ def find_mod_objs(modname, onlylocals=False):
         the other arguments)
 
     """
-
     mod = resolve_name(modname)
 
     if hasattr(mod, "__all__"):
@@ -431,7 +427,6 @@ def isinstancemethod(cls, obj):
     >>> isinstancemethod(MyClass, MyClass.an_instancemethod)
     True
     """
-
     return _isinstancemethod(cls, obj)
 
 

--- a/astropy/utils/metadata.py
+++ b/astropy/utils/metadata.py
@@ -306,7 +306,6 @@ def enable_merge_strategies(*merge_strategies):
         Merge strategies that will be enabled.
 
     """
-
     return _EnableMergeStrategies(*merge_strategies)
 
 

--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -56,7 +56,6 @@ _NOT_OVERWRITING_MSG_MATCH = (
 
 def isiterable(obj):
     """Returns `True` if the given object is iterable."""
-
     try:
         iter(obj)
         return True
@@ -66,7 +65,6 @@ def isiterable(obj):
 
 def indent(s, shift=1, width=4):
     """Indent a block of text.  The indentation is applied to each line."""
-
     indented = "\n".join(" " * (width * shift) + l if l else "" for l in s.splitlines())
     if s[-1] == "\n":
         indented += "\n"
@@ -84,7 +82,6 @@ class _DummyFile:
 @contextlib.contextmanager
 def silence():
     """A context manager that silences sys.stdout and sys.stderr."""
-
     old_stdout = sys.stdout
     old_stderr = sys.stderr
     sys.stdout = _DummyFile()
@@ -118,7 +115,6 @@ def format_exception(msg, *args, **kwargs):
         outside of an ``except`` clause - if it is, this will substitute
         '<unknown>' for the 4 formatting arguments.
     """
-
     tb = traceback.extract_tb(sys.exc_info()[2], limit=1)
     if len(tb) > 0:
         filename, lineno, func, text = tb[0]
@@ -603,7 +599,6 @@ class OrderedDescriptor(metaclass=abc.ABCMeta):
         Defined for convenient sorting of `OrderedDescriptor` instances, which
         are defined to sort in their creation order.
         """
-
         if isinstance(self, OrderedDescriptor) and isinstance(other, OrderedDescriptor):
             try:
                 return self.__order < other.__order

--- a/astropy/utils/shapes.py
+++ b/astropy/utils/shapes.py
@@ -344,7 +344,6 @@ def check_broadcast(*shapes):
         If all shapes are mutually broadcastable, returns a tuple of the full
         broadcast shape.
     """
-
     if len(shapes) == 0:
         return ()
     elif len(shapes) == 1:
@@ -383,7 +382,6 @@ def unbroadcast(array):
     See https://stackoverflow.com/questions/40845769/un-broadcasting-numpy-arrays
     for more details.
     """
-
     if array.ndim == 0:
         return array
 

--- a/astropy/utils/xml/validate.py
+++ b/astropy/utils/xml/validate.py
@@ -30,7 +30,6 @@ def validate_schema(filename, schema_file):
         Returns the returncode from xmllint and the stdout and stderr
         as strings
     """
-
     base, ext = os.path.splitext(schema_file)
     if ext == ".xsd":
         schema_part = "--schema"

--- a/astropy/visualization/interval.py
+++ b/astropy/visualization/interval.py
@@ -46,7 +46,6 @@ class BaseInterval(BaseTransform):
         vmin, vmax : float
             The mininium and maximum image value in the interval.
         """
-
         raise NotImplementedError("Needs to be implemented in a subclass.")
 
     def __call__(self, values, clip=True, out=None):
@@ -69,7 +68,6 @@ class BaseInterval(BaseTransform):
         result : ndarray
             The transformed values.
         """
-
         vmin, vmax = self.get_limits(values)
 
         if out is None:

--- a/astropy/visualization/mpl_normalize.py
+++ b/astropy/visualization/mpl_normalize.py
@@ -149,7 +149,6 @@ class ImageNormalize(Normalize):
             0).  If `None`, then the `ImageNormalize` instance value is
             used.  This keyword has no effect if ``clip=True``.
         """
-
         if clip is None:
             clip = self.clip
 
@@ -301,7 +300,6 @@ def simple_norm(
         An `ImageNormalize` instance that can be used for displaying
         images with Matplotlib.
     """
-
     if percent is not None:
         interval = PercentileInterval(percent)
     elif min_percent is not None or max_percent is not None:

--- a/astropy/visualization/stretch.py
+++ b/astropy/visualization/stretch.py
@@ -41,7 +41,6 @@ def _prepare(values, clip=True, out=None):
     Prepare the data by optionally clipping and copying, and return the
     array that should be subsequently used for in-place calculations.
     """
-
     if clip:
         return np.clip(values, 0.0, 1.0, out=out)
     else:
@@ -172,7 +171,6 @@ class SqrtStretch(BaseStretch):
         result : ndarray
             The transformed values.
         """
-
         values = _prepare(values, clip=clip, out=out)
         replace_invalid = not clip and invalid is not None
         with np.errstate(invalid="ignore"):
@@ -248,7 +246,6 @@ class PowerStretch(BaseStretch):
         result : ndarray
             The transformed values.
         """
-
         values = _prepare(values, clip=clip, out=out)
         replace_invalid = (
             not clip
@@ -420,7 +417,6 @@ class LogStretch(BaseStretch):
         result : ndarray
             The transformed values.
         """
-
         values = _prepare(values, clip=clip, out=out)
         replace_invalid = not clip and invalid is not None
         with np.errstate(invalid="ignore"):

--- a/astropy/visualization/time.py
+++ b/astropy/visualization/time.py
@@ -43,7 +43,6 @@ def time_support(*, scale=None, format=None, simplify=True):
         If possible, simplify labels, e.g. by removing 00:00:00.000 times from
         ISO strings if all labels fall on that time.
     """
-
     import matplotlib.units as units
     from matplotlib.ticker import MaxNLocator, ScalarFormatter
 

--- a/astropy/visualization/wcsaxes/coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/coordinate_helpers.py
@@ -167,7 +167,6 @@ class CoordinateHelper:
             is recommended. By default, 'lines' is used if the transform has
             an inverse, otherwise 'contours' is used.
         """
-
         if grid_type == "lines" and not self.transform.has_inverse:
             raise ValueError(
                 "The specified transform has no inverse, so the "
@@ -204,7 +203,6 @@ class CoordinateHelper:
         coord_wrap : `~astropy.units.Quantity`, optional
             The value to wrap at for angular coordinates.
         """
-
         self.coord_type = coord_type
 
         if coord_wrap is not None and not isinstance(coord_wrap, u.Quantity):
@@ -270,7 +268,6 @@ class CoordinateHelper:
             depending on whether Matplotlib is using LaTeX or MathTex. To
             get plain ASCII strings, use format='ascii'.
         """
-
         if not hasattr(self, "_fl_spacing"):
             return ""  # _update_ticks has not been called yet
 
@@ -367,7 +364,6 @@ class CoordinateHelper:
         direction : {'in','out'}, optional
             Whether the ticks should point inwards or outwards.
         """
-
         if sum([values is None, spacing is None, number is None]) < 2:
             raise ValueError(
                 "At most one of values, spacing, or number should be specified"
@@ -632,7 +628,6 @@ class CoordinateHelper:
         """
         Draw all ticks and ticklabels.
         """
-
         renderer.open_group("ticks")
         self.ticks.draw(renderer)
         self.ticklabels.draw(
@@ -1235,7 +1230,6 @@ class CoordinateHelper:
             The style of the grid lines (accepts any valid Matplotlib line
             style).
         """
-
         # First do some sanity checking on the keyword arguments
 
         # colors= is a fallback default for color and labelcolor

--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -207,7 +207,6 @@ class WCSAxes(Axes):
 
         All arguments are passed to :meth:`~matplotlib.axes.Axes.imshow`.
         """
-
         origin = kwargs.pop("origin", "lower")
 
         # plt.imshow passes origin as None, which we should default to lower.
@@ -241,7 +240,6 @@ class WCSAxes(Axes):
         positional and keyword arguments are the same as for
         :meth:`~matplotlib.axes.Axes.contour`.
         """
-
         # In Matplotlib, when calling contour() with a transform, each
         # individual path in the contour map is transformed separately. However,
         # this is much too slow for us since each call to the transforms results
@@ -273,7 +271,6 @@ class WCSAxes(Axes):
         positional and keyword arguments are the same as for
         :meth:`~matplotlib.axes.Axes.contourf`.
         """
-
         # See notes for contour above.
 
         transform = kwargs.pop("transform", None)
@@ -353,7 +350,6 @@ class WCSAxes(Axes):
             This method is called from this function with all arguments passed to it.
 
         """
-
         args, kwargs = self._transform_plot_args(*args, **kwargs)
 
         return super().plot(*args, **kwargs)
@@ -380,7 +376,6 @@ class WCSAxes(Axes):
         --------
         matplotlib.axes.Axes.scatter : This method is called from this function with all arguments passed to it.
         """
-
         args, kwargs = self._transform_plot_args(*args, **kwargs)
 
         return super().scatter(*args, **kwargs)
@@ -389,7 +384,6 @@ class WCSAxes(Axes):
         """
         Reset the current Axes, to use a new WCS object.
         """
-
         # Here determine all the coordinate axes that should be shown.
         if wcs is None and transform is None:
             self.wcs = IDENTITY
@@ -506,7 +500,6 @@ class WCSAxes(Axes):
 
     def draw(self, renderer, **kwargs):
         """Draw the axes."""
-
         # Before we do any drawing, we need to remove any existing grid lines
         # drawn with contours, otherwise if we try and remove the contours
         # part way through drawing, we end up with the issue mentioned in
@@ -682,7 +675,6 @@ class WCSAxes(Axes):
         """
         Return a transform from data to the specified frame.
         """
-
         if isinstance(frame, (BaseLowLevelWCS, BaseHighLevelWCS)):
             if isinstance(frame, BaseHighLevelWCS):
                 frame = frame.low_level_wcs
@@ -762,7 +754,6 @@ class WCSAxes(Axes):
         which : str
             Currently only ``'major'`` is supported.
         """
-
         if not hasattr(self, "coords"):
             return
 
@@ -839,7 +830,6 @@ class WCSAxes(Axes):
             The style of the grid lines (accepts any valid Matplotlib line
             style).
         """
-
         if not hasattr(self, "coords"):
             # Axes haven't been fully initialized yet, so just ignore, as
             # Axes.__init__ calls this method

--- a/astropy/visualization/wcsaxes/grid_paths.py
+++ b/astropy/visualization/wcsaxes/grid_paths.py
@@ -28,7 +28,6 @@ def get_lon_lat_path(lon_lat, pixel, lon_lat_check):
         The world coordinates derived from converting from ``pixel``, which is
         used to ensure round-tripping.
     """
-
     # In some spherical projections, some parts of the curve are 'behind' or
     # 'in front of' the plane of the image, so we find those by reversing the
     # transformation and finding points where the result is not consistent.
@@ -103,7 +102,6 @@ def get_gridline_path(world, pixel):
     pixel : ndarray
         The pixel coordinates corresponding to ``lon_lat``
     """
-
     # Mask values with invalid pixel positions
     mask = np.isnan(pixel[:, 0]) | np.isnan(pixel[:, 1])
 

--- a/astropy/visualization/wcsaxes/helpers.py
+++ b/astropy/visualization/wcsaxes/helpers.py
@@ -79,7 +79,6 @@ def add_beam(
       (e.g., rectangular pixels)
 
     """
-
     if header and major:
         raise ValueError(
             "Either header or major/minor/angle must be specified, not both."
@@ -173,7 +172,6 @@ def add_scalebar(
       (e.g., rectangular pixels)
 
     """
-
     if isinstance(length, u.Quantity):
         length = length.to(u.degree).value
 

--- a/astropy/visualization/wcsaxes/patches.py
+++ b/astropy/visualization/wcsaxes/patches.py
@@ -40,7 +40,6 @@ def _rotate_polygon(lon, lat, lon0, lat0):
     lat0). Therefore, to end up with a polygon centered on (lon0, lat0), the
     polygon should initially be drawn around the North pole.
     """
-
     # Create a representation object
     polygon = UnitSphericalRepresentation(lon=lon, lat=lat)
 

--- a/astropy/visualization/wcsaxes/utils.py
+++ b/astropy/visualization/wcsaxes/utils.py
@@ -123,7 +123,6 @@ def transform_contour_set_inplace(cset, transform):
     contour line. It is more efficient to stack all the contour lines together
     temporarily and transform them in one go.
     """
-
     # The contours are represented as paths grouped into levels. Each can have
     # one or more paths. The approach we take here is to stack the vertices of
     # all paths and transform them in one go. The pos_level list helps us keep

--- a/astropy/wcs/utils.py
+++ b/astropy/wcs/utils.py
@@ -49,7 +49,6 @@ def add_stokes_axis_to_wcs(wcs, add_before_ind):
     `~astropy.wcs.WCS`
         A new `~astropy.wcs.WCS` instance with an additional axis
     """
-
     inds = [i + 1 for i in range(wcs.wcs.naxis)]
     inds.insert(add_before_ind, 0)
     newwcs = wcs.sub(inds)
@@ -503,7 +502,6 @@ def non_celestial_pixel_scales(inwcs):
     scale : `numpy.ndarray`
         The pixel scale along each axis.
     """
-
     if inwcs.is_celestial:
         raise ValueError("WCS is celestial, use celestial_pixel_scales instead")
 
@@ -554,7 +552,6 @@ def skycoord_to_pixel(coords, wcs, origin=0, mode="all"):
     --------
     astropy.coordinates.SkyCoord.from_pixel
     """
-
     if _has_distortion(wcs) and wcs.naxis != 2:
         raise ValueError("Can only handle WCS with distortions for 2-dimensional WCS")
 
@@ -627,7 +624,6 @@ def pixel_to_skycoord(xp, yp, wcs, origin=0, mode="all", cls=None):
     --------
     astropy.coordinates.SkyCoord.from_pixel
     """
-
     # Import astropy.coordinates here to avoid circular imports
     from astropy.coordinates import SkyCoord, UnitSphericalRepresentation
 
@@ -693,7 +689,6 @@ def _pixel_to_world_correlation_matrix(wcs):
     The shape of the matrix is ``(n_world, n_pix)``, where ``n_world`` is the
     number of high level world coordinates.
     """
-
     # We basically want to collapse the world dimensions together that are
     # combined into the same high-level objects.
 
@@ -725,7 +720,6 @@ def _pixel_to_pixel_correlation_matrix(wcs_in, wcs_out):
     pixel transformation. The shape of the matrix is
     ``(n_pixel_out, n_pixel_in)``.
     """
-
     matrix1, classes1 = _pixel_to_world_correlation_matrix(wcs_in)
     matrix2, classes2 = _pixel_to_world_correlation_matrix(wcs_out)
 
@@ -777,7 +771,6 @@ def _split_matrix(matrix):
 
     and this function will return ``[([0, 1], [0, 1]), ([2], [2])]``.
     """
-
     pixel_used = []
 
     split_info = []
@@ -820,7 +813,6 @@ def pixel_to_pixel(wcs_in, wcs_out, *inputs):
     *inputs :
         Scalars or arrays giving the pixel coordinates to transform.
     """
-
     # Shortcut for scalars
     if np.isscalar(inputs[0]):
         world_outputs = wcs_in.pixel_to_world(*inputs)
@@ -879,7 +871,6 @@ def local_partial_pixel_derivatives(wcs, *pixel, normalize_by_world=False):
         If `True`, the matrix is normalized so that for each world entry
         the derivatives add up to 1.
     """
-
     # Find the world coordinates at the requested pixel
     pixel_ref = np.array(pixel)
     world_ref = np.array(wcs.pixel_to_world_values(*pixel_ref))
@@ -945,7 +936,6 @@ def _sip_fit(params, lon, lat, u, v, w_obj, order, coeff_names):
     w_obj: `~astropy.wcs.WCS`
         WCS object
     """
-
     from astropy.modeling.models import SIP  # here to avoid circular import
 
     # unpack params
@@ -1040,7 +1030,6 @@ def fit_wcs_from_points(
     wcs : `~astropy.wcs.WCS`
         The best-fit WCS to the points given.
     """
-
     from scipy.optimize import least_squares
 
     import astropy.units as u

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -991,7 +991,6 @@ reduce these to 2 dimensions using the naxis kwarg.
         Writes a `distortion paper`_ type lookup table to the given
         `~astropy.io.fits.HDUList`.
         """
-
         if self.det2im1 is None and self.det2im2 is None:
             return
         dist = "D2IMDIS"
@@ -2728,7 +2727,6 @@ reduce these to 2 dimensions using the naxis kwarg.
         -------
         hdulist : `~astropy.io.fits.HDUList`
         """
-
         header = self.to_header(relax=relax, key=key)
 
         hdu = fits.PrimaryHDU(header=header)
@@ -2921,7 +2919,6 @@ reduce these to 2 dimensions using the naxis kwarg.
             If the user requested SIP distortion to be written out add "-SIP" to
             CTYPE if it is missing.
         """
-
         _add_sip_to_ctype = """
         Inconsistent SIP distortion information is present in the current WCS:
         SIP coefficients were detected, but CTYPE is missing "-SIP" suffix,
@@ -3171,7 +3168,6 @@ reduce these to 2 dimensions using the naxis kwarg.
         Support pickling of WCS objects.  This is done by serializing
         to an in-memory FITS file and dumping that as a string.
         """
-
         hdulist = self.to_fits(relax=True)
 
         buffer = io.BytesIO()
@@ -3493,7 +3489,6 @@ reduce these to 2 dimensions using the naxis kwarg.
         response : bool
            True means the WCS footprint contains the coordinate, False means it does not.
         """
-
         return coord.contained_by(self, **kwargs)
 
 
@@ -3501,7 +3496,6 @@ def __WCS_unpickle__(cls, dct, fits_data):
     """
     Unpickles a WCS object from a serialized FITS string.
     """
-
     self = cls.__new__(cls)
 
     buffer = io.BytesIO(fits_data)
@@ -3582,7 +3576,6 @@ def find_all_wcs(
     -------
     wcses : list of `WCS`
     """
-
     if isinstance(header, (str, bytes)):
         header_string = header
     elif isinstance(header, fits.Header):

--- a/astropy/wcs/wcsapi/utils.py
+++ b/astropy/wcs/wcsapi/utils.py
@@ -11,7 +11,6 @@ def deserialize_class(tpl, construct=True):
     """
     Deserialize classes recursively.
     """
-
     if not isinstance(tpl, tuple) or len(tpl) != 3:
         raise ValueError("Expected a tuple of three values")
 

--- a/astropy/wcs/wcsapi/wrappers/sliced_wcs.py
+++ b/astropy/wcs/wcsapi/wrappers/sliced_wcs.py
@@ -17,7 +17,6 @@ def sanitize_slices(slices, ndim):
 
     This function returns a list ``ndim`` long containing slice objects (or ints).
     """
-
     if not isinstance(slices, (tuple, list)):  # We just have a single int
         slices = (slices,)
 
@@ -66,7 +65,6 @@ def combine_slices(slice1, slice2):
     slice that corresponds to the combination of both slices. We assume that
     slice2 can be an integer, but slice1 cannot.
     """
-
     if isinstance(slice1, slice) and slice1.step is not None:
         raise ValueError("Only slices with steps of 1 are supported")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,7 +136,6 @@ extend-ignore = [
     "D107",  # Missing docstring in __init__. Don't check b/c class docstring.
     # Whitespace Issues
     "D200",  # FitsOnOneLine
-    "D202",  # NoBlankLineAfterFunction                # TODO: autofix
     "D203",  # OneBlankLineBeforeClass. Don't check.
     "D205",  # BlankLineAfterSummary                   # TODO: fix
     "D212", "D213",  # MultiLineSummaryFirst/Second Line  # TODO: fix one of these


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

This PR targets the pydocstyle error D202 - having blank lines between the docstring and the code in a function.
D202 affects many files so I'm fixing this error code separately from others to make review easier.

As part of pre-commit `ruff` will now auto-fix this error, as part of CI or locally if the contributor has pre-commit installed as a git hook (https://pre-commit.com/#3-install-the-git-hook-scripts).

For reference from discussion below: D202 is part of the numpydoc style, which we try to use. 

https://github.com/numpy/numpydoc/blob/7ea993a6177b5b2186cd1bd96b83ee19d2bd641a/doc/example.py#L125-L129
```
    """
    # After closing class docstring, there should be one blank line to
    # separate following codes (according to PEP257).
    # But for function, method and module, there should be no blank lines
    # after closing the docstring.
```

Why should we do this?

IMO it's easier to stick closer to default settings. Most other python libraries do, which makes our code more similar stylistically and often therefore easier to read. At this point I'm so used to black that it takes me a hot sec to grok non-blackened code.

That said, D202 is definitely a lesser issue and if we choose not to enforce D202, that's alright too!


### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
