### PR TITLE
Allow fraction and inline options for unit.to_string()

### DIFF
--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -746,7 +746,7 @@ class UnitBase:
         return [1]
 
     def to_string(self, format=unit_format.Generic, **kwargs):
-        """Output the unit in the given format as a string.
+        r"""Output the unit in the given format as a string.
 
         Parameters
         ----------
@@ -756,12 +756,36 @@ class UnitBase:
 
         **kwargs
             Further options forwarded to the formatter. Currently
-            recognized is **fraction**.  If not `False`, units with
-            bases raised to negative powers are represented using a
-            fraction, with `True` or 'inline' used to produce a single
-            line, and 'display' to produce a multi-line string (for
-            the ``latex``, ``console`` and ``unicode`` formats only).
+            recognized is ``fraction``, which can take the following values:
 
+            - `False` : display unit bases with negative powers as they are;
+            - 'inline' or `True` : use a single-line fraction;
+            - 'multiline' : use a multiline fraction (available for the
+              'latex', 'console' and 'unicode' formats only).
+
+        Raises
+        ------
+        TypeError
+            If ``format`` is of the wrong type.
+        ValueError
+            If ``format`` or ``fraction`` are not recognized.
+
+        Examples
+        --------
+        >>> import astropy.units as u
+        >>> kms = u.Unit('km / s')
+        >>> kms.to_string()  # Generic uses fraction='inline' by default
+        'km / s'
+        >>> kms.to_string('latex')  # Latex uses fraction='multiline' by default
+        '$\\mathrm{\\frac{km}{s}}$'
+        >>> print(kms.to_string('unicode', fraction=False))
+        km s⁻¹
+        >>> print(kms.to_string('unicode', fraction='inline'))
+        km / s
+        >>> print(kms.to_string('unicode', fraction='multiline'))
+        km
+        ──
+        s
         """
         f = unit_format.get_format(format)
         return f.to_string(self, **kwargs)

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -756,8 +756,9 @@ class UnitBase:
 
         **kwargs :
             Further options forwarded to the formatter. Currently
-            recognized is **inline** (:class:`bool`) for the
-            ``"latex"``, ``"console"``, and``"unicode"`` formats.
+            recognized is **fraction** (:class:`bool`), which determines
+            whether a unit with bases raised to negative powers is
+            represented using a fraction or not.
 
         """
         f = unit_format.get_format(format)

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -754,14 +754,13 @@ class UnitBase:
             The name of a format or a formatter object.  If not
             provided, defaults to the generic format.
 
-        **kwargs :
+        **kwargs
             Further options forwarded to the formatter. Currently
-            recognized is **fraction** (:class:`bool`), which determines
-            whether a unit with bases raised to negative powers is
-            represented using a fraction or not, and **inline**, which
-            determines whether the fraction is set with a solidus, or
-            displayed with a numerator and denominator (the latter only
-            for the ``latex``, ``console``, and ``unicode`` formats).
+            recognized is **fraction**.  If not `False`, units with
+            bases raised to negative powers are represented using a
+            fraction, with `True` or 'inline' used to produce a single
+            line, and 'display' to produce a multi-line string (for
+            the ``latex``, ``console`` and ``unicode`` formats only).
 
         """
         f = unit_format.get_format(format)

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -758,7 +758,10 @@ class UnitBase:
             Further options forwarded to the formatter. Currently
             recognized is **fraction** (:class:`bool`), which determines
             whether a unit with bases raised to negative powers is
-            represented using a fraction or not.
+            represented using a fraction or not, and **inline**, which
+            determines whether the fraction is set with a solidus, or
+            displayed with a numerator and denominator (the latter only
+            for the ``latex``, ``console``, and ``unicode`` formats).
 
         """
         f = unit_format.get_format(format)

--- a/astropy/units/format/base.py
+++ b/astropy/units/format/base.py
@@ -81,7 +81,7 @@ class Base:
         return f"{scale}{numerator} / {denominator}"
 
     @classmethod
-    def to_string(cls, unit, inline=False):
+    def to_string(cls, unit, fraction=True):
         # First the scale.  Normally unity, in which case we omit
         # it, but non-unity scale can happen, e.g., in decompositions
         # like u.Ry.decompose(), which gives "2.17987e-18 kg m2 / s2".
@@ -95,13 +95,13 @@ class Base:
         if len(unit.bases):
             if s:
                 s += cls._scale_unit_separator
-            if inline:
-                numerator = list(zip(unit.bases, unit.powers))
-                denominator = []
-            else:
+            if fraction:
                 numerator, denominator = utils.get_grouped_by_powers(
                     unit.bases, unit.powers
                 )
+            else:
+                numerator = list(zip(unit.bases, unit.powers))
+                denominator = []
             if len(denominator):
                 if len(numerator):
                     numerator = cls._format_unit_list(numerator)

--- a/astropy/units/format/base.py
+++ b/astropy/units/format/base.py
@@ -73,7 +73,7 @@ class Base:
         )
 
     @classmethod
-    def _format_fraction(cls, scale, numerator, denominator):
+    def _format_fraction(cls, scale, numerator, denominator, inline=True):
         if cls._space in denominator:
             denominator = f"({denominator})"
         if scale and numerator == "1":
@@ -81,7 +81,21 @@ class Base:
         return f"{scale}{numerator} / {denominator}"
 
     @classmethod
-    def to_string(cls, unit, fraction=True):
+    def to_string(cls, unit, *, fraction=True, inline=True):
+        """Convert a unit to its string representation.
+
+        Parameters
+        ----------
+        unit : |Unit|
+            The unit to convert.
+        fraction : bool, optional
+            Whether to use a fraction if the unit has bases raised to negative powers
+            (e.g., ``km / s``), or to just display those as is (e.g., ``km s^-1``).
+        inline : bool, optional
+            For a fraction, whether to use a solidus to keep the unit on a single
+            line, or to use display style, with parts above and below a horizontal line.
+            Ignored if ``fraction=False`` or if the format class does not support it.
+        """
         # First the scale.  Normally unity, in which case we omit
         # it, but non-unity scale can happen, e.g., in decompositions
         # like u.Ry.decompose(), which gives "2.17987e-18 kg m2 / s2".
@@ -108,7 +122,7 @@ class Base:
                 else:
                     numerator = "1"
                 denominator = cls._format_unit_list(denominator)
-                s = cls._format_fraction(s, numerator, denominator)
+                s = cls._format_fraction(s, numerator, denominator, inline=inline)
             else:
                 s += cls._format_unit_list(numerator)
 

--- a/astropy/units/format/base.py
+++ b/astropy/units/format/base.py
@@ -73,9 +73,12 @@ class Base:
         )
 
     @classmethod
