### PR TITLE
Refactor to_string in the unit formats

### DIFF
--- a/astropy/units/format/base.py
+++ b/astropy/units/format/base.py
@@ -24,6 +24,10 @@ class Base:
         super().__init_subclass__(**kwargs)
 
     @classmethod
+    def _get_unit_name(cls, unit):
+        return unit.get_format_name(cls.name)
+
+    @classmethod
     def parse(cls, s):
         """
         Convert a string to a unit object.

--- a/astropy/units/format/base.py
+++ b/astropy/units/format/base.py
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+from . import utils
 
 
 class Base:
@@ -7,6 +8,7 @@ class Base:
     """
 
     registry = {}
+    _space = " "
 
     def __new__(cls, *args, **kwargs):
         # This __new__ is to make it clear that there is no reason to
@@ -33,6 +35,28 @@ class Base:
         Convert a string to a unit object.
         """
         raise NotImplementedError(f"Can not parse with {cls.__name__} format")
+
+    @classmethod
+    def _format_superscript(cls, number):
+        return f"^{number}"
+
+    @classmethod
+    def _format_unit_power(cls, unit, power=1):
+        """Format the unit for this format class raised to the given power.
+
+        This is overridden in Latex where the name of the unit can depend on the power
+        (e.g., for degrees).
+        """
+        name = cls._get_unit_name(unit)
+        if power != 1:
+            name += cls._format_superscript(utils.format_power(power))
+        return name
+
+    @classmethod
+    def _format_unit_list(cls, units):
+        return cls._space.join(
+            cls._format_unit_power(base_, power) for base_, power in units
+        )
 
     @classmethod
     def to_string(cls, u):

--- a/astropy/units/format/cds.py
+++ b/astropy/units/format/cds.py
@@ -307,10 +307,6 @@ class CDS(Base):
                 else:
                     raise ValueError("Syntax error")
 
-    @staticmethod
-    def _get_unit_name(unit):
-        return unit.get_format_name("cds")
-
     @classmethod
     def _format_unit_list(cls, units):
         out = []

--- a/astropy/units/format/cds.py
+++ b/astropy/units/format/cds.py
@@ -33,6 +33,7 @@ class CDS(Base):
     by VOTable up to version 1.2.
     """
 
+    _space = "."
     _tokens = (
         "PRODUCT",
         "DIVISION",
@@ -308,14 +309,8 @@ class CDS(Base):
                     raise ValueError("Syntax error")
 
     @classmethod
-    def _format_unit_list(cls, units):
-        out = []
-        for base, power in units:
-            if power == 1:
-                out.append(cls._get_unit_name(base))
-            else:
-                out.append(f"{cls._get_unit_name(base)}{int(power)}")
-        return ".".join(out)
+    def _format_superscript(cls, number):
+        return number
 
     @classmethod
     def to_string(cls, unit):

--- a/astropy/units/format/console.py
+++ b/astropy/units/format/console.py
@@ -26,6 +26,7 @@ class Console(base.Base):
 
     _times = "*"
     _line = "-"
+    _space = " "
 
     @classmethod
     def _format_mantissa(cls, m):
@@ -46,7 +47,7 @@ class Console(base.Base):
                     cls._get_unit_name(base_)
                     + cls._format_superscript(utils.format_power(power))
                 )
-        return " ".join(out)
+        return cls._space.join(out)
 
     @classmethod
     def format_exponential_notation(cls, val):
@@ -62,6 +63,19 @@ class Console(base.Base):
         return cls._times.join(parts)
 
     @classmethod
+    def _format_fraction(cls, scale, nominator, denominator):
+        fraclength = max(len(nominator), len(denominator))
+        f = f"{{0:<{len(scale)}s}}{{1:^{fraclength}s}}"
+
+        return "\n".join(
+            (
+                f.format("", nominator),
+                f.format(scale, cls._line * fraclength),
+                f.format("", denominator),
+            )
+        )
+
+    @classmethod
     def to_string(cls, unit, inline=True):
         if unit.scale == 1:
             s = ""
@@ -74,7 +88,7 @@ class Console(base.Base):
         # have a scale; e.g., u.percent.decompose() gives "0.01").
         if len(unit.bases):
             if s:
-                s += " "
+                s += cls._space
             if inline:
                 nominator = zip(unit.bases, unit.powers)
                 denominator = []
@@ -88,16 +102,7 @@ class Console(base.Base):
                 else:
                     nominator = "1"
                 denominator = cls._format_unit_list(denominator)
