### PR TITLE
Avoid copying non-contiguous data in CompImageHDU

### DIFF
--- a/astropy/io/fits/hdu/compressed.py
+++ b/astropy/io/fits/hdu/compressed.py
@@ -1800,10 +1800,6 @@ class CompImageHDU(BinTableHDU):
             # First delete the original compressed data, if it exists
             del self.compressed_data
 
-            # Make sure that the data is contiguous otherwise CFITSIO
-            # will not write the expected data
-            self.data = np.ascontiguousarray(self.data)
-
             # Compress the data.
             # compress_hdu returns the size of the heap for the written
             # compressed image table

--- a/astropy/io/fits/tests/test_image.py
+++ b/astropy/io/fits/tests/test_image.py
@@ -14,7 +14,11 @@ from hypothesis.extra.numpy import basic_indices
 from numpy.testing import assert_equal
 
 from astropy.io import fits
-from astropy.io.fits.hdu.compressed import DITHER_SEED_CHECKSUM, SUBTRACTIVE_DITHER_1, COMPRESSION_TYPES
+from astropy.io.fits.hdu.compressed import (
+    COMPRESSION_TYPES,
+    DITHER_SEED_CHECKSUM,
+    SUBTRACTIVE_DITHER_1,
+)
 from astropy.utils.data import download_file, get_pkg_data_filename
 from astropy.utils.exceptions import AstropyUserWarning
 
@@ -1929,7 +1933,9 @@ class TestCompressedImage(FitsTestCase):
         new = fits.getdata(testfile)
         np.testing.assert_array_equal(data, new)
 
-    @pytest.mark.parametrize(('dtype', 'compression_type'), product(('f', 'i4'), COMPRESSION_TYPES))
+    @pytest.mark.parametrize(
+        ("dtype", "compression_type"), product(("f", "i4"), COMPRESSION_TYPES)
+    )
     def test_write_non_contiguous_data(self, dtype, compression_type):
         """
         Regression test for https://github.com/astropy/astropy/issues/2150


### PR DESCRIPTION
The fix from https://github.com/astropy/astropy/pull/9958 is no longer required as with the new tiled compression module we convert each tile to bytes using ``tobytes()`` which effectively returns contiguous bytes, before we pass the bytes to the various compression algorithms. I have removed the overall conversion of the data array to be C contiguous, and have adjusted the test to really check that it works with a couple of dtypes (with/without quantization which does a copy in itself) and for all the supported compression types.

When passing non-contiguous arrays to ``CompImageHDU``, this should make things a bit more efficient memory-wise and also time wise, but also importantly will ensure that ``CompImageHDU.data`` is not changed in-place.

I don't think this needs a changelog entry - but this did make me wonder where performance improvements should go in the current changelog system - ``other`` entries can't be assigned to specific sub-packages, but maybe we should allow this?

This addresses the second bullet point in https://github.com/astropy/astropy/issues/3895