### PR TITLE
Add support for persisting big-endian arrays to Parquet by byte-swapping on write.

### DIFF
--- a/docs/changes/io.misc/14373.bugfix.rst
+++ b/docs/changes/io.misc/14373.bugfix.rst
@@ -1,0 +1,1 @@
+Columns with big-endian byte ordering (such as those read in from a FITS table) can now be serialized with Parquet.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This PR adds support to the parquet writer for big-endian columns.  This is particularly relevant because arrays serialized with FITS will be converted to big-endian arrays, and then this won't be serializable with Parquet.  For example with the current Parquet code this fails:

```
from astropy.table import Table
import numpy as np

table = Table(data=np.zeros(10, dtype=[("a", np.float64)]))
table.write("test.fits", overwrite=True)
table2 = Table.read("test.fits")
table2.write("test.parq", overwrite=True)
```
with
```
ArrowNotImplementedError: Byte-swapped arrays not supported
```

This PR now checks for this error and will do the byte-swapping on write if possible.  Note that the table after reading will have all columns in little-endian order.  This behavior is analogous to that of the FITS io where little-endian columns will be switched to big-endian after reading (as in the failing example above).

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>
