### PR TITLE
Adds a fuzz test for test_precision

### DIFF
--- a/astropy/time/tests/fuzz_precision.py
+++ b/astropy/time/tests/fuzz_precision.py
@@ -10,64 +10,64 @@ with atheris.instrument_imports():
 def TestOneInput(data):
     fdp = atheris.FuzzedDataProvider(data)
     byte_size = fdp.ConsumeIntInRange(0, 1000)
-    tp.test_abs_jd2_always_less_than_half_on_construction.hypothesis.fuzz_one_input(
-        fdp.ConsumeBytes(byte_size))
-    tp.test_round_to_even.hypothesis.fuzz_one_input(
-        fdp.ConsumeBytes(byte_size))
-    tp.test_two_sum.hypothesis.fuzz_one_input(
-        fdp.ConsumeBytes(byte_size))
-    tp.test_two_sum_symmetric.hypothesis.fuzz_one_input(
-        fdp.ConsumeBytes(byte_size))
-    tp.test_two_sum_size.hypothesis.fuzz_one_input(
-        fdp.ConsumeBytes(byte_size))
-    tp.test_day_frac_harmless.hypothesis.fuzz_one_input(
-        fdp.ConsumeBytes(byte_size))
-    tp.test_day_frac_exact.hypothesis.fuzz_one_input(
-        fdp.ConsumeBytes(byte_size))
-    tp.test_day_frac_idempotent.hypothesis.fuzz_one_input(
-        fdp.ConsumeBytes(byte_size))
-    tp.test_mjd_initialization_precise.hypothesis.fuzz_one_input(
-        fdp.ConsumeBytes(byte_size))
-    tp.test_day_frac_always_less_than_half.hypothesis.fuzz_one_input(
-        fdp.ConsumeBytes(byte_size))
-    tp.test_day_frac_round_to_even.hypothesis.fuzz_one_input(
-        fdp.ConsumeBytes(byte_size))
-    tp.test_resolution_never_decreases.hypothesis.fuzz_one_input(
-        fdp.ConsumeBytes(byte_size))
-    tp.test_resolution_never_decreases_utc.hypothesis.fuzz_one_input(
-        fdp.ConsumeBytes(byte_size))
-    tp.test_conversion_preserves_jd1_jd2_invariant.hypothesis.fuzz_one_input(
-        fdp.ConsumeBytes(byte_size))
-    tp.test_conversion_never_loses_precision.hypothesis.fuzz_one_input(
-        fdp.ConsumeBytes(byte_size))
-    tp.test_leap_stretch_mjd.hypothesis.fuzz_one_input(
-        fdp.ConsumeBytes(byte_size))
-    tp.test_jd_add_subtract_round_trip.hypothesis.fuzz_one_input(
-        fdp.ConsumeBytes(byte_size))
-    tp.test_time_argminmaxsort.hypothesis.fuzz_one_input(
-        fdp.ConsumeBytes(byte_size))
-    tp.test_timedelta_full_precision.hypothesis.fuzz_one_input(
-        fdp.ConsumeBytes(byte_size))
-    tp.test_timedelta_full_precision_arithmetic.hypothesis.fuzz_one_input(
-        fdp.ConsumeBytes(byte_size))
-    tp.test_timedelta_conversion.hypothesis.fuzz_one_input(
-        fdp.ConsumeBytes(byte_size))
+    # tp.test_abs_jd2_always_less_than_half_on_construction.hypothesis.fuzz_one_input(
+    #     fdp.ConsumeBytes(byte_size))
+    # tp.test_round_to_even.hypothesis.fuzz_one_input(
+    #     fdp.ConsumeBytes(byte_size))
+    # tp.test_two_sum.hypothesis.fuzz_one_input(
+    #     fdp.ConsumeBytes(byte_size))
+    # tp.test_two_sum_symmetric.hypothesis.fuzz_one_input(
+    #     fdp.ConsumeBytes(byte_size))
+    # tp.test_two_sum_size.hypothesis.fuzz_one_input(
+    #     fdp.ConsumeBytes(byte_size))
+    # tp.test_day_frac_harmless.hypothesis.fuzz_one_input(
+    #     fdp.ConsumeBytes(byte_size))
+    # tp.test_day_frac_exact.hypothesis.fuzz_one_input(
+    #     fdp.ConsumeBytes(byte_size))
+    # tp.test_day_frac_idempotent.hypothesis.fuzz_one_input(
+    #     fdp.ConsumeBytes(byte_size))
+    # tp.test_mjd_initialization_precise.hypothesis.fuzz_one_input(
+    #     fdp.ConsumeBytes(byte_size))
+    # tp.test_day_frac_always_less_than_half.hypothesis.fuzz_one_input(
+    #     fdp.ConsumeBytes(byte_size))
+    # tp.test_day_frac_round_to_even.hypothesis.fuzz_one_input(
+    #     fdp.ConsumeBytes(byte_size))
+    # tp.test_resolution_never_decreases.hypothesis.fuzz_one_input(
+    #     fdp.ConsumeBytes(byte_size))
+    # tp.test_resolution_never_decreases_utc.hypothesis.fuzz_one_input(
+    #     fdp.ConsumeBytes(byte_size))
+    # tp.test_conversion_preserves_jd1_jd2_invariant.hypothesis.fuzz_one_input(
+    #     fdp.ConsumeBytes(byte_size))
+    # tp.test_conversion_never_loses_precision.hypothesis.fuzz_one_input(
+    #     fdp.ConsumeBytes(byte_size))
+    # tp.test_leap_stretch_mjd.hypothesis.fuzz_one_input(
+    #     fdp.ConsumeBytes(byte_size))
+    # tp.test_jd_add_subtract_round_trip.hypothesis.fuzz_one_input(
+    #     fdp.ConsumeBytes(byte_size))
+    # tp.test_time_argminmaxsort.hypothesis.fuzz_one_input(
+    #     fdp.ConsumeBytes(byte_size))
+    # tp.test_timedelta_full_precision.hypothesis.fuzz_one_input(
+    #     fdp.ConsumeBytes(byte_size))
+    # tp.test_timedelta_full_precision_arithmetic.hypothesis.fuzz_one_input(
+    #     fdp.ConsumeBytes(byte_size))
+    # tp.test_timedelta_conversion.hypothesis.fuzz_one_input(
+    #     fdp.ConsumeBytes(byte_size))
     tp.test_datetime_difference_agrees_with_timedelta.hypothesis.fuzz_one_input(
         fdp.ConsumeBytes(byte_size))
     tp.test_datetime_to_timedelta.hypothesis.fuzz_one_input(
         fdp.ConsumeBytes(byte_size))
     tp.test_datetime_timedelta_roundtrip.hypothesis.fuzz_one_input(
         fdp.ConsumeBytes(byte_size))
