### PR TITLE
Ruff fix select flake8-bugbear

### DIFF
--- a/astropy/cosmology/io/model.py
+++ b/astropy/cosmology/io/model.py
@@ -238,7 +238,7 @@ def to_model(cosmology, *_, method):
     # make Model class
     CosmoModel = type(clsname, (_CosmologyModel,), {**attrs, **params})
     # override __signature__ and format the doc.
-    setattr(CosmoModel.evaluate, "__signature__", msig)
+    CosmoModel.evaluate.__signature__ = msig
     CosmoModel.evaluate.__doc__ = CosmoModel.evaluate.__doc__.format(
         cosmo_cls=cosmo_cls.__qualname__, method=method
     )

--- a/astropy/io/fits/convenience.py
+++ b/astropy/io/fits/convenience.py
@@ -628,7 +628,7 @@ def table_to_hdu(table, character_as_bytes=False):
             setattr(col, attr, col_info.get(attr, None))
         trpos = col_info.get("time_ref_pos", None)
         if trpos is not None:
-            setattr(col, "time_ref_pos", trpos)
+            col.time_ref_pos = trpos
 
     for key, value in table.meta.items():
         if is_column_keyword(key.upper()) or key.upper() in REMOVE_KEYWORDS:

--- a/astropy/io/fits/fitstime.py
+++ b/astropy/io/fits/fitstime.py
@@ -620,7 +620,7 @@ def time_to_fits(table):
         coord_meta[col.info.name]["coord_unit"] = "d"
 
         # Time column reference position
-        if getattr(col, "location") is None:
+        if col.location is None:
             coord_meta[col.info.name]["time_ref_pos"] = None
             if location is not None:
                 warnings.warn(

--- a/astropy/io/fits/hdu/base.py
+++ b/astropy/io/fits/hdu/base.py
@@ -203,7 +203,7 @@ class _BaseHDU:
                     if has_getrefcount and data_refcount == 2:
                         self._file._maybe_close_mmap()
 
-            setattr(cls, "data", data_prop.deleter(data))
+            cls.data = data_prop.deleter(data)
 
         return super().__init_subclass__(**kwargs)
 

--- a/astropy/io/votable/tests/exception_test.py
+++ b/astropy/io/votable/tests/exception_test.py
@@ -9,15 +9,11 @@ def test_reraise():
     def fail():
         raise RuntimeError("This failed")
 
-    try:
+    with pytest.raises(RuntimeError, match="From here"):
         try:
             fail()
         except RuntimeError as e:
             exceptions.vo_reraise(e, additional="From here")
-    except RuntimeError as e:
-        assert "From here" in str(e)
-    else:
-        assert False
 
 
 def test_parse_vowarning():

--- a/astropy/units/function/core.py
+++ b/astropy/units/function/core.py
@@ -543,7 +543,7 @@ class FunctionQuantity(Quantity):
                 # if iterable, see if first item has a unit
                 # (mixed lists fail in super call below).
                 try:
-                    value_unit = getattr(value[0], "unit")
+                    value_unit = value[0].unit
                 except Exception:
                     pass
             physical_unit = getattr(value_unit, "physical_unit", value_unit)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,6 @@ extend-ignore = [
     "B006",  # MutableArgumentDefault                  # NOTE: low priority fix
     "B007",  # UnusedLoopControlVariable               # TODO: autofix
     "B008",  # FunctionCallArgumentDefault
-    "B010",  # SetAttrWithConstant                     # TODO: autofix
     "B011",  # DoNotAssertFalse                        # TODO: autofix
     "B015",  # UselessComparison                       # TODO: fix
     "B020",  # LoopVariableOverridesIterator           # TODO: fix

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,6 @@ extend-ignore = [
     "B006",  # MutableArgumentDefault                  # NOTE: low priority fix
     "B007",  # UnusedLoopControlVariable               # TODO: autofix
     "B008",  # FunctionCallArgumentDefault
-    "B011",  # DoNotAssertFalse                        # TODO: autofix
     "B015",  # UselessComparison                       # TODO: fix
     "B020",  # LoopVariableOverridesIterator           # TODO: fix
     "B023",  # FunctionUsesLoopVariable                # TODO: fix

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,6 @@ extend-ignore = [
     "B006",  # MutableArgumentDefault                  # NOTE: low priority fix
     "B007",  # UnusedLoopControlVariable               # TODO: autofix
     "B008",  # FunctionCallArgumentDefault
-    "B009",  # GetAttrWithConstant                     # TODO: autofix
     "B010",  # SetAttrWithConstant                     # TODO: autofix
     "B011",  # DoNotAssertFalse                        # TODO: autofix
     "B015",  # UselessComparison                       # TODO: fix


### PR DESCRIPTION
These are all the easy auto-fix for flake8 bugbear.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
