### PR TITLE
Backport PR 14771 to v5.2.x ( Revert Gaussian test change from #14718)

### DIFF
--- a/astropy/modeling/tests/test_core.py
+++ b/astropy/modeling/tests/test_core.py
@@ -730,7 +730,7 @@ def test_prepare_outputs_mixed_broadcast():
 
     output = model(4, [5, 6])
     assert output.shape == (2,)
-    np.testing.assert_array_equal(output, [0.8146473164114145, 0.7371233743916278])
+    np.testing.assert_allclose(output, [0.8146473164114145, 0.7371233743916278])
 
 
 def test_prepare_outputs_complex_reshape():

--- a/astropy/modeling/tests/test_functional_models.py
+++ b/astropy/modeling/tests/test_functional_models.py
@@ -568,8 +568,8 @@ def test_trig_inverse(trig):
     lower, upper = trig[1]
 
     x = np.arange(lower, upper, 0.01)
-    assert_allclose(mdl.inverse(mdl(x)), x, atol=1e-10)
-    assert_allclose(mdl(mdl.inverse(x)), x, atol=1e-10)
+    assert_allclose(mdl.inverse(mdl(x)), x, rtol=1e-13, atol=1e-8)
+    assert_allclose(mdl(mdl.inverse(x)), x, rtol=1e-13, atol=1e-8)
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason="requires scipy")

--- a/astropy/modeling/tests/test_models.py
+++ b/astropy/modeling/tests/test_models.py
@@ -252,10 +252,7 @@ class Fittable2DModelTester:
         outside_bbox = model(x2, y2, with_bounding_box=True)
         outside_bbox = outside_bbox[~np.isnan(outside_bbox)]
 
-        # FIXME: https://github.com/astropy/astropy/issues/14705
-        # ValueError: operands could not be broadcast together with shapes (1100,) (1099,)
-        if model_class != Gaussian2D:
-            assert np.all(inside_bbox == outside_bbox)
+        assert np.all(inside_bbox == outside_bbox)
 
     def test_bounding_box2D_peak(self, model_class, test_parameters):
         if not test_parameters.pop("bbox_peak", False):


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

Manual backport of #14771 to v5.2.x