### PR TITLE
Expose tile shape and compression type on CompImageHDU

### DIFF
--- a/astropy/io/fits/_tiled_compression/tests/test_fitsio.py
+++ b/astropy/io/fits/_tiled_compression/tests/test_fitsio.py
@@ -56,9 +56,9 @@ else:
         # ],
         # >3D Data are not currently supported by cfitsio
     ),
-    ids=lambda x: f"shape: {x[0]} tile_dims: {x[1]}",
+    ids=lambda x: f"shape: {x[0]} tile_shape: {x[1]}",
 )
-def array_shapes_tile_dims(request, compression_type):
+def array_shapes_tile_shape(request, compression_type):
     shape, tile_dim = request.param
     # H_COMPRESS needs >=2D data and always 2D tiles
     if compression_type == "HCOMPRESS_1":
@@ -86,13 +86,13 @@ def array_shapes_tile_dims(request, compression_type):
 
 
 @pytest.fixture(scope="module")
-def tile_dims(array_shapes_tile_dims):
-    return array_shapes_tile_dims[1]
+def tile_shape(array_shapes_tile_shape):
+    return array_shapes_tile_shape[1]
 
 
 @pytest.fixture(scope="module")
-def data_shape(array_shapes_tile_dims):
-    return array_shapes_tile_dims[0]
+def data_shape(array_shapes_tile_shape):
+    return array_shapes_tile_shape[0]
 
 
 @pytest.fixture(scope="module")
@@ -114,7 +114,7 @@ def fitsio_compressed_file_path(
     comp_param_dtype,
     base_original_data,
     data_shape,  # For debugging
-    tile_dims,
+    tile_shape,
 ):
     compression_type, param, dtype = comp_param_dtype
 
