### PR TITLE
Correct the docstring of `redshift_distance()`

### DIFF
--- a/astropy/cosmology/units.py
+++ b/astropy/cosmology/units.py
@@ -79,7 +79,7 @@ def redshift_distance(cosmology=None, kind="comoving", **atzkw):
         A cosmology realization or built-in cosmology's name (e.g. 'Planck18').
         If None, will use the default cosmology
         (controlled by :class:`~astropy.cosmology.default_cosmology`).
-    kind : {'comoving', 'lookback', 'luminosity'} or None, optional
+    kind : {'comoving', 'lookback', 'luminosity'}, optional
         The distance type for the Equivalency.
         Note this does NOT include the angular diameter distance as this
         distance measure is not monotonic.


### PR DESCRIPTION
### Description

The docstring of `astropy.cosmology.units.redshift_distance()` erroneously claims that `kind=None` is a valid argument, even though there is a unit test that checks that it is not: https://github.com/astropy/astropy/blob/5e73a254b60c39f559037228811f53aa804d0df3/astropy/cosmology/tests/test_units.py#L191-L194

Changing the description of what argument values are allowed in the docstring can be considered to be an API change, but this commit does not change how the code actually behaves, so it doesn't create compatibility problems, and I don't see much point in changing the code to allow `kind=None` just so that it could be deprecated.