### PR TITLE
Add `submodel_types` property to CompoundModel

### DIFF
--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -3262,6 +3262,14 @@ class CompoundModel(Model):
                 newnames.append(item)
         return tuple(newnames)
 
+    @property
+    def submodel_classnames(self):
+        """Return the types of submodels in a ``CompoundModel``."""
+        if self._leaflist is None:
+            self._make_leaflist()
+        classnames = [item.__class__.name for item in self._leaflist]
+        return tuple(classnames)
+
     def both_inverses_exist(self):
         """
         if both members of this compound model have inverses return True.

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -3263,11 +3263,11 @@ class CompoundModel(Model):
         return tuple(newnames)
 
     @property
-    def submodel_classnames(self):
+    def submodel_types(self):
         """Return the types of submodels in a ``CompoundModel``."""
         if self._leaflist is None:
             self._make_leaflist()
-        return tuple(type(item).__name__ for item in self._leaflist)
+        return tuple(type(item) for item in self._leaflist)
 
     def both_inverses_exist(self):
         """

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -3267,8 +3267,7 @@ class CompoundModel(Model):
         """Return the types of submodels in a ``CompoundModel``."""
         if self._leaflist is None:
             self._make_leaflist()
-        classnames = [item.__class__.name for item in self._leaflist]
-        return tuple(classnames)
+        return tuple(type(item).__name__ for item in self._leaflist)
 
     def both_inverses_exist(self):
         """

--- a/astropy/modeling/tests/test_compound.py
+++ b/astropy/modeling/tests/test_compound.py
@@ -612,6 +612,13 @@ def test_name():
     assert m1.name == "M1"
 
 
+def test_types():
+    poly = Polynomial1D(1, c0=1, c1=2)
+    g1 = Gaussian1D(1, 1, 1)
+    m = poly + g1
+    assert m.submodel_types == ("Polynomial1D", "Gaussian1D")
+
+
 def test_name_index():
     g1 = Gaussian1D(1, 1, 1)
     g2 = Gaussian1D(1, 2, 1)

--- a/docs/changes/modeling/14816.feature.rst
+++ b/docs/changes/modeling/14816.feature.rst
@@ -1,0 +1,1 @@
+``CompoundModel`` now has a ``submodel_classnames`` property that returns a tuple of string class names.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

I've run into a couple situations where it would  be useful to be able to get the component model types (not just their names) out of `CompoundModel`. As far as I could tell, there was no way to do this currently, so I added a `submodel_types` property that returns the component model class names as strings. I assumed that model type can't be `None` in the same way that the model names can, so I left out the analogous `None` handling.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Possibly related to #9888, although that maybe should have been closed already.

I'll add a changelog entry once I see what the PR number is!