### PR TITLE
Ensure the unit is kept in ``np.median`` even if the result is a scalar ``nan``

### DIFF
--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -13,7 +13,6 @@ import math
 
 import numpy as np
 
-import astropy.units as u
 
 from . import _stats
 
@@ -815,30 +814,12 @@ def median_absolute_deviation(data, axis=None, func=None, ignore_nan=False):
     # np.nanmedian has `keepdims`, which is a good option if we're not allowing
     # user-passed functions here
     data_median = func(data, axis=axis)
-    # this conditional can be removed after this PR is merged:
-    # https://github.com/astropy/astropy/issues/12165
-    if (
-        isinstance(data, u.Quantity)
-        and func is np.median
-        and data_median.ndim == 0
-        and np.isnan(data_median)
-    ):
-        data_median = data.__array_wrap__(data_median)
 
     # broadcast the median array before subtraction
     if axis is not None:
         data_median = np.expand_dims(data_median, axis=axis)
 
     result = func(np.abs(data - data_median), axis=axis, overwrite_input=True)
-    # this conditional can be removed after this PR is merged:
-    # https://github.com/astropy/astropy/issues/12165
-    if (
-        isinstance(data, u.Quantity)
-        and func is np.median
-        and result.ndim == 0
-        and np.isnan(result)
-    ):
-        result = data.__array_wrap__(result)
 
     if axis is None and np.ma.isMaskedArray(result):
         # return scalar version

--- a/astropy/units/quantity_helper/function_helpers.py
+++ b/astropy/units/quantity_helper/function_helpers.py
@@ -47,7 +47,7 @@ from astropy.units.core import (
     dimensionless_unscaled,
 )
 from astropy.utils import isiterable
-from astropy.utils.compat import NUMPY_LT_1_23
+from astropy.utils.compat import NUMPY_LT_1_22, NUMPY_LT_1_23
 
 # In 1.17, overrides are enabled by default, but it is still possible to
 # turn them off using an environment variable.  We use getattr since it
@@ -81,7 +81,7 @@ SUBCLASS_SAFE_FUNCTIONS |= {
     np.round_,  # Alias for np.round in NUMPY_LT_1_25, but deprecated since.
     np.fix, np.angle, np.i0, np.clip,
     np.isposinf, np.isneginf, np.isreal, np.iscomplex,
-    np.average, np.mean, np.std, np.var, np.median, np.trace,
+    np.average, np.mean, np.std, np.var, np.trace,
     np.nanmax, np.nanmin, np.nanargmin, np.nanargmax, np.nanmean,
     np.nanmedian, np.nansum, np.nancumsum, np.nanstd, np.nanvar,
     np.nanprod, np.nancumprod,
@@ -93,6 +93,10 @@ SUBCLASS_SAFE_FUNCTIONS |= {
     np.apply_along_axis, np.take_along_axis, np.put_along_axis,
     np.linalg.cond, np.linalg.multi_dot,
 }  # fmt: skip
+
+if not NUMPY_LT_1_22:
+    SUBCLASS_SAFE_FUNCTIONS |= {np.median}
+
 
 # Implemented as methods on Quantity:
 # np.ediff1d is from setops, but we support it anyway; the others
@@ -374,6 +378,23 @@ def _iterable_helper(*args, out=None, **kwargs):
 
     arrays, unit = _quantities2arrays(*args)
     return arrays, kwargs, unit, out
+
+
+if NUMPY_LT_1_22:
+
+    @function_helper
+    def median(a, axis=None, out=None, overwrite_input=False, keepdims=False):
+        kwargs = {"overwrite_input": overwrite_input, "keepdims": keepdims}
+        if out is not None:
+            from astropy.units import Quantity
+
+            if not isinstance(out, Quantity):
+                raise NotImplementedError
+            # We may get here just because of out, so ensure input is Quantity.
+            a = _as_quantity(a)
+            kwargs["out"] = out.view(np.ndarray)
+
+        return (a.value, axis), kwargs, a.unit, out
 
 
 @function_helper

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -872,6 +872,12 @@ class TestReductionLikeFunctions(InvariantUnitTestSetup):
     def test_median(self):
         self.check(np.median)
 
+    def test_median_nan_scalar(self):
+        # See gh-12165; this dropped the unit in numpy < 1.22
+        data = [1.0, 2, np.nan, 3, 4] << u.km
+        result = np.median(data)
+        assert_array_equal(result, np.nan * u.km)
+
     @needs_array_function
     def test_quantile(self):
         self.check(np.quantile, 0.5)

--- a/docs/changes/units/14635.bugfix.rst
+++ b/docs/changes/units/14635.bugfix.rst
@@ -1,0 +1,2 @@
+Ensure the unit is kept in ``np.median`` even if the result is a scalar ``nan``
+(the unit was lost for numpy < 1.22).


### PR DESCRIPTION
#14634 reminded me that really #12165 should be fixed in `units`, not worked around in `stats`.

Fixes #12165 and close #14634