### PR TITLE
Avoid resorting units when converting to strings

### DIFF
--- a/astropy/modeling/physical_models.py
+++ b/astropy/modeling/physical_models.py
@@ -47,7 +47,7 @@ class BlackBody(Fittable1DModel):
     >>> from astropy import units as u
     >>> bb = models.BlackBody(temperature=5000*u.K)
     >>> bb(6000 * u.AA)  # doctest: +FLOAT_CMP
-    <Quantity 1.53254685e-05 erg / (cm2 Hz s sr)>
+    <Quantity 1.53254685e-05 erg / (Hz s sr cm2)>
 
     .. plot::
         :include-source:

--- a/astropy/nddata/tests/test_nddata.py
+++ b/astropy/nddata/tests/test_nddata.py
@@ -478,7 +478,7 @@ def test_nddata_str():
 
     # what if it had these units?
     arr = NDData(np.array([1, 2, 3]), unit="erg cm^-2 s^-1 A^-1")
-    assert str(arr) == "[1 2 3] erg / (A cm2 s)"
+    assert str(arr) == "[1 2 3] erg / (A s cm2)"
 
 
 def test_nddata_repr():

--- a/astropy/units/format/generic.py
+++ b/astropy/units/format/generic.py
@@ -594,11 +594,6 @@ class Generic(Base):
                 else:
                     raise ValueError(f"Syntax error parsing unit '{s}'")
 
-    @classmethod
-    def _format_unit_list(cls, units):
-        units.sort(key=lambda x: cls._get_unit_name(x[0]).lower())
-        return super()._format_unit_list(units)
-
 
 # 2023-02-18: The statement in the docstring is no longer true, the class is not used
 # anywhere so can be safely removed in 6.0.

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -432,8 +432,8 @@ def test_latex_inline_scale():
 @pytest.mark.parametrize(
     "format_spec, string, decomposed",
     [
-        ("generic", "erg / (Angstrom cm2 s)", "1e+07 kg / (m s3)"),
-        ("s", "erg / (Angstrom cm2 s)", "1e+07 kg / (m s3)"),
+        ("generic", "erg / (Angstrom s cm2)", "1e+07 kg / (m s3)"),
+        ("s", "erg / (Angstrom s cm2)", "1e+07 kg / (m s3)"),
         ("console", "erg Angstrom^-1 s^-1 cm^-2", "10000000 kg m^-1 s^-3"),
         (
             "latex",
@@ -446,11 +446,11 @@ def test_latex_inline_scale():
             r"$\mathrm{10000000\,kg\,m^{-1}\,s^{-3}}$",
         ),
         ("unicode", "erg Å⁻¹ s⁻¹ cm⁻²", "10000000 kg m⁻¹ s⁻³"),
-        (">25s", "   erg / (Angstrom cm2 s)", "        1e+07 kg / (m s3)"),
+        (">25s", "   erg / (Angstrom s cm2)", "        1e+07 kg / (m s3)"),
         ("cds", "erg.Angstrom-1.s-1.cm-2", "10000000kg.m-1.s-3"),
-        ("ogip", "10 erg / (cm**2 nm s)", "1e+07 kg / (m s**3)"),
-        ("fits", "Angstrom-1 cm-2 erg s-1", "10**7 kg m-1 s-3"),
-        ("vounit", "Angstrom**-1.cm**-2.erg.s**-1", "10000000kg.m**-1.s**-3"),
+        ("ogip", "10 erg / (nm s cm**2)", "1e+07 kg / (m s**3)"),
+        ("fits", "erg Angstrom-1 s-1 cm-2", "10**7 kg m-1 s-3"),
+        ("vounit", "erg.Angstrom**-1.s**-1.cm**-2", "10000000kg.m**-1.s**-3"),
         # TODO: make fits and vounit less awful!
     ],
 )
