### PR TITLE
Add "inline" option for unicode and console unit formats to give negative powers instead of fractions

### DIFF
--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -745,18 +745,23 @@ class UnitBase:
         """
         return [1]
 
-    def to_string(self, format=unit_format.Generic):
-        """
-        Output the unit in the given format as a string.
+    def to_string(self, format=unit_format.Generic, **kwargs):
+        """Output the unit in the given format as a string.
 
         Parameters
         ----------
         format : `astropy.units.format.Base` instance or str
             The name of a format or a formatter object.  If not
             provided, defaults to the generic format.
+
+        **kwargs :
+            Further options forwarded to the formatter. Currently
+            recognized is **inline** (:class:`bool`) for the
+            ``"latex"``, ``"console"``, and``"unicode"`` formats.
+
         """
         f = unit_format.get_format(format)
-        return f.to_string(self)
+        return f.to_string(self, **kwargs)
 
     def __format__(self, format_spec):
         """Try to format units using a formatter."""

--- a/astropy/units/format/console.py
+++ b/astropy/units/format/console.py
@@ -17,6 +17,8 @@ class Console(base.Base):
 
       >>> import astropy.units as u
       >>> print(u.Ry.decompose().to_string('console'))  # doctest: +FLOAT_CMP
+      2.1798721*10^-18m^2 kg s^-2
+      >>> print(u.Ry.decompose().to_string('console', inline=False))  # doctest: +FLOAT_CMP
                        m^2 kg
       2.1798721*10^-18 ------
                         s^2
@@ -60,7 +62,7 @@ class Console(base.Base):
         return cls._times.join(parts)
 
     @classmethod
-    def to_string(cls, unit):
+    def to_string(cls, unit, inline=True):
         if isinstance(unit, core.CompositeUnit):
             if unit.scale == 1:
                 s = ""
@@ -68,9 +70,13 @@ class Console(base.Base):
                 s = cls.format_exponential_notation(unit.scale)
 
             if len(unit.bases):
-                positives, negatives = utils.get_grouped_by_powers(
-                    unit.bases, unit.powers
-                )
+                if inline:
+                    positives = zip(unit.bases, unit.powers)
+                    negatives = []
+                else:
+                    positives, negatives = utils.get_grouped_by_powers(
+                        unit.bases, unit.powers
+                    )
                 if len(negatives):
                     if len(positives):
                         positives = cls._format_unit_list(positives)

--- a/astropy/units/format/console.py
+++ b/astropy/units/format/console.py
@@ -83,13 +83,12 @@ class Console(base.Base):
                     else:
                         nominator = "1"
                     denominator = cls._format_unit_list(denominator)
-                    l = len(s)
-                    r = max(len(nominator), len(denominator))
-                    f = f"{{0:^{l}s}} {{1:^{r}s}}"
+                    fraclength = max(len(nominator), len(denominator))
+                    f = f"{{0:^{len(s)}s}} {{1:^{fraclength}s}}"
 
                     lines = [
                         f.format("", nominator),
-                        f.format(s, cls._line * r),
+                        f.format(s, cls._line * fraclength),
                         f.format("", denominator),
                     ]
 

--- a/astropy/units/format/console.py
+++ b/astropy/units/format/console.py
@@ -71,32 +71,32 @@ class Console(base.Base):
 
             if len(unit.bases):
                 if inline:
-                    positives = zip(unit.bases, unit.powers)
-                    negatives = []
+                    nominator = zip(unit.bases, unit.powers)
+                    denominator = []
                 else:
