### PR TITLE
Fix `astropy` citations

### DIFF
--- a/astropy/CITATION
+++ b/astropy/CITATION
@@ -111,7 +111,7 @@ archivePrefix = {arXiv},
 	{Buddelmeijer}, H. and {Burke}, D.~J. and {Calderone}, G. and
 	{Cano Rodr{\'{\i}}guez}, J.~L. and {Cara}, M. and {Cardoso}, J.~V.~M. and
 	{Cheedella}, S. and {Copin}, Y. and {Corrales}, L. and {Crichton}, D. and
-	{D{\rsquo}Avella}, D. and {Deil}, C. and {Depagne}, {\'E}. and
+	{D{\'A}vella}, D. and {Deil}, C. and {Depagne}, {\'E}. and
 	{Dietrich}, J.~P. and {Donath}, A. and {Droettboom}, M. and
 	{Earl}, N. and {Erben}, T. and {Fabbro}, S. and {Ferreira}, L.~A. and
 	{Finethy}, T. and {Fox}, R.~T. and {Garrison}, L.~H. and {Gibbons}, S.~L.~J. and

--- a/astropy/CITATION
+++ b/astropy/CITATION
@@ -97,7 +97,7 @@ archivePrefix = {arXiv},
 }
 
 @ARTICLE{astropy:2018,
-   author = {{The Astropy Collaboration} and {Price-Whelan}, A.~M. and {Sip{\H o}cz}, B.~M. and
+   author = {{Astropy Collaboration} and {Price-Whelan}, A.~M. and {Sip{\H o}cz}, B.~M. and
 	{G{\"u}nther}, H.~M. and {Lim}, P.~L. and {Crawford}, S.~M. and
 	{Conseil}, S. and {Shupe}, D.~L. and {Craig}, M.~W. and {Dencheva}, N. and
 	{Ginsburg}, A. and {VanderPlas}, J.~T. and {Bradley}, L.~D. and


### PR DESCRIPTION
### Description

Currently the first author of the `astropy` 2013 and 2022 papers is `Astropy Collaboration`:
https://github.com/astropy/astropy/blob/9bcaf0d5288e9e87e5b3177fe2cdac89798b878a/astropy/CITATION#L39
https://github.com/astropy/astropy/blob/9bcaf0d5288e9e87e5b3177fe2cdac89798b878a/astropy/CITATION#L158
But the first author of the 2018 paper is `The Astropy Collaboration`:
https://github.com/astropy/astropy/blob/9bcaf0d5288e9e87e5b3177fe2cdac89798b878a/astropy/CITATION#L100
Because of this the citations appear in a compiled LaTeX file as needlessly verbose
> (Astropy Collaboration et al. 2013; The Astropy Collaboration et al. 2018; Astropy Collaboration et al. 2022)

instead of the intended

> (Astropy Collaboration et al. 2013, 2018, 2022)

Furthermore, in 67d87536f182efe436f4af54429b6550fe95a001 the name of a contributor was changed from `D{\'A}vella` to `D{\rsquo}Avella`, which causes a compilation error. I couldn't find any explanation why that change was made, so I restored the previous name that doesn't cause problems for LaTeX.