@@ -471,7 +471,7 @@ def test_format_styles(format_spec, string, decomposed):
 @pytest.mark.parametrize(
     "format_spec, fraction, string, decomposed",
     [
-        ("generic", False, "cm-2 erg s-1", "0.001 kg s-3"),
+        ("generic", False, "erg s-1 cm-2", "0.001 kg s-3"),
         (
             "console",
             "multiline",
@@ -689,7 +689,7 @@ def test_vounit_details():
     with pytest.warns(UnitsWarning, match="deprecated"):
         flam = u.erg / u.cm / u.cm / u.s / u.AA
         x = u.format.VOUnit.to_string(flam)
-        assert x == "Angstrom**-1.cm**-2.erg.s**-1"
+        assert x == "erg.Angstrom**-1.s**-1.cm**-2"
         new_flam = u.format.VOUnit.parse(x)
         assert new_flam == flam
 
@@ -762,11 +762,11 @@ def test_vounit_implicit_custom():
 def test_fits_scale_factor(scale, number, string):
     x = u.Unit(scale + " erg/(s cm**2 Angstrom)", format="fits")
     assert x == number * (u.erg / u.s / u.cm**2 / u.Angstrom)
-    assert x.to_string(format="fits") == string + " Angstrom-1 cm-2 erg s-1"
+    assert x.to_string(format="fits") == string + " erg Angstrom-1 s-1 cm-2"
 
     x = u.Unit(scale + "*erg/(s cm**2 Angstrom)", format="fits")
     assert x == number * (u.erg / u.s / u.cm**2 / u.Angstrom)
-    assert x.to_string(format="fits") == string + " Angstrom-1 cm-2 erg s-1"
+    assert x.to_string(format="fits") == string + " erg Angstrom-1 s-1 cm-2"
 
 
 def test_fits_scale_factor_errors():

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -153,7 +153,7 @@ def test_multiple_solidus():
 
     # Regression test for #9000: solidi in exponents do not count towards this.
     x = u.Unit("kg(3/10) * m(5/2) / s", format="vounit")
-    assert x.to_string() == "kg(3/10) m(5/2) / s"
+    assert x.to_string() == "m(5/2) kg(3/10) / s"
 
 
 def test_unknown_unit3():

--- a/docs/changes/units/14439.api.rst
+++ b/docs/changes/units/14439.api.rst
@@ -1,0 +1,6 @@
+The order in which unit bases are displayed has been changed to match the
+order bases are stored in internally, which is by descending power to which
+the base is raised, and alphabetical after. This helps avoid monstrosities
+like ``beam^-1 Jy`` for ``format='fits'``.
+
+Note that this may affect doctests that use quantities with complicated units.

--- a/docs/units/combining_and_defining.rst
+++ b/docs/units/combining_and_defining.rst
@@ -12,9 +12,9 @@ numeric operators::
   >>> from astropy import units as u
   >>> fluxunit = u.erg / (u.cm ** 2 * u.s)
   >>> fluxunit
-  Unit("erg / (cm2 s)")
+  Unit("erg / (s cm2)")
   >>> 52.0 * fluxunit  # doctest: +FLOAT_CMP
-  <Quantity  52. erg / (cm2 s)>
+  <Quantity  52. erg / (s cm2)>
   >>> 52.0 * fluxunit / u.s  # doctest: +FLOAT_CMP
   <Quantity  52. erg / (cm2 s2)>
 

--- a/docs/units/decomposing_and_composing.rst
+++ b/docs/units/decomposing_and_composing.rst
@@ -22,7 +22,7 @@ To decompose a unit with :meth:`~astropy.units.core.UnitBase.decompose`::
   >>> u.Ry
   Unit("Ry")
   >>> u.Ry.decompose()
-  Unit("2.17987e-18 kg m2 / s2")
+  Unit("2.17987e-18 m2 kg / s2")
 
 To get the list of units in the decomposition, the
 `~astropy.units.core.UnitBase.bases` and `~astropy.units.core.UnitBase.powers`
@@ -36,7 +36,7 @@ You can limit the selection of units that you want to decompose by
 using the ``bases`` keyword argument::
 
   >>> u.Ry.decompose(bases=[u.m, u.N])
-  Unit("2.17987e-18 m N")
+  Unit("2.17987e-18 N m")
 
 This is also useful to decompose to a particular system. For example,
 to decompose the Rydberg unit of energy in terms of `CGS
@@ -104,7 +104,7 @@ imaginable. In that case, the system will do its best to reduce the
 unit to the fewest possible symbols::
 
    >>> (u.cd * u.sr * u.V * u.s).compose()
-   [Unit("lm Wb"), Unit("1e+08 lm Mx")]
+   [Unit("Wb lm"), Unit("1e+08 Mx lm")]
 
 .. EXAMPLE END
 

--- a/docs/units/equivalencies.rst
+++ b/docs/units/equivalencies.rst
@@ -219,10 +219,10 @@ To perform unit conversions with
 
     >>> (1.5 * u.Jy).to(u.photon / u.cm**2 / u.s / u.Hz,
     ...                 equivalencies=u.spectral_density(3500 * u.AA)) # doctest: +FLOAT_CMP
-    <Quantity 2.6429114293019694e-12 ph / (cm2 Hz s)>
+    <Quantity 2.6429112e-12 ph / (Hz s cm2)>
     >>> (1.5 * u.Jy).to(u.photon / u.cm**2 / u.s / u.micron,
     ...                 equivalencies=u.spectral_density(3500 * u.AA))  # doctest: +FLOAT_CMP
-    <Quantity 6467.9584789120845 ph / (cm2 micron s)>
+    <Quantity 6467.95791275 ph / (micron s cm2)>
     >>> a = 1. * (u.photon / u.s / u.angstrom)
     >>> a.to(u.erg / u.s / u.Hz,
     ...      equivalencies=u.spectral_density(5500 * u.AA))  # doctest: +FLOAT_CMP
@@ -231,9 +231,9 @@ To perform unit conversions with
     >>> a = 1. * (u.erg / u.cm**2 / u.s)
     >>> b = a.to(u.photon / u.cm**2 / u.s, u.spectral_density(w))
     >>> b  # doctest: +FLOAT_CMP
-    <Quantity 2.51705828e+11 ph / (cm2 s)>
+    <Quantity 2.51705828e+11 ph / (s cm2)>
     >>> b.to(a.unit, u.spectral_density(w))  # doctest: +FLOAT_CMP
-    <Quantity 1. erg / (cm2 s)>
+    <Quantity 1. erg / (s cm2)>
 
 .. EXAMPLE END
 
@@ -626,27 +626,27 @@ However, when passing the spectral equivalency, you can see there are
 all kinds of things that ``Hz`` can be converted to::
 
   >>> u.Hz.find_equivalent_units(equivalencies=u.spectral())
-    Primary name | Unit definition        | Aliases
+  Primary name | Unit definition        | Aliases
   [
-    AU           | 1.49598e+11 m          | au, astronomical_unit ,
-    Angstrom     | 1e-10 m                | AA, angstrom          ,
-    Bq           | 1 / s                  | becquerel             ,
-    Ci           | 3.7e+10 / s            | curie                 ,
-    Hz           | 1 / s                  | Hertz, hertz          ,
-    J            | kg m2 / s2             | Joule, joule          ,
-    Ry           | 2.17987e-18 kg m2 / s2 | rydberg               ,
-    cm           | 0.01 m                 | centimeter            ,
-    eV           | 1.60218e-19 kg m2 / s2 | electronvolt          ,
-    earthRad     | 6.3781e+06 m           | R_earth, Rearth       ,
-    erg          | 1e-07 kg m2 / s2       |                       ,
+    AU           | 1.49598e+11 m          | au, astronomical_unit            ,
+    Angstrom     | 1e-10 m                | AA, angstrom                     ,
+    Bq           | 1 / s                  | becquerel                        ,
+    Ci           | 3.7e+10 / s            | curie                            ,
+    Hz           | 1 / s                  | Hertz, hertz                     ,
+    J            | m2 kg / s2             | Joule, joule                     ,
+    Ry           | 2.17987e-18 m2 kg / s2 | rydberg                          ,
+    cm           | 0.01 m                 | centimeter                       ,
+    eV           | 1.60218e-19 m2 kg / s2 | electronvolt                     ,
+    earthRad     | 6.3781e+06 m           | R_earth, Rearth                  ,
+    erg          | 1e-07 m2 kg / s2       |                                  ,
     jupiterRad   | 7.1492e+07 m           | R_jup, Rjup, R_jupiter, Rjupiter ,
-    k            | 100 / m                | Kayser, kayser        ,
-    lsec         | 2.99792e+08 m          | lightsecond           ,
-    lyr          | 9.46073e+15 m          | lightyear             ,
-    m            | irreducible            | meter                 ,
-    micron       | 1e-06 m                |                       ,
-    pc           | 3.08568e+16 m          | parsec                ,
-    solRad       | 6.957e+08 m            | R_sun, Rsun           ,
+    k            | 100 / m                | Kayser, kayser                   ,
+    lsec         | 2.99792e+08 m          | lightsecond                      ,
+    lyr          | 9.46073e+15 m          | lightyear                        ,
+    m            | irreducible            | meter                            ,
+    micron       | 1e-06 m                |                                  ,
+    pc           | 3.08568e+16 m          | parsec                           ,
+    solRad       | 6.957e+08 m            | R_sun, Rsun                      ,
   ]
 
 .. EXAMPLE END

--- a/docs/units/format.rst
+++ b/docs/units/format.rst
@@ -90,13 +90,13 @@ take an optional parameter to select a different format::
     '$10 \\; \\mathrm{km}$'
     >>> fluxunit = u.erg / (u.cm ** 2 * u.s)
     >>> f"{fluxunit}"
-    'erg / (cm2 s)'
+    'erg / (s cm2)'
     >>> print(f"{fluxunit:unicode}")
     erg s⁻¹ cm⁻²
     >>> f"{fluxunit:latex}"
     '$\\mathrm{\\frac{erg}{s\\,cm^{2}}}$'
     >>> f"{fluxunit:>20s}"
-    '       erg / (cm2 s)'
+    '       erg / (s cm2)'
 
 The `UnitBase.to_string() <astropy.units.core.UnitBase.to_string>` method is an
 alternative way to format units as strings, and is the underlying
@@ -117,9 +117,9 @@ formats using the `~astropy.units.Unit` class::
   >>> u.Unit("m")
   Unit("m")
   >>> u.Unit("erg / (s cm2)")
-  Unit("erg / (cm2 s)")
+  Unit("erg / (s cm2)")
   >>> u.Unit("erg.s-1.cm-2", format="cds")
-  Unit("erg / (cm2 s)")
+  Unit("erg / (s cm2)")
 
 It is also possible to create a scalar |Quantity| from a string::
 

--- a/docs/units/logarithmic_units.rst
+++ b/docs/units/logarithmic_units.rst
@@ -135,15 +135,15 @@ first star has a known ST magnitude, so we can calculate zero points::
     (<Magnitude 17.2 mag(ST)>, <Magnitude 17. mag(ST)>)
     >>> zp_b, zp_v = b_ref - b_i0[0], v_ref - v_i0[0]
     >>> zp_b, zp_v  # doctest: +FLOAT_CMP
-    (<Magnitude 18.56250876 mag(s ST / ct)>,
-     <Magnitude 18.67485561 mag(s ST / ct)>)
+    (<Magnitude 18.56250876 mag(ST s / ct)>,
+     <Magnitude 18.67485561 mag(ST s / ct)>)
 
 Here, ``ST`` is shorthand for the ST zero-point flux::
 
     >>> (0. * u.STmag).to(u.erg/u.s/u.cm**2/u.AA)  # doctest: +FLOAT_CMP
-    <Quantity 3.63078055e-09 erg / (Angstrom cm2 s)>
+    <Quantity 3.63078055e-09 erg / (Angstrom s cm2)>
     >>> (-21.1 * u.STmag).to(u.erg/u.s/u.cm**2/u.AA)  # doctest: +FLOAT_CMP
-    <Quantity 1. erg / (Angstrom cm2 s)>
+    <Quantity 1. erg / (Angstrom s cm2)>
 
 .. Note::
 
@@ -173,7 +173,7 @@ flux density per unit wavelength using the
 
     >>> flam = V.to(u.erg/u.s/u.cm**2/u.AA)
     >>> flam  # doctest: +FLOAT_CMP
-    <Quantity [5.75439937e-16, 1.29473986e-17, 3.59649961e-18] erg / (Angstrom cm2 s)>
+    <Quantity [5.75439937e-16, 1.29473986e-17, 3.59649961e-18] erg / (Angstrom s cm2)>
 
 To convert ``V`` to flux density per unit frequency (:math:`f_\nu`), we again
 need the appropriate :ref:`equivalency <unit_equivalencies>`, which in this case
@@ -182,14 +182,14 @@ is the central wavelength of the magnitude band, 5500 Angstroms::
     >>> lam = 5500 * u.AA
     >>> fnu = V.to(u.erg/u.s/u.cm**2/u.Hz, u.spectral_density(lam))
     >>> fnu  # doctest: +FLOAT_CMP
-    <Quantity [5.80636959e-27, 1.30643316e-28, 3.62898099e-29] erg / (cm2 Hz s)>
+    <Quantity [5.80636959e-27, 1.30643316e-28, 3.62898099e-29] erg / (Hz s cm2)>
 
 We could have used the central frequency instead::
 
     >>> nu = 5.45077196e+14 * u.Hz
     >>> fnu = V.to(u.erg/u.s/u.cm**2/u.Hz, u.spectral_density(nu))
     >>> fnu  # doctest: +FLOAT_CMP
-    <Quantity [5.80636959e-27, 1.30643316e-28, 3.62898099e-29] erg / (cm2 Hz s)>
+    <Quantity [5.80636959e-27, 1.30643316e-28, 3.62898099e-29] erg / (Hz s cm2)>
 
 .. Note::
 

--- a/docs/units/quantity.rst
+++ b/docs/units/quantity.rst
@@ -239,7 +239,7 @@ This method is also useful for more complicated arithmetic:
     >>> 15. * u.kg * 32. * u.cm * 15 * u.m / (11. * u.s * 1914.15 * u.ms)  # doctest: +FLOAT_CMP
     <Quantity 0.34195097 cm kg m / (ms s)>
     >>> (15. * u.kg * 32. * u.cm * 15 * u.m / (11. * u.s * 1914.15 * u.ms)).decompose()  # doctest: +FLOAT_CMP
-    <Quantity 3.41950973 kg m2 / s2>
+    <Quantity 3.41950973 m2 kg / s2>
 
 .. EXAMPLE END
 

--- a/docs/whatsnew/5.3.rst
+++ b/docs/whatsnew/5.3.rst
@@ -17,6 +17,7 @@ In particular, this release includes:
 .. * :ref:`whatsnew-5.3-compressed-fits`
 .. * :ref:`whatsnew-5.3-compressed-fits-nocompress`
 .. * :ref:`whatsnew-5.3-unit-formats-fraction`
+.. * :ref:`whatsnew-5.3-unit-formats-order`
 .. * :ref:`whatsnew-5.3-nddata-collapse-arbitrary-axes`
 .. * :ref:`whatsnew-5.3-coordinates-refresh-site-registry`
 
@@ -151,6 +152,21 @@ Note that the ``'console'`` and ``'unicode'`` formats now use
 readable results when printing quantities, table headers and cells, etc.
 For ``'latex'`` the default remains ``fraction='display'``, for an
 unchanged experience with IPython notebook.
+
+.. _whatsnew-5.3-unit-formats-order:
+
+Change in order in unit string representations
+==============================================
+
+In string representations of units, the order of bases now is by decreasing
+power first, then alphabetical, instead of alphabetical independent of power.
+This is also how unit bases are stored internally and helps particularly for
+units without fractions (such as FITS), where a unit like ``Jy/beam`` was
+typeset as ``beam-1 Jy`` instead of the more logical ``Jy beam-1``.
+
+For typesetting with fractions, there is usually less effect, but the string
+representations of complicated units will change (e.g., what previously was
+``erg / (Angstrom cm2 s)`` will now be ``erg / (Angstrom s cm2)``).
 
 .. _whatsnew-5.3-nddata-collapse-arbitrary-axes:
 


### PR DESCRIPTION
When converting units to strings, the order of the base units is now always the same as it is in the unit itself: by decreasing power to which the unit is raised, and then alphabetical. This avoids super-ugly representations such as `beam-1 Jy` (such as could happen for FITS; see #13217).

However, as can be seen from the PR, it also means some (doc)tests had to be adapted, and it can reasonably be foreseen that this will cause similar down-stream failures. ~Hence, opening as draft for now.~ EDIT: given initial positive feedback, changed to regular PR.

~(Note based on #14437 for now; will rebase once that is in.)~ EDIT: rebased now previous format PRs are in.

Fixes #13217
