### PR TITLE
Fix problem creating codespaces environment

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
     "name": "AstroPy",
     "image": "mcr.microsoft.com/devcontainers/miniconda:0-3",
     "onCreateCommand": "conda init bash && sudo cp .devcontainer/welcome-message.txt /usr/local/etc/vscode-dev-containers/first-run-notice.txt",
-    "postCreateCommand": "git fetch --tag && pip install tox && pip install -e .[all,test_all,docs]",
+    "postCreateCommand": "git fetch --tags && pip install tox && pip install -e .[all,test_all,docs]",
     "waitFor": "postCreateCommand",
     "customizations": {
         "vscode": {


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to try fixing a problem creating codespaces. What was happening is that for some reason the full list of repository tags was not being pulled down, despite the `git fetch --tag`. Then when running the `pip install -e .[doc,test-all,docs]` it thought it was installing `astropy-0.1-xxx` and some packages that depend on a minimum astropy version failed.

I was able to reproduce this in my fork, although it was getting astropy 4.1-xxx. I found that using `git fetch --all` fixed the problem in my fork, so giving it a try here as a PR.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #14750 
