### PR TITLE
Allow WCSAxes ticklabels to be rasterized

### DIFF
--- a/astropy/visualization/wcsaxes/coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/coordinate_helpers.py
@@ -636,7 +636,11 @@ class CoordinateHelper:
         self.ticks.draw(renderer)
 
         self.ticklabels._tick_out_size = self.ticks.out_size
-        self.ticklabels.draw(renderer, bboxes=bboxes, ticklabels_bbox=ticklabels_bbox)
+        self.ticklabels.draw(renderer, bboxes=bboxes)
+
+        # Save copies of the ticklabel bounding boxes
+        for axis in self.ticklabels._ticklabels_bbox:
+            ticklabels_bbox[axis] += self.ticklabels._ticklabels_bbox[axis]
 
         renderer.close_group("ticks")
 

--- a/astropy/visualization/wcsaxes/coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/coordinate_helpers.py
@@ -628,14 +628,22 @@ class CoordinateHelper:
 
         renderer.close_group("grid lines")
 
-    def _draw_ticks(self, renderer):
+    def _draw_ticks(self, renderer, existing_bboxes):
         """
         Draw all ticks and ticklabels.
+
+        Parameters
+        ----------
+        existing_bboxes : list[Bbox]
+            All bboxes for ticks that have already been drawn by other
+            coordinates.
         """
         renderer.open_group("ticks")
         self.ticks.draw(renderer)
 
         self.ticklabels._tick_out_size = self.ticks.out_size
+
+        self.ticklabels._set_existing_bboxes(existing_bboxes)
         self.ticklabels.draw(renderer)
 
         renderer.close_group("ticks")

--- a/astropy/visualization/wcsaxes/coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/coordinate_helpers.py
@@ -639,8 +639,9 @@ class CoordinateHelper:
         self.ticklabels.draw(renderer, bboxes=bboxes)
 
         # Save copies of the ticklabel bounding boxes
-        for axis in self.ticklabels._ticklabels_bbox:
-            ticklabels_bbox[axis] += self.ticklabels._ticklabels_bbox[axis]
+        for axis, bbs in self.ticklabels._ticklabels_bbox.items():
+            ticklabels_bbox[axis] += bbs
+            bboxes += bbs
 
         renderer.close_group("ticks")
 

--- a/astropy/visualization/wcsaxes/coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/coordinate_helpers.py
@@ -628,7 +628,7 @@ class CoordinateHelper:
 
         renderer.close_group("grid lines")
 
-    def _draw_ticks(self, renderer, bboxes, ticklabels_bbox):
+    def _draw_ticks(self, renderer):
         """
         Draw all ticks and ticklabels.
         """
@@ -636,12 +636,7 @@ class CoordinateHelper:
         self.ticks.draw(renderer)
 
         self.ticklabels._tick_out_size = self.ticks.out_size
-        self.ticklabels.draw(renderer, bboxes=bboxes)
-
-        # Save copies of the ticklabel bounding boxes
-        for axis, bbs in self.ticklabels._ticklabels_bbox.items():
-            ticklabels_bbox[axis] += bbs
-            bboxes += bbs
+        self.ticklabels.draw(renderer)
 
         renderer.close_group("ticks")
 

--- a/astropy/visualization/wcsaxes/coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/coordinate_helpers.py
@@ -634,12 +634,9 @@ class CoordinateHelper:
         """
         renderer.open_group("ticks")
         self.ticks.draw(renderer)
-        self.ticklabels.draw(
-            renderer,
-            bboxes=bboxes,
-            ticklabels_bbox=ticklabels_bbox,
-            tick_out_size=self.ticks.out_size,
-        )
+
+        self.ticklabels._tick_out_size = self.ticks.out_size
+        self.ticklabels.draw(renderer, bboxes=bboxes, ticklabels_bbox=ticklabels_bbox)
 
         renderer.close_group("ticks")
 

--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -511,12 +511,12 @@ class WCSAxes(Axes):
         for coords in self._all_coords:
             # Draw tick labels
             for coord in coords:
-                coord._draw_ticks(
-                    renderer,
-                    bboxes=self._bboxes,
-                    ticklabels_bbox=ticklabels_bbox[coord],
-                )
+                coord._draw_ticks(renderer)
+
                 visible_ticks.extend(coord.ticklabels.get_visible_axes())
+                # Save ticklabel bboxes
+                ticklabels_bbox[coord] = coord.ticklabels._axis_bboxes
+                self._bboxes += coord.ticklabels._all_bboxes
 
         for coords in self._all_coords:
             # Draw axis labels

--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -511,7 +511,7 @@ class WCSAxes(Axes):
         for coords in self._all_coords:
             # Draw tick labels
             for coord in coords:
-                coord._draw_ticks(renderer)
+                coord._draw_ticks(renderer, self._bboxes)
 
                 visible_ticks.extend(coord.ticklabels.get_visible_axes())
                 # Save ticklabel bboxes

--- a/astropy/visualization/wcsaxes/ticklabels.py
+++ b/astropy/visualization/wcsaxes/ticklabels.py
@@ -170,7 +170,7 @@ class TickLabels(Text):
     def set_exclude_overlapping(self, exclude_overlapping):
         self._exclude_overlapping = exclude_overlapping
 
-    def _set_xy_alignments(self, renderer, tick_out_size):
+    def _set_xy_alignments(self, renderer):
         """
         Compute and set the x, y positions and the horizontal/vertical alignment of
         each label.
