### PR TITLE
Implement transformation to / from CoordinateFrame from / to related WCS

### DIFF
--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -132,6 +132,12 @@ jobs:
 
           install: |
             apt-get update -q -y
+            apt-get install -q -y gnupg2
+            # Add test-support repository for wcslib8
+            echo "deb http://ppa.launchpadcontent.net/astropy/test-support/ubuntu lunar main" > /etc/apt/sources.list.d/test-support.list
+            gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv CC75F07B3EF41EFC
+            gpg --export --armor CC75F07B3EF41EFC | tee /etc/apt/trusted.gpg.d/test-support.asc
+            apt-get update -q -y
             apt-get install -q -y git \
                                   g++ \
                                   pkg-config \
@@ -141,7 +147,6 @@ jobs:
                                   python3-ply \
                                   python3-venv \
                                   cython3 \
-                                  libwcs7 \
                                   wcslib-dev \
                                   liberfa1
 

--- a/astropy/wcs/docstrings.py
+++ b/astropy/wcs/docstrings.py
@@ -85,6 +85,11 @@ a_order = """
 ``int`` (read-only) Order of the polynomial (``A_ORDER``).
 """
 
+a_radius = """
+``double``  semimajor axis of the ellipsoid that defines the approximate shape
+of a target body used in projection (m). If undefined, this is set to `None`.
+"""
+
 all_pix2world = f"""
 all_pix2world(pixcrd, origin) -> ``double array[ncoord][nelem]``
 
@@ -160,6 +165,32 @@ resized, without creating a new `~astropy.wcs.Sip` object.
 
 ap_order = """
 ``int`` (read-only) Order of the polynomial (``AP_ORDER``).
+"""
+
+b_radius = """
+``double``  intermediate axis of the ellipsoid that defines the approximate shape
+of a target body used in projection (m). If undefined, this is set to `None`.
+"""
+
+bdis_obs = """
+``double``  Distance between the centre of the celestial body and the observer (m).
+If undefined, this is set to `None`.
+"""
+
+blon_obs = """
+``double``  Bodycentric longitude of the observer in the body-fixed reference frame
+of the target body, spanning from 0 to 360 deg (deg).
+If undefined, this is set to `None`.
+"""
+
+blat_obs = """
+``double``  Bodycentric latitude of the observer in the body-fixed reference frame
+of the target body (deg). If undefined, this is set to `None`.
+"""
+
+c_radius = """
+``double``  semiminor axis of the ellipsoid that defines the approximate shape
+of a target body used in projection (m). If undefined, this is set to `None`.
 """
 
 cel = """

--- a/astropy/wcs/src/wcslib_auxprm_wrap.c
+++ b/astropy/wcs/src/wcslib_auxprm_wrap.c
@@ -72,7 +72,18 @@ static void auxprmprt(const struct auxprm *aux) {
   if (aux->hgln_obs != UNDEFINED) wcsprintf(" %f", aux->hgln_obs);
   wcsprintf("\nhglt_obs:");
   if (aux->hglt_obs != UNDEFINED) wcsprintf(" %f", aux->hglt_obs);
-
+  wcsprintf("\na_radius:");
+  if (aux->a_radius != UNDEFINED) wcsprintf(" %f", aux->a_radius);
+  wcsprintf("\nb_radius:");
+  if (aux->b_radius != UNDEFINED) wcsprintf(" %f", aux->b_radius);
+  wcsprintf("\nc_radius:");
+  if (aux->c_radius != UNDEFINED) wcsprintf(" %f", aux->c_radius);
+  wcsprintf("\nbdis_obs:");
+  if (aux->bdis_obs != UNDEFINED) wcsprintf(" %f", aux->bdis_obs);
+  wcsprintf("\nblon_obs:");
+  if (aux->blon_obs != UNDEFINED) wcsprintf(" %f", aux->blon_obs);
+  wcsprintf("\nblat_obs:");
+  if (aux->blat_obs != UNDEFINED) wcsprintf(" %f", aux->blat_obs);
   return;
 }
 
@@ -185,6 +196,121 @@ static int PyAuxprm_set_hglt_obs(PyAuxprm* self, PyObject* value, void* closure)
   }
 }
 
