### PR TITLE
MNT: Pin asdf<3 in LTS

### DIFF
--- a/docs/changes/14796.other.rst
+++ b/docs/changes/14796.other.rst
@@ -1,0 +1,1 @@
+LTS is not compatible with asdf 3 or later.

--- a/setup.cfg
+++ b/setup.cfg
@@ -89,7 +89,7 @@ all =
     pytz
     jplephem
     mpmath
-    asdf>=2.9.2
+    asdf>=2.9.2,<3
     bottleneck
     ipython>=4.2
     pytest>=7.0

--- a/tox.ini
+++ b/tox.ini
@@ -91,7 +91,6 @@ deps =
     # or nightly wheel of key dependencies.
     devdeps: scipy>=0.0.dev0
     devdeps,mpldev: matplotlib>=0.0.dev0
-    devdeps: git+https://github.com/asdf-format/asdf.git#egg=asdf
     devdeps: git+https://github.com/liberfa/pyerfa.git#egg=pyerfa
 
 # The following indicates which extras_require from setup.cfg will be installed


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

Pin asdf<3 in LTS because of breaking changes upstream that we cannot reconcile.

See https://github.com/astropy/astropy/issues/14795 and discussions on https://github.com/asdf-format/asdf/pull/1464
