### PR TITLE
Backport of PR 14869 onto v5.0.x (TST: Upstream nightly wheels location has changed)

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -109,7 +109,7 @@ jobs:
       if: startsWith(matrix.os, 'ubuntu')
       run: |
         sudo apt-get update
-        sudo apt-get install language-pack-fr tzdata libopenblas-dev
+        sudo apt-get install language-pack-fr tzdata
     - name: Install tox
       run: python -m pip install "tox<4"
     - name: Run tests

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ setenv =
     !image: MPLFLAGS =
     clocale: LC_CTYPE = C.ascii
     clocale: LC_ALL = C
-    devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/scipy-wheels-nightly/simple
+    devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
 
 # Run the tests in a temporary directory to make sure that we don't import
 # astropy from the source tree
@@ -90,7 +90,7 @@ deps =
     # The devdeps factor is intended to be used to install the latest developer version
     # or nightly wheel of key dependencies.
     devdeps: scipy>=0.0.dev0
-    devdeps,mpldev: matplotlib>=0.0.dev0
+    devdeps: matplotlib>=0.0.dev0
     devdeps: git+https://github.com/asdf-format/asdf.git#egg=asdf
     devdeps: git+https://github.com/liberfa/pyerfa.git#egg=pyerfa
 
@@ -104,6 +104,8 @@ extras =
     alldeps: test_all
 
 commands =
+    mpldev: pip install -U --pre -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple matplotlib
+
     pip freeze
     !cov-!double: pytest --pyargs astropy {toxinidir}/docs {env:MPLFLAGS} {posargs}
     cov-!double: pytest --pyargs astropy {toxinidir}/docs {env:MPLFLAGS} --cov astropy --cov-config={toxinidir}/setup.cfg {posargs}


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to backport #14869 onto v5.0.x