-                fraclength = max(len(nominator), len(denominator))
-                f = f"{{0:<{len(s)}s}}{{1:^{fraclength}s}}"
-
-                s = "\n".join(
-                    (
-                        f.format("", nominator),
-                        f.format(s, cls._line * fraclength),
-                        f.format("", denominator),
-                    )
-                )
+                s = cls._format_fraction(s, nominator, denominator)
             else:
                 nominator = cls._format_unit_list(nominator)
                 s += nominator

--- a/astropy/units/format/console.py
+++ b/astropy/units/format/console.py
@@ -50,8 +50,24 @@ class Console(base.Base):
         return cls._space.join(out)
 
     @classmethod
-    def format_exponential_notation(cls, val):
-        m, ex = utils.split_mantissa_exponent(val)
+    def format_exponential_notation(cls, val, format_spec=".8g"):
+        """
+        Formats a value in exponential notation.
+
+        Parameters
+        ----------
+        val : number
+            The value to be formatted
+
+        format_spec : str, optional
+            Format used to split up mantissa and exponent
+
+        Returns
+        -------
+        string : str
+            The value in exponential notation in a this class's format.
+        """
+        m, ex = utils.split_mantissa_exponent(val, format_spec)
 
         parts = []
         if m:

--- a/astropy/units/format/console.py
+++ b/astropy/units/format/console.py
@@ -33,28 +33,6 @@ class Console(base.Base):
         return m
 
     @classmethod
-    def _format_superscript(cls, number):
-        return f"^{number}"
-
-    @classmethod
-    def _format_unit_power(cls, unit, power=1):
-        """Format the unit for this format class raised to the given power.
-
-        This is overridden in Latex where the name of the unit can depend on the power
-        (e.g., for degrees).
-        """
-        name = cls._get_unit_name(unit)
-        if power != 1:
-            name += cls._format_superscript(utils.format_power(power))
-        return name
-
-    @classmethod
-    def _format_unit_list(cls, units):
-        return cls._space.join(
-            cls._format_unit_power(base_, power) for base_, power in units
-        )
-
-    @classmethod
     def format_exponential_notation(cls, val, format_spec=".8g"):
         """
         Formats a value in exponential notation.

--- a/astropy/units/format/console.py
+++ b/astropy/units/format/console.py
@@ -28,10 +28,6 @@ class Console(base.Base):
     _line = "-"
 
     @classmethod
-    def _get_unit_name(cls, unit):
-        return unit.get_format_name("console")
-
-    @classmethod
     def _format_mantissa(cls, m):
         return m
 

--- a/astropy/units/format/console.py
+++ b/astropy/units/format/console.py
@@ -33,23 +33,11 @@ class Console(base.Base):
         return m
 
     @classmethod
+    def _format_superscript(cls, number):
+        return f"^{number}"
+
+    @classmethod
     def format_exponential_notation(cls, val, format_spec=".8g"):
-        """
-        Formats a value in exponential notation.
-
-        Parameters
-        ----------
-        val : number
-            The value to be formatted
-
-        format_spec : str, optional
-            Format used to split up mantissa and exponent
-
-        Returns
-        -------
-        string : str
-            The value in exponential notation in a this class's format.
-        """
         m, ex = utils.split_mantissa_exponent(val, format_spec)
 
         parts = []
@@ -76,34 +64,5 @@ class Console(base.Base):
 
     @classmethod
     def to_string(cls, unit, inline=True):
-        if unit.scale == 1:
-            s = ""
-        else:
-            # Non-unity scale happens mostly for decomposed units.
-            # E.g., u.Ry.decompose() gives "2.17987e-18 kg m2 / s2".
-            s = cls.format_exponential_notation(unit.scale)
-
-        # Take care that dimensionless does not have bases (but can
-        # have a scale; e.g., u.percent.decompose() gives "0.01").
-        if len(unit.bases):
-            if s:
-                s += cls._space
-            if inline:
-                nominator = zip(unit.bases, unit.powers)
-                denominator = []
-            else:
-                nominator, denominator = utils.get_grouped_by_powers(
-                    unit.bases, unit.powers
-                )
-            if len(denominator):
-                if len(nominator):
-                    nominator = cls._format_unit_list(nominator)
-                else:
-                    nominator = "1"
-                denominator = cls._format_unit_list(denominator)
-                s = cls._format_fraction(s, nominator, denominator)
-            else:
-                nominator = cls._format_unit_list(nominator)
-                s += nominator
-
-        return s
+        # Change default of inline to True.
+        return super().to_string(unit, inline=inline)

--- a/astropy/units/format/console.py
+++ b/astropy/units/format/console.py
@@ -37,17 +37,22 @@ class Console(base.Base):
         return f"^{number}"
 
     @classmethod
+    def _format_unit_power(cls, unit, power=1):
+        """Format the unit for this format class raised to the given power.
+
+        This is overridden in Latex where the name of the unit can depend on the power
+        (e.g., for degrees).
+        """
+        name = cls._get_unit_name(unit)
+        if power != 1:
+            name += cls._format_superscript(utils.format_power(power))
+        return name
+
+    @classmethod
     def _format_unit_list(cls, units):
-        out = []
-        for base_, power in units:
-            if power == 1:
-                out.append(cls._get_unit_name(base_))
-            else:
-                out.append(
-                    cls._get_unit_name(base_)
-                    + cls._format_superscript(utils.format_power(power))
-                )
-        return cls._space.join(out)
+        return cls._space.join(
+            cls._format_unit_power(base_, power) for base_, power in units
+        )
 
     @classmethod
     def format_exponential_notation(cls, val, format_spec=".8g"):

--- a/astropy/units/format/fits.py
+++ b/astropy/units/format/fits.py
@@ -22,8 +22,6 @@ class Fits(generic.Generic):
     Standard <https://fits.gsfc.nasa.gov/fits_standard.html>`_.
     """
 
