### PR TITLE
Add the ability to convert a compressed image HDU to a dask array for parallel decompression

### DIFF
--- a/astropy/io/fits/hdu/compressed.py
+++ b/astropy/io/fits/hdu/compressed.py
@@ -461,6 +461,7 @@ class CompImageHDU(BinTableHDU):
         uint=False,
         scale_back=False,
         tile_size=None,
+        use_dask=False,
     ):
         """
         Parameters
@@ -709,6 +710,8 @@ class CompImageHDU(BinTableHDU):
         self._do_not_scale_image_data = do_not_scale_image_data
         self._uint = uint
         self._scale_back = scale_back
+
+        self._use_dask = use_dask
 
         self._axes = [
             self._header.get("ZNAXIS" + str(axis + 1), 0)
@@ -1553,13 +1556,21 @@ class CompImageHDU(BinTableHDU):
         if len(self.compressed_data) == 0:
             return None
 
-        # Since .section has general code to load any arbitrary part of the
-        # data, we can just use this - and the @lazyproperty on the current
-        # property will ensure that we do this only once.
-        data = self.section[...]
+        if self._use_dask:
 
-        # Right out of _ImageBaseHDU.data
-        self._update_header_scale_info(data.dtype)
+            import dask.array as da
+
+            data = da.from_array(self.section, chunks=_tile_shape(self._header))
+
+        else:
+
+            # Since .section has general code to load any arbitrary part of the
+            # data, we can just use this - and the @lazyproperty on the current
+            # property will ensure that we do this only once.
+            data = self.section[...]
+
+            # Right out of _ImageBaseHDU.data
+            self._update_header_scale_info(data.dtype)
 
         return data
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -104,6 +104,7 @@ intersphinx_mapping.update(
         "pytest": ("https://docs.pytest.org/en/stable/", None),
         "ipython": ("https://ipython.readthedocs.io/en/stable/", None),
         "pandas": ("https://pandas.pydata.org/pandas-docs/stable/", None),
+        "dask": ("https://docs.dask.org/en/stable/", None),
         "sphinx_automodapi": (
             "https://sphinx-automodapi.readthedocs.io/en/stable/",
             None,


### PR DESCRIPTION
*This is work towards part 2 of the proposal for funding [Improve FITS compressed image performance and Dask integration in io.fits](https://github.com/astropy/astropy-project/blob/main/finance/proposal-calls/cycle3/aperio_fits_dask.md)*

*This should be rebased once https://github.com/astropy/astropy/pull/14430 is merged*

This is an experimental PR to show how we could easily (at least for some FITS HDU classes) have an option to get dask arrays - for now I'm focusing on ``CompImageHDU`` because there are clear gains to be made since tiles can be decompressed in parallel but we can extend this to other HDU classes if we agree on the approach/API. With this PR, we can control whether ``.data`` is a Numpy array or a dask array. To demonstrate this, we can first generate a test dataset:

```python
import numpy as np
from astropy.io import fits

data = np.random.randint(0, 100, (10000, 10000)).astype('i4')

hdu = fits.CompImageHDU(data, fits.Header(), compression_type='RICE_1', tile_size=(2000, 2000))
hdu.writeto('test_10k.fits', overwrite=True)
```

We can now read this in using the default options:

```python
In [1]: from astropy.io import fits

In [2]: hdu = fits.open('test_10k.fits')[1]

In [3]: %time hdu.data
CPU times: user 874 ms, sys: 210 ms, total: 1.08 s
Wall time: 1.08 s
Out[3]: 
array([[81, 14, 91, ..., 50, 19, 12],
       [65, 36,  9, ..., 58, 26,  4],
       [37, 18, 72, ..., 34, 14, 55],
       ...,
       [19, 27, 34, ..., 58, 81,  7],
       [26, 75, 29, ..., 69,  0, 36],
       [48, 60, 91, ..., 10, 43, 34]], dtype=int32)

In [4]: type(hdu.data)
Out[4]: numpy.ndarray
```

With this PR, we can specify ``use_dask=True`` in the ``open`` options:

```python
In [1]: from astropy.io import fits

In [2]: hdu = fits.open('test_10k.fits', use_dask=True)[1]

In [3]: hdu.data
Out[3]: dask.array<array, shape=(10000, 10000), dtype=int32, chunksize=(2000, 2000), chunktype=numpy.ndarray>
```

And we can then choose to use e.g. the multi-threaded scheduler to compute the array, which is faster (the wall time is the relevant time here):

```python
In [4]: %time hdu.data.compute(scheduler='synchronous')
CPU times: user 971 ms, sys: 521 ms, total: 1.49 s
Wall time: 1.49 s
Out[4]: 
array([[81, 14, 91, ..., 50, 19, 12],
       [65, 36,  9, ..., 58, 26,  4],
       [37, 18, 72, ..., 34, 14, 55],
       ...,
       [19, 27, 34, ..., 58, 81,  7],
       [26, 75, 29, ..., 69,  0, 36],
       [48, 60, 91, ..., 10, 43, 34]], dtype=int32)

In [5]: %time hdu.data.compute(scheduler='threads')
CPU times: user 1.27 s, sys: 528 ms, total: 1.79 s
Wall time: 478 ms
Out[5]: 
array([[81, 14, 91, ..., 50, 19, 12],
       [65, 36,  9, ..., 58, 26,  4],
       [37, 18, 72, ..., 34, 14, 55],
       ...,
       [19, 27, 34, ..., 58, 81,  7],
       [26, 75, 29, ..., 69,  0, 36],
       [48, 60, 91, ..., 10, 43, 34]], dtype=int32)
```

A factor of 2x or more faster compared to the non-dask version! The reason this works is because in https://github.com/astropy/astropy/pull/14430 we made it so the GIL is released inside the C extensions.

In any case, I think it would be useful to make it easy for users to get dask arrays out of HDUs, but I'm open as to how we achieve this. We can either use ``use_dask`` as done here, or we could instead have a property ``dask_data`` or similar that exists on ``CompImageHDU``. We could add this to all HDU classes even though for some of them there might not be a benefit yet (but we can always improve the efficiency of the implementation on different HDU classes over time).

Having this would address (I think) the last point in https://github.com/astropy/astropy/issues/3895 which was to implement multi-threaded decompression of tiles - rather than implement a thread pool ourselves, I think it would be much cleaner to simply use dask to achieve this.

@saimn - do you have any thoughts on this? The changes in this PR are actually trivial (see last commit) - the rest is commits that will go away once other PRs are merged.

Obviously if we go ahead I would add docs etc to demonstrate this (and tests etc).



