### PR TITLE
Split out tile validation from CompImageHDU into (private) dedicated function

### DIFF
--- a/astropy/io/fits/hdu/compressed.py
+++ b/astropy/io/fits/hdu/compressed.py
@@ -1200,18 +1200,7 @@ class CompImageHDU(BinTableHDU):
             znaxis = "ZNAXIS" + str(idx + 1)
             ztile = "ZTILE" + str(idx + 1)
 
-            if tile_shape and len(tile_shape) >= idx + 1:
-                ts = tile_shape[len(self._axes) - 1 - idx]
-            else:
-                if ztile not in self._header:
-                    # Default tile size
-                    if not idx:
-                        ts = self._image_header["NAXIS1"]
-                    else:
-                        ts = 1
-                else:
-                    ts = self._header[ztile]
-                tile_shape.insert(0, ts)
+            ts = tile_shape[len(self._axes) - 1 - idx]
 
             if not nrows:
                 nrows = (axis - 1) // ts + 1

--- a/astropy/io/fits/hdu/compressed.py
+++ b/astropy/io/fits/hdu/compressed.py
@@ -198,7 +198,6 @@ def _validate_tile_shape(*, tile_shape, compression_type, image_header):
     return tuple(tile_shape)
 
 
-
 class CompImageHeader(Header):
     """
     Header object for compressed image HDUs designed to keep the compression
@@ -1178,9 +1177,11 @@ class CompImageHDU(BinTableHDU):
         # Verify that any input tile size parameter is the appropriate
         # size to match the HDU's data.
 
-        tile_shape = _validate_tile_shape(tile_shape=tile_shape,
-                                          compression_type=compression_type,
-                                          image_header=self._image_header)
+        tile_shape = _validate_tile_shape(
+            tile_shape=tile_shape,
+            compression_type=compression_type,
+            image_header=self._image_header,
+        )
 
         # Set up locations for writing the next cards in the header.
         last_znaxis = "ZNAXIS"

--- a/astropy/io/fits/hdu/compressed.py
+++ b/astropy/io/fits/hdu/compressed.py
@@ -84,6 +84,118 @@ COMPRESSION_KEYWORDS = {
 }
 
 
+def _validate_tile_shape(*, tile_shape, compression_type, image_header):
+
+    naxis = image_header["NAXIS"]
+
+    if not tile_shape:
+        tile_shape = []
+    elif len(tile_shape) != naxis:
+        warnings.warn(
+            "Provided tile size not appropriate for the data.  "
+            "Default tile size will be used.",
+            AstropyUserWarning,
+        )
+        tile_shape = []
+
+    # Set default tile dimensions for HCOMPRESS_1
+
+    if compression_type == "HCOMPRESS_1":
+        if image_header["NAXIS1"] < 4 or image_header["NAXIS2"] < 4:
+            raise ValueError("Hcompress minimum image dimension is 4 pixels")
+        elif tile_shape:
+            if tile_shape[-1] < 4 or tile_shape[-2] < 4:
+                # user specified tile size is too small
+                raise ValueError("Hcompress minimum tile dimension is 4 pixels")
+            major_dims = len([ts for ts in tile_shape if ts > 1])
+            if major_dims > 2:
+                raise ValueError(
+                    "HCOMPRESS can only support 2-dimensional tile sizes."
+                    "All but two of the tile_shape dimensions must be set "
+                    "to 1."
+                )
+
+        if tile_shape and (tile_shape[-1] == 0 and tile_shape[-2] == 0):
+            # compress the whole image as a single tile
+            tile_shape[-1] = image_header["NAXIS1"]
+            tile_shape[-2] = image_header["NAXIS2"]
+
+            for i in range(2, naxis):
+                # set all higher tile dimensions = 1
+                tile_shape[i] = 1
+        elif not tile_shape:
+            # The Hcompress algorithm is inherently 2D in nature, so the
+            # row by row tiling that is used for other compression
+            # algorithms is not appropriate.  If the image has less than 30
+            # rows, then the entire image will be compressed as a single
+            # tile.  Otherwise the tiles will consist of 16 rows of the
+            # image.  This keeps the tiles to a reasonable size, and it
+            # also includes enough rows to allow good compression
+            # efficiency.  It the last tile of the image happens to contain
+            # less than 4 rows, then find another tile size with between 14
+            # and 30 rows (preferably even), so that the last tile has at
+            # least 4 rows.
+
+            # 1st tile dimension is the row length of the image
+            tile_shape = [image_header["NAXIS1"]]
+
+            if image_header["NAXIS2"] <= 30:
+                tile_shape.insert(0, image_header["NAXIS1"])
+            else:
+                # look for another good tile dimension
+                naxis2 = image_header["NAXIS2"]
+                for dim in [16, 24, 20, 30, 28, 26, 22, 18, 14]:
+                    if naxis2 % dim == 0 or naxis2 % dim > 3:
+                        tile_shape.insert(0, dim)
+                        break
+                else:
+                    tile_shape.insert(0, 17)
+
+            for i in range(2, naxis):
+                # set all higher tile dimensions = 1
+                tile_shape.insert(0, 1)
+
+        # check if requested tile size causes the last tile to have
+        # less than 4 pixels
+
+        remain = image_header["NAXIS1"] % tile_shape[-1]  # 1st dimen
+
+        original_tile_shape = tile_shape[:]
+
+        if remain > 0 and remain < 4:
+            tile_shape[-1] += 1  # try increasing tile size by 1
+
+            remain = image_header["NAXIS1"] % tile_shape[-1]
+
+            if remain > 0 and remain < 4:
+                raise ValueError(
+                    "Last tile along 1st dimension has less than 4 pixels"
+                )
+
+        remain = image_header["NAXIS2"] % tile_shape[-2]  # 2nd dimen
+
+        if remain > 0 and remain < 4:
+            tile_shape[-2] += 1  # try increasing tile size by 1
+
+            remain = image_header["NAXIS2"] % tile_shape[-2]
+
+            if remain > 0 and remain < 4:
+                raise ValueError(
+                    "Last tile along 2nd dimension has less than 4 pixels"
+                )
+
+        if tile_shape != original_tile_shape:
+            warnings.warn(
+                f"The tile shape should be such that no tiles have "
+                f"fewer than 4 pixels. The tile shape has "
+                f"automatically been changed from {original_tile_shape} "
+                f"to {tile_shape}, but in future this will raise an "
+                f"error and the correct tile shape should be specified "
+                f"directly.",
+                AstropyDeprecationWarning,
+            )
+
+
 class CompImageHeader(Header):
     """
     Header object for compressed image HDUs designed to keep the compression