-    def _format_fraction(cls, scale, numerator, denominator, inline=True):
-        if not inline:
-            raise ValueError("format {cls.name!r} only supports inline fractions.")
+    def _format_fraction(cls, scale, numerator, denominator, *, fraction="inline"):
+        if not (fraction is True or fraction == "inline"):
+            raise ValueError(
+                "format {cls.name!r} only supports inline fractions,"
+                f"not fraction={fraction!r}."
+            )
 
         if cls._space in denominator:
             denominator = f"({denominator})"
@@ -84,20 +87,19 @@ class Base:
         return f"{scale}{numerator} / {denominator}"
 
     @classmethod
-    def to_string(cls, unit, *, fraction=True, inline=True):
+    def to_string(cls, unit, *, fraction=True):
         """Convert a unit to its string representation.
 
         Parameters
         ----------
         unit : |Unit|
             The unit to convert.
-        fraction : bool, optional
-            Whether to use a fraction if the unit has bases raised to negative powers
-            (e.g., ``km / s``), or to just display those as is (e.g., ``km s^-1``).
-        inline : bool, optional
-            For a fraction, whether to use a solidus to keep the unit on a single
-            line, or to use display style, with parts above and below a horizontal line.
-            Ignored if ``fraction=False`` or if the format class does not support it.
+        fraction : {False|True|'inline'|'display'}, optional
+            If `False`, display any unit bases raised to negative powers as
+            they are (e.g., ``km s^-1``).  If not `False`, use a fraction
+            instead (e.g., ``km / s``), either inline or with a multiline
+            display (if the format class supports it). If `True`, use the
+            default fraction style.
         """
         # First the scale.  Normally unity, in which case we omit
         # it, but non-unity scale can happen, e.g., in decompositions
@@ -125,7 +127,7 @@ class Base:
                 else:
                     numerator = "1"
                 denominator = cls._format_unit_list(denominator)
-                s = cls._format_fraction(s, numerator, denominator, inline=inline)
+                s = cls._format_fraction(s, numerator, denominator, fraction=fraction)
             else:
                 s += cls._format_unit_list(numerator)
 

--- a/astropy/units/format/base.py
+++ b/astropy/units/format/base.py
@@ -90,16 +90,26 @@ class Base:
     def to_string(cls, unit, *, fraction=True):
         """Convert a unit to its string representation.
 
+        Implementation for `~astropy.units.UnitBase.to_string`.
+
         Parameters
         ----------
         unit : |Unit|
             The unit to convert.
-        fraction : {False|True|'inline'|'display'}, optional
-            If `False`, display any unit bases raised to negative powers as
-            they are (e.g., ``km s^-1``).  If not `False`, use a fraction
-            instead (e.g., ``km / s``), either inline or with a multiline
-            display (if the format class supports it). If `True`, use the
-            default fraction style.
+        fraction : {False|True|'inline'|'multiline'}, optional
+            Options are as follows:
+
+            - `False` : display unit bases with negative powers as they are
+              (e.g., ``km s-1``);
+            - 'inline' or `True` : use a single-line fraction (e.g., ``km / s``);
+            - 'multiline' : use a multiline fraction (available for the
+              ``latex``, ``console`` and ``unicode`` formats only; e.g.,
+              ``$\\mathrm{\\frac{km}{s}}$``).
+
+        Raises
+        ------
+        ValueError
+            If ``fraction`` is not recognized.
         """
         # First the scale.  Normally unity, in which case we omit
         # it, but non-unity scale can happen, e.g., in decompositions

--- a/astropy/units/format/base.py
+++ b/astropy/units/format/base.py
@@ -74,6 +74,9 @@ class Base:
 
     @classmethod
     def _format_fraction(cls, scale, numerator, denominator, inline=True):
+        if not inline:
+            raise ValueError("format {cls.name!r} only supports inline fractions.")
+
         if cls._space in denominator:
             denominator = f"({denominator})"
         if scale and numerator == "1":

--- a/astropy/units/format/cds.py
+++ b/astropy/units/format/cds.py
@@ -12,7 +12,6 @@
 
 """Handles the CDS string format for units."""
 
-import operator
 import re
 
 from astropy.units.utils import is_effectively_unity
@@ -34,6 +33,9 @@ class CDS(Base):
     """
 
     _space = "."
+    _times = "x"
+    _scale_unit_separator = ""
+
     _tokens = (
         "PRODUCT",
         "DIVISION",
@@ -309,40 +311,30 @@ class CDS(Base):
                     raise ValueError("Syntax error")
 
     @classmethod
+    def format_exponential_notation(cls, val, format_spec=".8g"):
+        m, ex = utils.split_mantissa_exponent(val)
+        parts = []
+        if m not in ("", "1"):
+            parts.append(m)
+        if ex:
+            if not ex.startswith("-"):
+                ex = "+" + ex
+            parts.append(f"10{cls._format_superscript(ex)}")
+        return cls._times.join(parts)
+
+    @classmethod
     def _format_superscript(cls, number):
         return number
 
     @classmethod
-    def to_string(cls, unit):
+    def to_string(cls, unit, fraction=False, inline=True):
         # Remove units that aren't known to the format
         unit = utils.decompose_to_known_units(unit, cls._get_unit_name)
 
-        if isinstance(unit, core.CompositeUnit):
-            if unit == core.dimensionless_unscaled:
+        if not unit.bases:
+            if unit.scale == 1:
                 return "---"
             elif is_effectively_unity(unit.scale * 100.0):
                 return "%"
 
-            if unit.scale == 1:
-                s = ""
-            else:
-                m, e = utils.split_mantissa_exponent(unit.scale)
-                parts = []
-                if m not in ("", "1"):
-                    parts.append(m)
-                if e:
-                    if not e.startswith("-"):
-                        e = "+" + e
-                    parts.append(f"10{e}")
-                s = "x".join(parts)
-
-            pairs = list(zip(unit.bases, unit.powers))
-            if len(pairs) > 0:
-                pairs.sort(key=operator.itemgetter(1), reverse=True)
-
-                s += cls._format_unit_list(pairs)
-
-        elif isinstance(unit, core.NamedUnit):
-            s = cls._get_unit_name(unit)
-
-        return s
+        return super().to_string(unit, fraction=fraction, inline=inline)

--- a/astropy/units/format/cds.py
+++ b/astropy/units/format/cds.py
@@ -327,7 +327,7 @@ class CDS(Base):
         return number
 
     @classmethod
-    def to_string(cls, unit, fraction=False, inline=True):
+    def to_string(cls, unit, fraction=False):
         # Remove units that aren't known to the format
         unit = utils.decompose_to_known_units(unit, cls._get_unit_name)
 
@@ -337,4 +337,4 @@ class CDS(Base):
             elif is_effectively_unity(unit.scale * 100.0):
                 return "%"
 
-        return super().to_string(unit, fraction=fraction, inline=inline)
+        return super().to_string(unit, fraction=fraction)

--- a/astropy/units/format/console.py
+++ b/astropy/units/format/console.py
@@ -22,6 +22,8 @@ class Console(base.Base):
                        m^2 kg
       2.1798721*10^-18 ------
                         s^2
+      >>> print(u.Ry.decompose().to_string('console', fraction=True, inline=True))  # doctest: +FLOAT_CMP
+      2.1798721*10^-18 m^2 kg / s^2
     """
 
     _times = "*"