-    name = "fits"
-
     @staticmethod
     def _generate_unit_names():
         from astropy import units as u
@@ -104,7 +102,7 @@ class Fits(generic.Generic):
 
     @classmethod
     def _get_unit_name(cls, unit):
-        name = unit.get_format_name("fits")
+        name = super()._get_unit_name(unit)
         cls._validate_unit(name)
         return name
 

--- a/astropy/units/format/generic.py
+++ b/astropy/units/format/generic.py
@@ -22,7 +22,7 @@ from fractions import Fraction
 from astropy.utils import classproperty, deprecated, parsing
 from astropy.utils.misc import did_you_mean
 
-from . import core, utils
+from . import core
 from .base import Base
 
 
@@ -595,39 +595,9 @@ class Generic(Base):
                     raise ValueError(f"Syntax error parsing unit '{s}'")
 
     @classmethod
-    def _format_superscript(cls, number):
-        return f"({number})" if "/" in number or "." in number else number
-
-    @classmethod
     def _format_unit_list(cls, units):
         units.sort(key=lambda x: cls._get_unit_name(x[0]).lower())
         return super()._format_unit_list(units)
-
-    @classmethod
-    def to_string(cls, unit):
-        parts = []
-
-        if unit.scale != 1:
-            parts.append(f"{unit.scale:g}")
-
-        if len(unit.bases):
-            nominator, denominator = utils.get_grouped_by_powers(
-                unit.bases, unit.powers
-            )
-            if len(nominator):
-                parts.append(cls._format_unit_list(nominator))
-            elif len(parts) == 0:
-                parts.append("1")
-
-            if len(denominator):
-                parts.append("/")
-                unit_list = cls._format_unit_list(denominator)
-                if len(denominator) == 1:
-                    parts.append(f"{unit_list}")
-                else:
-                    parts.append(f"({unit_list})")
-
-        return " ".join(parts)
 
 
 # 2023-02-18: The statement in the docstring is no longer true, the class is not used

--- a/astropy/units/format/generic.py
+++ b/astropy/units/format/generic.py
@@ -595,10 +595,6 @@ class Generic(Base):
                     raise ValueError(f"Syntax error parsing unit '{s}'")
 
     @classmethod
-    def _get_unit_name(cls, unit):
-        return unit.get_format_name("generic")
-
-    @classmethod
     def _format_unit_list(cls, units):
         out = []
         units.sort(key=lambda x: cls._get_unit_name(x[0]).lower())

--- a/astropy/units/format/generic.py
+++ b/astropy/units/format/generic.py
@@ -595,20 +595,13 @@ class Generic(Base):
                     raise ValueError(f"Syntax error parsing unit '{s}'")
 
     @classmethod
-    def _format_unit_list(cls, units):
-        out = []
-        units.sort(key=lambda x: cls._get_unit_name(x[0]).lower())
+    def _format_superscript(cls, number):
+        return f"({number})" if "/" in number or "." in number else number
 