-                    positives, negatives = utils.get_grouped_by_powers(
+                    nominator, denominator = utils.get_grouped_by_powers(
                         unit.bases, unit.powers
                     )
-                if len(negatives):
-                    if len(positives):
-                        positives = cls._format_unit_list(positives)
+                if len(denominator):
+                    if len(nominator):
+                        nominator = cls._format_unit_list(nominator)
                     else:
-                        positives = "1"
-                    negatives = cls._format_unit_list(negatives)
+                        nominator = "1"
+                    denominator = cls._format_unit_list(denominator)
                     l = len(s)
-                    r = max(len(positives), len(negatives))
+                    r = max(len(nominator), len(denominator))
                     f = f"{{0:^{l}s}} {{1:^{r}s}}"
 
                     lines = [
-                        f.format("", positives),
+                        f.format("", nominator),
                         f.format(s, cls._line * r),
-                        f.format("", negatives),
+                        f.format("", denominator),
                     ]
 
                     s = "\n".join(lines)
                 else:
-                    positives = cls._format_unit_list(positives)
-                    s += positives
+                    nominator = cls._format_unit_list(nominator)
+                    s += nominator
         elif isinstance(unit, core.NamedUnit):
             s = cls._get_unit_name(unit)
 

--- a/astropy/units/format/generic.py
+++ b/astropy/units/format/generic.py
@@ -34,16 +34,18 @@ def _to_string(cls, unit):
             parts.append(f"{unit.scale:g}")
 
         if len(unit.bases):
-            positives, negatives = utils.get_grouped_by_powers(unit.bases, unit.powers)
-            if len(positives):
-                parts.append(cls._format_unit_list(positives))
+            nominator, denominator = utils.get_grouped_by_powers(
+                unit.bases, unit.powers
+            )
+            if len(nominator):
+                parts.append(cls._format_unit_list(nominator))
             elif len(parts) == 0:
                 parts.append("1")
 
-            if len(negatives):
+            if len(denominator):
                 parts.append("/")
-                unit_list = cls._format_unit_list(negatives)
-                if len(negatives) == 1:
+                unit_list = cls._format_unit_list(denominator)
+                if len(denominator) == 1:
                     parts.append(f"{unit_list}")
                 else:
                     parts.append(f"({unit_list})")

--- a/astropy/units/format/latex.py
+++ b/astropy/units/format/latex.py
@@ -66,22 +66,22 @@ class Latex(base.Base):
 
             if len(unit.bases):
                 if inline:
-                    positives = zip(unit.bases, unit.powers)
-                    negatives = []
+                    nominator = zip(unit.bases, unit.powers)
+                    denominator = []
                 else:
-                    positives, negatives = utils.get_grouped_by_powers(
+                    nominator, denominator = utils.get_grouped_by_powers(
                         unit.bases, unit.powers
                     )
-                if len(negatives):
-                    if len(positives):
-                        positives = cls._format_unit_list(positives)
+                if len(denominator):
+                    if len(nominator):
+                        nominator = cls._format_unit_list(nominator)
                     else:
-                        positives = "1"
-                    negatives = cls._format_unit_list(negatives)
-                    s += rf"\frac{{{positives}}}{{{negatives}}}"
+                        nominator = "1"
+                    denominator = cls._format_unit_list(denominator)
+                    s += rf"\frac{{{nominator}}}{{{denominator}}}"
                 else:
-                    positives = cls._format_unit_list(positives)
-                    s += positives
+                    nominator = cls._format_unit_list(nominator)
+                    s += nominator
 
         elif isinstance(unit, core.NamedUnit):
             s = cls._latex_escape(unit.name)

--- a/astropy/units/format/latex.py
+++ b/astropy/units/format/latex.py
@@ -51,24 +51,7 @@ class Latex(base.Base):
         return r"\,".join(out)
 
     @classmethod
-    def _format_bases(cls, unit):
-        positives, negatives = utils.get_grouped_by_powers(unit.bases, unit.powers)
-
-        if len(negatives):
-            if len(positives):
-                positives = cls._format_unit_list(positives)
-            else:
-                positives = "1"
-            negatives = cls._format_unit_list(negatives)
-            s = rf"\frac{{{positives}}}{{{negatives}}}"
-        else:
-            positives = cls._format_unit_list(positives)
-            s = positives
-
-        return s
-
-    @classmethod
-    def to_string(cls, unit):
+    def to_string(cls, unit, inline=False):
         latex_name = None
         if hasattr(unit, "_format"):
             latex_name = unit._format.get("latex")
@@ -82,7 +65,23 @@ class Latex(base.Base):
                 s = cls.format_exponential_notation(unit.scale) + r"\,"
 
             if len(unit.bases):
-                s += cls._format_bases(unit)
+                if inline:
+                    positives = zip(unit.bases, unit.powers)
+                    negatives = []
+                else:
+                    positives, negatives = utils.get_grouped_by_powers(
+                        unit.bases, unit.powers
+                    )
+                if len(negatives):
+                    if len(positives):
+                        positives = cls._format_unit_list(positives)
+                    else:
+                        positives = "1"
+                    negatives = cls._format_unit_list(negatives)
+                    s += rf"\frac{{{positives}}}{{{negatives}}}"
+                else:
+                    positives = cls._format_unit_list(positives)
+                    s += positives
 
         elif isinstance(unit, core.NamedUnit):
             s = cls._latex_escape(unit.name)
@@ -142,5 +141,5 @@ class LatexInline(Latex):
     name = "latex_inline"
 
     @classmethod
-    def _format_bases(cls, unit):
-        return cls._format_unit_list(zip(unit.bases, unit.powers))
+    def to_string(cls, unit, inline=True):
+        return super().to_string(unit, inline)

--- a/astropy/units/format/unicode_format.py
+++ b/astropy/units/format/unicode_format.py
@@ -17,6 +17,8 @@ class Unicode(console.Console):
 
       >>> import astropy.units as u
       >>> print(u.bar.decompose().to_string('unicode'))
+      100000kg m⁻¹ s⁻²
+      >>> print(u.bar.decompose().to_string('unicode', inline=False))
               kg
       100000 ────
              m s²

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -434,15 +434,29 @@ def test_latex_inline_scale():
     [
         ("generic", "erg / (cm2 s)"),
         ("s", "erg / (cm2 s)"),
-        ("console", "  erg  \n ------\n s cm^2"),
+        ("console", "erg s^-1 cm^-2"),
         ("latex", "$\\mathrm{\\frac{erg}{s\\,cm^{2}}}$"),
         ("latex_inline", "$\\mathrm{erg\\,s^{-1}\\,cm^{-2}}$"),
+        ("unicode", "erg s⁻¹ cm⁻²"),
         (">20s", "       erg / (cm2 s)"),
     ],
 )
 def test_format_styles(format_spec, string):
     fluxunit = u.erg / (u.cm**2 * u.s)
     assert format(fluxunit, format_spec) == string
+
+
+@pytest.mark.parametrize(
+    "format_spec, inline, string",
+    [
+        ("console", False, "  erg  \n ------\n s cm^2"),
+        ("unicode", False, "  erg \n ─────\n s cm²"),
+        ("latex", True, "$\\mathrm{erg\\,s^{-1}\\,cm^{-2}}$"),
+    ],
+)
+def test_format_styles_inline(format_spec, inline, string):
+    fluxunit = u.erg / (u.cm**2 * u.s)
+    assert fluxunit.to_string(format_spec, inline=inline) == string
 
 
 def test_flatten_to_known():

--- a/docs/changes/units/14393.feature.rst
+++ b/docs/changes/units/14393.feature.rst
@@ -1,0 +1,2 @@
+Add "inline" option to and "unicode and "console" unit formats to use
+negative powers instead of fractions.

--- a/docs/units/format.rst
+++ b/docs/units/format.rst
@@ -91,10 +91,8 @@ take an optional parameter to select a different format::
     >>> fluxunit = u.erg / (u.cm ** 2 * u.s)
     >>> f"{fluxunit}"
     'erg / (cm2 s)'
-    >>> print(f"{fluxunit:console}")
-     erg
-    ------
-    s cm^2
+    >>> print(f"{fluxunit:unicode}")
+    erg s⁻¹ cm⁻²
     >>> f"{fluxunit:latex}"
     '$\\mathrm{\\frac{erg}{s\\,cm^{2}}}$'
     >>> f"{fluxunit:>20s}"
@@ -200,10 +198,15 @@ following formats:
 
        \mathrm{erg\,s^{-1}\,cm^{-2}}
 
-  - ``"console"``: Writes a multiline representation of the unit
-    useful for display in a text console::
+  - ``"console"``: Writes a representation of the unit useful for
+    display in a text console::
 
       >>> print(fluxunit.to_string('console'))
+       erg s^-1 cm^-2
+
+    It is also possible to write a multiline representation:
+
+      >>> print(fluxunit.to_string('console', inline=False))
        erg
       ------
       s cm^2
@@ -212,6 +215,8 @@ following formats:
     characters::
 
       >>> print(u.Ry.decompose().to_string('unicode'))  # doctest: +FLOAT_CMP
+      2.1798724×10⁻¹⁸m² kg s⁻²
+      >>> print(u.Ry.decompose().to_string('unicode', inline=False))  # doctest: +FLOAT_CMP
                       m² kg
       2.1798724×10⁻¹⁸ ─────
                        s²

--- a/docs/whatsnew/5.3.rst
+++ b/docs/whatsnew/5.3.rst
@@ -73,6 +73,33 @@ When using ``|=``, the other object does not need to be a |Table|, it can be
 anything that can be used for :ref:`construct_table` with a compatible number
 of rows.
 
+.. _whatsnew-5.3-unit-formats-inline:
+
+New "inline" option for ``"unicode"``, ``"console"``, and ``"latex"`` unit formats
+==================================================================================
+
+A new formatting option for unit is added to switch between inline and
+multiline prettyprinting of quantities::
+
+	>>> import astropy.units as u
+	>>> unit = u.Unit("erg / (s cm2)")
+	>>> print(unit.to_string('console'))
+	erg s^-1 cm^-2
+	>>> print(unit.to_string('console', inline=False))
+         erg
+        ------
+        s cm^2
+	>>> print(unit.to_string('unicode'))
+	erg s⁻¹ cm⁻²
+	>>> print(unit.to_string('unicode', inline=False))
+         erg
+        ─────
+        s cm²
+
+Note that the ``"console"`` and ``"unicode"`` formats now use
+``inline=False`` as default, while for ``"latex"`` the default remains
+``inline=True``, for an unchanged experience with IPython notebook.
+
 Full change log
 ===============
 


### PR DESCRIPTION
### Description

This PR adds inline versions of the unicode and console format representations for units. My primary interest is `unicode_inline`, but since I modified the console format as well, `console_inline` came out for (almost) free -- it is up to discussion whether it is useful enough to keep.

It looks like this:
```Python
>>> from astropy.constants import G
>>> print(f'{G:unicode_inline}')
6.6743e-11 m³ kg⁻¹ s⁻²
>>> print(f'{G:console_inline}')
6.6743e-11 m^3 kg^-1 s^-2
```
~~The change is done in the same way as in #2622 (which added `latex_inline`), to keep the same structure.~~

Im am also unsure what the use real case for the existing non-inline versions is as they are broken when used for quantities (IMO they should at least be disabled for formatting units, or switched to the proposed inline variants then):
```Python
>>> print(f'{G:unicode}')
6.6743e-11   m³  
 ─────
 kg s²
>>> print(f'{G:console}')
6.6743e-11   m^3  
 ------
 kg s^2
```
