### PR TITLE
prevent div by zero for mean of all-masks

### DIFF
--- a/astropy/utils/masked/core.py
+++ b/astropy/utils/masked/core.py
@@ -1113,7 +1113,16 @@ class MaskedNDArray(Masked, np.ndarray, base_cls=np.ndarray, data_cls=np.ndarray
             axis=axis, dtype=dtype, out=out, keepdims=keepdims, where=where
         )
         n = np.add.reduce(where, axis=axis, keepdims=keepdims)
+
+        # catch the case when an axis is fully masked to prevent div by zero:
+        n = np.add.reduce(where, axis=axis, keepdims=keepdims)
+        neq0 = n == 0
+        n += neq0
         result /= n
+
+        # correct fully-masked slice results to what is expected for 0/0 division
+        result.unmasked[neq0] = np.nan
+
         if is_float16_result:
             result = result.astype(self.dtype)
         return result

--- a/astropy/utils/masked/tests/test_masked.py
+++ b/astropy/utils/masked/tests/test_masked.py
@@ -850,6 +850,14 @@ class TestMaskedArrayMethods(MaskedArraySetup):
         assert_array_equal(ma_mean.unmasked, expected_data)
         assert_array_equal(ma_mean.mask, expected_mask)
 
+    @pytest.mark.parametrize("axis", (0, 1, None))
+    def test_mean_all_masked(self, axis):
+        # test corner case when all values are masked
+        md = Masked(self.a, np.ones(self.a.shape, dtype=bool))
+        md_mean = md.mean(axis)
+        assert np.all(np.isnan(md_mean.unmasked))
+        assert np.all(md_mean.mask)
+
     def test_mean_int16(self):
         ma = self.ma.astype("i2")
         ma_mean = ma.mean()

--- a/docs/changes/utils/14341.feature.rst
+++ b/docs/changes/utils/14341.feature.rst
@@ -1,0 +1,3 @@
+The ``mean`` method on ``NDDataArray`` now avoids a division by zero
+warning when taking the mean of a fully-masked slice (and still
+returns ``np.nan``).


### PR DESCRIPTION


### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

In testing #14175, I was often doing operations on Masked arrays. Sometimes all entries along a given axis in the array are masked. You can run into trouble if you take the `mean` of an array that is masked everywhere, since the `mean` is `sum(axis)/n` where the number of non-masked points `n` can be zero. There are a bunch of `filterwarnings` for this in the masked tests like this:

https://github.com/astropy/astropy/blob/93d9d9dba5b87645c85d81988dfc766b01f3d389/astropy/utils/masked/tests/test_masked.py#L884

I go back and forth on whether or not the current behavior (warning) above is helpful. On one hand, the warning is useful if you don't know how `masked` works and you need to trace nans. On the other, the module is emitting a warning when nothing is "actually going wrong," because the undefined result will be masked anyway.

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This PR circumvents the warning from division by zero. The modified `mean` method will divide by `1` where `n=0` to dodge the warning, and return a masked nan value for that result.