-        for base, power in units:
-            if power == 1:
-                out.append(cls._get_unit_name(base))
-            else:
-                power = utils.format_power(power)
-                if "/" in power or "." in power:
-                    out.append(f"{cls._get_unit_name(base)}({power})")
-                else:
-                    out.append(f"{cls._get_unit_name(base)}{power}")
-        return " ".join(out)
+    @classmethod
+    def _format_unit_list(cls, units):
+        units.sort(key=lambda x: cls._get_unit_name(x[0]).lower())
+        return super()._format_unit_list(units)
 
     @classmethod
     def to_string(cls, unit):

--- a/astropy/units/format/latex.py
+++ b/astropy/units/format/latex.py
@@ -6,8 +6,6 @@ Handles the "LaTeX" unit format.
 
 import re
 
-import numpy as np
-
 from . import console, utils
 
 
@@ -20,6 +18,7 @@ class Latex(console.Console):
     """
 
     _space = r"\,"
+    _times = r" \times "
 
     @classmethod
     def _get_unit_name(cls, unit):
@@ -51,6 +50,14 @@ class Latex(console.Console):
         return r"\,".join(out)
 
     @classmethod
+    def _format_mantissa(cls, m):
+        return m.replace("nan", r"{\rm NaN}").replace("inf", r"\infty")
+
+    @classmethod
+    def _format_superscript(cls, number):
+        return f"^{{{number}}}"
+
+    @classmethod
     def _format_fraction(cls, scale, nominator, denominator):
         return rf"{scale}\frac{{{nominator}}}{{{denominator}}}"
 
@@ -58,44 +65,6 @@ class Latex(console.Console):
     def to_string(cls, unit, inline=False):
         s = super().to_string(unit, inline=inline)
         return rf"$\mathrm{{{s}}}$"
-
-    @classmethod
-    def format_exponential_notation(cls, val, format_spec=".8g"):
-        """
-        Formats a value in exponential notation for LaTeX.
-
-        Parameters
-        ----------
-        val : number
-            The value to be formatted
-
-        format_spec : str, optional
-            Format used to split up mantissa and exponent
-
-        Returns
-        -------
-        latex_string : str
-            The value in exponential notation in a format suitable for LaTeX.
-        """
-        if np.isfinite(val):
-            m, ex = utils.split_mantissa_exponent(val, format_spec)
-
-            parts = []
-            if m:
-                parts.append(m)
-            if ex:
-                parts.append(f"10^{{{ex}}}")
-
-            return r" \times ".join(parts)
-        else:
-            if np.isnan(val):
-                return r"{\rm NaN}"
-            elif val > 0:
-                # positive infinity
-                return r"\infty"
-            else:
-                # negative infinity
-                return r"-\infty"
 
 
 class LatexInline(Latex):

--- a/astropy/units/format/latex.py
+++ b/astropy/units/format/latex.py
@@ -20,18 +20,16 @@ class Latex(base.Base):
     """
 
     @classmethod
-    def _latex_escape(cls, name):
-        # This doesn't escape arbitrary LaTeX strings, but it should
-        # be good enough for unit names which are required to be alpha
-        # + "_" anyway.
-        return name.replace("_", r"\_")
-
-    @classmethod
     def _get_unit_name(cls, unit):
+        # Do not use super() to help latex_inline subclass.
         name = unit.get_format_name("latex")
         if name == unit.name:
-            return cls._latex_escape(name)
-        return name
+            # This doesn't escape arbitrary LaTeX strings, but it should
+            # be good enough for unit names which are required to be alpha
+            # + "_" anyway.
+            return name.replace("_", r"\_")
+        else:
+            return name
 
     @classmethod
     def _format_unit_list(cls, units):

--- a/astropy/units/format/latex.py
+++ b/astropy/units/format/latex.py
@@ -33,29 +33,25 @@ class Latex(console.Console):
             return name
 
     @classmethod
-    def _format_unit_list(cls, units):
-        out = []
-        for base_, power in units:
-            base_latex = cls._get_unit_name(base_)
-            if power == 1:
-                out.append(base_latex)
-            else:
-                # If the LaTeX representation of the base unit already ends with
-                # a superscript, we need to spell out the unit to avoid double
-                # superscripts. For example, the logic below ensures that
-                # `u.deg**2` returns `deg^{2}` instead of `{}^{\circ}^{2}`.
-                if re.match(r".*\^{[^}]*}$", base_latex):  # ends w/ superscript?
-                    base_latex = base_.short_names[0]
-                out.append(f"{base_latex}^{{{utils.format_power(power)}}}")
-        return r"\,".join(out)
-
-    @classmethod
     def _format_mantissa(cls, m):
         return m.replace("nan", r"{\rm NaN}").replace("inf", r"\infty")
 
     @classmethod
     def _format_superscript(cls, number):
         return f"^{{{number}}}"
