### PR TITLE
remove deprecated import path

### DIFF
--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -589,26 +589,3 @@ class FlatCosmologyMixin(metaclass=abc.ABCMeta):
         )
 
         return params_eq
-
-
-# -----------------------------------------------------------------------------
-
-
-def __getattr__(attr):
-    from . import flrw
-
-    if hasattr(flrw, attr) and attr not in ("__path__",):
-        import warnings
-
-        from astropy.utils.exceptions import AstropyDeprecationWarning
-
-        warnings.warn(
-            f"`astropy.cosmology.core.{attr}` has been moved (since v5.0) and "
-            f"should be imported as ``from astropy.cosmology import {attr}``."
-            " In future this will raise an exception.",
-            AstropyDeprecationWarning,
-        )
-
-        return getattr(flrw, attr)
-
-    raise AttributeError(f"module {__name__!r} has no attribute {attr!r}.")

--- a/astropy/cosmology/tests/test_core.py
+++ b/astropy/cosmology/tests/test_core.py
@@ -2,19 +2,13 @@
 
 """Testing :mod:`astropy.cosmology.core`."""
 
-##############################################################################
-# IMPORTS
-
-# STDLIB
 import abc
 import inspect
 import pickle
 
-# THIRD PARTY
 import numpy as np
 import pytest
 
-# LOCAL
 import astropy.cosmology.units as cu
 import astropy.units as u
 from astropy.cosmology import Cosmology, FlatCosmologyMixin
@@ -22,7 +16,6 @@ from astropy.cosmology.core import _COSMOLOGY_CLASSES
 from astropy.cosmology.parameter import Parameter
 from astropy.table import Column, QTable, Table
 from astropy.utils.compat import PYTHON_LT_3_11
-from astropy.utils.exceptions import AstropyDeprecationWarning
 from astropy.utils.metadata import MetaData
 
 from .test_connect import ReadWriteTestMixin, ToFromFormatTestMixin
@@ -537,18 +530,3 @@ def test__nonflatclass__multiple_nonflat_inheritance():
             @property
             def nonflat(self):
                 pass
-
-
-# -----------------------------------------------------------------------------
-
-
-def test_flrw_moved_deprecation():
-    """Test the deprecation warning about the move of FLRW classes."""
-    from astropy.cosmology import flrw
-
-    # it's deprecated to import `flrw/*` from `core.py`
-    with pytest.warns(AstropyDeprecationWarning):
-        from astropy.cosmology.core import FLRW
-
-    # but they are the same object
-    assert FLRW is flrw.FLRW

--- a/docs/changes/cosmology/14782.api.rst
+++ b/docs/changes/cosmology/14782.api.rst
@@ -1,0 +1,1 @@
+Removed deprecated import paths from ``astropy.cosmology.core``.


### PR DESCRIPTION
Importing FLRW from core has been deprecated since v5.0. Now it's removed. 
