### PR TITLE
Deprecate unused functions in `astropy.utils.misc`

### DIFF
--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -18,6 +18,8 @@ import traceback
 import unicodedata
 from contextlib import contextmanager
 
+from astropy.utils import deprecated
+
 __all__ = [
     "isiterable",
     "silence",
@@ -303,6 +305,8 @@ def signal_number_to_name(signum):
     return signal_to_name_map.get(signum, "UNKNOWN")
 
 
+# _has_hidden_attribute() can be deleted together with deprecated is_path_hidden() and
+# walk_skip_hidden().
 if sys.platform == "win32":
     import ctypes
 
@@ -327,6 +331,7 @@ else:
         return False
 
 
+@deprecated(since="6.0")
 def is_path_hidden(filepath):
     """
     Determines if a given file or directory is hidden.
@@ -349,6 +354,7 @@ def is_path_hidden(filepath):
     return is_dotted or _has_hidden_attribute(filepath)
 
 
+@deprecated(since="6.0")
 def walk_skip_hidden(top, onerror=None, followlinks=False):
     """
     A wrapper for `os.walk` that skips hidden files and directories.

--- a/astropy/utils/tests/test_misc.py
+++ b/astropy/utils/tests/test_misc.py
@@ -11,6 +11,7 @@ import pytest
 
 from astropy.io import fits
 from astropy.utils import data, misc
+from astropy.utils.exceptions import AstropyDeprecationWarning
 
 
 def test_isiterable():
@@ -52,6 +53,14 @@ def test_api_lookup():
     )
 
 
+def test_is_path_hidden_deprecation():
+    with pytest.warns(
+        AstropyDeprecationWarning, match="^The is_path_hidden function is deprecated"
+    ):
+        misc.is_path_hidden("data")
+
+
+# This is the only test that uses astropy/utils/tests/data/.hidden_file.txt
 def test_skip_hidden():
     path = data.get_pkg_data_path("data")
     for root, dirs, files in os.walk(path):
@@ -60,11 +69,13 @@ def test_skip_hidden():
         # break after the first level since the data dir contains some other
         # subdirectories that don't have these files
         break
-
-    for root, dirs, files in misc.walk_skip_hidden(path):
-        assert ".hidden_file.txt" not in files
-        assert "local.dat" in files
-        break
+    with pytest.warns(
+        AstropyDeprecationWarning, match="^The walk_skip_hidden function is deprecated"
+    ):
+        for root, dirs, files in misc.walk_skip_hidden(path):
+            assert ".hidden_file.txt" not in files
+            assert "local.dat" in files
+            break
 
 
 def test_JsonCustomEncoder():

--- a/docs/changes/utils/14759.api.rst
+++ b/docs/changes/utils/14759.api.rst
@@ -1,0 +1,1 @@
+``is_path_hidden()`` and ``walk_skip_hidden()`` are deprecated.

--- a/setup.cfg
+++ b/setup.cfg
@@ -107,10 +107,11 @@ docs =
 * = data/*, data/*/*, data/*/*/*, data/*/*/*/*, data/*/*/*/*/*, data/*/*/*/*/*/*
 astropy = astropy.cfg, CITATION
 astropy.cosmology = *.ecsv
-astropy.utils.tests = data/.hidden_file.txt
 astropy.tests.figures = *.json
 astropy.wcs = include/*/*.h
 astropy.wcs.tests = extension/*.c
+# Delete with deprecated astropy.utils.misc.walk_skip_hidden()
+astropy.utils.tests = data/.hidden_file.txt
 
 [tool:pytest]
 minversion = 7.0


### PR DESCRIPTION
### Description

`walk_skip_hidden()` has not been used by `astropy` since 4641bb247ca8b64062b85b1fae23916c17722535 and can be deprecated. `is_path_hidden()` is only used by `walk_skip_hidden()`. When these functions are removed then some private code and a test data file can also be deleted.

The functions deprecated here are implemented in `extension-helpers`: https://github.com/astropy/extension-helpers/blob/28d24b527c5b56b92bb58e6ac7ac551d1eadc524/extension_helpers/_utils.py#L35 and https://github.com/astropy/extension-helpers/blob/28d24b527c5b56b92bb58e6ac7ac551d1eadc524/extension_helpers/_utils.py#L58