### PR TITLE
Fixed incorrect attribute access in high level WCS classes

### DIFF
--- a/astropy/wcs/wcsapi/high_level_api.py
+++ b/astropy/wcs/wcsapi/high_level_api.py
@@ -112,7 +112,7 @@ class BaseHighLevelWCS(metaclass=abc.ABCMeta):
         pixel indexing and ordering conventions. The indices should be returned
         as rounded integers.
         """
-        if self.pixel_n_dim == 1:
+        if self.low_level_wcs.pixel_n_dim == 1:
             return _toindex(self.world_to_pixel(*world_objects))
         else:
             return tuple(_toindex(self.world_to_pixel(*world_objects)[::-1]).tolist())
@@ -326,7 +326,7 @@ class HighLevelWCSMixin(BaseHighLevelWCS):
         # Compute the world coordinate values
         world_values = self.low_level_wcs.pixel_to_world_values(*pixel_arrays)
 
-        if self.world_n_dim == 1:
+        if self.low_level_wcs.world_n_dim == 1:
             world_values = (world_values,)
 
         pixel_values = values_to_high_level_objects(

--- a/docs/changes/wcs/14495.bugfix.rst
+++ b/docs/changes/wcs/14495.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed a bug that caused subclasses of BaseHighLevelWCS and HighLevelWCSMixin to
+not work correctly under certain conditions if they did not have ``world_n_dim``
+and ``pixel_n_dim`` defined on them.


### PR DESCRIPTION
``world_n_dim`` and ``pixel_n_dim`` are not required to exist on high level WCS classes, so we should always get these from the wrapped low level WCS object.