### PR TITLE
Run the `ruff` pre-commit hook before `black`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,16 +62,16 @@ repos:
         additional_dependencies:
           - tomli
 
-  - repo: https://github.com/psf/black
-    rev: 23.1.0
-    hooks:
-      - id: black
-
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     rev: "v0.0.254"
     hooks:
       - id: ruff
         args: ["--fix"]
+
+  - repo: https://github.com/psf/black
+    rev: 23.1.0
+    hooks:
+      - id: black
 
   - repo: local
     hooks:


### PR DESCRIPTION
### Description

[`ruff` pre-commit hook documentation recommends running it before formatting tools such as `black`](https://github.com/charliermarsh/ruff-pre-commit#using-ruff-with-pre-commit) because some of the changes `ruff` makes might result in code that formatters would edit. Running `black` after `ruff` is safe because `black` is careful to only edit formatting and does not change the Abstract Syntax Tree of the code. For example, suppose that we have the following setup:
`.pre-commit-config.yaml`
```yaml
  - repo: https://github.com/psf/black
    rev: 23.1.0
    hooks:
      - id: black

  - repo: https://github.com/charliermarsh/ruff-pre-commit
    rev: "v0.0.254"
    hooks:
      - id: ruff
        args: ["--fix"]
```
`pyproject.toml`
```toml
[tool.black]
line-length = 50

[tool.ruff]
select = ["SIM101"]
line-length = 50
```
`example.py`
```python
def is_number(a):
    return (
        isinstance(a, int)
        or isinstance(a, float)
        or False
    )
```
If we try to commit `example.py` the `ruff` pre-commit hook intervenes and changes the file:
```python
def is_number(a):
    return (
        isinstance(a, (int, float)) or False
    )
```
But if we try to commit that `black` intervenes and produces
```python
def is_number(a):
    return isinstance(a, (int, float)) or False
```
Making the commit succeeds only on the third attempt. Now suppose the following `.pre-commit-config.yaml` so that `ruff` runs before `black`:
```yaml
  - repo: https://github.com/charliermarsh/ruff-pre-commit
    rev: "v0.0.254"
    hooks:
      - id: ruff
        args: ["--fix"]

  - repo: https://github.com/psf/black
    rev: 23.1.0
    hooks:
      - id: black
```
If we try to commit the very first version of `example.py` then `ruff` modifies it first and then `black` edits the version modified by `ruff` so that the third version of `example.py` is produced already after the first commit attempt.