### PR TITLE
BUG: ignore io.misc.asdf tests for asdf >= 3.0.0.dev

### DIFF
--- a/astropy/io/misc/asdf/conftest.py
+++ b/astropy/io/misc/asdf/conftest.py
@@ -4,9 +4,13 @@ from astropy.utils.introspection import minversion
 
 
 def get_asdf_tests():
+    # return a list of filenames for all ".py" files in this
+    # directory and recursively in every sub directory. These
+    # are the files that pytest will import while attempting
+    # to find tests. This list is used below to ignore all of
+    # these files if an incompatible version of ASDF is installed
     asdf_dir = Path(__file__).parent.resolve()
-    paths = Path(asdf_dir).rglob("test_*.py")
-
+    paths = Path(asdf_dir).rglob("*.py")
     return [str(p.relative_to(asdf_dir)) for p in paths]
 
 


### PR DESCRIPTION


### Description

ASDF has begun 3.0 development which includes removing deprecated features used by `astropy.io.misc.asdf`.

#12905 introduced checks to ignore `io.misc.asdf` tests for ASDF versions >= 3.0. This PR builds upon those changes to include ignoring non-test python files within `io.misc.asdf` to avoid errors that will occur when those files are imported during test discovery. Examples of these errors can be seen in the ASDF PR removing the relied upon legacy features:
https://github.com/asdf-format/asdf/pull/1464
which show failures in downstream testing of astropy
https://github.com/asdf-format/asdf/actions/runs/4385550995/jobs/7678448225

Additionally, the main development branch for ASDF is currently tagged as `3.0.0.dev`, this PR fixes the version check in the `astropy.io.misc.asdf` `conftest.py` to identify this as a 3.0 version.
