### PR TITLE
Add strict arg to Time.to_datetime() for leap second handling

### DIFF
--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -2679,11 +2679,13 @@ class Time(TimeBase):
         else:
             return super().__array_function__(function, types, args, kwargs)
 
-    def to_datetime(self, timezone=None, strict=True):
+    def to_datetime(self, timezone=None, leap_second_strict="raise"):
         # TODO: this could likely go through to_value, as long as that
         # had an **kwargs part that was just passed on to _time.
         tm = self.replicate(format="datetime")
-        return tm._shaped_like_input(tm._time.to_value(timezone, strict=strict))
+        return tm._shaped_like_input(
+            tm._time.to_value(timezone, leap_second_strict=leap_second_strict)
+        )
 
     to_datetime.__doc__ = TimeDatetime.to_value.__doc__
 

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -2679,11 +2679,11 @@ class Time(TimeBase):
         else:
             return super().__array_function__(function, types, args, kwargs)
 
-    def to_datetime(self, timezone=None):
+    def to_datetime(self, timezone=None, strict=True):
         # TODO: this could likely go through to_value, as long as that
         # had an **kwargs part that was just passed on to _time.
         tm = self.replicate(format="datetime")
-        return tm._shaped_like_input(tm._time.to_value(timezone))
+        return tm._shaped_like_input(tm._time.to_value(timezone, strict=strict))
 
     to_datetime.__doc__ = TimeDatetime.to_value.__doc__
 

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -1758,16 +1758,25 @@ def test_to_datetime():
         assert tz.tzname(dt) == tz_dt.tzname()
     assert np.all(time == forced_to_astropy_time)
 
+
+def test_to_datetime_leap_second_strict():
+    t = Time("2015-06-30 23:59:60.000")
+    dt_exp = datetime.datetime(2015, 7, 1, 0, 0, 0)
+
     with pytest.raises(ValueError, match=r"does not support leap seconds"):
-        Time("2015-06-30 23:59:60.000").to_datetime()
+        t.to_datetime()
 
-
-def test_to_datetime_warn():
     with pytest.warns(
         AstropyDatetimeLeapSecondWarning, match=r"does not support leap seconds"
     ):
-        dt = Time("2015-06-30 23:59:60.000").to_datetime(strict=False)
-        assert dt == datetime.datetime(2015, 7, 1, 0, 0, 0)
+        dt = t.to_datetime(leap_second_strict="warn")
+        assert dt == dt_exp
+
+    dt = t.to_datetime(leap_second_strict="silent")
+    assert dt == dt_exp
+
+    with pytest.raises(ValueError, match=r"leap_second_strict must be 'raise'"):
+        t.to_datetime(leap_second_strict="invalid")
 
 
 @pytest.mark.skipif(not HAS_PYTZ, reason="requires pytz")

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -20,6 +20,7 @@ from astropy.table import Column, Table
 from astropy.time import (
     STANDARD_TIME_SCALES,
     TIME_FORMATS,
+    AstropyDatetimeLeapSecondWarning,
     ScaleValueError,
     Time,
     TimeDelta,
@@ -1759,6 +1760,14 @@ def test_to_datetime():
 
     with pytest.raises(ValueError, match=r"does not support leap seconds"):
         Time("2015-06-30 23:59:60.000").to_datetime()
+
+
+def test_to_datetime_warn():
+    with pytest.warns(
+        AstropyDatetimeLeapSecondWarning, match=r"does not support leap seconds"
+    ):
+        dt = Time("2015-06-30 23:59:60.000").to_datetime(strict=False)
+        assert dt == datetime.datetime(2015, 7, 1, 0, 0, 0)
 
 
 @pytest.mark.skipif(not HAS_PYTZ, reason="requires pytz")

--- a/docs/changes/time/14606.feature.rst
+++ b/docs/changes/time/14606.feature.rst
@@ -1,3 +1,3 @@
-Add a ``strict`` option to the ``Time.to_datetime()`` method. If set to ``False`` this
-will allow converting a time within a leap second to a datetime object with only an
-``AstropyDatetimeLeapSecondWarning`` instead of raising an exception.
+Add a ``leap_second_strict`` argument to the ``Time.to_datetime()`` method. This
+controls the behavior when converting a time within a leap second to the ``datetime``
+format and can take the values ``raise`` (the default), ``warn``, or ``silent``.

--- a/docs/changes/time/14606.feature.rst
+++ b/docs/changes/time/14606.feature.rst
@@ -1,0 +1,3 @@
+Add a ``strict`` option to the ``Time.to_datetime()`` method. If set to ``False`` this
+will allow converting a time within a leap second to a datetime object with only an
+``AstropyDatetimeLeapSecondWarning`` instead of raising an exception.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address a feature request in https://community.openastronomy.org/t/converting-astropy-time-time-to-datetime-leapseconds/637 for a way to convert times within a leap second to `datetime` format.

The new `leap_second_strict` argument of `Time.to_datetime` can be set to `warn` in which case only a warning will be issued, or `silent` to silently handle the leap second. The default is `raise`, corresponding to the previous behavior.
