### PR TITLE
Ruff fix D204-D215

### DIFF
--- a/astropy/config/paths.py
+++ b/astropy/config/paths.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-""" This module contains functions to determine where configuration and
+"""This module contains functions to determine where configuration and
 data/cache files used by Astropy should be placed.
 """
 

--- a/astropy/coordinates/angles.py
+++ b/astropy/coordinates/angles.py
@@ -544,7 +544,8 @@ class Latitude(Angle):
 
     def _validate_angles(self, angles=None):
         """Check that angles are between -90 and 90 degrees.
-        If not given, the check is done on the object itself"""
+        If not given, the check is done on the object itself
+        """
         # Convert the lower and upper bounds to the "native" unit of
         # this angle.  This limits multiplication to two values,
         # rather than the N values in `self.value`.  Also, the

--- a/astropy/coordinates/errors.py
+++ b/astropy/coordinates/errors.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-""" This module defines custom errors and exceptions used in astropy.coordinates.
+"""This module defines custom errors and exceptions used in astropy.coordinates.
 """
 
 from astropy.utils.exceptions import AstropyWarning

--- a/astropy/cosmology/__init__.py
+++ b/astropy/cosmology/__init__.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-""" astropy.cosmology contains classes and functions for cosmological
+"""``astropy.cosmology`` contains classes and functions for cosmological
 distance measures and other cosmology-related calculations.
 
 See the `Astropy documentation

--- a/astropy/io/ascii/basic.py
+++ b/astropy/io/ascii/basic.py
@@ -57,6 +57,7 @@ class Basic(core.BaseReader):
       1 2 3
       4 5 6
     """
+
     _format_name = "basic"
     _description = "Basic table with custom delimiters"
     _io_registry_format_aliases = ["ascii"]

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-""" An extensible ASCII table reader and writer.
+"""An extensible ASCII table reader and writer.
 
 core.py:
   Core base classes and functions for reading and writing tables.

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -369,7 +369,8 @@ class BaseInputter:
         Override this method if something more has to be done to convert raw
         input lines to the table rows.  For example the
         ContinuationLinesInputter derived class accounts for continuation
-        characters if a row is split into lines."""
+        characters if a row is split into lines.
+        """
         return lines
 
 
@@ -456,7 +457,8 @@ class DefaultSplitter(BaseSplitter):
     def process_line(self, line):
         """Remove whitespace at the beginning or end of line.  This is especially useful for
         whitespace-delimited files to prevent spurious columns at the beginning or end.
-        If splitting on whitespace then replace unquoted tabs with space first"""
+        If splitting on whitespace then replace unquoted tabs with space first
+        """
         if self.delimiter == r"\s":
             line = _replace_tab_with_space(line, self.escapechar, self.quotechar)
         return line.strip() + "\n"
@@ -842,7 +844,8 @@ class BaseData:
 
     def get_str_vals(self):
         """Return a generator that returns a list of column values (as strings)
-        for each data line."""
+        for each data line.
+        """
         return self.splitter(self.data_lines)
 
     def masks(self, cols):
@@ -1063,7 +1066,8 @@ class BaseOutputter:
     def _validate_and_copy(col, converters):
         """Validate the format for the type converters and then copy those
         which are valid converters for this column (i.e. converter type is
-        a subclass of col.type)"""
+        a subclass of col.type)
+        """
         # Allow specifying a single converter instead of a list of converters.
         # The input `converters` must be a ``type`` value that can init np.dtype.
         try:
@@ -1793,7 +1797,8 @@ extra_writer_pars = (
 def _get_writer(Writer, fast_writer, **kwargs):
     """Initialize a table writer allowing for common customizations. This
     routine is for internal (package) use only and is useful because it depends
-    only on the "core" module."""
+    only on the "core" module.
+    """
 
     from .fastbasic import FastBasic
 