@@ -195,7 +195,7 @@ class TickLabels(Text):
                     continue
 
                 x, y = self._frame.parent_axes.transData.transform(self.data[axis][i])
-                pad = renderer.points_to_pixels(self.get_pad() + tick_out_size)
+                pad = renderer.points_to_pixels(self.get_pad() + self._tick_out_size)
 
                 if isinstance(self._frame, RectangularFrame):
                     # This is just to preserve the current results, but can be
@@ -297,11 +297,11 @@ class TickLabels(Text):
         self.set_va(self.va[axis][i])
         return super().get_window_extent(renderer)
 
-    def draw(self, renderer, bboxes, ticklabels_bbox, tick_out_size):
+    def draw(self, renderer, bboxes, ticklabels_bbox, tick_out_size=None):
         if not self.get_visible():
             return
 
-        self._set_xy_alignments(renderer, tick_out_size)
+        self._set_xy_alignments(renderer)
 
         for axis in self.get_visible_axes():
             for i in range(len(self.world[axis])):

--- a/astropy/visualization/wcsaxes/ticklabels.py
+++ b/astropy/visualization/wcsaxes/ticklabels.py
@@ -297,8 +297,17 @@ class TickLabels(Text):
         self.set_va(self.va[axis][i])
         return super().get_window_extent(renderer)
 
+    @property
+    def _all_bboxes(self):
+        # List of all tick label bounding boxes
+        ret = []
+        for axis in self._axis_bboxes:
+            ret += self._axis_bboxes[axis]
+        return ret
+
     def draw(self, renderer, bboxes=None, ticklabels_bbox=None, tick_out_size=None):
-        self._ticklabels_bbox = defaultdict(list)
+        # Mapping from axis > list[bounding boxes]
+        self._axis_bboxes = defaultdict(list)
 
         if not self.get_visible():
             return
@@ -316,6 +325,9 @@ class TickLabels(Text):
                 # that has a key starting bit such as -0:30 where the -0
                 # might be dropped from all other labels.
 
-                if not self._exclude_overlapping or bb.count_overlaps(bboxes) == 0:
+                if (
+                    not self._exclude_overlapping
+                    or bb.count_overlaps(self._all_bboxes) == 0
+                ):
                     super().draw(renderer)
-                    self._ticklabels_bbox[axis].append(bb)
+                    self._axis_bboxes[axis].append(bb)

--- a/astropy/visualization/wcsaxes/ticklabels.py
+++ b/astropy/visualization/wcsaxes/ticklabels.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 
 import numpy as np
 from matplotlib import rcParams
+from matplotlib.artist import allow_rasterization
 from matplotlib.text import Text
 
 from astropy.utils.exceptions import AstropyDeprecationWarning
@@ -305,6 +306,7 @@ class TickLabels(Text):
             ret += self._axis_bboxes[axis]
         return ret
 
+    @allow_rasterization
     def draw(self, renderer, bboxes=None, ticklabels_bbox=None, tick_out_size=None):
         # Mapping from axis > list[bounding boxes]
         self._axis_bboxes = defaultdict(list)

--- a/astropy/visualization/wcsaxes/ticklabels.py
+++ b/astropy/visualization/wcsaxes/ticklabels.py
@@ -7,11 +7,10 @@ from matplotlib import rcParams
 from matplotlib.artist import allow_rasterization
 from matplotlib.text import Text
 
+from astropy.utils.decorators import deprecated_renamed_argument
 from astropy.utils.exceptions import AstropyDeprecationWarning
 
 from .frame import RectangularFrame
