### PR TITLE
Replace pyupgrade with ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,13 +53,6 @@ repos:
       - id: python-check-blanket-noqa
         # Enforce that all noqa annotations always occur with specific codes.
 
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.3.1
-    hooks:
-      - id: pyupgrade
-        args: ["--py38-plus"]
-        exclude: ".*(extern.*|_parsetab.py|_lextab.py)$"
-
 
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.2

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -1600,7 +1600,7 @@ class UnitBase:
                     for i, col in enumerate(line):
                         widths[i] = max(widths[i], len(col))
 
-                f = "  {{0:<{0}s}} | {{1:<{1}s}} | {{2:<{2}s}}".format(*widths)
+                f = "  {{0:<{}s}} | {{1:<{}s}} | {{2:<{}s}}".format(*widths)
                 lines = [f.format(*line) for line in lines]
                 lines = lines[0:1] + ["["] + [f"{x} ," for x in lines[1:]] + ["]"]
                 return "\n".join(lines)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ exclude= [
 
 
 [tool.ruff]
+target-version = "py38"
 line-length = 88
 select = ["ALL"]
 exclude=[
@@ -291,10 +292,6 @@ extend-ignore = [
     "TRY300",  # Consider `else` block               # TODO: fix
     "TRY301",  # raise-within-try                    # TODO: fix
     "TRY400",  # error-instead-of-exception          # TODO: fix
-
-    # pyupgrade (UP)
-    # TODO: replace pyupgrade with this
-    "UP",
 
     # flake8-quotes (Q)
     "Q000",  # use double quotes                     # TODO: fix


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