-    tp.test_timedelta_datetime_roundtrip.hypothesis.fuzz_one_input(
-        fdp.ConsumeBytes(byte_size))
-    tp.test_timedelta_from_parts.hypothesis.fuzz_one_input(
-        fdp.ConsumeBytes(byte_size))
-    tp.test_datetime_timedelta_sum.hypothesis.fuzz_one_input(
-        fdp.ConsumeBytes(byte_size))
-    tp.test_sidereal_lat_independent.hypothesis.fuzz_one_input(
-        fdp.ConsumeBytes(byte_size))
-    tp.test_sidereal_lon_independent.hypothesis.fuzz_one_input(
-       fdp.ConsumeBytes(byte_size))
+    # tp.test_timedelta_datetime_roundtrip.hypothesis.fuzz_one_input(
+    #     fdp.ConsumeBytes(byte_size))
+    # tp.test_timedelta_from_parts.hypothesis.fuzz_one_input(
+    #     fdp.ConsumeBytes(byte_size))
+    # tp.test_datetime_timedelta_sum.hypothesis.fuzz_one_input(
+    #     fdp.ConsumeBytes(byte_size))
+    # tp.test_sidereal_lat_independent.hypothesis.fuzz_one_input(
+    #     fdp.ConsumeBytes(byte_size))
+    # tp.test_sidereal_lon_independent.hypothesis.fuzz_one_input(
+    #    fdp.ConsumeBytes(byte_size))
 
 tp.setup_module()
 atheris.Setup(sys.argv, TestOneInput)

