### PR TITLE
Fix bug for Parameter with a getter but no setter

### DIFF
--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -355,15 +355,13 @@ class Parameter:
             # units that the parameter advertises to what it actually
             # uses internally.
             if self.internal_unit:
-                return np.float64(
-                    self._getter(
-                        self._internal_value, self.internal_unit, self.unit
-                    ).value
-                )
-            elif self._getter:
-                return np.float64(self._getter(self._internal_value))
-            elif self._setter:
-                return np.float64(self._internal_value)
+                value = self._getter(
+                    self._internal_value, self.internal_unit, self.unit
+                ).value
+            else:
+                value = self._getter(self._internal_value)
+
+            return np.float64(value)
 
     @value.setter
     def value(self, value):

--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -343,11 +343,7 @@ class Parameter:
     def value(self):
         """The unadorned value proxied by this parameter."""
         if self._getter is None and self._setter is None:
-            if self._value.size == 1:
-                return np.float64(
-                    self._value.item()
-                )  # return scalar number as np.float64 object
-            return self._value
+            value = self._value
         else:
             # This new implementation uses the names of internal_unit
             # in place of raw_unit used previously. The contrast between
@@ -361,7 +357,11 @@ class Parameter:
             else:
                 value = self._getter(self._internal_value)
 
-            return np.float64(value)
+        if value.size == 1:
+            # return scalar number as np.float64 object
+            return np.float64(value.item())
+
+        return np.float64(value)
 
     @value.setter
     def value(self, value):

--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -158,15 +158,18 @@ class Parameter:
         if specified, the parameter will be in these units, and when the
         parameter is updated in future, it should be set to a
         :class:`~astropy.units.Quantity` that has equivalent units.
-    getter : callable
-        a function that wraps the raw (internal) value of the parameter
-        when returning the value through the parameter proxy (eg. a
-        parameter may be stored internally as radians but returned to the
-        user as degrees). The internal value is what is used for computations
-        while the proxy value is what users will interact with (passing and viewing).
-    setter : callable
-        a function that wraps any values assigned to this parameter; should
-        be the inverse of getter
+    getter : callable or `None`, optional
+        A function that wraps the raw (internal) value of the parameter
+        when returning the value through the parameter proxy (e.g., a
+        parameter may be stored internally as radians but returned to
+        the user as degrees). The internal value is what is used for
+        computations while the proxy value is what users will interact
+        with (passing and viewing). If ``getter`` is not `None`, then a
+        ``setter`` must also be input.
+    setter : callable or `None`, optional
+        A function that wraps any values assigned to this parameter; should
+        be the inverse of ``getter``.  If ``setter`` is not `None`, then a
+        ``getter`` must also be input.
     fixed : bool
         if True the parameter is not varied during fitting
     tied : callable or False
@@ -213,6 +216,11 @@ class Parameter:
 
         self._model = None
         self._model_required = False
+
+        if (setter is not None and getter is None) or (
+            getter is not None and setter is None
+        ):
+            raise ValueError("setter and getter must both be input")
         self._setter = self._create_value_wrapper(setter, None)
         self._getter = self._create_value_wrapper(getter, None)
         self._name = name

--- a/astropy/modeling/tests/test_parameters.py
+++ b/astropy/modeling/tests/test_parameters.py
@@ -729,6 +729,20 @@ class TestParameters:
         assert isinstance(param.value, np.ndarray)
         assert (param.value == [1, 2, 3]).all()
 
+        param = Parameter(name="test", default=[1], setter=setter1, getter=getter1)
+        assert not isinstance(param.value, np.ndarray)
+        assert param.value == 1
+
+        param = Parameter(name="test", default=[[1]], setter=setter1, getter=getter1)
+        assert not isinstance(param.value, np.ndarray)
+        assert param.value == 1
+
+        param = Parameter(
+            name="test", default=np.array([1]), setter=setter1, getter=getter1
+        )
+        assert not isinstance(param.value, np.ndarray)
+        assert param.value == 1
+
     def test_raw_value(self):
         param = Parameter(name="test", default=[1, 2, 3, 4])
 

--- a/astropy/modeling/tests/test_parameters.py
+++ b/astropy/modeling/tests/test_parameters.py
@@ -840,6 +840,16 @@ class TestParameters:
         param = Parameter(name="test", default=[1, 2, 3, 4] * u.m)
         assert param_repr_oneline(param) == "[1., 2., 3., 4.] m"
 
+    def test_getter_setter(self):
+        def my_getter(value):
+            return value
+
+        msg = "setter and getter must both be input"
+        with pytest.raises(ValueError, match=msg):
+            Parameter(name="test", default=1, getter=my_getter)
+        with pytest.raises(ValueError, match=msg):
+            Parameter(name="test", default=1, setter=setter1)
+
 
 class TestMultipleParameterSets:
     def setup_class(self):

--- a/astropy/modeling/tests/test_parameters.py
+++ b/astropy/modeling/tests/test_parameters.py
@@ -34,12 +34,16 @@ def setter2(val, model):
     return val * model.p
 
 
+def getter1(val):
+    return val
+
+
 class SetterModel(FittableModel):
     n_inputs = 2
     n_outputs = 1
 
-    xc = Parameter(default=1, setter=setter1)
-    yc = Parameter(default=1, setter=setter2)
+    xc = Parameter(default=1, setter=setter1, getter=getter1)
+    yc = Parameter(default=1, setter=setter2, getter=getter1)
 
     def do_something(self, v):
         pass
@@ -841,12 +845,9 @@ class TestParameters:
         assert param_repr_oneline(param) == "[1., 2., 3., 4.] m"
 
     def test_getter_setter(self):
-        def my_getter(value):
-            return value
-
         msg = "setter and getter must both be input"
         with pytest.raises(ValueError, match=msg):
-            Parameter(name="test", default=1, getter=my_getter)
+            Parameter(name="test", default=1, getter=getter1)
         with pytest.raises(ValueError, match=msg):
             Parameter(name="test", default=1, setter=setter1)
 

--- a/astropy/modeling/tests/test_parameters.py
+++ b/astropy/modeling/tests/test_parameters.py
@@ -677,8 +677,8 @@ class TestParameters:
         model1 = mk.MagicMock()
         setter1 = mk.MagicMock()
         getter1 = mk.MagicMock()
-        setter1.return_value = [9, 10, 11, 12]
-        getter1.return_value = [9, 10, 11, 12]
+        setter1.return_value = np.array([9, 10, 11, 12])
+        getter1.return_value = np.array([9, 10, 11, 12])
         with mk.patch.object(
             Parameter, "_create_value_wrapper", side_effect=[setter1, getter1]
         ) as mkCreate:

--- a/docs/changes/modeling/14708.bugfix.rst
+++ b/docs/changes/modeling/14708.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed an issue with Parameter where a getter could be input without a
+setter (or vice versa).


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

Currently if a `Parameter` is defined without a `setter`, the `_internal_value` never gets set.  If a `getter` was input, this then causes errors with the `value` attribute.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->
