### PR TITLE
Added section to docs about new hash libraries

### DIFF
--- a/docs/development/testguide.rst
+++ b/docs/development/testguide.rst
@@ -817,6 +817,28 @@ logs. If any changes/additions look good, you can download from the summary page
 a JSON file with the hashes which you can use to replace the existing one in
 ``astropy/tests/figures``.
 
+New hash libraries
+------------------
+
+When adding a new tox environment for image testing, such as for a new Matplotlib
+or Python version, the tests will fail as the hash library does not exist yet. To
+generate it, you should run the tests the first time with::
+
+    tox -e <envname> -- --mpl-generate-hash-library=astropy/tests/figures/<envname>.json
+
+for example::
+
+    tox -e py39-test-image-mpl322-cov -- --mpl-generate-hash-library=astropy/tests/figures/py39-test-image-mpl322-cov.json
+
+Then add and commit the new JSON file and try running the tests again. The tests
+may fail in the continuous integration if e.g. the freetype version does not
+match or if you generated the JSON file on a Mac or Windows machine - if that is
+the case, follow the instructions in `Failing tests`_ to update the hashes.
+
+As an alternative to generating the JSON file above, you can also simply copy a
+previous version of the JSON file and update any failing hashes as described
+in `Failing tests`_.
+
 Generating reference images
 ---------------------------
 


### PR DESCRIPTION
### Description

This describes how to deal with a missing hash library for figure tests.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html#pre-commit).
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
