### PR TITLE
Implement `astropy.table.Row.get()`

### DIFF
--- a/astropy/table/row.py
+++ b/astropy/table/row.py
@@ -106,6 +106,35 @@ class Row:
         for col in self._table.columns.values():
             yield col[index]
 
+    def get(self, key, default=None, /):
+        """Return the value for key if key is in the columns, else default.
+
+        Parameters
+        ----------
+        key : `str`, positional-only
+            The name of the column to look for.
+        default : `object`, optional, positional-only
+            The value to return if the ``key`` is not among the columns.
+
+        Returns
+        -------
+        `object`
+            The value in the ``key`` column of the row if present,
+            ``default`` otherwise.
+
+        Examples
+        --------
+        >>> from astropy.table import Table
+        >>> t = Table({"a": [2, 3, 5], "b": [7, 11, 13]})
+        >>> t[0].get("a")
+        2
+        >>> t[1].get("b", 0)
+        11
+        >>> t[2].get("c", 0)
+        0
+        """
+        return self[key] if key in self._table.columns else default
+
     def keys(self):
         return self._table.columns.keys()
 

--- a/astropy/table/tests/test_row.py
+++ b/astropy/table/tests/test_row.py
@@ -372,3 +372,11 @@ def test_uint_indexing():
     assert repr(t[1]).splitlines() == trepr
     assert repr(t[np.int_(1)]).splitlines() == trepr
     assert repr(t[np.uint(1)]).splitlines() == trepr
+
+
+def test_row_get():
+    row = table.Table({"a": [2, 4], "b": [3, 9]})[0]
+    assert row.get("a") == 2
+    assert row.get("x") is None
+    assert row.get("b", -1) == 3
+    assert row.get("y", -1) == -1

--- a/docs/changes/table/14878.feature.rst
+++ b/docs/changes/table/14878.feature.rst
@@ -1,0 +1,3 @@
+The new ``Row.get()`` method, analogous to ``dict.get()``, returns the value of
+the specified column from the row if the column present, otherwise it returns a
+fallback value, which by default is ``None``.

--- a/docs/table/access_table.rst
+++ b/docs/table/access_table.rst
@@ -334,6 +334,16 @@ columns can be provided using the :meth:`dict.get` method::
     >>> t.columns.get("x", np.zeros(len(t)))
     array([0., 0., 0., 0., 0.])
 
+In case of a single |Row| it is possible to use its
+:meth:`~astropy.table.Row.get` method without having to go through
+``columns``::
+
+    >>> row = t[2]
+    >>> row.get("c", -1)
+    8
+    >>> row.get("y", -1)
+    -1
+
 
 Table Equality
 --------------

--- a/docs/table/access_table.rst
+++ b/docs/table/access_table.rst
@@ -315,6 +315,26 @@ structured array by creating a copy or reference with :func:`numpy.array`::
   >>> data = np.array(t, copy=False)  # reference to data in t
 
 
+Possibly missing columns
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+In some cases it might not be guaranteed that a column is present in a table,
+but there does exist a good default value that can be used if it is not. The
+columns of a |Table| can be represented as a :class:`dict` subclass instance
+through the ``columns`` attribute, which means that a replacement for missing
+columns can be provided using the :meth:`dict.get` method::
+
+    >>> t.columns.get("b", np.zeros(len(t)))
+    <Column name='b' dtype='int32' length=5>
+     1
+     4
+     7
+    10
+    13
+    >>> t.columns.get("x", np.zeros(len(t)))
+    array([0., 0., 0., 0., 0.])
+
+
 Table Equality
 --------------
 


### PR DESCRIPTION
### Description

Currently code that tries to access a column in a `Row` when the presence of the column is not guaranteed either has to check for the presence of the column beforehand or handle the resulting `KeyError` explicitly. In many cases (see e.g. https://github.com/astropy/astropy/pull/14780#discussion_r1200857265) it might be appealing to use `Row.columns.get()` instead, which allows specifying a fallback value to be used if the column is not present, but (surprisingly) `Row.columns` actually returns the `columns` from the parent table of the `Row`: https://github.com/astropy/astropy/blob/88790514bdf248e43c2fb15ee18cfd3390846145/astropy/table/row.py#L152-L154

Changing the behavior of `Row.columns` would be a backwards-incompatible change, so it is safer to implement a new `Row.get()` method.

~~When implementing the unit tests for the new feature I thought that it would be better if the test table would be a module level fixture so that it would not be recreated for every instance of the parametrized tests, and then I found it useful to share the test table with an already existing test so that it could be reused even more. Because of this I also refactored and parametrized an already existing unit test for `Row`.~~