### PR TITLE
Deprecate automatic changes to the tile size with HCOMPRESS_1

### DIFF
--- a/astropy/io/fits/hdu/compressed.py
+++ b/astropy/io/fits/hdu/compressed.py
@@ -1137,11 +1137,12 @@ class CompImageHDU(BinTableHDU):
                     )
 
             if tile_size != original_tile_size:
-                warnings.warn(f"The data size should be a multiple of the tile "
-                            f"size. The tile size has automatically been changed "
-                            f"from {original_tile_size} to {tile_size}, but in "
-                            f"future this will raise an error and the correct tile "
-                            f"size should be specified directly.", AstropyDeprecationWarning)
+                warnings.warn(f"The tile size should be such that no tiles have "
+                              f"fewer than 4 pixels. The tile size has "
+                              f"automatically been changed from {original_tile_size} "
+                              f"to {tile_size}, but in future this will raise an "
+                              f"error and the correct tile size should be specified "
+                              f"directly.", AstropyDeprecationWarning)
 
         # Set up locations for writing the next cards in the header.
         last_znaxis = "ZNAXIS"

--- a/astropy/io/fits/hdu/compressed.py
+++ b/astropy/io/fits/hdu/compressed.py
@@ -11,6 +11,7 @@ from contextlib import suppress
 
 import numpy as np
 
+from astropy.utils.exceptions import AstropyDeprecationWarning
 from astropy.io.fits import conf
 from astropy.io.fits._tiled_compression import compress_hdu, decompress_hdu_section
 from astropy.io.fits._tiled_compression.utils import _data_shape, _n_tiles, _tile_shape
@@ -1111,6 +1112,8 @@ class CompImageHDU(BinTableHDU):
 
             remain = self._image_header["NAXIS1"] % tile_size[0]  # 1st dimen
 
+            original_tile_size = tile_size[:]
+
             if remain > 0 and remain < 4:
                 tile_size[0] += 1  # try increasing tile size by 1
 
@@ -1132,6 +1135,13 @@ class CompImageHDU(BinTableHDU):
                     raise ValueError(
                         "Last tile along 2nd dimension has less than 4 pixels"
                     )
+
+            if tile_size != original_tile_size:
+                warnings.warn(f"The data size should be a multiple of the tile "
+                            f"size. The tile size has automatically been changed "
+                            f"from {original_tile_size} to {tile_size}, but in "
+                            f"future this will raise an error and the correct tile "
+                            f"size should be specified directly.", AstropyDeprecationWarning)
 
         # Set up locations for writing the next cards in the header.
         last_znaxis = "ZNAXIS"

--- a/astropy/io/fits/hdu/compressed.py
+++ b/astropy/io/fits/hdu/compressed.py
@@ -11,7 +11,6 @@ from contextlib import suppress
 
 import numpy as np
 
-from astropy.utils.exceptions import AstropyDeprecationWarning
 from astropy.io.fits import conf
 from astropy.io.fits._tiled_compression import compress_hdu, decompress_hdu_section
 from astropy.io.fits._tiled_compression.utils import _data_shape, _n_tiles, _tile_shape
@@ -27,7 +26,7 @@ from astropy.io.fits.util import (
     _pseudo_zero,
 )
 from astropy.utils import lazyproperty
-from astropy.utils.exceptions import AstropyUserWarning
+from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyUserWarning
 from astropy.utils.shapes import simplify_basic_index
 
 from .base import BITPIX2DTYPE, DELAYED, DTYPE2BITPIX, ExtensionHDU
@@ -1137,12 +1136,15 @@ class CompImageHDU(BinTableHDU):
                     )
 
             if tile_size != original_tile_size:
-                warnings.warn(f"The tile size should be such that no tiles have "
-                              f"fewer than 4 pixels. The tile size has "
-                              f"automatically been changed from {original_tile_size} "
-                              f"to {tile_size}, but in future this will raise an "
-                              f"error and the correct tile size should be specified "
-                              f"directly.", AstropyDeprecationWarning)
+                warnings.warn(
+                    f"The tile size should be such that no tiles have "
+                    f"fewer than 4 pixels. The tile size has "
+                    f"automatically been changed from {original_tile_size} "
+                    f"to {tile_size}, but in future this will raise an "
+                    f"error and the correct tile size should be specified "
+                    f"directly.",
+                    AstropyDeprecationWarning,
+                )
 
         # Set up locations for writing the next cards in the header.
         last_znaxis = "ZNAXIS"

