### PR TITLE
Remove kwargs from WCSAxes.draw()

### DIFF
--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -41,7 +41,7 @@ class _WCSAxesArtist(Artist):
     and gridlines in the standary way.
     """
 
-    def draw(self, renderer, *args, **kwargs):
+    def draw(self, renderer):
         self.axes.draw_wcsaxes(renderer)
 
 
@@ -502,7 +502,7 @@ class WCSAxes(Axes):
 
         self.coords.frame.draw(renderer)
 
-    def draw(self, renderer, **kwargs):
+    def draw(self, renderer):
         """Draw the axes."""
         # Before we do any drawing, we need to remove any existing grid lines
         # drawn with contours, otherwise if we try and remove the contours
@@ -533,7 +533,7 @@ class WCSAxes(Axes):
         # We need to make sure that that frame path is up to date
         self.coords.frame._update_patch_path()
 
-        super().draw(renderer, **kwargs)
+        super().draw(renderer)
 
         self._drawn = True
 

--- a/docs/changes/visualization/14772.api.rst
+++ b/docs/changes/visualization/14772.api.rst
@@ -1,0 +1,2 @@
+It is now not possible to pass any keyword arguments to ``astropy.visualization.wcsaxes.WCSAxes.draw()``.
+Previously passing any keyword arguments would have errored anyway, as ``matplotlib.axes.Axes.draw()`` does not accept keyword arguments.


### PR DESCRIPTION
Matplotlib Axes do not take any kwargs anyway, so before this would error if a user passed them. I can't think of a good way to do a deprecation here, but since it would have errored before anyway I think it's safe to do this without a deprecation period?

Part of fixing https://github.com/astropy/astropy/issues/12672