@@ -147,7 +147,7 @@ def fitsio_compressed_file_path(
 
     filename = tmp_path / f"{compression_type}_{dtype}.fits"
     fits = fitsio.FITS(filename, "rw")
-    fits.write(original_data, compress=compression_type, tile_dims=tile_dims, **param)
+    fits.write(original_data, compress=compression_type, tile_shape=tile_shape, **param)
 
     return filename
 
@@ -158,7 +158,7 @@ def astropy_compressed_file_path(
     tmp_path_factory,
     base_original_data,
     data_shape,  # For debugging
-    tile_dims,
+    tile_shape,
 ):
     compression_type, param, dtype = comp_param_dtype
     original_data = base_original_data.astype(dtype)
@@ -170,8 +170,7 @@ def astropy_compressed_file_path(
     hdu = fits.CompImageHDU(
         data=original_data,
         compression_type=compression_type,
-        # TODO: why does this require a list??
-        tile_size=list(tile_dims) if tile_dims is not None else tile_dims,
+        tile_shape=tile_shape,
         **param,
     )
     hdu.writeto(filename)

--- a/astropy/io/fits/_tiled_compression/tests/test_tiled_compression.py
+++ b/astropy/io/fits/_tiled_compression/tests/test_tiled_compression.py
@@ -52,7 +52,7 @@ def test_zblank_support(canonical_data_base_path, tmp_path):
     # Now generate a file ourselves and check that the output has the ZBLANK
     # keyword set automatically
 
-    hdu = fits.CompImageHDU(data=reference, compression_type="RICE_1", tile_size=(6, 6))
+    hdu = fits.CompImageHDU(data=reference, compression_type="RICE_1", tile_shape=(6, 6))
 
     hdu.writeto(tmp_path / "test_zblank.fits")
 
@@ -62,7 +62,7 @@ def test_zblank_support(canonical_data_base_path, tmp_path):
 
 
 @pytest.mark.parametrize(
-    ("shape", "tile_dim"),
+    ("shape", "tile_shape"),
     (
         ([10, 10], [5, 5]),  # something for HCOMPRESS
         ([5, 5, 5], [5, 5, 5]),
@@ -75,22 +75,22 @@ def test_zblank_support(canonical_data_base_path, tmp_path):
     ),
 )
 def test_roundtrip_high_D(
-    numpy_rng, compression_type, compression_param, tmp_path, dtype, shape, tile_dim
+    numpy_rng, compression_type, compression_param, tmp_path, dtype, shape, tile_shape
 ):
     if compression_type == "HCOMPRESS_1" and (
         # We don't have at least a 2D image
         len(shape) < 2
         or
         # We don't have 2D tiles
-        np.count_nonzero(np.array(tile_dim) != 1) != 2
+        np.count_nonzero(np.array(tile_shape) != 1) != 2
         or
         # TODO: The following restrictions can be lifted with some extra work.
         # The tile is not the first two dimensions of the data
-        tile_dim[0] == 1
-        or tile_dim[1] == 1
+        tile_shape[0] == 1
+        or tile_shape[1] == 1
         or
         # The tile dimensions not an integer multiple of the array dims
-        np.count_nonzero(np.array(shape[:2]) % tile_dim[:2]) != 0
+        np.count_nonzero(np.array(shape[:2]) % tile_shape[:2]) != 0
     ):
         pytest.xfail("HCOMPRESS requires 2D tiles.")
     random = numpy_rng.uniform(high=255, size=shape)
@@ -112,7 +112,7 @@ def test_roundtrip_high_D(
     hdu = fits.CompImageHDU(
         data=original_data,
         compression_type=compression_type,
-        tile_size=tile_dim,
+        tile_shape=tile_shape,
         **param,
     )
     hdu.writeto(filename)

--- a/astropy/io/fits/_tiled_compression/tests/test_tiled_compression.py
+++ b/astropy/io/fits/_tiled_compression/tests/test_tiled_compression.py
@@ -52,7 +52,9 @@ def test_zblank_support(canonical_data_base_path, tmp_path):
     # Now generate a file ourselves and check that the output has the ZBLANK
     # keyword set automatically
 
-    hdu = fits.CompImageHDU(data=reference, compression_type="RICE_1", tile_shape=(6, 6))
+    hdu = fits.CompImageHDU(
+        data=reference, compression_type="RICE_1", tile_shape=(6, 6)
+    )
 
     hdu.writeto(tmp_path / "test_zblank.fits")
 

--- a/astropy/io/fits/_tiled_compression/tiled_compression.py
+++ b/astropy/io/fits/_tiled_compression/tiled_compression.py
@@ -303,7 +303,7 @@ def decompress_hdu_section(hdu, first_tile_index, last_tile_index):
             )
 
         else:
-            if hdu._header["ZCMPTYPE"] == "GZIP_2":
+            if hdu.compression_type == "GZIP_2":
                 # Decompress with GZIP_1 just to find the total number of
                 # elements in the uncompressed data.
                 # TODO: find a way to avoid doing this for all tiles
@@ -313,14 +313,14 @@ def decompress_hdu_section(hdu, first_tile_index, last_tile_index):
                 )
 
             tile_buffer = _decompress_tile(
-                cdata, algorithm=hdu._header["ZCMPTYPE"], **settings
+                cdata, algorithm=hdu.compression_type, **settings
             )
 
             tile_data = _finalize_array(
                 tile_buffer,
                 bitpix=hdu._header["ZBITPIX"],
                 tile_shape=actual_tile_shape,
-                algorithm=hdu._header["ZCMPTYPE"],
+                algorithm=hdu.compression_type,
                 lossless=not quantized,
             )
 
@@ -464,7 +464,7 @@ def compress_hdu(hdu):
         if gzip_fallback[-1]:
             cbytes = _compress_tile(data, algorithm="GZIP_1")
         else:
-            cbytes = _compress_tile(data, algorithm=hdu._header["ZCMPTYPE"], **settings)
+            cbytes = _compress_tile(data, algorithm=hdu.compression_type, **settings)
         compressed_bytes.append(cbytes)
 
     if zblank is not None:
@@ -489,11 +489,11 @@ def compress_hdu(hdu):
 
     # For PLIO_1, the size of each heap element is a factor of two lower than
     # the real size - not clear if this is deliberate or bug somewhere.
-    if hdu._header["ZCMPTYPE"] == "PLIO_1":
+    if hdu.compression_type == "PLIO_1":
         table["COMPRESSED_DATA"][:, 0] //= 2
 
     # For PLIO_1, it looks like the compressed data is always stored big endian
-    if hdu._header["ZCMPTYPE"] == "PLIO_1":
+    if hdu.compression_type == "PLIO_1":
         for irow in range(len(compressed_bytes)):
             if not gzip_fallback[irow]:
                 array = np.frombuffer(compressed_bytes[irow], dtype="i2")

--- a/astropy/io/fits/hdu/compressed.py
+++ b/astropy/io/fits/hdu/compressed.py
@@ -484,8 +484,9 @@ class CompImageHDU(BinTableHDU):
             ``'GZIP_2'``, ``'HCOMPRESS_1'``, ``'NOCOMPRESS'``
 
         tile_shape : tuple, optional
-            Compression tile sizes.  Default treats each row of image as a
-            tile.
+            Compression tile shape, which should be specified using the Numpy
+            convention for axis order. The default is to treat each row of
+            image as a tile.
 
         hcomp_scale : float, optional
             HCOMPRESS scale parameter

--- a/astropy/io/fits/hdu/compressed.py
+++ b/astropy/io/fits/hdu/compressed.py
@@ -2141,6 +2141,11 @@ class CompImageHDU(BinTableHDU):
 
     @property
     def tile_shape(self):
+        """
+        The tile shape used for the tiled compression.
+
+        This shape is given in Numpy/C order
+        """
         return tuple(
             [
                 self._header[f"ZTILE{idx + 1}"]
@@ -2150,6 +2155,9 @@ class CompImageHDU(BinTableHDU):
 
     @property
     def compression_type(self):
+        """
+        The name of the compression algorithm.
+        """
         return self._header.get("ZCMPTYPE", DEFAULT_COMPRESSION_TYPE)
 
 

--- a/astropy/io/fits/hdu/compressed.py
+++ b/astropy/io/fits/hdu/compressed.py
@@ -890,7 +890,7 @@ class CompImageHDU(BinTableHDU):
                 "ZCMPTYPE", compression_type, "compression algorithm", after="TFIELDS"
             )
         else:
-            compression_type = self._header.get("ZCMPTYPE", DEFAULT_COMPRESSION_TYPE)
+            compression_type = self.compression_type
             compression_type = CMTYPE_ALIASES.get(compression_type, compression_type)
 
         # If the input image header had BSCALE/BZERO cards, then insert
@@ -2080,9 +2080,7 @@ class CompImageHDU(BinTableHDU):
 
         if seed == DITHER_SEED_CHECKSUM:
             # Determine the tile dimensions from the ZTILEn keywords
-            naxis = self._header["ZNAXIS"]
-            tile_dims = [self._header[f"ZTILE{idx + 1}"] for idx in range(naxis)]
-            tile_dims.reverse()
+            tile_dims = self.tile_size
 
             # Get the first tile by using the tile dimensions as the end
             # indices of slices (starting from 0)
@@ -2121,6 +2119,16 @@ class CompImageHDU(BinTableHDU):
         can be used to slice :class:`~astropy.io.fits.CompImageSection`.
         """
         return CompImageSection(self)
+
+    @property
+    def tile_size(self):
+        return tuple(
+            [self._header[f"ZTILE{idx + 1}"] for idx in range(self._header["ZNAXIS"])]
+        )
+
+    @property
+    def compression_type(self):
+        return self._header.get("ZCMPTYPE", DEFAULT_COMPRESSION_TYPE)
 
 
 class CompImageSection:

--- a/astropy/io/fits/hdu/compressed.py
+++ b/astropy/io/fits/hdu/compressed.py
@@ -443,7 +443,7 @@ class CompImageHDU(BinTableHDU):
         since="5.3",
         message="The tile_size argument has been deprecated. Use tile_shape "
         "instead, but note that this should be given in the reverse "
-        "order to tile_size (tile_shape should be in Numpy order).",
+        "order to tile_size (tile_shape should be in Numpy C order).",
     )
     def __init__(
         self,
@@ -484,9 +484,9 @@ class CompImageHDU(BinTableHDU):
             ``'GZIP_2'``, ``'HCOMPRESS_1'``, ``'NOCOMPRESS'``
 
         tile_shape : tuple, optional
-            Compression tile shape, which should be specified using the Numpy
-            convention for axis order. The default is to treat each row of
-            image as a tile.
+            Compression tile shape, which should be specified using the default
+            Numpy convention for array shapes (C order). The default is to
+            treat each row of image as a tile.
 
         hcomp_scale : float, optional
             HCOMPRESS scale parameter

--- a/astropy/io/fits/hdu/compressed.py
+++ b/astropy/io/fits/hdu/compressed.py
@@ -26,9 +26,9 @@ from astropy.io.fits.util import (
     _pseudo_zero,
 )
 from astropy.utils import lazyproperty
+from astropy.utils.decorators import deprecated_renamed_argument
 from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyUserWarning
 from astropy.utils.shapes import simplify_basic_index
-from astropy.utils.decorators import deprecated_renamed_argument
 
 from .base import BITPIX2DTYPE, DELAYED, DTYPE2BITPIX, ExtensionHDU
 from .image import ImageHDU
@@ -667,6 +667,12 @@ class CompImageHDU(BinTableHDU):
 
         if tile_shape is None and tile_size is not None:
             tile_shape = tuple(tile_size[::-1])
+        elif tile_shape is not None and tile_size is not None:
+            raise ValueError(
+                "Cannot specify both tile_size and tile_shape. "
+                "Note that tile_size is deprecated and tile_shape "
+                "alone should be used."
+            )
 
         if data is DELAYED:
             # Reading the HDU from a file

--- a/astropy/io/fits/tests/test_image.py
+++ b/astropy/io/fits/tests/test_image.py
@@ -1243,7 +1243,7 @@ class TestCompressedImage(FitsTestCase):
             name="SCI",
             compression_type="HCOMPRESS_1",
             quantize_level=16,
-            tile_size=[2, 10, 10],
+            tile_shape=(2, 10, 10),
         )
 
     def test_comp_image_hcompress_image_stack(self):
@@ -1261,7 +1261,7 @@ class TestCompressedImage(FitsTestCase):
             name="SCI",
             compression_type="HCOMPRESS_1",
             quantize_level=16,
-            tile_size=[5, 5, 1],
+            tile_shape=(1, 1, 5),
         )
         hdu.writeto(self.temp("test.fits"))
 
@@ -1971,12 +1971,12 @@ class TestCompressedImage(FitsTestCase):
 
     def test_comp_image_properties_default(self):
         chdu = fits.CompImageHDU(np.zeros((3, 4, 5)))
-        assert chdu.tile_size == (5, 1, 1)
+        assert chdu.tile_shape == (1, 1, 5)
         assert chdu.compression_type == 'RICE_1'
 
     def test_comp_image_properties_set(self):
-        chdu = fits.CompImageHDU(np.zeros((3, 4, 5)), compression_type='PLIO_1', tile_size=(2, 3, 4))
-        assert chdu.tile_size == (2, 3, 4)
+        chdu = fits.CompImageHDU(np.zeros((3, 4, 5)), compression_type='PLIO_1', tile_shape=(2, 3, 4))
+        assert chdu.tile_shape == (2, 3, 4)
         assert chdu.compression_type == 'PLIO_1'
 
 

--- a/astropy/io/fits/tests/test_image.py
+++ b/astropy/io/fits/tests/test_image.py
@@ -1982,7 +1982,6 @@ class TestCompressedImage(FitsTestCase):
         assert chdu.tile_shape == (1, 2, 5)
 
     def test_comp_image_deprecated_tile_size_and_tile_shape(self):
-
         # Make sure that tile_size and tile_shape are not both specified
 
         with pytest.warns(AstropyDeprecationWarning) as w:

--- a/astropy/io/fits/tests/test_image.py
+++ b/astropy/io/fits/tests/test_image.py
@@ -1969,6 +1969,16 @@ class TestCompressedImage(FitsTestCase):
             with fits.open(self.temp("test.fits")) as hdul2:
                 assert_equal(hdul1[1].data[:200, :100], hdul2[1].data)
 
+    def test_comp_image_properties_default(self):
+        chdu = fits.CompImageHDU(np.zeros((3, 4, 5)))
+        assert chdu.tile_size == (5, 1, 1)
+        assert chdu.compression_type == 'RICE_1'
+
+    def test_comp_image_properties_set(self):
+        chdu = fits.CompImageHDU(np.zeros((3, 4, 5)), compression_type='PLIO_1', tile_size=(2, 3, 4))
+        assert chdu.tile_size == (2, 3, 4)
+        assert chdu.compression_type == 'PLIO_1'
+
 
 class TestCompHDUSections:
     @pytest.fixture(autouse=True)

--- a/astropy/io/fits/tests/test_image.py
+++ b/astropy/io/fits/tests/test_image.py
@@ -1511,7 +1511,7 @@ class TestCompressedImage(FitsTestCase):
         np.random.seed(1337)
         data1 = np.random.uniform(size=(6 * 4, 7 * 4))
         data1[: data2.shape[0], : data2.shape[1]] = data2
-        chdu = fits.CompImageHDU(data1, compression_type="RICE_1", tile_size=(6, 7))
+        chdu = fits.CompImageHDU(data1, compression_type="RICE_1", tile_shape=(6, 7))
         chdu.writeto(self.temp("test.fits"))
 
         with fits.open(self.temp("test.fits"), disable_image_compression=True) as h:
@@ -1981,14 +1981,17 @@ class TestCompressedImage(FitsTestCase):
 
         assert chdu.tile_shape == (1, 2, 5)
 
+    def test_comp_image_deprecated_tile_size_and_tile_shape(self):
+
         # Make sure that tile_size and tile_shape are not both specified
 
-        with pytest.raises(
-            ValueError, match="Cannot specify both tile_size and tile_shape."
-        ):
-            fits.CompImageHDU(
-                np.zeros((3, 4, 5)), tile_size=(5, 2, 1), tile_shape=(3, 2, 3)
-            )
+        with pytest.warns(AstropyDeprecationWarning) as w:
+            with pytest.raises(
+                ValueError, match="Cannot specify both tile_size and tile_shape."
+            ):
+                fits.CompImageHDU(
+                    np.zeros((3, 4, 5)), tile_size=(5, 2, 1), tile_shape=(3, 2, 3)
+                )
 
     def test_comp_image_properties_default(self):
         chdu = fits.CompImageHDU(np.zeros((3, 4, 5)))
@@ -2011,14 +2014,14 @@ class TestCompHDUSections:
 
         header1 = fits.Header()
         hdu1 = fits.CompImageHDU(
-            self.data, header1, compression_type="RICE_1", tile_size=(5, 4, 5)
+            self.data, header1, compression_type="RICE_1", tile_shape=(5, 4, 5)
         )
 
         header2 = fits.Header()
         header2["BSCALE"] = 2
         header2["BZERO"] = 100
         hdu2 = fits.CompImageHDU(
-            self.data, header2, compression_type="RICE_1", tile_size=(5, 4, 5)
+            self.data, header2, compression_type="RICE_1", tile_shape=(5, 4, 5)
         )
         hdulist = fits.HDUList([fits.PrimaryHDU(), hdu1, hdu2])
         hdulist.writeto(tmp_path / "sections.fits")

--- a/docs/changes/io.fits/14428.api.rst
+++ b/docs/changes/io.fits/14428.api.rst
@@ -1,0 +1,5 @@
+The ``tile_size=`` argument to ``CompImageHDU`` has been deprecated
+as it was confusing that it was required to be in the opposite
+order to the data shape (it was in header rather than Numpy order).
+Instead, users should make use of the ``tile_shape=`` argument which
+is in Numpy shape order.

--- a/docs/changes/io.fits/14428.feature.rst
+++ b/docs/changes/io.fits/14428.feature.rst
@@ -1,0 +1,3 @@
+Added new properties ``compression_type`` and ``tile_shape`` on
+``CompImageHDU``, giving the name of the compression algorithm
+and the shape of the tiles in the tiled compression respectively.


### PR DESCRIPTION
I think it would be useful to expose the compression type and tile size/shape as public properties on ``CompImageHDU`` - but I have run into an API design issue. The tile_size passed in to ``CompImageHDU`` is in reverse Numpy order, so if we exposed a property such as ``tile_size`` as done in this PR it should return what is passed in to the ``CompImageHDU`` (in general this is a good design - if a parameter is passed in, accessing it via a property should give the same result).

However, I think most use cases for this would actually be interested more in the actual Numpy tile shape, so it's not clear what the best option is here. There are several options:

1. Make a new property ``tile_shape`` which is in Numpy order and deliberately has a different name from ``tile_size``
2. Deprecate ``tile_size`` as input to ``CompImageHDU`` in favor of ``tile_shape``, which would be in Numpy order, then have a ``tile_shape`` property that matches#
3. Another option I'm not thinking of?

Personally I find it very confusing that the input tile size is not in Numpy order and would prefer 2. but perhaps this would need a long deprecation phase depending on how widely this is used in the wild.

In principle we could also expose other settings (dithering etc) as properties but I wanted to first see if we can figure this one out.