### PR TITLE
BUG: fixing pytest plugin discovery

### DIFF
--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -175,7 +175,7 @@ class TestRunnerBase:
         "pytest_astropy_header",
     ]
     _missing_dependancy_error = (
-        "Test dependencies are missing: {module}. You should install the "
+        "Test dependencies are missing: {}. You should install the "
         "'pytest-astropy' package (you may need to update the package if you "
         "have a previous version installed, e.g., "
         "'pip install pytest-astropy --upgrade' or the equivalent with conda)."
@@ -196,7 +196,7 @@ class TestRunnerBase:
                 try:
                     pluginmanager.import_plugin(module)
                 except ImportError:
-                    raise RuntimeError(cls._missing_dependancy_error.format(module=module))
+                    raise RuntimeError(cls._missing_dependancy_error.format(module))
 
     def run_tests(self, **kwargs):
         # The following option will include eggs inside a .eggs folder in

--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -192,6 +192,7 @@ class TestRunnerBase:
             if spec is None or spec.loader is None:
                 # Don't import pytest until it's actually needed
                 import pytest
+
                 pluginmanager = pytest.PytestPluginManager()
                 try:
                     pluginmanager.import_plugin(module)


### PR DESCRIPTION
The testrunner doesn't correctly recognize the editable installs when there is an uninstalled version is around, see comment here: https://github.com/astropy/astropy/pull/6891#issuecomment-1496797227


BUT, for pytest plugins, they don't need to be importable as a runtime library dependency should be, so checking on their availability with the plugin manager should be sufficient.

This PR fixes the problem I see locally with astroquery. The testrunner is not exactly public API, and as the previous PR didn't get one, I'm not adding a changelog entry for this one either.



