### PR TITLE
Alter NDArithmetic propagate_uncertainties behaviour for v6.0

### DIFF
--- a/astropy/nddata/mixins/ndarithmetic.py
+++ b/astropy/nddata/mixins/ndarithmetic.py
@@ -9,7 +9,7 @@ import numpy as np
 from astropy.nddata.nduncertainty import NDUncertainty
 from astropy.units import dimensionless_unscaled
 from astropy.utils import format_doc, sharedmethod
-from astropy.utils.exceptions import AstropyUserWarning
+from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyUserWarning
 
 __all__ = ["NDArithmeticMixin"]
 
@@ -253,9 +253,19 @@ class NDArithmeticMixin:
         result = self._arithmetic_data(operation, operand, **kwds2["data"])
 
         # Determine the other properties
-        if propagate_uncertainties is None:
+        if propagate_uncertainties is False:
+            warnings.warn(
+                (
+                    "propagate_uncertainties=False will become equivalent to "
+                    "propagate_uncertainties=None in v6.0. To maintain current behaviour, "
+                    "please use propagate_uncertainties='first_found'."
+                ),
+                category=AstropyDeprecationWarning,
+            )
+            propagate_uncertainties = "first_found"
+        if propagate_uncertainties is None or propagate_uncertainties is False:
             kwargs["uncertainty"] = None
-        elif not propagate_uncertainties:
+        elif propagate_uncertainties in {"ff", "first_found"}:
             if self.uncertainty is None:
                 kwargs["uncertainty"] = deepcopy(operand.uncertainty)
             else:

--- a/astropy/nddata/mixins/ndarithmetic.py
+++ b/astropy/nddata/mixins/ndarithmetic.py
@@ -9,7 +9,7 @@ import numpy as np
 from astropy.nddata.nduncertainty import NDUncertainty
 from astropy.units import dimensionless_unscaled
 from astropy.utils import format_doc, sharedmethod
-from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyUserWarning
+from astropy.utils.exceptions import AstropyUserWarning
 
 __all__ = ["NDArithmeticMixin"]
 
@@ -253,16 +253,6 @@ class NDArithmeticMixin:
         result = self._arithmetic_data(operation, operand, **kwds2["data"])
 
         # Determine the other properties
-        if propagate_uncertainties is False:
-            warnings.warn(
-                (
-                    "propagate_uncertainties=False will become equivalent to "
-                    "propagate_uncertainties=None in v6.0. To maintain current behaviour, "
-                    "please use propagate_uncertainties='first_found'."
-                ),
-                category=AstropyDeprecationWarning,
-            )
-            propagate_uncertainties = "first_found"
         if propagate_uncertainties is None or propagate_uncertainties is False:
             kwargs["uncertainty"] = None
         elif propagate_uncertainties in {"ff", "first_found"}:

--- a/astropy/nddata/mixins/tests/test_ndarithmetic.py
+++ b/astropy/nddata/mixins/tests/test_ndarithmetic.py
@@ -1106,7 +1106,7 @@ def test_arithmetics_handle_switches(use_abbreviation):
     # Only second has attributes and False is chosen
     nd_ = nd3.add(
         nd2,
-        propagate_uncertainties=False,
+        propagate_uncertainties="first_found",
         handle_meta=use_abbreviation,
         handle_mask=use_abbreviation,
         compare_wcs=use_abbreviation,
@@ -1119,7 +1119,7 @@ def test_arithmetics_handle_switches(use_abbreviation):
     # Only first has attributes and False is chosen
     nd_ = nd1.add(
         nd3,
-        propagate_uncertainties=False,
+        propagate_uncertainties="first_found",
         handle_meta=use_abbreviation,
         handle_mask=use_abbreviation,
         compare_wcs=use_abbreviation,
@@ -1276,7 +1276,7 @@ def test_arithmetics_unknown_uncertainties():
     with pytest.raises(IncompatibleUncertaintiesException):
         ndd1.add(ndd2)
     # But it should be possible without propagation
-    ndd3 = ndd1.add(ndd2, propagate_uncertainties=False)
+    ndd3 = ndd1.add(ndd2, propagate_uncertainties="first_found")
     np.testing.assert_array_equal(ndd1.uncertainty.array, ndd3.uncertainty.array)
 
     ndd4 = ndd1.add(ndd2, propagate_uncertainties=None)


### PR DESCRIPTION
### Description
This PR triggers a breaking API change flagged by #14414.  It changes the `NDArithmetic` `propagate_uncertainties=False` behaviour to be the same as `propagate_uncertainties=None`.  The old behaviour can still be accessed via `propagate_uncertainties='first_found'` 

ONLY MERGE FOR v6.0 release

Fixes #14404 
