### PR TITLE
MNT: Remove deprecated Cosmology Parameter fmt

### DIFF
--- a/astropy/cosmology/parameter.py
+++ b/astropy/cosmology/parameter.py
@@ -3,7 +3,6 @@
 import copy
 
 import astropy.units as u
-from astropy.utils.decorators import deprecated_attribute, deprecated_renamed_argument
 
 __all__ = ["Parameter"]
 
@@ -34,13 +33,6 @@ class Parameter:
         For other valid string options, see ``Parameter._registry_validators``.
         'fvalidate' can also be set through a decorator with
         :meth:`~astropy.cosmology.Parameter.validator`.
-    fmt : str (optional, keyword-only)
-        `format` specification, used when making string representation
-        of the containing Cosmology.
-        See https://docs.python.org/3/library/string.html#formatspec
-
-        .. deprecated::  5.1
-
     doc : str or None (optional, keyword-only)
         Parameter description.
 
@@ -51,7 +43,6 @@ class Parameter:
 
     _registry_validators = {}
 
-    @deprecated_renamed_argument("fmt", None, since="5.1")
     def __init__(
         self,
         *,
@@ -59,7 +50,6 @@ class Parameter:
         unit=None,
         equivalencies=[],
         fvalidate="default",
-        fmt="",
         doc=None,
     ):
         # attribute name on container cosmology class.
@@ -68,7 +58,6 @@ class Parameter:
         self._attr_name = self._attr_name_private = None
 
         self._derived = derived
-        self._format_spec = str(fmt)  # deprecated.
         self.__doc__ = doc
 
         # units stuff
@@ -110,8 +99,6 @@ class Parameter:
     def equivalencies(self):
         """Equivalencies used when initializing Parameter."""
         return self._equivalencies
-
-    format_spec = deprecated_attribute("format_spec", since="5.1")
 
     @property
     def derived(self):
@@ -254,10 +241,6 @@ class Parameter:
             "fvalidate": self.fvalidate if processed else self._fvalidate_in,
             "doc": self.__doc__,
         }
-        # fmt will issue a deprecation warning if passed, so only passed if
-        # it's not the default.
-        if self._format_spec:
-            kw["fmt"] = self._format_spec
         return kw
 
     def clone(self, **kw):

--- a/astropy/cosmology/tests/test_parameter.py
+++ b/astropy/cosmology/tests/test_parameter.py
@@ -100,7 +100,6 @@ class ParameterTestMixin:
         assert hasattr(all_parameter, "_unit")
         assert hasattr(all_parameter, "_equivalencies")
         assert hasattr(all_parameter, "_derived")
-        assert hasattr(all_parameter, "_format_spec")
 
         # __set_name__
         assert hasattr(all_parameter, "_attr_name")
@@ -303,7 +302,6 @@ class TestParameter(ParameterTestMixin):
         # custom from init
         assert param._unit == u.m
         assert param._equivalencies == u.mass_energy()
-        assert param._format_spec == ""
         assert param._derived == np.False_
 
         # custom from set_name

--- a/astropy/cosmology/tests/test_parameter.py
+++ b/astropy/cosmology/tests/test_parameter.py
@@ -21,7 +21,6 @@ from astropy.cosmology.parameter import (
     _validate_to_float,
     _validate_with_unit,
 )
-from astropy.utils.exceptions import AstropyDeprecationWarning
 
 ##############################################################################
 # TESTS
@@ -90,17 +89,6 @@ class ParameterTestMixin:
         assert parameter.equivalencies == [u.mass_energy()]
         assert parameter.derived is True
 
-    def test_Parameter_init_deprecated_fmt(self):
-        """Test that passing the argument ``fmt`` is deprecated."""
-        with pytest.warns(AstropyDeprecationWarning):
-            parameter = Parameter(fmt=".4f")
-
-        assert parameter._format_spec == ".4f"
-
-        # Test that it appears in initializing arguments
-        init_args = parameter._get_init_arguments()
-        assert init_args["fmt"] == ".4f"
-
     def test_Parameter_instance_attributes(self, all_parameter):
         """Test :class:`astropy.cosmology.Parameter` attributes from init."""
         assert hasattr(all_parameter, "fvalidate")
@@ -140,14 +128,6 @@ class ParameterTestMixin:
         assert hasattr(all_parameter, "equivalencies")
         assert isinstance(all_parameter.equivalencies, (list, u.Equivalency))
         assert all_parameter.equivalencies is all_parameter._equivalencies
-
-    def test_Parameter_format_spec(self, all_parameter):
-        """Test :attr:`astropy.cosmology.Parameter.format_spec`."""
-        with pytest.warns(AstropyDeprecationWarning):
-            fmt = all_parameter.format_spec
-
-        assert isinstance(fmt, str)
-        assert fmt is all_parameter._format_spec
 
     def test_Parameter_derived(self, cosmo_cls, all_parameter):
         """Test :attr:`astropy.cosmology.Parameter.derived`."""
@@ -354,13 +334,6 @@ class TestParameter(ParameterTestMixin):
         super().test_Parameter_equivalencies(param)
 
         assert param.equivalencies == u.mass_energy()
-
-    def test_Parameter_format_spec(self, param):
-        """Test :attr:`astropy.cosmology.Parameter.format_spec`."""
-        super().test_Parameter_format_spec(param)
-
-        with pytest.warns(AstropyDeprecationWarning):
-            assert param.format_spec == ""
 
     def test_Parameter_derived(self, cosmo_cls, param):
         """Test :attr:`astropy.cosmology.Parameter.derived`."""

--- a/docs/changes/cosmology/14673.api.rst
+++ b/docs/changes/cosmology/14673.api.rst
@@ -1,0 +1,1 @@
+Removed deprecated Cosmology Parameter argument ``fmt``.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to fix #13147
