### PR TITLE
Backport PR #14566: Disallow the use of quantity input for 'decimalyear' format (v5.0.x)

### DIFF
--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -1502,6 +1502,11 @@ def test_decimalyear():
     assert np.all(t.jd == [jd0 + 0.5 * d_jd, jd0 + 0.75 * d_jd])
 
 
+def test_decimalyear_no_quantity():
+    with pytest.raises(ValueError, match="cannot use Quantities"):
+        Time(2005.5 * u.yr, format="decimalyear")
+
+
 def test_fits_year0():
     t = Time(1721425.5, format="jd", scale="tai")
     assert t.fits == "0001-01-01T00:00:00.000"

--- a/docs/changes/time/14566.bugfix.rst
+++ b/docs/changes/time/14566.bugfix.rst
@@ -1,0 +1,6 @@
+Using quantities with units of time for ``Time`` format 'decimalyear' will now
+raise an error instead of converting the quantity to days and then
+interpreting the value as years. An error is raised instead of attempting to
+interpret the unit as years, since the interpretation is ambiguous: in
+'decimaltime' years are equal to 365 or 366 days, while for regular time units
+the year is defined as 365.25 days.

--- a/docs/time/index.rst
+++ b/docs/time/index.rst
@@ -1420,7 +1420,7 @@ To use |Quantity| objects with units of time::
   Traceback (most recent call last):
     ...
   ValueError: Input values did not match the format class byear:
-  ValueError: Cannot use Quantities for 'byear' format, as the interpretation would be ambiguous. Use float with Besselian year instead.
+  ValueError: cannot use Quantities for 'byear' format, as the unit of year is defined as 365.25 days, while the length of year is variable in this format. Use float instead.
 
   >>> TimeDelta(10.*u.yr)            # With a quantity, no format is required
   <TimeDelta object: scale='None' format='jd' value=3652.5>


### PR DESCRIPTION
(cherry picked from commit b40081ff722c5ca0a4ff1578abe4587e44c0eeba)

<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to backport #14566