### PR TITLE
Release: Drop i686 wheels

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,11 +51,6 @@ jobs:
       targets: |
         # Linux wheels
 
-        - cp38-manylinux_i686
-        - cp39-manylinux_i686
-        # - cp310*manylinux_i686  # We can't build this as PyYAML doesn't have i686 wheels for 3.10 yet so the build takes too long
-        # - cp311*manylinux_i686
-
         - cp38-manylinux_x86_64
         - cp39-manylinux_x86_64
         - cp310-manylinux_x86_64

--- a/docs/changes/14517.other.rst
+++ b/docs/changes/14517.other.rst
@@ -1,0 +1,1 @@
+``astropy`` no longer publishes wheels for i686 architecture.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,13 +30,6 @@ test-skip = "*-macosx_arm64 *-manylinux_aarch64 *-musllinux_x86_64"
 # set this for Python<=3.10.
 select = "cp3{8,9,10}-*"
 manylinux-x86_64-image = "manylinux2010"
-manylinux-i686-image = "manylinux2010"
-
-[[tool.cibuildwheel.overrides]]
-# Numpy 1.22 doesn't have wheels for i386, so we pin Numpy to an older version
-# that does - this pin can be removed once we drop support for 32-bit wheels.
-select = "cp3{8,9}-*"
-test-requires = "numpy==1.21.*"
 
 [tool.cibuildwheel.macos]
 archs = ["x86_64", "arm64"]


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to drop building wheels for i686 because numpy no longer does it either.

This hopefully is much less controversial than #14513.