### PR TITLE
Modified `astropy.units.Quantity.__array_ufunc__` to catch `AttributeError`

### DIFF
--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -682,7 +682,7 @@ class Quantity(np.ndarray):
 
             return self._result_as_quantity(result, unit, out)
 
-        except (TypeError, ValueError) as e:
+        except (TypeError, ValueError, AttributeError) as e:
             out_normalized = kwargs.get("out", tuple())
             inputs_and_outputs = inputs + out_normalized
             ignored_ufunc = (

--- a/astropy/units/tests/test_quantity_ufuncs.py
+++ b/astropy/units/tests/test_quantity_ufuncs.py
@@ -1343,6 +1343,12 @@ class DuckQuantity3(DuckQuantity2):
         return NotImplemented
 
 
+class DuckQuantity4(DuckQuantity3):
+    @property
+    def unit(self):
+        return DuckQuantity1(1 * self.data.unit)
+
+
 class TestUfuncReturnsNotImplemented:
     @pytest.mark.parametrize("ufunc", (np.negative, np.abs))
     class TestUnaryUfuncs:
@@ -1355,7 +1361,12 @@ class TestUfuncReturnsNotImplemented:
                 ufunc(duck_quantity)
 
         @pytest.mark.parametrize(
-            "duck_quantity", [DuckQuantity3(1 * u.mm), DuckQuantity3([1, 2] * u.mm)]
+            "duck_quantity",
+            [
+                DuckQuantity3(1 * u.mm),
+                DuckQuantity3([1, 2] * u.mm),
+                DuckQuantity4(1 * u.mm),
+            ],
         )
         @pytest.mark.parametrize("out", [None, "empty"])
         def test_full(self, ufunc, duck_quantity, out):
@@ -1391,7 +1402,11 @@ class TestUfuncReturnsNotImplemented:
 
         @pytest.mark.parametrize(
             "duck_quantity",
-            [DuckQuantity3(1 * u.mm), DuckQuantity3([1, 2] * u.mm)],
+            [
+                DuckQuantity3(1 * u.mm),
+                DuckQuantity3([1, 2] * u.mm),
+                DuckQuantity4(1 * u.mm),
+            ],
         )
         @pytest.mark.parametrize("out", [None, "empty"])
         def test_full(self, ufunc, quantity, duck_quantity, out):


### PR DESCRIPTION
### Description

PR #13977 allowed `Quantity.__array_ufunc__` to return `NotImplemented` if `TypeError` or `ValueError` was raised in the body of the function. This PR is an improvement to that change, and allows `Quantity.__array_ufunc__` to also return `NotImplemented` if `AttributeError` is raised in the body of the function. This is necessary if one of the arguments has a `unit` attribute that does not return an instance of `astropy.units.UnitBase`.
