### PR TITLE
Refactor EarthLocation as instance of BodyLocation. Add flattening and equatorial radius as parameters.

### DIFF
--- a/astropy/coordinates/__init__.py
+++ b/astropy/coordinates/__init__.py
@@ -16,6 +16,7 @@ from .distances import *
 from .earth import *
 from .errors import *
 from .funcs import *
+from .geodetic import *
 from .matching import *
 from .name_resolve import *
 from .representation import *

--- a/astropy/coordinates/earth.py
+++ b/astropy/coordinates/earth.py
@@ -8,38 +8,28 @@ import urllib.parse
 import urllib.request
 from warnings import warn
 
-import erfa
 import numpy as np
 
 from astropy import constants as consts
 from astropy import units as u
 from astropy.units.quantity import QuantityInfoBase
 from astropy.utils import data
-from astropy.utils.decorators import format_doc
 from astropy.utils.exceptions import AstropyUserWarning
 
 from .angles import Angle, Latitude, Longitude
 from .errors import UnknownSiteException
 from .matrix_utilities import matrix_transpose
 from .representation import (
-    BaseRepresentation,
     CartesianDifferential,
     CartesianRepresentation,
 )
+from .geodetic import ELLIPSOIDS
 
 __all__ = [
     "EarthLocation",
-    "BaseGeodeticRepresentation",
-    "WGS84GeodeticRepresentation",
-    "WGS72GeodeticRepresentation",
-    "GRS80GeodeticRepresentation",
 ]
 
 GeodeticLocation = collections.namedtuple("GeodeticLocation", ["lon", "lat", "height"])