@@ -1063,114 +1175,9 @@ class CompImageHDU(BinTableHDU):
         # Verify that any input tile size parameter is the appropriate
         # size to match the HDU's data.
 
-        naxis = self._image_header["NAXIS"]
-
-        if not tile_shape:
-            tile_shape = []
-        elif len(tile_shape) != naxis:
-            warnings.warn(
-                "Provided tile size not appropriate for the data.  "
-                "Default tile size will be used.",
-                AstropyUserWarning,
-            )
-            tile_shape = []
-
-        # Set default tile dimensions for HCOMPRESS_1
-
-        if compression_type == "HCOMPRESS_1":
-            if self._image_header["NAXIS1"] < 4 or self._image_header["NAXIS2"] < 4:
-                raise ValueError("Hcompress minimum image dimension is 4 pixels")
-            elif tile_shape:
-                if tile_shape[-1] < 4 or tile_shape[-2] < 4:
-                    # user specified tile size is too small
-                    raise ValueError("Hcompress minimum tile dimension is 4 pixels")
-                major_dims = len([ts for ts in tile_shape if ts > 1])
-                if major_dims > 2:
-                    raise ValueError(
-                        "HCOMPRESS can only support 2-dimensional tile sizes."
-                        "All but two of the tile_shape dimensions must be set "
-                        "to 1."
-                    )
-
-            if tile_shape and (tile_shape[-1] == 0 and tile_shape[-2] == 0):
-                # compress the whole image as a single tile
-                tile_shape[-1] = self._image_header["NAXIS1"]
-                tile_shape[-2] = self._image_header["NAXIS2"]
-
-                for i in range(2, naxis):
-                    # set all higher tile dimensions = 1
-                    tile_shape[i] = 1
-            elif not tile_shape:
-                # The Hcompress algorithm is inherently 2D in nature, so the
-                # row by row tiling that is used for other compression
-                # algorithms is not appropriate.  If the image has less than 30
-                # rows, then the entire image will be compressed as a single
-                # tile.  Otherwise the tiles will consist of 16 rows of the
-                # image.  This keeps the tiles to a reasonable size, and it
-                # also includes enough rows to allow good compression
-                # efficiency.  It the last tile of the image happens to contain
-                # less than 4 rows, then find another tile size with between 14
-                # and 30 rows (preferably even), so that the last tile has at
-                # least 4 rows.
-
-                # 1st tile dimension is the row length of the image
-                tile_shape = [self._image_header["NAXIS1"]]
-
-                if self._image_header["NAXIS2"] <= 30:
-                    tile_shape.insert(0, self._image_header["NAXIS1"])
-                else:
-                    # look for another good tile dimension
-                    naxis2 = self._image_header["NAXIS2"]
-                    for dim in [16, 24, 20, 30, 28, 26, 22, 18, 14]:
-                        if naxis2 % dim == 0 or naxis2 % dim > 3:
-                            tile_shape.insert(0, dim)
-                            break
-                    else:
-                        tile_shape.insert(0, 17)
-
-                for i in range(2, naxis):
-                    # set all higher tile dimensions = 1
-                    tile_shape.insert(0, 1)
-
-            # check if requested tile size causes the last tile to have
-            # less than 4 pixels
-
-            remain = self._image_header["NAXIS1"] % tile_shape[-1]  # 1st dimen
-
-            original_tile_shape = tile_shape[:]
-
-            if remain > 0 and remain < 4:
-                tile_shape[-1] += 1  # try increasing tile size by 1
-
-                remain = self._image_header["NAXIS1"] % tile_shape[-1]
-
-                if remain > 0 and remain < 4:
-                    raise ValueError(
-                        "Last tile along 1st dimension has less than 4 pixels"
-                    )
-
-            remain = self._image_header["NAXIS2"] % tile_shape[-2]  # 2nd dimen
-
-            if remain > 0 and remain < 4:
-                tile_shape[-2] += 1  # try increasing tile size by 1
-
-                remain = self._image_header["NAXIS2"] % tile_shape[-2]
-
-                if remain > 0 and remain < 4:
-                    raise ValueError(
-                        "Last tile along 2nd dimension has less than 4 pixels"
-                    )
-
-            if tile_shape != original_tile_shape:
-                warnings.warn(
-                    f"The tile shape should be such that no tiles have "
-                    f"fewer than 4 pixels. The tile shape has "
-                    f"automatically been changed from {original_tile_shape} "
-                    f"to {tile_shape}, but in future this will raise an "
-                    f"error and the correct tile shape should be specified "
-                    f"directly.",
-                    AstropyDeprecationWarning,
-                )
+        tile_shape = _validate_tile_shape(tile_shape=tile_shape,
+                                          compression_type=compression_type,
+                                          image_header=self._image_header)
 
         # Set up locations for writing the next cards in the header.
         last_znaxis = "ZNAXIS"

