### PR TITLE
Deprecate unused units.format.Unscaled format

### DIFF
--- a/astropy/units/format/generic.py
+++ b/astropy/units/format/generic.py
@@ -19,7 +19,7 @@ import unicodedata
 import warnings
 from fractions import Fraction
 
-from astropy.utils import classproperty, parsing
+from astropy.utils import classproperty, deprecated, parsing
 from astropy.utils.misc import did_you_mean
 
 from . import core, utils
@@ -30,7 +30,7 @@ def _to_string(cls, unit):
     if isinstance(unit, core.CompositeUnit):
         parts = []
 
-        if cls._show_scale and unit.scale != 1:
+        if unit.scale != 1:
             parts.append(f"{unit.scale:g}")
 
         if len(unit.bases):
@@ -63,8 +63,6 @@ class Generic(Base):
     but instead of only supporting the units that FITS knows about, it
     supports any unit available in the `astropy.units` namespace.
     """
-
-    _show_scale = True
 
     _tokens = (
         "COMMA",
@@ -650,6 +648,9 @@ class Generic(Base):
         return _to_string(cls, unit)
 
 
+# 2023-02-18: The statement in the docstring is no longer true, the class is not used
+# anywhere so can be safely removed in 6.0.
+@deprecated("5.3", alternative="Generic")
 class Unscaled(Generic):
     """
     A format that doesn't display the scale part of the unit, other
@@ -658,4 +659,8 @@ class Unscaled(Generic):
     This is used in some error messages where the scale is irrelevant.
     """
 
-    _show_scale = False
+    @classmethod
+    def to_string(cls, unit):
+        if unit.scale != 1:
+            unit = core.Unit(unit / unit.scale)
+        return super().to_string(unit)

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -856,7 +856,6 @@ def test_celsius_fits():
     "format_spec, string",
     [
         ("generic", "dB(1 / m)"),
-        ("unscaled", "dB(1 / m)"),
         ("latex", r"$\mathrm{dB}$$\mathrm{\left( \mathrm{\frac{1}{m}} \right)}$"),
         ("latex_inline", r"$\mathrm{dB}$$\mathrm{\left( \mathrm{m^{-1}} \right)}$"),
         ("console", "dB(m^-1)"),

--- a/docs/changes/units/14417.api.rst
+++ b/docs/changes/units/14417.api.rst
@@ -1,0 +1,1 @@
+The unused ``units.format.Unscaled`` format class has been deprecated.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to deprecate the unused "unscaled" format in units. I split this off from #14416 since on looking at that PR again, I realized it is just becoming very long and hard to see the logic. Plus, one should not really have API changes in refactoring PRs.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