+
+    @classmethod
+    def _format_unit_power(cls, unit, power=1):
+        name = cls._get_unit_name(unit)
+        if power != 1:
+            # If the LaTeX representation of the base unit already ends with
+            # a superscript, we need to spell out the unit to avoid double
+            # superscripts. For example, the logic below ensures that
+            # `u.deg**2` returns `deg^{2}` instead of `{}^{\circ}^{2}`.
+            if re.match(r".*\^{[^}]*}$", name):  # ends w/ superscript?
+                name = unit.short_names[0]
+            name += cls._format_superscript(utils.format_power(power))
+        return name
 
     @classmethod
     def _format_fraction(cls, scale, nominator, denominator):

--- a/astropy/units/format/latex.py
+++ b/astropy/units/format/latex.py
@@ -8,16 +8,18 @@ import re
 
 import numpy as np
 
-from . import base, utils
+from . import console, utils
 
 
-class Latex(base.Base):
+class Latex(console.Console):
     """
     Output LaTeX to display the unit based on IAU style guidelines.
 
     Attempts to follow the `IAU Style Manual
     <https://www.iau.org/static/publications/stylemanual1989.pdf>`_.
     """
+
+    _space = r"\,"
 
     @classmethod
     def _get_unit_name(cls, unit):
@@ -49,33 +51,12 @@ class Latex(base.Base):
         return r"\,".join(out)
 
     @classmethod
+    def _format_fraction(cls, scale, nominator, denominator):
+        return rf"{scale}\frac{{{nominator}}}{{{denominator}}}"
+
+    @classmethod
     def to_string(cls, unit, inline=False):
-        if unit.scale == 1:
-            s = ""
-        else:
-            s = cls.format_exponential_notation(unit.scale)
-
-        if len(unit.bases):
-            if s:
-                s += r"\,"
-            if inline:
-                nominator = zip(unit.bases, unit.powers)
-                denominator = []
-            else:
-                nominator, denominator = utils.get_grouped_by_powers(
-                    unit.bases, unit.powers
-                )
-            if len(denominator):
-                if len(nominator):
-                    nominator = cls._format_unit_list(nominator)
-                else:
-                    nominator = "1"
-                denominator = cls._format_unit_list(denominator)
-                s += rf"\frac{{{nominator}}}{{{denominator}}}"
-            else:
-                nominator = cls._format_unit_list(nominator)
-                s += nominator
-
+        s = super().to_string(unit, inline=inline)
         return rf"$\mathrm{{{s}}}$"
 
     @classmethod

--- a/astropy/units/format/ogip.py
+++ b/astropy/units/format/ogip.py
@@ -391,20 +391,8 @@ class OGIP(generic.Generic):
         return name
 
     @classmethod
-    def _format_unit_list(cls, units):
-        out = []
-        units.sort(key=lambda x: cls._get_unit_name(x[0]).lower())
-
-        for base, power in units:
-            if power == 1:
-                out.append(cls._get_unit_name(base))
-            else:
-                power = utils.format_power(power)
-                if "/" in power:
-                    out.append(f"{cls._get_unit_name(base)}**({power})")
-                else:
-                    out.append(f"{cls._get_unit_name(base)}**{power}")
-        return " ".join(out)
+    def _format_superscript(cls, number):
+        return f"**({number})" if "/" in number else f"**{number}"
 
     @classmethod
     def to_string(cls, unit):

--- a/astropy/units/format/ogip.py
+++ b/astropy/units/format/ogip.py
@@ -386,7 +386,7 @@ class OGIP(generic.Generic):
 
     @classmethod
     def _get_unit_name(cls, unit):
-        name = unit.get_format_name("ogip")
+        name = super()._get_unit_name(unit)
         cls._validate_unit(name)
         return name
 

--- a/astropy/units/format/unicode_format.py
+++ b/astropy/units/format/unicode_format.py
@@ -28,10 +28,6 @@ class Unicode(console.Console):
     _line = "─"
 
     @classmethod
-    def _get_unit_name(cls, unit):
-        return unit.get_format_name("unicode")
-
-    @classmethod
     def _format_mantissa(cls, m):
         return m.replace("-", "−")
 

