### PR TITLE
Remove heuristic code to handle PTF files which is causing a bug

### DIFF
--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -705,52 +705,6 @@ reduce these to 2 dimensions using the naxis kwarg.
     if _wcs is not None:
         sub.__doc__ = _wcs.Wcsprm.sub.__doc__
 
-    def _fix_scamp(self):
-        """
-        Remove SCAMP's PVi_m distortion parameters if SIP distortion parameters
-        are also present. Some projects (e.g., Palomar Transient Factory)
-        convert SCAMP's distortion parameters (which abuse the PVi_m cards) to
-        SIP. However, wcslib gets confused by the presence of both SCAMP and
-        SIP distortion parameters.
-
-        See https://github.com/astropy/astropy/issues/299.
-        """
-        # Nothing to be done if no WCS attached
-        if self.wcs is None:
-            return
-
-        # Nothing to be done if no PV parameters attached
-        pv = self.wcs.get_pv()
-        if not pv:
-            return
-
-        # Nothing to be done if axes don't use SIP distortion parameters
-        if self.sip is None:
-            return
-
-        # Nothing to be done if any radial terms are present...
-        # Loop over list to find any radial terms.
-        # Certain values of the `j' index are used for storing
-        # radial terms; refer to Equation (1) in
-        # <http://web.ipac.caltech.edu/staff/shupe/reprints/SIP_to_PV_SPIE2012.pdf>.
-        pv = np.asarray(pv)
-        # Loop over distinct values of `i' index
-        for i in set(pv[:, 0]):
-            # Get all values of `j' index for this value of `i' index
-            js = set(pv[:, 1][pv[:, 0] == i])
-            # Find max value of `j' index
-            max_j = max(js)
-            for j in (3, 11, 23, 39):
-                if j < max_j and j in js:
-                    return
-
-        self.wcs.set_pv([])
-        warnings.warn(
-            "Removed redundant SCAMP distortion parameters "
-            + "because SIP parameters are also present",
-            FITSFixedWarning,
-        )
-
     def fix(self, translate_units="", naxis=None):
         """
         Perform the fix operations from wcslib, and warn about any
@@ -790,7 +744,6 @@ reduce these to 2 dimensions using the naxis kwarg.
             invoked.
         """
         if self.wcs is not None:
-            self._fix_scamp()
             fixes = self.wcs.fix(translate_units, naxis)
             for key, val in fixes.items():
                 if val != "No change":


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

Currently the `_fix_scamp` function remove any PV keywords when SIP distortions are present and no radial terms are present which should not  be the case. This function was put in place for solving https://github.com/astropy/astropy/issues/299 but it causes the bug #14255.

We can either keep adding heuristic code to fix the edge cases as they come up with or remove `_fix_scamp` and let the user deal with non-standard files. I'm opening a pull request for the latter following the discusison in #14255.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #14255

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
