### PR TITLE
Remove astropy pre-install from codespaces setup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
     "name": "AstroPy",
     "image": "mcr.microsoft.com/devcontainers/miniconda:0-3",
     "onCreateCommand": "conda init bash && sudo cp .devcontainer/welcome-message.txt /usr/local/etc/vscode-dev-containers/first-run-notice.txt",
-    "postCreateCommand": "git fetch --tags && pip install tox && pip install -e .[all,test_all,docs]",
+    "postCreateCommand": "git fetch --tags && pip install tox",
     "waitFor": "postCreateCommand",
     "customizations": {
         "vscode": {

--- a/.devcontainer/welcome-message.txt
+++ b/.devcontainer/welcome-message.txt
@@ -1,9 +1,12 @@
 👋 Welcome to "AstroPy" in GitHub Codespaces!
 
-🛠️  To complete setup of your development environment run the following in the terminal:
-
-pip install -e ".[all,test_all,docs]"
-
 🔍 To explore VS Code to its fullest, search using the Command Palette (Cmd/Ctrl + Shift + P or F1).
 
-ℹ️  Look at https://docs.astropy.org/en/latest/development/workflow/development_workflow.html for more contribution details.
+ℹ️  Look at https://docs.astropy.org/en/latest/development/workflow/development_workflow.html 
+    for more contribution details.
+
+⭐⭐ =================================  IMPORTANT!!  ================================== ⭐⭐
+   To complete setup of your development environment run the following in the terminal:
+
+      pip install -e .[all,test_all,docs]
+⭐⭐ ================================================================================== ⭐⭐

--- a/.devcontainer/welcome-message.txt
+++ b/.devcontainer/welcome-message.txt
@@ -1,6 +1,8 @@
 👋 Welcome to "AstroPy" in GitHub Codespaces!
 
-🛠️  Your environment is fully setup with all the required software.
+🛠️  To complete setup of your development environment run the following in the terminal:
+
+pip install -e ".[all,test_all,docs]"
 
 🔍 To explore VS Code to its fullest, search using the Command Palette (Cmd/Ctrl + Shift + P or F1).
 

--- a/.devcontainer/welcome-message.txt
+++ b/.devcontainer/welcome-message.txt
@@ -2,7 +2,7 @@
 
 🔍 To explore VS Code to its fullest, search using the Command Palette (Cmd/Ctrl + Shift + P or F1).
 
-ℹ️  Look at https://docs.astropy.org/en/latest/development/workflow/development_workflow.html 
+ℹ️  Look at https://docs.astropy.org/en/latest/development/workflow/development_workflow.html
     for more contribution details.
 
 ⭐⭐ =================================  IMPORTANT!!  ================================== ⭐⭐


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is another attempt at making the astropy codespaces build without errors.

In this case we put the final build step in the welcome instructions and tell the user to do the `pip install -e .[all,test_all,docs]`. This is perhaps preferred anyway since it speeds up the time to get the environment going and maybe users want to use `tox` anyway.

#### More information about the problem

Digging a little more, the root issue seems to be that the original clone of astropy in the container is a shallow clone with `--depth 1`. 

Putting the following into the build results in a warning from `setuptools_scm` about running from a shallow clone, and indeed the output version that gets printed is 0.1-xxx.
```
git fetch --tags && pip install setuptools_scm && python -m setuptools_scm
```
But what I don't understand is that once the codespace comes up and I have a terminal, then `python -m setuptools_scm` produces the expected `6.0-xxx`. Somewhere along the way the repo becomes unshallow.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #14750 

### Testing

It works in my local fork, but we've been there before.
