### PR TITLE
Bugfix for ufunc getter on parameter with units

### DIFF
--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -227,9 +227,9 @@ class Gaussian1D(Fittable1DModel):
 
     @property
     def input_units(self):
-        if self.mean.unit is None:
+        if self.mean.input_unit is None:
             return None
-        return {self.inputs[0]: self.mean.unit}
+        return {self.inputs[0]: self.mean.input_unit}
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
         return {

--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -532,9 +532,13 @@ class Gaussian2D(Fittable2DModel):
 
     @property
     def input_units(self):
-        if self.x_mean.unit is None and self.y_mean.unit is None:
+        x_unit = self.x_mean.input_unit
+        y_unit = self.y_mean.input_unit
+
+        if x_unit is None and y_unit is None:
             return None
-        return {self.inputs[0]: self.x_mean.unit, self.inputs[1]: self.y_mean.unit}
+
+        return {self.inputs[0]: x_unit, self.inputs[1]: y_unit}
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
         # Note that here we need to make sure that x and y are in the same
@@ -569,9 +573,9 @@ class Shift(Fittable1DModel):
 
     @property
     def input_units(self):
-        if self.offset.unit is None:
+        if self.offset.input_unit is None:
             return None
-        return {self.inputs[0]: self.offset.unit}
+        return {self.inputs[0]: self.offset.input_unit}
 
     @property
     def inverse(self):
@@ -637,9 +641,9 @@ class Scale(Fittable1DModel):
 
     @property
     def input_units(self):
-        if self.factor.unit is None:
+        if self.factor.input_unit is None:
             return None
-        return {self.inputs[0]: self.factor.unit}
+        return {self.inputs[0]: self.factor.input_unit}
 
     @property
     def inverse(self):
@@ -856,9 +860,9 @@ class Sersic1D(Fittable1DModel):
 
     @property
     def input_units(self):
-        if self.r_eff.unit is None:
+        if self.r_eff.input_unit is None:
             return None
-        return {self.inputs[0]: self.r_eff.unit}
+        return {self.inputs[0]: self.r_eff.input_unit}
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
         return {
@@ -887,9 +891,9 @@ class _Trigonometric1D(Fittable1DModel):
 
     @property
     def input_units(self):
-        if self.frequency.unit is None:
+        if self.frequency.input_unit is None:
             return None
-        return {self.inputs[0]: 1.0 / self.frequency.unit}
+        return {self.inputs[0]: 1.0 / self.frequency.input_unit}
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
         return {
@@ -1160,9 +1164,9 @@ class _InverseTrigonometric1D(_Trigonometric1D):
 
     @property
     def input_units(self):
-        if self.amplitude.unit is None:
+        if self.amplitude.input_unit is None:
             return None
-        return {self.inputs[0]: self.amplitude.unit}
+        return {self.inputs[0]: self.amplitude.input_unit}
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
         return {
@@ -1487,9 +1491,9 @@ class Linear1D(Fittable1DModel):
 
     @property
     def input_units(self):
-        if self.intercept.unit is None and self.slope.unit is None:
+        if self.intercept.input_unit is None and self.slope.input_unit is None:
             return None
-        return {self.inputs[0]: self.intercept.unit / self.slope.unit}
+        return {self.inputs[0]: self.intercept.input_unit / self.slope.input_unit}
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
         return {
@@ -1638,9 +1642,9 @@ class Lorentz1D(Fittable1DModel):
 
     @property
     def input_units(self):
-        if self.x_0.unit is None:
+        if self.x_0.input_unit is None:
             return None
-        return {self.inputs[0]: self.x_0.unit}
+        return {self.inputs[0]: self.x_0.input_unit}
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
         return {
@@ -1800,9 +1804,9 @@ class Voigt1D(Fittable1DModel):
 
     @property
     def input_units(self):
-        if self.x_0.unit is None:
+        if self.x_0.input_unit is None:
             return None
-        return {self.inputs[0]: self.x_0.unit}
+        return {self.inputs[0]: self.x_0.input_unit}
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
         return {
@@ -2130,9 +2134,12 @@ class Ellipse2D(Fittable2DModel):
 
     @property
     def input_units(self):
-        if self.x_0.unit is None:
+        if self.x_0.input_unit is None:
             return None
-        return {self.inputs[0]: self.x_0.unit, self.inputs[1]: self.y_0.unit}
+        return {
+            self.inputs[0]: self.x_0.input_unit,
+            self.inputs[1]: self.y_0.input_unit,
+        }
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
         # Note that here we need to make sure that x and y are in the same
@@ -2212,9 +2219,12 @@ class Disk2D(Fittable2DModel):
 
     @property
     def input_units(self):
-        if self.x_0.unit is None and self.y_0.unit is None:
+        x_unit = self.x_0.input_unit
+        y_unit = self.y_0.input_unit
+
+        if x_unit is None and y_unit is None:
             return None
-        return {self.inputs[0]: self.x_0.unit, self.inputs[1]: self.y_0.unit}
+        return {self.inputs[0]: x_unit, self.inputs[1]: y_unit}
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
         # Note that here we need to make sure that x and y are in the same
@@ -2334,9 +2344,12 @@ class Ring2D(Fittable2DModel):
 
     @property
     def input_units(self):
-        if self.x_0.unit is None:
+        if self.x_0.input_unit is None:
             return None
-        return {self.inputs[0]: self.x_0.unit, self.inputs[1]: self.y_0.unit}
+        return {
+            self.inputs[0]: self.x_0.input_unit,
+            self.inputs[1]: self.y_0.input_unit,
+        }
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
         # Note that here we need to make sure that x and y are in the same
@@ -2429,9 +2442,9 @@ class Box1D(Fittable1DModel):
 
     @property
     def input_units(self):
-        if self.x_0.unit is None:
+        if self.x_0.input_unit is None:
             return None
-        return {self.inputs[0]: self.x_0.unit}
+        return {self.inputs[0]: self.x_0.input_unit}
 
     @property
     def return_units(self):
@@ -2520,9 +2533,12 @@ class Box2D(Fittable2DModel):
 
     @property
     def input_units(self):
-        if self.x_0.unit is None:
+        if self.x_0.input_unit is None:
             return None
-        return {self.inputs[0]: self.x_0.unit, self.inputs[1]: self.y_0.unit}
+        return {
+            self.inputs[0]: self.x_0.input_unit,
+            self.inputs[1]: self.y_0.input_unit,
+        }
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
         return {
@@ -2617,9 +2633,9 @@ class Trapezoid1D(Fittable1DModel):
 
     @property
     def input_units(self):
-        if self.x_0.unit is None:
+        if self.x_0.input_unit is None:
             return None
-        return {self.inputs[0]: self.x_0.unit}
+        return {self.inputs[0]: self.x_0.input_unit}
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
         return {
@@ -2687,9 +2703,13 @@ class TrapezoidDisk2D(Fittable2DModel):
 
     @property
     def input_units(self):
-        if self.x_0.unit is None and self.y_0.unit is None:
+        x_unit = self.x_0.input_unit
+        y_unit = self.y_0.input_unit
+
+        if x_unit is None and y_unit is None:
             return None
-        return {self.inputs[0]: self.x_0.unit, self.inputs[1]: self.y_0.unit}
+
+        return {self.inputs[0]: x_unit, self.inputs[1]: y_unit}
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
         # Note that here we need to make sure that x and y are in the same
@@ -2788,9 +2808,9 @@ class RickerWavelet1D(Fittable1DModel):
 
     @property
     def input_units(self):
-        if self.x_0.unit is None:
+        if self.x_0.input_unit is None:
             return None
-        return {self.inputs[0]: self.x_0.unit}
+        return {self.inputs[0]: self.x_0.input_unit}
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
         return {
@@ -2850,9 +2870,12 @@ class RickerWavelet2D(Fittable2DModel):
 
     @property
     def input_units(self):
-        if self.x_0.unit is None:
+        if self.x_0.input_unit is None:
             return None
-        return {self.inputs[0]: self.x_0.unit, self.inputs[1]: self.y_0.unit}
+        return {
+            self.inputs[0]: self.x_0.input_unit,
+            self.inputs[1]: self.y_0.input_unit,
+        }
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
         # Note that here we need to make sure that x and y are in the same
@@ -2955,9 +2978,12 @@ class AiryDisk2D(Fittable2DModel):
 
     @property
     def input_units(self):
-        if self.x_0.unit is None:
+        if self.x_0.input_unit is None:
             return None
-        return {self.inputs[0]: self.x_0.unit, self.inputs[1]: self.y_0.unit}
+        return {
+            self.inputs[0]: self.x_0.input_unit,
+            self.inputs[1]: self.y_0.input_unit,
+        }
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
         # Note that here we need to make sure that x and y are in the same
@@ -3055,9 +3081,9 @@ class Moffat1D(Fittable1DModel):
 
     @property
     def input_units(self):
-        if self.x_0.unit is None:
+        if self.x_0.input_unit is None:
             return None
-        return {self.inputs[0]: self.x_0.unit}
+        return {self.inputs[0]: self.x_0.input_unit}
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
         return {
@@ -3137,10 +3163,13 @@ class Moffat2D(Fittable2DModel):
 
     @property
     def input_units(self):
-        if self.x_0.unit is None:
+        if self.x_0.input_unit is None:
             return None
         else:
-            return {self.inputs[0]: self.x_0.unit, self.inputs[1]: self.y_0.unit}
+            return {
+                self.inputs[0]: self.x_0.input_unit,
+                self.inputs[1]: self.y_0.input_unit,
+            }
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
         # Note that here we need to make sure that x and y are in the same
@@ -3266,9 +3295,12 @@ class Sersic2D(Fittable2DModel):
 
     @property
     def input_units(self):
-        if self.x_0.unit is None:
+        if self.x_0.input_unit is None:
             return None
-        return {self.inputs[0]: self.x_0.unit, self.inputs[1]: self.y_0.unit}
+        return {
+            self.inputs[0]: self.x_0.input_unit,
+            self.inputs[1]: self.y_0.input_unit,
+        }
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
         # Note that here we need to make sure that x and y are in the same
@@ -3420,9 +3452,9 @@ class KingProjectedAnalytic1D(Fittable1DModel):
 
     @property
     def input_units(self):
-        if self.r_core.unit is None:
+        if self.r_core.input_unit is None:
             return None
-        return {self.inputs[0]: self.r_core.unit}
+        return {self.inputs[0]: self.r_core.input_unit}
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
         return {
@@ -3472,9 +3504,9 @@ class Logarithmic1D(Fittable1DModel):
 
     @property
     def input_units(self):
-        if self.tau.unit is None:
+        if self.tau.input_unit is None:
             return None
-        return {self.inputs[0]: self.tau.unit}
+        return {self.inputs[0]: self.tau.input_unit}
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
         return {
@@ -3525,9 +3557,9 @@ class Exponential1D(Fittable1DModel):
 
     @property
     def input_units(self):
-        if self.tau.unit is None:
+        if self.tau.input_unit is None:
             return None
-        return {self.inputs[0]: self.tau.unit}
+        return {self.inputs[0]: self.tau.input_unit}
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
         return {

--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -762,8 +762,17 @@ def param_repr_oneline(param):
 
 def _wrap_ufunc(ufunc):
     def _wrapper(value, raw_unit=None, orig_unit=None):
+        """
+        Wrap ufuncs to support passing in units
+            raw_unit is the unit of the value
+            orig_unit is the value after the ufunc has been applied
+            it is assumed ufunc(raw_unit) == orig_unit
+        """
         if orig_unit is not None:
-            return ufunc(value * raw_unit) * orig_unit
+            return ufunc(value) * orig_unit
+        elif raw_unit is not None:
+            return ufunc(value * raw_unit)
+
         return ufunc(value)
 
     return _wrapper

--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -342,9 +342,6 @@ class Parameter:
             # units that the parameter advertises to what it actually
             # uses internally.
             if self.internal_unit:
-                # assert self.unit == u.dimensionless_unscaled
-                # assert self.internal_unit == u.dimensionless_unscaled
-                # raise RuntimeError(f"FAIL {self._getter}, {self._internal_value}, {type(self.internal_unit)}, {type(self.unit)}, {self._description}")
                 return np.float64(
                     self._getter(
                         self._internal_value, self.internal_unit, self.unit
@@ -418,6 +415,16 @@ class Parameter:
         representation used internally.
         """
         self._internal_unit = internal_unit
+
+    @property
+    def input_unit(self):
+        """Unit for the input value."""
+        if self.internal_unit is not None:
+            return self.internal_unit
+        elif self.unit is not None:
+            return self.unit
+        else:
+            return None
 
     @property
     def quantity(self):
@@ -756,7 +763,7 @@ def param_repr_oneline(param):
 def _wrap_ufunc(ufunc):
     def _wrapper(value, raw_unit=None, orig_unit=None):
         if orig_unit is not None:
-            return ufunc(value) * orig_unit
+            return ufunc(value * raw_unit) * orig_unit
         return ufunc(value)
 
     return _wrapper

--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -342,6 +342,9 @@ class Parameter:
             # units that the parameter advertises to what it actually
             # uses internally.
             if self.internal_unit:
+                # assert self.unit == u.dimensionless_unscaled
+                # assert self.internal_unit == u.dimensionless_unscaled
+                # raise RuntimeError(f"FAIL {self._getter}, {self._internal_value}, {type(self.internal_unit)}, {type(self.unit)}, {self._description}")
                 return np.float64(
                     self._getter(
                         self._internal_value, self.internal_unit, self.unit
@@ -681,6 +684,8 @@ class Parameter:
                     "getter/setter may only take one input "
                     "argument"
                 )
+
+            return _wrap_ufunc(wrapper)
         elif wrapper is None:
             # Just allow non-wrappers to fall through silently, for convenience
             return None
@@ -746,3 +751,12 @@ def param_repr_oneline(param):
     if param.unit is not None:
         out = f"{out} {param.unit!s}"
     return out
+
+
+def _wrap_ufunc(ufunc):
+    def _wrapper(value, raw_unit=None, orig_unit=None):
+        if orig_unit is not None:
+            return ufunc(value) * orig_unit
+        return ufunc(value)
+
+    return _wrapper

--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -162,7 +162,8 @@ class Parameter:
         a function that wraps the raw (internal) value of the parameter
         when returning the value through the parameter proxy (eg. a
         parameter may be stored internally as radians but returned to the
-        user as degrees)
+        user as degrees). The internal value is what is used for computations
+        while the proxy value is what users will interact with (passing and viewing).
     setter : callable
         a function that wraps any values assigned to this parameter; should
         be the inverse of getter

--- a/astropy/modeling/physical_models.py
+++ b/astropy/modeling/physical_models.py
@@ -329,9 +329,9 @@ class Drude1D(Fittable1DModel):
 
     @property
     def input_units(self):
-        if self.x_0.unit is None:
+        if self.x_0.input_unit is None:
             return None
-        return {self.inputs[0]: self.x_0.unit}
+        return {self.inputs[0]: self.x_0.input_unit}
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
         return {
@@ -418,10 +418,13 @@ class Plummer1D(Fittable1DModel):
 
     @property
     def input_units(self):
-        if self.mass.unit is None and self.r_plum.unit is None:
+        mass_unit = self.mass.input_unit
+        r_plum_unit = self.r_plum.input_unit
+
+        if mass_unit is None and r_plum_unit is None:
             return None
-        else:
-            return {self.inputs[0]: self.r_plum.unit}
+
+        return {self.inputs[0]: r_plum_unit}
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
         return {

--- a/astropy/modeling/polynomial.py
+++ b/astropy/modeling/polynomial.py
@@ -1075,10 +1075,10 @@ class Polynomial1D(_PolyDomainWindow1D):
 
     @property
     def input_units(self):
-        if self.degree == 0 or self.c1.unit is None:
+        if self.degree == 0 or self.c1.input_unit is None:
             return None
         else:
-            return {self.inputs[0]: self.c0.unit / self.c1.unit}
+            return {self.inputs[0]: self.c0.input_unit / self.c1.input_unit}
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
         mapping = {}
@@ -1296,11 +1296,13 @@ class Polynomial2D(PolynomialModel):
 
     @property
     def input_units(self):
-        if self.degree == 0 or (self.c1_0.unit is None and self.c0_1.unit is None):
+        if self.degree == 0 or (
+            self.c1_0.input_unit is None and self.c0_1.input_unit is None
+        ):
             return None
         return {
-            self.inputs[0]: self.c0_0.unit / self.c1_0.unit,
-            self.inputs[1]: self.c0_0.unit / self.c0_1.unit,
+            self.inputs[0]: self.c0_0.input_unit / self.c1_0.input_unit,
+            self.inputs[1]: self.c0_0.input_unit / self.c0_1.input_unit,
         }
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):

--- a/astropy/modeling/powerlaws.py
+++ b/astropy/modeling/powerlaws.py
@@ -68,9 +68,9 @@ class PowerLaw1D(Fittable1DModel):
 
     @property
     def input_units(self):
-        if self.x_0.unit is None:
+        if self.x_0.input_unit is None:
             return None
-        return {self.inputs[0]: self.x_0.unit}
+        return {self.inputs[0]: self.x_0.input_unit}
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
         return {
@@ -141,9 +141,9 @@ class BrokenPowerLaw1D(Fittable1DModel):
 
     @property
     def input_units(self):
-        if self.x_break.unit is None:
+        if self.x_break.input_unit is None:
             return None
-        return {self.inputs[0]: self.x_break.unit}
+        return {self.inputs[0]: self.x_break.input_unit}
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
         return {
@@ -383,9 +383,9 @@ class SmoothlyBrokenPowerLaw1D(Fittable1DModel):
 
     @property
     def input_units(self):
-        if self.x_break.unit is None:
+        if self.x_break.input_unit is None:
             return None
-        return {self.inputs[0]: self.x_break.unit}
+        return {self.inputs[0]: self.x_break.input_unit}
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
         return {
@@ -449,9 +449,9 @@ class ExponentialCutoffPowerLaw1D(Fittable1DModel):
 
     @property
     def input_units(self):
-        if self.x_0.unit is None:
+        if self.x_0.input_unit is None:
             return None
-        return {self.inputs[0]: self.x_0.unit}
+        return {self.inputs[0]: self.x_0.input_unit}
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
         return {
@@ -518,9 +518,9 @@ class LogParabola1D(Fittable1DModel):
 
     @property
     def input_units(self):
-        if self.x_0.unit is None:
+        if self.x_0.input_unit is None:
             return None
-        return {self.inputs[0]: self.x_0.unit}
+        return {self.inputs[0]: self.x_0.input_unit}
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
         return {
@@ -647,9 +647,9 @@ class Schechter1D(Fittable1DModel):
 
     @property
     def input_units(self):
-        if self.m_star.unit is None:
+        if self.m_star.input_unit is None:
             return None
-        return {self.inputs[0]: self.m_star.unit}
+        return {self.inputs[0]: self.m_star.input_unit}
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
         return {

--- a/astropy/modeling/projections.py
+++ b/astropy/modeling/projections.py
@@ -1633,12 +1633,15 @@ class AffineTransformation2D(Model):
 
     @property
     def input_units(self):
-        if self.translation.unit is None and self.matrix.unit is None:
+        translation_unit = self.translation.input_unit
+        matrix_unit = self.matrix.input_unit
+
+        if translation_unit is None and matrix_unit is None:
             return None
-        elif self.translation.unit is not None:
-            return dict(zip(self.inputs, [self.translation.unit] * 2))
+        elif translation_unit is not None:
+            return dict(zip(self.inputs, [translation_unit] * 2))
         else:
-            return dict(zip(self.inputs, [self.matrix.unit] * 2))
+            return dict(zip(self.inputs, [matrix_unit] * 2))
 
 
 for long_name, short_name in _PROJ_NAME_CODE:

--- a/astropy/modeling/tests/test_parameters.py
+++ b/astropy/modeling/tests/test_parameters.py
@@ -723,7 +723,14 @@ class TestParameters:
         with pytest.raises(TypeError, match=MESSAGE):
             param._create_value_wrapper(np.add, mk.MagicMock())
         # Good ufunc
-        assert param._create_value_wrapper(np.negative, mk.MagicMock()) == np.negative
+        with mk.patch(
+            "astropy.modeling.parameters._wrap_ufunc", autospec=True
+        ) as mkWrap:
+            assert (
+                param._create_value_wrapper(np.negative, mk.MagicMock())
+                == mkWrap.return_value
+            )
+            assert mkWrap.call_args_list == [mk.call(np.negative)]
 
         # None
         assert param._create_value_wrapper(None, mk.MagicMock()) is None

--- a/astropy/modeling/tests/test_quantities_parameters.py
+++ b/astropy/modeling/tests/test_quantities_parameters.py
@@ -347,6 +347,9 @@ def test_magunit_parameter():
 def test_log_getter():
     """Regression test for issue #14511"""
 
+    x = 6000 * u.AA
+    mdl_base = BlackBody(temperature=5000 * u.K, scale=u.Quantity(1))
+
     class CustomBlackBody(BlackBody):
         scale = Parameter(
             "scale",
@@ -357,4 +360,44 @@ def test_log_getter():
             unit=u.dimensionless_unscaled,
         )
 
-    CustomBlackBody(temperature=5000 * u.K, scale=u.Quantity(1))
+    mdl = CustomBlackBody(temperature=5000 * u.K, scale=u.Quantity(np.log(1)))
+    assert mdl.scale == np.log(1)
+    assert_quantity_allclose(mdl(x), mdl_base(x))
+
+
+def test_sqrt_getter():
+    """Regression test for issue #14511"""
+
+    x = 1 * u.m
+    mdl_base = Gaussian1D(mean=32 * u.m, stddev=3 * u.m)
+
+    class CustomGaussian1D(Gaussian1D):
+        mean = Parameter(
+            "mean",
+            default=1 * u.m,
+            bounds=(0, None),
+            getter=np.sqrt,
+            setter=np.square,
+            unit=u.m,
+        )
+        stddev = Parameter(
+            "stddev",
+            default=1 * u.m,
+            bounds=(0, None),
+            getter=np.sqrt,
+            setter=np.square,
+            unit=u.m,
+        )
+
+    mdl = CustomGaussian1D(mean=np.sqrt(32 * u.m), stddev=np.sqrt(3 * u.m))
+    assert mdl.mean == np.sqrt(32 * u.m)
+    assert (
+        mdl.mean._internal_value == np.sqrt(32) ** 2
+    )  # numerical inaccuracy results in 32.00000000000001
+    assert mdl.mean._internal_unit == u.m
+    assert mdl.stddev == np.sqrt(3 * u.m)
+    assert (
+        mdl.stddev._internal_value == np.sqrt(3) ** 2
+    )  # numerical inaccuracy results in 3.0000000000000004
+    assert mdl.stddev._internal_unit == u.m
+    assert_quantity_allclose(mdl(x), mdl_base(x))

--- a/astropy/modeling/tests/test_quantities_parameters.py
+++ b/astropy/modeling/tests/test_quantities_parameters.py
@@ -350,8 +350,8 @@ def test_log_getter():
     class CustomBlackBody(BlackBody):
         scale = Parameter(
             "scale",
-            default=0,
-            bounds=(-1000, 1000),
+            default=1,
+            bounds=(0, None),
             getter=np.log,
             setter=np.exp,
             unit=u.dimensionless_unscaled,

--- a/astropy/modeling/tests/test_quantities_parameters.py
+++ b/astropy/modeling/tests/test_quantities_parameters.py
@@ -15,6 +15,7 @@ from astropy.modeling.models import (
     Pix2Sky_TAN,
     RotateNative2Celestial,
     Rotation2D,
+    BlackBody,
 )
 from astropy.modeling.parameters import Parameter, ParameterDefinitionError
 from astropy.tests.helper import assert_quantity_allclose
@@ -341,3 +342,19 @@ def test_magunit_parameter():
     model = Const1D(c)
 
     assert model(-23.0 * unit) == c
+
+
+def test_log_getter():
+    """Regression test for issue #14511"""
+
+    class CustomBlackBody(BlackBody):
+        scale = Parameter(
+            "scale",
+            default=0,
+            bounds=(-1000, 1000),
+            getter=np.log,
+            setter=np.exp,
+            unit=u.dimensionless_unscaled,
+        )
+
+    CustomBlackBody(temperature=5000 * u.K, scale=u.Quantity(1))

--- a/docs/changes/modeling/14512.bugfix.rst
+++ b/docs/changes/modeling/14512.bugfix.rst
@@ -1,0 +1,2 @@
+Bugfix for using ``getter/setter`` in properties to adjust the internal (computational)
+value of a property vs its external proxy value when the values involve units.


### PR DESCRIPTION
### Description
This pull request addresses the first problem raised in #14511; namely, that when a `ufunc` is set to be the `getter` for a `Parameter` object with units, and a new value with a unit is set, then then an error is raised due to miss-matching interfaces.

This PR resolves the issue by wrapping `ufuncs` in a function which facilitates the correct interface.