### PR TITLE
Fix missing .shape check for array data

### DIFF
--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -264,19 +264,16 @@ class _ImageBaseHDU(_ValidHDU):
             self._data_replaced = True
             was_unsigned = False
 
-        if (
-            data is not None
-            and not isinstance(data, np.ndarray)
-            and not _is_dask_array(data)
-        ):
-            # Try to coerce the data into a numpy array--this will work, on
-            # some level, for most objects
-            try:
-                data = np.array(data)
-            except Exception:
-                raise TypeError(
-                    f"data object {data!r} could not be coerced into an ndarray"
-                )
+        if data is not None:
+            if not isinstance(data, np.ndarray) and not _is_dask_array(data):
+                # Try to coerce the data into a numpy array--this will work, on
+                # some level, for most objects
+                try:
+                    data = np.array(data)
+                except Exception:  # pragma: no cover
+                    raise TypeError(
+                        f"data object {data!r} could not be coerced into an " f"ndarray"
+                    )
 
             if data.shape == ():
                 raise TypeError(

--- a/astropy/io/fits/tests/test_hdulist.py
+++ b/astropy/io/fits/tests/test_hdulist.py
@@ -547,11 +547,14 @@ class TestHDUListFunctions(FitsTestCase):
 
         h0 = fits.Header()
         hdu = fits.PrimaryHDU(header=h0)
-        sci = fits.ImageHDU(data=np.array(10))
-        image = fits.HDUList([hdu, sci])
-        image.writeto(self.temp("temp.fits"))
+        sci = fits.ImageHDU(data=np.array([10]))
+        hdul = fits.HDUList([hdu, sci])
         assert "EXTEND" in hdu.header
         assert hdu.header["EXTEND"] is True
+        hdul.writeto(self.temp("temp.fits"))
+        hdr = fits.getheader(self.temp("temp.fits"))
+        assert "EXTEND" in hdr
+        assert hdr["EXTEND"] is True
 
     def test_replace_memmaped_array(self, home_is_temp):
         # Copy the original before we modify it

--- a/astropy/io/fits/tests/test_image.py
+++ b/astropy/io/fits/tests/test_image.py
@@ -1126,6 +1126,11 @@ class TestImageFunctions(FitsTestCase):
             fits.ImageHDU(data=1)
         with pytest.raises(TypeError, match=msg):
             fits.PrimaryHDU(data=1)
+        # Regression test for https://github.com/astropy/astropy/issues/14527
+        with pytest.raises(TypeError, match=msg):
+            fits.ImageHDU(data=np.array(1))
+        with pytest.raises(TypeError, match=msg):
+            fits.PrimaryHDU(data=np.array(1))
 
 
 class TestCompressedImage(FitsTestCase):

--- a/docs/changes/io.fits/14528.bugfix.rst
+++ b/docs/changes/io.fits/14528.bugfix.rst
@@ -1,0 +1,1 @@
+``ImageHDU`` now properly rejects Numpy scalars, avoiding data corruption.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address `ImageHDU` missing a necessary check for zero-dimensional data.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #14527
