### PR TITLE
Add `BaseBodycentricRepresentation`

### DIFF
--- a/astropy/coordinates/representation/__init__.py
+++ b/astropy/coordinates/representation/__init__.py
@@ -8,6 +8,7 @@ from .cartesian import CartesianRepresentation, CartesianDifferential
 from .cylindrical import CylindricalRepresentation, CylindricalDifferential
 from .geodetic import (
     BaseGeodeticRepresentation,
+    BaseBodycentricRepresentation,
     WGS84GeodeticRepresentation,
     WGS72GeodeticRepresentation,
     GRS80GeodeticRepresentation,
@@ -56,6 +57,7 @@ __all__ = [
     "CylindricalDifferential",
     "PhysicsSphericalDifferential",
     "BaseGeodeticRepresentation",
+    "BaseBodycentricRepresentation",
     "WGS84GeodeticRepresentation",
     "WGS72GeodeticRepresentation",
     "GRS80GeodeticRepresentation",

--- a/astropy/coordinates/representation/geodetic.py
+++ b/astropy/coordinates/representation/geodetic.py
@@ -45,8 +45,9 @@ class BaseGeodeticRepresentation(BaseRepresentation):
     Subclasses need to set attributes ``_equatorial_radius`` and ``_flattening``
     to quantities holding correct values (with units of length and dimensionless,
     respectively), or alternatively an ``_ellipsoid`` attribute to the relevant ERFA
-    index (as passed in to `erfa.eform`).
-    Longitudes are east positive and span from 0 to 360 degrees by default.
+    index (as passed in to `erfa.eform`). The geodetic latitude is defined by the
+    angle between the vertical to the surface at a specific point of the spheroid and
+    its projection onto the equatorial plane.
     """
 
     attr_classes = {"lon": Longitude, "lat": Latitude, "height": u.Quantity}
@@ -100,12 +101,7 @@ class BaseGeodeticRepresentation(BaseRepresentation):
         lon, lat, height = erfa.gc2gde(
             cls._equatorial_radius, cls._flattening, cart.get_xyz(xyz_axis=-1)
         )
-        return cls(
-            lon,
-            lat,
-            height,
-            copy=False,
-        )
+        return cls(lon, lat, height, copy=False)
 
 
 @format_doc(geodetic_base_doc)
@@ -114,8 +110,8 @@ class BaseBodycentricRepresentation(BaseRepresentation):
 
     Subclasses need to set attributes ``_equatorial_radius`` and ``_flattening``
     to quantities holding correct values (with units of length and dimensionless,
-    respectively).
-    Longitudes are east positive and span from 0 to 360 degrees by default.
+    respectively). the bodicentric latitude and longitude are spherical latitude
+    and longitude relative to the barycenter of the body.
     """
 
     attr_classes = {"lon": Longitude, "lat": Latitude, "height": u.Quantity}
@@ -177,12 +173,7 @@ class BaseBodycentricRepresentation(BaseRepresentation):
         r_spheroid = np.hypot(p_spheroid, z_spheroid)
         height = d - r_spheroid
         lon = np.arctan2(cart.y, cart.x)
-        return cls(
-            lon,
-            lat,
-            height,
-            copy=False,
-        )
+        return cls(lon, lat, height, copy=False)
 
 
 @format_doc(geodetic_base_doc)

--- a/astropy/coordinates/representation/geodetic.py
+++ b/astropy/coordinates/representation/geodetic.py
@@ -110,7 +110,7 @@ class BaseBodycentricRepresentation(BaseRepresentation):
 
     Subclasses need to set attributes ``_equatorial_radius`` and ``_flattening``
     to quantities holding correct values (with units of length and dimensionless,
-    respectively). the bodicentric latitude and longitude are spherical latitude
+    respectively). the bodycentric latitude and longitude are spherical latitude
     and longitude relative to the barycenter of the body.
     """
 
@@ -145,12 +145,8 @@ class BaseBodycentricRepresentation(BaseRepresentation):
         sinlat = np.sin(self.lat)
         coslon = np.cos(self.lon)
         sinlon = np.sin(self.lon)
-        x_spheroid = self._equatorial_radius * coslat * coslon
-        y_spheroid = self._equatorial_radius * coslat * sinlon
-        z_spheroid = self._equatorial_radius * (1 - self._flattening) * sinlat
         r = (
-            self._equatorial_radius
-            * np.sqrt(coslat**2 + ((1 - self._flattening) * sinlat) ** 2)
+            self._equatorial_radius * np.hypot(coslat, (1 - self._flattening) * sinlat)
             + self.height
         )
         x = r * coslon * coslat
@@ -169,7 +165,7 @@ class BaseBodycentricRepresentation(BaseRepresentation):
         d = np.hypot(p, cart.z)
         lat = np.arctan2(cart.z, p)
         p_spheroid = cls._equatorial_radius * np.cos(lat)
-        z_spheroid = (cls._equatorial_radius * (1 - cls._flattening)) * np.sin(lat)
+        z_spheroid = cls._equatorial_radius * (1 - cls._flattening) * np.sin(lat)
         r_spheroid = np.hypot(p_spheroid, z_spheroid)
         height = d - r_spheroid
         lon = np.arctan2(cart.y, cart.x)

--- a/astropy/coordinates/tests/test_geodetic_representations.py
+++ b/astropy/coordinates/tests/test_geodetic_representations.py
@@ -169,10 +169,7 @@ def test_geodetic_to_geocentric():
 
 @pytest.mark.parametrize(
     "representation",
-    [
-        WGS84GeodeticRepresentation,
-        IAUMARS2000BodycentricRepresentation,
-    ],
+    [WGS84GeodeticRepresentation, IAUMARS2000BodycentricRepresentation],
 )
 def test_default_height_is_zero(representation):
     gd = representation(10 * u.deg, 20 * u.deg)
@@ -183,10 +180,7 @@ def test_default_height_is_zero(representation):
 
 @pytest.mark.parametrize(
     "representation",
-    [
-        WGS84GeodeticRepresentation,
-        IAUMARS2000BodycentricRepresentation,
-    ],
+    [WGS84GeodeticRepresentation, IAUMARS2000BodycentricRepresentation],
 )
 def test_non_angle_error(representation):
     with pytest.raises(u.UnitTypeError, match="require units equivalent to 'rad'"):
@@ -195,10 +189,7 @@ def test_non_angle_error(representation):
 
 @pytest.mark.parametrize(
     "representation",
-    [
-        WGS84GeodeticRepresentation,
-        IAUMARS2000BodycentricRepresentation,
-    ],
+    [WGS84GeodeticRepresentation, IAUMARS2000BodycentricRepresentation],
 )
 def test_non_length_error(representation):
     with pytest.raises(u.UnitTypeError, match="units of length"):
@@ -220,10 +211,7 @@ def test_subclass_bad_ellipsoid():
 
 @pytest.mark.parametrize(
     "baserepresentation",
-    [
-        BaseGeodeticRepresentation,
-        BaseBodycentricRepresentation,
-    ],
+    [BaseGeodeticRepresentation, BaseBodycentricRepresentation],
 )
 def test_geodetic_subclass_missing_equatorial_radius(baserepresentation):
     msg = "'_equatorial_radius' and '_flattening'."

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -1870,8 +1870,9 @@ class TestCartesianRepresentationWithDifferential:
                 # TODO: Converting a CartesianDifferential to a
                 #       RadialDifferential fails, even on `main`
                 continue
-            elif name.endswith("geodetic"):
-                # TODO: Geodetic representations do not have differentials yet
+            elif "geodetic" in name or "bodycentric" in name:
+                # TODO: spheroidal representations (geodetic or bodycentric)
+                # do not have differentials yet
                 continue
             new_rep = rep1.represent_as(
                 REPRESENTATION_CLASSES[name], DIFFERENTIAL_CLASSES[name]

--- a/docs/changes/coordinates/14851.feature.rst
+++ b/docs/changes/coordinates/14851.feature.rst
@@ -1,2 +1,2 @@
 Add ``BaseBodycentricRepresentation``, a new spheroidal representation for bodycentric
-latitudes and longitudes spanning from 0 to 360 degrees.
+latitudes and longitudes.

--- a/docs/changes/coordinates/14851.feature.rst
+++ b/docs/changes/coordinates/14851.feature.rst
@@ -1,0 +1,2 @@
+Add ``BaseBodycentricRepresentation``, a new spheroidal representation for bodycentric
+latitudes and longitudes spanning from 0 to 360 degrees.

--- a/docs/coordinates/representations.rst
+++ b/docs/coordinates/representations.rst
@@ -35,30 +35,35 @@ The built-in representation classes are:
 Astropy also offers a `~astropy.coordinates.BaseGeodeticRepresentation` and
 a `~astropy.coordinates.BaseBodycentricRepresentation` useful to
 create specific representations on spheroidal bodies.
-`~astropy.coordinates.BaseGeodeticRepresentation` is used internally for the standard
-Earth ellipsoids used in
-`~astropy.coordinates.EarthLocation`
-(`~astropy.coordinates.WGS84GeodeticRepresentation`,
-`~astropy.coordinates.WGS72GeodeticRepresentation`, and
-`~astropy.coordinates.GRS80GeodeticRepresentation`), but
-can also be customized; see :ref:`astropy-coordinates-create-geodetic`.
-All these are coordinates on a surface of a spheroid (an ellipsoid with equal
+
+`~astropy.coordinates.BaseGeodeticRepresentation` is the coordinate representation on
+a surface of a spheroid (an ellipsoid with equal
 equatorial radii), represented by a longitude (``lon``) a geodetic latitude (``lat``)
 and a height (``height``) above the surface.
 The geodetic latitude is defined by the angle
 between the vertical to the surface at a specific point of the spheroid and its
 projection onto the equatorial plane.
 The latitude is a value ranging from -90 to 90 degrees, the longitude from 0 to 360
-degrees, the height is the elevation above the surface of the spheroid (measured on the
+degrees, the height is the elevation above the surface of the spheroid (measured
 perpendicular to the surface).
 
 `~astropy.coordinates.BaseBodycentricRepresentation` is the coordinate representation
 recommended by the Cartographic Coordinates & Rotational Elements Working Group
 (see for example its `2019 report <https://rdcu.be/b32WL>`_): the bodycentric latitude
 and longitude are spherical latitude and longitude relative to the barycenter of the
-body, the height is the distance from the spheroid surface on the line of sight.
+body, the height is the distance from the spheroid surface (measured radially).
 The latitude is a value ranging from -90 to 90 degrees, the longitude from 0 to 360
 degrees.
+
+`~astropy.coordinates.BaseGeodeticRepresentation` is used internally for the standard
+Earth ellipsoids used in
+`~astropy.coordinates.EarthLocation`
+(`~astropy.coordinates.WGS84GeodeticRepresentation`,
+`~astropy.coordinates.WGS72GeodeticRepresentation`, and
+`~astropy.coordinates.GRS80GeodeticRepresentation`).
+`~astropy.coordinates.BaseGeodeticRepresentation` and
+`~astropy.coordinates.BaseBodycentricRepresentation`
+can be customized as described in :ref:`astropy-coordinates-create-geodetic`.
 
 .. Note::
    For information about using and changing the representation of
@@ -717,8 +722,8 @@ In pseudo-code, this means that a class will look like::
 
 .. _astropy-coordinates-create-geodetic:
 
-Creating Your Own Geodetic and Bodycentric Representation
----------------------------------------------------------
+Creating Your Own Geodetic and Bodycentric Representations
+----------------------------------------------------------
 
 If you would like to use geodetic coordinates on planetary bodies other than the Earth,
 you can define a new class that inherits from

--- a/docs/coordinates/representations.rst
+++ b/docs/coordinates/representations.rst
@@ -32,9 +32,11 @@ The built-in representation classes are:
   (``rho``), azimuthal angle (``phi``), and height (``z``).
 
 
-Astropy also offers a `~astropy.coordinates.BaseGeodeticRepresentation` useful to
+Astropy also offers a `~astropy.coordinates.BaseGeodeticRepresentation` and
+a `~astropy.coordinates.BaseBodycentricRepresentation` useful to
 create specific representations on spheroidal bodies.
-This is used internally for the standard Earth ellipsoids used in
+`~astropy.coordinates.BaseGeodeticRepresentation` is used internally for the standard
+Earth ellipsoids used in
 `~astropy.coordinates.EarthLocation`
 (`~astropy.coordinates.WGS84GeodeticRepresentation`,
 `~astropy.coordinates.WGS72GeodeticRepresentation`, and
@@ -46,6 +48,13 @@ and a height (``height``) above the surface.
 The geodetical latitude is defined by the angle
 between the vertical to the surface at a specific point of the spheroid and its
 projection onto the equatorial plane.
+The latitude is a value ranging from -90 to 90 degrees, the longitude from 0 to 360
+degrees.
+`~astropy.coordinates.BaseBodycentricRepresentation` is the coordinate representation
+recommended by the Cartographic Coordinates & Rotational Elements Working Group
+(see for example its `2019 report <https://rdcu.be/b32WL>`_): the bodicentric latitude
+and longitude are spherical latitude and longitude originated at the barycenter of the
+body, the height is the distance from the spheroid surface on the line of sight.
 The latitude is a value ranging from -90 to 90 degrees, the longitude from 0 to 360
 degrees.
 
@@ -706,11 +715,13 @@ In pseudo-code, this means that a class will look like::
 
 .. _astropy-coordinates-create-geodetic:
 
-Creating Your Own Geodetic Representation
------------------------------------------
+Creating Your Own Geodetic and Bodycentric Representation
+---------------------------------------------------------
 
 If you would like to use geodetic coordinates on planetary bodies other than the Earth,
-you can define a new class that inherits from  `~astropy.coordinates.BaseGeodeticRepresentation`.
+you can define a new class that inherits from
+`~astropy.coordinates.BaseGeodeticRepresentation` or
+`~astropy.coordinates.BaseBodycentricRepresentation`.
 The equatorial radius and flattening must be both assigned via the attributes
 `_equatorial_radius` and `_flattening`.
 
@@ -721,3 +732,11 @@ For example the spheroid describing Mars as in the
 
         _equatorial_radius = 3393400.0 * u.m
         _flattening = 0.518650 * u.percent
+
+The bodycentric coordinate system representing Mars as in the
+`2000 IAU standard <https://doi.org/10.1023/A:1013939327465>`_ could be defined as::
+
+    class IAUMARS2000BodycentricRepresentation(BaseBodycentricRepresentation):
+
+        _equatorial_radius = 3396190.0 * u.m
+        _flattening = 0.5886008 * u.percent

--- a/docs/coordinates/representations.rst
+++ b/docs/coordinates/representations.rst
@@ -43,17 +43,19 @@ Earth ellipsoids used in
 `~astropy.coordinates.GRS80GeodeticRepresentation`), but
 can also be customized; see :ref:`astropy-coordinates-create-geodetic`.
 All these are coordinates on a surface of a spheroid (an ellipsoid with equal
-equatorial radii), represented by a longitude (``lon``) a geodetical latitude (``lat``)
+equatorial radii), represented by a longitude (``lon``) a geodetic latitude (``lat``)
 and a height (``height``) above the surface.
-The geodetical latitude is defined by the angle
+The geodetic latitude is defined by the angle
 between the vertical to the surface at a specific point of the spheroid and its
 projection onto the equatorial plane.
 The latitude is a value ranging from -90 to 90 degrees, the longitude from 0 to 360
-degrees.
+degrees, the height is the elevation above the surface of the spheroid (measured on the
+perpendicular to the surface).
+
 `~astropy.coordinates.BaseBodycentricRepresentation` is the coordinate representation
 recommended by the Cartographic Coordinates & Rotational Elements Working Group
-(see for example its `2019 report <https://rdcu.be/b32WL>`_): the bodicentric latitude
-and longitude are spherical latitude and longitude originated at the barycenter of the
+(see for example its `2019 report <https://rdcu.be/b32WL>`_): the bodycentric latitude
+and longitude are spherical latitude and longitude relative to the barycenter of the
 body, the height is the distance from the spheroid surface on the line of sight.
 The latitude is a value ranging from -90 to 90 degrees, the longitude from 0 to 360
 degrees.

--- a/docs/whatsnew/6.0.rst
+++ b/docs/whatsnew/6.0.rst
@@ -25,15 +25,17 @@ By the numbers:
 
 .. _whatsnew-6.0-geodetic-representation-geometry:
 
-Define Geodetic Representations via their geometric parameters
-==============================================================
+Define Geodetic and Bodycentric Representations via their geometric parameters
+==============================================================================
 
 The user may now define custom spheroidal models for the Earth or other planetary
-bodies by subclassing `~astropy.coordinates.BaseGeodeticRepresentation` and defining
+bodies by subclassing `~astropy.coordinates.BaseGeodeticRepresentation` or
+`~astropy.coordinates.BaseBodycentricRepresentation` and defining
 ``_equatorial_radius`` and ``_flattening`` attributes::
 
 
-    >>> from astropy.coordinates import BaseGeodeticRepresentation, WGS84GeodeticRepresentation
+    >>> from astropy.coordinates import (BaseGeodeticRepresentation,
+    ...     WGS84GeodeticRepresentation, BaseBodycentricRepresentation)
     >>> from astropy import units as u
     >>> class IAU1976EarthGeodeticRepresentation(BaseGeodeticRepresentation):
     ...     _equatorial_radius = 6378140 * u.m
@@ -46,6 +48,12 @@ bodies by subclassing `~astropy.coordinates.BaseGeodeticRepresentation` and defi
     >>> representation.represent_as(WGS84GeodeticRepresentation) # doctest: +FLOAT_CMP
     <WGS84GeodeticRepresentation (lon, lat, height) in (rad, rad, m)
         (0.79999959, 0.98000063, 370.01796023)>
+    >>> class IAU1976EarthBodycentricRepresentation(BaseBodycentricRepresentation):
+    ...     _equatorial_radius = 6378140 * u.m
+    ...     _flattening = 0.3352805 * u.percent
+    >>> representation.represent_as(IAU1976EarthBodycentricRepresentation) # doctest: +FLOAT_CMP
+    <IAU1976EarthBodycentricRepresentation (lon, lat, height) in (rad, rad, m)
+        (0.79999959, 0.9768896, 336.12620429)>
 
 See :ref:`astropy-coordinates-create-geodetic` for more details.
 


### PR DESCRIPTION
### Description
This pull request adds the possibility to create geodetic representations described by [planetocentric latitudes]
~~(https://en.wikipedia.org/wiki/Latitude#Geodetic_and_geocentric_latitudes), west positive longitudes, longitudes spanning from 0 to 360 degrees.~~
The default behavior is backward compatible.
Suggested in https://github.com/astropy/astropy/issues/11170#issuecomment-1543528585.

Towards #11170.

This work is funded by the Europlanet 2024 Research Infrastructure (RI) Grant.
