### PR TITLE
Remove the list of Git GUIs from developer documentation

### DIFF
--- a/docs/development/workflow/development_workflow.rst
+++ b/docs/development/workflow/development_workflow.rst
@@ -109,7 +109,9 @@ to Astropy:
 
 .. note::
     A good graphical interface to git makes some of these steps much
-    easier. Some options are described in :ref:`git_gui_options`.
+    easier.
+    You might find this
+    `list of GUI Clients <https://git-scm.com/downloads/guis/>`_ to be helpful.
 
 If something goes wrong
 =======================

--- a/docs/development/workflow/git_edit_workflow_examples.rst
+++ b/docs/development/workflow/git_edit_workflow_examples.rst
@@ -212,7 +212,9 @@ Use ``git diff`` to see what changes have been made::
     +    assert len(c) == input_length
 
 A graphical interface to git makes keeping track of these sorts of changes
-even easier; see :ref:`git_gui_options` if you are interested.
+even easier; see this
+`list of GUI Clients <https://git-scm.com/downloads/guis/>`_ if you are
+interested.
 
 Stage the change
 ----------------
@@ -354,8 +356,9 @@ snippet below accomplishes that in bash (and similar shells)::
     [fix-1761 f196771] Add len() to coordinates
      1 file changed, 4 insertions(+)
 
-Another option for multi-line commit message is to use a Git GUI or to
-run ``git commit`` without a message to get prompted by an editor.
+Another option for multi-line commit message is to use a
+`Git GUI Client <https://git-scm.com/downloads/guis/>`_ or to run
+``git commit`` without a message to get prompted by an editor.
 
 The message after committing should look like this when you inspect with
 ``git log``::

--- a/docs/development/workflow/git_install.rst
+++ b/docs/development/workflow/git_install.rst
@@ -35,29 +35,3 @@ Check it with::
     user.name=Your Name
     user.email=you@yourdomain.example.com
     # ...likely followed by many other configuration values
-
-.. _git_gui_options:
-
-Get a git GUI (optional)
-========================
-
-There are several good, free graphical interfaces for git.
-Even if you are proficient with `git`_ at the command line a GUI can be useful.
-
-Mac and Windows:
-
-+ `SourceTree`_
-+ The github client for `Mac`_ or `Windows`_
-
-Linux, Mac and Windows:
-
-+ `git-cola`_
-
-There is a more extensive list of `git GUIs`_, including non-free options, for
-all platforms.
-
-.. _git GUIs: https://git-scm.com/downloads/guis
-.. _SourceTree: https://www.sourcetreeapp.com/
-.. _Mac: https://desktop.github.com/
-.. _Windows: https://desktop.github.com/
-.. _git-cola: http://git-cola.github.io/


### PR DESCRIPTION
### Description

The developer documentation contains a very short list of Git graphical user interfaces. Even if a user chooses to use a GUI for Git, the choices available for them depend on their operating system and whether they want a stand-alone client or something that is integrated with their editor. Maintaining a list of Git GUIs is therefore far beyond the scope of `astropy`. It is better to provide links to a list on the Git webpage instead.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
