### PR TITLE
Bugfix: propagation of measurement uncertainties into parameter covariances

### DIFF
--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -1317,9 +1317,14 @@ class _NonLinearLSQFitter(metaclass=_FitterMeta):
         z : array, optional
            input coordinates
         weights : array, optional
-            Weights for fitting.
-            For data with Gaussian uncertainties, the weights should be
-            1/sigma.
+            Weights for fitting. For data with Gaussian uncertainties, the weights
+            should be 1/sigma.
+
+            .. versionchanged:: 5.3
+                Calculate parameter covariances while accounting for ``weights``
+                as "absolute" inverse uncertainties. To recover the old behavior,
+                choose ``weights=None``.
+
         maxiter : int
             maximum number of iterations
         acc : float

--- a/docs/changes/modeling/14519.api.rst
+++ b/docs/changes/modeling/14519.api.rst
@@ -1,0 +1,2 @@
+Propagate measurement uncertainties via the ``weights`` keyword argument into the
+parameter covariances.

--- a/docs/whatsnew/5.3.rst
+++ b/docs/whatsnew/5.3.rst
@@ -19,6 +19,7 @@ In particular, this release includes:
 .. * :ref:`whatsnew-5.3-unit-formats-fraction`
 .. * :ref:`whatsnew-5.3-unit-formats-order`
 .. * :ref:`whatsnew-5.3-nddata-collapse-arbitrary-axes`
+.. * :ref:`whatsnew-5.3-modeling-measurement-uncertainties`
 .. * :ref:`whatsnew-5.3-coordinates-refresh-site-registry`
 
 In addition to these major changes, Astropy v5.3 includes a large number of
@@ -198,6 +199,7 @@ we can take the sum of ND masked quantities along the ``1`` axis like so::
      array([ True, False]),
      StdDevUncertainty([1.41421356, 1.73205081]))
 
+
 .. _whatsnew-5.3-coordinates-refresh-site-registry:
 
 Refresh cached observatory site registry for |EarthLocation| methods
@@ -213,6 +215,16 @@ user's computer for quick access.  The online version of the registry,
 however, is updated from time to time to include new locations.  The user
 may refresh their locally cached site registry by passing the new
 ``refresh_cache=True`` option to these two functions.
+
+.. _whatsnew-5.3-modeling-measurement-uncertainties:
+
+Support for collapse operations on arbitrary axes in ``nddata``
+===============================================================
+
+Propagate measurement uncertainties into the best-fit parameter covariances
+via the ``weights`` keyword argument in non-linear fitters. Decreasing
+the ``weights`` will now increase the uncertainties on the best-fit parameters.
+
 
 Full change log
 ===============


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

`astropy.modeling` can fit nonlinear models to observations with uncertainties, and return best-fit parameters and their covariances. However, if you increase the measurement uncertainties and re-run the fit, you will find that the parameter covariances do not respond to the changing uncertainties. An example is collapsed below.

<details><summary>Example</summary>
<p>

# Example

The code below currently runs without error on `main`, meaning the parameter covariance does not respond to increases in the uncertainties in the observations:

```python
import numpy as np
import matplotlib.pyplot as plt

from astropy.modeling import fitting
from astropy.modeling.models import Linear1D

linear_model = Linear1D()
fitter = fitting.LMLSQFitter(calc_uncertainties=True)

err_scales = np.geomspace(1, 100, 10)

np.random.seed(42)
x = np.linspace(0, 1)
yerrs = np.random.normal(
    loc=0.1, 
    scale=0.01, 
    size=x.size
)
true_slope, true_intercept = 2, 3

y = np.random.normal(
    loc=true_slope * x + true_intercept, 
    scale=yerrs,
    size=x.size
)

uncertainties = []

for err_scale in err_scales:
    fit_model = fitter(
        linear_model, x, y, weights=1/err_scale/yerrs
    )

    uncertainties.append(fit_model.intercept.std)
    
# this assert block should FAIL because we don't expect the
# best-fit parameter uncertainties to be identical as we 
# increase the measurement uncertainties:
for i in range(1, len(uncertainties)):
    np.testing.assert_almost_equal(uncertainties[0], uncertainties[i])
```
If the code were working correctly, the parameter uncertainties should increase.
***
</p>
</details>

This problem arises because `astropy.modeling.fitting` renormalizes the covariance matrix on these lines:

https://github.com/astropy/astropy/blob/eccdccfdf332ecb9b3889cc14fb798f79eadd379/astropy/modeling/fitting.py#L1246-L1248

An analogous normalization is done in [scipy's curve_fit](https://github.com/scipy/scipy/blob/c1ed5ece8ffbf05356a22a8106affcd11bd3aee0/scipy/optimize/_minpack_py.py#L899-L900) but _only_ in the case where `absolute_sigma == False`. We can see from [the definition of this argument in the curve_fit docstring](https://github.com/scipy/scipy/blob/c1ed5ece8ffbf05356a22a8106affcd11bd3aee0/scipy/optimize/_minpack_py.py#L591-L602) that this choice is equivalent to assuming that only the _relative_ scale of the uncertainties matters, not their actual ("absolute") values. 

This is not how I (or most astronomers?) might expect the `weight = 1 / sigma` parameter in `astropy.modeling` to behave. Usually when we bother to specify uncertainties, we are giving "absolute" ones, not "relative" ones.

This PR preserves the current behavior if no measurement uncertainties are provided via the `weights` kwarg. If `weights is not None`, the renormalization for "relative" sigmas is skipped, and the measurement uncertainties affect the covariance matrix. 

I've added a test with an ordinary least squares example with heteroscedastic errors, and check that the resulting covariances are correct.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->