### PR TITLE
TST: Compat with bleach v6 for test_raw_html_write_clean

### DIFF
--- a/astropy/io/ascii/tests/test_html.py
+++ b/astropy/io/ascii/tests/test_html.py
@@ -667,7 +667,7 @@ def test_raw_html_write_clean():
         format="ascii.html",
         htmldict={
             "raw_html_cols": t.colnames,
-            "raw_html_clean_kwargs": {"tags": bleach.ALLOWED_TAGS + ["p"]},
+            "raw_html_clean_kwargs": {"tags": list(bleach.ALLOWED_TAGS) + ["p"]},
         },
     )
     expected = """\


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

https://github.com/mozilla/bleach/releases/tag/v6.0.0 was released 3 hours ago. `bleach.ALLOWED_TAGS` is now `frozenset`. Without this patch:

```
__________________________ test_raw_html_write_clean ___________________________

    @pytest.mark.skipif(not HAS_BLEACH, reason="requires bleach")
    def test_raw_html_write_clean():
        """
        Test that columns can contain raw HTML which is not escaped.
        """
        import bleach
    
        t = Table(
            [["<script>x</script>"], ["<p>y</p>"], ["<em>y</em>"]], names=["a", "b", "c"]
        )
    
        # Confirm that <script> and <p> get escaped but not <em>
        out = StringIO()
        t.write(out, format="ascii.html", htmldict={"raw_html_cols": t.colnames})
        expected = """\
       <tr>
        <td>&lt;script&gt;x&lt;/script&gt;</td>
        <td>&lt;p&gt;y&lt;/p&gt;</td>
        <td><em>y</em></td>
       </tr>"""
        assert expected in out.getvalue()
    
        # Confirm that we can whitelist <p>
        out = StringIO()
        t.write(
            out,
            format="ascii.html",
            htmldict={
                "raw_html_cols": t.colnames,
>               "raw_html_clean_kwargs": {"tags": bleach.ALLOWED_TAGS + ["p"]},
            },
        )
E       TypeError: unsupported operand type(s) for +: 'frozenset' and 'list'

astropy/io/ascii/tests/test_html.py:670: TypeError
```

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [x] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