+static PyObject* PyAuxprm_get_a_radius(PyAuxprm* self, void* closure) {
+  if(self->x == NULL || self->x->a_radius == UNDEFINED) {
+    Py_RETURN_NONE;
+  } else {
+    return get_double("a_radius", self->x->a_radius);
+  }
+}
+
+static int PyAuxprm_set_a_radius(PyAuxprm* self, PyObject* value, void* closure) {
+  if(self->x == NULL) {
+    return -1;
+  } else if (value == Py_None) {
+    self->x->a_radius = UNDEFINED;
+    return 0;
+  } else {
+    return set_double("a_radius", value, &self->x->a_radius);
+  }
+}
+
+static PyObject* PyAuxprm_get_b_radius(PyAuxprm* self, void* closure) {
+  if(self->x == NULL || self->x->b_radius == UNDEFINED) {
+    Py_RETURN_NONE;
+  } else {
+    return get_double("b_radius", self->x->b_radius);
+  }
+}
+
+static int PyAuxprm_set_b_radius(PyAuxprm* self, PyObject* value, void* closure) {
+  if(self->x == NULL) {
+    return -1;
+  } else if (value == Py_None) {
+    self->x->b_radius = UNDEFINED;
+    return 0;
+  } else {
+    return set_double("b_radius", value, &self->x->b_radius);
+  }
+}
+
+static PyObject* PyAuxprm_get_c_radius(PyAuxprm* self, void* closure) {
+  if(self->x == NULL || self->x->c_radius == UNDEFINED) {
+    Py_RETURN_NONE;
+  } else {
+    return get_double("c_radius", self->x->c_radius);
+  }
+}
+
+static int PyAuxprm_set_c_radius(PyAuxprm* self, PyObject* value, void* closure) {
+  if(self->x == NULL) {
+    return -1;
+  } else if (value == Py_None) {
+    self->x->c_radius = UNDEFINED;
+    return 0;
+  } else {
+    return set_double("c_radius", value, &self->x->c_radius);
+  }
+}
+
+static PyObject* PyAuxprm_get_bdis_obs(PyAuxprm* self, void* closure) {
+  if(self->x == NULL || self->x->bdis_obs == UNDEFINED) {
+    Py_RETURN_NONE;
+  } else {
+    return get_double("bdis_obs", self->x->bdis_obs);
+  }
+}
+
+static int PyAuxprm_set_bdis_obs(PyAuxprm* self, PyObject* value, void* closure) {
+  if(self->x == NULL) {
+    return -1;
+  } else if (value == Py_None) {
+    self->x->bdis_obs = UNDEFINED;
+    return 0;
+  } else {
+    return set_double("bdis_obs", value, &self->x->bdis_obs);
+  }
+}
+
+static PyObject* PyAuxprm_get_blon_obs(PyAuxprm* self, void* closure) {
+  if(self->x == NULL || self->x->blon_obs == UNDEFINED) {
+    Py_RETURN_NONE;
+  } else {
+    return get_double("blon_obs", self->x->blon_obs);
+  }
+}
+
+static int PyAuxprm_set_blon_obs(PyAuxprm* self, PyObject* value, void* closure) {
+  if(self->x == NULL) {
+    return -1;
+  } else if (value == Py_None) {
+    self->x->blon_obs = UNDEFINED;
+    return 0;
+  } else {
+    return set_double("blon_obs", value, &self->x->blon_obs);
+  }
+}
+
+static PyObject* PyAuxprm_get_blat_obs(PyAuxprm* self, void* closure) {
+  if(self->x == NULL || self->x->blat_obs == UNDEFINED) {
+    Py_RETURN_NONE;
+  } else {
+    return get_double("blat_obs", self->x->blat_obs);
+  }
+}
+
+static int PyAuxprm_set_blat_obs(PyAuxprm* self, PyObject* value, void* closure) {
+  if(self->x == NULL) {
+    return -1;
+  } else if (value == Py_None) {
+    self->x->blat_obs = UNDEFINED;
+    return 0;
+  } else {
+    return set_double("blat_obs", value, &self->x->blat_obs);
+  }
+}
+
+
 /***************************************************************************
  * PyAuxprm definition structures
  */
