### PR TITLE
Fix pickling/unpicking of projection models

### DIFF
--- a/astropy/modeling/projections.py
+++ b/astropy/modeling/projections.py
@@ -158,6 +158,20 @@ class Projection(Model):
             self._prj.pv = None, *pv
             self._prj.set()
 
+    # Note that the Prjprm object can't be pickled, but we don't actually
+    # need to pickle it as it is recreated during __init__ and can be
+    # updated with update_prj.
+
+    def __getstate__(self):
+        state = super().__getstate__()
+        if '_prj' in state:
+            _ = state.pop('_prj')
+        return state
+
+    def __setstate__(self, state):
+        self.__init__()
+        self._update_prj()
+
 
 class Pix2SkyProjection(Projection):
     """Base class for all Pix2Sky projections."""

--- a/astropy/modeling/projections.py
+++ b/astropy/modeling/projections.py
@@ -160,17 +160,14 @@ class Projection(Model):
 
     # Note that the Prjprm object can't be pickled, but we don't actually
     # need to pickle it as it is recreated during __init__ and can be
-    # updated with update_prj.
+    # updated with update_prj. So instead we represent the state with a
+    # simple dictionary of parameter values.
 
     def __getstate__(self):
-        state = super().__getstate__()
-        if '_prj' in state:
-            _ = state.pop('_prj')
-        return state
+        return {p: getattr(self, p).value for p in self.param_names}
 
     def __setstate__(self, state):
-        self.__init__()
-        self._update_prj()
+        self.__init__(**state)
 
 
 class Pix2SkyProjection(Projection):

--- a/astropy/modeling/tests/test_projections.py
+++ b/astropy/modeling/tests/test_projections.py
@@ -1332,7 +1332,6 @@ def test_Sky2Pix_HEALPixPolar_inverse():
 
 @pytest.mark.parametrize(("code",), pars)
 def test_pickle(code):
-
     # Check that pickling/unpickling works for projection models
 
     model = getattr(projections, "Sky2Pix_" + code)
@@ -1345,7 +1344,6 @@ def test_pickle(code):
 
 
 def test_pickle_with_parameters():
-
     # Check a projection model with custom parameters
 
     m = projections.Pix2Sky_CylindricalPerspective(mu=2, lam=30)

--- a/astropy/modeling/tests/test_projections.py
+++ b/astropy/modeling/tests/test_projections.py
@@ -4,6 +4,7 @@
 # pylint: disable=invalid-name, no-member
 import os
 import unittest.mock as mk
+from pickle import loads, dumps
 
 import numpy as np
 import pytest
@@ -1327,3 +1328,32 @@ def test_Sky2Pix_HEALPixPolar_inverse():
     a, b = inverse(*model(x, y))
     assert_allclose(a, x, atol=1e-12)
     assert_allclose(b, y, atol=1e-12)
+
+
+@pytest.mark.parametrize(("code",), pars)
+def test_pickle(code):
+
+    # Check that pickling/unpickling works for projection models
+
+    model = getattr(projections, "Sky2Pix_" + code)
+    m = model()
+    assert_allclose(m(45, 45), loads(dumps(m))(45, 45))
+
+    model = getattr(projections, "Pix2Sky_" + code)
+    m = model()
+    assert_allclose(m(45, 45), loads(dumps(m))(45, 45))
+
+
+def test_pickle_with_parameters():
+
+    # Check a projection model with custom parameters
+
+    m = projections.Pix2Sky_CylindricalPerspective(mu=2, lam=30)
+    assert m.mu == 2
+    assert m.lam == 30
+    m_clone = loads(dumps(m))
+    assert m.mu == 2
+    assert m.lam == 30
+    assert m_clone.mu == 2
+    assert m_clone.lam == 30
+    assert_allclose(m(45, 45), m_clone(45, 45))


### PR DESCRIPTION
This is one approach of fixing the pickling of projection models. It isn't working fully yet, as it fails for projections with parameters with errors such as:

```
E       _pickle.PicklingError: Can't pickle <function Pix2Sky_CylindricalPerspective.mu at 0x139d0b7e0>: it's not the same object as astropy.modeling.projections.Pix2Sky_CylindricalPerspective.mu
```

@nden @perrygreenfield @WilliamJamieson - any idea how to fix this?

Once working, should fix https://github.com/astropy/astropy/issues/14849