### PR TITLE
#12355 Issue: Register latex to Cosmology.write

### DIFF
--- a/astropy/cosmology/io/__init__.py
+++ b/astropy/cosmology/io/__init__.py
@@ -5,4 +5,4 @@ Read/Write/Interchange methods for `astropy.cosmology`. **NOT public API**.
 """
 
 # Import to register with the I/O machinery
-from . import cosmology, ecsv, html, mapping, model, row, table, yaml
+from . import cosmology, ecsv, html, mapping, model, row, table, yaml, latex

--- a/astropy/cosmology/io/latex.py
+++ b/astropy/cosmology/io/latex.py
@@ -1,0 +1,79 @@
+import astropy.units as u
+from astropy.cosmology.connect import readwrite_registry
+from astropy.cosmology.core import Cosmology
+from astropy.cosmology.parameter import Parameter
+from astropy.table import QTable
+
+
+from .table import to_table
+
+_FORMAT_TABLE = {
+    "H0": "$$H_0$$",
+    "Om0": "$$\\Omega_{m,0}$$",
+    "Ode0": "$$\\Omega_{\\Lambda,0}$$",
+    "Tcmb0": "$$T_{0}$$",
+    "Neff": "$$N_{eff}$$",
+    "m_nu": "$$m_{nu}$$",
+    "Ob0": "$$\\Omega_{b,0}$$",
+    "w0": "$$w_{0}$$",
+    "wa": "$$w_{a}$$",
+    "wz": "$$w_{z}$$",
+    "wp": "$$w_{p}$$",
+    "zp": "$$z_{p}$$",
+}
+
+
+def write_latex(
+    cosmology, file, *, overwrite=False, cls=QTable, latex_names=True, **kwargs
+):
+    r"""Serialize the |Cosmology| into a LaTeX.
+
+    Parameters
+    ----------
+    cosmology : `~astropy.cosmology.Cosmology` subclass instance
+    file : path-like or file-like
+        Location to save the serialized cosmology.
+
+    overwrite : bool
+        Whether to overwrite the file, if it exists.
+    cls : type, optional keyword-only
+        Astropy :class:`~astropy.table.Table` (sub)class to use when writing.
+        Default is :class:`~astropy.table.QTable`.
+    latex_names : bool, optional keyword-only
+        Whether to use LaTeX names for the parameters. Default is `True`.
+    **kwargs
+        Passed to ``cls.write``
+
+    Raises
+    ------
+    TypeError
+        If kwarg (optional) 'cls' is not a subclass of `astropy.table.Table`
+    """
+    # Check that the format is 'latex' (or not specified)
+    format = kwargs.pop("format", "latex")
+    if format != "latex":
+        raise ValueError(f"format must be 'latex', not {format}")
+
+    # Set cosmology_in_meta as false for now since there is no metadata being kept
+    table = to_table(cosmology, cls=cls, cosmology_in_meta=False)
+
+    cosmo_cls = type(cosmology)
+    for name, col in table.columns.copy().items():
+        param = getattr(cosmo_cls, name, None)
+        if not isinstance(param, Parameter) or param.unit in (None, u.one):
+            continue
+        # Get column to correct unit
+        table[name] <<= param.unit
+
+    # Convert parameter names to LaTeX format
+    if latex_names:
+        new_names = [_FORMAT_TABLE.get(k, k) for k in cosmology.__parameters__]
+        table.rename_columns(cosmology.__parameters__, new_names)
+
+    table.write(file, overwrite=overwrite, format="latex", **kwargs)
+
+
+# ===================================================================
+# Register
+
+readwrite_registry.register_writer("latex", Cosmology, write_latex)

--- a/astropy/cosmology/io/tests/test_latex.py
+++ b/astropy/cosmology/io/tests/test_latex.py
@@ -1,0 +1,78 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+# THIRD PARTY
+import pytest
+
+# LOCAL
+from astropy.cosmology.io.latex import _FORMAT_TABLE, write_latex
+from astropy.table import QTable, Table
+
+from .base import ReadWriteDirectTestBase, ReadWriteTestMixinBase
+
+
+class WriteLATEXTestMixin(ReadWriteTestMixinBase):
+    """
+    Tests for a Cosmology[Write] with ``format="latex"``.
+    This class will not be directly called by :mod:`pytest` since its name does
+    not begin with ``Test``. To activate the contained tests this class must
+    be inherited in a subclass. Subclasses must dfine a :func:`pytest.fixture`
+    ``cosmo`` that returns/yields an instance of a |Cosmology|.
+    See ``TestCosmology`` for an example.
+    """
+
+    def test_to_latex_failed_cls(self, write, tmp_path):
+        """Test failed table type."""
+        fp = tmp_path / "test_to_latex_failed_cls.tex"
+
+        with pytest.raises(TypeError, match="'cls' must be"):
+            write(fp, format="latex", cls=list)
+
+    @pytest.mark.parametrize("tbl_cls", [QTable, Table])
+    def test_to_latex_cls(self, write, tbl_cls, tmp_path):
+        fp = tmp_path / "test_to_latex_cls.tex"
+        write(fp, format="latex", cls=tbl_cls)
+
+    def test_latex_columns(self, write, tmp_path):
+        fp = tmp_path / "test_rename_latex_columns.tex"
+        write(fp, format="latex", latex_names=True)
+        tbl = QTable.read(fp)
+        # asserts each column name has not been reverted yet
+        # For now, Cosmology class and name are stored in first 2 slots
+        for column_name in tbl.colnames[2:]:
+            assert column_name in _FORMAT_TABLE.values()
+
+    def test_write_latex_invalid_path(self, write):
+        """Test passing an invalid path"""
+        invalid_fp = ""
+        with pytest.raises(FileNotFoundError, match="No such file or directory"):
+            write(invalid_fp, format="latex")
+
+    def test_write_latex_false_overwrite(self, write, tmp_path):
+        """Test to write a LaTeX file without overwriting an existing file"""
+        # Test that passing an invalid path to write_latex() raises a IOError
+        fp = tmp_path / "test_write_latex_false_overwrite.tex"
+        write(fp, format="latex")
+        with pytest.raises(OSError, match="overwrite=True"):
+            write(fp, format="latex", overwrite=False)
+
+
+class TestReadWriteLaTex(ReadWriteDirectTestBase, WriteLATEXTestMixin):
+    """
+    Directly test ``write_latex``.
+    These are not public API and are discouraged from use, in favor of
+    ``Cosmology.write(..., format="latex")``, but should be
+    tested regardless b/c they are used internally.
+    """
+
+    def setup_class(self):
+        self.functions = {"write": write_latex}
+
+    def test_rename_direct_latex_columns(self, write, tmp_path):
+        """Tests renaming columns"""
+        fp = tmp_path / "test_rename_latex_columns.tex"
+        write(fp, format="latex", latex_names=True)
+        tbl = QTable.read(fp)
+        # asserts each column name has not been reverted yet
+        for column_name in tbl.colnames[2:]:
+            # for now, Cosmology as metadata and name is stored in first 2 slots
+            assert column_name in _FORMAT_TABLE.values()

--- a/astropy/cosmology/tests/test_connect.py
+++ b/astropy/cosmology/tests/test_connect.py
@@ -18,6 +18,7 @@ from astropy.cosmology.io.tests import (
     test_row,
     test_table,
     test_yaml,
+    test_latex,
 )
 from astropy.table import QTable, Row
 from astropy.utils.compat.optional_deps import HAS_BS4
@@ -33,6 +34,7 @@ readwrite_formats = {
     ("ascii.ecsv", True, True),
     ("ascii.html", False, HAS_BS4),
     ("json", True, True),
+    ("latex", False, True),
 }
 
 
@@ -55,6 +57,7 @@ class ReadWriteTestMixin(
     test_ecsv.ReadWriteECSVTestMixin,
     test_html.ReadWriteHTMLTestMixin,
     test_json.ReadWriteJSONTestMixin,
+    test_latex.WriteLATEXTestMixin,
 ):
     """
     Tests for a CosmologyRead/Write on a |Cosmology|.
