### PR TITLE
Support VLA columns with FITS Unified IO

### DIFF
--- a/astropy/io/fits/tests/test_connect.py
+++ b/astropy/io/fits/tests/test_connect.py
@@ -414,6 +414,61 @@ class TestSingleTable:
         tab = Table.read(filename, mask_invalid=False)
         assert tab.mask is None
 
+    def test_heterogeneous_VLA_tables(self, tmp_path):
+        """
+        Check the behaviour of heterogeneous VLA object.
+        """
+        filename = tmp_path / "test_table_object.fits"
+        msg = "Column 'col1' contains unsupported object types or mixed types: "
+
+        # The column format fix the type of the arrays in the VLF object.
+        a = np.array([45, 30])
+        b = np.array([11.0, 12.0, 13])
+        var = np.array([a, b], dtype=object)
+        tab = Table({"col1": var})
+        with pytest.raises(TypeError, match=msg):
+            tab.write(filename)
+
+        # Strings in the VLF object can't be added to the table
+        a = np.array(["five", "thirty"])
+        b = np.array([11.0, 12.0, 13])
+        var = np.array([a, b], dtype=object)
+        with pytest.raises(TypeError, match=msg):
+            tab.write(filename)
+
+    def test_write_object_tables_with_unified(self, tmp_path):
+        """
+        Write objects with the unified I/O interface.
+        See https://github.com/astropy/astropy/issues/1906
+        """
+        filename = tmp_path / "test_table_object.fits"
+        msg = r"Column 'col1' contains unsupported object types or mixed types: {dtype\('O'\)}"
+        # Make a FITS table with an object column
+        tab = Table({"col1": [None]})
+        with pytest.raises(TypeError, match=msg):
+            tab.write(filename)
+
+    def test_write_VLA_tables_with_unified(self, tmp_path):
+        """
+        Write VLA objects with the unified I/O interface.
+        See https://github.com/astropy/astropy/issues/11323
+        """
+
+        filename = tmp_path / "test_table_VLA.fits"
+        # Make a FITS table with a variable-length array column
+        a = np.array([45, 30])
+        b = np.array([11, 12, 13])
+        c = np.array([45, 55, 65, 75])
+        var = np.array([a, b, c], dtype=object)
+
+        tabw = Table({"col1": var})
+        tabw.write(filename)
+
+        tab = Table.read(filename)
+        assert np.array_equal(tab[0]["col1"], np.array([45, 30]))
+        assert np.array_equal(tab[1]["col1"], np.array([11, 12, 13]))
+        assert np.array_equal(tab[2]["col1"], np.array([45, 55, 65, 75]))
+
 
 class TestMultipleHDU:
     def setup_class(self):

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -3313,6 +3313,31 @@ class TestVLATables(FitsTestCase):
                 hdus[1].data["test"][1], np.array([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]])
             )
 
+    def test_heterogeneous_VLA_tables(self):
+        """
+        Check the behaviour of heterogeneous VLA object.
+        """
+
+        # The column format fix the type of the arrays in the VLF object.
+        a = np.array([45, 30])
+        b = np.array([11.0, 12.0, 13])
+        var = np.array([a, b], dtype=object)
+
+        c1 = fits.Column(name="var", format="PJ()", array=var)
+        hdu = fits.BinTableHDU.from_columns([c1])
+        assert hdu.data[0].array.dtype[0].subdtype[0] == "int32"
+
+        # Strings in the VLF object can't be added to the table
+        a = np.array([45, "thirty"])
+        b = np.array([11.0, 12.0, 13])
+        var = np.array([a, b], dtype=object)
+
+        c1 = fits.Column(name="var", format="PJ()", array=var)
+        with pytest.raises(
+            ValueError, match=r"invalid literal for int\(\) with base 10"
+        ):
+            fits.BinTableHDU.from_columns([c1])
+
 
 # These are tests that solely test the Column and ColDefs interfaces and
 # related functionality without directly involving full tables; currently there

--- a/docs/changes/io.fits/14578.feature.rst
+++ b/docs/changes/io.fits/14578.feature.rst
@@ -1,0 +1,3 @@
+VLA tables can now be written with the unified I/O interface.
+When object types are present or the VLA contains different types a `TypeError`
+is thrown.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request remove the  VLA illegal format object warning when writing of VLA tables with the unified I/O interface.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes https://github.com/astropy/astropy/issues/11323
Fixes #1906
