### PR TITLE
Refactor units formats FITS and VOUNIT a bit more

### DIFF
--- a/astropy/units/format/base.py
+++ b/astropy/units/format/base.py
@@ -73,12 +73,12 @@ class Base:
         )
 
     @classmethod
-    def _format_fraction(cls, scale, nominator, denominator):
+    def _format_fraction(cls, scale, numerator, denominator):
         if cls._space in denominator:
             denominator = f"({denominator})"
-        if scale and nominator == "1":
+        if scale and numerator == "1":
             return f"{scale}/ {denominator}"
-        return f"{scale}{nominator} / {denominator}"
+        return f"{scale}{numerator} / {denominator}"
 
     @classmethod
     def to_string(cls, unit, inline=False):
@@ -96,22 +96,21 @@ class Base:
             if s:
                 s += cls._scale_unit_separator
             if inline:
-                nominator = list(zip(unit.bases, unit.powers))
+                numerator = list(zip(unit.bases, unit.powers))
                 denominator = []
             else:
-                nominator, denominator = utils.get_grouped_by_powers(
+                numerator, denominator = utils.get_grouped_by_powers(
                     unit.bases, unit.powers
                 )
             if len(denominator):
-                if len(nominator):
-                    nominator = cls._format_unit_list(nominator)
+                if len(numerator):
+                    numerator = cls._format_unit_list(numerator)
                 else:
-                    nominator = "1"
+                    numerator = "1"
                 denominator = cls._format_unit_list(denominator)
-                s = cls._format_fraction(s, nominator, denominator)
+                s = cls._format_fraction(s, numerator, denominator)
             else:
-                nominator = cls._format_unit_list(nominator)
-                s += nominator
+                s += cls._format_unit_list(numerator)
 
         return s
 

--- a/astropy/units/format/base.py
+++ b/astropy/units/format/base.py
@@ -9,6 +9,7 @@ class Base:
 
     registry = {}
     _space = " "
+    _scale_unit_separator = " "
 
     def __new__(cls, *args, **kwargs):
         # This __new__ is to make it clear that there is no reason to
@@ -93,7 +94,7 @@ class Base:
         # (but can have a scale; e.g., u.percent.decompose() gives "0.01").
         if len(unit.bases):
             if s:
-                s += cls._space
+                s += cls._scale_unit_separator
             if inline:
                 nominator = list(zip(unit.bases, unit.powers))
                 denominator = []

--- a/astropy/units/format/console.py
+++ b/astropy/units/format/console.py
@@ -50,13 +50,13 @@ class Console(base.Base):
         return cls._times.join(parts)
 
     @classmethod
-    def _format_fraction(cls, scale, nominator, denominator):
-        fraclength = max(len(nominator), len(denominator))
+    def _format_fraction(cls, scale, numerator, denominator):
+        fraclength = max(len(numerator), len(denominator))
         f = f"{{0:<{len(scale)}s}}{{1:^{fraclength}s}}"
 
         return "\n".join(
             (
-                f.format("", nominator),
+                f.format("", numerator),
                 f.format(scale, cls._line * fraclength),
                 f.format("", denominator),
             )

--- a/astropy/units/format/latex.py
+++ b/astropy/units/format/latex.py
@@ -55,8 +55,8 @@ class Latex(console.Console):
         return name
 
     @classmethod
-    def _format_fraction(cls, scale, nominator, denominator):
-        return rf"{scale}\frac{{{nominator}}}{{{denominator}}}"
+    def _format_fraction(cls, scale, numerator, denominator):
+        return rf"{scale}\frac{{{numerator}}}{{{denominator}}}"
 
     @classmethod
     def to_string(cls, unit, inline=False):

--- a/astropy/units/format/latex.py
+++ b/astropy/units/format/latex.py
@@ -18,6 +18,7 @@ class Latex(console.Console):
     """
 
     _space = r"\,"
+    _scale_unit_separator = r"\,"
     _times = r" \times "
 
     @classmethod

--- a/astropy/units/format/utils.py
+++ b/astropy/units/format/utils.py
@@ -124,7 +124,7 @@ def format_power(power):
     if not hasattr(power, "denominator"):
         power = maybe_simple_fraction(power)
         if getattr(power, "denonimator", None) == 1:
-            power = power.nominator
+            power = power.numerator
 
     return str(power)
 

--- a/astropy/units/format/vounit.py
+++ b/astropy/units/format/vounit.py
@@ -6,7 +6,6 @@ Handles the "VOUnit" unit format.
 
 import copy
 import keyword
-import operator
 import re
 import warnings
 
@@ -25,6 +24,7 @@ class VOUnit(generic.Generic):
     _custom_unit_regex = re.compile(r"^((?!\d)\w)+$")
     _custom_units = {}
     _space = "."
+    _scale_unit_separator = ""
 
     @staticmethod
     def _generate_unit_names():
@@ -196,7 +196,11 @@ class VOUnit(generic.Generic):
         return f"({number})" if "/" in number or "." in number else f"**{number}"
 
     @classmethod
-    def to_string(cls, unit):
+    def format_exponential_notation(cls, val, format_spec=".8g"):
+        return super().format_exponential_notation(val, format_spec)
+
+    @classmethod
+    def to_string(cls, unit, inline=True):
         from astropy.units import core
 
         # Remove units that aren't known to the format
@@ -208,16 +212,8 @@ class VOUnit(generic.Generic):
                 "represent scale for dimensionless units. "
                 f"Multiply your data by {unit.scale:e}."
             )
-        s = ""
-        if unit.scale != 1:
-            s += f"{unit.scale:.8g}"
 
-        pairs = list(zip(unit.bases, unit.powers))
-        pairs.sort(key=operator.itemgetter(1), reverse=True)
-
-        s += cls._format_unit_list(pairs)
-
-        return s
+        return super().to_string(unit, inline=inline)
 
     @classmethod
     def _to_decomposed_alternative(cls, unit):

--- a/astropy/units/function/logarithmic.py
+++ b/astropy/units/function/logarithmic.py
@@ -326,7 +326,7 @@ class LogQuantity(FunctionQuantity):
     def __truediv__(self, other):
         # Divide by a float or a dimensionless quantity
         if isinstance(other, numbers.Number):
-            # Dividing a log means putting the nominator into the exponent
+            # Dividing a log means putting the denominator into the exponent
             # of the unit
             new_physical_unit = self.unit.physical_unit ** (1 / other)
             result = self.view(np.ndarray) / other


### PR DESCRIPTION
This pull request follows up on #14416 to refactor also FITS and VOUNIT a bit more. Mostly, it was an oversight of not realizing that the sorting done in those formats was not actually necessary, as it just duplicated what is done already in their superclass, `generic`. 

Note that on purpose this does not *change* the sorting -- which I think should be done but which changes a lot of tests, so needs separate discussion! (EDIT: see #14449)

EDIT: I added a commit that does not strictly belong, but I'm lazy: in the previous PRs, starting with #14393, we called the numerator of a fraction the nominator, which is incorrect (although apparently so common that ~`Fraction.nominator` exists and that~ none of the many reviewers noticed it...). Anyway, the last commit corrects it. EDIT: `Fraction.nominator` does not exists; apparently, that line in `utils.py` is never exercised... 