### PR TITLE
Backport PR #14635: Ensure the unit is kept in ``np.median`` even if  the result is a scalar ``nan`` (v5.0.x)

### DIFF
--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -13,7 +13,6 @@ import math
 
 import numpy as np
 
-import astropy.units as u
 from . import _stats
 
 __all__ = [
@@ -865,30 +864,12 @@ def median_absolute_deviation(data, axis=None, func=None, ignore_nan=False):
     # np.nanmedian has `keepdims`, which is a good option if we're not allowing
     # user-passed functions here
     data_median = func(data, axis=axis)
-    # this conditional can be removed after this PR is merged:
-    # https://github.com/astropy/astropy/issues/12165
-    if (
-        isinstance(data, u.Quantity)
-        and func is np.median
-        and data_median.ndim == 0
-        and np.isnan(data_median)
-    ):
-        data_median = data.__array_wrap__(data_median)
 
     # broadcast the median array before subtraction
     if axis is not None:
         data_median = _expand_dims(data_median, axis=axis)  # NUMPY_LT_1_18
 
     result = func(np.abs(data - data_median), axis=axis, overwrite_input=True)
-    # this conditional can be removed after this PR is merged:
-    # https://github.com/astropy/astropy/issues/12165
-    if (
-        isinstance(data, u.Quantity)
-        and func is np.median
-        and result.ndim == 0
-        and np.isnan(result)
-    ):
-        result = data.__array_wrap__(result)
 
     if axis is None and np.ma.isMaskedArray(result):
         # return scalar version

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -873,6 +873,12 @@ class TestReductionLikeFunctions(InvariantUnitTestSetup):
     def test_median(self):
         self.check(np.median)
 
+    def test_median_nan_scalar(self):
+        # See gh-12165; this dropped the unit in numpy < 1.22
+        data = [1.0, 2, np.nan, 3, 4] << u.km
+        result = np.median(data)
+        assert_array_equal(result, np.nan * u.km)
+
     @needs_array_function
     def test_quantile(self):
         self.check(np.quantile, 0.5)

--- a/docs/changes/units/14635.bugfix.rst
+++ b/docs/changes/units/14635.bugfix.rst
@@ -1,0 +1,2 @@
+Ensure the unit is kept in ``np.median`` even if the result is a scalar ``nan``
+(the unit was lost for numpy < 1.22).


### PR DESCRIPTION
Backport of #14635 onto v5.0.x