@@ -195,6 +321,12 @@ static PyGetSetDef PyAuxprm_getset[] = {
   {"crln_obs", (getter)PyAuxprm_get_crln_obs, (setter)PyAuxprm_set_crln_obs, (char *)doc_crln_obs},
   {"hgln_obs", (getter)PyAuxprm_get_hgln_obs, (setter)PyAuxprm_set_hgln_obs, (char *)doc_hgln_obs},
   {"hglt_obs", (getter)PyAuxprm_get_hglt_obs, (setter)PyAuxprm_set_hglt_obs, (char *)doc_hglt_obs},
+  {"a_radius", (getter)PyAuxprm_get_a_radius, (setter)PyAuxprm_set_a_radius, (char *)doc_a_radius},
+  {"b_radius", (getter)PyAuxprm_get_b_radius, (setter)PyAuxprm_set_b_radius, (char *)doc_b_radius},
+  {"c_radius", (getter)PyAuxprm_get_c_radius, (setter)PyAuxprm_set_c_radius, (char *)doc_c_radius},
+  {"bdis_obs", (getter)PyAuxprm_get_bdis_obs, (setter)PyAuxprm_set_bdis_obs, (char *)doc_bdis_obs},
+  {"blon_obs", (getter)PyAuxprm_get_blon_obs, (setter)PyAuxprm_set_blon_obs, (char *)doc_blon_obs},
+  {"blat_obs", (getter)PyAuxprm_get_blat_obs, (setter)PyAuxprm_set_blat_obs, (char *)doc_blat_obs},
   {NULL}
 };
 

--- a/astropy/wcs/tests/test_auxprm.py
+++ b/astropy/wcs/tests/test_auxprm.py
@@ -7,12 +7,24 @@ from numpy.testing import assert_allclose
 from astropy.io import fits
 from astropy.wcs import WCS
 
-STR_EXPECTED_EMPTY = """
+STR_PLANETARY_EXPECTED_EMPTY = """
+a_radius:
+b_radius:
+c_radius:
+bdis_obs:
+blon_obs:
+blat_obs:""".lstrip()
+
+
+STR_SOLAR_EXPECTED_EMPTY = """
 rsun_ref:
 dsun_obs:
 crln_obs:
 hgln_obs:
 hglt_obs:""".lstrip()
+
+
+STR_EXPECTED_EMPTY = STR_SOLAR_EXPECTED_EMPTY + "\n" + STR_PLANETARY_EXPECTED_EMPTY
 
 
 def test_empty():
@@ -22,6 +34,12 @@ def test_empty():
     assert w.wcs.aux.crln_obs is None
     assert w.wcs.aux.hgln_obs is None
     assert w.wcs.aux.hglt_obs is None
+    assert w.wcs.aux.a_radius is None
+    assert w.wcs.aux.b_radius is None
+    assert w.wcs.aux.c_radius is None
+    assert w.wcs.aux.bdis_obs is None
+    assert w.wcs.aux.blon_obs is None
+    assert w.wcs.aux.blat_obs is None
     assert str(w.wcs.aux) == STR_EXPECTED_EMPTY
 
 
@@ -57,12 +75,16 @@ HGLT_OBS=            -6.820544 / [deg] Heliographic latitude of observer
 )
 
 
-STR_EXPECTED_GET = """
+STR_EXPECTED_GET = (
+    """
 rsun_ref: 696000000.000000
 dsun_obs: 147724815128.000000
 crln_obs: 22.814522
 hgln_obs: 8.431123
 hglt_obs: -6.820544""".lstrip()
+    + "\n"
+    + STR_PLANETARY_EXPECTED_EMPTY
+)
 
 
 def test_solar_aux_get():
@@ -75,12 +97,16 @@ def test_solar_aux_get():
     assert str(w.wcs.aux) == STR_EXPECTED_GET
 
 