@@ -50,7 +52,12 @@ class Console(base.Base):
         return cls._times.join(parts)
 
     @classmethod
-    def _format_fraction(cls, scale, numerator, denominator):
+    def _format_fraction(cls, scale, numerator, denominator, inline=False):
+        if inline is not False:
+            return super()._format_fraction(
+                scale, numerator, denominator, inline=inline
+            )
+
         fraclength = max(len(numerator), len(denominator))
         f = f"{{0:<{len(scale)}s}}{{1:^{fraclength}s}}"
 
@@ -63,6 +70,8 @@ class Console(base.Base):
         )
 
     @classmethod
-    def to_string(cls, unit, fraction=False):
-        # Change default of fraction to False.
-        return super().to_string(unit, fraction=fraction)
+    def to_string(cls, unit, fraction=False, inline=False):
+        # Change default of fraction and inline to False, i.e., we
+        # typeset without a fraction by default, and using display style if
+        # Fraction is True.
+        return super().to_string(unit, fraction=fraction, inline=inline)

--- a/astropy/units/format/console.py
+++ b/astropy/units/format/console.py
@@ -18,7 +18,7 @@ class Console(base.Base):
       >>> import astropy.units as u
       >>> print(u.Ry.decompose().to_string('console'))  # doctest: +FLOAT_CMP
       2.1798721*10^-18 m^2 kg s^-2
-      >>> print(u.Ry.decompose().to_string('console', fraction='display'))  # doctest: +FLOAT_CMP
+      >>> print(u.Ry.decompose().to_string('console', fraction='multiline'))  # doctest: +FLOAT_CMP
                        m^2 kg
       2.1798721*10^-18 ------
                         s^2
@@ -52,9 +52,8 @@ class Console(base.Base):
         return cls._times.join(parts)
 
     @classmethod
-    def _format_fraction(cls, scale, numerator, denominator, fraction="display"):
-        # Default for fraction=True is multi-line display.
-        if fraction != "display":
+    def _format_fraction(cls, scale, numerator, denominator, fraction="multiline"):
+        if fraction != "multiline":
             return super()._format_fraction(
                 scale, numerator, denominator, fraction=fraction
             )

--- a/astropy/units/format/console.py
+++ b/astropy/units/format/console.py
@@ -18,11 +18,11 @@ class Console(base.Base):
       >>> import astropy.units as u
       >>> print(u.Ry.decompose().to_string('console'))  # doctest: +FLOAT_CMP
       2.1798721*10^-18 m^2 kg s^-2
-      >>> print(u.Ry.decompose().to_string('console', fraction=True))  # doctest: +FLOAT_CMP
+      >>> print(u.Ry.decompose().to_string('console', fraction='display'))  # doctest: +FLOAT_CMP
                        m^2 kg
       2.1798721*10^-18 ------
                         s^2
