### PR TITLE
Bugfix: fitting fails when `weights` are passed and `filter_non_finite=True`

### DIFF
--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -1267,7 +1267,7 @@ class _NonLinearLSQFitter(metaclass=_FitterMeta):
     def _run_fitter(self, model, farg, maxiter, acc, epsilon, estimate_jacobian):
         return None, None, None
 
-    def _filter_non_finite(self, x, y, z=None):
+    def _filter_non_finite(self, x, y, z=None, weights=None):
         """
         Filter out non-finite values in x, y, z.
 
@@ -1282,12 +1282,14 @@ class _NonLinearLSQFitter(metaclass=_FitterMeta):
             mask = np.isfinite(y)
             if not np.all(mask):
                 warnings.warn(MESSAGE, AstropyUserWarning)
-            return x[mask], y[mask], None
+            z_out = None
         else:
             mask = np.isfinite(z)
             if not np.all(mask):
                 warnings.warn(MESSAGE, AstropyUserWarning)
-            return x[mask], y[mask], z[mask]
+            z_out = z[mask]
+
+        return x[mask], y[mask], z_out, None if weights is None else weights[mask]
 
     @fitter_unit_support
     def __call__(
@@ -1355,7 +1357,7 @@ class _NonLinearLSQFitter(metaclass=_FitterMeta):
         model_copy.sync_constraints = False
 
         if filter_non_finite:
-            x, y, z = self._filter_non_finite(x, y, z)
+            x, y, z, weights = self._filter_non_finite(x, y, z, weights)
         farg = (
             model_copy,
             weights,

--- a/astropy/modeling/tests/test_fitters.py
+++ b/astropy/modeling/tests/test_fitters.py
@@ -1442,7 +1442,8 @@ def test_non_finite_filter_1D(fitter, weights):
 
 @pytest.mark.skipif(not HAS_SCIPY, reason="requires scipy")
 @pytest.mark.parametrize("fitter", non_linear_fitters)
-def test_non_finite_filter_2D(fitter):
+@pytest.mark.parametrize("weights", [np.ones((10, 10)), None])
+def test_non_finite_filter_2D(fitter, weights):
     """Regression test filter introduced to remove non-finte values from data"""
 
     x, y = np.mgrid[0:10, 0:10]
@@ -1461,7 +1462,7 @@ def test_non_finite_filter_2D(fitter):
         AstropyUserWarning,
         match=r"Non-Finite input data has been removed by the fitter",
     ):
-        fit(m_init, x, y, z, filter_non_finite=True)
+        fit(m_init, x, y, z, filter_non_finite=True, weights=weights)
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason="requires scipy")

--- a/astropy/modeling/tests/test_fitters.py
+++ b/astropy/modeling/tests/test_fitters.py
@@ -1404,7 +1404,8 @@ class TestFittingUncertanties:
 
 @pytest.mark.skipif(not HAS_SCIPY, reason="requires scipy")
 @pytest.mark.parametrize("fitter", non_linear_fitters)
-def test_non_finite_error(fitter):
+@pytest.mark.parametrize("weights", [np.ones(8), None])
+def test_non_finite_error(fitter, weights):
     """Regression test error introduced to solve issues #3575 and #12809"""
 
     x = np.array([1, 2, 3, 4, 5, np.nan, 7, np.inf])
@@ -1417,12 +1418,13 @@ def test_non_finite_error(fitter):
     with pytest.raises(
         NonFiniteValueError, match=r"Objective function has encountered.*"
     ):
-        fit(m_init, x, y)
+        fit(m_init, x, y, weights=weights)
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason="requires scipy")
 @pytest.mark.parametrize("fitter", non_linear_fitters)
-def test_non_finite_filter_1D(fitter):
+@pytest.mark.parametrize("weights", [np.ones(8), None])
+def test_non_finite_filter_1D(fitter, weights):
     """Regression test filter introduced to remove non-finte values from data"""
 
     x = np.array([1, 2, 3, 4, 5, 6, 7, 8])
@@ -1435,7 +1437,7 @@ def test_non_finite_filter_1D(fitter):
         AstropyUserWarning,
         match=r"Non-Finite input data has been removed by the fitter",
     ):
-        fit(m_init, x, y, filter_non_finite=True)
+        fit(m_init, x, y, filter_non_finite=True, weights=weights)
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason="requires scipy")

--- a/docs/changes/modeling/14695.bugfix.rst
+++ b/docs/changes/modeling/14695.bugfix.rst
@@ -1,0 +1,2 @@
+Fix issue with ``filter_non_finite`` option when fitting with ``weights`` via passing
+the ``weights`` through the non-finite-filter alongside the input data.


### PR DESCRIPTION
### Description
When fitting, there is an option `filter_non_finite` which enables automatic filtering of non-finite values from the input data to a non-linear fitter. Currently, using this option (setting it as `True`) combined with passing fitting `weights` results in a `ValueError` when some items are filtered. This is because the `weights` passed have not being filtered, resulting in a shape mismatch.

This PR fixes this issue by also filtering the `weights` in the same way the input data is filtered. This is a follow-on fix for oversights in #13259
