### PR TITLE
Use chained exceptions instead of combining them

### DIFF
--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -1090,8 +1090,8 @@ class BaseOutputter:
         except (ValueError, TypeError) as err:
             raise ValueError(
                 "Error: invalid format for converters, see "
-                f"documentation\n{converters}: {err}"
-            )
+                f"documentation\n{converters}"
+            ) from err 
         return converters_out
 
     def _convert_vals(self, cols):

--- a/astropy/io/ascii/ecsv.py
+++ b/astropy/io/ascii/ecsv.py
@@ -370,7 +370,7 @@ class EcsvOutputter(core.TableOutputter):
                     "column value is not valid JSON"
                 )
             except Exception as exc:
-                raise ValueError(f"column {col.name!r} failed to convert.") from exc
+                raise ValueError(f"column {col.name!r} failed to convert: {exc}") from exc 
 
 
 class EcsvData(basic.BasicData):

--- a/astropy/io/ascii/ecsv.py
+++ b/astropy/io/ascii/ecsv.py
@@ -370,7 +370,7 @@ class EcsvOutputter(core.TableOutputter):
                     "column value is not valid JSON"
                 )
             except Exception as exc:
-                raise ValueError(f"column {col.name!r} failed to convert: {exc}")
+                raise ValueError(f"column {col.name!r} failed to convert.") from exc
 
 
 class EcsvData(basic.BasicData):
@@ -436,7 +436,7 @@ class EcsvData(basic.BasicData):
                 col.str_vals = [format_col_item(idx) for idx in range(len(col))]
             except TypeError as exc:
                 raise TypeError(
-                    f"could not convert column {col.info.name!r} to string: {exc}"
+                    f"could not convert column {col.info.name!r} to string."
                 ) from exc
 
             # Replace every masked value in a 1-d column with an empty string.

--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -880,7 +880,7 @@ class FITS_rec(np.recarray):
             raise ValueError(
                 "{}; the header may be missing the necessary TNULL{} "
                 "keyword or the table contains invalid data".format(indx + 1)
-            )from exc
+            ) from exc
 
         return dummy
 

--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -879,8 +879,8 @@ class FITS_rec(np.recarray):
             indx = self.names.index(column.name)
             raise ValueError(
                 "{}; the header may be missing the necessary TNULL{} "
-                "keyword or the table contains invalid data".format(exc, indx + 1)
-            )
+                "keyword or the table contains invalid data".format(indx + 1)
+            )from exc
 
         return dummy
 

--- a/astropy/io/fits/util.py
+++ b/astropy/io/fits/util.py
@@ -827,7 +827,7 @@ def _free_space_check(hdulist, dirname=None):
         for hdu in hdulist:
             hdu._close()
 
-        raise OSError(error_message + str(exc))
+        raise OSError(error_message) from exc
 
 
 def _extract_number(value, default):


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

I chose some instances to make the change. After running the grep -r 'except .*Error as' astropy/io/ and grep -r 'except Exception as' astropy/io , I discovered these specific instances that need to be modified.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

