### PR TITLE
Document the policy of contributor `.mailmap` edits

### DIFF
--- a/docs/development/workflow/development_workflow.rst
+++ b/docs/development/workflow/development_workflow.rst
@@ -143,6 +143,8 @@ Astropy Guidelines for `git`_
 * Never merge changes from ``astropy/main`` into your feature branch. If
   changes in the development version require changes to our code you can
   :ref:`rebase`.
+* If you need to edit `.mailmap <https://git-scm.com/docs/gitmailmap>`_ and
+  know how to do it then you can open a pull request for that.
 
 In addition there are a couple of `git`_ naming conventions used in this
 document:


### PR DESCRIPTION
### Description

The name and email of the author and committer of a Git commit are recorded in the commit metadata and affect its hash. It is therefore not possible to edit them directly, but the data displayed to a Git user can be modified after the fact by [`.mailmap`](https://docs.astropy.org/en/latest/development/releasing.html#updating-the-what-s-new-and-contributors). Currently [our developer documentation describes how `.mailmap` has to be updated during the release process](https://docs.astropy.org/en/latest/development/releasing.html#updating-the-what-s-new-and-contributors), but there are no instructions for individual contributors who might wish to update their email address between releases. In the handful of cases a pull request editing `.mailmap` has been opened the changes have been merged, so this pull request adds a sentence to the developer documentation that records our current practice. This sentence is meant for knowledgeable contributors that are looking for this information. Explaining how to edit `.mailmap` to novices is beyond the scope of `astropy`.