### PR TITLE
Deprecate `coordinates.get_moon()`

### DIFF
--- a/astropy/coordinates/orbital_elements.py
+++ b/astropy/coordinates/orbital_elements.py
@@ -170,12 +170,12 @@ _coE = (1.0, -0.002516, -0.0000074)
 
 @deprecated(
     since="5.0",
-    alternative="astropy.coordinates.get_moon",
+    alternative="astropy.coordinates.get_body('moon')",
     message=(
         "The private calc_moon function has been deprecated, as its functionality is"
         " now available in ERFA. Note that the coordinate system was not interpreted"
         " quite correctly, leading to small inaccuracies. Please use the public"
-        " get_moon or get_body functions instead."
+        " get_body() function instead."
     ),
 )
 def calc_moon(t):

--- a/astropy/coordinates/solar_system.py
+++ b/astropy/coordinates/solar_system.py
@@ -500,6 +500,7 @@ def get_body(body, time, location=None, ephemeris=None):
     return SkyCoord(gcrs)
 
 
+@deprecated("5.3", alternative='get_body("moon")')
 def get_moon(time, location=None, ephemeris=None):
     """
     Get a `~astropy.coordinates.SkyCoord` for the Earth's Moon as observed

--- a/astropy/coordinates/tests/test_regression.py
+++ b/astropy/coordinates/tests/test_regression.py
@@ -38,7 +38,6 @@ from astropy.coordinates import (
     SphericalRepresentation,
     UnitSphericalRepresentation,
     get_body,
-    get_moon,
     get_sun,
 )
 from astropy.coordinates.sites import get_builtin_sites
@@ -313,7 +312,7 @@ def test_regression_4926():
     times = Time("2010-01-1") + np.arange(20) * u.day
     green = get_builtin_sites()["greenwich"]
     # this is the regression test
-    moon = get_moon(times, green)
+    moon = get_body("moon", times, green)
 
     # this is an additional test to make sure the GCRS->ICRS transform works for complex shapes
     moon.transform_to(ICRS())
@@ -326,7 +325,7 @@ def test_regression_4926():
 def test_regression_5209():
     "check that distances are not lost on SkyCoord init"
     time = Time("2015-01-01")
-    moon = get_moon(time)
+    moon = get_body("moon", time)
     new_coord = SkyCoord([moon])
     assert_quantity_allclose(new_coord[0].distance, moon.distance)
 
@@ -446,7 +445,7 @@ def test_regression_5889_5890():
         *u.Quantity([3980608.90246817, -102.47522911, 4966861.27310067], unit=u.m)
     )
     times = Time("2017-03-20T12:00:00") + np.linspace(-2, 2, 3) * u.hour
-    moon = get_moon(times, location=greenwich)
+    moon = get_body("moon", times, location=greenwich)
     targets = SkyCoord([350.7 * u.deg, 260.7 * u.deg], [18.4 * u.deg, 22.4 * u.deg])
     targs2d = targets[:, np.newaxis]
     targs2d.transform_to(moon)

--- a/docs/changes/coordinates/14354.api.rst
+++ b/docs/changes/coordinates/14354.api.rst
@@ -1,0 +1,3 @@
+``get_moon()`` is deprecated and may be removed in a future version of
+``astropy``. Calling ``get_moon(...)`` should be replaced with
+``get_body("moon", ...)``.

--- a/docs/coordinates/solarsystem.rst
+++ b/docs/coordinates/solarsystem.rst
@@ -19,11 +19,10 @@ use cases you may have (see the examples below).
    most conveniently achieved via ``pip install jplephem``, although whatever
    package management system you use might have it as well.
 
-Three functions are provided; :meth:`~astropy.coordinates.get_body`,
-:meth:`~astropy.coordinates.get_moon` and
-:meth:`~astropy.coordinates.get_body_barycentric`. The first two functions
-return |SkyCoord| objects in the `~astropy.coordinates.GCRS` frame, while the
-latter returns a `~astropy.coordinates.CartesianRepresentation` of the
+Two functions are provided; :func:`~astropy.coordinates.get_body` and
+:func:`~astropy.coordinates.get_body_barycentric`.
+The first returns |SkyCoord| objects in the `~astropy.coordinates.GCRS` frame,
+while the latter returns a `~astropy.coordinates.CartesianRepresentation` of the
 barycentric position of a body (i.e., in the `~astropy.coordinates.ICRS` frame).
 
 Examples
@@ -38,7 +37,7 @@ without the need to download a large ephemerides file)::
 
   >>> from astropy.time import Time
   >>> from astropy.coordinates import solar_system_ephemeris, EarthLocation
-  >>> from astropy.coordinates import get_body_barycentric, get_body, get_moon
+  >>> from astropy.coordinates import get_body_barycentric, get_body
   >>> t = Time("2014-09-22 23:22")
   >>> loc = EarthLocation.of_site('greenwich') # doctest: +REMOTE_DATA
   >>> with solar_system_ephemeris.set('builtin'):
@@ -64,7 +63,7 @@ ephemeris is set):
   >>> get_body('jupiter', t, loc) # doctest: +REMOTE_DATA, +FLOAT_CMP
   <SkyCoord (GCRS: obstime=2014-09-22 23:22:00.000, obsgeoloc=(3949481.69182405, -550931.91022387, 4961151.73597633) m, obsgeovel=(40.159527, 287.47873161, -0.04597922) m / s): (ra, dec, distance) in (deg, deg, km)
       (136.90234846, 17.03160654, 8.89196021e+08)>
-  >>> get_moon(t, loc) # doctest: +REMOTE_DATA, +FLOAT_CMP
+  >>> get_body('moon', t, loc) # doctest: +REMOTE_DATA, +FLOAT_CMP
   <SkyCoord (GCRS: obstime=2014-09-22 23:22:00.000, obsgeoloc=(3949481.69182405, -550931.91022387, 4961151.73597633) m, obsgeovel=(40.159527, 287.47873161, -0.04597922) m / s): (ra, dec, distance) in (deg, deg, km)
       (165.51854528, 2.32861794, 407229.55638763)>
   >>> get_body_barycentric('moon', t) # doctest: +REMOTE_DATA, +FLOAT_CMP

--- a/examples/coordinates/plot_obs-planning.py
+++ b/examples/coordinates/plot_obs-planning.py
@@ -119,13 +119,13 @@ sunaltazs_July12_to_13 = get_sun(times_July12_to_13).transform_to(frame_July12_t
 
 
 ##############################################################################
-# Do the same with `~astropy.coordinates.get_moon` to find when the moon is
+# Do the same with `~astropy.coordinates.get_body` to find when the moon is
 # up. Be aware that this will need to download a 10MB file from the internet
 # to get a precise location of the moon.
 
-from astropy.coordinates import get_moon
+from astropy.coordinates import get_body
 
-moon_July12_to_13 = get_moon(times_July12_to_13)
+moon_July12_to_13 = get_body("moon", times_July12_to_13)
 moonaltazs_July12_to_13 = moon_July12_to_13.transform_to(frame_July12_to_13)
 
 ##############################################################################


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description

`get_moon()` is simply a shortcut to calling `get_body("moon")` with a docstring that tends to get out of sync from the docstring of `get_body()` (as evidenced by #12683), and the presence of which complicates unit tests in `astropy.coordinates.tests.test_solar_system` because Moon is treated differently from all the other Solar System bodies. Deprecating and eventually removing it simplifies the code without sacrificing functionality or readability. Note that this pull request removes a net ~22~ 23 lines of code despite adding a deprecation test and a change log entry and `get_moon()` hasn't even been removed yet.

It seems to me the reason a separate function was created for the Moon in the first place was because it was introduced in 4a59bb8885817547e40caf570e21ecf4816bcbc2 together with a function called `get_planet()`, and calling ~`get_planet("moon")`~ the equivalent of `get_planet("moon")` would have been confusing. But `get_planet()` was renamed to `get_body()` already in cd408c2744b6309d6c871819238fec7893e8fa7e (committed on the same day). I don't understand why `get_moon()` was not removed then.