### PR TITLE
Improve detection of TPV and allow PVi_j with legitimate prj codes

### DIFF
--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -2,7 +2,6 @@
 
 import io
 import os
-import warnings
 from contextlib import nullcontext
 from datetime import datetime
 
@@ -788,13 +787,12 @@ def test_error_message():
 
     # make WCS transformation invalid
     hdr = fits.Header.fromstring(header)
-    del hdr['PV?_*']
-    hdr['PV1_2'] = 110
-    hdr['PV2_2'] = 110
-
+    del hdr["PV?_*"]
+    hdr["PV1_1"] = 110
+    hdr["PV1_2"] = 110
+    hdr["PV2_1"] = -110
+    hdr["PV2_2"] = -110
     with pytest.raises(wcs.InvalidTransformError):
-        # Both lines are in here, because 0.4 calls .set within WCS.__init__,
-        # whereas 0.3 and earlier did not.
         with pytest.warns(wcs.FITSFixedWarning):
             w = wcs.WCS(hdr, _do_set=False)
             w.all_pix2world([[536.0, 894.0]], 0)
@@ -998,113 +996,101 @@ def test_sip_tpv_agreement():
 
 def test_tpv_ctype_sip():
     sip_header = fits.Header.fromstring(
-        get_pkg_data_contents(
-            os.path.join("data", "siponly.hdr"), encoding="binary"
-        )
+        get_pkg_data_contents(os.path.join("data", "siponly.hdr"), encoding="binary")
     )
     tpv_header = fits.Header.fromstring(
-        get_pkg_data_contents(
-            os.path.join("data", "tpvonly.hdr"), encoding="binary"
-        )
+        get_pkg_data_contents(os.path.join("data", "tpvonly.hdr"), encoding="binary")
     )
     sip_header.update(tpv_header)
-    sip_header['CTYPE1'] = 'RA---TAN-SIP'
-    sip_header['CTYPE2'] = 'DEC--TAN-SIP'
+    sip_header["CTYPE1"] = "RA---TAN-SIP"
+    sip_header["CTYPE2"] = "DEC--TAN-SIP"
 
     with pytest.warns(
         wcs.FITSFixedWarning,
         match="Removed redundant SCAMP distortion parameters "
-              "because SIP parameters are also present"
+        "because SIP parameters are also present",
     ):
         w_sip = wcs.WCS(sip_header)
 
-        assert w_sip.sip is not None
+    assert w_sip.sip is not None
 
 
 def test_tpv_ctype_tpv():
     sip_header = fits.Header.fromstring(
-        get_pkg_data_contents(
-            os.path.join("data", "siponly.hdr"), encoding="binary"
-        )
+        get_pkg_data_contents(os.path.join("data", "siponly.hdr"), encoding="binary")
     )
     tpv_header = fits.Header.fromstring(
-        get_pkg_data_contents(
-            os.path.join("data", "tpvonly.hdr"), encoding="binary"
-        )
+        get_pkg_data_contents(os.path.join("data", "tpvonly.hdr"), encoding="binary")
     )
     sip_header.update(tpv_header)
-    sip_header['CTYPE1'] = 'RA---TPV'
-    sip_header['CTYPE2'] = 'DEC--TPV'
+    sip_header["CTYPE1"] = "RA---TPV"
+    sip_header["CTYPE2"] = "DEC--TPV"
 
     with pytest.warns(
         wcs.FITSFixedWarning,
         match="Removed redundant SIP distortion parameters "
-              "because CTYPE explicitly specifies TPV distortions"
+        "because CTYPE explicitly specifies TPV distortions",
     ):
         w_sip = wcs.WCS(sip_header)
