### PR TITLE
Improve the docstring of `Table.rename_column()`

### DIFF
--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -3020,12 +3020,10 @@ class Table:
         """
         Rename a column.
 
-        This can also be done directly with by setting the ``name`` attribute
-        for a column::
+        This can also be done directly by setting the ``name`` attribute
+        of the ``info`` property of the column::
 
-          table[name].name = new_name
-
-        TODO: this won't work for mixins
+          table[name].info.name = new_name
 
         Parameters
         ----------


### PR DESCRIPTION
### Description

The docstring mentions an alternative way to rename a column, but warns that it does not work with a mixin column. Although that is still true there is a simple alternative that does work with all columns, which should be mentioned instead.  See also https://docs.astropy.org/en/stable/table/mixin_columns.html#mixin-attributes