### PR TITLE
Fix numpy-dev deprecation in model Parameter

### DIFF
--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -335,7 +335,11 @@ class Parameter:
     def value(self):
         """The unadorned value proxied by this parameter."""
         if self._getter is None and self._setter is None:
-            return np.float64(self._value)
+            if self._value.size == 1:
+                return np.float64(
+                    self._value.item()
+                )  # return scalar number as np.float64 object
+            return self._value
         else:
             # This new implementation uses the names of internal_unit
             # in place of raw_unit used previously. The contrast between

--- a/astropy/modeling/tests/test_parameters.py
+++ b/astropy/modeling/tests/test_parameters.py
@@ -20,7 +20,6 @@ from astropy.modeling.parameters import (
     _tofloat,
     param_repr_oneline,
 )
-from astropy.utils.compat import NUMPY_LT_1_25
 from astropy.utils.data import get_pkg_data_filename
 
 from . import irafutil
@@ -534,9 +533,6 @@ class TestParameters:
         param = Parameter(name="test", default=np.array([1]))
         assert param.shape == (1,)
         # Reshape error
-        if not NUMPY_LT_1_25:
-            # error message changed in numpy 1.25
-            MESSAGE = r"cannot reshape array of size 1"
         with pytest.raises(ValueError, match=MESSAGE):
             param.shape = (5,)
         param.shape = ()

--- a/astropy/modeling/tests/test_parameters.py
+++ b/astropy/modeling/tests/test_parameters.py
@@ -704,6 +704,27 @@ class TestParameters:
             ]
             assert param._value is None
 
+    def test_value(self):
+        param = Parameter(name="test", default=1)
+        assert not isinstance(param.value, np.ndarray)
+        assert param.value == 1
+
+        param = Parameter(name="test", default=[1])
+        assert not isinstance(param.value, np.ndarray)
+        assert param.value == 1
+
+        param = Parameter(name="test", default=[[1]])
+        assert not isinstance(param.value, np.ndarray)
+        assert param.value == 1
+
+        param = Parameter(name="test", default=np.array([1]))
+        assert not isinstance(param.value, np.ndarray)
+        assert param.value == 1
+
+        param = Parameter(name="test", default=[1, 2, 3])
+        assert isinstance(param.value, np.ndarray)
+        assert (param.value == [1, 2, 3]).all()
+
     def test_raw_value(self):
         param = Parameter(name="test", default=[1, 2, 3, 4])
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

While investigating devdeps CI failures in `photutils`, I discovered that `Parameter.value` can give a numpy 1.25+ deprecation warning ("Conversion of an array with ndim > 0 to a scalar "), e.g.:

```python
>>> from astropy.modeling import Parameter
>>> param = Parameter(name="test", default=[1])
>>> param.value
DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)   return np.float64(self._value)

```
This wasn't caught in `devdeps` tests because there was no test for it.

With the fix in this PR, the error message changed back for one of the other tests.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