-STR_EXPECTED_SET = """
+STR_EXPECTED_SET = (
+    """
 rsun_ref: 698000000.000000
 dsun_obs: 140000000000.000000
 crln_obs: 10.000000
 hgln_obs: 30.000000
 hglt_obs: 40.000000""".lstrip()
+    + "\n"
+    + STR_PLANETARY_EXPECTED_EMPTY
+)
 
 
 def test_solar_aux_set():
@@ -162,7 +188,7 @@ def test_unset_aux():
     w.wcs.aux.hglt_obs = None
     assert w.wcs.aux.hglt_obs is None
 
-    assert str(w.wcs.aux) == "rsun_ref:\ndsun_obs:\ncrln_obs:\nhgln_obs:\nhglt_obs:"
+    assert str(w.wcs.aux) == STR_EXPECTED_EMPTY
 
     header = w.to_header()
     assert "RSUN_REF" not in header

--- a/astropy/wcs/tests/test_utils.py
+++ b/astropy/wcs/tests/test_utils.py
@@ -13,6 +13,17 @@ from astropy.coordinates.representation.geodetic import (
     BaseBodycentricRepresentation,
     BaseGeodeticRepresentation,
 )
+from astropy.coordinates.tests.test_geodetic_representations import (
+    IAUMARS2000BodycentricRepresentation,
+    IAUMARS2000GeodeticRepresentation,
+)
+
+# Preserve the original REPRESENTATION_CLASSES dict so that importing
+#   the test file doesn't add a persistent test subclass
+from astropy.coordinates.tests.test_representation import (  # noqa: F401
+    setup_function,
+    teardown_function,
+)
 from astropy.io import fits
 from astropy.time import Time
 from astropy.units import Quantity
@@ -48,18 +59,6 @@ from astropy.wcs.wcs import (
     Sip,
 )
 from astropy.wcs.wcsapi.fitswcs import SlicedFITSWCS
-
-from astropy.coordinates.tests.test_geodetic_representations import (
-    IAUMARS2000GeodeticRepresentation,
-    IAUMARS2000BodycentricRepresentation,
-)
-
-# Preserve the original REPRESENTATION_CLASSES dict so that importing
-#   the test file doesn't add a persistent test subclass
-from astropy.coordinates.tests.test_representation import (  # noqa: F401
-    setup_function,
-    teardown_function,
-)
 
 
 def test_wcs_dropping():
@@ -456,11 +455,11 @@ def test_wcs_to_celestial_frame_extend():
 def test_celestial_frame_to_wcs():
     # Import astropy.coordinates here to avoid circular imports
     from astropy.coordinates import (
-        BaseCoordinateFrame,
         FK4,
         FK5,
         ICRS,
         ITRS,
+        BaseCoordinateFrame,
         FK4NoETerms,
         Galactic,
     )

--- a/astropy/wcs/tests/test_utils.py
+++ b/astropy/wcs/tests/test_utils.py
@@ -412,7 +412,7 @@ def test_wcs_to_body_frame():
     assert issubclass(frame.representation_type, BaseBodycentricRepresentation)
     assert frame.name == "Mars"
     assert frame.representation_type._equatorial_radius == 3396190.0 * u.m
-    assert frame.representation_type._flattening == 0.0
+    assert_almost_equal(frame.representation_type._flattening, 0.005888952031541227)
 
     mywcs = WCS(naxis=2)
     mywcs.wcs.ctype = ["EALN-TAN", "EALT-TAN"]
@@ -558,7 +558,8 @@ def test_body_to_wcs_frame():
     frame = IAUMARSSphereFrame()
 
     with pytest.raises(
-        ValueError, match="The representation type should be geodetic or bodycentric"
+        ValueError,
+        match="Planetary coordinates in WCS require a geodetic or bodycentric representation",
     ):
         celestial_frame_to_wcs(frame, projection="CAR")
 

--- a/astropy/wcs/tests/test_utils.py
+++ b/astropy/wcs/tests/test_utils.py
@@ -22,7 +22,6 @@ from astropy.utils.data import get_pkg_data_contents, get_pkg_data_filename
 from astropy.utils.exceptions import AstropyUserWarning
 from astropy.wcs import _wcs
 from astropy.wcs.utils import (
-    WCSLIB_LT8,
     _pixel_to_pixel_correlation_matrix,
     _pixel_to_world_correlation_matrix,
     _split_matrix,
@@ -381,44 +380,39 @@ def test_wcs_to_body_frame():
 
     triaxial_wcs = WCS(naxis=2)
     triaxial_wcs.wcs.ctype = ["MELN-TAN", "MELT-TAN"]
-    if not WCSLIB_LT8:
-        triaxial_wcs.wcs.aux.a_radius = 2439700.0
-        triaxial_wcs.wcs.aux.b_radius = 2439900.0
-        triaxial_wcs.wcs.aux.c_radius = 2438800.0
-        with pytest.raises(
-            NotImplementedError, match="triaxial systems are not supported at this time"
-        ):
-            frame = wcs_to_celestial_frame(triaxial_wcs)
+    triaxial_wcs.wcs.aux.a_radius = 2439700.0
+    triaxial_wcs.wcs.aux.b_radius = 2439900.0
+    triaxial_wcs.wcs.aux.c_radius = 2438800.0
+    with pytest.raises(
+        NotImplementedError, match="triaxial systems are not supported at this time"
+    ):
+        frame = wcs_to_celestial_frame(triaxial_wcs)
 
     mywcs = WCS(naxis=2)
     mywcs.wcs.ctype = ["MALN-TAN", "MALT-TAN"]
     mywcs.wcs.dateobs = "2017-08-17T12:41:04.430"
     mywcs.wcs.name = "Mars Bodycentric Body-Fixed"
 
-    if not WCSLIB_LT8:
-        mywcs.wcs.aux.a_radius = 3396190.0
-        mywcs.wcs.aux.b_radius = 3396190.0
-        mywcs.wcs.aux.c_radius = 3376190.0
+    mywcs.wcs.aux.a_radius = 3396190.0
+    mywcs.wcs.aux.b_radius = 3396190.0
+    mywcs.wcs.aux.c_radius = 3376190.0
     frame = wcs_to_celestial_frame(mywcs)
     assert issubclass(frame, BaseCoordinateFrame)
     assert issubclass(frame.representation_type, BaseBodycentricRepresentation)
     assert frame.name == "Mars"
-    if not WCSLIB_LT8:
-        assert frame.representation_type._equatorial_radius == 3396190.0 * u.m
+    assert frame.representation_type._equatorial_radius == 3396190.0 * u.m
 
     mywcs = WCS(naxis=2)
     mywcs.wcs.ctype = ["EALN-TAN", "EALT-TAN"]
     mywcs.wcs.name = "Earth Geodetic Body-Fixed"
-    if not WCSLIB_LT8:
-        mywcs.wcs.aux.a_radius = 6378137.0
-        mywcs.wcs.aux.b_radius = 6378137.0
-        mywcs.wcs.aux.c_radius = 6356752.3
+    mywcs.wcs.aux.a_radius = 6378137.0
+    mywcs.wcs.aux.b_radius = 6378137.0
+    mywcs.wcs.aux.c_radius = 6356752.3
     mywcs.wcs.set()
     frame = wcs_to_celestial_frame(mywcs)
     assert issubclass(frame, BaseCoordinateFrame)
     assert issubclass(frame.representation_type, BaseGeodeticRepresentation)
-    if not WCSLIB_LT8:
-        assert frame.representation_type._equatorial_radius == 6378137.0 * u.m
+    assert frame.representation_type._equatorial_radius == 6378137.0 * u.m
 
 
 def test_wcs_to_celestial_frame_correlated():
@@ -574,10 +568,9 @@ def test_body_to_wcs_frame():
     assert mywcs.wcs.ctype[1] == "MALT-CAR"
     assert mywcs.wcs.name == "Bodycentric Body-Fixed"
 
-    if not WCSLIB_LT8:
-        assert mywcs.wcs.aux.a_radius == 3396190.0
-        assert mywcs.wcs.aux.b_radius == 3396190.0
-        assert_almost_equal(mywcs.wcs.aux.c_radius, 3376200.0)
+    assert mywcs.wcs.aux.a_radius == 3396190.0
+    assert mywcs.wcs.aux.b_radius == 3396190.0
+    assert_almost_equal(mywcs.wcs.aux.c_radius, 3376200.0)
 
 
 def test_celestial_frame_to_wcs_extend():

--- a/astropy/wcs/tests/test_utils.py
+++ b/astropy/wcs/tests/test_utils.py
@@ -55,6 +55,13 @@ from astropy.coordinates.tests.test_geodetic_representations import (
     IAUMARS2000BodycentricRepresentation,
 )
 
+# Preserve the original REPRESENTATION_CLASSES dict so that importing
+#   the test file doesn't add a persistent test subclass
+from astropy.coordinates.tests.test_representation import (  # noqa: F401
+    setup_function,
+    teardown_function,
+)
+
 
 def test_wcs_dropping():
     wcs = WCS(naxis=4)

--- a/astropy/wcs/tests/test_utils.py
+++ b/astropy/wcs/tests/test_utils.py
@@ -385,14 +385,13 @@ def test_wcs_to_body_frame():
         triaxial_wcs.wcs.aux.a_radius = 2439700.0
         triaxial_wcs.wcs.aux.b_radius = 2439900.0
         triaxial_wcs.wcs.aux.c_radius = 2438800.0
-    with pytest.raises(
-        NotImplementedError, match="triaxial systems are not supported at this time"
-    ):
-        frame = wcs_to_celestial_frame(triaxial_wcs)
+        with pytest.raises(
+            NotImplementedError, match="triaxial systems are not supported at this time"
+        ):
+            frame = wcs_to_celestial_frame(triaxial_wcs)
 
     mywcs = WCS(naxis=2)
     mywcs.wcs.ctype = ["MALN-TAN", "MALT-TAN"]
-    mywcs.wcs.radesys = "ICRS"
     mywcs.wcs.dateobs = "2017-08-17T12:41:04.430"
     mywcs.wcs.name = "Mars Bodycentric Body-Fixed"
 
@@ -409,7 +408,6 @@ def test_wcs_to_body_frame():
 
     mywcs = WCS(naxis=2)
     mywcs.wcs.ctype = ["EALN-TAN", "EALT-TAN"]
-    mywcs.wcs.radesys = "ICRS"
     mywcs.wcs.name = "Earth Geodetic Body-Fixed"
     if not WCSLIB_LT8:
         mywcs.wcs.aux.a_radius = 6378137.0
@@ -556,7 +554,7 @@ def test_body_to_wcs_frame():
     with pytest.raises(
         ValueError, match="The representation type should be geodetic or bodycentric"
     ):
-        mywcs = celestial_frame_to_wcs(frame, projection="CAR")
+        celestial_frame_to_wcs(frame, projection="CAR")
 
     class IAUMARS2000BodyFrame(BaseCoordinateFrame):
         name = "Mars"
@@ -564,6 +562,7 @@ def test_body_to_wcs_frame():
     frame = IAUMARS2000BodyFrame()
 
     frame.representation_type = IAUMARS2000GeodeticRepresentation
+
     mywcs = celestial_frame_to_wcs(frame, projection="CAR")
     assert mywcs.wcs.ctype[0] == "MALN-CAR"
     assert mywcs.wcs.ctype[1] == "MALT-CAR"

--- a/astropy/wcs/tests/test_utils.py
+++ b/astropy/wcs/tests/test_utils.py
@@ -425,6 +425,7 @@ def test_wcs_to_body_frame():
     assert issubclass(frame, BaseCoordinateFrame)
     assert issubclass(frame.representation_type, BaseGeodeticRepresentation)
     assert frame.representation_type._equatorial_radius == 6378137.0 * u.m
+    assert_almost_equal(frame.representation_type._flattening, 0.0033528128981864433)
 
 
 def test_wcs_to_celestial_frame_correlated():

--- a/astropy/wcs/tests/test_utils.py
+++ b/astropy/wcs/tests/test_utils.py
@@ -559,7 +559,7 @@ def test_body_to_wcs_frame():
 
     with pytest.raises(
         ValueError,
-        match="Planetary coordinates in WCS require a geodetic or bodycentric representation",
+        match="Planetary coordinates in WCS require a geodetic or bodycentric",
     ):
         celestial_frame_to_wcs(frame, projection="CAR")
 

--- a/astropy/wcs/utils.py
+++ b/astropy/wcs/utils.py
@@ -190,9 +190,9 @@ def _wcs_to_celestial_frame_builtin(wcs):
                         "triaxial systems are not supported at this time."
                     )
 
-            # instance a new representation class
+            # create a new representation class
             representation_type = solar_system_body_representation_type.get(xcoord[:2])
-            if representation_type is None and object_name is not None:
+            if representation_type is None:
                 representation_type = type(
                     f"{object_name}{representation_type_name}",
                     (baserepresentation,),
@@ -200,9 +200,9 @@ def _wcs_to_celestial_frame_builtin(wcs):
                 )
                 solar_system_body_representation_type[xcoord[:2]] = representation_type
 
-            # instance a new frame class
+            # create a new frame class
             frame = solar_system_body_frames.get(xcoord[:2])
-            if frame is None and object_name is not None:
+            if frame is None:
                 frame = type(
                     f"{object_name}Frame",
                     (BaseCoordinateFrame,),
@@ -258,6 +258,10 @@ def _celestial_frame_to_wcs_builtin(frame, projection="TAN"):
         ycoord = "TLAT"
         wcs.wcs.radesys = "ITRS"
         wcs.wcs.dateobs = frame.obstime.utc.isot
+        if issubclass(frame.representation_type, BaseGeodeticRepresentation):
+            wcs.wcs.name = "Geodetic Terrestrial Representation"
+        elif issubclass(frame.representation_type, BaseBodycentricRepresentation):
+            wcs.wcs.name = "Angular Geocentric Representation"
     # TODO: once we have a BaseBodyFrame, replace this with an isinstance check
     elif hasattr(frame, "name") and frame.name in SOLAR_SYSTEM_OBJ_DICT.values():
         xcoord = frame.name[:2].upper().replace("MO", "SE") + "LN"

--- a/astropy/wcs/utils.py
+++ b/astropy/wcs/utils.py
@@ -49,6 +49,9 @@ SOLAR_SYSTEM_OBJ_DICT = {
     "NE": "Neptune",
 }
 
+solar_system_body_frames = {}
+solar_system_body_representation_type = {}
+
 
 def add_stokes_axis_to_wcs(wcs, add_before_ind):
     """
