### PR TITLE
TST: Handle new IntCastingNaNError from pandas v2 in test_masking when use_nullable_int is False

### DIFF
--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -2151,7 +2151,8 @@ class TestPandas:
         else:
             import pandas
             from packaging.version import Version
-            PANDAS_LT_2_0 = Version(pandas.__version__) < Version('2.0dev')
+
+            PANDAS_LT_2_0 = Version(pandas.__version__) < Version("2.0dev")
             if PANDAS_LT_2_0:
                 with pytest.warns(
                     TableReplaceWarning,
@@ -2160,7 +2161,11 @@ class TestPandas:
                     d = t.to_pandas(use_nullable_int=use_nullable_int)
             else:
                 from pandas.core.dtypes.cast import IntCastingNaNError
-                with pytest.raises(IntCastingNaNError, match=r"Cannot convert non-finite values \(NA or inf\) to integer"):
+
+                with pytest.raises(
+                    IntCastingNaNError,
+                    match=r"Cannot convert non-finite values \(NA or inf\) to integer",
+                ):
                     d = t.to_pandas(use_nullable_int=use_nullable_int)
                 return  # Do not continue
 

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -2149,11 +2149,20 @@ class TestPandas:
             # No warning with the default use_nullable_int=True
             d = t.to_pandas(use_nullable_int=use_nullable_int)
         else:
-            with pytest.warns(
-                TableReplaceWarning,
-                match=r"converted column 'a' from int(32|64) to float64",
-            ):
-                d = t.to_pandas(use_nullable_int=use_nullable_int)
+            import pandas
+            from packaging.version import Version
+            PANDAS_LT_2_0 = Version(pandas.__version__) < Version('2.0dev')
+            if PANDAS_LT_2_0:
+                with pytest.warns(
+                    TableReplaceWarning,
+                    match=r"converted column 'a' from int(32|64) to float64",
+                ):
+                    d = t.to_pandas(use_nullable_int=use_nullable_int)
+            else:
+                from pandas.core.dtypes.cast import IntCastingNaNError
+                with pytest.raises(IntCastingNaNError, match=r"Cannot convert non-finite values \(NA or inf\) to integer"):
+                    d = t.to_pandas(use_nullable_int=use_nullable_int)
+                return  # Do not continue
 
         t2 = table.Table.from_pandas(d)
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to handle the new error from pandas pre-release. I only know how to update the test, not table internals. If this is not the right way to fix the problem, feel free to close and propose something else.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #14426 
