### PR TITLE
Small bugs in structured units and quantities

### DIFF
--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -1687,8 +1687,9 @@ class Quantity(np.ndarray):
 
         # Setting names to ensure things like equality work (note that
         # above will have failed already if units did not match).
-        if self.dtype.names:
-            _value.dtype.names = self.dtype.names
+        # TODO: is this the best place to do this?
+        if _value.dtype.names is not None:
+            _value = _value.astype(self.dtype, copy=False)
         return _value
 
     def itemset(self, *args):

--- a/astropy/units/structured.py
+++ b/astropy/units/structured.py
@@ -22,7 +22,7 @@ def _names_from_dtype(dtype):
     """Recursively extract field names from a dtype."""
     names = []
     for name in dtype.names:
-        subdtype = dtype.fields[name][0]
+        subdtype = dtype.fields[name][0].base
         if subdtype.names:
             names.append([name, _names_from_dtype(subdtype)])
         else:

--- a/astropy/units/tests/test_quantity_array_methods.py
+++ b/astropy/units/tests/test_quantity_array_methods.py
@@ -610,9 +610,13 @@ class TestArrayConversion:
             q1.dumps()
 
 
-class TestRecArray:
-    """Record arrays are not specifically supported, but we should not
-    prevent their use unnecessarily"""
+class TestStructuredArray:
+    """Structured arrays are not specifically supported, but we should not
+    prevent their use unnecessarily.
+
+    Note that these tests use simple units.  Now that structured units are
+    supported, it may make sense to deprecate this.
+    """
 
     def setup_method(self):
         self.ra = (
@@ -627,3 +631,18 @@ class TestRecArray:
         qra = u.Quantity(self.ra, u.m)
         qra[1] = qra[2]
         assert qra[1] == qra[2]
+
+    def test_assignment_with_non_structured(self):
+        qra = u.Quantity(self.ra, u.m)
+        qra[1] = 0
+        assert qra[1] == np.zeros(3).view(qra.dtype)
+
+    def test_assignment_with_different_names(self):
+        qra = u.Quantity(self.ra, u.m)
+        dtype = np.dtype([("x", "f8"), ("y", "f8"), ("z", "f8")])
+        value = np.array((-1.0, -2.0, -3.0), dtype) << u.km
+        qra[1] = value
+        assert qra[1] == value
+        assert qra[1].value == np.array((-1000.0, -2000.0, -3000.0), qra.dtype)
+        # Ensure we do not override dtype names of value.
+        assert value.dtype.names == ("x", "y", "z")

--- a/astropy/units/tests/test_structured.py
+++ b/astropy/units/tests/test_structured.py
@@ -109,6 +109,21 @@ class TestStructuredUnitBasics(StructuredTestBase):
             'l',
         )  # fmt: skip
 
+        dt = np.dtype(
+            [("t", "f8"),
+             ("pvhd1d2",
+              ([("p", "f8"), ("v", "f8"), ("hd1d2",
+                                           [("h", "f8"), ("d1d2",
+                                                          [("d1", "f8"), ("d2", "f8")]),
+                                            ]),
+                ], (5, 5))),  # Note: structured subarray to improve test!
+             ("l", "f8")
+             ])  # fmt: skip
+
+        su2 = StructuredUnit("(yr,(AU,AU/day,(km,(day,day))),m)", dt)
+        assert su2.field_names == su.field_names
+        assert su2 == su
+
     @pytest.mark.parametrize(
         "names, invalid",
         [
@@ -122,7 +137,7 @@ class TestStructuredUnitBasics(StructuredTestBase):
     )
     def test_initialization_names_invalid_list_errors(self, names, invalid):
         with pytest.raises(ValueError) as exc:
-            StructuredUnit("(yr,(AU,AU/day)", names)
+            StructuredUnit("yr,(AU,AU/day)", names)
         assert f"invalid entry {invalid}" in str(exc)
 
     def test_looks_like_unit(self):

--- a/docs/changes/units/14680.bugfix.rst
+++ b/docs/changes/units/14680.bugfix.rst
@@ -1,0 +1,4 @@
+Ensure that ``Quantity`` with structured dtype can be set using non-structured
+``Quantity`` (if units match), and that structured dtype names are inferred
+correctly in the creation of ``StructuredUnit``, thus avoiding mismatches
+when setting units.


### PR DESCRIPTION
This pull request fixes 2 small bugs I found for `units` while trying to make `uncertainty` deal with structured dtypes better:
1. Assigning to a `Quantity` with a structured dtype using a non-structured value does not work. It should - it should just be assigned to all elements (as is the case for `ndarray`).
2. For structured dtypes with subarrays, the inference of field names for `StructuredUnit` failed.

Neither is easy to hit, but might as well backport anyway. 
