### PR TITLE
Fix if statement in ImageHDU data setter

### DIFF
--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -283,7 +283,7 @@ class _ImageBaseHDU(_ValidHDU):
         self.__dict__["data"] = data
         self._modified = True
 
-        if self.data is None:
+        if data is None:
             self._axes = []
         else:
             # Set new values of bitpix, bzero, and bscale now, but wait to


### PR DESCRIPTION
This makes sure that it does not rely on the local ``data`` variable not class attribute, as the latter could be hypothetically problematic if it results in code execution in ImageHDU subclasses. Using the local data variable makes more logical sense since it is the variable used inside the if statement.

This came up as being an issue when I was experimenting with changing ``CompImageHDU`` to subclass ``ImageHDU`` instead of ``BinTableHDU``.

Not really a bug as such since right now it shouldn't affect astropy, but this will avoid issues in future. - so not marking it as needing backporting.