@@ -90,9 +93,6 @@ def _wcs_to_celestial_frame_builtin(wcs):
 
     # Import astropy.time here otherwise setup.py fails before extensions are compiled
     from astropy.time import Time
-
-    solar_system_body_frames = {}
-    solar_system_body_representation_type = {}
 
     if wcs.wcs.lng == -1 or wcs.wcs.lat == -1:
         return None
@@ -140,12 +140,7 @@ def _wcs_to_celestial_frame_builtin(wcs):
                 representation_type=SphericalRepresentation,
                 obstime=wcs.wcs.dateobs or None,
             )
-        elif (
-            "LN" in xcoord
-            and "LT" in ycoord
-            and "H" not in xcoord
-            and "CR" not in xcoord
-        ):
+        elif xcoord[2:4] in ("LN", "LT") and "H" not in xcoord and "CR" not in xcoord:
             # Coordinates on a planetary body, as defined in
             # https://agupubs.onlinelibrary.wiley.com/doi/10.1029/2018EA000388
 
@@ -253,9 +248,8 @@ def _celestial_frame_to_wcs_builtin(frame, projection="TAN"):
             wcs.wcs.name = "Bodycentric Body-Fixed"
         else:
             raise ValueError(
-                "The representation type should be geodetic or bodycentric,"
-                " not {frame.representation_type} for storing planetary"
-                " coordinates in a WCS."
+                "Planetary coordinates in WCS require a geodetic or bodycentric "
+                "representation, not {frame.representation_type}."
             )
         wcs.wcs.aux.a_radius = frame.representation_type._equatorial_radius.value
         wcs.wcs.aux.b_radius = frame.representation_type._equatorial_radius.value

