### PR TITLE
TST: Relax pyerfa pin for oldestdeps, skip URL in linkcheck (v5.0.x only)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -382,6 +382,7 @@ linkcheck_ignore = [
     "https://aa.usno.navy.mil/publications/docs/Circular_179.php",
     "http://data.astropy.org",
     "https://doi.org/",  # CI blocked by service provider
+    "https://ui.adsabs.harvard.edu",  # CI blocked by service provider
     "https://www.tandfonline.com/",  # 403 Client Error: Forbidden
     "https://physics.nist.gov/",  # SSL: CERTIFICATE_VERIFY_FAILED
     "https://pyfits.readthedocs.io/en/v3.2.1/",  # defunct page in CHANGES.rst

--- a/tox.ini
+++ b/tox.ini
@@ -73,7 +73,7 @@ deps =
 
     # The oldestdeps factor is intended to be used to install the oldest versions of all
     # dependencies that have a minimum version.
-    oldestdeps: pyerfa==2.0.0.1
+    oldestdeps: pyerfa==2.0.*
     oldestdeps: numpy==1.18.*
     oldestdeps: matplotlib==3.1.*
     oldestdeps: asdf==2.9.2


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to relax the pyerfa pin added in #14562 because pyerfa 2.0.0.3 is now released that reverted their numpy minversion change. This PR also excludes `ui.adsabs.harvard.edu` from linkcheck because I think they blocking our CI.

This patch is directly for v5.0.x. Separate PR will be made for main and v5.2.x (those were not affected by pyerfa 2.0.0.2 release).

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->