### PR TITLE
Allow the use of Distribution in Representations

### DIFF
--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -635,8 +635,8 @@ class BaseRepresentation(BaseRepresentationOrDifferential):
     info = RepresentationInfo()
 
     def __init_subclass__(cls, **kwargs):
-        # Register representation name (except for BaseRepresentation)
-        if cls.__name__ == "BaseRepresentation":
+        # Register representation name (except for anything starting with Base).
+        if cls.__name__.startswith("Base"):
             return
 
         if not hasattr(cls, "attr_classes"):
@@ -1313,7 +1313,7 @@ class CartesianRepresentation(BaseRepresentation):
         self, x, y=None, z=None, unit=None, xyz_axis=None, differentials=None, copy=True
     ):
         if y is None and z is None:
-            if isinstance(x, np.ndarray) and x.dtype.kind not in "OV":
+            if isinstance(x, np.ndarray):
                 # Short-cut for 3-D array input.
                 x = u.Quantity(x, unit, copy=copy, subok=True)
                 # Keep a link to the array with all three coordinates

--- a/astropy/uncertainty/core.py
+++ b/astropy/uncertainty/core.py
@@ -102,6 +102,14 @@ class Distribution:
                 else:
                     converted.append(input_)
 
+        if ufunc.signature:
+            # We're dealing with a gufunc.  This is OK only for a single axis.
+            # Need to generalize!!
+            axis = kwargs.get("axis", -1)
+            if axis < 0:
+                axis -= 1
+            kwargs["axis"] = axis
+
         results = getattr(ufunc, method)(*converted, **kwargs)
 
         if not isinstance(results, tuple):