--- a/astropy/wcs/utils.py
+++ b/astropy/wcs/utils.py
@@ -7,16 +7,15 @@ import numpy as np
 import astropy.units as u
 from astropy.coordinates import (
     ITRS,
-    CartesianRepresentation,
-    SphericalRepresentation,
-    BaseGeodeticRepresentation,
     BaseBodycentricRepresentation,
     BaseCoordinateFrame,
+    BaseGeodeticRepresentation,
+    CartesianRepresentation,
+    SphericalRepresentation,
 )
 from astropy.utils import unbroadcast
 
-from .wcs import WCS, WCSSUB_LATITUDE, WCSSUB_LONGITUDE, _wcs
-from packaging.version import Version
+from .wcs import WCS, WCSSUB_LATITUDE, WCSSUB_LONGITUDE
 
 __doctest_skip__ = ["wcs_to_celestial_frame", "celestial_frame_to_wcs"]
 
@@ -262,9 +261,7 @@ def _celestial_frame_to_wcs_builtin(frame, projection="TAN"):
         wcs.wcs.aux.b_radius = frame.representation_type._equatorial_radius.value
         wcs.wcs.aux.c_radius = wcs.wcs.aux.a_radius * (
             1.0
-            - frame.representation_type._flattening.to(
-                u.dimensionless_unscaled
-            ).value
+            - frame.representation_type._flattening.to(u.dimensionless_unscaled).value
         )
     else:
         return None