-
-ELLIPSOIDS = {}
-"""Available ellipsoids (defined in erfam.h, with numbers exposed in erfa)."""
-# Note: they get filled by the creation of the geodetic classes.
 
 OMEGA_EARTH = (1.002_737_811_911_354_48 * u.cycle / u.day).to(
     1 / u.s, u.dimensionless_angles()
@@ -905,87 +895,3 @@ class EarthLocation(u.Quantity):
             equivalencies = self._equivalencies
         new_array = self.unit.to(unit, array_view, equivalencies=equivalencies)
         return new_array.view(self.dtype).reshape(self.shape)
-
-
-geodetic_base_doc = """{__doc__}
-
-    Parameters
-    ----------
-    lon, lat : angle-like
-        The longitude and latitude of the point(s), in angular units. The
-        latitude should be between -90 and 90 degrees, and the longitude will
-        be wrapped to an angle between 0 and 360 degrees. These can also be
-        instances of `~astropy.coordinates.Angle` and either
-        `~astropy.coordinates.Longitude` not `~astropy.coordinates.Latitude`,
-        depending on the parameter.
-    height : `~astropy.units.Quantity` ['length']
-        The height to the point(s).
-    copy : bool, optional
-        If `True` (default), arrays will be copied. If `False`, arrays will
-        be references, though possibly broadcast to ensure matching shapes.
-
-"""
-
-
-@format_doc(geodetic_base_doc)
-class BaseGeodeticRepresentation(BaseRepresentation):
-    """Base geodetic representation."""
-
-    attr_classes = {"lon": Longitude, "lat": Latitude, "height": u.Quantity}
-
-    def __init_subclass__(cls, **kwargs):
-        super().__init_subclass__(**kwargs)
-        if "_ellipsoid" in cls.__dict__:
-            ELLIPSOIDS[cls._ellipsoid] = cls
-
-    def __init__(self, lon, lat=None, height=None, copy=True):
-        if height is None and not isinstance(lon, self.__class__):
-            height = 0 << u.m
-
-        super().__init__(lon, lat, height, copy=copy)
-        if not self.height.unit.is_equivalent(u.m):
-            raise u.UnitTypeError(
-                f"{self.__class__.__name__} requires height with units of length."
-            )
-
-    def to_cartesian(self):
-        """
-        Converts WGS84 geodetic coordinates to 3D rectangular (geocentric)
-        cartesian coordinates.
-        """
-        xyz = erfa.gd2gc(
-            getattr(erfa, self._ellipsoid), self.lon, self.lat, self.height
-        )
-        return CartesianRepresentation(xyz, xyz_axis=-1, copy=False)
-
-    @classmethod
-    def from_cartesian(cls, cart):
-        """
-        Converts 3D rectangular cartesian coordinates (assumed geocentric) to
-        WGS84 geodetic coordinates.
-        """
-        lon, lat, height = erfa.gc2gd(
-            getattr(erfa, cls._ellipsoid), cart.get_xyz(xyz_axis=-1)
-        )
-        return cls(lon, lat, height, copy=False)
-
-
-@format_doc(geodetic_base_doc)
-class WGS84GeodeticRepresentation(BaseGeodeticRepresentation):
-    """Representation of points in WGS84 3D geodetic coordinates."""
-
-    _ellipsoid = "WGS84"
-
-
-@format_doc(geodetic_base_doc)
-class WGS72GeodeticRepresentation(BaseGeodeticRepresentation):
-    """Representation of points in WGS72 3D geodetic coordinates."""
-
-    _ellipsoid = "WGS72"
-
-
-@format_doc(geodetic_base_doc)
-class GRS80GeodeticRepresentation(BaseGeodeticRepresentation):
-    """Representation of points in GRS80 3D geodetic coordinates."""
-
-    _ellipsoid = "GRS80"

--- a/astropy/coordinates/geodetic.py
+++ b/astropy/coordinates/geodetic.py
@@ -1,0 +1,129 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+import erfa
+
+from astropy import units as u
+from astropy.utils.decorators import format_doc
+
+from .angles import Latitude, Longitude
+from .representation import (
+    BaseRepresentation,
+    CartesianRepresentation,
+)
+
+__all__ = [
+    "BaseGeodeticRepresentation",
+    "WGS84GeodeticRepresentation",
+    "WGS72GeodeticRepresentation",
+    "GRS80GeodeticRepresentation",
+]
+
+ELLIPSOIDS = {}
+"""Available ellipsoids (defined in erfam.h, with numbers exposed in erfa)."""
+# Note: they get filled by the creation of the geodetic classes.
+
+
+geodetic_base_doc = """{__doc__}
+
+    Parameters
+    ----------
+    lon, lat : angle-like
+        The longitude and latitude of the point(s), in angular units. The
+        latitude should be between -90 and 90 degrees, and the longitude will
+        be wrapped to an angle between 0 and 360 degrees. These can also be
+        instances of `~astropy.coordinates.Angle` and either
+        `~astropy.coordinates.Longitude` not `~astropy.coordinates.Latitude`,
+        depending on the parameter.
+
+    height : `~astropy.units.Quantity` ['length']
+        The height to the point(s).
+
+    copy : bool, optional
+        If `True` (default), arrays will be copied. If `False`, arrays will
+        be references, though possibly broadcast to ensure matching shapes.
+"""
+
+
+@format_doc(geodetic_base_doc)
+class BaseGeodeticRepresentation(BaseRepresentation):
+    """
+    Base class for geodetic representations.
+
+    Subclasses need to set attributes ``_equatorial_radius`` and ``_flattening``
+    to quantities holding correct values (with units of length and dimensionless,
+    respectively), or alternatively an ``_ellipsoid`` attribute to the relevant ERFA
+    index (as passed in to `erfa.eform`).
+    """
+
+    attr_classes = {"lon": Longitude, "lat": Latitude, "height": u.Quantity}
+
+    def __init_subclass__(cls, **kwargs):
+        if "_ellipsoid" in cls.__dict__:
+            equatorial_radius, flattening = erfa.eform(getattr(erfa, cls._ellipsoid))
+            cls._equatorial_radius = equatorial_radius * u.m
+            cls._flattening = flattening * u.dimensionless_unscaled
+            ELLIPSOIDS[cls._ellipsoid] = cls
+        elif (
+            "_equatorial_radius" not in cls.__dict__
+            or "_flattening" not in cls.__dict__
+        ):
+            raise AttributeError(
+                f"{cls.__name__} requires '_ellipsoid' or '_equatorial_radius' and '_flattening'."
+            )
+        super().__init_subclass__(**kwargs)
+
+    def __init__(self, lon, lat=None, height=None, copy=True):
+        if height is None and not isinstance(lon, self.__class__):
+            height = 0 << u.m
+
+        super().__init__(lon, lat, height, copy=copy)
+        if not self.height.unit.is_equivalent(u.m):
+            raise u.UnitTypeError(
+                f"{self.__class__.__name__} requires height with units of length."
+            )
+
+    def to_cartesian(self):
+        """
+        Converts geodetic coordinates to 3D rectangular (geocentric)
+        cartesian coordinates.
+        """
+        xyz = erfa.gd2gce(
+            self._equatorial_radius,
+            self._flattening,
+            self.lon,
+            self.lat,
+            self.height,
+        )
+        return CartesianRepresentation(xyz, xyz_axis=-1, copy=False)
+
+    @classmethod
+    def from_cartesian(cls, cart):
+        """
+        Converts 3D rectangular cartesian coordinates (assumed geocentric) to
+        geodetic coordinates.
+        """
+        lon, lat, height = erfa.gc2gde(
+            cls._equatorial_radius, cls._flattening, cart.get_xyz(xyz_axis=-1)
+        )
+        return cls(lon, lat, height, copy=False)
+
+
+@format_doc(geodetic_base_doc)
+class WGS84GeodeticRepresentation(BaseGeodeticRepresentation):
+    """Representation of points in WGS84 3D geodetic coordinates."""
+
+    _ellipsoid = "WGS84"
+
+
+@format_doc(geodetic_base_doc)
+class WGS72GeodeticRepresentation(BaseGeodeticRepresentation):
+    """Representation of points in WGS72 3D geodetic coordinates."""
+
+    _ellipsoid = "WGS72"
+
+
+@format_doc(geodetic_base_doc)
+class GRS80GeodeticRepresentation(BaseGeodeticRepresentation):
+    """Representation of points in GRS80 3D geodetic coordinates."""
+
+    _ellipsoid = "GRS80"

--- a/astropy/coordinates/tests/test_earth.py
+++ b/astropy/coordinates/tests/test_earth.py
@@ -10,8 +10,9 @@ import pytest
 from astropy import constants
 from astropy import units as u
 from astropy.coordinates.angles import Latitude, Longitude
-from astropy.coordinates.earth import ELLIPSOIDS, EarthLocation
+from astropy.coordinates.earth import EarthLocation
 from astropy.coordinates.name_resolve import NameResolveError
+from astropy.coordinates.geodetic import ELLIPSOIDS
 from astropy.time import Time
 from astropy.units import allclose as quantity_allclose
 from astropy.units.tests.test_quantity_erfa_ufuncs import vvd

--- a/docs/changes/coordinates/14763.feature.rst
+++ b/docs/changes/coordinates/14763.feature.rst
@@ -1,0 +1,2 @@
+Support for ``_equatorial_radius`` and ``_flattening`` is added in
+``BaseGeodeticRepresentation``.

--- a/docs/coordinates/representations.rst
+++ b/docs/coordinates/representations.rst
@@ -30,6 +30,14 @@ The built-in representation classes are:
 * `~astropy.coordinates.CylindricalRepresentation`:
   cylindrical polar coordinates, represented by a cylindrical radius
   (``rho``), azimuthal angle (``phi``), and height (``z``).
+* `~astropy.coordinates.BaseGeodeticRepresentation`:
+  coordinates on a surface of a spheroid (an ellipsoid with equal equatorial radii),
+  represented by a longitude (``lon``) a geodetical latitude (``lat``) and a height
+  (``height``) above the surface. The geodetical latitude is defined by the angle
+  between the vertical to the surface at a specific point of the spheroid and its
+  projection onto the equatorial plane.
+  The latitude is a value ranging from -90 to 90 degrees, the longitude from 0 to 360
+  degrees.
 
 .. Note::
    For information about using and changing the representation of
@@ -685,3 +693,22 @@ In pseudo-code, this means that a class will look like::
 
     class MyDifferential(BaseDifferential):
         base_representation = MyRepresentation
+
+.. _astropy-coordinates-create-geodetic:
+
+Creating Your Own Geodetic Representation
+-----------------------------------------
+
+Geodetic representations are implemented to allow the representation of planetary bodies.
+Your planetary class must inherit from the `~astropy.coordinates.BaseGeodeticRepresentation`.
+The equatorial radius and flattening must be both assigned via the attributes
+`_equatorial_radius` and `_flattening`. Alternatively an `_ellipsoid` attribute may be
+set to the relevant ERFA index (as passed in to `erfa.eform`).
+
+For example the spheroid describing Mars as in the
+`1979 IAU standard <https://doi.org/10.1007/BF01229508>`_ should be defined like::
+
+    class IAUMARS1979GeodeticRepresentation(BaseGeodeticRepresentation):
+
+        _equatorial_radius = 3393400.0 * u.m
+        _flattening = 0.518650e-2 * u.dimensionless_unscaled

--- a/docs/whatsnew/6.0.rst
+++ b/docs/whatsnew/6.0.rst
@@ -12,7 +12,7 @@ the 5.3 release.
 
 In particular, this release includes:
 
-* nothing yet
+* :ref:`whatsnew-6.0-geodetic-representation-geometry`
 
 In addition to these major changes, Astropy v6.0 includes a large number of
 smaller improvements and bug fixes, which are described in the :ref:`changelog`.
@@ -21,6 +21,29 @@ By the numbers:
 * X issues have been closed since v5.3
 * X pull requests have been merged since v5.3
 * X distinct people have contributed code
+
+.. _whatsnew-6.0-geodetic-representation-geometry:
+
+Define Geodetic Representations via their geometric parameters
+==============================================================
+
+The `~astropy.coordinates.BaseGeodeticRepresentation` now exposes its geometric
+parameters via the attributes ``_equatorial_radius`` and ``_flattening``.
+The user may now define custom spheroidal models for the Earth or other Solar System
+bodies::
+
+    >>> from astropy.coordinates import BaseGeodeticRepresentation
+    >>> from astropy import units as u
+    >>> class IAU1976EarthGeodeticRepresentation(BaseGeodeticRepresentation):
+    ...     _equatorial_radius = 6378140 * u.m
+    ...     _flattening = 0.003352805 * u.dimensionless_unscaled
+    >>> representation = IAU1976EarthGeodeticRepresentation(lon=0.8*u.radian,
+    ...     lat=0.98*u.radian, height=367*u.m)
+    >>> representation.to_cartesian()
+    <CartesianRepresentation (x, y, z) in m
+        (2481113.87541373, 2554650.51055863, 5274062.32189811)>
+
+See :ref:`astropy-coordinates-create-geodetic` for more details.
 
 Full change log
 ===============

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -309,6 +309,7 @@ unfixable = [
 "setup.py" = ["INP001"]  # Part of configuration, not a package.
 "__init__.py" = ["E402", "F401", "F403"]
 "astropy/coordinates/angle_formats.py" = ["D415"]  # The docstrings are regexes.
+"astropy/coordinates/tests/test_geodetic_representations.py" = ["F401"]  # Unused import needed.
 "astropy/io/registry/compat.py" = ["F822"]
 "astropy/modeling/models.py" = ["F401", "F403", "F405"]
 "astropy/units/format/*.py" = ["D415"]  # The docstrings are regexes.


### PR DESCRIPTION
### Description
Towards #11170.

This pull request refactors `EarthLocation` as instance of `BodyLocation`.

The class `BaseGeodeticRepresentation` can now be described using custom `equatorial_radius` and `flattening` parameters.
Geodetic computations are then performed calling `erfa.gc2gde` and `erfa.gd2gce` when no standard ellipsoid is available.
Helpers for those two functions have been added.

This work is funded by the Europlanet 2024 Research Infrastructure (RI) Grant.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->
