### PR TITLE
BUG: fix asdf 3.0 version check

### DIFF
--- a/astropy/io/misc/asdf/conftest.py
+++ b/astropy/io/misc/asdf/conftest.py
@@ -20,5 +20,5 @@ try:
 except ImportError:
     pass
 else:
-    if not minversion(asdf, "3.0.0"):
+    if not minversion(asdf, "3.0.0.dev"):
         collect_ignore = []


### PR DESCRIPTION
### Description

The fix initially included in https://github.com/astropy/astropy/pull/14516 was lost during the squash or a subsequent commit.

This PR reintroduces the corrected ASDF version check to prevent running asdf.io.misc.asdf tests for ASDF 3.0.