--- a/astropy/wcs/utils.py
+++ b/astropy/wcs/utils.py
@@ -259,10 +259,6 @@ def _celestial_frame_to_wcs_builtin(frame, projection="TAN"):
         ycoord = "TLAT"
         wcs.wcs.radesys = "ITRS"
         wcs.wcs.dateobs = frame.obstime.utc.isot
-        if issubclass(frame.representation_type, BaseGeodeticRepresentation):
-            wcs.wcs.name = "Geodetic Terrestrial Representation"
-        elif issubclass(frame.representation_type, BaseBodycentricRepresentation):
-            wcs.wcs.name = "Angular Geocentric Representation"
     # TODO: once we have a BaseBodyFrame, replace this with an isinstance check
     elif hasattr(frame, "name") and frame.name in SOLAR_SYSTEM_OBJ_DICT.values():
         xcoord = frame.name[:2].upper().replace("MO", "SE") + "LN"

--- a/astropy/wcs/utils.py
+++ b/astropy/wcs/utils.py
@@ -191,29 +191,11 @@ def _wcs_to_celestial_frame_builtin(wcs):
                 equatorial_radius,
                 flattening,
             )
-            if representation_type is None:
-                representation_type = type(
-                    f"{object_name}{representation_type_name}",
-                    (baserepresentation,),
-                    dict(_equatorial_radius=equatorial_radius, _flattening=flattening),
-                )
-                solar_system_body_representation_type[xcoord[:2]] = representation_type
 
             # create a new frame class
             frame = solar_system_body_frame(
                 SOLAR_SYSTEM_OBJ_DICT.get(xcoord[:2]), representation_type
             )
-            if frame is None:
-                frame = type(
-                    f"{object_name}Frame",
-                    (BaseCoordinateFrame,),
-                    dict(
-                        name=object_name,
-                        representation_type=representation_type,
-                        obstime=None,
-                    ),
-                )
-                solar_system_body_frames[xcoord[:2]] = frame
         else:
             frame = None
 

--- a/docs/changes/wcs/14820.feature.rst
+++ b/docs/changes/wcs/14820.feature.rst
@@ -1,0 +1,1 @@
+Add WCS description of basic planetary coordinate frames.

--- a/docs/changes/wcs/14820.feature.rst
+++ b/docs/changes/wcs/14820.feature.rst
@@ -1,1 +1,1 @@
-Add WCS description of basic planetary coordinate frames.
+Support WCS descriptions of basic planetary coordinate frames.


### PR DESCRIPTION
### Description

This pull request Implement transformation to / from CoordinateFrame from / to related WCS.
This new frames are meant to be used for body-fixed reference frames for spheroidal Solar System bodies.
The implementation of the already available related WCS is also added.

Towards https://github.com/astropy/astropy/issues/11170.

Thanks for considering it.

This work is funded by the Europlanet 2024 Research Infrastructure (RI) Grant.