### PR TITLE
Ruff fix select SIM codes

### DIFF
--- a/astropy/cosmology/io/tests/test_mapping.py
+++ b/astropy/cosmology/io/tests/test_mapping.py
@@ -190,7 +190,7 @@ class ToFromMappingTestMixin(ToFromTestMixinBase):
         assert not isinstance(obj, Cosmology)
 
         is_equiv = cosmo.is_equivalent(obj, format=format)
-        assert is_equiv is (True if format is not False else False)
+        assert is_equiv is (bool(format is not False))
 
 
 class TestToFromMapping(ToFromDirectTestBase, ToFromMappingTestMixin):

--- a/astropy/cosmology/io/tests/test_mapping.py
+++ b/astropy/cosmology/io/tests/test_mapping.py
@@ -190,7 +190,7 @@ class ToFromMappingTestMixin(ToFromTestMixinBase):
         assert not isinstance(obj, Cosmology)
 
         is_equiv = cosmo.is_equivalent(obj, format=format)
-        assert is_equiv is (bool(format is not False))
+        assert is_equiv is (format is not False)
 
 
 class TestToFromMapping(ToFromDirectTestBase, ToFromMappingTestMixin):

--- a/astropy/cosmology/io/tests/test_model.py
+++ b/astropy/cosmology/io/tests/test_model.py
@@ -164,7 +164,7 @@ class ToFromModelTestMixin(ToFromTestMixinBase):
         assert not isinstance(obj, Cosmology)
 
         is_equiv = cosmo.is_equivalent(obj, format=format)
-        assert is_equiv is (True if format is not False else False)
+        assert is_equiv is (bool(format is not False))
 
 
 class TestToFromModel(ToFromDirectTestBase, ToFromModelTestMixin):

--- a/astropy/cosmology/io/tests/test_model.py
+++ b/astropy/cosmology/io/tests/test_model.py
@@ -164,7 +164,7 @@ class ToFromModelTestMixin(ToFromTestMixinBase):
         assert not isinstance(obj, Cosmology)
 
         is_equiv = cosmo.is_equivalent(obj, format=format)
-        assert is_equiv is (bool(format is not False))
+        assert is_equiv is (format is not False)
 
 
 class TestToFromModel(ToFromDirectTestBase, ToFromModelTestMixin):

--- a/astropy/cosmology/io/tests/test_row.py
+++ b/astropy/cosmology/io/tests/test_row.py
@@ -113,7 +113,7 @@ class ToFromRowTestMixin(ToFromTestMixinBase):
         assert not isinstance(obj, Cosmology)
 
         is_equiv = cosmo.is_equivalent(obj, format=format)
-        assert is_equiv is (True if format is not False else False)
+        assert is_equiv is (bool(format is not False))
 
 
 class TestToFromTable(ToFromDirectTestBase, ToFromRowTestMixin):

--- a/astropy/cosmology/io/tests/test_row.py
+++ b/astropy/cosmology/io/tests/test_row.py
@@ -113,7 +113,7 @@ class ToFromRowTestMixin(ToFromTestMixinBase):
         assert not isinstance(obj, Cosmology)
 
         is_equiv = cosmo.is_equivalent(obj, format=format)
-        assert is_equiv is (bool(format is not False))
+        assert is_equiv is (format is not False)
 
 
 class TestToFromTable(ToFromDirectTestBase, ToFromRowTestMixin):

--- a/astropy/cosmology/io/tests/test_table.py
+++ b/astropy/cosmology/io/tests/test_table.py
@@ -218,7 +218,7 @@ class ToFromTableTestMixin(ToFromTestMixinBase):
         assert not isinstance(obj, Cosmology)
 
         is_equiv = cosmo.is_equivalent(obj, format=format)
-        assert is_equiv is bool(format is not False)
+        assert is_equiv is (format is not False)
 
 
 class TestToFromTable(ToFromDirectTestBase, ToFromTableTestMixin):

--- a/astropy/cosmology/io/tests/test_table.py
+++ b/astropy/cosmology/io/tests/test_table.py
@@ -218,7 +218,7 @@ class ToFromTableTestMixin(ToFromTestMixinBase):
         assert not isinstance(obj, Cosmology)
 
         is_equiv = cosmo.is_equivalent(obj, format=format)
