### PR TITLE
FIT_rec._scale_down(): _FormatQ being incorrectly checked for a heapsize greater than 2**31

### DIFF
--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -1165,7 +1165,7 @@ class FITS_rec(np.recarray):
                 # Even if this VLA has not been read or updated, we need to
                 # include the size of its constituent arrays in the heap size
                 # total
-                if heapsize >= 2**31:
+                if type(recformat) == _FormatP and heapsize >= 2**31:
                     raise ValueError(
                         "The heapsize limit for 'P' format "
                         "has been reached. "


### PR DESCRIPTION
### Description

Package: astropy.io.fits
Module: fitsrec.py

If a table is created with a column using TFORMn="Q(...)" and the heapsize becomes greater than 2**31, a ValueError that recommends the user to use the "Q" format is incorrectly raised.

The problem originates in line 1168 of fitsrec.py within the "v5.2.x" branch:

```python
                if heapsize >= 2**31:
                    raise ValueError(
                        "The heapsize limit for 'P' format "
                        "has been reached. "
                        "Please consider using the 'Q' format "
                        "for your file."
                    )
```

Since _FormatQ is a subclass of _FormatP, the condition at line 1145 `if isinstance(recformat, _FormatP):` is True for both types. The above heapsize check is performed when 1145 condition is True.

The fix is to modify line 1168 of fitsrec.py to:

```python
              if type(recformat) == _FormatP and heapsize >= 2**31:
                   raise ValueError(
                        "The heapsize limit for 'P' format "
                        "has been reached. "
                        "Please consider using the 'Q' format "
                        "for your file."
                    )
```

This causes the heapsize check to be only performed when recformat's type is _FormatP.

<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->


<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->


<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #14808
