### PR TITLE
DOC: Remove warning from Sersic2D docstring rendering

### DIFF
--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -3204,7 +3204,7 @@ class Sersic2D(Fittable2DModel):
         plt.ylabel('y')
         cbar = plt.colorbar()
         cbar.set_label('Log Brightness', rotation=270, labelpad=25)
-        cbar.set_ticks([-1, 0, 1, 2], update_ticks=True)
+        cbar.set_ticks([-1, 0, 1, 2])
         plt.show()
 
     References


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

Matplotlib v3.7 gives warning when `set_ticks` are called with keywords but no labels given.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #14389
