### PR TITLE
Ensure masks are propagated correctly for ufunc.outer

### DIFF
--- a/astropy/utils/masked/core.py
+++ b/astropy/utils/masked/core.py
@@ -801,9 +801,10 @@ class MaskedNDArray(Masked, np.ndarray, base_cls=np.ndarray, data_cls=np.ndarray
 
         elif method == "outer":
             # Must have two arguments; adjust masks as will be done for data.
-            assert len(masks) == 2
-            masks = [(m if m is not None else False) for m in masks]
-            mask = np.logical_or.outer(masks[0], masks[1], out=out_mask)
+            m0, m1 = masks
+            if m0 is not None and m0.ndim > 0:
+                m0 = m0[(...,) + (np.newaxis,) * np.ndim(unmasked[1])]
+            mask = self._combine_masks((m0, m1), out=out_mask)
 
         elif method in {"reduce", "accumulate"}:
             # Reductions like np.add.reduce (sum).

--- a/docs/changes/utils/14624.bugfix.rst
+++ b/docs/changes/utils/14624.bugfix.rst
@@ -1,0 +1,2 @@
+Ensure masks are propagated correctly for ``outer`` methods of ufuncs also if
+one of the inputs is not actually masked.


### PR DESCRIPTION
This pull request fixes a small bug I noticed while implementing `where` for `Masked` in #14590, that the masks might not be propagated correctly in `np.add.outer` (and other `.outer` ufuncs) if one of the inputs was not masked. I also added a test for regular `ufunc` calls that either input can indeed be unmasked.
