### PR TITLE
Fix docs warnings

### DIFF
--- a/astropy/timeseries/io/kepler.py
+++ b/astropy/timeseries/io/kepler.py
@@ -11,7 +11,7 @@ from astropy.timeseries.sampled import TimeSeries
 __all__ = ["kepler_fits_reader"]
 
 
-def kepler_fits_reader(filename):
+def kepler_fits_reader(filename, unit_parse_strict="warn"):
     """
     This serves as the FITS reader for KEPLER or TESS files within
     astropy-timeseries.
@@ -27,6 +27,12 @@ def kepler_fits_reader(filename):
     ----------
     filename : `str` or `pathlib.Path`
         File to load.
+    unit_parse_strict : str, optional
+        Behaviour when encountering invalid column units in the FITS header.
+        Default is "warn", which will emit a ``UnitsWarning`` and create a
+        :class:`~astropy.units.core.UnrecognizedUnit`.
+        Values are the ones allowed by the ``parse_strict`` argument of
+        :class:`~astropy.units.core.Unit`: ``raise``, ``warn`` and ``silent``.
 
     Returns
     -------
@@ -60,7 +66,7 @@ def kepler_fits_reader(filename):
             f" {hdu.header['TELESCOP']} reader"
         )
 
-    tab = Table.read(hdu, format="fits")
+    tab = Table.read(hdu, format="fits", unit_parse_strict=unit_parse_strict)
 
     # Some KEPLER files have a T column instead of TIME.
     if "T" in tab.colnames:

--- a/astropy/timeseries/io/kepler.py
+++ b/astropy/timeseries/io/kepler.py
@@ -100,7 +100,7 @@ def kepler_fits_reader(filename, unit_parse_strict="warn"):
         scale=hdu.header["TIMESYS"].lower(),
         format="jd",
     )
-    time = reference_date + TimeDelta(tab["time"].data)
+    time = reference_date + TimeDelta(tab["time"].data, format="jd")
     time.format = "isot"
 
     # Remove original time column

--- a/docs/changes/timeseries/14294.feature.rst
+++ b/docs/changes/timeseries/14294.feature.rst
@@ -1,0 +1,2 @@
+Add ``unit_parse_strict`` parameter to the Kepler reader to control the warnings
+emitted when reading files.

--- a/docs/timeseries/analysis.rst
+++ b/docs/timeseries/analysis.rst
@@ -138,7 +138,7 @@ we read in the data using:
     from astropy.timeseries import TimeSeries
     from astropy.utils.data import get_pkg_data_filename
     example_data = get_pkg_data_filename('timeseries/kplr010666592-2009131110544_slc.fits')
-    kepler = TimeSeries.read(example_data, format='kepler.fits')
+    kepler = TimeSeries.read(example_data, format='kepler.fits', unit_parse_strict='silent')
 
 (See :ref:`timeseries-io` for more details about reading in data). We can then
 downsample using:
@@ -192,7 +192,7 @@ the case of uneven-size contiguous bins:
     from astropy.utils.data import get_pkg_data_filename
 
     example_data = get_pkg_data_filename('timeseries/kplr010666592-2009131110544_slc.fits')
-    kepler = TimeSeries.read(example_data, format='kepler.fits')
+    kepler = TimeSeries.read(example_data, format='kepler.fits', unit_parse_strict='silent')
 
     import warnings
     warnings.filterwarnings('ignore', message='All-NaN slice encountered')
@@ -235,7 +235,7 @@ an epoch as a :class:`~astropy.time.Time`, which defines a zero time offset:
    from astropy.utils.data import get_pkg_data_filename
 
    example_data = get_pkg_data_filename('timeseries/kplr010666592-2009131110544_slc.fits')
-   kepler = TimeSeries.read(example_data, format='kepler.fits')
+   kepler = TimeSeries.read(example_data, format='kepler.fits', unit_parse_strict='silent')
 
 .. plot::
    :include-source:
@@ -274,7 +274,7 @@ sigma-clipped median value.
    from astropy.utils.data import get_pkg_data_filename
 
    example_data = get_pkg_data_filename('timeseries/kplr010666592-2009131110544_slc.fits')
-   kepler = TimeSeries.read(example_data, format='kepler.fits')
+   kepler = TimeSeries.read(example_data, format='kepler.fits', unit_parse_strict='silent')
    kepler_folded = kepler.fold(period=2.2 * u.day, epoch_time='2009-05-02T20:53:40')
 
 .. plot::

--- a/docs/timeseries/index.rst
+++ b/docs/timeseries/index.rst
@@ -169,7 +169,7 @@ details). We can use what we have seen so far to make a plot:
     from astropy.utils.data import get_pkg_data_filename
     filename = get_pkg_data_filename('timeseries/kplr010666592-2009131110544_slc.fits')
     from astropy.timeseries import TimeSeries
-    ts = TimeSeries.read(filename, format='kepler.fits')
+    ts = TimeSeries.read(filename, format='kepler.fits', unit_parse_strict='silent')
 
 .. plot::
    :include-source:

--- a/docs/timeseries/io.rst
+++ b/docs/timeseries/io.rst
@@ -45,7 +45,7 @@ read in the time series using:
    :nofigs:
 
    from astropy.timeseries import TimeSeries
-   kepler = TimeSeries.read(example_data, format='kepler.fits')
+   kepler = TimeSeries.read(example_data, format='kepler.fits', unit_parse_strict='silent')
 
 Now we can check that the time series has been read in correctly:
 


### PR DESCRIPTION
Fix warnings in the doc build:
```
WARNING: UnitsWarning: 'BJD - 2454833' did not parse as fits unit: At col 0, Unit 'BJD' not supported by the FITS standard.  If this is meant to be a custom unit, define it with 'u.def_unit'. To have it recognized inside a file reader or other code, enable it with 'u.add_enabled_units'. For details, see https://docs.astropy.org/en/latest/units/combining_and_defining.html [astropy.units.core]
WARNING: UnitsWarning: 'e-/s' did not parse as fits unit: At col 0, Unit 'e' not supported by the FITS standard.  If this is meant to be a custom unit, define it with 'u.def_unit'. To have it recognized inside a file reader or other code, enable it with 'u.add_enabled_units'. For details, see https://docs.astropy.org/en/latest/units/combining_and_defining.html [astropy.units.core]
WARNING: UnitsWarning: 'pixels' did not parse as fits unit: At col 0, Unit 'pixels' not supported by the FITS standard. Did you mean pixel? If this is meant to be a custom unit, define it with 'u.def_unit'. To have it recognized inside a file reader or other code, enable it with 'u.add_enabled_units'. For details, see https://docs.astropy.org/en/latest/units/combining_and_defining.html [astropy.units.core]
WARNING: TimeDeltaMissingUnitWarning: Numerical value without unit or explicit format passed to TimeDelta, assuming days [astropy.time.core]
```

Those warnings come from parsing units with the Kepler reader. So I added a `unit_parse_strict` parameter to this reader, which is propagated to `Table.read`.

<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address ...

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
