### PR TITLE
TST: codecov to only upload when necessary

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -49,7 +49,7 @@ jobs:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
     with:
       submodules: false
-      coverage: codecov
+      coverage: ''
       libraries: |
         apt:
           - language-pack-fr
@@ -59,6 +59,7 @@ jobs:
         #       run only with minimal dependencies.
         - name: Python 3.10 with minimal dependencies and full coverage
           linux: py310-test-cov
+          coverage: codecov
 
         - name: Python 3.9 with all optional dependencies
           linux: py39-test-alldeps-fitsio
@@ -73,6 +74,7 @@ jobs:
         - name: Python 3.8 with oldest supported version of all dependencies
           linux: py38-test-oldestdeps-alldeps-cov-clocale
           posargs: --remote-data=astropy
+          coverage: codecov
 
         - name: Python 3.9 with all optional dependencies (Windows)
           windows: py39-test-alldeps
@@ -87,7 +89,7 @@ jobs:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
     with:
       submodules: false
-      coverage: codecov
+      coverage: ''
       libraries: |
         apt:
           - language-pack-de


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to not call the uploader blindly, as suggested by https://github.com/OpenAstronomy/github-actions-workflows/issues/109