--- a/astropy/io/fits/hdu/compressed.py
+++ b/astropy/io/fits/hdu/compressed.py
@@ -85,7 +85,6 @@ COMPRESSION_KEYWORDS = {
 
 
 def _validate_tile_shape(*, tile_shape, compression_type, image_header):
-
     naxis = image_header["NAXIS"]
 
     if not tile_shape:
@@ -97,6 +96,8 @@ def _validate_tile_shape(*, tile_shape, compression_type, image_header):
             AstropyUserWarning,
         )
         tile_shape = []
+    else:
+        tile_shape = list(tile_shape)
 
     # Set default tile dimensions for HCOMPRESS_1
 
@@ -168,9 +169,7 @@ def _validate_tile_shape(*, tile_shape, compression_type, image_header):
             remain = image_header["NAXIS1"] % tile_shape[-1]
 
             if remain > 0 and remain < 4:
-                raise ValueError(
-                    "Last tile along 1st dimension has less than 4 pixels"
-                )
+                raise ValueError("Last tile along 1st dimension has less than 4 pixels")
 
         remain = image_header["NAXIS2"] % tile_shape[-2]  # 2nd dimen
 
@@ -180,9 +179,7 @@ def _validate_tile_shape(*, tile_shape, compression_type, image_header):
             remain = image_header["NAXIS2"] % tile_shape[-2]
 
             if remain > 0 and remain < 4:
-                raise ValueError(
-                    "Last tile along 2nd dimension has less than 4 pixels"
-                )
+                raise ValueError("Last tile along 2nd dimension has less than 4 pixels")
 
         if tile_shape != original_tile_shape:
             warnings.warn(
@@ -194,6 +191,12 @@ def _validate_tile_shape(*, tile_shape, compression_type, image_header):
                 f"directly.",
                 AstropyDeprecationWarning,
             )
+
+    if len(tile_shape) == 0 and image_header["NAXIS"] > 0:
+        tile_shape = [1] * (naxis - 1) + [image_header["NAXIS1"]]
+
+    return tuple(tile_shape)
+
 
 
 class CompImageHeader(Header):


### PR DESCRIPTION
The ``CompImageHDU`` code is currently quite 'monolithic' and there are some things that could be better split out into separate functions - one of them is the validation/updating of the tile shape which fits nicely into a dedicated function. This is just internal refactoring but improves (IMHO) the code clarity.