--- a/astropy/time/tests/fuzz_precision.py
+++ b/astropy/time/tests/fuzz_precision.py
@@ -1,0 +1,74 @@
+#!/usr/bin/python
+import atheris
+import sys
+
+
+with atheris.instrument_imports():
+    import astropy.time.tests.test_precision as tp
+
+
+def TestOneInput(data):
+    fdp = atheris.FuzzedDataProvider(data)
+    byte_size = fdp.ConsumeIntInRange(0, 1000)
+    tp.test_abs_jd2_always_less_than_half_on_construction.hypothesis.fuzz_one_input(
+        fdp.ConsumeBytes(byte_size))
+    tp.test_round_to_even.hypothesis.fuzz_one_input(
+        fdp.ConsumeBytes(byte_size))
+    tp.test_two_sum.hypothesis.fuzz_one_input(
+        fdp.ConsumeBytes(byte_size))
+    tp.test_two_sum_symmetric.hypothesis.fuzz_one_input(
+        fdp.ConsumeBytes(byte_size))
+    tp.test_two_sum_size.hypothesis.fuzz_one_input(
+        fdp.ConsumeBytes(byte_size))
+    tp.test_day_frac_harmless.hypothesis.fuzz_one_input(
+        fdp.ConsumeBytes(byte_size))
+    tp.test_day_frac_exact.hypothesis.fuzz_one_input(
+        fdp.ConsumeBytes(byte_size))
+    tp.test_day_frac_idempotent.hypothesis.fuzz_one_input(
+        fdp.ConsumeBytes(byte_size))
+    tp.test_mjd_initialization_precise.hypothesis.fuzz_one_input(
+        fdp.ConsumeBytes(byte_size))
+    tp.test_day_frac_always_less_than_half.hypothesis.fuzz_one_input(
+        fdp.ConsumeBytes(byte_size))
+    tp.test_day_frac_round_to_even.hypothesis.fuzz_one_input(
+        fdp.ConsumeBytes(byte_size))
+    tp.test_resolution_never_decreases.hypothesis.fuzz_one_input(
+        fdp.ConsumeBytes(byte_size))
+    tp.test_resolution_never_decreases_utc.hypothesis.fuzz_one_input(
+        fdp.ConsumeBytes(byte_size))
+    tp.test_conversion_preserves_jd1_jd2_invariant.hypothesis.fuzz_one_input(
+        fdp.ConsumeBytes(byte_size))
+    tp.test_conversion_never_loses_precision.hypothesis.fuzz_one_input(
+        fdp.ConsumeBytes(byte_size))
+    tp.test_leap_stretch_mjd.hypothesis.fuzz_one_input(
+        fdp.ConsumeBytes(byte_size))
+    tp.test_jd_add_subtract_round_trip.hypothesis.fuzz_one_input(
+        fdp.ConsumeBytes(byte_size))
+    tp.test_time_argminmaxsort.hypothesis.fuzz_one_input(
+        fdp.ConsumeBytes(byte_size))
+    tp.test_timedelta_full_precision.hypothesis.fuzz_one_input(
+        fdp.ConsumeBytes(byte_size))
+    tp.test_timedelta_full_precision_arithmetic.hypothesis.fuzz_one_input(
+        fdp.ConsumeBytes(byte_size))
+    tp.test_timedelta_conversion.hypothesis.fuzz_one_input(
+        fdp.ConsumeBytes(byte_size))
+    tp.test_datetime_difference_agrees_with_timedelta.hypothesis.fuzz_one_input(
+        fdp.ConsumeBytes(byte_size))
+    tp.test_datetime_to_timedelta.hypothesis.fuzz_one_input(
+        fdp.ConsumeBytes(byte_size))
+    tp.test_datetime_timedelta_roundtrip.hypothesis.fuzz_one_input(
+        fdp.ConsumeBytes(byte_size))
+    tp.test_timedelta_datetime_roundtrip.hypothesis.fuzz_one_input(
+        fdp.ConsumeBytes(byte_size))
+    tp.test_timedelta_from_parts.hypothesis.fuzz_one_input(
+        fdp.ConsumeBytes(byte_size))
+    tp.test_datetime_timedelta_sum.hypothesis.fuzz_one_input(
+        fdp.ConsumeBytes(byte_size))
+    tp.test_sidereal_lat_independent.hypothesis.fuzz_one_input(
+        fdp.ConsumeBytes(byte_size))
+    tp.test_sidereal_lon_independent.hypothesis.fuzz_one_input(
+       fdp.ConsumeBytes(byte_size))
+
+tp.setup_module()
+atheris.Setup(sys.argv, TestOneInput)
+atheris.Fuzz()

--- a/astropy/time/tests/fuzz_precision/fuzz_datetime_difference_agrees_with_timedelta.py
+++ b/astropy/time/tests/fuzz_precision/fuzz_datetime_difference_agrees_with_timedelta.py
@@ -1,0 +1,12 @@
+#!/usr/bin/python
+import atheris
+import sys
+
+
+with atheris.instrument_imports():
+    import astropy.time.tests.test_precision as tp
+
+tp.setup_module()
+atheris.Setup(
+    sys.argv, tp.test_datetime_difference_agrees_with_timedelta.hypothesis.fuzz_one_input)
+atheris.Fuzz()

--- a/astropy/time/tests/fuzz_precision/fuzz_datetime_timedelta_roundtrip.py
+++ b/astropy/time/tests/fuzz_precision/fuzz_datetime_timedelta_roundtrip.py
@@ -1,0 +1,12 @@
+#!/usr/bin/python
+import atheris
+import sys
+
+
+with atheris.instrument_imports():
+    import astropy.time.tests.test_precision as tp
+
+tp.setup_module()
+atheris.Setup(
+    sys.argv, tp.test_datetime_timedelta_roundtrip.hypothesis.fuzz_one_input)
+atheris.Fuzz()

--- a/astropy/time/tests/fuzz_precision/fuzz_datetime_to_timedelta.py
+++ b/astropy/time/tests/fuzz_precision/fuzz_datetime_to_timedelta.py
@@ -1,0 +1,12 @@
+#!/usr/bin/python
+import atheris
+import sys
+
+
+with atheris.instrument_imports():
+    import astropy.time.tests.test_precision as tp
+
+tp.setup_module()
+atheris.Setup(
+    sys.argv, tp.test_datetime_to_timedelta.hypothesis.fuzz_one_input)
+atheris.Fuzz()


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request creates an adapter between hypothesis and atheris to make use of coverage-driven fuzzing.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

EDIT: Fix #14691