### PR TITLE
Fix `format_tag` deprecation

### DIFF
--- a/astropy/io/misc/asdf/tags/tests/helpers.py
+++ b/astropy/io/misc/asdf/tags/tests/helpers.py
@@ -9,17 +9,24 @@ def run_schema_example_test(organization, standard, name, version, check_func=No
     from asdf.exceptions import AsdfDeprecationWarning
     from asdf.schema import load_schema
     from asdf.tests import helpers
-    from asdf.types import format_tag
-
-    tag = format_tag(organization, standard, version, name)
 
     with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            category=AsdfDeprecationWarning,
+            message=r"asdf.types.format_tag is deprecated.*",
+        )
+        from asdf.types import format_tag
+
+        tag = format_tag(organization, standard, version, name)
+
         warnings.filterwarnings(
             "ignore",
             category=AsdfDeprecationWarning,
             message=r"default_extensions is deprecated.*",
         )
         uri = asdf.extension.default_extensions.extension_list.tag_mapping(tag)
+
         warnings.filterwarnings(
             "ignore",
             category=AsdfDeprecationWarning,


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

ASDF deprecated `format_tag` imports from `asdf.types` (its been moved) in asdf-format/asdf#1433. Since `astropy.io.misc.asdf` is deprecated, I'm just catching and ignoring the warning.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>
