### PR TITLE
Table io null fix

### DIFF
--- a/astropy/io/fits/connect.py
+++ b/astropy/io/fits/connect.py
@@ -265,6 +265,9 @@ def read_table_fits(
         # string, empty strings.
         # Since Multi-element columns with dtypes such as '2f8' have a subdtype,
         # we should look up the type of column on that.
+        # Also propagate TNULL (for ints) or the FITS default null value for
+        # floats and strings to the column's fill_value to ensure round trips
+        # preserve null values.
         masked = mask = False
         coltype = col.dtype.subdtype[0].type if col.dtype.subdtype else col.dtype.type
         if col.null is not None:
@@ -272,14 +275,18 @@ def read_table_fits(
             # Return a MaskedColumn even if no elements are masked so
             # we roundtrip better.
             masked = True
+            fill_value = col.null
         elif mask_invalid and issubclass(coltype, np.inexact):
             mask = np.isnan(data[col.name])
+            fill_value = np.NaN
         elif mask_invalid and issubclass(coltype, np.character):
             mask = col.array == b""
+            fill_value = b""
 
         if masked or np.any(mask):
             column = MaskedColumn(
-                data=data[col.name], name=col.name, mask=mask, copy=False
+                data=data[col.name], name=col.name, mask=mask, copy=False,
+                fill_value=fill_value,
             )
         else:
             column = Column(data=data[col.name], name=col.name, copy=False)

--- a/astropy/io/fits/connect.py
+++ b/astropy/io/fits/connect.py
@@ -269,6 +269,7 @@ def read_table_fits(
         # floats and strings to the column's fill_value to ensure round trips
         # preserve null values.
         masked = mask = False
+        fill_value = None
         coltype = col.dtype.subdtype[0].type if col.dtype.subdtype else col.dtype.type
         if col.null is not None:
             mask = data[col.name] == col.null

--- a/astropy/io/fits/connect.py
+++ b/astropy/io/fits/connect.py
@@ -279,7 +279,7 @@ def read_table_fits(
             fill_value = col.null
         elif mask_invalid and issubclass(coltype, np.inexact):
             mask = np.isnan(data[col.name])
-            fill_value = np.NaN
+            fill_value = np.nan
         elif mask_invalid and issubclass(coltype, np.character):
             mask = col.array == b""
             fill_value = b""

--- a/astropy/io/fits/connect.py
+++ b/astropy/io/fits/connect.py
@@ -285,7 +285,10 @@ def read_table_fits(
 
         if masked or np.any(mask):
             column = MaskedColumn(
-                data=data[col.name], name=col.name, mask=mask, copy=False,
+                data=data[col.name],
+                name=col.name,
+                mask=mask,
+                copy=False,
                 fill_value=fill_value,
             )
         else:

--- a/astropy/io/fits/tests/test_connect.py
+++ b/astropy/io/fits/tests/test_connect.py
@@ -1076,3 +1076,28 @@ def test_keep_masked_state_integer_columns(tmp_path):
     assert not isinstance(tr["a"], MaskedColumn)
     assert not isinstance(tr["b"], MaskedColumn)
     assert isinstance(tr["c"], MaskedColumn)
+
+
+def test_null_propagation_in_table_read(tmp_path):
+    """Checks that integer columns with a TNULL value set (e.g. masked columns)
+    have their TNULL value propagated when being read in by Table.read"""
+
+    # Could be anything except for 999999, which is the "default" fill_value
+    # for masked int arrays
+    NULL_VALUE = -1
+
+    output_filename = tmp_path / "null_table.fits"
+
+    data = np.asarray([1, 2, NULL_VALUE, 4], dtype=np.int32)
+
+    # Create table with BinTableHDU, with integer column containing a custom
+    # null
+    c = fits.Column(name="a", array=data, null=NULL_VALUE, format="J")
+    hdu = BinTableHDU.from_columns([c])
+    hdul = fits.HDUList([PrimaryHDU(), hdu])
+    hdul.writeto(output_filename)
+
+    # Read the table in with Table.read, and ensure the column's fill_value is
+    # equal to NULL_VALUE
+    t = Table.read(output_filename)
+    assert t["a"].fill_value == NULL_VALUE

--- a/astropy/io/fits/tests/test_connect.py
+++ b/astropy/io/fits/tests/test_connect.py
@@ -1090,12 +1090,10 @@ def test_null_propagation_in_table_read(tmp_path):
 
     data = np.asarray([1, 2, NULL_VALUE, 4], dtype=np.int32)
 
-    # Create table with BinTableHDU, with integer column containing a custom
-    # null
+    # Create table with BinTableHDU, with integer column containing a custom null
     c = fits.Column(name="a", array=data, null=NULL_VALUE, format="J")
     hdu = BinTableHDU.from_columns([c])
-    hdul = fits.HDUList([PrimaryHDU(), hdu])
-    hdul.writeto(output_filename)
+    hdu.writeto(output_filename)
 
     # Read the table in with Table.read, and ensure the column's fill_value is
     # equal to NULL_VALUE

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -678,6 +678,12 @@ class Table:
             if masked and has_info_class(col, MixinInfo) and hasattr(col, "mask"):
                 data[col.info.name].mask = col.mask
 
+            # Propagate the fill_value from the table column to the output array.
+            # If this is not done, then the output array will use numpy.ma's default
+            # fill values (999999 for ints, 1E20 for floats, "N/A" for strings)
+            if masked and hasattr(col, "fill_value"):
+                data[col.info.name].fill_value = col.fill_value
+
         return data
 
     def __init__(

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -3319,3 +3319,32 @@ def test_table_write_preserves_nulls(tmp_path):
         header = hdul[1].header
 
     assert header["TNULL1"] == NULL_VALUE
+
+
+def test_as_array_preserve_fill_value():
+    """Ensures that Table.as_array propagates a MaskedColumn's fill_value to
+    the output array"""
+
+    INT_FILL = 123
+    FLOAT_FILL = 123.0
+    STR_FILL = "xyz"
+    CMPLX_FILL = complex(3.14, 2.71)
+
+    # set up a table with some columns with different data types
+    c_int = MaskedColumn(name="int", data=[1, 2, 3], fill_value=INT_FILL)
+    c_float = MaskedColumn(name="float", data=[1.0, 2.0, 3.0], fill_value=FLOAT_FILL)
+    c_str = MaskedColumn(name="str", data=["abc", "def", "ghi"], fill_value=STR_FILL)
+    c_cmplx = MaskedColumn(
+        name="cmplx",
+        data=[complex(1, 0), complex(0, 1), complex(1, 1)],
+        fill_value=CMPLX_FILL,
+    )
+
+    t = Table([c_int, c_float, c_str, c_cmplx])
+
+    tn = t.as_array()
+
+    assert tn["int"].fill_value == INT_FILL
+    assert tn["float"].fill_value == FLOAT_FILL
+    assert tn["str"].fill_value == STR_FILL
+    assert tn["cmplx"].fill_value == CMPLX_FILL

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -3301,8 +3301,12 @@ def test_table_write_preserves_nulls(tmp_path):
     NULL_VALUE = -1
 
     # Create table with an integer MaskedColumn with custom fill_value
-    c1 = MaskedColumn(name="a", data=np.asarray([1, 2, 3], dtype=np.int32),
-                      mask=[True, False, True], fill_value=NULL_VALUE)
+    c1 = MaskedColumn(
+        name="a",
+        data=np.asarray([1, 2, 3], dtype=np.int32),
+        mask=[True, False, True],
+        fill_value=NULL_VALUE,
+    )
     t = Table([c1])
 
     table_filename = tmp_path / "nultable.fits"

--- a/docs/changes/io.fits/14723.bugfix.rst
+++ b/docs/changes/io.fits/14723.bugfix.rst
@@ -1,1 +1,2 @@
-Reading a table from FITS now respects the TNULL property of a column, passing it into the column's `fill_value`
+Reading a table from FITS now respects the TNULL property of a column, passing
+it into the column's ``fill_value``.

--- a/docs/changes/io.fits/14723.bugfix.rst
+++ b/docs/changes/io.fits/14723.bugfix.rst
@@ -1,2 +1,1 @@
 Reading a table from FITS now respects the TNULL property of a column, passing it into the column's `fill_value` 
-

--- a/docs/changes/io.fits/14723.bugfix.rst
+++ b/docs/changes/io.fits/14723.bugfix.rst
@@ -1,1 +1,1 @@
-Reading a table from FITS now respects the TNULL property of a column, passing it into the column's `fill_value` 
+Reading a table from FITS now respects the TNULL property of a column, passing it into the column's `fill_value`

--- a/docs/changes/io.fits/14723.bugfix.rst
+++ b/docs/changes/io.fits/14723.bugfix.rst
@@ -1,0 +1,2 @@
+Reading a table from FITS now respects the TNULL property of a column, passing it into the column's `fill_value` 
+

--- a/docs/changes/table/14723.bugfix.rst
+++ b/docs/changes/table/14723.bugfix.rst
@@ -1,1 +1,1 @@
-`Table.as_array` now respects the `fill_value` property of masked columns
+``Table.as_array`` now respects the ``fill_value`` property of masked columns.

--- a/docs/changes/table/14723.bugfix.rst
+++ b/docs/changes/table/14723.bugfix.rst
@@ -1,0 +1,1 @@
+`Table.as_array` now respects the `fill_value` property of masked columns


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request addresses two related bugs in writing/reading astropy.table.Table objects with NULL values in int columns to/from FITS. The first bug is in reading a table from a FITS file, where the `fill_value` parameter of the MaskedColumn is the default (999999) not the value recorded in the input file's `TNULL` parameter. The second bug is when writing a table to file, the value of the `fill_value` column is not propagated through to the written table, so for an int column` TNULL` is always defaulted to 999999.

The changes proposed by this PR ensure that `TNULL`/`fill_value` are correctly propagated to/from the Table object upon read/write.

Also included in this PR is the propagation of the FITS standard's NULL for floats (`NaN`) and strings (`""`) into a column's `fill_value`, rather than the default (from `numpy.ma`) of `1E20` and `"N/A"` for floats and strings respectively.


<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #14693 