--- a/astropy/units/format/vounit.py
+++ b/astropy/units/format/vounit.py
@@ -24,6 +24,7 @@ class VOUnit(generic.Generic):
     _explicit_custom_unit_regex = re.compile(r"^[YZEPTGMkhdcmunpfazy]?'((?!\d)\w)+'$")
     _custom_unit_regex = re.compile(r"^((?!\d)\w)+$")
     _custom_units = {}
+    _space = "."
 
     @staticmethod
     def _generate_unit_names():
@@ -191,20 +192,8 @@ class VOUnit(generic.Generic):
         return def_base(unit)
 
     @classmethod
-    def _format_unit_list(cls, units):
-        out = []
-        units.sort(key=lambda x: cls._get_unit_name(x[0]).lower())
-
-        for base, power in units:
-            if power == 1:
-                out.append(cls._get_unit_name(base))
-            else:
-                power = utils.format_power(power)
-                if "/" in power or "." in power:
-                    out.append(f"{cls._get_unit_name(base)}({power})")
-                else:
-                    out.append(f"{cls._get_unit_name(base)}**{power}")
-        return ".".join(out)
+    def _format_superscript(cls, number):
+        return f"({number})" if "/" in number or "." in number else f"**{number}"
 
     @classmethod
     def to_string(cls, unit):

--- a/astropy/units/format/vounit.py
+++ b/astropy/units/format/vounit.py
@@ -141,7 +141,7 @@ class VOUnit(generic.Generic):
                     "(deci) prefix"
                 )
 
-        name = unit.get_format_name("vounit")
+        name = super()._get_unit_name(unit)
 
         if unit in cls._custom_units.values():
             return name

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -432,25 +432,25 @@ def test_latex_inline_scale():
 @pytest.mark.parametrize(
     "format_spec, string, decomposed",
     [
-        ("generic", "erg / (cm2 s)", "0.001 kg / s3"),
-        ("s", "erg / (cm2 s)", "0.001 kg / s3"),
-        ("console", "erg s^-1 cm^-2", "0.001 kg s^-3"),
+        ("generic", "erg / (Angstrom cm2 s)", "1e+07 kg / (m s3)"),
+        ("s", "erg / (Angstrom cm2 s)", "1e+07 kg / (m s3)"),
+        ("console", "erg Angstrom^-1 s^-1 cm^-2", "10000000 kg m^-1 s^-3"),
         (
             "latex",
-            r"$\mathrm{\frac{erg}{s\,cm^{2}}}$",
-            r"$\mathrm{0.001\,\frac{kg}{s^{3}}}$",
+            r"$\mathrm{\frac{erg}{\mathring{A}\,s\,cm^{2}}}$",
+            r"$\mathrm{10000000\,\frac{kg}{m\,s^{3}}}$",
         ),
         (
             "latex_inline",
-            r"$\mathrm{erg\,s^{-1}\,cm^{-2}}$",
-            r"$\mathrm{0.001\,kg\,s^{-3}}$",
+            r"$\mathrm{erg\,\mathring{A}^{-1}\,s^{-1}\,cm^{-2}}$",
+            r"$\mathrm{10000000\,kg\,m^{-1}\,s^{-3}}$",
         ),
-        ("unicode", "erg s⁻¹ cm⁻²", "0.001 kg s⁻³"),
-        (">20s", "       erg / (cm2 s)", "       0.001 kg / s3"),
+        ("unicode", "erg Å⁻¹ s⁻¹ cm⁻²", "10000000 kg m⁻¹ s⁻³"),
+        (">25s", "   erg / (Angstrom cm2 s)", "        1e+07 kg / (m s3)"),
     ],
 )
 def test_format_styles(format_spec, string, decomposed):
-    fluxunit = u.erg / (u.cm**2 * u.s)
+    fluxunit = u.erg / (u.cm**2 * u.s * u.Angstrom)
     assert format(fluxunit, format_spec) == string
     # Decomposed mostly to test that scale factors are dealt with properly
     # in the various formats.


### PR DESCRIPTION
This pull request refactors the output in the `units.format` classes, making `to_string()` simpler. 

Right now there is no behaviour change except that the unused "unscaled" class is deprecated (removing a test for it that I had just added).

EDIT: this PR is too complex, and I decided to break it up in parts (leaving this ~as draft to give a sense where it is going, and perhaps still use it~ for the wrap-up):
- [X] #14413
- [X] #14417
- [x] #14418
- [x] This PR with moving most things to `Base` and inheriting it.

EDIT: possible follow-up:
- Change `inline` to `fraction={False|'display'|'inline'}` or something similar;
- Change fits and vounit formatting to something a bit less ugly (see also #13217).
