### PR TITLE
Added `astropy.units.mixins.QuantityOperatorsMixin`.

### DIFF
--- a/astropy/units/mixins.py
+++ b/astropy/units/mixins.py
@@ -1,0 +1,33 @@
+import numpy as np
+import astropy.units as u
+
+__all__ = [
+    "QuantityOperatorsMixin",
+]
+
+
+class QuantityOperatorsMixin(np.lib.mixins.NDArrayOperatorsMixin):
+
+    def __mul__(self, other):
+        if isinstance(other, (u.UnitBase, str)):
+            try:
+                other = u.Quantity(1, other)
+            except Exception:
+                return NotImplemented
+        return super().__mul__(other)
+
+    def __truediv__(self, other):
+        if isinstance(other, (u.UnitBase, str)):
+            try:
+                other = u.Quantity(1, other)
+            except Exception:
+                return NotImplemented
+        return super().__truediv__(other)
+
+    def __lshift__(self, other):
+        if isinstance(other, (u.UnitBase, str)):
+            try:
+                other = u.Quantity(1, other)
+            except Exception:
+                return NotImplemented
+        return super().__lshift__(other)

--- a/astropy/units/tests/test_mixins.py
+++ b/astropy/units/tests/test_mixins.py
@@ -1,0 +1,107 @@
+import pytest
+import dataclasses
+import numpy as np
+import astropy.units as u
+import astropy.units.mixins
+
+
+@dataclasses.dataclass
+class DuckQuantity(astropy.units.mixins.QuantityOperatorsMixin):
+
+    data: float | np.ndarray | u.Quantity
+
+    def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
+        inputs = [
+            inp.data if isinstance(inp, DuckQuantity) else inp
+            for inp in inputs
+        ]
+
+        return DuckQuantity(
+            getattr(ufunc, method)(*inputs, **kwargs)
+        )
+
+
+@pytest.mark.parametrize(
+    argnames='operand_left',
+    argvalues=[
+        DuckQuantity(3),
+        DuckQuantity(np.array([3, 4])),
+        DuckQuantity(3 * u.mm),
+        DuckQuantity([3, 4] * u.mm),
+    ]
+)
+@pytest.mark.parametrize('operand_right', [u.mm, u.s])
+class TestQuantityOperatorsMixin:
+
+    def _unwrap(self, operand):
+        if isinstance(operand, DuckQuantity):
+            return operand.data
+        elif isinstance(operand, str):
+            return u.Unit(operand)
+        else:
+            return operand
+
+    def test__mul__(
+            self,
+            operand_left: str | u.UnitBase | u.FunctionUnitBase | DuckQuantity,
+            operand_right: str | u.UnitBase | u.FunctionUnitBase | DuckQuantity,
+    ):
+
+        result = operand_left * operand_right
+
+        operand_left_unwrapped = self._unwrap(operand_left)
+        operand_right_unwrapped = self._unwrap(operand_right)
+        result_expected = operand_left_unwrapped * operand_right_unwrapped
+
+        assert isinstance(result, DuckQuantity)
+        assert np.all(result.data == result_expected)
+
+    def test__mul__reversed(
+            self,
+            operand_left: str | u.UnitBase | u.FunctionUnitBase | DuckQuantity,
+            operand_right: str | u.UnitBase | u.FunctionUnitBase | DuckQuantity,
+    ):
+        self.test__mul__(
+            operand_left=operand_right,
+            operand_right=operand_left
+        )
+
+    def test__truediv__(
+            self,
+            operand_left: str | u.UnitBase | u.FunctionUnitBase | DuckQuantity,
+            operand_right: str | u.UnitBase | u.FunctionUnitBase | DuckQuantity,
+    ):
+
+        result = operand_left / operand_right
+
+        operand_left_unwrapped = self._unwrap(operand_left)
+        operand_right_unwrapped = self._unwrap(operand_right)
+        result_expected = operand_left_unwrapped / operand_right_unwrapped
+
+        assert isinstance(result, DuckQuantity)
+        assert np.all(result.data == result_expected)
+
+    def test__truediv__reversed(
+            self,
+            operand_left: str | u.UnitBase | u.FunctionUnitBase | DuckQuantity,
+            operand_right: str | u.UnitBase | u.FunctionUnitBase | DuckQuantity,
+    ):
+        self.test__truediv__(
+            operand_left=operand_right,
+            operand_right=operand_left,
+        )
+
+    def test__lshift__(
+            self,
+            operand_left: str | u.UnitBase | u.FunctionUnitBase | DuckQuantity,
+            operand_right: str | u.UnitBase | u.FunctionUnitBase | DuckQuantity,
+    ):
+
+        result = operand_left << operand_right
+
+        operand_left_unwrapped = self._unwrap(operand_left)
+        operand_right_unwrapped = self._unwrap(operand_right)
+        result_expected = operand_left_unwrapped << operand_right_unwrapped
+
+        assert isinstance(result, DuckQuantity)
+        assert np.all(result.data == result_expected)


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request allows `astropy.units.Quantity` duck types to use instances of `astropy.units.Unit` by introducing a mixin class `QuantityOperatorsMixin`, which overrides the `__mul__`, `__truediv__`, and `__lshift__` operators.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #14479
