### PR TITLE
Improve toctree on coordinates landing page

### DIFF
--- a/docs/coordinates/index.rst
+++ b/docs/coordinates/index.rst
@@ -30,9 +30,6 @@ optional velocities) with specified units and a coordinate frame. Sky positions
 are commonly passed in as `~astropy.units.Quantity` objects and the frame is
 specified with the string name.
 
-Example
--------
-
 ..
   EXAMPLE START
   Using the SkyCoord Class
@@ -144,9 +141,6 @@ Transformation
 One convenient way to transform to a new coordinate frame is by accessing
 the appropriately named attribute.
 
-Example
-^^^^^^^
-
 ..
   EXAMPLE START
   Transforming to a New Coordinate Frame
@@ -196,9 +190,6 @@ representation such as Cartesian or Cylindrical. This can be done by setting
 the ``representation_type`` for either |SkyCoord| objects or low-level frame
 coordinate objects.
 
-Example
-^^^^^^^
-
 ..
   EXAMPLE START
   Working with Nonspherical Coordinate Representations
@@ -230,9 +221,6 @@ Distance
 from the frame origin. The origin depends on the particular coordinate frame;
 this can be, for example, centered on the earth, centered on the solar system
 barycenter, etc.
-
-Examples
-^^^^^^^^
 
 ..
   EXAMPLE START
@@ -266,9 +254,6 @@ Convenience Methods
 
 |SkyCoord| defines a number of convenience methods that support, for example,
 computing on-sky (i.e., angular) and 3D separations between two coordinates.
-
-Examples
-^^^^^^^^
 
 ..
   EXAMPLE START

--- a/docs/coordinates/performance.inc.rst
+++ b/docs/coordinates/performance.inc.rst
@@ -23,9 +23,6 @@ single |SkyCoord| with arrays of values as opposed to looping over the
 Finally, for more advanced users, note that you can use broadcasting to
 transform |SkyCoord| objects into frames with vector properties.
 
-Example
--------
-
 ..
   EXAMPLE START
   Performance Tips for Transforming SkyCoord Objects


### PR DESCRIPTION
Currently the table of contents for the coordinates landing page is hard to parse:

![Screenshot 2023-03-22 at 14 23 55](https://user-images.githubusercontent.com/6197628/226934434-a0ad5f7a-f35e-423a-a534-0fed7df349f5.png)

This PR removes the "Examples" section headings, making for a slightly nicer and easier to read table of contents:
![Screenshot 2023-03-22 at 14 24 40](https://user-images.githubusercontent.com/6197628/226934672-4023ed95-c2a0-47ec-bc5a-7dba3fab3021.png)

