### PR TITLE
Manual backport of PR 14357 onto v5.0.x (Fix bug creating QTable with units arg set)

### DIFF
--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -922,7 +922,12 @@ class Table:
                     value = None
 
             if value not in (np.ma.masked, None):
-                setattr(self[name].info, attr, value)
+                col = self[name]
+                if attr == "unit" and isinstance(col, Quantity):
+                    # Update the Quantity unit in-place
+                    col <<= value
+                else:
+                    setattr(col.info, attr, value)
 
     def __getstate__(self):
         columns = OrderedDict(

--- a/astropy/table/tests/test_init_table.py
+++ b/astropy/table/tests/test_init_table.py
@@ -6,8 +6,8 @@ from collections.abc import Mapping
 import pytest
 import numpy as np
 
-from astropy.table import Column, TableColumns, Table, MaskedColumn
 import astropy.units as u
+from astropy.table import Column, MaskedColumn, QTable, Table, TableColumns
 
 
 class DictLike(Mapping):
@@ -619,3 +619,16 @@ def test_init_Table_from_list_of_quantity():
     assert np.all(t["x"] == [5, 10])
     assert t["y"][0] == 1 * u.m
     assert t["y"][1] == 3
+
+
+def test_init_QTable_and_set_units():
+    """
+    Test fix for #14336 where providing units to QTable init fails.
+
+    This applies when the input is a Quantity.
+    """
+    t = QTable([[1, 2] * u.km, [1, 2]], units={"col0": u.m, "col1": u.s})
+    assert t["col0"].unit == u.m
+    assert np.all(t["col0"].value == [1000, 2000])
+    assert t["col1"].unit == u.s
+    assert np.all(t["col1"].value == [1, 2])

--- a/docs/changes/table/14357.bugfix.rst
+++ b/docs/changes/table/14357.bugfix.rst
@@ -1,0 +1,3 @@
+Fix a bug when creating a ``QTable`` when a ``Quantity`` input column is present and the
+``units`` argument modifies the unit of that column. This now works as expected where
+previously this caused an exception.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to manually backport #14357 to v5.0.x