### PR TITLE
Backport PR #14566: Disallow the use of quantity input for 'decimalyear' format

### DIFF
--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -116,6 +116,8 @@ class TimeFormat:
     ----------
     val1 : numpy ndarray, list, number, str, or bytes
         Values to initialize the time or times.  Bytes are decoded as ascii.
+        Quantities with time units are allowed for formats where the
+        interpretation is unambiguous.
     val2 : numpy ndarray, list, or number; optional
         Value(s) to initialize the time or times.  Only used for numerical
         input, to help preserve precision.
@@ -540,6 +542,7 @@ class TimeNumeric(TimeFormat):
 class TimeJD(TimeNumeric):
     """
     Julian Date time format.
+
     This represents the number of days since the beginning of
     the Julian Period.
     For example, 2451544.5 in JD is midnight on January 1, 2000.
@@ -555,6 +558,7 @@ class TimeJD(TimeNumeric):
 class TimeMJD(TimeNumeric):
     """
     Modified Julian Date time format.
+
     This represents the number of days since midnight on November 17, 1858.
     For example, 51544.0 in MJD is midnight on January 1, 2000.
     """
@@ -575,14 +579,35 @@ class TimeMJD(TimeNumeric):
     value = property(to_value)
 
 
+def _check_val_type_not_quantity(format_name, val1, val2):
+    # If val2 is a Quantity, the super() call that follows this check
+    # will raise a TypeError.
+    if hasattr(val1, "to") and getattr(val1, "unit", None) is not None:
+        raise ValueError(
+            f"cannot use Quantities for {format_name!r} format, as the unit of year "
+            "is defined as 365.25 days, while the length of year is variable "
+            "in this format. Use float instead."
+        )
+
+
 class TimeDecimalYear(TimeNumeric):
     """
     Time as a decimal year, with integer values corresponding to midnight
-    of the first day of each year.  For example 2000.5 corresponds to the
-    ISO time '2000-07-02 00:00:00'.
+    of the first day of each year.
+
+    For example 2000.5 corresponds to the ISO time '2000-07-02 00:00:00'.
+
+    Since for this format the length of the year varies between 365 and
+    366 days, it is not possible to use Quantity input, in which a year
+    is always 365.25 days.
     """
 
     name = "decimalyear"
+
+    def _check_val_type(self, val1, val2):
+        _check_val_type_not_quantity(self.name, val1, val2)
+        # if val2 is a Quantity, super() will raise a TypeError.
+        return super()._check_val_type(val1, val2)
 
     def set_jds(self, val1, val2):
         self._check_scale(self._scale)  # Validate scale.
@@ -642,7 +667,7 @@ class TimeDecimalYear(TimeNumeric):
 class TimeFromEpoch(TimeNumeric):
     """
     Base class for times that represent the interval from a particular
-    epoch as a floating point multiple of a unit time interval (e.g. seconds
+    epoch as a numerical multiple of a unit time interval (e.g. seconds
     or days).
     """
 
@@ -1913,7 +1938,7 @@ class TimeFITS(TimeString):
 
 class TimeEpochDate(TimeNumeric):
     """
-    Base class for support floating point Besselian and Julian epoch dates
+    Base class for support of Besselian and Julian epoch dates.
     """
 
     _default_scale = "tt"  # As of astropy 3.2, this is no longer 'utc'.
@@ -1933,25 +1958,25 @@ class TimeEpochDate(TimeNumeric):
 
 
 class TimeBesselianEpoch(TimeEpochDate):
-    """Besselian Epoch year as floating point value(s) like 1950.0"""
+    """Besselian Epoch year as value(s) like 1950.0.
+
+    Since for this format the length of the year varies, input needs to
+    be floating point; it is not possible to use Quantity input, for
+    which a year always equals 365.25 days.
+    """
 
     name = "byear"
     epoch_to_jd = "epb2jd"
     jd_to_epoch = "epb"
 
     def _check_val_type(self, val1, val2):
-        """Input value validation, typically overridden by derived classes"""
-        if hasattr(val1, "to") and hasattr(val1, "unit") and val1.unit is not None:
-            raise ValueError(
-                "Cannot use Quantities for 'byear' format, as the interpretation "
-                "would be ambiguous. Use float with Besselian year instead."
-            )
+        _check_val_type_not_quantity(self.name, val1, val2)
         # FIXME: is val2 really okay here?
         return super()._check_val_type(val1, val2)
 
 
 class TimeJulianEpoch(TimeEpochDate):
-    """Julian Epoch year as floating point value(s) like 2000.0"""
+    """Julian Epoch year as value(s) like 2000.0."""
 
     name = "jyear"
     unit = erfa.DJY  # 365.25, the Julian year, for conversion to quantities

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -1503,6 +1503,11 @@ def test_decimalyear():
     assert np.all(t.jd == [jd0 + 0.5 * d_jd, jd0 + 0.75 * d_jd])
 
 
+def test_decimalyear_no_quantity():
+    with pytest.raises(ValueError, match="cannot use Quantities"):
+        Time(2005.5 * u.yr, format="decimalyear")
+
+
 def test_fits_year0():
     t = Time(1721425.5, format="jd", scale="tai")
     assert t.fits == "0001-01-01T00:00:00.000"

--- a/docs/changes/time/14566.bugfix.rst
+++ b/docs/changes/time/14566.bugfix.rst
@@ -1,0 +1,6 @@
+Using quantities with units of time for ``Time`` format 'decimalyear' will now
+raise an error instead of converting the quantity to days and then
+interpreting the value as years. An error is raised instead of attempting to
+interpret the unit as years, since the interpretation is ambiguous: in
+'decimaltime' years are equal to 365 or 366 days, while for regular time units
+the year is defined as 365.25 days.

--- a/docs/time/index.rst
+++ b/docs/time/index.rst
@@ -1449,7 +1449,7 @@ To use |Quantity| objects with units of time::
   Traceback (most recent call last):
     ...
   ValueError: Input values did not match the format class byear:
-  ValueError: Cannot use Quantities for 'byear' format, as the interpretation would be ambiguous. Use float with Besselian year instead.
+  ValueError: cannot use Quantities for 'byear' format, as the unit of year is defined as 365.25 days, while the length of year is variable in this format. Use float instead.
 
   >>> TimeDelta(10.*u.yr)            # With a quantity, no format is required
   <TimeDelta object: scale='None' format='jd' value=3652.5>


### PR DESCRIPTION
…ar' format.

<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address ...

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>
