### PR TITLE
Allow "console" and "unicode" formats for function units

### DIFF
--- a/astropy/units/function/core.py
+++ b/astropy/units/function/core.py
@@ -429,6 +429,13 @@ class FunctionUnitBase(metaclass=ABCMeta):
                 self_str = "\n".join(lines)
         return self_str
 
+    def __format__(self, format_spec):
+        """Try to format units using a formatter."""
+        try:
+            return self.to_string(format=format_spec)
+        except ValueError:
+            return format(str(self), format_spec)
+
     def __str__(self):
         """Return string representation for unit."""
         self_str = str(self.function_unit)

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -834,6 +834,7 @@ def test_celsius_fits():
 def test_function_format_styles(format_spec, string):
     dbunit = u.decibel(u.m**-1)
     assert dbunit.to_string(format_spec) == string
+    assert f"{dbunit:{format_spec}}" == string
 
 
 @pytest.mark.parametrize(

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -818,3 +818,32 @@ def test_celsius_fits():
     assert u.Unit("deg C kg-1", format="fits") == u.C * u.deg / u.kg
     assert u.Unit("Celsius kg-1", format="fits") == u.deg_C / u.kg
     assert u.deg_C.to_string("fits") == "Celsius"
+
+
+@pytest.mark.parametrize(
+    "format_spec, string",
+    [
+        ("generic", "dB(1 / m)"),
+        ("unscaled", "dB(1 / m)"),
+        ("latex", r"$\mathrm{dB}$$\mathrm{\left( \mathrm{\frac{1}{m}} \right)}$"),
+        ("latex_inline", r"$\mathrm{dB}$$\mathrm{\left( \mathrm{m^{-1}} \right)}$"),
+        ("console", "dB(m^-1)"),
+        ("unicode", "dB(m⁻¹)"),
+    ],
+)
+def test_function_format_styles(format_spec, string):
+    dbunit = u.decibel(u.m**-1)
+    assert dbunit.to_string(format_spec) == string
+
+
+@pytest.mark.parametrize(
+    "format_spec, inline, string",
+    [
+        ("console", False, "    1\ndB( -)\n    m"),
+        ("unicode", False, "    1\ndB( ─)\n    m"),
+        ("latex", True, r"$\mathrm{dB}$$\mathrm{\left( \mathrm{m^{-1}} \right)}$"),
+    ],
+)
+def test_function_format_styles_inline(format_spec, inline, string):
+    dbunit = u.decibel(u.m**-1)
+    assert dbunit.to_string(format_spec, inline=inline) == string

--- a/docs/changes/units/14407.feature.rst
+++ b/docs/changes/units/14407.feature.rst
@@ -1,0 +1,2 @@
+Allow "console" and "unicode" formats for conversion to string of
+function units.


### PR DESCRIPTION
### Description

Originally, function unit format were restricted to `generic`, `unscaled`, `latex` and `latex_inline`:
```python
>>> import astropy.units as u
>>> print(u.decibel(u.m**-1).to_string('unicode'))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3/dist-packages/astropy/units/function/core.py", line 395, in to_string
    raise ValueError(
ValueError: Function units cannot be written in unicode format. Only 'generic', 'unscaled', 'latex' and 'latex_inline' are supported.
```

Also, functional units didn't support the `__format__` function:
```python
>>> print(f"{u.decibel(u.m**-1):generic}")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: unsupported format string passed to DecibelUnit.__format__
```

This PR implements both, including the required implementation of function units with multiline unit format:
```python
>>> import astropy.units as u
>>> print(u.decibel(u.m**-1).to_string('unicode'))
    1
dB( ─)
    m
>>> print(f"{u.decibel(u.m**-1):generic}")
dB(1 / m)
>>> print(f"{u.decibel(u.m**-1):unicode}")
    1
dB( ─)
    m
```
If #14393 is merged before this, we need to adjust this one a bit depending on the outcome of #14393. Specifically, we could to add `**kwargs` propagation to the `to_string()` function to enable/disable multiline.
