### PR TITLE
TST: Test against Python 3.12 pre-prelease

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -106,8 +106,9 @@ jobs:
           - language-pack-de
           - tzdata
       envs: |
-        - name: (Allowed Failure) Python 3.11 with remote data and dev version of key dependencies
-          linux: py311-test-devdeps
+        - name: (Allowed Failure) Python 3.12 with remote data and dev version of key dependencies
+          linux: py312-test-devdeps
+          python-version: '3.12-dev'
           posargs: --remote-data=any --verbose
 
         # https://github.com/matplotlib/matplotlib/issues/26847

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,16 +55,19 @@ jobs:
         - cp39-manylinux_x86_64
         - cp310-manylinux_x86_64
         - cp311-manylinux_x86_64
+        - cp312-manylinux_x86_64
 
         # Note that following wheels are not currently tested:
 
         - cp39-manylinux_aarch64
         - cp310-manylinux_aarch64
         - cp311-manylinux_aarch64
+        - cp312-manylinux_aarch64
 
         - cp39-musllinux_x86_64
         - cp310-musllinux_x86_64
         - cp311-musllinux_x86_64
+        - cp312-musllinux_x86_64
 
         # MacOS X wheels - as noted in https://github.com/astropy/astropy/pull/12379 we deliberately
         # do not build universal2 wheels. Note that the arm64 wheels are not actually tested so we
@@ -73,20 +76,24 @@ jobs:
         - cp39*macosx_x86_64
         - cp310*macosx_x86_64
         - cp311*macosx_x86_64
+        - cp312*macosx_x86_64
 
         - cp39*macosx_arm64
         - cp310*macosx_arm64
         - cp311*macosx_arm64
+        - cp312*macosx_arm64
 
         # Windows wheels
 
         - cp39*win32
         - cp310*win32
         - cp311*win32
+        - cp312*win32
 
         - cp39*win_amd64
         - cp310*win_amd64
         - cp311*win_amd64
+        - cp312*win_amd64
 
     secrets:
       pypi_token: ${{ secrets.pypi_token }}

--- a/astropy/nddata/mixins/ndslicing.py
+++ b/astropy/nddata/mixins/ndslicing.py
@@ -105,8 +105,9 @@ class NDSlicingMixin:
             return None
         try:
             return self.uncertainty[item]
-        except TypeError:
+        except (TypeError, KeyError):
             # Catching TypeError in case the object has no __getitem__ method.
+            # Catching KeyError for Python 3.12.
             # But let IndexError raise.
             log.info("uncertainty cannot be sliced.")
         return self.uncertainty
@@ -116,7 +117,7 @@ class NDSlicingMixin:
             return None
         try:
             return self.mask[item]
-        except TypeError:
+        except (TypeError, KeyError):
             log.info("mask cannot be sliced.")
         return self.mask
 

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -2898,14 +2898,19 @@ def test_table_attribute_ecsv():
 
 
 def test_table_attribute_fail():
-    # Code raises ValueError(f'{attr} not allowed as TableAttribute') but in this
-    # context it gets re-raised as a RuntimeError during class definition.
-    with pytest.raises(RuntimeError, match="Error calling __set_name__"):
+    if sys.version_info[:2] >= (3, 12):
+        ctx = pytest.raises(ValueError, match=".* not allowed as TableAttribute")
+    else:
+        # Code raises ValueError(f'{attr} not allowed as TableAttribute') but in this
+        # context it gets re-raised as a RuntimeError during class definition.
+        ctx = pytest.raises(RuntimeError, match="Error calling __set_name__")
+
+    with ctx:
 
         class MyTable2(Table):
             descriptions = TableAttribute()  # Conflicts with init arg
 
-    with pytest.raises(RuntimeError, match="Error calling __set_name__"):
+    with ctx:
 
         class MyTable3(Table):
             colnames = TableAttribute()  # Conflicts with built-in property

--- a/docs/changes/14784.other.rst
+++ b/docs/changes/14784.other.rst
@@ -1,0 +1,1 @@
+Compatibility with Python 3.12.

