### PR TITLE
Revert Gaussian test change from #14718

### DIFF
--- a/astropy/modeling/tests/test_core.py
+++ b/astropy/modeling/tests/test_core.py
@@ -730,7 +730,7 @@ def test_prepare_outputs_mixed_broadcast():
 
     output = model(4, [5, 6])
     assert output.shape == (2,)
-    np.testing.assert_array_equal(output, [0.8146473164114145, 0.7371233743916278])
+    np.testing.assert_allclose(output, [0.8146473164114145, 0.7371233743916278])
 
 
 def test_prepare_outputs_complex_reshape():

--- a/astropy/modeling/tests/test_functional_models.py
+++ b/astropy/modeling/tests/test_functional_models.py
@@ -603,8 +603,8 @@ def test_trig_inverse(trig):
     lower, upper = trig[1]
 
     x = np.arange(lower, upper, 0.01)
-    assert_allclose(mdl.inverse(mdl(x)), x, atol=1e-10)
-    assert_allclose(mdl(mdl.inverse(x)), x, atol=1e-10)
+    assert_allclose(mdl.inverse(mdl(x)), x, rtol=1e-13, atol=1e-8)
+    assert_allclose(mdl(mdl.inverse(x)), x, rtol=1e-13, atol=1e-8)
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason="requires scipy")

--- a/astropy/modeling/tests/test_models.py
+++ b/astropy/modeling/tests/test_models.py
@@ -252,10 +252,7 @@ class Fittable2DModelTester:
         outside_bbox = model(x2, y2, with_bounding_box=True)
         outside_bbox = outside_bbox[~np.isnan(outside_bbox)]
 
-        # FIXME: https://github.com/astropy/astropy/issues/14705
-        # ValueError: operands could not be broadcast together with shapes (1100,) (1099,)
-        if model_class != Gaussian2D:
-            assert np.all(inside_bbox == outside_bbox)
+        assert np.all(inside_bbox == outside_bbox)
 
     def test_bounding_box2D_peak(self, model_class, test_parameters):
         if not test_parameters.pop("bbox_peak", False):


### PR DESCRIPTION
I can no longer reproduce the error skipped by #14718 for the Gaussian locally, this PR demonstrates that skipping this was unnecessary. However, there are new issues... This PR goes on to correct the remaining modeling issues as those were only related to slight numerical changes that required slightly changing tolerances.

I believe this change maybe due to numpy/numpy#23721 or numpy/numpy#23695 updating some underlying things.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #14766