### PR TITLE
Ensure np.linalg overrides continue to work with numpy >= 1.25

### DIFF
--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -716,7 +716,10 @@ class Quantity(np.ndarray):
         if isinstance(result, (tuple, list)):
             if out is None:
                 out = (None,) * len(result)
-            return result.__class__(
+            # Some np.linalg functions return namedtuple, which is handy to access
+            # elements by name, but cannot be directly initialized with an iterator.
+            result_cls = getattr(result, "_make", result.__class__)
+            return result_cls(
                 self._result_as_quantity(result_, unit_, out_)
                 for (result_, unit_, out_) in zip(result, unit, out)
             )


### PR DESCRIPTION
In numpy >=1.25, some functions return namedtuple, which is nice but sadly needs special treatment.

Fixes #14846 (together with #14859)

(Not sure about backporting - did 5.3 only, but perhaps should do 5.0? Then again, #14589 was only backported to 5.3)