-
-from astropy.utils.decorators import deprecated_renamed_argument
 
 
 def sort_using(X, Y):

--- a/astropy/visualization/wcsaxes/ticklabels.py
+++ b/astropy/visualization/wcsaxes/ticklabels.py
@@ -11,6 +11,8 @@ from astropy.utils.exceptions import AstropyDeprecationWarning
 
 from .frame import RectangularFrame
 
+from astropy.utils.decorators import deprecated_renamed_argument
+
 
 def sort_using(X, Y):
     return [x for (y, x) in sorted(zip(Y, X))]
@@ -312,6 +314,9 @@ class TickLabels(Text):
         self._existing_bboxes = bboxes
 
     @allow_rasterization
+    @deprecated_renamed_argument(old_name="bboxes", new_name=None, since="6.0")
+    @deprecated_renamed_argument(old_name="ticklabels_bbox", new_name=None, since="6.0")
+    @deprecated_renamed_argument(old_name="tick_out_size", new_name=None, since="6.0")
     def draw(self, renderer, bboxes=None, ticklabels_bbox=None, tick_out_size=None):
         # Reset bounding boxes
         self._axis_bboxes = defaultdict(list)

--- a/astropy/visualization/wcsaxes/ticklabels.py
+++ b/astropy/visualization/wcsaxes/ticklabels.py
@@ -297,7 +297,9 @@ class TickLabels(Text):
         self.set_va(self.va[axis][i])
         return super().get_window_extent(renderer)
 
-    def draw(self, renderer, bboxes, ticklabels_bbox, tick_out_size=None):
+    def draw(self, renderer, bboxes, ticklabels_bbox=None, tick_out_size=None):
+        self._ticklabels_bbox = defaultdict(list)
+
         if not self.get_visible():
             return
 
@@ -317,4 +319,4 @@ class TickLabels(Text):
                 if not self._exclude_overlapping or bb.count_overlaps(bboxes) == 0:
                     super().draw(renderer)
                     bboxes.append(bb)
-                    ticklabels_bbox[axis].append(bb)
+                    self._ticklabels_bbox[axis].append(bb)

--- a/astropy/visualization/wcsaxes/ticklabels.py
+++ b/astropy/visualization/wcsaxes/ticklabels.py
@@ -297,7 +297,7 @@ class TickLabels(Text):
         self.set_va(self.va[axis][i])
         return super().get_window_extent(renderer)
 
-    def draw(self, renderer, bboxes, ticklabels_bbox=None, tick_out_size=None):
+    def draw(self, renderer, bboxes=None, ticklabels_bbox=None, tick_out_size=None):
         self._ticklabels_bbox = defaultdict(list)
 
         if not self.get_visible():
@@ -318,5 +318,4 @@ class TickLabels(Text):
 
                 if not self._exclude_overlapping or bb.count_overlaps(bboxes) == 0:
                     super().draw(renderer)
-                    bboxes.append(bb)
                     self._ticklabels_bbox[axis].append(bb)

--- a/docs/changes/visualization/14760.api.rst
+++ b/docs/changes/visualization/14760.api.rst
@@ -1,0 +1,2 @@
+The ``bboxes``, ``ticklabels_bbox``, and ``tick_out_size`` arguments to ``astropy.visualization.wcaxes.ticklabels.TickLabels.draw()`` now have no effect and are deprecated.
+This is to allow rasterized ticks to be drawn correctly on WCSAxes.

--- a/docs/changes/visualization/14760.bugfix.rst
+++ b/docs/changes/visualization/14760.bugfix.rst
@@ -1,0 +1,1 @@
+The location of ticklabels on a WCSAxes is now correctly calculated when the figure is rasterized.


### PR DESCRIPTION
This refactors code in `WCSAxes` to allow ticklabels to be rasterized. This required modifying the signature of `draw()` so it can work with only `renderer` passed as an argument.

Using the example given in https://github.com/astropy/astropy/issues/12568, this improves the resulting plot from

![grid-False-new](https://user-images.githubusercontent.com/6197628/200173927-8ac5215d-129d-495e-b0fa-cfcd73bd19b1.png)

to
<img width="460" alt="Screenshot 2023-05-05 at 19 25 50" src="https://user-images.githubusercontent.com/6197628/236538590-bd4ed1b2-d33c-42b5-9f3c-14e00e19b076.png">


Part 3/4 of https://github.com/astropy/astropy/issues/12672, and part of fixing https://github.com/astropy/astropy/issues/12568.