### PR TITLE
Fix numpy 1.25 deprecation warnings.

### DIFF
--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -732,7 +732,7 @@ def convolve_fft(
     kernshape = kernel.shape
 
     array_size_B = (
-        np.product(arrayshape, dtype=np.int64) * np.dtype(complex_dtype).itemsize
+        np.prod(arrayshape, dtype=np.int64) * np.dtype(complex_dtype).itemsize
     ) * u.byte
     if array_size_B > 1 * u.GB and not allow_huge:
         raise ValueError(
@@ -838,7 +838,7 @@ def convolve_fft(
 
     # perform a second check after padding
     array_size_C = (
-        np.product(newshape, dtype=np.int64) * np.dtype(complex_dtype).itemsize
+        np.prod(newshape, dtype=np.int64) * np.dtype(complex_dtype).itemsize
     ) * u.byte
     if array_size_C > 1 * u.GB and not allow_huge:
         raise ValueError(
@@ -852,12 +852,12 @@ def convolve_fft(
     #         (kernel*array)fft +
     #         optional(weight image + weight_fft + weight_ifft) +
     #         optional(returned_fft))
-    # total_memory_used_GB = (np.product(newshape)*np.dtype(complex_dtype).itemsize
+    # total_memory_used_GB = (np.prod(newshape)*np.dtype(complex_dtype).itemsize
     #                        * (5 + 3*((interpolate_nan or ) and kernel_is_normalized))
     #                        + (1 + (not return_fft)) *
-    #                          np.product(arrayshape)*np.dtype(complex_dtype).itemsize
-    #                        + np.product(arrayshape)*np.dtype(bool).itemsize
-    #                        + np.product(kernshape)*np.dtype(bool).itemsize)
+    #                          np.prod(arrayshape)*np.dtype(complex_dtype).itemsize
+    #                        + np.prod(arrayshape)*np.dtype(bool).itemsize
+    #                        + np.prod(kernshape)*np.dtype(bool).itemsize)
     #                        ) / 1024.**3
 
     # separate each dimension by the padding size...  this is to determine the

--- a/astropy/io/fits/_tiled_compression/tests/test_fitsio.py
+++ b/astropy/io/fits/_tiled_compression/tests/test_fitsio.py
@@ -104,7 +104,7 @@ def base_original_data(data_shape, dtype, numpy_rng, compression_type):
     # There seems to be a bug with the fitsio library where HCOMPRESS doesn't
     # work with int16 random data, so use a bit for structured test data.
     if compression_type.startswith("HCOMPRESS") and "i2" in dtype or "u1" in dtype:
-        random = np.arange(np.product(data_shape)).reshape(data_shape)
+        random = np.arange(np.prod(data_shape)).reshape(data_shape)
     return random.astype(dtype)
 
 

--- a/astropy/io/fits/tests/test_image.py
+++ b/astropy/io/fits/tests/test_image.py
@@ -2009,7 +2009,7 @@ class TestCompHDUSections:
     @pytest.fixture(autouse=True)
     def setup_method(self, tmp_path):
         shape = (13, 17, 25)
-        self.data = np.arange(np.product(shape)).reshape(shape).astype(np.int32)
+        self.data = np.arange(np.prod(shape)).reshape(shape).astype(np.int32)
 
         header1 = fits.Header()
         hdu1 = fits.CompImageHDU(

--- a/astropy/modeling/tests/test_core.py
+++ b/astropy/modeling/tests/test_core.py
@@ -803,7 +803,7 @@ def test_prepare_outputs_sparse_grid():
     """
 
     shape = (3, 3)
-    data = np.arange(np.product(shape)).reshape(shape) * u.m / u.s
+    data = np.arange(np.prod(shape)).reshape(shape) * u.m / u.s
 
     points_unit = u.pix
     points = [np.arange(size) * points_unit for size in shape]

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -17,7 +17,7 @@ from astropy.units.quantity_helper.function_helpers import (
     TBD_FUNCTIONS,
     UNSUPPORTED_FUNCTIONS,
 )
-from astropy.utils.compat import NUMPY_LT_1_23, NUMPY_LT_1_24, NUMPY_LT_1_25
+from astropy.utils.compat import NUMPY_LT_1_23, NUMPY_LT_1_24
 
 needs_array_function = pytest.mark.xfail(
     not ARRAY_FUNCTION_ENABLED, reason="Needs __array_function__ support"
@@ -671,14 +671,9 @@ class TestUfuncLike(InvariantUnitTestSetup):
     def test_round(self):
         self.check(np.round)
 
+    @pytest.mark.filterwarnings("ignore:`round_` is deprecated as of NumPy 1.25.0")
     def test_round_(self):
-        if NUMPY_LT_1_25:
-            self.check(np.round_)
-        else:
-            with pytest.warns(
-                DeprecationWarning, match="`round_` is deprecated as of NumPy 1.25.0"
-            ):
-                self.check(np.round_)
+        self.check(np.round_)
 
     def test_around(self):
         self.check(np.around)

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -634,10 +634,12 @@ class TestUfuncReductions(InvariantUnitTestSetup):
         with pytest.raises(TypeError):
             np.all(self.q)
 
+    @pytest.mark.filterwarnings("ignore:`sometrue` is deprecated as of NumPy 1.25.0")
     def test_sometrue(self):
         with pytest.raises(TypeError):
             np.sometrue(self.q)
 
+    @pytest.mark.filterwarnings("ignore:`alltrue` is deprecated as of NumPy 1.25.0")
     def test_alltrue(self):
         with pytest.raises(TypeError):
             np.alltrue(self.q)
@@ -646,6 +648,7 @@ class TestUfuncReductions(InvariantUnitTestSetup):
         with pytest.raises(u.UnitsError):
             np.prod(self.q)
 
+    @pytest.mark.filterwarnings("ignore:`product` is deprecated as of NumPy 1.25.0")
     def test_product(self):
         with pytest.raises(u.UnitsError):
             np.product(self.q)
@@ -654,6 +657,7 @@ class TestUfuncReductions(InvariantUnitTestSetup):
         with pytest.raises(u.UnitsError):
             np.cumprod(self.q)
 
+    @pytest.mark.filterwarnings("ignore:`cumproduct` is deprecated as of NumPy 1.25.0")
     def test_cumproduct(self):
         with pytest.raises(u.UnitsError):
             np.cumproduct(self.q)

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -634,11 +634,13 @@ class TestUfuncReductions(InvariantUnitTestSetup):
         with pytest.raises(TypeError):
             np.all(self.q)
 
+    # NUMPY_LT_1_25
     @pytest.mark.filterwarnings("ignore:`sometrue` is deprecated as of NumPy 1.25.0")
     def test_sometrue(self):
         with pytest.raises(TypeError):
             np.sometrue(self.q)
 
+    # NUMPY_LT_1_25
     @pytest.mark.filterwarnings("ignore:`alltrue` is deprecated as of NumPy 1.25.0")
     def test_alltrue(self):
         with pytest.raises(TypeError):
@@ -648,6 +650,7 @@ class TestUfuncReductions(InvariantUnitTestSetup):
         with pytest.raises(u.UnitsError):
             np.prod(self.q)
 
+    # NUMPY_LT_1_25
     @pytest.mark.filterwarnings("ignore:`product` is deprecated as of NumPy 1.25.0")
     def test_product(self):
         with pytest.raises(u.UnitsError):
@@ -657,6 +660,7 @@ class TestUfuncReductions(InvariantUnitTestSetup):
         with pytest.raises(u.UnitsError):
             np.cumprod(self.q)
 
+    # NUMPY_LT_1_25
     @pytest.mark.filterwarnings("ignore:`cumproduct` is deprecated as of NumPy 1.25.0")
     def test_cumproduct(self):
         with pytest.raises(u.UnitsError):
@@ -671,6 +675,7 @@ class TestUfuncLike(InvariantUnitTestSetup):
     def test_round(self):
         self.check(np.round)
 
+    # NUMPY_LT_1_25
     @pytest.mark.filterwarnings("ignore:`round_` is deprecated as of NumPy 1.25.0")
     def test_round_(self):
         self.check(np.round_)

--- a/astropy/utils/masked/tests/test_function_helpers.py
+++ b/astropy/utils/masked/tests/test_function_helpers.py
@@ -603,10 +603,12 @@ class TestMethodLikes(MaskedArraySetup):
     def test_all(self):
         self.check(np.all)
 
+    # NUMPY_LT_1_25
     @pytest.mark.filterwarnings("ignore:`sometrue` is deprecated as of NumPy 1.25.0")
     def test_sometrue(self):
         self.check(np.sometrue, method="any")
 
+    # NUMPY_LT_1_25
     @pytest.mark.filterwarnings("ignore:`alltrue` is deprecated as of NumPy 1.25.0")
     def test_alltrue(self):
         self.check(np.alltrue, method="all")
@@ -614,6 +616,7 @@ class TestMethodLikes(MaskedArraySetup):
     def test_prod(self):
         self.check(np.prod)
 
+    # NUMPY_LT_1_25
     @pytest.mark.filterwarnings("ignore:`product` is deprecated as of NumPy 1.25.0")
     def test_product(self):
         self.check(np.product, method="prod")
@@ -621,6 +624,7 @@ class TestMethodLikes(MaskedArraySetup):
     def test_cumprod(self):
         self.check(np.cumprod)
 
+    # NUMPY_LT_1_25
     @pytest.mark.filterwarnings("ignore:`cumproduct` is deprecated as of NumPy 1.25.0")
     def test_cumproduct(self):
         self.check(np.cumproduct, method="cumprod")
@@ -632,14 +636,10 @@ class TestMethodLikes(MaskedArraySetup):
     def test_round(self):
         self.check(np.round, method="round")
 
+    # NUMPY_LT_1_25
+    @pytest.mark.filterwarnings("ignore:`round_` is deprecated as of NumPy 1.25.0")
     def test_round_(self):
-        if NUMPY_LT_1_25:
-            self.check(np.round_, method="round")
-        else:
-            with pytest.warns(
-                DeprecationWarning, match="`round_` is deprecated as of NumPy 1.25.0"
-            ):
-                self.check(np.round_, method="round")
+        self.check(np.round_, method="round")
 
     def test_around(self):
         self.check(np.around, method="round")

--- a/astropy/utils/masked/tests/test_function_helpers.py
+++ b/astropy/utils/masked/tests/test_function_helpers.py
@@ -603,21 +603,25 @@ class TestMethodLikes(MaskedArraySetup):
     def test_all(self):
         self.check(np.all)
 
+    @pytest.mark.filterwarnings("ignore:`sometrue` is deprecated as of NumPy 1.25.0")
     def test_sometrue(self):
         self.check(np.sometrue, method="any")
 
+    @pytest.mark.filterwarnings("ignore:`alltrue` is deprecated as of NumPy 1.25.0")
     def test_alltrue(self):
         self.check(np.alltrue, method="all")
 
     def test_prod(self):
         self.check(np.prod)
 
+    @pytest.mark.filterwarnings("ignore:`product` is deprecated as of NumPy 1.25.0")
     def test_product(self):
         self.check(np.product, method="prod")
 
     def test_cumprod(self):
         self.check(np.cumprod)
 
+    @pytest.mark.filterwarnings("ignore:`cumproduct` is deprecated as of NumPy 1.25.0")
     def test_cumproduct(self):
         self.check(np.cumproduct, method="cumprod")
 

--- a/examples/io/skip_create-large-fits.py
+++ b/examples/io/skip_create-large-fits.py
@@ -92,7 +92,7 @@ with open('large.fits', 'rb+') as fobj:
 
 shape = tuple(header[f'NAXIS{ii}'] for ii in range(1, header['NAXIS']+1))
 with open('large.fits', 'rb+') as fobj:
-    fobj.seek(len(header.tostring()) + (np.product(shape) * np.abs(header['BITPIX']//8)) - 1)
+    fobj.seek(len(header.tostring()) + (np.prod(shape) * np.abs(header['BITPIX']//8)) - 1)
     fobj.write(b'\0')
 
 ##############################################################################


### PR DESCRIPTION
In numpy 1.25 several functions will be deprecated. I've either replaced the functions with like-for-like functions that aren't deprecated, or filtered the warnings in tests that should stay.

Fixes https://github.com/astropy/astropy/issues/14509.