### PR TITLE
Automatically determine longitude wrap angle and units for coordinate overlays

### DIFF
--- a/astropy/visualization/wcsaxes/tests/test_utils.py
+++ b/astropy/visualization/wcsaxes/tests/test_utils.py
@@ -4,10 +4,12 @@
 from numpy.testing import assert_almost_equal
 
 from astropy import units as u
+from astropy.coordinates import Angle, Galactic, HADec
 from astropy.tests.helper import (
     assert_quantity_allclose as assert_almost_equal_quantity,
 )
 from astropy.visualization.wcsaxes.utils import (
+    get_coord_meta,
     select_step_degree,
     select_step_hour,
     select_step_scalar,
@@ -71,3 +73,15 @@ def test_select_step_scalar():
     assert_almost_equal(select_step_scalar(0.00022), 0.0002)
     assert_almost_equal(select_step_scalar(0.000012), 0.00001)
     assert_almost_equal(select_step_scalar(0.000000443), 0.0000005)
+
+
+def test_get_coord_meta():
+    galactic_meta = get_coord_meta(Galactic)
+    assert galactic_meta["name"] == ["l", "b"]
+    assert galactic_meta["wrap"] == (Angle(360 * u.deg), None)
+    assert galactic_meta["unit"] == (u.deg, u.deg)
+
+    hadec_meta = get_coord_meta(HADec)
+    assert hadec_meta["name"] == ["ha", "dec"]
+    assert hadec_meta["wrap"] == (Angle(180 * u.deg), None)
+    assert hadec_meta["unit"] == (u.hourangle, u.deg)

--- a/astropy/visualization/wcsaxes/utils.py
+++ b/astropy/visualization/wcsaxes/utils.py
@@ -4,7 +4,7 @@
 import numpy as np
 
 from astropy import units as u
-from astropy.coordinates import BaseCoordinateFrame
+from astropy.coordinates import BaseCoordinateFrame, UnitSphericalRepresentation
 
 __all__ = [
     "select_step_degree",
@@ -92,8 +92,6 @@ def select_step_scalar(dv):
 def get_coord_meta(frame):
     coord_meta = {}
     coord_meta["type"] = ("longitude", "latitude")
-    coord_meta["wrap"] = (None, None)
-    coord_meta["unit"] = (u.deg, u.deg)
 
     from astropy.coordinates import frame_transform_graph
 
@@ -108,6 +106,11 @@ def get_coord_meta(frame):
 
     names = list(frame.representation_component_names.keys())
     coord_meta["name"] = names[:2]
+
+    # Add dummy data to the frame to determine the longitude wrap angle and the units
+    frame = frame.realize_frame(UnitSphericalRepresentation(0 * u.deg, 0 * u.deg))
+    coord_meta["wrap"] = (frame.spherical.lon.wrap_angle, None)
+    coord_meta["unit"] = (frame.spherical.lon.unit, frame.spherical.lat.unit)
 
     return coord_meta
 

--- a/docs/changes/visualization/14326.bugfix.rst
+++ b/docs/changes/visualization/14326.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed a bug where coordinate overlays did not automatically determine the
+longitude wrap angle or the appropriate units.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

`WCSAxes.get_coord_overlay()` calls `astropy.visualization.wcsaxes.utils.get_coord_meta()` to obtain coordinate metadata for the overlay frame if that metadata was not explicitly provided.  However, `get_coord_meta()` does not currently determine the longitude wrap angle or the units from the frame.  This PR fixes that.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [x] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [x] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [x] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [x] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [x] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [x] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [x] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [x] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [x] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
