### PR TITLE
Update circvar docstring for scipy updates

### DIFF
--- a/astropy/stats/circstats.py
+++ b/astropy/stats/circstats.py
@@ -151,9 +151,11 @@ def circvar(data, axis=None, weights=None):
 
     Notes
     -----
-    The definition used here differs from the one in scipy.stats.circvar.
-    Precisely, Scipy circvar uses an approximation based on the limit of small
-    angles which approaches the linear variance.
+    For Scipy < 1.9.0, ``scipy.stats.circvar`` uses a different
+    definition based on an approximation using the limit of small
+    angles that approaches the linear variance. For Scipy >= 1.9.0,
+    ``scipy.stats.cirvar`` uses a definition consistent with this
+    implementation.
     """
     return 1.0 - _length(data, 1, 0.0, axis, weights)
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This PR updates the notes in the `circvar` docstring to reflect that `scipy.stats.circvar` now uses the same definition for scipy >= 1.9.0.  xref: https://github.com/astropy/astropy/issues/13749#issuecomment-1466429048

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->