--- a/astropy/io/ascii/ecsv.py
+++ b/astropy/io/ascii/ecsv.py
@@ -51,7 +51,8 @@ class EcsvHeader(basic.BasicHeader):
 
     def process_lines(self, lines):
         """Return only non-blank lines that start with the comment regexp.  For these
-        lines strip out the matching characters and leading/trailing whitespace."""
+        lines strip out the matching characters and leading/trailing whitespace.
+        """
         re_comment = re.compile(self.comment)
         for line in lines:
             line = line.strip()

--- a/astropy/io/ascii/ipac.py
+++ b/astropy/io/ascii/ipac.py
@@ -449,6 +449,7 @@ class Ipac(basic.Basic):
         `IPAC <https://irsa.ipac.caltech.edu/applications/DDGEN/Doc/ipac_tbl.html>`_
         definition.
     """
+
     _format_name = "ipac"
     _io_registry_format_aliases = ["ipac"]
     _io_registry_can_write = True

--- a/astropy/io/ascii/ipac.py
+++ b/astropy/io/ascii/ipac.py
@@ -86,7 +86,8 @@ class IpacHeader(fixedwidth.FixedWidthHeader):
 
     def process_lines(self, lines):
         """Generator to yield IPAC header lines, i.e. those starting and ending with
-        delimiter character (with trailing whitespace stripped)"""
+        delimiter character (with trailing whitespace stripped)
+        """
         delim = self.splitter.delimiter
         for line in lines:
             line = line.rstrip()
@@ -315,7 +316,8 @@ class IpacHeader(fixedwidth.FixedWidthHeader):
         The width of each column is determined in Ipac.write. Writing the header
         must be delayed until that time.
         This function is called from there, once the width information is
-        available."""
+        available.
+        """
 
         for vals in self.str_vals():
             lines.append(self.splitter.join(vals, widths))

--- a/astropy/io/ascii/latex.py
+++ b/astropy/io/ascii/latex.py
@@ -107,7 +107,8 @@ class LatexSplitter(core.BaseSplitter):
 
     def process_line(self, line):
         """Remove whitespace at the beginning or end of line. Also remove
-        \\ at end of line"""
+        \\ at end of line
+        """
         line = RE_COMMENT.split(line)[0]
         line = line.strip()
         if line.endswith(r"\\"):

--- a/astropy/io/ascii/latex.py
+++ b/astropy/io/ascii/latex.py
@@ -319,6 +319,7 @@ class Latex(core.BaseReader):
             latexdict['col_align'] = col_align
 
     """
+
     _format_name = "latex"
     _io_registry_format_aliases = ["latex"]
     _io_registry_suffix = ".tex"
@@ -409,6 +410,7 @@ class AASTexHeader(LatexHeader):
 
     This header is modified to take that into account.
     """
+
     header_start = r"\tablehead"
     splitter_class = AASTexHeaderSplitter
 
@@ -446,6 +448,7 @@ class AASTexHeader(LatexHeader):
 
 class AASTexData(LatexData):
     r"""In a `deluxetable`_ the data is enclosed in `\startdata` and `\enddata`"""
+
     data_start = r"\startdata"
     data_end = r"\enddata"
 

--- a/astropy/io/ascii/sextractor.py
+++ b/astropy/io/ascii/sextractor.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-""" sextractor.py:
+"""sextractor.py:
   Classes to read SExtractor table format
 
 Built on daophot.py:

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -788,7 +788,8 @@ def _read_in_chunks_generator(table, chunk_size, **kwargs):
     @contextlib.contextmanager
     def passthrough_fileobj(fileobj, encoding=None):
         """Stub for get_readable_fileobj, which does not seem to work in Py3
-        for input file-like object, see #6460"""
+        for input file-like object, see #6460
+        """
         yield fileobj
 
     # Set up to coerce `table` input into a readable file object by selecting

--- a/astropy/io/fits/header.py
+++ b/astropy/io/fits/header.py
@@ -2155,7 +2155,8 @@ class _BasicHeader(collections.abc.Mapping):
     @classmethod
     def fromfile(cls, fileobj):
         """The main method to parse a FITS header from a file. The parsing is