-      >>> print(u.Ry.decompose().to_string('console', fraction=True, inline=True))  # doctest: +FLOAT_CMP
+      >>> print(u.Ry.decompose().to_string('console', fraction='inline'))  # doctest: +FLOAT_CMP
       2.1798721*10^-18 m^2 kg / s^2
     """
 
@@ -52,10 +52,11 @@ class Console(base.Base):
         return cls._times.join(parts)
 
     @classmethod
-    def _format_fraction(cls, scale, numerator, denominator, inline=False):
-        if inline is not False:
+    def _format_fraction(cls, scale, numerator, denominator, fraction="display"):
+        # Default for fraction=True is multi-line display.
+        if fraction != "display":
             return super()._format_fraction(
-                scale, numerator, denominator, inline=inline
+                scale, numerator, denominator, fraction=fraction
             )
 
         fraclength = max(len(numerator), len(denominator))
@@ -70,8 +71,7 @@ class Console(base.Base):
         )
 
     @classmethod
-    def to_string(cls, unit, fraction=False, inline=False):
-        # Change default of fraction and inline to False, i.e., we
-        # typeset without a fraction by default, and using display style if
-        # Fraction is True.
-        return super().to_string(unit, fraction=fraction, inline=inline)
+    def to_string(cls, unit, fraction=False):
+        # Change default of fraction to False, i.e., we typeset
+        # without a fraction by default.
+        return super().to_string(unit, fraction=fraction)

--- a/astropy/units/format/console.py
+++ b/astropy/units/format/console.py
@@ -18,7 +18,7 @@ class Console(base.Base):
       >>> import astropy.units as u
       >>> print(u.Ry.decompose().to_string('console'))  # doctest: +FLOAT_CMP
       2.1798721*10^-18 m^2 kg s^-2
-      >>> print(u.Ry.decompose().to_string('console', inline=False))  # doctest: +FLOAT_CMP
+      >>> print(u.Ry.decompose().to_string('console', fraction=True))  # doctest: +FLOAT_CMP
                        m^2 kg
       2.1798721*10^-18 ------
                         s^2
@@ -63,6 +63,6 @@ class Console(base.Base):
         )
 
     @classmethod
-    def to_string(cls, unit, inline=True):
-        # Change default of inline to True.
-        return super().to_string(unit, inline=inline)
+    def to_string(cls, unit, fraction=False):
+        # Change default of fraction to False.
+        return super().to_string(unit, fraction=fraction)

--- a/astropy/units/format/fits.py
+++ b/astropy/units/format/fits.py
@@ -106,7 +106,7 @@ class Fits(generic.Generic):
         return name
 
     @classmethod
-    def to_string(cls, unit, fraction=False):
+    def to_string(cls, unit, fraction=False, inline=True):
         # Remove units that aren't known to the format
         unit = utils.decompose_to_known_units(unit, cls._get_unit_name)
 
@@ -129,7 +129,7 @@ class Fits(generic.Generic):
             unit = core.CompositeUnit(1, unit.bases, unit.powers)
 
         if unit.bases:
-            parts.append(super().to_string(unit, fraction=fraction))
+            parts.append(super().to_string(unit, fraction=fraction, inline=inline))
 
         return cls._scale_unit_separator.join(parts)
 

--- a/astropy/units/format/fits.py
+++ b/astropy/units/format/fits.py
@@ -106,7 +106,7 @@ class Fits(generic.Generic):
         return name
 
     @classmethod
-    def to_string(cls, unit, inline=True):
+    def to_string(cls, unit, fraction=False):
         # Remove units that aren't known to the format
         unit = utils.decompose_to_known_units(unit, cls._get_unit_name)
 
@@ -129,7 +129,7 @@ class Fits(generic.Generic):
             unit = core.CompositeUnit(1, unit.bases, unit.powers)
 
         if unit.bases:
-            parts.append(super().to_string(unit, inline=inline))
+            parts.append(super().to_string(unit, fraction=fraction))
 
         return cls._scale_unit_separator.join(parts)
 

--- a/astropy/units/format/fits.py
+++ b/astropy/units/format/fits.py
@@ -106,7 +106,7 @@ class Fits(generic.Generic):
         return name
 
     @classmethod
-    def to_string(cls, unit, fraction=False, inline=True):
+    def to_string(cls, unit, fraction=False):
         # Remove units that aren't known to the format
         unit = utils.decompose_to_known_units(unit, cls._get_unit_name)
 
@@ -129,7 +129,7 @@ class Fits(generic.Generic):
             unit = core.CompositeUnit(1, unit.bases, unit.powers)
 
         if unit.bases:
-            parts.append(super().to_string(unit, fraction=fraction, inline=inline))
+            parts.append(super().to_string(unit, fraction=fraction))
 
         return cls._scale_unit_separator.join(parts)
 

--- a/astropy/units/format/latex.py
+++ b/astropy/units/format/latex.py
@@ -55,8 +55,8 @@ class Latex(console.Console):
         return name
 
     @classmethod
-    def _format_fraction(cls, scale, numerator, denominator, *, fraction="display"):
-        if fraction != "display":
+    def _format_fraction(cls, scale, numerator, denominator, *, fraction="multiline"):
+        if fraction != "multiline":
             return super()._format_fraction(
                 scale, numerator, denominator, fraction=fraction
             )
@@ -64,7 +64,7 @@ class Latex(console.Console):
         return rf"{scale}\frac{{{numerator}}}{{{denominator}}}"
 
     @classmethod
-    def to_string(cls, unit, fraction="display"):
+    def to_string(cls, unit, fraction="multiline"):
         s = super().to_string(unit, fraction=fraction)
         return rf"$\mathrm{{{s}}}$"
 

--- a/astropy/units/format/latex.py
+++ b/astropy/units/format/latex.py
@@ -55,17 +55,17 @@ class Latex(console.Console):
         return name
 
     @classmethod
-    def _format_fraction(cls, scale, numerator, denominator, inline=False):
-        if inline is not False:
+    def _format_fraction(cls, scale, numerator, denominator, *, fraction="display"):
+        if fraction != "display":
             return super()._format_fraction(
-                scale, numerator, denominator, inline=inline
+                scale, numerator, denominator, fraction=fraction
             )
 
         return rf"{scale}\frac{{{numerator}}}{{{denominator}}}"
 
     @classmethod
-    def to_string(cls, unit, fraction=True, inline=False):
-        s = super().to_string(unit, fraction=fraction, inline=inline)
+    def to_string(cls, unit, fraction="display"):
+        s = super().to_string(unit, fraction=fraction)
         return rf"$\mathrm{{{s}}}$"
 
 
@@ -83,5 +83,5 @@ class LatexInline(Latex):
     name = "latex_inline"
 
     @classmethod
-    def to_string(cls, unit, fraction=False, inline=True):
-        return super().to_string(unit, fraction=fraction, inline=inline)
+    def to_string(cls, unit, fraction=False):
+        return super().to_string(unit, fraction=fraction)

--- a/astropy/units/format/latex.py
+++ b/astropy/units/format/latex.py
@@ -55,12 +55,17 @@ class Latex(console.Console):
         return name
 
     @classmethod
-    def _format_fraction(cls, scale, numerator, denominator):
+    def _format_fraction(cls, scale, numerator, denominator, inline=False):
+        if inline is not False:
+            return super()._format_fraction(
+                scale, numerator, denominator, inline=inline
+            )
+
         return rf"{scale}\frac{{{numerator}}}{{{denominator}}}"
 
     @classmethod
-    def to_string(cls, unit, fraction=True):
-        s = super().to_string(unit, fraction=fraction)
+    def to_string(cls, unit, fraction=True, inline=False):
+        s = super().to_string(unit, fraction=fraction, inline=inline)
         return rf"$\mathrm{{{s}}}$"
 
 
@@ -78,5 +83,5 @@ class LatexInline(Latex):
     name = "latex_inline"
 
     @classmethod
-    def to_string(cls, unit, fraction=False):
-        return super().to_string(unit, fraction=fraction)
+    def to_string(cls, unit, fraction=False, inline=True):
+        return super().to_string(unit, fraction=fraction, inline=inline)

--- a/astropy/units/format/latex.py
+++ b/astropy/units/format/latex.py
@@ -59,8 +59,8 @@ class Latex(console.Console):
         return rf"{scale}\frac{{{numerator}}}{{{denominator}}}"
 
     @classmethod
-    def to_string(cls, unit, inline=False):
-        s = super().to_string(unit, inline=inline)
+    def to_string(cls, unit, fraction=True):
+        s = super().to_string(unit, fraction=fraction)
         return rf"$\mathrm{{{s}}}$"
 
 
@@ -78,5 +78,5 @@ class LatexInline(Latex):
     name = "latex_inline"
 
     @classmethod
-    def to_string(cls, unit, inline=True):
-        return super().to_string(unit, inline)
+    def to_string(cls, unit, fraction=False):
+        return super().to_string(unit, fraction=fraction)

--- a/astropy/units/format/ogip.py
+++ b/astropy/units/format/ogip.py
@@ -395,7 +395,7 @@ class OGIP(generic.Generic):
         return f"**({number})" if "/" in number else f"**{number}"
 
     @classmethod
-    def to_string(cls, unit):
+    def to_string(cls, unit, fraction=True, inline=True):
         # Remove units that aren't known to the format
         unit = utils.decompose_to_known_units(unit, cls._get_unit_name)
 
@@ -407,7 +407,7 @@ class OGIP(generic.Generic):
                     core.UnitsWarning,
                 )
 
-        return super().to_string(unit)
+        return super().to_string(unit, fraction=fraction, inline=inline)
 
     @classmethod
     def _to_decomposed_alternative(cls, unit):

--- a/astropy/units/format/ogip.py
+++ b/astropy/units/format/ogip.py
@@ -395,7 +395,7 @@ class OGIP(generic.Generic):
         return f"**({number})" if "/" in number else f"**{number}"
 
     @classmethod
-    def to_string(cls, unit, fraction=True, inline=True):
+    def to_string(cls, unit, fraction="inline"):
         # Remove units that aren't known to the format
         unit = utils.decompose_to_known_units(unit, cls._get_unit_name)
 
@@ -407,7 +407,7 @@ class OGIP(generic.Generic):
                     core.UnitsWarning,
                 )
 
-        return super().to_string(unit, fraction=fraction, inline=inline)
+        return super().to_string(unit, fraction=fraction)
 
     @classmethod
     def _to_decomposed_alternative(cls, unit):

--- a/astropy/units/format/unicode_format.py
+++ b/astropy/units/format/unicode_format.py
@@ -18,7 +18,7 @@ class Unicode(console.Console):
       >>> import astropy.units as u
       >>> print(u.bar.decompose().to_string('unicode'))
       100000 kg m⁻¹ s⁻²
-      >>> print(u.bar.decompose().to_string('unicode', inline=False))
+      >>> print(u.bar.decompose().to_string('unicode', fraction=True))
               kg
       100000 ────
              m s²

--- a/astropy/units/format/unicode_format.py
+++ b/astropy/units/format/unicode_format.py
@@ -22,6 +22,8 @@ class Unicode(console.Console):
               kg
       100000 ────
              m s²
+      >>> print(u.bar.decompose().to_string('unicode', fraction=True, inline=True))
+      100000 kg / (m s²)
     """
 
     _times = "×"

