### PR TITLE
Manual backport of PR14495 to v5.0.x (Fixed incorrect attribute access in high level WCS classes)

### DIFF
--- a/astropy/wcs/wcsapi/high_level_api.py
+++ b/astropy/wcs/wcsapi/high_level_api.py
@@ -111,7 +111,7 @@ class BaseHighLevelWCS(metaclass=abc.ABCMeta):
         pixel indexing and ordering conventions. The indices should be returned
         as rounded integers.
         """
-        if self.pixel_n_dim == 1:
+        if self.low_level_wcs.pixel_n_dim == 1:
             return _toindex(self.world_to_pixel(*world_objects))
         else:
             return tuple(_toindex(self.world_to_pixel(*world_objects)[::-1]).tolist())
@@ -327,7 +327,7 @@ class HighLevelWCSMixin(BaseHighLevelWCS):
         # Compute the world coordinate values
         world_values = self.low_level_wcs.pixel_to_world_values(*pixel_arrays)
 
-        if self.world_n_dim == 1:
+        if self.low_level_wcs.world_n_dim == 1:
             world_values = (world_values,)
 
         pixel_values = values_to_high_level_objects(

--- a/astropy/wcs/wcsapi/tests/test_high_level_api.py
+++ b/astropy/wcs/wcsapi/tests/test_high_level_api.py
@@ -1,8 +1,9 @@
 import numpy as np
 from numpy.testing import assert_allclose
 
-from astropy.units import Quantity
 from astropy.coordinates import SkyCoord
+from astropy.units import Quantity
+from astropy.wcs import WCS
 
 from astropy.wcs.wcsapi.low_level_api import BaseLowLevelWCS
 from astropy.wcs.wcsapi.high_level_api import (
@@ -203,3 +204,29 @@ def test_values_to_objects():
 
     assert c1.dec == c1_out.dec
     assert c2.b == c2_out.b
+
+
+class MinimalHighLevelWCS(HighLevelWCSMixin):
+    def __init__(self, low_level_wcs):
+        self._low_level_wcs = low_level_wcs
+
+    @property
+    def low_level_wcs(self):
+        return self._low_level_wcs
+
+
+def test_minimal_mixin_subclass():
+    # Regression test for a bug that caused coordinate conversions to fail
+    # unless the WCS dimensions were defined on the high level WCS (which they
+    # are not required to be)
+
+    fits_wcs = WCS(naxis=2)
+    high_level_wcs = MinimalHighLevelWCS(fits_wcs)
+
+    coord = high_level_wcs.pixel_to_world(1, 2)
+    pixel = high_level_wcs.world_to_pixel(*coord)
+
+    coord = high_level_wcs.array_index_to_world(1, 2)
+    pixel = high_level_wcs.world_to_array_index(*coord)
+
+    assert_allclose(pixel, (1, 2))

--- a/docs/changes/wcs/14495.bugfix.rst
+++ b/docs/changes/wcs/14495.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed a bug that caused subclasses of BaseHighLevelWCS and HighLevelWCSMixin to
+not work correctly under certain conditions if they did not have ``world_n_dim``
+and ``pixel_n_dim`` defined on them.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to manually backport #14495 to v5.0.x
