### PR TITLE
MNT: Remove pedantic option from astropy.io.votable

### DIFF
--- a/astropy/io/votable/__init__.py
+++ b/astropy/io/votable/__init__.py
@@ -41,11 +41,10 @@ class Conf(_config.ConfigNamespace):
     """
 
     verify = _config.ConfigItem(
-        "ignore",
+        ["ignore", "warn", "exception"],
         "Can be 'exception' (treat fixable violations of the VOTable spec as "
         "exceptions), 'warn' (show warnings for VOTable spec violations), or "
         "'ignore' (silently ignore VOTable spec violations)",
-        aliases=["astropy.io.votable.table.pedantic", "astropy.io.votable.pedantic"],
     )
 
 

--- a/astropy/io/votable/__init__.py
+++ b/astropy/io/votable/__init__.py
@@ -34,6 +34,8 @@ __all__ = [
     "VOTableSpecError",
 ]
 
+VERIFY_OPTIONS = ["ignore", "warn", "exception"]  # First one is default
+
 
 class Conf(_config.ConfigNamespace):
     """
@@ -41,7 +43,7 @@ class Conf(_config.ConfigNamespace):
     """
 
     verify = _config.ConfigItem(
-        ["ignore", "warn", "exception"],
+        VERIFY_OPTIONS,
         "Can be 'exception' (treat fixable violations of the VOTable spec as "
         "exceptions), 'warn' (show warnings for VOTable spec violations), or "
         "'ignore' (silently ignore VOTable spec violations)",

--- a/astropy/io/votable/table.py
+++ b/astropy/io/votable/table.py
@@ -13,7 +13,6 @@ import textwrap
 import warnings
 
 from astropy.utils import data
-from astropy.utils.decorators import deprecated_renamed_argument
 from astropy.utils.xml import iterparser
 
 # LOCAL
@@ -31,7 +30,6 @@ __all__ = [
 VERIFY_OPTIONS = ["ignore", "warn", "exception"]
 
 
-@deprecated_renamed_argument("pedantic", "verify", since="5.0")
 def parse(
     source,
     columns=None,
@@ -80,6 +78,8 @@ def parse(
            deprecated in future.
         .. versionchanged:: 5.0
             The ``pedantic`` argument is deprecated.
+        .. versionchanged:: 6.0
+            The ``pedantic`` argument is removed.
 
     chunk_size : int, optional
         The number of rows to read before converting to an array.
@@ -136,18 +136,7 @@ def parse(
         )
 
     if verify is None:
-        conf_verify_lowercase = conf.verify.lower()
-
-        # We need to allow verify to be booleans as strings since the
-        # configuration framework doesn't make it easy/possible to have mixed
-        # types.
-        if conf_verify_lowercase in ["false", "true"]:
-            verify = conf_verify_lowercase == "true"
-        else:
-            verify = conf_verify_lowercase
-
-    if isinstance(verify, bool):
-        verify = "exception" if verify else "warn"
+        verify = conf.verify
     elif verify not in VERIFY_OPTIONS:
         raise ValueError(f"verify should be one of {'/'.join(VERIFY_OPTIONS)}")
 

--- a/astropy/io/votable/table.py
+++ b/astropy/io/votable/table.py
@@ -27,8 +27,6 @@ __all__ = [
     "reset_vo_warnings",
 ]
 
-VERIFY_OPTIONS = ["ignore", "warn", "exception"]
-
 
 def parse(
     source,
@@ -127,7 +125,7 @@ def parse(
     --------
     astropy.io.votable.exceptions : The exceptions this function may raise.
     """
-    from . import conf
+    from . import conf, VERIFY_OPTIONS
 
     invalid = invalid.lower()
     if invalid not in ("exception", "mask"):

--- a/astropy/io/votable/tests/table_test.py
+++ b/astropy/io/votable/tests/table_test.py
@@ -9,7 +9,6 @@ import pathlib
 import numpy as np
 import pytest
 
-from astropy.config import reload_config, set_temp_config
 from astropy.io.votable import conf, from_table, is_votable, tree, validate
 from astropy.io.votable.exceptions import E25, W39, VOWarning
 from astropy.io.votable.table import parse, writeto
@@ -21,7 +20,6 @@ from astropy.utils.data import (
     get_pkg_data_fileobj,
     get_pkg_data_path,
 )
-from astropy.utils.exceptions import AstropyDeprecationWarning
 from astropy.utils.misc import _NOT_OVERWRITING_MSG_MATCH
 
 
@@ -421,18 +419,6 @@ class TestVerifyOptions:
         with pytest.raises(VOWarning):
             parse(get_pkg_data_filename("data/gemini.xml"), verify="exception")
 
-    # Make sure the deprecated pedantic option still works for now
-
-    def test_pedantic_false(self):
-        with pytest.warns(VOWarning) as w:
-            parse(get_pkg_data_filename("data/gemini.xml"), pedantic=False)
-        assert len(w) == 25
-
-    def test_pedantic_true(self):
-        with pytest.warns(AstropyDeprecationWarning):
-            with pytest.raises(VOWarning):
-                parse(get_pkg_data_filename("data/gemini.xml"), pedantic=True)
-
     # Make sure that the default behavior can be set via configuration items
 
     def test_conf_verify_ignore(self):
@@ -449,27 +435,3 @@ class TestVerifyOptions:
         with conf.set_temp("verify", "exception"):
             with pytest.raises(VOWarning):
                 parse(get_pkg_data_filename("data/gemini.xml"))
-
-    # And make sure the old configuration item will keep working
-
-    def test_conf_pedantic_false(self, tmp_path):
-        with set_temp_config(tmp_path):
-            with open(tmp_path / "astropy" / "astropy.cfg", "w") as f:
-                f.write("[io.votable]\npedantic = False")
-
-            reload_config("astropy.io.votable")
-
-            with pytest.warns(VOWarning) as w:
-                parse(get_pkg_data_filename("data/gemini.xml"))
-            assert len(w) == 25
-
-    def test_conf_pedantic_true(self, tmp_path):
-        with set_temp_config(tmp_path):
-            with open(tmp_path / "astropy" / "astropy.cfg", "w") as f:
-                f.write("[io.votable]\npedantic = True")
-
-            reload_config("astropy.io.votable")
-
-            with pytest.warns(AstropyDeprecationWarning):
-                with pytest.raises(VOWarning):
-                    parse(get_pkg_data_filename("data/gemini.xml"))

--- a/docs/changes/io.votable/14669.api.rst
+++ b/docs/changes/io.votable/14669.api.rst
@@ -1,0 +1,3 @@
+Removed deprecated ``pedantic`` option from the
+``astropy.io.votable.table.parse()`` function and the corresponding configuration
+setting. Use the ``verify`` option instead.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to remove the deprecated `pedantic` option.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #12134
