### PR TITLE
BUG: Fix improper deprecated usage (all release branches)

### DIFF
--- a/astropy/coordinates/angle_utilities.py
+++ b/astropy/coordinates/angle_utilities.py
@@ -260,7 +260,7 @@ __old_angle_utilities_funcs = [
 ]
 for funcname in __old_angle_utilities_funcs:
     vars()[funcname] = deprecated(
+        "4.3",
         name="astropy.coordinates.angle_utilities." + funcname,
         alternative="astropy.coordinates.angle_formats." + funcname,
-        since="v4.3",
     )(getattr(angle_formats, funcname))

--- a/astropy/coordinates/orbital_elements.py
+++ b/astropy/coordinates/orbital_elements.py
@@ -169,7 +169,7 @@ _coE = (1.0, -0.002516, -0.0000074)
 
 
 @deprecated(
-    since="5.0",
+    "5.0",
     alternative="astropy.coordinates.get_body('moon')",
     message=(
         "The private calc_moon function has been deprecated, as its functionality is"

--- a/astropy/coordinates/solar_system.py
+++ b/astropy/coordinates/solar_system.py
@@ -552,7 +552,7 @@ should be used instead.
 """
 
 
-@deprecated("4.2", deprecation_msg)
+@deprecated("4.2", message=deprecation_msg)
 def _apparent_position_in_true_coordinates(skycoord):
     """
     Convert Skycoord in GCRS frame into one in which RA and Dec

--- a/astropy/cosmology/utils.py
+++ b/astropy/cosmology/utils.py
@@ -63,7 +63,7 @@ def vectorize_redshift_method(func=None, nin=1):
 
 
 @deprecated(
-    since="5.0",
+    "5.0",
     message=(
         "vectorize_if_needed has been removed because it constructs a new ufunc on each"
         " call"
@@ -95,7 +95,7 @@ def vectorize_if_needed(f, *x, **vkw):
 
 
 @deprecated(
-    since="5.0",
+    "5.0",
     message=(
         "inf_like has been removed because it duplicates "
         "functionality provided by numpy.full_like()"

--- a/astropy/modeling/utils.py
+++ b/astropy/modeling/utils.py
@@ -25,7 +25,7 @@ inside astropy.
 """
 
 
-@deprecated("5.0", deprecation_msg)
+@deprecated("5.0", message=deprecation_msg)
 class AliasDict(MutableMapping):
     """
     Creates a `dict` like object that wraps an existing `dict` or other

--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -528,7 +528,7 @@ The {func} {obj_type} is deprecated and may be removed in a future version.
 """
 
 
-@deprecated("4.3", _ordered_descriptor_deprecation_message)
+@deprecated("4.3", message=_ordered_descriptor_deprecation_message)
 class OrderedDescriptor(metaclass=abc.ABCMeta):
     """
     Base class for descriptors whose order in the class body should be
@@ -612,7 +612,7 @@ class OrderedDescriptor(metaclass=abc.ABCMeta):
             return NotImplemented
 
 
-@deprecated("4.3", _ordered_descriptor_deprecation_message)
+@deprecated("4.3", message=_ordered_descriptor_deprecation_message)
 class OrderedDescriptorContainer(type):
     """
     Classes should use this metaclass if they wish to use `OrderedDescriptor`


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to fix improper usage of the `deprecated` machinery, resulting in confusing warning message to users.

Also streamlines syntax.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Address part of #14662 that can be backported to v5.0.x (LTS)