### PR TITLE
Cosmo param dataclass

### DIFF
--- a/astropy/cosmology/parameter/_core.py
+++ b/astropy/cosmology/parameter/_core.py
@@ -144,17 +144,16 @@ class Parameter:
         self._fvalidate_in: FValidateCallable | str
         self._fvalidate: FValidateCallable
         object.__setattr__(self, "__doc__", self.doc)
-        # attribute name on container cosmology class.
-        # really set in __set_name__, but if Parameter is not init'ed as a
-        # descriptor this ensures that the attributes exist.
-        object.__setattr__(self, "name", None)
-        object.__setattr__(self, "_attr_name", None)
+        # Now setting a dummy attribute name. The cosmology class will call
+        # `__set_name__`, passing the real attribute name. However, if Parameter is not
+        # init'ed as a descriptor then this ensures that all declared fields exist.
+        self.__set_name__(None, None)
 
-    def __set_name__(self, cosmo_cls: type, name: str) -> None:
+    def __set_name__(self, cosmo_cls: type, name: str | None) -> None:
         # attribute name on container cosmology class
         self._attr_name: str
         object.__setattr__(self, "name", name)
-        object.__setattr__(self, "_attr_name", "_" + name)
+        object.__setattr__(self, "_attr_name", "_" + (name or ""))
 
     # -------------------------------------------
     # descriptor and property-like methods
@@ -263,8 +262,7 @@ class Parameter:
         cloned = replace(self, **kw)
         # Transfer over the __set_name__ stuff. If `clone` is used to make a
         # new descriptor, __set_name__ will be called again, overwriting this.
-        object.__setattr__(cloned, "name", self.name)
-        object.__setattr__(cloned, "_attr_name", self._attr_name)
+        cloned.__set_name__(None, self.name)
 
         return cloned
 

--- a/astropy/cosmology/tests/test_parameter.py
+++ b/astropy/cosmology/tests/test_parameter.py
@@ -7,6 +7,7 @@
 
 # STDLIB
 import inspect
+from typing import Callable
 
 # THIRD PARTY
 import numpy as np
@@ -97,8 +98,8 @@ class ParameterTestMixin:
 
         # Parameter
         assert hasattr(all_parameter, "_unit")
-        assert hasattr(all_parameter, "_equivalencies")
-        assert hasattr(all_parameter, "_derived")
+        assert hasattr(all_parameter, "equivalencies")
+        assert hasattr(all_parameter, "derived")
 
         # __set_name__
         assert hasattr(all_parameter, "_attr_name")
@@ -108,6 +109,8 @@ class ParameterTestMixin:
         """Test :attr:`astropy.cosmology.Parameter.fvalidate`."""
         assert hasattr(all_parameter, "fvalidate")
         assert callable(all_parameter.fvalidate)
+        assert hasattr(all_parameter, "_fvalidate_in")
+        assert isinstance(all_parameter._fvalidate_in, (str, Callable))
 
     def test_Parameter_name(self, all_parameter):
         """Test :attr:`astropy.cosmology.Parameter.name`."""
@@ -125,19 +128,16 @@ class ParameterTestMixin:
         """Test :attr:`astropy.cosmology.Parameter.equivalencies`."""
         assert hasattr(all_parameter, "equivalencies")
         assert isinstance(all_parameter.equivalencies, (list, u.Equivalency))
-        assert all_parameter.equivalencies is all_parameter._equivalencies
 
     def test_Parameter_derived(self, cosmo_cls, all_parameter):
         """Test :attr:`astropy.cosmology.Parameter.derived`."""
         assert hasattr(all_parameter, "derived")
         assert isinstance(all_parameter.derived, bool)
-        assert all_parameter.derived is all_parameter._derived
 
         # test value
-        if all_parameter.name in cosmo_cls.__parameters__:
-            assert all_parameter.derived is False
-        else:
-            assert all_parameter.derived is True
+        assert all_parameter.derived is (
+            all_parameter.name not in cosmo_cls.__parameters__
+        )
 
     # -------------------------------------------
     # descriptor methods
@@ -305,8 +305,8 @@ class TestParameter(ParameterTestMixin):
 
         # custom from init
         assert param._unit == u.m
-        assert param._equivalencies == u.mass_energy()
-        assert param._derived == np.False_
+        assert param.equivalencies == u.mass_energy()
+        assert param.derived == np.False_
 
         # custom from set_name
         assert param._attr_name == "param"

--- a/astropy/cosmology/tests/test_parameter.py
+++ b/astropy/cosmology/tests/test_parameter.py
@@ -102,8 +102,8 @@ class ParameterTestMixin:
         assert hasattr(all_parameter, "derived")
 
         # __set_name__
+        assert hasattr(all_parameter, "name")
         assert hasattr(all_parameter, "_attr_name")
-        assert hasattr(all_parameter, "_attr_name_private")
 
     def test_Parameter_fvalidate(self, all_parameter):
         """Test :attr:`astropy.cosmology.Parameter.fvalidate`."""
@@ -116,7 +116,7 @@ class ParameterTestMixin:
         """Test :attr:`astropy.cosmology.Parameter.name`."""
         assert hasattr(all_parameter, "name")
         assert isinstance(all_parameter.name, str)
-        assert all_parameter.name is all_parameter._attr_name
+        assert all_parameter._attr_name == f"_{all_parameter.name}"
 
     def test_Parameter_unit(self, all_parameter):
         """Test :attr:`astropy.cosmology.Parameter.unit`."""