--- a/docs/time/index.rst
+++ b/docs/time/index.rst
@@ -512,7 +512,7 @@ Example
 
 To infer input format::
 
-  >>> from datetime import datetime
+  >>> from datetime import datetime, timezone
   >>> t = Time(datetime(2010, 1, 2, 1, 2, 3))
   >>> t.format
   'datetime'
@@ -717,7 +717,7 @@ The current time can be determined as a |Time| object using the
 `~astropy.time.Time.now` class method::
 
   >>> nt = Time.now()
-  >>> ut = Time(datetime.utcnow(), scale='utc')
+  >>> ut = Time(datetime.now(tz=timezone.utc), scale='utc')
 
 The two should be very close to each other.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -202,6 +202,10 @@ doctest_norecursedirs = [
     "*/tests/command.py",
 ]
 doctest_subpackage_requires = [
+    "astropy/cosmology/_io/mapping.py = python<3.12",  # PYTHON_LT_3_12 (PR 14784)
+    "astropy/cosmology/_io/row.py = python<3.12",  # PYTHON_LT_3_12 (PR 14784)
+    "astropy/cosmology/_io/table.py = python<3.12",  # PYTHON_LT_3_12 (PR 14784)
+    "astropy/table/table.py = python<3.12",  # PYTHON_LT_3_12 (PR 14784)
     "astropy/table/mixins/dask.py = dask",
     "docs/io/fits/index.rst = numpy<1.25",  # NUMPY_LT_1_25 (Issue 14545)
     "docs/io/fits/usage/image.rst = numpy<1.25",  # NUMPY_LT_1_25 (Issue 14545)

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{39,310,311,dev}-test{,-recdeps,-alldeps,-oldestdeps,-devdeps,-mpldev,-devinfra,-predeps,-numpy122,-numpy123,-mpl334}{,-cov}{,-clocale}{,-fitsio}
+    py{39,310,311,312,dev}-test{,-recdeps,-alldeps,-oldestdeps,-devdeps,-mpldev,-devinfra,-predeps,-numpy122,-numpy123,-mpl334}{,-cov}{,-clocale}{,-fitsio}
     # Only these two exact tox environments have corresponding figure hash files.
     py39-test-image-mpl334-cov
     py39-test-image-mpldev-cov


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to see if we will be compatible with Python 3.12 (https://github.com/astropy/astropy/issues/14783). Only the alpha is out, so I am feeling this is going to fail horribly now because we also need upstream stuff to be compatible first. We can always re-run this PR as needed.

Fix #14783

Close #15238 (hopefully)

Companion of https://github.com/astropy/astropy/pull/15331

TODO:

- [x] Confirm that nddata patch is correct.
- [x] Undo commenting out mpldev when they have 3.9.dev wheels uploaded.
- [x] Simplify build logic when numpy 1.26 is released for real.
- [x] Fix chronic remote data timeout in a separate PR. CI probably blocked it. https://github.com/astropy/astropy/pull/15355
- [x] Move votable bug fix into a separate PR. Python 3.12 smoked it out but it is its own thing. https://github.com/astropy/astropy/pull/15359
- [x] Investigate why devdeps still pulling in numpy 1.26.0 and not numpy-dev. https://github.com/matplotlib/matplotlib/issues/26847

Blocked by:

* https://github.com/matplotlib/matplotlib/pull/26582 (devdeps)
* https://github.com/liberfa/pyerfa/pull/111 (devdeps) 
* https://github.com/OpenAstronomy/github-actions-workflows/issues/149 (for wheels)
* https://github.com/astropy/asdf-astropy/issues/203
* https://github.com/astropy/astropy/pull/15298
* https://github.com/matplotlib/matplotlib/issues/26786
* https://github.com/liberfa/pyerfa/pull/115
* https://github.com/astropy/astropy/pull/15363

Not blocker but linked to this PR:

* https://github.com/OpenAstronomy/github-actions-workflows/issues/159
* https://github.com/matplotlib/matplotlib/issues/26847