-        assert is_equiv is (True if format is not False else False)
+        assert is_equiv is bool(format is not False)
 
 
 class TestToFromTable(ToFromDirectTestBase, ToFromTableTestMixin):

--- a/astropy/io/ascii/tests/test_c_reader.py
+++ b/astropy/io/ascii/tests/test_c_reader.py
@@ -1629,7 +1629,7 @@ def test_fortran_invalid_exp(parallel, guess):
         read_values = [col[0] for col in t5.itercols()]
         if os.name == "nt":
             # Apparently C strtod() on (some?) MSVC recognizes 'd' exponents!
-            assert read_values == vals_v or read_values == vals_e
+            assert read_values in (vals_v, vals_e)
         else:
             assert read_values == vals_e
 

--- a/astropy/io/fits/connect.py
+++ b/astropy/io/fits/connect.py
@@ -69,10 +69,7 @@ def is_fits(origin, filepath, fileobj, *args, **kwargs):
             (".fits", ".fits.gz", ".fit", ".fit.gz", ".fts", ".fts.gz")
         ):
             return True
-    elif isinstance(args[0], (HDUList, TableHDU, BinTableHDU, GroupsHDU)):
-        return True
-    else:
-        return False
+    return isinstance(args[0], (HDUList, TableHDU, BinTableHDU, GroupsHDU))
 
 
 def _decode_mixins(tbl):

--- a/astropy/io/fits/header.py
+++ b/astropy/io/fits/header.py
@@ -2205,11 +2205,7 @@ class _CardAccessor:
             else:
                 return False
 
-        for a, b in itertools.zip_longest(self, other):
-            if a != b:
-                return False
-        else:
-            return True
+        return all(not a != b for a, b in itertools.zip_longest(self, other))
 
     def __ne__(self, other):
         return not (self == other)

--- a/astropy/io/fits/header.py
+++ b/astropy/io/fits/header.py
@@ -2205,7 +2205,7 @@ class _CardAccessor:
             else:
                 return False
 
-        return all(not a != b for a, b in itertools.zip_longest(self, other))
+        return all(a == b for a, b in itertools.zip_longest(self, other))
 
     def __ne__(self, other):
         return not (self == other)

