### PR TITLE
Backport of PR 14869 onto v5.3.x (TST: Upstream nightly wheels location has changed)

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -102,7 +102,6 @@ jobs:
         apt:
           - language-pack-de
           - tzdata
-          - libopenblas-dev  # To enable compiling scipy from source if a wheel doesn't exist
       envs: |
         - name: (Allowed Failure) Python 3.11 with remote data and dev version of key dependencies
           linux: py311-test-devdeps

--- a/docs/coordinates/index.rst
+++ b/docs/coordinates/index.rst
@@ -394,17 +394,8 @@ While ``astropy.coordinates`` does not natively support converting an Earth
 location to a timezone, the longitude and latitude can be retrieved from any
 `~astropy.coordinates.EarthLocation` object, which could then be passed to any
 third-party package that supports timezone solving, such as `timezonefinder
-<https://timezonefinder.readthedocs.io/>`_. For example, ``timezonefinder`` can
-be used to retrieve the timezone name for an address with:
-
-.. doctest-remote-data::
-
-    >>> loc = EarthLocation.of_address('Tucson, AZ')
-    >>> from timezonefinder import TimezoneFinder
-    >>> tz_name = TimezoneFinder().timezone_at(lng=loc.lon.degree,
-    ...                                        lat=loc.lat.degree)
-    >>> tz_name
-    'America/Phoenix'
+<https://timezonefinder.readthedocs.io/>`_, in which case you might have to
+pass in their ``.degree`` attributes.
 
 The resulting timezone name could then be used with any packages that support
 time zone definitions, such as the (Python 3.9 default package) `zoneinfo
@@ -414,7 +405,7 @@ time zone definitions, such as the (Python 3.9 default package) `zoneinfo
 
     >>> import datetime
     >>> from zoneinfo import ZoneInfo
-    >>> tz = ZoneInfo(tz_name)
+    >>> tz = ZoneInfo('America/Phoenix')
     >>> dt = datetime.datetime(2021, 4, 12, 20, 0, 0, tzinfo=tz)
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -70,7 +70,6 @@ test_all =  # Required for testing, plus packages used by particular tests.
     coverage[toml]
     skyfield>=1.20
     sgp4>=2.3
-    timezonefinder
 recommended =
     scipy>=1.5
     matplotlib>=3.3,!=3.4.0,!=3.5.2

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ setenv =
     !image: MPLFLAGS =
     clocale: LC_CTYPE = C.ascii
     clocale: LC_ALL = C
-    devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/scipy-wheels-nightly/simple
+    devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
     fitsio: ASTROPY_ALWAYS_TESTS_FITSIO = "true"
 
 # Run the tests in a temporary directory to make sure that we don't import
@@ -87,7 +87,7 @@ deps =
     # Do not install asdf-astropy so we can test astropy.io.misc.asdf until we remove it.
     devdeps: scipy>=0.0.dev0
     devdeps: numpy>=0.0.dev0
-    devdeps,mpldev: matplotlib>=0.0.dev0
+    devdeps: matplotlib>=0.0.dev0
     devdeps: git+https://github.com/asdf-format/asdf.git#egg=asdf
     devdeps: git+https://github.com/liberfa/pyerfa.git#egg=pyerfa
 
@@ -112,6 +112,8 @@ extras =
     alldeps: test_all
 
 commands =
+    mpldev: pip install -U --pre -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple matplotlib
+
     pip freeze
     !cov-!double: pytest --pyargs astropy {toxinidir}/docs {env:MPLFLAGS} {posargs}
     cov-!double: pytest --pyargs astropy {toxinidir}/docs {env:MPLFLAGS} --cov astropy --cov-config={toxinidir}/pyproject.toml {posargs}


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to backport #14869 onto v5.3.x