@@ -75,6 +78,8 @@ class ReadWriteTestMixin(
         """
         if not has_deps:
             pytest.skip("missing a dependency")
+        if (format, Cosmology) not in readwrite_registry._readers:
+            pytest.xfail(f"no read method is registered for format {format!r}")
 
         fname = str(tmp_path / f"{cosmo.name}.{format}")
         cosmo.write(fname, format=format)
@@ -103,6 +108,8 @@ class ReadWriteTestMixin(
         """
         if not has_deps:
             pytest.skip("missing a dependency")
+        if (format, Cosmology) not in readwrite_registry._readers:
+            pytest.xfail(f"no read method is registered for format {format!r}")
 
         fname = str(tmp_path / f"{cosmo.name}.{format}")
         cosmo.write(fname, format=format)
@@ -140,6 +147,8 @@ class TestCosmologyReadWrite(ReadWriteTestMixin):
     def test_write_methods_have_explicit_kwarg_overwrite(self, format, _, has_deps):
         if not has_deps:
             pytest.skip("missing a dependency")
+        if (format, Cosmology) not in readwrite_registry._readers:
+            pytest.xfail(f"no read method is registered for format {format!r}")
 
         writer = readwrite_registry.get_writer(format, Cosmology)
         # test in signature
@@ -156,6 +165,8 @@ class TestCosmologyReadWrite(ReadWriteTestMixin):
         """Test when the reader class doesn't match the file."""
         if not has_deps:
             pytest.skip("missing a dependency")
+        if (format, Cosmology) not in readwrite_registry._readers:
+            pytest.xfail(f"no read method is registered for format {format!r}")
 
         fname = tmp_path / f"{cosmo.name}.{format}"
         cosmo.write(fname, format=format)

--- a/docs/changes/cosmology/14701.feature.rst
+++ b/docs/changes/cosmology/14701.feature.rst
@@ -1,0 +1,1 @@
+Added a ``write_latex()`` method for exporting a Cosmology object to a LaTex table.

--- a/docs/whatsnew/6.0.rst
+++ b/docs/whatsnew/6.0.rst
@@ -13,6 +13,7 @@ the 5.3 release.
 In particular, this release includes:
 
 * :ref:`whatsnew-6.0-geodetic-representation-geometry`
+* :ref:`whatsnew-6.0-cosmology-latex-export`
 
 In addition to these major changes, Astropy v6.0 includes a large number of
 smaller improvements and bug fixes, which are described in the :ref:`changelog`.
@@ -47,6 +48,22 @@ bodies by subclassing `~astropy.coordinates.BaseGeodeticRepresentation` and defi
         (0.79999959, 0.98000063, 370.01796023)>
 
 See :ref:`astropy-coordinates-create-geodetic` for more details.
+
+
+.. _whatsnew-6.0-cosmology-latex-export:
+
+Updates to `~astropy.cosmology`
+===============================
+
+The :class:`~astropy.cosmology.Cosmology` class in :mod:`~astropy.cosmology` now
+supports the latex format in its :attr:`~astropy.cosmology.Cosmology.write()`
+method, allowing users to export a cosmology object to a LaTeX table.::
+
+    >>> from astropy.cosmology import Planck18
+    >>> Planck18.write("example_cosmology.tex", format="latex")
+
+This will write the cosmology object to a file in LaTeX format,
+with appropriate formatting of units and table alignment.
 
 Full change log
 ===============


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address Issue #12355 

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #12355 

I've added a new write_latex() method to the Cosmology package that allows you to export a Cosmology object to a Latex table. 

Test:
```python
from astropy.cosmology import Planck18
from astropy.cosmology.io import latex 

latex.write_latex(Planck18, "dd.tex", overwrite=True, latex_names=True)
```
Output:
```latex
\begin{table}
\begin{tabular}{cccccccc}
cosmology & name & $$H_0 
{[\mathrm{km\,s^{-1}\,Mpc^{-1}}]}$$ & Om0 & $$T_{0} 
{[\mathrm{K}]}$$ & Neff & $$m_{nu} 
{[\mathrm{eV}]}$$ & Ob0 \\
FlatLambdaCDM & Planck18 & 67.66 & 0.30966 & 2.7255 & 3.046 & 0.0 .. 0.06 & 0.04897 \\
\end{tabular}
\end{table}
```
Please let me know if you have any feedback or suggestions for improvements.