### PR TITLE
TST: Apparently Danbury CT moved a little

### DIFF
--- a/docs/coordinates/index.rst
+++ b/docs/coordinates/index.rst
@@ -363,7 +363,7 @@ names, city names, etc:
     >>> EarthLocation.of_address('1002 Holy Grail Court, St. Louis, MO')  # doctest: +FLOAT_CMP
     <EarthLocation (-26769.86528679, -4997007.71191864, 3950273.57633915) m>
     >>> EarthLocation.of_address('Danbury, CT')  # doctest: +FLOAT_CMP
-    <EarthLocation ( 1364606.64511651, -4593292.9428273,  4195415.93695139) m>
+    <EarthLocation (1362610.66896362, -4590755.48088484, 4198817.69912853) m>
 
 By default the `OpenStreetMap Nominatim service
 <https://wiki.openstreetmap.org/wiki/Nominatim>`_ is used, but by providing a


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

Apparently Danbury CT moved a little so we update the doctest. Otherwise, this failure will pop up in the remote data job:

```
_____________________________ [doctest] index.rst ______________________________
341 For arbitrary Earth addresses (e.g., not observatory sites), use the
342 :func:`~astropy.coordinates.EarthLocation.of_address` classmethod to retrieve
343 the latitude and longitude. This works with fully specified addresses, location
344 names, city names, etc:
345 
346 .. doctest-remote-data::
347 
348     >>> EarthLocation.of_address('1002 Holy Grail Court, St. Louis, MO')  # doctest: +FLOAT_CMP
349     <EarthLocation (-26769.86528679, -4997007.71191864, 3950273.57633915) m>
350     >>> EarthLocation.of_address('Danbury, CT')  # doctest: +FLOAT_CMP
Expected:
    <EarthLocation ( 1364606.64511651, -4593292.9428273,  4195415.93695139) m>
Got:
    <EarthLocation (1362610.66896362, -4590755.48088484, 4198817.69912853) m>
```

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->
