### PR TITLE
Do not explicitly call gc.collect in `CompImageHDU.compressed_data`

### DIFF
--- a/astropy/io/fits/hdu/compressed.py
+++ b/astropy/io/fits/hdu/compressed.py
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see PYFITS.rst
 
 import ctypes
-import gc
 import itertools
 import math
 import re
@@ -1606,12 +1605,6 @@ class CompImageHDU(BinTableHDU):
             # lazyproperty.__delete__ does this for us, but we can prempt it to
             # do some additional cleanup
             del self.__dict__["compressed_data"]
-
-            # If this file was mmap'd, numpy.memmap will hold open a file
-            # handle until the underlying mmap object is garbage-collected;
-            # since this reference leak can sometimes hang around longer than
-            # welcome go ahead and force a garbage collection
-            gc.collect()
 
     @property
     def shape(self):

--- a/docs/changes/io.fits/14576.feature.rst
+++ b/docs/changes/io.fits/14576.feature.rst
@@ -1,0 +1,2 @@
+Do not call ``gc.collect()`` when closing a ``CompImageHDU`` object as it has a
+large performance penalty.


### PR DESCRIPTION
I have a nice pathological benchmark where I load 150 files and read all the data:

Before:

```
$ python run_timeit.py dkist_visp_tiled_post
Using DKIST dataset (BEJZP) with shape: (4, 18, 150, 996, 2545)
FITS tile shape is (1, 256, 256) (numpy order).
Ran dkist_visp_tiled_post 5 times, average time 27.755185409799743 s
```

After:

```
$ python run_timeit.py dkist_visp_tiled_post
Using DKIST dataset (BEJZP) with shape: (4, 18, 150, 996, 2545)
FITS tile shape is (1, 256, 256) (numpy order).
Ran dkist_visp_tiled_post 5 times, average time 4.998688907800533 s
```

We already discuss the reason why this line exists pretty comprehensively in the docs here: https://docs.astropy.org/en/stable/io/fits/appendix/faq.html#i-am-opening-many-fits-files-in-a-loop-and-getting-oserror-too-many-open-files

I am not really sure I see the benefit of this still being here?