--- a/docs/changes/io.fits/14410.api.rst
+++ b/docs/changes/io.fits/14410.api.rst
@@ -1,0 +1,3 @@
+Deprecate the auto-fixing of tile sizes for HCOMPRESS_1 tiled
+image compression when the tile size could be changed by +1
+to make it acceptable.


### PR DESCRIPTION
When creating a ``CompImageHDU`` with a tile size that results in tiles having <4 pixels along one or more dimensions, the tile size is automatically and silently updated - but only if it can be changed by adding +1 to one of the dimensions:

```python
In [1]: import numpy as np

In [2]: from astropy.io import fits

In [4]: hdu = fits.CompImageHDU(np.zeros((50, 50)), compression_type='HCOMPRESS_1', tile_size=[24, 24])

In [5]: hdu._header['ZTILE1']
Out[5]: 25
```

If the tile size cannot automatically be adjusted, an error is raised:

```
ValueError: Last tile along 1st dimension has less than 4 pixels
```

The auto changing is confusing IMHO as it only works in very specific cases (it would have to be that adding 1 makes the tile size acceptable, not removing 1 or not adding 2) and I think we should simply deprecate and eventually remove this behavior in favor of always raising an explicit error, so this PR is to add a deprecation warning to that effect - but this is just a suggestion, I'm happy to be told that the above behavior is desirable! With this PR:

```python
In [3]: hdu = fits.CompImageHDU(np.zeros((50, 50)), compression_type='HCOMPRESS_1', tile_size=[24, 24])
WARNING: AstropyDeprecationWarning: The tile size should be such that no tiles have fewer than 4 pixels. The tile size has automatically been changed from [24, 24] to [25, 25], but in future this will raise an error and the correct tile size should be specified directly. [astropy.io.fits.hdu.compressed]
```

Note that a side effect of the current behavior is that tuples cannot be passed for the tile size which is also confusing:

```python
In [3]: hdu = fits.CompImageHDU(np.zeros((50, 50)), compression_type='HCOMPRESS_1', tile_size=(24, 24))
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[3], line 1
----> 1 hdu = fits.CompImageHDU(np.zeros((50, 50)), compression_type='HCOMPRESS_1', tile_size=(24, 24))

File ~/Dropbox/Code/Astropy/astropy/astropy/io/fits/hdu/compressed.py:662, in CompImageHDU.__init__(self, data, header, name, compression_type, tile_size, hcomp_scale, hcomp_smooth, quantize_level, quantize_method, dither_seed, do_not_scale_image_data, uint, scale_back, **kwargs)
    654     self.data = data
    656     # Update the table header (_header) to the compressed
    657     # image format and to match the input data (if any);
    658     # Create the image header (_image_header) from the input
    659     # image header (if any) and ensure it matches the input
    660     # data; Create the initially empty table data array to
    661     # hold the compressed data.
--> 662     self._update_header_data(
    663         header,
    664         name,
    665         compression_type=compression_type,
    666         tile_size=tile_size,
    667         hcomp_scale=hcomp_scale,
    668         hcomp_smooth=hcomp_smooth,
    669         quantize_level=quantize_level,
    670         quantize_method=quantize_method,
    671         dither_seed=dither_seed,
    672     )
    674 # TODO: A lot of this should be passed on to an internal image HDU o
    675 # something like that, see ticket #88
    676 self._do_not_scale_image_data = do_not_scale_image_data

File ~/Dropbox/Code/Astropy/astropy/astropy/io/fits/hdu/compressed.py:1110, in CompImageHDU._update_header_data(self, image_header, name, compression_type, tile_size, hcomp_scale, hcomp_smooth, quantize_level, quantize_method, dither_seed)
   1107 original_tile_size = tile_size[:]
   1109 if remain > 0 and remain < 4:
-> 1110     tile_size[0] += 1  # try increasing tile size by 1
   1112     remain = self._image_header["NAXIS1"] % tile_size[0]
   1114     if remain > 0 and remain < 4:

TypeError: 'tuple' object does not support item assignment
```