-        assert w_sip.sip is None
+
+    assert w_sip.sip is None
 
 
 def test_tpv_ctype_tan():
     sip_header = fits.Header.fromstring(
-        get_pkg_data_contents(
-            os.path.join("data", "siponly.hdr"), encoding="binary"
-        )
+        get_pkg_data_contents(os.path.join("data", "siponly.hdr"), encoding="binary")
     )
     tpv_header = fits.Header.fromstring(
-        get_pkg_data_contents(
-            os.path.join("data", "tpvonly.hdr"), encoding="binary"
-        )
+        get_pkg_data_contents(os.path.join("data", "tpvonly.hdr"), encoding="binary")
     )
     sip_header.update(tpv_header)
-    sip_header['CTYPE1'] = 'RA---TAN'
-    sip_header['CTYPE2'] = 'DEC--TAN'
+    sip_header["CTYPE1"] = "RA---TAN"
+    sip_header["CTYPE2"] = "DEC--TAN"
 
     with pytest.warns(
         wcs.FITSFixedWarning,
         match="Removed redundant SIP distortion parameters "
-              "because SCAMP' PV distortions are also present"
+        "because SCAMP' PV distortions are also present",
     ):
         w_sip = wcs.WCS(sip_header)
-        assert w_sip.sip is None
+
+    assert w_sip.sip is None
 
 
 def test_car_sip_with_pv():
     # https://github.com/astropy/astropy/issues/14255
     header_dict = {
-        'SIMPLE': True,
-        'BITPIX': -32,
-        'NAXIS': 2,
-        'NAXIS1': 1024,
-        'NAXIS2': 1024,
-        'CRPIX1': 512.0,
-        'CRPIX2': 512.0,
-        'CDELT1': 0.01,
-        'CDELT2': 0.01,
-        'CRVAL1': 120.0,
-        'CRVAL2': 29.0,
-        'CTYPE1': 'RA---CAR-SIP',
-        'CTYPE2': 'DEC--CAR-SIP',
-        'PV1_1': 120.0,
-        'PV1_2': 29.0,
-        'PV1_0': 1.0,
-        'A_ORDER': 2,
-        'A_2_0': 5.0e-4,
-        'B_ORDER': 2,
-        'B_2_0': 5.0e-4,
+        "SIMPLE": True,
+        "BITPIX": -32,
+        "NAXIS": 2,
+        "NAXIS1": 1024,
+        "NAXIS2": 1024,
+        "CRPIX1": 512.0,
+        "CRPIX2": 512.0,
+        "CDELT1": 0.01,
+        "CDELT2": 0.01,
+        "CRVAL1": 120.0,
+        "CRVAL2": 29.0,
+        "CTYPE1": "RA---CAR-SIP",
+        "CTYPE2": "DEC--CAR-SIP",
+        "PV1_1": 120.0,
+        "PV1_2": 29.0,
+        "PV1_0": 1.0,
+        "A_ORDER": 2,
+        "A_2_0": 5.0e-4,
+        "B_ORDER": 2,
+        "B_2_0": 5.0e-4,
     }
 
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
-        w = wcs.WCS(header_dict)
+    w = wcs.WCS(header_dict)
 
     assert w.sip is not None
 
     assert w.wcs.get_pv() == [(1, 1, 120.0), (1, 2, 29.0), (1, 0, 1.0)]
 
     assert np.allclose(
-        w.all_pix2world(header_dict['CRPIX1'], header_dict['CRPIX2'], 1),
-        [header_dict['CRVAL1'], header_dict['CRVAL2']]
+        w.all_pix2world(header_dict["CRPIX1"], header_dict["CRPIX2"], 1),
+        [header_dict["CRVAL1"], header_dict["CRVAL2"]],
     )
 
 

--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -2,6 +2,7 @@
 
 import io
 import os
+import warnings
 from contextlib import nullcontext
 from datetime import datetime
 
@@ -785,11 +786,17 @@ def test_validate_faulty_wcs():
 def test_error_message():
     header = get_pkg_data_contents("data/invalid_header.hdr", encoding="binary")
 