--- a/astropy/uncertainty/distribution_helpers.py
+++ b/astropy/uncertainty/distribution_helpers.py
@@ -1,0 +1,103 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""Helpers for letting numpy functions interact with Distributions."""
+
+import numpy as np
+
+from astropy.units.quantity_helper.function_helpers import FunctionAssigner
+
+# This module should not really be imported, but we define __all__
+# such that sphinx can typeset the functions with docstrings.
+# The latter are added to __all__ at the end.
+__all__ = [
+    "DISTRIBUTION_SAFE_FUNCTIONS",
+    "FUNCTION_HELPERS",
+    "DISPATCHED_FUNCTIONS",
+    "UNSUPPORTED_FUNCTIONS",
+]
+
+
+DISTRIBUTION_SAFE_FUNCTIONS = set()
+"""Set of functions that work fine on Distributions already.
+
+Most of these internally use `numpy.ufunc` or other functions that
+are already covered.
+"""
+
+FUNCTION_HELPERS = {}
+"""Functions with implementations usable with conversion to regular arrays.
+
+Should return args, kwargs, out, with the first two passed on for a super() call
+and out the actual distribution in which output is meant to be stored.
+
+It should raise `NotImplementedError` if one of the arguments is
+a Distribution when it should not be or vice versa.
+"""
+
+DISPATCHED_FUNCTIONS = {}
+"""Dict of functions that provide the numpy function's functionality.
+
+These should return ``result, out``, with result the regular array,
+and ``out`` a possible Distribution to put the output in.
+
+It should raise `NotImplementedError` if one of the arguments is
+a Distribution when it should not be or vice versa.
+"""
+
+UNSUPPORTED_FUNCTIONS = set()
+"""Set of numpy functions that are not supported for Distributions.
+
+For most, distributions simply makes no sense, but for others it may have
+been lack of time.  Issues or PRs for support for functions are welcome.
+"""
+
+
+function_helper = FunctionAssigner(FUNCTION_HELPERS)
+
+dispatched_function = FunctionAssigner(DISPATCHED_FUNCTIONS)
+
+
+def is_distribution(x):
+    from astropy.uncertainty import Distribution
+
+    return isinstance(x, Distribution)
+
+
+def get_n_samples(*arrays):
+    for array in arrays:
+        if is_distribution(array):
+            return array.n_samples
+
+    raise RuntimeError("no Distribution found! Please raise an issue.")
+
+
+@function_helper
+def concatenate(arrays, axis=0, out=None, dtype=None, casting="same_kind"):
+    n_samples = get_n_samples(*arrays, out)
+    converted = tuple(
+        array.distribution
+        if is_distribution(array)
+        else (
+            np.broadcast_to(
+                array[..., np.newaxis], array.shape + (n_samples,), subok=True
+            )
+            if getattr(array, "shape", ())
+            else array
+        )
+        for array in arrays
+    )
+    if axis < 0:
+        axis = axis - 1  # not in-place, just in case.
+    kwargs = dict(axis=axis, dtype=dtype, casting=casting)
+    if is_distribution(out):
+        kwargs["out"] = out.distribution
+    return (converted,), kwargs, out
+
+
+# Add any dispatched or helper function that has a docstring to
+# __all__, so they will be typeset by sphinx. The logic is that for
+# those presumably the use of the mask is not entirely obvious.
+__all__ += sorted(
+    helper.__name__
+    for helper in (set(FUNCTION_HELPERS.values()) | set(DISPATCHED_FUNCTIONS.values()))
+    if helper.__doc__
+)

--- a/astropy/uncertainty/tests/test_containers.py
+++ b/astropy/uncertainty/tests/test_containers.py
@@ -6,9 +6,20 @@ import pytest
 from numpy.testing import assert_array_equal
 
 import astropy.units as u
-from astropy.coordinates import Angle, Latitude, Longitude, SphericalRepresentation
-from astropy.coordinates.tests.test_representation import (
+from astropy.coordinates import (
+    Angle,
+    CartesianDifferential,
+    CartesianRepresentation,
+    Latitude,
+    Longitude,
+    SphericalDifferential,
+    SphericalRepresentation,
+)
+from astropy.coordinates.representation import (
+    DIFFERENTIAL_CLASSES,
     REPRESENTATION_CLASSES,
+)
+from astropy.coordinates.tests.test_representation import (
     components_allclose,
     representation_equal,
 )
@@ -95,20 +106,77 @@ class TestRepresentation:
     def assert_representation_equal(rep1, rep2):
         assert np.all(representation_equal(rep1, rep2))
 
+    @staticmethod
+    def assert_representation_allclose(rep1, rep2):
+        result = True
+        if type(rep1) is not type(rep2):
+            return False
+        if getattr(rep1, "_differentials", False):
+            if rep1._differentials.keys() != rep2._differentials.keys():
+                return False
+            for key, diff1 in rep1._differentials.items():
+                result &= components_allclose(diff1, rep2._differentials[key])
+        elif getattr(rep2, "_differentials", False):
+            return False
+
+        return np.all(result & components_allclose(rep1, rep2))
+
     def test_cartesian(self):
         dcart = self.dsph.to_cartesian()
         cart = self.sph.to_cartesian()
-        # Explicit for one component
         assert isinstance(dcart.x, Distribution)
         assert_array_equal(dcart.x.distribution, cart.x)
-        # Check all just in case
-        self.assert_representation_equal(self.get_distribution(dcart), cart)
+        assert_array_equal(dcart.y.distribution, cart.y)
+        assert_array_equal(dcart.z.distribution, cart.z)
 
-        sph = SphericalRepresentation.from_cartesian(dcart)
-        assert components_allclose(self.get_distribution(sph), self.sph)
+    def test_cartesian_roundtrip(self):
+        roundtrip = SphericalRepresentation.from_cartesian(self.dsph.to_cartesian())
+        self.assert_representation_allclose(self.get_distribution(roundtrip), self.sph)
 
     @pytest.mark.parametrize("rep_cls", REPRESENTATION_CLASSES.values())
     def test_other_reps(self, rep_cls):
         drep = self.dsph.represent_as(rep_cls)
         rep = self.sph.represent_as(rep_cls)
+        self.assert_representation_equal(self.get_distribution(drep), rep)
+
+
+class TestRepresentationWithDifferential(TestRepresentation):
+    @classmethod
+    def setup_class(cls):
+        super().setup_class()
+        cls.d_lon = Distribution(np.ones(10) << u.deg / u.hour)
+        cls.d_lat = np.ones(cls.lat.shape) << u.deg / u.hour
+        cls.d_r = 1 * u.m / u.s
+        cls.d_sph = SphericalDifferential(
+            cls.d_lon.distribution, cls.d_lat[:, np.newaxis], cls.d_r
+        )
+        cls.dd_sph = SphericalDifferential(cls.d_lon, cls.d_lat, cls.d_r)
+        cls.sph = cls.sph.with_differentials({"s": cls.d_sph})
+        cls.dsph = cls.dsph.with_differentials({"s": cls.dd_sph})
+
+    def test_cartesian(self):
+        dcart = self.dsph.represent_as(CartesianRepresentation, CartesianDifferential)
+        cart = self.sph.represent_as(CartesianRepresentation, CartesianDifferential)
+        assert isinstance(dcart.x, Distribution)
+        assert_array_equal(dcart.x.distribution, cart.x)
+        assert_array_equal(dcart.y.distribution, cart.y)
+        assert_array_equal(dcart.z.distribution, cart.z)
+        assert "s" in dcart._differentials
+        dd_cart = dcart._differentials["s"]
+        d_cart = cart._differentials["s"]
+        assert_array_equal(dd_cart.d_x.distribution, d_cart.d_x)
+        assert_array_equal(dd_cart.d_y.distribution, d_cart.d_y)
+        assert_array_equal(dd_cart.d_z.distribution, d_cart.d_z)
+
+    def test_cartesian_roundtrip(self):
+        roundtrip = self.dsph.represent_as(
+            CartesianRepresentation, CartesianDifferential
+        ).represent_as(SphericalRepresentation, SphericalDifferential)
+        self.assert_representation_allclose(self.get_distribution(roundtrip), self.sph)
+
+    @pytest.mark.parametrize("diff_cls", DIFFERENTIAL_CLASSES.values())
+    def test_other_reps(self, diff_cls):
+        repr_cls = diff_cls.base_representation
+        drep = self.dsph.represent_as(repr_cls, diff_cls)
+        rep = self.sph.represent_as(repr_cls, diff_cls)
         self.assert_representation_equal(self.get_distribution(drep), rep)

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -1698,7 +1698,8 @@ class Quantity(np.ndarray):
 
         # Setting names to ensure things like equality work (note that
         # above will have failed already if units did not match).
-        if self.dtype.names:
+        # TODO: is this the best place to do this?
+        if _value.dtype.names:
             _value.dtype.names = self.dtype.names
         return _value
 


### PR DESCRIPTION
This pull request implements the basics needed to pass in `Distribution` arrays to representations, and have transformations to other representations work, also in the presence of differentials. Some small changes were required to be made to `Quantity` and some representations, but arguably those really are bug fixes.

This is not quite done, of course:
- [ ] gufuncs should be fully supported rather than just with a hack (which will break on `matmul`).
- [ ] numpy function overrides should be more complete. Many will likely just work, but this needs testing

EDIT: ~EDIT: built on top of #14421.~ now merged. Also moved the milestone to 6.0 since this remains a draft. Likely should be split in more bite-size pieces; e.g., `gufunc` (e.g., check with some `erfa` routines and `matmul`), `__array_function__` (tedious test writing...), and then combining it for `Representation` and after that `Frame` and `SkyCoord`.
