### PR TITLE
Add ``atol`` argument to function ``is_O3``

### DIFF
--- a/astropy/coordinates/tests/test_matrix_utilities.py
+++ b/astropy/coordinates/tests/test_matrix_utilities.py
@@ -72,6 +72,10 @@ def test_is_O3():
     # and (M, 3, 3)
     n1 = np.tile(m1, (2, 1, 1))
     assert tuple(is_O3(n1)) == (True, True)  # (show the broadcasting)
+    # Test atol parameter
+    nn1 = np.tile(0.5 * m1, (2, 1, 1))
+    assert tuple(is_O3(nn1)) == (False, False)  # (show the broadcasting)
+    assert tuple(is_O3(nn1, atol=1)) == (True, True)  # (show the broadcasting)
 
     # reflection
     m2 = m1.copy()
@@ -98,6 +102,10 @@ def test_is_rotation():
     # and (M, 3, 3)
     n1 = np.tile(m1, (2, 1, 1))
     assert tuple(is_rotation(n1)) == (True, True)  # (show the broadcasting)
+    # Test atol parameter
+    nn1 = np.tile(0.5 * m1, (2, 1, 1))
+    assert tuple(is_rotation(nn1)) == (False, False)  # (show the broadcasting)
+    assert tuple(is_rotation(nn1, atol=10)) == (True, True)  # (show the broadcasting)
 
     # Improper rotation (unit rotation + reflection)
     m2 = np.identity(3)

--- a/docs/changes/coordinates/14371.feature.rst
+++ b/docs/changes/coordinates/14371.feature.rst
@@ -1,0 +1,1 @@
+Added ``atol`` argument to function ``is_O3`` and ``is_rotation`` in matrix utilities.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address the addition of the ``atol`` argument to the function ``is_O3``.
Related test is added.
 
<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #13694

Thank you for considering it.