@@ -151,16 +151,16 @@ class ParameterTestMixin:
 
         # from instance
         parameter = getattr(cosmo, all_parameter.name)
-        assert np.all(parameter == getattr(cosmo, all_parameter._attr_name_private))
+        assert np.all(parameter == getattr(cosmo, all_parameter._attr_name))
 
     def test_Parameter_descriptor_set(self, cosmo, all_parameter):
         """Test :attr:`astropy.cosmology.Parameter.__set__`."""
         # test it's already set
-        assert hasattr(cosmo, all_parameter._attr_name_private)
+        assert hasattr(cosmo, all_parameter._attr_name)
 
         # and raises an error if set again
         with pytest.raises(AttributeError, match="can't set attribute"):
-            setattr(cosmo, all_parameter._attr_name, None)
+            setattr(cosmo, all_parameter.name, None)
 
     # -------------------------------------------
     # validate value
@@ -309,8 +309,8 @@ class TestParameter(ParameterTestMixin):
         assert param.derived == np.False_
 
         # custom from set_name
-        assert param._attr_name == "param"
-        assert param._attr_name_private == "_param"
+        assert param.name == "param"
+        assert param._attr_name == "_param"
 
     def test_Parameter_fvalidate(self, cosmo, param):
         """Test :attr:`astropy.cosmology.Parameter.fvalidate`."""

--- a/astropy/utils/compat/misc.py
+++ b/astropy/utils/compat/misc.py
@@ -11,9 +11,10 @@ import sys
 
 from astropy.utils.decorators import deprecated
 
-__all__ = ["override__dir__", "PYTHON_LT_3_11"]
+__all__ = ["override__dir__", "PYTHON_LT_3_10", "PYTHON_LT_3_11"]
 
 PYTHON_LT_3_11 = sys.version_info < (3, 11)
+PYTHON_LT_3_10 = sys.version_info < (3, 10)
 
 
 @deprecated(

--- a/docs/changes/cosmology/14874.api.rst
+++ b/docs/changes/cosmology/14874.api.rst
@@ -1,0 +1,2 @@
+Cosmology ``Parameter`` is now a ``dataclass``, and can work with all of Python's dataclasses
+machinery, like field introspection and type conversion.

--- a/docs/whatsnew/6.0.rst
+++ b/docs/whatsnew/6.0.rst
@@ -107,6 +107,36 @@ format::
     -------- ------------ ------- ------- ------- ----------- -------
     Planck18        67.66 0.30966  2.7255   3.046 0.0 .. 0.06 0.04897
 
+
+:class:`~astropy.cosmology.Parameter` as a :func:`~dataclasses.dataclass`
+-------------------------------------------------------------------------
+
+The :class:`~astropy.cosmology.Parameter` class is now a :func:`~dataclasses.dataclass`.
+This means that the :mod:`dataclasses` machinery can be used to work with
+:class:`~astropy.cosmology.Parameter` objects. For example::
+
+    >>> from dataclasses import replace
+    >>> from astropy.cosmology import FlatLambdaCDM
+    >>> H0 = FlatLambdaCDM.H0
+    >>> H0
+    Parameter(derived=False, unit=Unit("km / (Mpc s)"), equivalencies=[], ...)
+    >>> replace(H0, derived=True)
+    Parameter(derived=True, unit=Unit("km / (Mpc s)"), equivalencies=[], ...)
+
+    >>> from dataclasses import asdict
+    >>> asdict(H0)
+    {'derived': False, 'unit': Unit("km / (Mpc s)"), 'equivalencies': [], ...
+
+
+It's also much easier to create new :class:`~astropy.cosmology.Parameter` subclasses
+
+    >>> from dataclasses import make_dataclass, field, fields
+    >>> from astropy.cosmology import Parameter
+    >>> NewP = make_dataclass("NewP", [("newfield", float, field(default=None))], bases=(Parameter,), frozen=True)
+    >>> tuple(f.name for f in fields(NewP))
+    (..., 'newfield')
+
+
 .. _whatsnew-6.0-iers-data:
 
 Updates to how IERS data are handled
@@ -128,6 +158,7 @@ IERS data can now install the latest version of the
 `astropy-iers-data`_ package using ``pip`` or ``conda``, or alternatively
 download the package manually and transfer it to a computer that has no
 public internet connection.
+
 
 Full change log
 ===============


### PR DESCRIPTION
### Description

Cosmology Parameters are now [dataclass](https://docs.python.org/3.10/library/dataclasses.html).
Why? b/c dataclasses are nice:

- clean, modern code & syntax
- convenient how it writes the dunder methods
- more introspectable, using tools from the `dataclasses` module.
- work with ``dataclasses``'s functions
- easy to build subclasses.

In this PR:

- Add a compatibility flag for python 3.10
- Refactored Parameter to be a dataclass
    - Due to the nature of dataclases, the private attribute `_registry_validators` had to be factored off of the class.
    - Got to remove the `_init_arguments` because dataclasses have `replace`!
    - ~Changed `fvalidate` from the processed value to the original one. This is a breaking change.~

Future note: in py3.13+ https://peps.python.org/pep-0712/ will allow the ``UnitField`` class to be replaced with the ``converter`` argument to ``field()``. In the meantime, it's a private dataclass field descriptor.