--- a/astropy/io/fits/tests/test_connect.py
+++ b/astropy/io/fits/tests/test_connect.py
@@ -50,10 +50,7 @@ mixin_cols = {
 
 
 def equal_data(a, b):
-    for name in a.dtype.names:
-        if not np.all(a[name] == b[name]):
-            return False
-    return True
+    return all(np.all(a[name] == b[name]) for name in a.dtype.names)
 
 
 class TestSingleTable:

--- a/astropy/io/fits/tests/test_core.py
+++ b/astropy/io/fits/tests/test_core.py
@@ -1241,8 +1241,9 @@ class TestFileFunctions(FitsTestCase):
                 hdulist.writeto(fileobj)
 
         assert (
-            "Not enough space on disk: requested 8000, available 0. "
-            "Fake error raised when writing file." == exc.value.args[0]
+            exc.value.args[0]
+            == "Not enough space on disk: requested 8000, available 0. "
+            "Fake error raised when writing file."
         )
 
     def test_flush_full_disk(self, monkeypatch):
@@ -1272,8 +1273,9 @@ class TestFileFunctions(FitsTestCase):
                 hdul.flush()
 
         assert (
-            "Not enough space on disk: requested 8000, available 0. "
-            "Fake error raised when writing file." == exc.value.args[0]
+            exc.value.args[0]
+            == "Not enough space on disk: requested 8000, available 0. "
+            "Fake error raised when writing file."
         )
 
     def _test_write_string_bytes_io(self, fileobj):

--- a/astropy/io/fits/tests/test_core.py
+++ b/astropy/io/fits/tests/test_core.py
@@ -1228,7 +1228,11 @@ class TestFileFunctions(FitsTestCase):
         def get_free_space_in_dir(path):
             return 0
 
-        with pytest.raises(OSError) as exc:
+        msg = (
+            "Not enough space on disk: requested 8000, available 0. "
+            "Fake error raised when writing file."
+        )
+        with pytest.raises(OSError, match=msg) as exc:
             monkeypatch.setattr(fits.hdu.base._BaseHDU, "_writeto", _writeto)
             monkeypatch.setattr(data, "get_free_space_in_dir", get_free_space_in_dir)
 
@@ -1239,12 +1243,6 @@ class TestFileFunctions(FitsTestCase):
 
             with open(filename, mode="wb") as fileobj:
                 hdulist.writeto(fileobj)
-
-        assert (
-            exc.value.args[0]
-            == "Not enough space on disk: requested 8000, available 0. "
-            "Fake error raised when writing file."
-        )
 
     def test_flush_full_disk(self, monkeypatch):
         """
@@ -1266,17 +1264,15 @@ class TestFileFunctions(FitsTestCase):
         monkeypatch.setattr(fits.hdu.base._BaseHDU, "_writedata", _writedata)
         monkeypatch.setattr(data, "get_free_space_in_dir", get_free_space_in_dir)
 
-        with pytest.raises(OSError) as exc:
+        msg = (
+            "Not enough space on disk: requested 8000, available 0. "
+            "Fake error raised when writing file."
+        )
+        with pytest.raises(OSError, match=msg) as exc:
             with fits.open(filename, mode="update") as hdul:
                 hdul[0].data = np.arange(0, 1000, dtype="int64")
                 hdul.insert(1, fits.ImageHDU())
                 hdul.flush()
-
-        assert (
-            exc.value.args[0]
-            == "Not enough space on disk: requested 8000, available 0. "
-            "Fake error raised when writing file."
-        )
 
     def _test_write_string_bytes_io(self, fileobj):
         """

--- a/astropy/io/fits/tests/test_header.py
+++ b/astropy/io/fits/tests/test_header.py
@@ -93,7 +93,7 @@ class TestHeaderFunctions(FitsTestCase):
         """Test Card constructor with default argument values."""
 
         c = fits.Card()
-        assert "" == c.keyword
+        assert c.keyword == ""
 
     def test_card_from_bytes(self):
         """

--- a/astropy/io/votable/connect.py
+++ b/astropy/io/votable/connect.py
@@ -39,10 +39,8 @@ def is_votable(origin, filepath, fileobj, *args, **kwargs):
             return result
         elif filepath is not None:
             return is_votable(filepath)
-        elif isinstance(args[0], (VOTableFile, VOTable)):
-            return True
-        else:
-            return False
+        return isinstance(args[0], (VOTableFile, VOTable))
+
     else:
         return False
 

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -4574,7 +4574,7 @@ def _custom_model_wrapper(func, fit_deriv=None):
     members.update(params)
 
     cls = type(model_name, (FittableModel,), members)
-    cls._separable = bool(len(inputs) == 1)
+    cls._separable = len(inputs) == 1
     return cls
 
 

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -4574,7 +4574,7 @@ def _custom_model_wrapper(func, fit_deriv=None):
     members.update(params)
 
     cls = type(model_name, (FittableModel,), members)
-    cls._separable = True if (len(inputs) == 1) else False
+    cls._separable = bool(len(inputs) == 1)
     return cls
 
 

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -1522,9 +1522,7 @@ class Model(metaclass=_ModelMeta):
             # We use this to explicitly set an unimplemented bounding box (as
             # opposed to no user bounding box defined)
             bounding_box = NotImplemented
-        elif isinstance(bounding_box, CompoundBoundingBox) or isinstance(
-            bounding_box, dict
-        ):
+        elif isinstance(bounding_box, (CompoundBoundingBox, dict)):
             cls = CompoundBoundingBox
         elif isinstance(self._bounding_box, type) and issubclass(
             self._bounding_box, ModelBoundingBox

--- a/astropy/modeling/tests/test_bounding_box.py
+++ b/astropy/modeling/tests/test_bounding_box.py
@@ -686,7 +686,7 @@ class Test_BoundingDomain:
         bounding_box = self.BoundingDomain(mk.MagicMock())
 
         # set no unit
-        assert 27 == bounding_box._set_outputs_unit(27, None)
+        assert bounding_box._set_outputs_unit(27, None) == 27
 
         # set unit
         assert 27 * u.m == bounding_box._set_outputs_unit(27, u.m)

--- a/astropy/modeling/tests/test_bounding_box.py
+++ b/astropy/modeling/tests/test_bounding_box.py
@@ -689,7 +689,7 @@ class Test_BoundingDomain:
         assert bounding_box._set_outputs_unit(27, None) == 27
 
         # set unit
-        assert 27 * u.m == bounding_box._set_outputs_unit(27, u.m)
+        assert bounding_box._set_outputs_unit(27, u.m) == 27 * u.m
 
     def test_evaluate(self):
         bounding_box = self.BoundingDomain(Gaussian2D())

--- a/astropy/modeling/tests/test_constraints.py
+++ b/astropy/modeling/tests/test_constraints.py
@@ -199,9 +199,7 @@ class TestBounds:
             theta=0.5,
             bounds=bounds,
         )
-        if isinstance(fitter, fitting.LevMarLSQFitter) or isinstance(
-            fitter, fitting.DogBoxLSQFitter
-        ):
+        if isinstance(fitter, (fitting.LevMarLSQFitter, fitting.DogBoxLSQFitter)):
             with pytest.warns(AstropyUserWarning, match="The fit may be unsuccessful"):
                 model = fitter(gauss, X, Y, self.data)
         else:
@@ -545,9 +543,7 @@ def test_gaussian2d_positive_stddev(fitter):
     # fmt: on
 
     g_init = models.Gaussian2D(x_mean=8, y_mean=8)
-    if isinstance(fitter, fitting.TRFLSQFitter) or isinstance(
-        fitter, fitting.DogBoxLSQFitter
-    ):
+    if isinstance(fitter, (fitting.TRFLSQFitter, fitting.DogBoxLSQFitter)):
         pytest.xfail("TRFLSQFitter seems to be broken for this test.")
 
     y, x = np.mgrid[:17, :17]

--- a/astropy/modeling/tests/test_core.py
+++ b/astropy/modeling/tests/test_core.py
@@ -696,8 +696,8 @@ def test__prepare_output_single_model():
     ).all()
 
     # Broadcast to scalar
-    assert 1 == model._prepare_output_single_model(np.array([1]), ())
-    assert 2 == model._prepare_output_single_model(np.asanyarray(2), ())
+    assert model._prepare_output_single_model(np.array([1]), ()) == 1
+    assert model._prepare_output_single_model(np.asanyarray(2), ()) == 2
 
     # Broadcast reshape
     output = np.array([[1, 2, 3], [4, 5, 6]])
@@ -706,8 +706,8 @@ def test__prepare_output_single_model():
     assert (reshape == model._prepare_output_single_model(output, (3, 2))).all()
 
     # Broadcast reshape scalar
-    assert 1 == model._prepare_output_single_model(np.array([1]), (1, 2))
-    assert 2 == model._prepare_output_single_model(np.asanyarray(2), (3, 4))
+    assert model._prepare_output_single_model(np.array([1]), (1, 2)) == 1
+    assert model._prepare_output_single_model(np.asanyarray(2), (3, 4)) == 2
 
     # Fail to broadcast
     assert (output == model._prepare_output_single_model(output, (1, 2))).all()

--- a/astropy/modeling/tests/test_fitters.py
+++ b/astropy/modeling/tests/test_fitters.py
@@ -551,7 +551,7 @@ class TestNonLinearFitters:
         assert_allclose(tf1.parameters, c, rtol=10 ** (-2), atol=10 ** (-2))
 
         model = models.Gaussian1D()
-        if isinstance(fitter, TRFLSQFitter) or isinstance(fitter, LMLSQFitter):
+        if isinstance(fitter, (TRFLSQFitter, LMLSQFitter)):
             with pytest.warns(
                 AstropyUserWarning, match=r"The fit may be unsuccessful; *."
             ):
@@ -1106,7 +1106,7 @@ def test_fitters_interface(fitter):
     else:
         kwargs = {"maxiter": 77, "verblevel": 1, "epsilon": 1e-2, "acc": 1e-6}
 
-    if isinstance(fitter, LevMarLSQFitter) or isinstance(fitter, _NLLSQFitter):
+    if isinstance(fitter, (LevMarLSQFitter, _NLLSQFitter)):
         kwargs.pop("verblevel")
 
     _ = fitter(model, x, y, **kwargs)

--- a/astropy/modeling/tests/test_models.py
+++ b/astropy/modeling/tests/test_models.py
@@ -489,7 +489,7 @@ class Fittable1DModelTester:
         model = create_model(model_class, test_parameters)
         bbox = model.bounding_box
 
-        if isinstance(model, models.Lorentz1D) or isinstance(model, models.Drude1D):
+        if isinstance(model, (models.Lorentz1D, models.Drude1D)):
             rtol = 0.01  # 1% agreement is enough due to very extended wings
             ddx = 0.1  # Finer sampling to "integrate" flux for narrow peak
         else:

--- a/astropy/modeling/tests/test_physical_models.py
+++ b/astropy/modeling/tests/test_physical_models.py
@@ -82,7 +82,7 @@ def test_blackbody_return_units():
 def test_blackbody_fit(fitter):
     fitter = fitter()
 
-    if isinstance(fitter, TRFLSQFitter) or isinstance(fitter, DogBoxLSQFitter):
+    if isinstance(fitter, (TRFLSQFitter, DogBoxLSQFitter)):
         rtol = 0.54
         atol = 1e-15
     else:

--- a/astropy/nddata/tests/test_utils.py
+++ b/astropy/nddata/tests/test_utils.py
@@ -218,9 +218,10 @@ def test_extract_array_odd_shape_rounding():
 
 def test_extract_array_wrong_mode():
     """Call extract_array with non-existing mode."""
-    with pytest.raises(ValueError) as e:
+    with pytest.raises(
+        ValueError, match="Valid modes are 'partial', 'trim', and 'strict'."
+    ):
         extract_array(np.arange(4), (2,), (0,), mode="full")
-    assert str(e.value) == "Valid modes are 'partial', 'trim', and 'strict'."
 
 
 def test_extract_array_1d_even():

--- a/astropy/nddata/tests/test_utils.py
+++ b/astropy/nddata/tests/test_utils.py
@@ -220,7 +220,7 @@ def test_extract_array_wrong_mode():
     """Call extract_array with non-existing mode."""
     with pytest.raises(ValueError) as e:
         extract_array(np.arange(4), (2,), (0,), mode="full")
-    assert "Valid modes are 'partial', 'trim', and 'strict'." == str(e.value)
+    assert str(e.value) == "Valid modes are 'partial', 'trim', and 'strict'."
 
 
 def test_extract_array_1d_even():

--- a/astropy/stats/tests/test_funcs.py
+++ b/astropy/stats/tests/test_funcs.py
@@ -255,10 +255,10 @@ def test_binned_binom_proportion_exception():
 
 def test_signal_to_noise_oir_ccd():
     result = funcs.signal_to_noise_oir_ccd(1, 25, 0, 0, 0, 1)
-    assert 5.0 == result
+    assert result == 5.0
     # check to make sure gain works
     result = funcs.signal_to_noise_oir_ccd(1, 5, 0, 0, 0, 1, 5)
-    assert 5.0 == result
+    assert result == 5.0
 
     # now add in sky, dark current, and read noise
     # make sure the snr goes down

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -2086,9 +2086,7 @@ class Table:
             # If item is an empty array/list/tuple then return the table with no rows
             return self._new_from_slice([])
         elif (
-            isinstance(item, slice)
-            or isinstance(item, np.ndarray)
-            or isinstance(item, list)
+            isinstance(item, (slice, np.ndarray, list))
             or isinstance(item, tuple)
             and all(isinstance(x, np.ndarray) for x in item)
         ):
@@ -2127,13 +2125,9 @@ class Table:
                 self._set_row(idx=item, colnames=self.colnames, vals=value)
 
             elif (
-                isinstance(item, slice)
-                or isinstance(item, np.ndarray)
-                or isinstance(item, list)
-                or (
-                    isinstance(item, tuple)  # output from np.where
-                    and all(isinstance(x, np.ndarray) for x in item)
-                )
+                isinstance(item, (slice, np.ndarray, list))
+                or isinstance(item, tuple)
+                and all(isinstance(x, np.ndarray) for x in item)
             ):
                 if isinstance(value, Table):
                     vals = (col for col in value.columns.values())

--- a/astropy/table/tests/test_groups.py
+++ b/astropy/table/tests/test_groups.py
@@ -557,8 +557,11 @@ def test_table_filter():
     """
 
     def all_positive(table, key_colnames):
-        colnames = [name for name in table.colnames if name not in key_colnames]
-        return all(not np.any(table[colname] < 0) for colname in colnames)
+        return all(
+            np.all(table[colname] >= 0)
+            for colname in table.colnames
+            if colname not in key_colnames
+        )
 
     # Negative value in 'a' column should not filter because it is a key col
     t = Table.read(

--- a/astropy/table/tests/test_groups.py
+++ b/astropy/table/tests/test_groups.py
@@ -558,10 +558,7 @@ def test_table_filter():
 
     def all_positive(table, key_colnames):
         colnames = [name for name in table.colnames if name not in key_colnames]
-        for colname in colnames:
-            if np.any(table[colname] < 0):
-                return False
-        return True
+        return all(not np.any(table[colname] < 0) for colname in colnames)
 
     # Negative value in 'a' column should not filter because it is a key col
     t = Table.read(

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -1196,7 +1196,7 @@ class UnitBase:
         def is_final_result(unit):
             # Returns True if this result contains only the expected
             # units
-            return all(not base not in namespace for base in unit.bases)
+            return all(base in namespace for base in unit.bases)
 
         unit = self.decompose()
         key = hash(unit)

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -1196,10 +1196,7 @@ class UnitBase:
         def is_final_result(unit):
             # Returns True if this result contains only the expected
             # units
-            for base in unit.bases:
-                if base not in namespace:
-                    return False
-            return True
+            return all(not base not in namespace for base in unit.bases)
 
         unit = self.decompose()
         key = hash(unit)

--- a/astropy/wcs/tests/test_wtbarr.py
+++ b/astropy/wcs/tests/test_wtbarr.py
@@ -43,16 +43,16 @@ def test_wtbarr_print(tab_wcs_2di, capfd):
     s = str(tab_wcs_2di.wcs.wtb[0])
     lines = s.split("\n")
     assert captured.out == s
-    assert "     i: 1" == lines[0]
-    assert "     m: 1" == lines[1]
-    assert "  kind: c" == lines[2]
-    assert "extnam: WCS-TABLE" == lines[3]
-    assert "extver: 1" == lines[4]
-    assert "extlev: 1" == lines[5]
-    assert " ttype: wavelength" == lines[6]
-    assert "   row: 1" == lines[7]
-    assert "  ndim: 3" == lines[8]
+    assert lines[0] == "     i: 1"
+    assert lines[1] == "     m: 1"
+    assert lines[2] == "  kind: c"
+    assert lines[3] == "extnam: WCS-TABLE"
+    assert lines[4] == "extver: 1"
+    assert lines[5] == "extlev: 1"
+    assert lines[6] == " ttype: wavelength"
+    assert lines[7] == "   row: 1"
+    assert lines[8] == "  ndim: 3"
     assert lines[9].startswith("dimlen: ")
-    assert "        0:   4" == lines[10]
-    assert "        1:   2" == lines[11]
+    assert lines[10] == "        0:   4"
+    assert lines[11] == "        1:   2"
     assert lines[12].startswith("arrayp: ")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -245,10 +245,9 @@ extend-ignore = [
     "SIM108",  # UseTernaryOperator                  # TODO: autofix
     "SIM115",  # OpenFileWithContextHandler          # TODO: fix to prevent resource leak
     "SIM117",  # MultipleWithStatements              # TODO: fix
-    "SIM118",  # KeyInDict                           # TODO: autofix
-    "SIM201",  # NegateEqualOp                       # TODO: autofix
-    "SIM202",  # NegateNotEqualOp                    # TODO: autofix
-    "SIM210",  # IfExprWithTrueFalse                 # TODO: autofix
+    "SIM118",  # KeyInDict                           # TODO: autofix, but be careful of Mapping
+    "SIM201",  # NegateEqualOp                       # TODO: autofix, ensure neq is implemented
+    "SIM202",  # NegateNotEqualOp                    # TODO: autofix, ensure eq is implemented
     "SIM300",  # YodaConditions                      # TODO: autofix
 
     # flake8-print (T20)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -240,7 +240,6 @@ extend-ignore = [
     "S324",	 # HashlibInsecureHashFunction           # TODO: fix or noqa
 
     # flake8-simplify (SIM)
-    "SIM101",  # DuplicateIsinstanceCall             # TODO: autofix
     "SIM102",  # NestedIfStatements                  # TODO: fixable with `pass`.
     "SIM103",  # ReturnBoolConditionDirectly         # TODO: autofix
     "SIM105",  # UseContextlibSuppress

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -243,7 +243,6 @@ extend-ignore = [
     "SIM102",  # NestedIfStatements                  # TODO: fixable with `pass`.
     "SIM105",  # UseContextlibSuppress
     "SIM108",  # UseTernaryOperator                  # TODO: autofix
-    "SIM111",  # ConvertLoopToAll                    # TODO: autofix
     "SIM115",  # OpenFileWithContextHandler          # TODO: fix to prevent resource leak
     "SIM117",  # MultipleWithStatements              # TODO: fix
     "SIM118",  # KeyInDict                           # TODO: autofix

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -241,7 +241,6 @@ extend-ignore = [
 
     # flake8-simplify (SIM)
     "SIM102",  # NestedIfStatements                  # TODO: fixable with `pass`.
-    "SIM103",  # ReturnBoolConditionDirectly         # TODO: autofix
     "SIM105",  # UseContextlibSuppress
     "SIM108",  # UseTernaryOperator                  # TODO: autofix
     "SIM109",  # CompareWithTuple                    # TODO: autofix

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -242,13 +242,12 @@ extend-ignore = [
     # flake8-simplify (SIM)
     "SIM102",  # NestedIfStatements                  # TODO: fixable with `pass`.
     "SIM105",  # UseContextlibSuppress
-    "SIM108",  # UseTernaryOperator                  # TODO: autofix
+    "SIM108",  # UseTernaryOperator                  # TODO? autofix. Impact on readability?
     "SIM115",  # OpenFileWithContextHandler          # TODO: fix to prevent resource leak
     "SIM117",  # MultipleWithStatements              # TODO: fix
     "SIM118",  # KeyInDict                           # TODO: autofix, but be careful of Mapping
     "SIM201",  # NegateEqualOp                       # TODO: autofix, ensure neq is implemented
     "SIM202",  # NegateNotEqualOp                    # TODO: autofix, ensure eq is implemented
-    "SIM300",  # YodaConditions                      # TODO: autofix
 
     # flake8-print (T20)
     "T201",  # PrintUsed                             # TODO: change to logging

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -243,7 +243,6 @@ extend-ignore = [
     "SIM102",  # NestedIfStatements                  # TODO: fixable with `pass`.
     "SIM105",  # UseContextlibSuppress
     "SIM108",  # UseTernaryOperator                  # TODO: autofix
-    "SIM109",  # CompareWithTuple                    # TODO: autofix
     "SIM111",  # ConvertLoopToAll                    # TODO: autofix
     "SIM115",  # OpenFileWithContextHandler          # TODO: fix to prevent resource leak
     "SIM117",  # MultipleWithStatements              # TODO: fix


### PR DESCRIPTION
### Description

Flake8-simplify helps to simplify python code by e.g. collapsing ``isintance(x, int) or isinstance(x, float)`` to ``isinstance(x, (int, float))``.

This PR implements some of the SIM checks, using Ruff

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
