### PR TITLE
MNT: Remove deprecated Reader/Writer from io.ascii UI

### DIFF
--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -118,15 +118,13 @@ def set_guess(guess):
     _GUESS = guess
 
 
-def get_reader(Reader=None, Inputter=None, Outputter=None, **kwargs):
+def get_reader(*, Inputter=None, Outputter=None, **kwargs):
     """
     Initialize a table reader allowing for common customizations.  Most of the
     default behavior for various parameters is determined by the Reader class.
 
     Parameters
     ----------
-    Reader : `~astropy.io.ascii.BaseReader`
-        Reader class (DEPRECATED). Default is :class:`Basic`.
     Inputter : `~astropy.io.ascii.BaseInputter`
         Inputter class
     Outputter : `~astropy.io.ascii.BaseOutputter`
@@ -172,13 +170,12 @@ def get_reader(Reader=None, Inputter=None, Outputter=None, **kwargs):
     """
     # This function is a light wrapper around core._get_reader to provide a
     # public interface with a default Reader.
-    if Reader is None:
-        # Default reader is Basic unless fast reader is forced
-        fast_reader = _get_fast_reader_dict(kwargs)
-        if fast_reader["enable"] == "force":
-            Reader = fastbasic.FastBasic
-        else:
-            Reader = basic.Basic
+    # Default reader is Basic unless fast reader is forced
+    fast_reader = _get_fast_reader_dict(kwargs)
+    if fast_reader["enable"] == "force":
+        Reader = fastbasic.FastBasic
+    else:
+        Reader = basic.Basic
 
     reader = core._get_reader(Reader, Inputter=Inputter, Outputter=Outputter, **kwargs)
     return reader
@@ -318,7 +315,6 @@ def read(table, guess=None, **kwargs):
     # Get the Reader class based on possible format and Reader kwarg inputs.
     Reader = _get_format_class(format, kwargs.get("Reader"), "Reader")
     if Reader is not None:
-        new_kwargs["Reader"] = Reader
         format = Reader._format_name
 
     # Remove format keyword if there, this is only allowed in read() not get_reader()
@@ -387,7 +383,6 @@ def read(table, guess=None, **kwargs):
         # will fail and the else-clause below will be used.
         if fast_reader["enable"] and f"fast_{format}" in core.FAST_CLASSES:
             fast_kwargs = copy.deepcopy(new_kwargs)
-            fast_kwargs["Reader"] = core.FAST_CLASSES[f"fast_{format}"]
             fast_reader_rdr = get_reader(**fast_kwargs)
             try:
                 dat = fast_reader_rdr.read(table)
@@ -862,15 +857,13 @@ extra_writer_pars = (
 )
 
 
-def get_writer(Writer=None, fast_writer=True, **kwargs):
+def get_writer(*, fast_writer=True, **kwargs):
     """
     Initialize a table writer allowing for common customizations.  Most of the
     default behavior for various parameters is determined by the Writer class.
 
     Parameters
     ----------
-    Writer : ``Writer``
-        Writer class (DEPRECATED). Defaults to :class:`Basic`.
     delimiter : str
         Column delimiter string
     comment : str
@@ -895,8 +888,7 @@ def get_writer(Writer=None, fast_writer=True, **kwargs):
     writer : `~astropy.io.ascii.BaseReader` subclass
         ASCII format writer instance
     """
-    if Writer is None:
-        Writer = basic.Basic
+    Writer = basic.Basic
     if "strip_whitespace" not in kwargs:
         kwargs["strip_whitespace"] = True
     writer = core._get_writer(Writer, fast_writer, **kwargs)
@@ -923,7 +915,6 @@ def write(
     table,
     output=None,
     format=None,
-    Writer=None,
     fast_writer=True,
     *,
     overwrite=False,
@@ -972,8 +963,7 @@ def write(
     if table.has_mixin_columns:
         fast_writer = False
 
-    Writer = _get_format_class(format, Writer, "Writer")
-    writer = get_writer(Writer=Writer, fast_writer=fast_writer, **kwargs)
+    writer = get_writer(fast_writer=fast_writer, **kwargs)
     if writer._format_name in core.FAST_CLASSES:
         writer.write(table, output)
         return

--- a/docs/changes/io.ascii/14667.api.rst
+++ b/docs/changes/io.ascii/14667.api.rst
@@ -1,0 +1,1 @@
+Removed deprecated Reader and Writer from unified IO interface.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to remove what I think is the stuff @taldcroft mentioned in #8567 though I cannot find any "unified IO" usage of `aastex`, so I only tackled Reader and Writer.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #8567

### TODO

- [ ] Fix test failures, or
- [ ] Declare that these are not really deprecated because things still break without them