--- a/astropy/units/format/unicode_format.py
+++ b/astropy/units/format/unicode_format.py
@@ -18,7 +18,7 @@ class Unicode(console.Console):
       >>> import astropy.units as u
       >>> print(u.bar.decompose().to_string('unicode'))
       100000 kg m⁻¹ s⁻²
-      >>> print(u.bar.decompose().to_string('unicode', fraction='display'))
+      >>> print(u.bar.decompose().to_string('unicode', fraction='multiline'))
               kg
       100000 ────
              m s²

--- a/astropy/units/format/unicode_format.py
+++ b/astropy/units/format/unicode_format.py
@@ -18,11 +18,11 @@ class Unicode(console.Console):
       >>> import astropy.units as u
       >>> print(u.bar.decompose().to_string('unicode'))
       100000 kg m⁻¹ s⁻²
-      >>> print(u.bar.decompose().to_string('unicode', fraction=True))
+      >>> print(u.bar.decompose().to_string('unicode', fraction='display'))
               kg
       100000 ────
              m s²
-      >>> print(u.bar.decompose().to_string('unicode', fraction=True, inline=True))
+      >>> print(u.bar.decompose().to_string('unicode', fraction='inline'))
       100000 kg / (m s²)
     """
 

--- a/astropy/units/format/vounit.py
+++ b/astropy/units/format/vounit.py
@@ -200,7 +200,7 @@ class VOUnit(generic.Generic):
         return super().format_exponential_notation(val, format_spec)
 
     @classmethod
-    def to_string(cls, unit, fraction=False, inline=True):
+    def to_string(cls, unit, fraction=False):
         from astropy.units import core
 
         # Remove units that aren't known to the format
@@ -213,7 +213,7 @@ class VOUnit(generic.Generic):
                 f"Multiply your data by {unit.scale:e}."
             )
 
-        return super().to_string(unit, fraction=fraction, inline=inline)
+        return super().to_string(unit, fraction=fraction)
 
     @classmethod
     def _to_decomposed_alternative(cls, unit):

--- a/astropy/units/format/vounit.py
+++ b/astropy/units/format/vounit.py
@@ -200,7 +200,7 @@ class VOUnit(generic.Generic):
         return super().format_exponential_notation(val, format_spec)
 
     @classmethod
-    def to_string(cls, unit, fraction=False):
+    def to_string(cls, unit, fraction=False, inline=True):
         from astropy.units import core
 
         # Remove units that aren't known to the format
@@ -213,7 +213,7 @@ class VOUnit(generic.Generic):
                 f"Multiply your data by {unit.scale:e}."
             )
 
-        return super().to_string(unit, fraction=fraction)
+        return super().to_string(unit, fraction=fraction, inline=inline)
 
     @classmethod
     def _to_decomposed_alternative(cls, unit):

--- a/astropy/units/format/vounit.py
+++ b/astropy/units/format/vounit.py
@@ -200,7 +200,7 @@ class VOUnit(generic.Generic):
         return super().format_exponential_notation(val, format_spec)
 
     @classmethod
-    def to_string(cls, unit, inline=True):
+    def to_string(cls, unit, fraction=False):
         from astropy.units import core
 
         # Remove units that aren't known to the format
@@ -213,7 +213,7 @@ class VOUnit(generic.Generic):
                 f"Multiply your data by {unit.scale:e}."
             )
 
-        return super().to_string(unit, inline=inline)
+        return super().to_string(unit, fraction=fraction)
 
     @classmethod
     def _to_decomposed_alternative(cls, unit):

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -469,24 +469,45 @@ def test_format_styles(format_spec, string, decomposed):
 
 
 @pytest.mark.parametrize(
-    "format_spec, fraction, string, decomposed",
+    "format_spec, fraction, inline, string, decomposed",
     [
-        ("generic", False, "cm-2 erg s-1", "0.001 kg s-3"),
-        ("console", True, " erg  \n------\ns cm^2", "      kg \n0.001 ---\n      s^3"),
-        ("unicode", True, " erg \n─────\ns cm²", "      kg\n0.001 ──\n      s³"),
+        ("generic", False, False, "cm-2 erg s-1", "0.001 kg s-3"),
+        (
+            "console",
+            True,
+            False,
+            " erg  \n------\ns cm^2",
+            "      kg \n0.001 ---\n      s^3",
+        ),
+        ("console", True, True, "erg / (s cm^2)", "0.001 kg / s^3"),
+        ("unicode", True, False, " erg \n─────\ns cm²", "      kg\n0.001 ──\n      s³"),
+        ("unicode", True, True, "erg / (s cm²)", "0.001 kg / s³"),
         (
             "latex",
+            False,
             False,
             r"$\mathrm{erg\,s^{-1}\,cm^{-2}}$",
             r"$\mathrm{0.001\,kg\,s^{-3}}$",
         ),
+        (
+            "latex",
+            True,
+            True,
+            r"$\mathrm{erg / (s\,cm^{2})}$",
+            r"$\mathrm{0.001\,kg / s^{3}}$",
+        ),
         # TODO: make generic with inline=True less awful!
     ],
 )
-def test_format_styles_non_default_fraction(format_spec, fraction, string, decomposed):
+def test_format_styles_non_default_fraction(
+    format_spec, fraction, inline, string, decomposed
+):
     fluxunit = u.erg / (u.cm**2 * u.s)
-    assert fluxunit.to_string(format_spec, fraction=fraction) == string
-    assert fluxunit.decompose().to_string(format_spec, fraction=fraction) == decomposed
+    assert fluxunit.to_string(format_spec, fraction=fraction, inline=inline) == string
+    assert (
+        fluxunit.decompose().to_string(format_spec, fraction=fraction, inline=inline)
+        == decomposed
+    )
 
 
 def test_flatten_to_known():

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -474,12 +474,12 @@ def test_format_styles(format_spec, string, decomposed):
         ("generic", False, "cm-2 erg s-1", "0.001 kg s-3"),
         (
             "console",
-            "display",
+            "multiline",
             " erg  \n------\ns cm^2",
             "      kg \n0.001 ---\n      s^3",
         ),
         ("console", "inline", "erg / (s cm^2)", "0.001 kg / s^3"),
-        ("unicode", "display", " erg \n─────\ns cm²", "      kg\n0.001 ──\n      s³"),
+        ("unicode", "multiline", " erg \n─────\ns cm²", "      kg\n0.001 ──\n      s³"),
         ("unicode", "inline", "erg / (s cm²)", "0.001 kg / s³"),
         (
             "latex",
@@ -503,10 +503,10 @@ def test_format_styles_non_default_fraction(format_spec, fraction, string, decom
 
 
 @pytest.mark.parametrize("format_spec", ["generic", "cds", "fits", "ogip", "vounit"])
-def test_no_display_fraction(format_spec):
+def test_no_multiline_fraction(format_spec):
     fluxunit = u.W / u.m**2
-    with pytest.raises(ValueError, match="only supports.*not fraction='display'"):
-        fluxunit.to_string(format_spec, fraction="display")
+    with pytest.raises(ValueError, match="only supports.*not fraction='multiline'"):
+        fluxunit.to_string(format_spec, fraction="multiline")
 
 
 @pytest.mark.parametrize(
@@ -924,9 +924,9 @@ def test_function_format_styles(format_spec, string):
 @pytest.mark.parametrize(
     "format_spec, fraction, string",
     [
-        ("console", "display", "   1\ndB(-)\n   m"),
+        ("console", "multiline", "   1\ndB(-)\n   m"),
         ("console", "inline", "dB(1 / m)"),
-        ("unicode", "display", "   1\ndB(─)\n   m"),
+        ("unicode", "multiline", "   1\ndB(─)\n   m"),
         ("unicode", "inline", "dB(1 / m)"),
         ("latex", False, r"$\mathrm{dB}$$\mathrm{\left( \mathrm{m^{-1}} \right)}$"),
         ("latex", "inline", r"$\mathrm{dB}$$\mathrm{\left( \mathrm{1 / m} \right)}$"),

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -469,24 +469,24 @@ def test_format_styles(format_spec, string, decomposed):
 
 
 @pytest.mark.parametrize(
-    "format_spec, inline, string, decomposed",
+    "format_spec, fraction, string, decomposed",
     [
-        ("generic", True, "cm-2 erg s-1", "0.001 kg s-3"),
-        ("console", False, " erg  \n------\ns cm^2", "      kg \n0.001 ---\n      s^3"),
-        ("unicode", False, " erg \n─────\ns cm²", "      kg\n0.001 ──\n      s³"),
+        ("generic", False, "cm-2 erg s-1", "0.001 kg s-3"),
+        ("console", True, " erg  \n------\ns cm^2", "      kg \n0.001 ---\n      s^3"),
+        ("unicode", True, " erg \n─────\ns cm²", "      kg\n0.001 ──\n      s³"),
         (
             "latex",
-            True,
+            False,
             r"$\mathrm{erg\,s^{-1}\,cm^{-2}}$",
             r"$\mathrm{0.001\,kg\,s^{-3}}$",
         ),
         # TODO: make generic with inline=True less awful!
     ],
 )
-def test_format_styles_non_default_inline(format_spec, inline, string, decomposed):
+def test_format_styles_non_default_fraction(format_spec, fraction, string, decomposed):
     fluxunit = u.erg / (u.cm**2 * u.s)
-    assert fluxunit.to_string(format_spec, inline=inline) == string
-    assert fluxunit.decompose().to_string(format_spec, inline=inline) == decomposed
+    assert fluxunit.to_string(format_spec, fraction=fraction) == string
+    assert fluxunit.decompose().to_string(format_spec, fraction=fraction) == decomposed
 
 
 def test_flatten_to_known():
@@ -892,13 +892,13 @@ def test_function_format_styles(format_spec, string):
 
 
 @pytest.mark.parametrize(
-    "format_spec, inline, string",
+    "format_spec, fraction, string",
     [
-        ("console", False, "   1\ndB(-)\n   m"),
-        ("unicode", False, "   1\ndB(─)\n   m"),
-        ("latex", True, r"$\mathrm{dB}$$\mathrm{\left( \mathrm{m^{-1}} \right)}$"),
+        ("console", True, "   1\ndB(-)\n   m"),
+        ("unicode", True, "   1\ndB(─)\n   m"),
+        ("latex", False, r"$\mathrm{dB}$$\mathrm{\left( \mathrm{m^{-1}} \right)}$"),
     ],
 )
-def test_function_format_styles_inline(format_spec, inline, string):
+def test_function_format_styles_non_default_fraction(format_spec, fraction, string):
     dbunit = u.decibel(u.m**-1)
-    assert dbunit.to_string(format_spec, inline=inline) == string
+    assert dbunit.to_string(format_spec, fraction=fraction) == string

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -510,6 +510,13 @@ def test_format_styles_non_default_fraction(
     )
 
 
+@pytest.mark.parametrize("format_spec", ["generic", "cds", "fits", "ogip", "vounit"])
+def test_no_display_fraction(format_spec):
+    fluxunit = u.W / u.m**2
+    with pytest.raises(ValueError, match="only supports"):
+        fluxunit.to_string(format_spec, fraction=True, inline=False)
+
+
 def test_flatten_to_known():
     myunit = u.def_unit("FOOBAR_One", u.erg / u.Hz)
     assert myunit.to_string("fits") == "erg Hz-1"

--- a/docs/changes/units/14393.feature.rst
+++ b/docs/changes/units/14393.feature.rst
@@ -1,2 +1,0 @@
-Add "inline" option to and "unicode and "console" unit formats to use
-negative powers instead of fractions.

--- a/docs/changes/units/14449.feature.rst
+++ b/docs/changes/units/14449.feature.rst
@@ -1,0 +1,7 @@
+Add a "fraction" and "inline" options to all the unit ``format`` classes,
+which determine whether, if a unit has bases raised to a negative power,
+a string representation should just show the negative powers (``fraction=False``)
+or use a fraction, and, in the latter case, whether to use a
+single-line representation using a solidus (``inline=True``) or, if
+the format supports it, a multi-line presentation with the numerator
+and denominator separated by a horizontal line (``inline=False``).

--- a/docs/changes/units/14449.feature.rst
+++ b/docs/changes/units/14449.feature.rst
@@ -4,4 +4,4 @@ representation should just show the negative powers (``fraction=False``) or
 use a fraction, and, in the latter case, whether to use a single-line
 representation using a solidus (``fraction='inline'`` or ``fraction=True``)
 or, if the format supports it, a multi-line presentation with the numerator
-and denominator separated by a horizontal line (``fraction='display'``).
+and denominator separated by a horizontal line (``fraction='multiline'``).

--- a/docs/changes/units/14449.feature.rst
+++ b/docs/changes/units/14449.feature.rst
@@ -1,7 +1,7 @@
-Add a "fraction" and "inline" options to all the unit ``format`` classes,
-which determine whether, if a unit has bases raised to a negative power,
-a string representation should just show the negative powers (``fraction=False``)
-or use a fraction, and, in the latter case, whether to use a
-single-line representation using a solidus (``inline=True``) or, if
-the format supports it, a multi-line presentation with the numerator
-and denominator separated by a horizontal line (``inline=False``).
+Add a "fraction" options to all the unit ``format`` classes, which determine
+whether, if a unit has bases raised to a negative power, a string
+representation should just show the negative powers (``fraction=False``) or
+use a fraction, and, in the latter case, whether to use a single-line
+representation using a solidus (``fraction='inline'`` or ``fraction=True``)
+or, if the format supports it, a multi-line presentation with the numerator
+and denominator separated by a horizontal line (``fraction='display'``).

--- a/docs/units/format.rst
+++ b/docs/units/format.rst
@@ -211,7 +211,7 @@ following formats:
 
     or using a multiline representation:
 
-      >>> print(fluxunit.to_string('console', fraction='display'))
+      >>> print(fluxunit.to_string('console', fraction='multiline'))
        erg
       ------
       s cm^2
@@ -223,7 +223,7 @@ following formats:
       2.1798724×10⁻¹⁸ m² kg s⁻²
       >>> print(u.Ry.decompose().to_string('unicode', fraction=True))  # doctest: +FLOAT_CMP
       2.1798724×10⁻¹⁸ m² kg / s²
-      >>> print(u.Ry.decompose().to_string('unicode', fraction='display'))  # doctest: +FLOAT_CMP
+      >>> print(u.Ry.decompose().to_string('unicode', fraction='multiline'))  # doctest: +FLOAT_CMP
                       m² kg
       2.1798724×10⁻¹⁸ ─────
                        s²

--- a/docs/units/format.rst
+++ b/docs/units/format.rst
@@ -206,7 +206,7 @@ following formats:
 
     It is also possible to write a multiline representation:
 
-      >>> print(fluxunit.to_string('console', inline=False))
+      >>> print(fluxunit.to_string('console', fraction=True))
        erg
       ------
       s cm^2
@@ -216,7 +216,7 @@ following formats:
 
       >>> print(u.Ry.decompose().to_string('unicode'))  # doctest: +FLOAT_CMP
       2.1798724×10⁻¹⁸ m² kg s⁻²
-      >>> print(u.Ry.decompose().to_string('unicode', inline=False))  # doctest: +FLOAT_CMP
+      >>> print(u.Ry.decompose().to_string('unicode', fraction=True))  # doctest: +FLOAT_CMP
                       m² kg
       2.1798724×10⁻¹⁸ ─────
                        s²

--- a/docs/units/format.rst
+++ b/docs/units/format.rst
@@ -204,17 +204,17 @@ following formats:
       >>> print(fluxunit.to_string('console'))
        erg s^-1 cm^-2
 
-    It is also possible to write a multiline representation:
+    It is also possible to use a fraction, either on a single line,
 
-      >>> print(fluxunit.to_string('console', fraction=True))
+      >>> print(fluxunit.to_string('console', fraction='inline'))
+      erg / (s cm^2)
+
+    or using a multiline representation:
+
+      >>> print(fluxunit.to_string('console', fraction='display'))
        erg
       ------
       s cm^2
-
-    Or to have just a fraction:
-
-      >>> print(fluxunit.to_string('console', fraction=True, inline=True))
-      erg / (s cm^2)
 
   - ``"unicode"``: Same as ``"console"``, except uses Unicode
     characters::
@@ -222,11 +222,11 @@ following formats:
       >>> print(u.Ry.decompose().to_string('unicode'))  # doctest: +FLOAT_CMP
       2.1798724×10⁻¹⁸ m² kg s⁻²
       >>> print(u.Ry.decompose().to_string('unicode', fraction=True))  # doctest: +FLOAT_CMP
+      2.1798724×10⁻¹⁸ m² kg / s²
+      >>> print(u.Ry.decompose().to_string('unicode', fraction='display'))  # doctest: +FLOAT_CMP
                       m² kg
       2.1798724×10⁻¹⁸ ─────
                        s²
-      >>> print(u.Ry.decompose().to_string('unicode', fraction=True, inline=True))  # doctest: +FLOAT_CMP
-      2.1798724×10⁻¹⁸ m² kg / s²
 
 .. _astropy-units-format-unrecognized:
 

--- a/docs/units/format.rst
+++ b/docs/units/format.rst
@@ -211,6 +211,11 @@ following formats:
       ------
       s cm^2
 
+    Or to have just a fraction:
+
+      >>> print(fluxunit.to_string('console', fraction=True, inline=True))
+      erg / (s cm^2)
+
   - ``"unicode"``: Same as ``"console"``, except uses Unicode
     characters::
 
@@ -220,6 +225,8 @@ following formats:
                       m² kg
       2.1798724×10⁻¹⁸ ─────
                        s²
+      >>> print(u.Ry.decompose().to_string('unicode', fraction=True, inline=True))  # doctest: +FLOAT_CMP
+      2.1798724×10⁻¹⁸ m² kg / s²
 
 .. _astropy-units-format-unrecognized:
 

--- a/docs/whatsnew/5.3.rst
+++ b/docs/whatsnew/5.3.rst
@@ -113,35 +113,37 @@ uncompressed tiles by specifying ``compression_type='NOCOMPRESS'`` in
 
 .. _whatsnew-5.3-unit-formats-fraction-inline:
 
-New "fraction" and "inline" options for representing units as strings
-=====================================================================
+New "fraction" option for representing units as strings
+=======================================================
 
-New formatting options are added to switch between using fractions or
-using negative powers directly, and between inline and multiline
-prettyprinting of quantities::
+A new formatting option is added to switch between using fractions or
+using negative powers directly, with the fraction option also
+allowing to switch between inline and multiline prettyprinting of
+units::
+
 
 	>>> import astropy.units as u
 	>>> unit = u.Unit("erg / (s cm2)")
 	>>> print(unit.to_string('console'))
 	erg s^-1 cm^-2
-	>>> print(unit.to_string('console', fraction=True))
+	>>> print(unit.to_string('console', fraction='inline'))
+        erg / (s cm^2)
+	>>> print(unit.to_string('console', fraction='display'))
          erg
         ------
         s cm^2
-	>>> print(unit.to_string('console', fraction=True, inline=True))
-        erg / (s cm^2)
 	>>> print(unit.to_string('unicode'))
 	erg s⁻¹ cm⁻²
-	>>> print(unit.to_string('unicode', fraction=True))
+	>>> print(unit.to_string('unicode', fraction='inline'))
+        erg / (s cm²)
+	>>> print(unit.to_string('unicode', fraction='display'))
          erg
         ─────
         s cm²
-	>>> print(unit.to_string('unicode', fraction=True, inline=True))
-        erg / (s cm²)
 
 Note that the ``"console"`` and ``"unicode"`` formats now use
-``fraction=False`` as default, while for ``"latex"`` the default remains
-``fraction=True, inline=False``, for an unchanged experience with IPython notebook.
+``fraction=False`` by default, while for ``"latex"`` the default remains
+``fraction='display'``, for an unchanged experience with IPython notebook.
 
 Full change log
 ===============

--- a/docs/whatsnew/5.3.rst
+++ b/docs/whatsnew/5.3.rst
@@ -13,6 +13,7 @@ the 5.2 release.
 In particular, this release includes:
 
 .. * :ref:`whatsnew-5.3-table-union-operators`
+.. * :ref:`whatsnew-5.3-unit-formats-fraction`
 
 In addition to these major changes, Astropy v5.3 includes a large number of
 smaller improvements and bug fixes, which are described in the :ref:`changelog`.
@@ -111,24 +112,23 @@ It is now possible to read and write compressed FITS files that make use of the
 uncompressed tiles by specifying ``compression_type='NOCOMPRESS'`` in
 :class:`~astropy.io.fits.CompImageHDU`.
 
-.. _whatsnew-5.3-unit-formats-fraction-inline:
+.. _whatsnew-5.3-unit-formats-fraction:
 
-New "fraction" option for representing units as strings
-=======================================================
+New ``fraction`` option for representing units as strings
+=========================================================
 
 A new formatting option is added to switch between using fractions or
 using negative powers directly, with the fraction option also
 allowing to switch between inline and multiline prettyprinting of
 units::
 
-
 	>>> import astropy.units as u
-	>>> unit = u.Unit("erg / (s cm2)")
+	>>> unit = u.Unit('erg / (s cm2)')
 	>>> print(unit.to_string('console'))
 	erg s^-1 cm^-2
 	>>> print(unit.to_string('console', fraction='inline'))
         erg / (s cm^2)
-	>>> print(unit.to_string('console', fraction='display'))
+	>>> print(unit.to_string('console', fraction='multiline'))
          erg
         ------
         s cm^2
@@ -136,14 +136,16 @@ units::
 	erg s⁻¹ cm⁻²
 	>>> print(unit.to_string('unicode', fraction='inline'))
         erg / (s cm²)
-	>>> print(unit.to_string('unicode', fraction='display'))
+	>>> print(unit.to_string('unicode', fraction='multiline'))
          erg
         ─────
         s cm²
 
-Note that the ``"console"`` and ``"unicode"`` formats now use
-``fraction=False`` by default, while for ``"latex"`` the default remains
-``fraction='display'``, for an unchanged experience with IPython notebook.
+Note that the ``'console'`` and ``'unicode'`` formats now use
+``fraction=False`` by default, since this will more reliably produce
+readable results when printing quantities, table headers and cells, etc.
+For ``'latex'`` the default remains ``fraction='display'``, for an
+unchanged experience with IPython notebook.
 
 Full change log
 ===============

--- a/docs/whatsnew/5.3.rst
+++ b/docs/whatsnew/5.3.rst
@@ -111,32 +111,37 @@ It is now possible to read and write compressed FITS files that make use of the
 uncompressed tiles by specifying ``compression_type='NOCOMPRESS'`` in
 :class:`~astropy.io.fits.CompImageHDU`.
 
-.. _whatsnew-5.3-unit-formats-inline:
+.. _whatsnew-5.3-unit-formats-fraction-inline:
 
-New "inline" option for ``"unicode"``, ``"console"``, and ``"latex"`` unit formats
-==================================================================================
+New "fraction" and "inline" options for representing units as strings
+=====================================================================
 
-A new formatting option for unit is added to switch between inline and
-multiline prettyprinting of quantities::
+New formatting options are added to switch between using fractions or
+using negative powers directly, and between inline and multiline
+prettyprinting of quantities::
 
 	>>> import astropy.units as u
 	>>> unit = u.Unit("erg / (s cm2)")
 	>>> print(unit.to_string('console'))
 	erg s^-1 cm^-2
-	>>> print(unit.to_string('console', inline=False))
+	>>> print(unit.to_string('console', fraction=True))
          erg
         ------
         s cm^2
+	>>> print(unit.to_string('console', fraction=True, inline=True))
+        erg / (s cm^2)
 	>>> print(unit.to_string('unicode'))
 	erg s⁻¹ cm⁻²
-	>>> print(unit.to_string('unicode', inline=False))
+	>>> print(unit.to_string('unicode', fraction=True))
          erg
         ─────
         s cm²
+	>>> print(unit.to_string('unicode', fraction=True, inline=True))
+        erg / (s cm²)
 
 Note that the ``"console"`` and ``"unicode"`` formats now use
-``inline=False`` as default, while for ``"latex"`` the default remains
-``inline=True``, for an unchanged experience with IPython notebook.
+``fraction=False`` as default, while for ``"latex"`` the default remains
+``fraction=True, inline=False``, for an unchanged experience with IPython notebook.
 
 Full change log
 ===============


### PR DESCRIPTION
This pull request continues the work started by @olebole in #14393 in giving the user options for how to represent a unit in a given format. It deviates from #14393 in using `fraction` as the primary option argument, to indicate whether or not bases raised to negative powers should be shown as is (`fraction=False`) or a fraction should be used (`fraction=True`). 

~In addition, an `inline` option allows the choice between using a solidus (`inline=True`) or a displayed fraction (`inline=False`). The latter is only available for `latex`, `console`, and `unicode` formats.~
EDIT: I changed to follow option 1 below and only have a `fraction={False|True|'inline'|'display'}` argument.

Opening as a draft since there are some implementation questions:
1. Does the nomenclature make sense? An alternative that I considered was having only a `fraction` option, with possible values `False`, `'inline'` and `'display'`, with `True` as a short-cut to ~the default fraction style~ `'inline'`. This is more concise and perhaps better (I'm wavering!);
2. Right now, the `inline` option is ignored for formats that do not support it. Should it raise an error instead? EDIT: yes, since machine-readable formats should be strict about what they allow, and raise if an option would make the format no longer readable.

To do:
- [x] Raise on bad options.

p.s. Just in case: the `inline` option was just introduced and is only in `-dev` - hence the replacement of the #14393 changelog fragment with a new one (EDIT: and the `skip-changelog-checks` entry since that is misled by the deletion of `14393.feature.rst`).
~p.s.2 For my own convenience, on top of #14437; will rebase once that is in.~