-        done with the parse_header function implemented in Cython."""
+        done with the parse_header function implemented in Cython.
+        """
 
         close_file = False
         if isinstance(fileobj, str):

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -4213,7 +4213,8 @@ class CompoundModel(Model):
 
 def _get_submodel_path(model, name):
     """Find the route down a CompoundModel's tree to the model with the
-    specified name (whether it's a leaf or not)"""
+    specified name (whether it's a leaf or not)
+    """
     if getattr(model, "name", None) == name:
         return []
     try:

--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -1775,7 +1775,8 @@ class Voigt1D(Fittable1DModel):
 
     def _wrap_wofz(self, z):
         """Call complex error (Faddeeva) function w(z) implemented by algorithm `method`;
-        cache results for consecutive calls from `evaluate`, `fit_deriv`."""
+        cache results for consecutive calls from `evaluate`, `fit_deriv`.
+        """
 
         if z.shape == self._last_z.shape and np.allclose(
             z, self._last_z, rtol=1.0e-14, atol=1.0e-15

--- a/astropy/modeling/polynomial.py
+++ b/astropy/modeling/polynomial.py
@@ -497,6 +497,7 @@ class Chebyshev1D(_PolyDomainWindow1D):
     third Chebyshev polynomial (T2) is 2x^2-1, but if x was specified with
     units, 2x^2 and -1 would have incompatible units.
     """
+
     n_inputs = 1
     n_outputs = 1
 
@@ -620,6 +621,7 @@ class Hermite1D(_PolyDomainWindow1D):
     third Hermite polynomial (H2) is 4x^2-2, but if x was specified with units,
     4x^2 and -2 would have incompatible units.
     """
+
     n_inputs = 1
     n_outputs = 1
 
@@ -752,6 +754,7 @@ class Hermite2D(OrthoPolynomialBase):
     example, the third Hermite polynomial (H2) is 4x^2-2, but if x was
     specified with units, 4x^2 and -2 would have incompatible units.
     """
+
     _separable = False
 
     def __init__(
@@ -1415,6 +1418,7 @@ class Chebyshev2D(OrthoPolynomialBase):
     example, the third Chebyshev polynomial (T2) is 2x^2-1, but if x was
     specified with units, 2x^2 and -1 would have incompatible units.
     """
+
     _separable = False
 
     def __init__(
@@ -1573,6 +1577,7 @@ class Legendre2D(OrthoPolynomialBase):
     third Legendre polynomial (P2) is 1.5x^2-0.5, but if x was specified with
     units, 1.5x^2 and -0.5 would have incompatible units.
     """
+
     _separable = False
 
     def __init__(

--- a/astropy/modeling/powerlaws.py
+++ b/astropy/modeling/powerlaws.py
@@ -325,7 +325,8 @@ class SmoothlyBrokenPowerLaw1D(Fittable1DModel):
     @staticmethod
     def fit_deriv(x, amplitude, x_break, alpha_1, alpha_2, delta):
         """One dimensional smoothly broken power law derivative with respect
-        to parameters"""
+        to parameters
+        """
 
         # Pre-calculate `x_b` and `x/x_b` and `logt` (see comments in
         # SmoothlyBrokenPowerLaw1D.evaluate)

--- a/astropy/modeling/projections.py
+++ b/astropy/modeling/projections.py
@@ -298,6 +298,7 @@ class Pix2Sky_ZenithalPerspective(Pix2SkyProjection, Zenithal):
         Look angle γ in degrees.  Default is 0°.
 
     """
+
     mu = _ParameterDS(
         default=0.0, description="Distance from point of projection to center of sphere"
     )
@@ -342,6 +343,7 @@ class Sky2Pix_ZenithalPerspective(Sky2PixProjection, Zenithal):
         Look angle γ in degrees. Default is 0°.
 
     """
+
     mu = _ParameterDS(
         default=0.0, description="Distance from point of projection to center of sphere"
     )
@@ -381,6 +383,7 @@ class Pix2Sky_SlantZenithalPerspective(Pix2SkyProjection, Zenithal):
         is 90°.
 
     """
+
     mu = _ParameterDS(
         default=0.0, description="Distance from point of projection to center of sphere"
     )
@@ -426,6 +429,7 @@ class Sky2Pix_SlantZenithalPerspective(Sky2PixProjection, Zenithal):
         is 90°.
 
     """
+
     mu = _ParameterDS(
         default=0.0, description="Distance from point of projection to center of sphere"
     )
@@ -532,6 +536,7 @@ class Pix2Sky_SlantOrthographic(Pix2SkyProjection, Zenithal):
         Obliqueness parameter, η.  Default is 0.0.
 
     """
+
     xi = _ParameterDS(default=0.0, description="Obliqueness parameter")
     eta = _ParameterDS(default=0.0, description="Obliqueness parameter")
 
@@ -557,6 +562,7 @@ class Sky2Pix_SlantOrthographic(Sky2PixProjection, Zenithal):
         y &= \frac{180^\circ}{\pi}[\cos \theta \cos \phi + \eta(1 - \sin \theta)]
 
     """
+
     xi = _ParameterDS(default=0.0)
     eta = _ParameterDS(default=0.0)
 
@@ -628,6 +634,7 @@ class Pix2Sky_Airy(Pix2SkyProjection, Zenithal):
         The latitude :math:`\theta_b` at which to minimize the error,
         in degrees.  Default is 90°.
     """
+
     theta_b = _ParameterDS(default=90.0)
 
 
@@ -656,6 +663,7 @@ class Sky2Pix_Airy(Sky2PixProjection, Zenithal):
         in degrees.  Default is 90°.
 
     """
+
     theta_b = _ParameterDS(
         default=90.0,
         description="The latitude at which to minimize the error,in degrees",
@@ -668,6 +676,7 @@ class Cylindrical(Projection):
     Cylindrical projections are so-named because the surface of
     projection is a cylinder.
     """
+
     _separable = True
 
 
@@ -696,6 +705,7 @@ class Pix2Sky_CylindricalPerspective(Pix2SkyProjection, Cylindrical):
         Radius of the cylinder in spherical radii, λ. Default is 1.
 
     """
+
     mu = _ParameterDS(default=1.0)
     lam = _ParameterDS(default=1.0)
 
@@ -730,6 +740,7 @@ class Sky2Pix_CylindricalPerspective(Sky2PixProjection, Cylindrical):
         Radius of the cylinder in spherical radii, λ.  Default is 0.
 
     """
+
     mu = _ParameterDS(
         default=1.0, description="Distance from center of sphere in spherical radii"
     )
@@ -763,6 +774,7 @@ class Pix2Sky_CylindricalEqualArea(Pix2SkyProjection, Cylindrical):
     lam : float
         Radius of the cylinder in spherical radii, λ.  Default is 1.
     """
+
     lam = _ParameterDS(default=1)
 
 
@@ -781,6 +793,7 @@ class Sky2Pix_CylindricalEqualArea(Sky2PixProjection, Cylindrical):
     lam : float
         Radius of the cylinder in spherical radii, λ.  Default is 0.
     """
+
     lam = _ParameterDS(default=1)
 
 
@@ -854,6 +867,7 @@ class PseudoCylindrical(Projection):
     lengths toward the polar regions in order to reduce lateral
     distortion there.  Consequently, the meridians are curved.
     """
+
     _separable = True
 
 
@@ -992,6 +1006,7 @@ class Conic(Projection):
     .. math::
         C = \frac{180^\circ \cos \theta}{\pi R_\theta}
     """
+
     sigma = _ParameterDS(default=90.0, getter=_to_orig_unit, setter=_to_radian)
     delta = _ParameterDS(default=0.0, getter=_to_orig_unit, setter=_to_radian)
 
@@ -1294,6 +1309,7 @@ class Pix2Sky_BonneEqualArea(Pix2SkyProjection, PseudoConic):
     theta1 : float
         Bonne conformal latitude, in degrees.
     """
+
     _separable = True
 
     theta1 = _ParameterDS(default=0.0, getter=_to_orig_unit, setter=_to_radian)
@@ -1321,6 +1337,7 @@ class Sky2Pix_BonneEqualArea(Sky2PixProjection, PseudoConic):
     theta1 : float
         Bonne conformal latitude, in degrees.
     """
+
     _separable = True
 
     theta1 = _ParameterDS(
@@ -1431,6 +1448,7 @@ class Pix2Sky_HEALPix(Pix2SkyProjection, HEALPix):
         The number of facets in latitude direction.
 
     """
+
     _separable = True
 
     H = _ParameterDS(
@@ -1456,6 +1474,7 @@ class Sky2Pix_HEALPix(Sky2PixProjection, HEALPix):
         The number of facets in latitude direction.
 
     """
+
     _separable = True
 
     H = _ParameterDS(

--- a/astropy/modeling/tests/irafutil.py
+++ b/astropy/modeling/tests/irafutil.py
@@ -52,7 +52,6 @@ def get_database_string(fname):
 
 
 class Record:
-
     """
     A base class for all records - represents an IRAF database record
 
@@ -119,7 +118,6 @@ class Record:
 
 
 class IdentifyRecord(Record):
-
     """
     Represents a database record for the onedspec.identify task
 
@@ -182,7 +180,6 @@ class IdentifyRecord(Record):
 
 
 class FitcoordsRecord(Record):
-
     """
     Represents a database record for the longslit.fitccords task
 
@@ -218,7 +215,6 @@ class FitcoordsRecord(Record):
 
 
 class IDB:
-
     """
     Base class for an IRAF identify database
 
@@ -249,7 +245,6 @@ class IDB:
 
 
 class ReidentifyRecord(IDB):
-
     """
     Represents a database record for the onedspec.reidentify task
     """

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -1668,7 +1668,8 @@ class MaskedColumn(Column, _MaskedColumnGetitemShim, ma.MaskedArray):
     @fill_value.setter
     def fill_value(self, val):
         """Set fill value both in the masked column view and in the parent table
-        if it exists.  Setting one or the other alone doesn't work."""
+        if it exists.  Setting one or the other alone doesn't work.
+        """
 
         # another ma bug workaround: If the value of fill_value for a string array is
         # requested but not yet set then it gets created as 'N/A'.  From this point onward

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -967,7 +967,8 @@ class Table:
     def _mask(self):
         """This is needed so that comparison of a masked Table and a
         MaskedArray works.  The requirement comes from numpy.ma.core
-        so don't remove this property."""
+        so don't remove this property.
+        """
         return self.as_array().mask
 
     def filled(self, fill_value=None):

--- a/astropy/units/function/core.py
+++ b/astropy/units/function/core.py
@@ -669,7 +669,8 @@ class FunctionQuantity(Quantity):
     def _comparison(self, other, comparison_func):
         """Do a comparison between self and other, raising UnitsError when
         other cannot be converted to self because it has different physical
-        unit, and returning NotImplemented when there are other errors."""
+        unit, and returning NotImplemented when there are other errors.
+        """
         try:
             # will raise a UnitsError if physical units not equivalent
             other_in_own_unit = self._to_own_unit(other, check_precision=False)

--- a/astropy/units/function/logarithmic.py
+++ b/astropy/units/function/logarithmic.py
@@ -61,12 +61,14 @@ class LogUnit(FunctionUnitBase):
 
     def from_physical(self, x):
         """Transformation from value in physical to value in logarithmic units.
-        Used in equivalency."""
+        Used in equivalency.
+        """
         return dex.to(self._function_unit, np.log10(x))
 
     def to_physical(self, x):
         """Transformation from value in logarithmic to value in physical units.
-        Used in equivalency."""
+        Used in equivalency.
+        """
         return 10 ** self._function_unit.to(dex, x)
 
     # ^^^^ the four essential overrides of FunctionUnitBase

--- a/astropy/units/quantity_helper/helpers.py
+++ b/astropy/units/quantity_helper/helpers.py
@@ -31,7 +31,8 @@ def _d(unit):
 
 def get_converter(from_unit, to_unit):
     """Like Unit._get_converter, except returns None if no scaling is needed,
-    i.e., if the inferred scale is unity."""
+    i.e., if the inferred scale is unity.
+    """
     converter = from_unit._get_converter(to_unit)
     return None if converter is unit_scale_converter else converter
 

--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -39,7 +39,8 @@ class _WCSAxesArtist(Artist):
     ersatz ticks, labels, and gridlines by explicitly calling the functions
     ``CoordinateHelper._draw_ticks``, ``CoordinateHelper._draw_grid``, etc.
     This hack would not be necessary if ``WCSAxes`` drew ticks, tick labels,
-    and gridlines in the standary way."""
+    and gridlines in the standary way.
+    """
 
     def draw(self, renderer, *args, **kwargs):
         self.axes.draw_wcsaxes(renderer)

--- a/astropy/visualization/wcsaxes/frame.py
+++ b/astropy/visualization/wcsaxes/frame.py
@@ -381,8 +381,8 @@ class EllipticalFrame(BaseFrame):
 
     def _update_patch_path(self):
         """Override path patch to include only the outer ellipse,
-        not the major and minor axes in the middle."""
-
+        not the major and minor axes in the middle.
+        """
         self.update_spines()
         vertices = self["c"].data
 
@@ -396,7 +396,8 @@ class EllipticalFrame(BaseFrame):
         not the major and minor axes in the middle.
 
         FIXME: we may want to add a general method to give the user control
-        over which spines are drawn."""
+        over which spines are drawn.
+        """
         axis = "c"
         x, y = self[axis].pixel[:, 0], self[axis].pixel[:, 1]
         line = Line2D(x, y, linewidth=self._linewidth, color=self._color, zorder=1000)

--- a/examples/coordinates/plot_sgr-coordinate-frame.py
+++ b/examples/coordinates/plot_sgr-coordinate-frame.py
@@ -145,9 +145,7 @@ SGR_MATRIX = (
 
 @frame_transform_graph.transform(coord.StaticMatrixTransform, coord.Galactic, Sagittarius)
 def galactic_to_sgr():
-    """ Compute the transformation matrix from Galactic spherical to
-        heliocentric Sgr coordinates.
-    """
+    """Compute the Galactic spherical to heliocentric Sgr transformation matrix."""
     return SGR_MATRIX
 
 
@@ -162,9 +160,7 @@ def galactic_to_sgr():
 
 @frame_transform_graph.transform(coord.StaticMatrixTransform, Sagittarius, coord.Galactic)
 def sgr_to_galactic():
-    """ Compute the transformation matrix from heliocentric Sgr coordinates to
-        spherical Galactic.
-    """
+    """Compute the heliocentric Sgr to spherical Galactic transformation matrix."""
     return matrix_transpose(SGR_MATRIX)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,7 +131,6 @@ extend-ignore = [
     "D200",  # FitsOnOneLine
     "D202",  # NoBlankLineAfterFunction                # TODO: autofix
     "D203",  # OneBlankLineBeforeClass. Don't check.
-    "D204",  # OneBlankLineAfterClass                  # TODO: autofix
     "D205",  # BlankLineAfterSummary                   # TODO: autofix
     "D207",  # NoUnderIndentation                      # TODO: autofix
     "D208",  # NoOverIndentation                       # TODO: autofix

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,7 +132,6 @@ extend-ignore = [
     "D202",  # NoBlankLineAfterFunction                # TODO: autofix
     "D203",  # OneBlankLineBeforeClass. Don't check.
     "D205",  # BlankLineAfterSummary                   # TODO: fix
-    "D209",  # NewLineAfterLastParagraph               # TODO: autofix
     "D210",  # NoSurroundingWhitespace                 # TODO: autofix
     "D211",  # NoBlankLineBeforeClass                  # TODO: autofix
     "D212", "D213",  # MultiLineSummaryFirst/Second Line  # TODO: fix one of these

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,7 +133,6 @@ extend-ignore = [
     "D203",  # OneBlankLineBeforeClass. Don't check.
     "D205",  # BlankLineAfterSummary                   # TODO: fix
     "D212", "D213",  # MultiLineSummaryFirst/Second Line  # TODO: fix one of these
-    "D215",  # SectionUnderlineNotOverIndented         # TODO: autofix
     # Quotes Issues
     "D300",  # UsesTripleQuotes                        # TODO: fix
     "D301",  # UsesRPrefixForBackslashedContent        # TODO: fix
@@ -273,7 +272,7 @@ exclude=[
 "__init__.py" = ["E402", "F401", "F403"]
 "astropy/io/registry/compat.py" = ["F822"]
 "astropy/modeling/models.py" = ["F401", "F403", "F405"]
-"astropy/utils/decorators.py" = ["D214"]  # keep Examples section indented.
+"astropy/utils/decorators.py" = ["D214", "D215"]  # keep Examples section indented.
 "test_*.py" = ["B011", "D", "E402", "PGH001", "S101"]
 "examples/*.py" = ["E402", "T203"]
 "*/examples/*.py" = ["E402"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,7 +132,6 @@ extend-ignore = [
     "D202",  # NoBlankLineAfterFunction                # TODO: autofix
     "D203",  # OneBlankLineBeforeClass. Don't check.
     "D205",  # BlankLineAfterSummary                   # TODO: fix
-    "D210",  # NoSurroundingWhitespace                 # TODO: autofix
     "D211",  # NoBlankLineBeforeClass                  # TODO: autofix
     "D212", "D213",  # MultiLineSummaryFirst/Second Line  # TODO: fix one of these
     "D214",  # SectionNotOverIndented                  # TODO: autofix

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,7 +133,6 @@ extend-ignore = [
     "D203",  # OneBlankLineBeforeClass. Don't check.
     "D205",  # BlankLineAfterSummary                   # TODO: fix
     "D212", "D213",  # MultiLineSummaryFirst/Second Line  # TODO: fix one of these
-    "D214",  # SectionNotOverIndented                  # TODO: autofix
     "D215",  # SectionUnderlineNotOverIndented         # TODO: autofix
     # Quotes Issues
     "D300",  # UsesTripleQuotes                        # TODO: fix
@@ -274,6 +273,7 @@ exclude=[
 "__init__.py" = ["E402", "F401", "F403"]
 "astropy/io/registry/compat.py" = ["F822"]
 "astropy/modeling/models.py" = ["F401", "F403", "F405"]
+"astropy/utils/decorators.py" = ["D214"]  # keep Examples section indented.
 "test_*.py" = ["B011", "D", "E402", "PGH001", "S101"]
 "examples/*.py" = ["E402", "T203"]
 "*/examples/*.py" = ["E402"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,7 +132,6 @@ extend-ignore = [
     "D202",  # NoBlankLineAfterFunction                # TODO: autofix
     "D203",  # OneBlankLineBeforeClass. Don't check.
     "D205",  # BlankLineAfterSummary                   # TODO: fix
-    "D211",  # NoBlankLineBeforeClass                  # TODO: autofix
     "D212", "D213",  # MultiLineSummaryFirst/Second Line  # TODO: fix one of these
     "D214",  # SectionNotOverIndented                  # TODO: autofix
     "D215",  # SectionUnderlineNotOverIndented         # TODO: autofix

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,8 +131,7 @@ extend-ignore = [
     "D200",  # FitsOnOneLine
     "D202",  # NoBlankLineAfterFunction                # TODO: autofix
     "D203",  # OneBlankLineBeforeClass. Don't check.
-    "D205",  # BlankLineAfterSummary                   # TODO: autofix
-    "D207",  # NoUnderIndentation                      # TODO: autofix
+    "D205",  # BlankLineAfterSummary                   # TODO: fix
     "D208",  # NoOverIndentation                       # TODO: autofix
     "D209",  # NewLineAfterLastParagraph               # TODO: autofix
     "D210",  # NoSurroundingWhitespace                 # TODO: autofix

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,7 +132,6 @@ extend-ignore = [
     "D202",  # NoBlankLineAfterFunction                # TODO: autofix
     "D203",  # OneBlankLineBeforeClass. Don't check.
     "D205",  # BlankLineAfterSummary                   # TODO: fix
-    "D208",  # NoOverIndentation                       # TODO: autofix
     "D209",  # NewLineAfterLastParagraph               # TODO: autofix
     "D210",  # NoSurroundingWhitespace                 # TODO: autofix
     "D211",  # NoBlankLineBeforeClass                  # TODO: autofix


### PR DESCRIPTION
This PR targets the pydocstyle errors D204-D215, which are mostly about whitespace. I special-cased the file "astropy/utils/decorators.py" from the indentation checks because the Examples sections in the docstring decorators contains code examples that were getting de-dented. I believe the rest, sans some manual corrections I did in astropy.cosmology, are ruff's automatic fixes.

As part of pre-commit ruff will now auto-fix these error, as part of CI or locally if the contributor has pre-commit installed as a git hook (https://pre-commit.com/#3-install-the-git-hook-scripts).

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