+    # make WCS transformation invalid
+    hdr = fits.Header.fromstring(header)
+    del hdr['PV?_*']
+    hdr['PV1_2'] = 110
+    hdr['PV2_2'] = 110
+
     with pytest.raises(wcs.InvalidTransformError):
         # Both lines are in here, because 0.4 calls .set within WCS.__init__,
         # whereas 0.3 and earlier did not.
         with pytest.warns(wcs.FITSFixedWarning):
-            w = wcs.WCS(header, _do_set=False)
+            w = wcs.WCS(hdr, _do_set=False)
             w.all_pix2world([[536.0, 894.0]], 0)
 
 
@@ -987,6 +994,118 @@ def test_sip_tpv_agreement():
             w_sip2.all_pix2world([w_sip.wcs.crpix], 1),
             w_tpv2.all_pix2world([w_tpv.wcs.crpix], 1),
         )
+
+
+def test_tpv_ctype_sip():
+    sip_header = fits.Header.fromstring(
+        get_pkg_data_contents(
+            os.path.join("data", "siponly.hdr"), encoding="binary"
+        )
+    )
+    tpv_header = fits.Header.fromstring(
+        get_pkg_data_contents(
+            os.path.join("data", "tpvonly.hdr"), encoding="binary"
+        )
+    )
+    sip_header.update(tpv_header)
+    sip_header['CTYPE1'] = 'RA---TAN-SIP'
+    sip_header['CTYPE2'] = 'DEC--TAN-SIP'
+
+    with pytest.warns(
+        wcs.FITSFixedWarning,
+        match="Removed redundant SCAMP distortion parameters "
+              "because SIP parameters are also present"
+    ):
+        w_sip = wcs.WCS(sip_header)
+
+        assert w_sip.sip is not None
+
+
+def test_tpv_ctype_tpv():
+    sip_header = fits.Header.fromstring(
+        get_pkg_data_contents(
+            os.path.join("data", "siponly.hdr"), encoding="binary"
+        )
+    )
+    tpv_header = fits.Header.fromstring(
+        get_pkg_data_contents(
+            os.path.join("data", "tpvonly.hdr"), encoding="binary"
+        )
+    )
+    sip_header.update(tpv_header)
+    sip_header['CTYPE1'] = 'RA---TPV'
+    sip_header['CTYPE2'] = 'DEC--TPV'
+
+    with pytest.warns(
+        wcs.FITSFixedWarning,
+        match="Removed redundant SIP distortion parameters "
+              "because CTYPE explicitly specifies TPV distortions"
+    ):
+        w_sip = wcs.WCS(sip_header)
+        assert w_sip.sip is None
+
+
+def test_tpv_ctype_tan():
+    sip_header = fits.Header.fromstring(
+        get_pkg_data_contents(
+            os.path.join("data", "siponly.hdr"), encoding="binary"
+        )
+    )
+    tpv_header = fits.Header.fromstring(
+        get_pkg_data_contents(
+            os.path.join("data", "tpvonly.hdr"), encoding="binary"
+        )
+    )
+    sip_header.update(tpv_header)
+    sip_header['CTYPE1'] = 'RA---TAN'
+    sip_header['CTYPE2'] = 'DEC--TAN'
+
+    with pytest.warns(
+        wcs.FITSFixedWarning,
+        match="Removed redundant SIP distortion parameters "
+              "because SCAMP' PV distortions are also present"
+    ):
+        w_sip = wcs.WCS(sip_header)
+        assert w_sip.sip is None
+
+
+def test_car_sip_with_pv():
+    # https://github.com/astropy/astropy/issues/14255
+    header_dict = {
+        'SIMPLE': True,
+        'BITPIX': -32,
+        'NAXIS': 2,
+        'NAXIS1': 1024,
+        'NAXIS2': 1024,
+        'CRPIX1': 512.0,
+        'CRPIX2': 512.0,
+        'CDELT1': 0.01,
+        'CDELT2': 0.01,
+        'CRVAL1': 120.0,
+        'CRVAL2': 29.0,
+        'CTYPE1': 'RA---CAR-SIP',
+        'CTYPE2': 'DEC--CAR-SIP',
+        'PV1_1': 120.0,
+        'PV1_2': 29.0,
+        'PV1_0': 1.0,
+        'A_ORDER': 2,
+        'A_2_0': 5.0e-4,
+        'B_ORDER': 2,
+        'B_2_0': 5.0e-4,
+    }
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        w = wcs.WCS(header_dict)
+
+    assert w.sip is not None
+
+    assert w.wcs.get_pv() == [(1, 1, 120.0), (1, 2, 29.0), (1, 0, 1.0)]
+
+    assert np.allclose(
+        w.all_pix2world(header_dict['CRPIX1'], header_dict['CRPIX2'], 1),
+        [header_dict['CRVAL1'], header_dict['CRVAL2']]
+    )
 
 
 @pytest.mark.skipif(

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -726,7 +726,7 @@ reduce these to 2 dimensions using the naxis kwarg.
 
         # Delete SIP if CTYPE explicitly has '-TPV' code:
         ctype = [ct.strip().upper() for ct in self.wcs.ctype]
-        if sum(ct.endswith('-TPV') for ct in ctype) == 2:
+        if sum(ct.endswith("-TPV") for ct in ctype) == 2:
             if self.sip is not None:
                 self.sip = None
                 warnings.warn(
@@ -748,18 +748,17 @@ reduce these to 2 dimensions using the naxis kwarg.
 
         # Loop over distinct values of `i' index
         has_scamp = False
-        for i in set(v[0] for v in pv):
+        for i in {v[0] for v in pv}:
             # Get all values of `j' index for this value of `i' index
             js = tuple(v[1] for v in pv if v[0] == i)
-            if '-TAN' in self.wcs.ctype[i - 1].upper() and js and max(js) >= 5:
+            if "-TAN" in self.wcs.ctype[i - 1].upper() and js and max(js) >= 5:
                 # TAN projection *may* use PVi_j with j up to 4 - see
                 # Sections 2.5, 2.6, and Table 13
                 # in https://doi.org/10.1051/0004-6361:20021327
                 has_scamp = True
                 break
 
-        if (has_scamp and
-                all(ct.endswith('-SIP') for ct in ctype)):
+        if has_scamp and all(ct.endswith("-SIP") for ct in ctype):
             # Prefer SIP - see recommendations in Section 7 in
             # http://web.ipac.caltech.edu/staff/shupe/reprints/SIP_to_PV_SPIE2012.pdf
             self.wcs.set_pv([])
@@ -1194,12 +1193,12 @@ reduce these to 2 dimensions using the naxis kwarg.
         write_dist(1, self.cpdis1)
         write_dist(2, self.cpdis2)
 
-    def _fix_pre2012_scamp_tpv(self, header, wcskey=''):
+    def _fix_pre2012_scamp_tpv(self, header, wcskey=""):
         """
         Replace -TAN with TPV (for pre-2012 SCAMP headers that use -TAN
         in CTYPE). Ignore SIP if present. This follows recommendations in
         Section 7 in
-        http://web.ipac.caltech.edu/staff/shupe/reprints/SIP_to_PV_SPIE2012.pdf
+        http://web.ipac.caltech.edu/staff/shupe/reprints/SIP_to_PV_SPIE2012.pdf.
 
         This is to deal with pre-2012 headers that may contain TPV with a
         CTYPE that ends in '-TAN' (post-2012 they should end in '-TPV' when
@@ -1210,23 +1209,27 @@ reduce these to 2 dimensions using the naxis kwarg.
 
         wcskey = wcskey.strip().upper()
         cntype = [
-            (nax, header.get(f"CTYPE{nax}{wcskey}", '').strip())
+            (nax, header.get(f"CTYPE{nax}{wcskey}", "").strip())
             for nax in range(1, self.naxis + 1)
         ]
 
-        tan_axes = [ct[0] for ct in cntype if ct[1].endswith('-TAN')]
+        tan_axes = [ct[0] for ct in cntype if ct[1].endswith("-TAN")]
 
         if len(tan_axes) == 2:
             # check if PVi_j with j >= 5 is present and if so, do not load SIP
             tan_to_tpv = False
             for nax in tan_axes:
                 js = []
-                for p in header[f'PV{nax}_*{wcskey}'].keys():
-                    prefix = f'PV{nax}_'
+                for p in header[f"PV{nax}_*{wcskey}"].keys():
+                    prefix = f"PV{nax}_"
                     if p.startswith(prefix):
-                        p = p[len(prefix):]
-                    p = p.rstrip(wcskey)
-                    js.append(int(p))
+                        p = p[len(prefix) :]
+                        p = p.rstrip(wcskey)
+                        try:
+                            p = int(p)
+                        except ValueError:
+                            continue
+                        js.append(p)
 
                 if js and max(js) >= 5:
                     tan_to_tpv = True
@@ -1240,9 +1243,11 @@ reduce these to 2 dimensions using the naxis kwarg.
                 )
                 self._remove_sip_kw(header, del_order=True)
                 for i in tan_axes:
-                    kwd = f'CTYPE{i:d}{wcskey}'
+                    kwd = f"CTYPE{i:d}{wcskey}"
                     if kwd in header:
-                        header[kwd] = header[kwd].strip().upper().replace('-TAN', '-TPV')
+                        header[kwd] = (
+                            header[kwd].strip().upper().replace("-TAN", "-TPV")
+                        )
 
     @staticmethod
     def _remove_sip_kw(header, del_order=False):
@@ -1257,7 +1262,7 @@ reduce these to 2 dimensions using the naxis kwarg.
             del header[key]
 
         if del_order:
-            for kwd in ['A_ORDER', 'B_ORDER', 'AP_ORDER', 'BP_ORDER']:
+            for kwd in ["A_ORDER", "B_ORDER", "AP_ORDER", "BP_ORDER"]:
                 if kwd in header:
                     del header[kwd]
 

--- a/docs/changes/wcs/14295.bugfix.rst
+++ b/docs/changes/wcs/14295.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed a bug in how WCS handles ``PVi_ja`` header coefficients when ``CTYPE``
+has ``-SIP`` suffix and in how code detects TPV distortions.


### PR DESCRIPTION
### Description
This is an alternative to #14293 which, instead of removing detection of SCAMP PV distortions as in #14293, this PR implements a more complicated logic that fixes the problems described in #14255 while also supporting SCAMP PV distortions in PTF data both pre-2012 (`CTYPE` ends in `-TAN`) and post-2012 (`CTYPE` ends in `-TPV`).

Specifically, this PR implements the following logic for dealing with PV, TPV, SIP based on my understanding of recommendations from the section 7 of https://web.ipac.caltech.edu/staff/shupe/reprints/SIP_to_PV_SPIE2012.pdf:

1. if `-SIP` is in `CTYPE` and `-TAN` in `CTYPE`:
    - check that `j` in `PVi_j` is < 5. If it is - allow these PVs (pass them to 
    - if `max(j) >= 5` - these are SCAMP PV distortions but ignore them due to explicit `-SIP` in `CTYPE`
2. if `max(j)` in `PVi_j` is >= 5 and  `CTYPE` ends in `-TAN`, then these are SCAMP pre-2012 distortions. Replace `-TAN` with `-TPV` and pass PVs to WCSLIB; If SIP is present - ignore it (TPV takes precedence).
3. if projection code is anything else other than `TAN`, pass all (if any) `PVi_j` coefficients to WCSLIB regardless of the presence of the `-SIP` suffix.
4. if `CTYPE` ends in `-TPV` pass all `PVi_j` to WCSLIB and ignore SIP (if present).

CC: @navii98

Fixes #14255
Closes #14293

### Checklist for package maintainer(s)

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
