### PR TITLE
Make ascii.qdp case insensitive

### DIFF
--- a/astropy/io/ascii/qdp.py
+++ b/astropy/io/ascii/qdp.py
@@ -68,11 +68,11 @@ def _line_type(line, delimiter=None):
     _new_re = rf"NO({sep}NO)+"
     _data_re = rf"({_decimal_re}|NO|[-+]?nan)({sep}({_decimal_re}|NO|[-+]?nan))*)"
     _type_re = rf"^\s*((?P<command>{_command_re})|(?P<new>{_new_re})|(?P<data>{_data_re})?\s*(\!(?P<comment>.*))?\s*$"
-    _line_type_re = re.compile(_type_re)
+    _line_type_re = re.compile(_type_re, re.IGNORECASE)
     line = line.strip()
     if not line:
         return "comment"
-    match = _line_type_re.match(line.upper())
+    match = _line_type_re.match(line)
 
     if match is None:
         raise ValueError(f"Unrecognized QDP line: {line}")
@@ -306,7 +306,7 @@ def _get_tables_from_qdp_file(qdp_file, input_colnames=None, delimiter=None):
 
             values = []
             for v in line.split(delimiter):
-                if v == "NO":
+                if v.upper() == "NO":
                     values.append(np.ma.masked)
                 else:
                     # Understand if number is int or float

--- a/astropy/io/ascii/qdp.py
+++ b/astropy/io/ascii/qdp.py
@@ -72,7 +72,7 @@ def _line_type(line, delimiter=None):
     line = line.strip()
     if not line:
         return "comment"
-    match = _line_type_re.match(line)
+    match = _line_type_re.match(line.upper())
 
     if match is None:
         raise ValueError(f"Unrecognized QDP line: {line}")

--- a/astropy/io/ascii/tests/test_qdp.py
+++ b/astropy/io/ascii/tests/test_qdp.py
@@ -43,7 +43,18 @@ def test_get_tables_from_qdp_file(tmp_path):
     assert np.isclose(table2["MJD_nerr"][0], -2.37847222222222e-05)
 
 
-def test_roundtrip(tmp_path):
+def lowercase_header(value):
+    """Make every non-comment line lower case."""
+    lines = []
+    for line in value.splitlines():
+        if not line.startswith("!"):
+            line = line.lower()
+        lines.append(line)
+    return "\n".join(lines)
+
+
+@pytest.mark.parametrize("lowercase", [False, True])
+def test_roundtrip(tmp_path, lowercase):
     example_qdp = """
     ! Swift/XRT hardness ratio of trigger: XXXX, name: BUBU X-2
     ! Columns are as labelled
@@ -70,6 +81,8 @@ def test_roundtrip(tmp_path):
     53000.123456 2.37847222222222e-05    -2.37847222222222e-05   -0.292553       -0.374935
     NO 1.14467592592593e-05    -1.14467592592593e-05   0.000000        NO
     """
+    if lowercase:
+        example_qdp = lowercase_header(example_qdp)
 
     path = str(tmp_path / "test.qdp")
     path2 = str(tmp_path / "test2.qdp")

--- a/docs/changes/io.ascii/14365.bugfix.rst
+++ b/docs/changes/io.ascii/14365.bugfix.rst
@@ -1,0 +1,2 @@
+Fix an issue in the `io.ascii` QDP format reader to allow lower-case commands in the
+table data file. Previously it required all upper case in order to parse QDP files.

--- a/docs/changes/io.ascii/14365.bugfix.rst
+++ b/docs/changes/io.ascii/14365.bugfix.rst
@@ -1,2 +1,2 @@
-Fix an issue in the `io.ascii` QDP format reader to allow lower-case commands in the
+Fix an issue in the ``io.ascii`` QDP format reader to allow lower-case commands in the
 table data file. Previously it required all upper case in order to parse QDP files.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address the issue that `Table` format `ascii.qdp` assumes that all QDP commands must be upper case, where QDP itself is case insensitive. 

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #14363
