### PR TITLE
Fix vounits incorrectly marked as deprecated

### DIFF
--- a/astropy/units/format/vounit.py
+++ b/astropy/units/format/vounit.py
@@ -33,14 +33,14 @@ class VOUnit(generic.Generic):
 
         names = {}
         deprecated_names = set()
+        # The tropical year is missing here compared to the standard
         bases = [
-            "A", "C", "D", "F", "G", "H", "Hz", "J", "Jy", "K", "N",
-            "Ohm", "Pa", "R", "Ry", "S", "T", "V", "W", "Wb", "a",
-            "adu", "arcmin", "arcsec", "barn", "beam", "bin", "cd",
-            "chan", "count", "ct", "d", "deg", "eV", "erg", "g", "h",
-            "lm", "lx", "lyr", "m", "mag", "min", "mol", "pc", "ph",
-            "photon", "pix", "pixel", "rad", "rad", "s", "solLum",
-            "solMass", "solRad", "sr", "u", "voxel", "yr",
+            "A", "a", "adu", "arcmin", "arcsec", "barn", "beam", "bin",
+            "C", "cd", "chan", "count", "ct", "d", "D", "deg", "erg", "eV",
+            "F", "g", "G", "H", "h", "Hz", "J", "Jy", "K", "lm", "lx", "lyr",
+            "m", "mag", "min", "mol", "N", "Ohm", "Pa", "pc", "ph", "photon",
+            "pix", "pixel", "R", "rad", "Ry", "s", "S", "solLum", "solMass",
+            "solRad", "sr", "T", "u", "V", "voxel", "W", "Wb", "yr",
         ]  # fmt: skip
         binary_bases = ["bit", "byte", "B"]
         simple_units = ["Angstrom", "angstrom", "AU", "au", "Ba", "dB", "mas"]
@@ -48,10 +48,11 @@ class VOUnit(generic.Generic):
             "y", "z", "a", "f", "p", "n", "u", "m", "c", "d",
             "", "da", "h", "k", "M", "G", "T", "P", "E", "Z", "Y"
         ]  # fmt: skip
+        # While zebi and yobi are part of the standard for binary prefixes,
+        # they are not implemented here due to computation limitations
         binary_prefixes = ["Ki", "Mi", "Gi", "Ti", "Pi", "Ei"]
         deprecated_units = {
-            "a", "angstrom", "Angstrom", "au", "Ba", "barn", "ct",
-            "erg", "G", "ph", "pix",
+            "angstrom", "Angstrom", "Ba", "barn", "erg", "G", "ta",
         }  # fmt: skip
 
         def do_defines(bases, prefixes, skips=[]):

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -457,7 +457,7 @@ def test_latex_inline_scale():
 def test_format_styles(format_spec, string, decomposed):
     fluxunit = u.erg / (u.cm**2 * u.s * u.Angstrom)
     if format_spec == "vounit":
-        # erg is deprecated in vounit.
+        # erg and Angstrom are deprecated in vounit.
         with pytest.warns(UnitsWarning, match="deprecated"):
             formatted = format(fluxunit, format_spec)
     else:
@@ -677,9 +677,7 @@ def test_vounit_unknown():
 
 
 def test_vounit_details():
-    with pytest.warns(UnitsWarning, match="deprecated") as w:
-        assert u.Unit("Pa", format="vounit") is u.Pascal
-    assert len(w) == 1
+    assert u.Unit("Pa", format="vounit") is u.Pascal
 
     # The da- prefix is not allowed, and the d- prefix is discouraged
     assert u.dam.to_string("vounit") == "10m"

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -662,9 +662,9 @@ def test_vounit_function(string):
 
 
 def test_vounit_binary_prefix():
-    u.Unit("KiB", format="vounit") == u.Unit("1024 B")
-    u.Unit("Kibyte", format="vounit") == u.Unit("1024 B")
-    u.Unit("Kibit", format="vounit") == u.Unit("1024 B")
+    assert u.Unit("KiB", format="vounit") == u.Unit("1024 B")
+    assert u.Unit("Kibyte", format="vounit") == u.Unit("1024 B")
+    assert u.Unit("Kibit", format="vounit") == u.Unit("128 B")
     with pytest.warns(UnitsWarning) as w:
         u.Unit("kibibyte", format="vounit")
     assert len(w) == 1
@@ -678,6 +678,8 @@ def test_vounit_unknown():
 
 def test_vounit_details():
     assert u.Unit("Pa", format="vounit") is u.Pascal
+    assert u.Unit("ka", format="vounit") == u.Unit("1000 yr")
+    assert u.Unit("pix", format="vounit") == u.Unit("pixel", format="vounit")
 
     # The da- prefix is not allowed, and the d- prefix is discouraged
     assert u.dam.to_string("vounit") == "10m"

--- a/docs/changes/units/14885.bugfix.rst
+++ b/docs/changes/units/14885.bugfix.rst
@@ -1,0 +1,1 @@
+In VOunits, "pix", "au", "a", and "ct" are removed from the list of deprecated units.


### PR DESCRIPTION
There was a tiny confusion in the vounit implementation between deprecation and preferred syntax. 

This PR removes the units "pix", "au", "a", "ct" from the list of deprecated units, as specified in the [standard cited in the docstring](https://www.ivoa.net/documents/VOUnits/20140523/VOUnits-REC-1.0-20140523.pdf) and this table extracted from the document: 

![image](https://github.com/astropy/astropy/assets/16650466/80e8d70b-e859-4d01-b155-7b507ae0dd72)
Where `d` is for `deprecated` but `p` is only for `prefered`.

Additionnaly, it fixes the tests in `test_vounit_binary_prefix` that were not calling assert and had a typo for `Kibit` and add tests in ` test_vounit_details`.

Tagging one of the authors of the standard for confirmation :wink:  @SebastienDerriere
