### PR TITLE
Ensure degree and arcmin symbols are not used when prefixed

### DIFF
--- a/astropy/units/si.py
+++ b/astropy/units/si.py
@@ -83,7 +83,6 @@ def_unit(
     namespace=_ns,
     prefixes=True,
     doc="degree: angular measurement 1/360 of full rotation",
-    format={"latex": r"{}^{\circ}", "unicode": "°"},
 )
 def_unit(
     ["hourangle"],
@@ -99,7 +98,6 @@ def_unit(
     namespace=_ns,
     prefixes=True,
     doc="arc minute: angular measurement",
-    format={"latex": r"{}^{\prime}", "unicode": "′"},
 )
 def_unit(
     ["arcsec", "arcsecond"],
@@ -109,6 +107,8 @@ def_unit(
     doc="arc second: angular measurement",
 )
 # These special formats should only be used for the non-prefix versions
+deg._format = {"latex": r"{}^{\circ}", "unicode": "°"}
+arcmin._format = {"latex": r"{}^{\prime}", "unicode": "′"}
 arcsec._format = {"latex": r"{}^{\prime\prime}", "unicode": "″"}
 def_unit(
     ["mas"],

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -755,6 +755,16 @@ def test_double_superscript():
     assert (u.electron**2).to_string("latex") == r"$\mathrm{electron^{2}}$"
 
 
+def test_no_prefix_superscript():
+    """Regression test for gh-911 and #14419."""
+    assert u.mdeg.to_string("latex") == r"$\mathrm{mdeg}$"
+    assert u.narcmin.to_string("latex") == r"$\mathrm{narcmin}$"
+    assert u.parcsec.to_string("latex") == r"$\mathrm{parcsec}$"
+    assert u.mdeg.to_string("unicode") == "mdeg"
+    assert u.narcmin.to_string("unicode") == "narcmin"
+    assert u.parcsec.to_string("unicode") == "parcsec"
+
+
 @pytest.mark.parametrize(
     "power,expected",
     (

--- a/docs/changes/units/14419.bugfix.rst
+++ b/docs/changes/units/14419.bugfix.rst
@@ -1,0 +1,3 @@
+Prefixed degrees and arcmin are now typeset without using the symbol in
+``latex`` and ``unicode`` formats (i.e., ``mdeg`` instead of ``m°``),
+as was already the case for arcsec.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address the fact that as is prefixed degrees and arcminutes use the symbols (as in `m°`). The solution is the same used in #911 (!) for arcseconds -- apparently, it was not noticed at the time that the same should be done for the others. 

This doesn't quite seem worth backporting, but if others disagree, fine to do it.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->
