### PR TITLE
Ensure Distribution can be used in Latitude and Longitude

### DIFF
--- a/astropy/uncertainty/core.py
+++ b/astropy/uncertainty/core.py
@@ -320,6 +320,23 @@ class ArrayDistribution(Distribution, np.ndarray):
         else:
             return result
 
+    # Override __eq__ and __ne__ to pass on directly to the ufunc since
+    # otherwise comparisons with non-distributions do not work (but
+    # deferring if other defines __array_ufunc__ = None -- see
+    # numpy/core/src/common/binop_override.h for the logic; we assume we
+    # will never deal with __array_priority__ any more).  Note: there is no
+    # problem for other comparisons, since for those, structured arrays are
+    # not treated differently in numpy/core/src/multiarray/arrayobject.c.
+    def __eq__(self, other):
+        if getattr(other, "__array_ufunc__", False) is None:
+            return NotImplemented
+        return np.equal(self, other)
+
+    def __ne__(self, other):
+        if getattr(other, "__array_ufunc__", False) is None:
+            return NotImplemented
+        return np.not_equal(self, other)
+
 
 class _DistributionRepr:
     def __repr__(self):

--- a/astropy/uncertainty/tests/test_containers.py
+++ b/astropy/uncertainty/tests/test_containers.py
@@ -1,0 +1,48 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""Test that Distribution works with classes other than ndarray and Quantity."""
+
+import numpy as np
+import pytest
+from numpy.testing import assert_array_equal
+
+import astropy.units as u
+from astropy.coordinates import Angle, Latitude, Longitude
+from astropy.uncertainty import Distribution
+from astropy.utils import NumpyRNGContext
+
+
+@pytest.mark.parametrize("angle_cls", [Angle, Longitude, Latitude])
+class TestAngles:
+    @classmethod
+    def setup_class(cls):
+        with NumpyRNGContext(12345):
+            cls.a = np.random.normal(10, [[0.2], [1.5], [4], [1]], size=(4, 10))
+        cls.d = Distribution(cls.a)
+        cls.q = cls.a << u.deg
+        cls.dq = Distribution(cls.q)
+
+    def test_as_input_for_angle(self, angle_cls):
+        da = angle_cls(self.dq)
+        assert isinstance(da, angle_cls)
+        assert isinstance(da, Distribution)
+        assert_array_equal(da.distribution, angle_cls(self.q))
+
+    def test_using_angle_as_input(self, angle_cls):
+        a = angle_cls(self.q)
+        da = Distribution(a)
+        assert isinstance(da, angle_cls)
+        assert isinstance(da, Distribution)
+
+    def test_operation_gives_correct_subclass(self, angle_cls):
+        # Lon and Lat always fall back to Angle
+        da = angle_cls(self.dq)
+        da2 = da + da
+        assert isinstance(da, Angle)
+        assert isinstance(da, Distribution)
+
+    def test_pdfmean_gives_correct_subclass(self, angle_cls):
+        # Lon and Lat always fall back to Angle
+        da = angle_cls(self.dq)
+        mean = da.pdf_mean()
+        assert isinstance(mean, Angle)
+        assert_array_equal(mean, Angle(self.q.mean(-1)))

--- a/astropy/uncertainty/tests/test_containers.py
+++ b/astropy/uncertainty/tests/test_containers.py
@@ -8,31 +8,54 @@ from numpy.testing import assert_array_equal
 import astropy.units as u
 from astropy.coordinates import Angle, Latitude, Longitude
 from astropy.uncertainty import Distribution
-from astropy.utils import NumpyRNGContext
 
 
-@pytest.mark.parametrize("angle_cls", [Angle, Longitude, Latitude])
 class TestAngles:
     @classmethod
     def setup_class(cls):
-        with NumpyRNGContext(12345):
-            cls.a = np.random.normal(10, [[0.2], [1.5], [4], [1]], size=(4, 10))
+        cls.a = np.arange(27.0).reshape(3, 9)
         cls.d = Distribution(cls.a)
         cls.q = cls.a << u.deg
         cls.dq = Distribution(cls.q)
 
+    @pytest.mark.parametrize("angle_cls", [Angle, Longitude, Latitude])
     def test_as_input_for_angle(self, angle_cls):
         da = angle_cls(self.dq)
         assert isinstance(da, angle_cls)
         assert isinstance(da, Distribution)
         assert_array_equal(da.distribution, angle_cls(self.q))
 
+    @pytest.mark.parametrize("angle_cls", [Angle, Longitude, Latitude])
     def test_using_angle_as_input(self, angle_cls):
         a = angle_cls(self.q)
         da = Distribution(a)
         assert isinstance(da, angle_cls)
         assert isinstance(da, Distribution)
 
+    # Parametrize the unit to check the various branches in Latitude._validate_angles
+    @pytest.mark.parametrize("dtype", ["f8", "f4"])
+    @pytest.mark.parametrize(
+        "value", [90 * u.deg, np.pi / 2 * u.radian, 90 * 60 * u.arcmin]
+    )
+    def test_at_limit_for_latitude(self, value, dtype):
+        q = u.Quantity(value, dtype=dtype).reshape(1)
+        qd = Distribution(q)
+        ld = Latitude(qd)
+        assert_array_equal(ld.distribution, Latitude(q))
+
+    # Parametrize the unit in case Longitude._wrap_at becomes unit-dependent.
+    @pytest.mark.parametrize("dtype", ["f8", "f4"])
+    @pytest.mark.parametrize(
+        "value", [360 * u.deg, 2 * np.pi * u.radian, 360 * 60 * u.arcmin]
+    )
+    def test_at_wrap_angle_for_longitude(self, value, dtype):
+        q = u.Quantity(value, dtype=dtype).reshape(1)
+        qd = Distribution(q)
+        ld = Longitude(qd)
+        assert_array_equal(ld.distribution, Longitude(q))
+        assert np.all(ld.distribution == 0)
+
+    @pytest.mark.parametrize("angle_cls", [Longitude, Latitude])
     def test_operation_gives_correct_subclass(self, angle_cls):
         # Lon and Lat always fall back to Angle
         da = angle_cls(self.dq)
@@ -40,9 +63,10 @@ class TestAngles:
         assert isinstance(da, Angle)
         assert isinstance(da, Distribution)
 
-    def test_pdfmean_gives_correct_subclass(self, angle_cls):
+    @pytest.mark.parametrize("angle_cls", [Longitude, Latitude])
+    def test_pdfstd_gives_correct_subclass(self, angle_cls):
         # Lon and Lat always fall back to Angle
         da = angle_cls(self.dq)
-        mean = da.pdf_mean()
-        assert isinstance(mean, Angle)
-        assert_array_equal(mean, Angle(self.q.mean(-1)))
+        std = da.pdf_std()
+        assert isinstance(std, Angle)
+        assert_array_equal(std, Angle(self.q.std(-1)))

--- a/astropy/uncertainty/tests/test_distribution.py
+++ b/astropy/uncertainty/tests/test_distribution.py
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import operator
 
 import numpy as np
 import pytest
@@ -471,3 +472,32 @@ def test_scalar_quantity_distribution():
     assert isinstance(sin_angles, Distribution)
     assert isinstance(sin_angles, u.Quantity)
     assert_array_equal(sin_angles, Distribution(np.sin([90.0, 30.0, 0.0] * u.deg)))
+
+
+@pytest.mark.parametrize("op", [operator.eq, operator.ne, operator.gt])
+class TestComparison:
+    @classmethod
+    def setup_class(cls):
+        cls.d = Distribution([90.0, 30.0, 0.0])
+
+        class Override:
+            __array_ufunc__ = None
+
+            def __eq__(self, other):
+                return "eq"
+
+            def __ne__(self, other):
+                return "ne"
+
+            def __lt__(self, other):
+                return "gt"  # Since it is called for the reverse of gt
+
+        cls.override = Override()
+
+    def test_distribution_can_be_compared_to_non_distribution(self, op):
+        result = op(self.d, 0.0)
+        assert_array_equal(result, Distribution(op(self.d.distribution, 0.0)))
+
+    def test_distribution_comparison_defers_correctly(self, op):
+        result = op(self.d, self.override)
+        assert result == op.__name__

--- a/astropy/uncertainty/tests/test_distribution.py
+++ b/astropy/uncertainty/tests/test_distribution.py
@@ -501,3 +501,15 @@ class TestComparison:
     def test_distribution_comparison_defers_correctly(self, op):
         result = op(self.d, self.override)
         assert result == op.__name__
+
+
+class TestSetItemWithSelection:
+    def test_setitem(self):
+        d = Distribution([90.0, 30.0, 0.0])
+        d[d > 50] = 0.0
+        assert_array_equal(d, Distribution([0.0, 30.0, 0.0]))
+
+    def test_inplace_operation(self):
+        d = Distribution([90.0, 30.0, 0.0])
+        d[d > 50] *= -1.0
+        assert_array_equal(d, Distribution([-90.0, 30.0, 0.0]))

--- a/docs/changes/uncertainty/14421.bugfix.rst
+++ b/docs/changes/uncertainty/14421.bugfix.rst
@@ -1,3 +1,3 @@
 Ensure that ``Distribution`` can be compared with ``==`` and ``!=``
-with regular arrays or scalars.  This also ensures that the ``Angle`` subclass
-``Longitude`` can be initialized with a ``Distribution``.
+with regular arrays or scalars, and that inplace operations like
+``dist[dist<0] *= -1`` work.

--- a/docs/changes/uncertainty/14421.bugfix.rst
+++ b/docs/changes/uncertainty/14421.bugfix.rst
@@ -1,0 +1,3 @@
+Ensure that ``Distribution`` can be compared with ``==`` and ``!=``
+with regular arrays or scalars.  This also ensures that the ``Angle`` subclass
+``Longitude`` can be initialized with a ``Distribution``.


### PR DESCRIPTION
This pull request is to address the fact that one cannot initialize a `Longitude` with a `Distribution`, which resulted from an error being raised on comparing a `Distribution` with a non-void array -- the solution was to override `__eq__` and `__ne__` (other comparisons are not affected). 

EDIT: Furthermore, for wrapping, `__getitem__` and `__setitem__` needed to be changed to ensure that things like `dist[dist < 0] += 360` work. And in `Latitude._validate_angles`, one needs to be sure that no assumption of a `float` dtype is made.

This part of a hopefully larger attempt to ensure we can use `Distribution` also inside `SkyCoord`, etc.

Note: ~since this is a bug, backporting to 5.2. But perhaps note to 5.0, since really this late it does not seem helpful to fix LTS for this any more.~ EDIT: while this is a bug, the change to `coordinates` makes me feel that it is better to treat it as an "enhancement" and not back-port.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->