### PR TITLE
io.misc.asdf: skip modeling doctest that requires removed features in asdf (v5.3.x)

### DIFF
--- a/docs/modeling/models.rst
+++ b/docs/modeling/models.rst
@@ -942,7 +942,7 @@ format. This can be useful in many contexts, one of which is the implementation 
 
 Serializing a model to disk is possible by assigning the object to ``AsdfFile.tree``:
 
-.. doctest-requires:: asdf
+.. doctest-requires:: asdf<3.0.0.dev
 
     >>> from asdf import AsdfFile
     >>> from astropy.modeling import models
@@ -953,7 +953,7 @@ Serializing a model to disk is possible by assigning the object to ``AsdfFile.tr
 
 To read the file and create the model:
 
-.. doctest-requires:: asdf
+.. doctest-requires:: asdf<3.0.0.dev
 
     >>> import asdf
     >>> with asdf.open('rotation.asdf') as f:


### PR DESCRIPTION
### Description

2 modeling doctests (like the following):
https://github.com/astropy/astropy/blob/eec06978bcf37dba7e998f198003a3b6cbfcfb94/docs/modeling/models.rst?plain=1#L947-L952
should have been skipped in https://github.com/astropy/astropy/pull/14516

It has since been updated in main: https://github.com/astropy/astropy/pull/14668

and requires a manual backport to fix this failing test as described:
https://github.com/astropy/astropy/issues/14795


<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

