### PR TITLE
DOC: Replace stats link to broken cfa URL

### DIFF
--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -550,7 +550,7 @@ def poisson_conf_interval(
 
     **4. 'sherpagehrels'** This rule is used by default in the fitting
     package 'sherpa'. The `documentation
-    <https://cxc.harvard.edu/sherpa4.4/statistics/#chigehrels>`_ claims
+    <https://web.archive.org/web/20220126234440/https://cxc.harvard.edu/sherpa4.4/statistics/#chigehrels>`_ claims
     it is based on a numerical approximation published in `Gehrels
     (1986) <https://ui.adsabs.harvard.edu/abs/1986ApJ...303..336G>`_ but it
     does not actually appear there.  It is symmetrical, and while the

--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -550,7 +550,7 @@ def poisson_conf_interval(
 
     **4. 'sherpagehrels'** This rule is used by default in the fitting
     package 'sherpa'. The `documentation
-    <https://web.archive.org/web/20220126234440/https://cxc.harvard.edu/sherpa4.4/statistics/#chigehrels>`_ claims
+    <https://cxc.cfa.harvard.edu/sherpa/statistics/#chigehrels>`_ claims
     it is based on a numerical approximation published in `Gehrels
     (1986) <https://ui.adsabs.harvard.edu/abs/1986ApJ...303..336G>`_ but it
     does not actually appear there.  It is symmetrical, and while the


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to replace a broken URL found in linkcheck.

Not sure how I feel that so many URLs in this module have to point to internet archive, but I guess math is math.

Fix #14464
