### PR TITLE
Add np.max and np.min to SUBCLASS_SAFE_FUNCTIONS

### DIFF
--- a/astropy/units/quantity_helper/function_helpers.py
+++ b/astropy/units/quantity_helper/function_helpers.py
@@ -78,6 +78,7 @@ SUBCLASS_SAFE_FUNCTIONS |= {
     np.max, np.min, np.amax, np.amin, np.ptp, np.sum, np.cumsum,
     np.prod, np.product, np.cumprod, np.cumproduct,
     np.round, np.around,
+    np.round_,  # Alias for np.round in NUMPY_LT_1_25, but deprecated since.
     np.fix, np.angle, np.i0, np.clip,
     np.isposinf, np.isneginf, np.isreal, np.iscomplex,
     np.average, np.mean, np.std, np.var, np.median, np.trace,

--- a/astropy/units/quantity_helper/function_helpers.py
+++ b/astropy/units/quantity_helper/function_helpers.py
@@ -75,7 +75,7 @@ SUBCLASS_SAFE_FUNCTIONS |= {
     np.put, np.fill_diagonal, np.tile, np.repeat,
     np.split, np.array_split, np.hsplit, np.vsplit, np.dsplit,
     np.stack, np.column_stack, np.hstack, np.vstack, np.dstack,
-    np.amax, np.amin, np.ptp, np.sum, np.cumsum,
+    np.max, np.min, np.amax, np.amin, np.ptp, np.sum, np.cumsum,
     np.prod, np.product, np.cumprod, np.cumproduct,
     np.round, np.around,
     np.fix, np.angle, np.i0, np.clip,

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -608,6 +608,12 @@ class TestSplit(metaclass=CoverageMeta):
 
 
 class TestUfuncReductions(InvariantUnitTestSetup):
+    def test_max(self):
+        self.check(np.max)
+
+    def test_min(self):
+        self.check(np.min)
+
     def test_amax(self):
         self.check(np.amax)
 

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -17,7 +17,7 @@ from astropy.units.quantity_helper.function_helpers import (
     TBD_FUNCTIONS,
     UNSUPPORTED_FUNCTIONS,
 )
-from astropy.utils.compat import NUMPY_LT_1_23, NUMPY_LT_1_24
+from astropy.utils.compat import NUMPY_LT_1_23, NUMPY_LT_1_24, NUMPY_LT_1_25
 
 needs_array_function = pytest.mark.xfail(
     not ARRAY_FUNCTION_ENABLED, reason="Needs __array_function__ support"
@@ -664,8 +664,17 @@ class TestUfuncLike(InvariantUnitTestSetup):
         self.check(np.ptp)
         self.check(np.ptp, axis=0)
 
+    def test_round(self):
+        self.check(np.round)
+
     def test_round_(self):
-        self.check(np.round_)
+        if NUMPY_LT_1_25:
+            self.check(np.round_)
+        else:
+            with pytest.warns(
+                DeprecationWarning, match="`round_` is deprecated as of NumPy 1.25.0"
+            ):
+                self.check(np.round_)
 
     def test_around(self):
         self.check(np.around)

--- a/astropy/utils/masked/tests/test_function_helpers.py
+++ b/astropy/utils/masked/tests/test_function_helpers.py
@@ -579,6 +579,12 @@ class TestMethodLikes(MaskedArraySetup):
         x = getattr(self.ma, method)(*args, **kwargs)
         assert_masked_equal(o, x)
 
+    def test_max(self):
+        self.check(np.max, method="max")
+
+    def test_min(self):
+        self.check(np.min, method="min")
+
     def test_amax(self):
         self.check(np.amax, method="max")
 
@@ -619,8 +625,17 @@ class TestMethodLikes(MaskedArraySetup):
         self.check(np.ptp)
         self.check(np.ptp, axis=0)
 
+    def test_round(self):
+        self.check(np.round, method="round")
+
     def test_round_(self):
-        self.check(np.round_, method="round")
+        if NUMPY_LT_1_25:
+            self.check(np.round_, method="round")
+        else:
+            with pytest.warns(
+                DeprecationWarning, match="`round_` is deprecated as of NumPy 1.25.0"
+            ):
+                self.check(np.round_, method="round")
 
     def test_around(self):
         self.check(np.around, method="round")


### PR DESCRIPTION
In https://github.com/numpy/numpy/pull/23302, `numpy` deprecated `np.amax` and `np.amin` in favor of `np.max` and `np.min`.  This PR adds `np.max` and `np.min` to the `Quantity` `SUBCLASS_SAFE_FUNCTIONS` list. 

Fixes #14483 

CC: @mhvk, @pllim 

<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->



<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->


<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->
