### PR TITLE
Pickle most models

### DIFF
--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -3497,10 +3497,11 @@ class Logarithmic1D(Fittable1DModel):
         new_tau = self.amplitude
         return Exponential1D(amplitude=new_amplitude, tau=new_tau)
 
-    @tau.validator
-    def tau(self, val):
+    def _tau_validator(self, val):
         if np.all(val == 0):
             raise ValueError("0 is not an allowed value for tau")
+
+    tau._validator = _tau_validator
 
     @property
     def input_units(self):
@@ -3549,11 +3550,12 @@ class Exponential1D(Fittable1DModel):
         new_tau = self.amplitude
         return Logarithmic1D(amplitude=new_amplitude, tau=new_tau)
 
-    @tau.validator
-    def tau(self, val):
+    def _tau_validator(self, val):
         """tau cannot be 0."""
         if np.all(val == 0):
             raise ValueError("0 is not an allowed value for tau")
+
+    tau._validator = _tau_validator
 
     @property
     def input_units(self):

--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -589,6 +589,11 @@ class Parameter:
         set on the parameter is invalid (typically an `InputParameterError`
         should be raised, though this is not currently a requirement).
 
+        Note: Using this method as a decorator will cause problems with
+        pickling the model. An alternative is to assign the actual validator
+        function to ``Parameter._validator`` (see examples in modeling).
+
+
         """
 
         def validator(func, self=self):

--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -593,7 +593,6 @@ class Parameter:
         pickling the model. An alternative is to assign the actual validator
         function to ``Parameter._validator`` (see examples in modeling).
 
-
         """
 
         def validator(func, self=self):

--- a/astropy/modeling/physical_models.py
+++ b/astropy/modeling/physical_models.py
@@ -346,11 +346,12 @@ class Drude1D(Fittable1DModel):
             return None
         return {self.outputs[0]: self.amplitude.unit}
 
-    @x_0.validator
-    def x_0(self, val):
+    def _x_0_validator(self, val):
         """Ensure `x_0` is not 0."""
         if np.any(val == 0):
             raise InputParameterError("0 is not an allowed value for x_0")
+
+    x_0._validator = _x_0_validator
 
     def bounding_box(self, factor=50):
         """Tuple defining the default ``bounding_box`` limits,

--- a/astropy/modeling/powerlaws.py
+++ b/astropy/modeling/powerlaws.py
@@ -253,15 +253,17 @@ class SmoothlyBrokenPowerLaw1D(Fittable1DModel):
     alpha_2 = Parameter(default=2, description="Power law index after break point")
     delta = Parameter(default=1, min=1.0e-3, description="Smoothness Parameter")
 
-    @amplitude.validator
-    def amplitude(self, value):
+    def _amplitude_validator(self, value):
         if np.any(value <= 0):
             raise InputParameterError("amplitude parameter must be > 0")
 
-    @delta.validator
-    def delta(self, value):
+    amplitude._validator = _amplitude_validator
+
+    def _delta_validator(self, value):
         if np.any(value < 0.001):
             raise InputParameterError("delta parameter must be >= 0.001")
+
+    delta._validator = _delta_validator
 
     @staticmethod
     def evaluate(x, amplitude, x_break, alpha_1, alpha_2, delta):

--- a/astropy/modeling/spline.py
+++ b/astropy/modeling/spline.py
@@ -215,6 +215,16 @@ class _Spline(FittableModel):
         self._t = None
         self._degree = degree
 
+    def __getstate__(self):
+        return {
+            "t": self._t,
+            "c": self._c,
+            "k": self._degree,
+        }
+
+    def __setstate__(self, state):
+        return self.__init__(knots=state["t"], coeffs=state["c"], degree=state["k"])
+
 
 class Spline1D(_Spline):
     """

--- a/astropy/modeling/tests/test_parameters.py
+++ b/astropy/modeling/tests/test_parameters.py
@@ -603,6 +603,10 @@ class TestParameters:
         param = Parameter(name="test", default=[1, 2, 3, 4])
         assert param._validator is None
 
+        valid = mk.MagicMock()
+        param.validator(valid)
+        assert param._validator == valid
+
         MESSAGE = r"This decorator method expects a callable.*"
         with pytest.raises(ValueError, match=MESSAGE):
             param.validator(mk.NonCallableMagicMock())

--- a/astropy/modeling/tests/test_parameters.py
+++ b/astropy/modeling/tests/test_parameters.py
@@ -603,10 +603,6 @@ class TestParameters:
         param = Parameter(name="test", default=[1, 2, 3, 4])
         assert param._validator is None
 
-        valid = mk.MagicMock()
-        param.validator(valid)
-        assert param._validator == valid
-
         MESSAGE = r"This decorator method expects a callable.*"
         with pytest.raises(ValueError, match=MESSAGE):
             param.validator(mk.NonCallableMagicMock())

--- a/astropy/modeling/tests/test_pickle.py
+++ b/astropy/modeling/tests/test_pickle.py
@@ -1,0 +1,197 @@
+"""Tests that models are picklable."""
+
+from pickle import dumps, loads
+from numpy.testing import assert_allclose
+import pytest
+
+from astropy import units as u
+from astropy.utils.compat.optional_deps import HAS_SCIPY
+
+from astropy.modeling import functional_models
+from astropy.modeling import mappings
+from astropy.modeling import math_functions
+from astropy.modeling import physical_models
+from astropy.modeling import polynomial
+from astropy.modeling import powerlaws
+from astropy.modeling import projections
+from astropy.modeling import rotations
+from astropy.modeling import spline
+from astropy.modeling import tabular
+
+from astropy.modeling.math_functions import ArctanhUfunc
+
+math_functions_all = math_functions.__all__[:]
+math_functions_all.remove('ArctanhUfunc')
+
+polynomial_all = polynomial.__all__[:]
+# remove base classes
+polynomial_all.remove('PolynomialModel')
+polynomial_all.remove('OrthoPolynomialBase')
+
+projections_all = projections.__all__[:]
+proj_to_remove = ['Projection', 'Pix2SkyProjection', 'Sky2PixProjection',
+                  'Zenithal', 'Conic', 'Cylindrical', 'PseudoCylindrical',
+                  'PseudoConic', 'QuadCube', 'HEALPix', 'AffineTransformation2D',
+                  'projcodes', 'Pix2Sky_ZenithalPerspective',]
+for p in proj_to_remove:
+    projections_all.remove(p)
+
+for code in projections.projcodes:
+    projections_all.remove(f'Pix2Sky_{code}')
+    projections_all.remove(f'Sky2Pix_{code}')
+
+
+# can parametrize on x,y as well
+x, y = .3, .4
+x_math, y_math = 1, -.5
+
+
+@pytest.mark.skipif(not HAS_SCIPY, reason="requires scipy")
+@pytest.mark.parametrize("model", functional_models.__all__[:])
+def test_pickle_functional(model):
+    m = getattr(functional_models, model)()
+    m1 = loads(dumps(m))
+    if m.n_inputs == 1:
+        assert_allclose(m(x) , m1(x))
+    else:
+        assert_allclose(m(x, y), m1(x, y))
+
+
+@pytest.mark.parametrize("model", math_functions_all)
+def test_pickle_math_functions(model):
+    m = getattr(math_functions, model)()
+    m1 = loads(dumps(m))
+    if m.n_inputs == 1:
+        assert_allclose(m(x_math) , m1(x_math))
+    else:
+        assert_allclose(m(x_math, y_math), m1(x_math, y_math))
+
+
+@pytest.mark.skipif(not HAS_SCIPY, reason="requires scipy")
+def test_pickle_other():
+    # Test models which don't fit in the other test functions.
+
+    x = .5
+    y = 1
+
+    model = mappings.Mapping((1, 0))
+    modelp = loads(dumps(model))
+    assert_allclose(model(x, y), modelp(x, y))
+
+    model = mappings.Identity(2)
+    modelp = loads(dumps(model))
+    assert_allclose(model(x, y), modelp(x, y))
+
+    model = mappings.UnitsMapping(((u.m, None),))
+    modelp = loads(dumps(model))
+    assert_allclose(model(x * u.km), modelp(x * u.km))
+
+    model = ArctanhUfunc()
+    modelp = loads(dumps(model))
+    assert_allclose(model(x), modelp(x))
+
+    model = rotations.Rotation2D(23)
+    modelp = loads(dumps(model))
+    assert_allclose(model(x, y), modelp(x, y))
+
+    model = tabular.Tabular1D(lookup_table=[1, 2, 3, 4])
+    modelp = loads(dumps(model))
+    assert_allclose(model(y), modelp(y))
+
+    model = tabular.Tabular2D(lookup_table=[[1, 2, 3, 4], [5, 6, 7, 8]])
+    modelp = loads(dumps(model))
+    assert_allclose(model(x, y), modelp(x, y))
+
+    model = spline.Spline1D()
+    modelp = loads(dumps(model))
+    assert_allclose(model(x), modelp(x))
+
+    model = projections.AffineTransformation2D(matrix=[[1, 1], [1, 1]], translation=[1, 1])
+    model.matrix.fixed = True
+    modelp = loads(dumps(model))
+    assert_allclose(model(x, y), modelp(x, y))
+    assert model.matrix.fixed is True
+
+
+@pytest.mark.parametrize("model", physical_models.__all__)
+def test_pickle_physical_models(model):
+    m = getattr(physical_models, model)()
+    m1 = loads(dumps(m))
+    if m.n_inputs == 1:
+        assert_allclose(m(x) , m1(x))
+    else:
+        assert_allclose(m(x, y), m1(x, y))
+
+
+def test_pickle_polynomial():
+    # models initialized with 1 degree
+    models2d = ['Chebyshev2D', 'Hermite2D', 'Legendre2D', 'InverseSIP']
+    # models initialized with 2 degree
+    models1d = ['Chebyshev1D', 'Hermite1D', 'Legendre1D', 'Polynomial1D']
+
+    sip = ['SIP', 'InverseSIP']
+
+    for model in models1d:
+        m = getattr(polynomial, model)
+        m = m(2)
+        m1 = loads(dumps(m))
+        assert_allclose(m(x) , m1(x))
+
+    for model in models2d:
+        m = getattr(polynomial, model)
+        m = m(2, 3)
+        m1 = loads(dumps(m))
+        assert_allclose(m(x, y), m1(x, y))
+
+    # Polynomial2D is initialized with 1 degree but
+    # requires 2 inputs
+    m = getattr(polynomial, 'Polynomial2D')
+    m = m(2)
+    m1 = loads(dumps(m))
+    assert_allclose(m(x, y) , m1(x, y))
+
+    m = getattr(polynomial, 'SIP')
+    m = m((21, 23), 2, 3)
+    m1 = loads(dumps(m))
+    assert_allclose(m(x, y), m1(x, y))
+
+
+@pytest.mark.parametrize("model", powerlaws.__all__)
+def test_pickle_powerlaws(model):
+    m = getattr(powerlaws, model)()
+    m1 = loads(dumps(m))
+    if m.n_inputs == 1:
+        assert_allclose(m(x) , m1(x))
+    else:
+        assert_allclose(m(x, y), m1(x, y))
+
+
+@pytest.mark.parametrize("model", projections_all)
+def test_pickle_projections(model):
+    m = getattr(projections, model)()
+    m1 = loads(dumps(m))
+    assert_allclose(m(x, y), m1(x, y))
+
+
+def test_pickle_rotations():
+
+    for model in ['RotateCelestial2Native', 'RotateNative2Celestial']:
+        m = getattr(rotations, model)(12, 23, 34)
+        m1 = loads(dumps(m))
+        assert_allclose(m(x, y), m1(x, y))
+
+    m = getattr(rotations, 'EulerAngleRotation')(12, 23, 34, 'xyz')
+    m1 = loads(dumps(m))
+    assert_allclose(m(x, y), m1(x, y))
+
+    m = getattr(rotations, 'RotationSequence3D')([12, 23, 34], axes_order='xyz')
+    m1 = loads(dumps(m))
+    assert_allclose(m(x, y, y), m1(x, y, y))
+
+    m = getattr(rotations, 'SphericalRotationSequence')([12, 23, 34], 'xyz')
+    m1 = loads(dumps(m))
+    assert_allclose(m(x, y), m1(x, y))
+
+    m = getattr(rotations, 'Rotation2D')(12)
+    m1 = loads(dumps(m))
+    assert_allclose(m(x, y), m1(x, y))

--- a/astropy/modeling/tests/test_pickle.py
+++ b/astropy/modeling/tests/test_pickle.py
@@ -188,7 +188,7 @@ def test_pickle_projections(model):
 
 
 def test_pickle_rotations():
-    for model in ["RotateCelestial2Native", "RotateNative2Celestial"]:
+    for model in ("RotateCelestial2Native", "RotateNative2Celestial"):
         m = getattr(rotations, model)(12, 23, 34)
         m1 = loads(dumps(m))
         assert_allclose(m(x, y), m1(x, y))

--- a/astropy/modeling/tests/test_pickle.py
+++ b/astropy/modeling/tests/test_pickle.py
@@ -21,29 +21,40 @@ from astropy.modeling import tabular
 from astropy.modeling.math_functions import ArctanhUfunc
 
 math_functions_all = math_functions.__all__[:]
-math_functions_all.remove('ArctanhUfunc')
+math_functions_all.remove("ArctanhUfunc")
 
 polynomial_all = polynomial.__all__[:]
 # remove base classes
-polynomial_all.remove('PolynomialModel')
-polynomial_all.remove('OrthoPolynomialBase')
+polynomial_all.remove("PolynomialModel")
+polynomial_all.remove("OrthoPolynomialBase")
 
 projections_all = projections.__all__[:]
-proj_to_remove = ['Projection', 'Pix2SkyProjection', 'Sky2PixProjection',
-                  'Zenithal', 'Conic', 'Cylindrical', 'PseudoCylindrical',
-                  'PseudoConic', 'QuadCube', 'HEALPix', 'AffineTransformation2D',
-                  'projcodes', 'Pix2Sky_ZenithalPerspective',]
+proj_to_remove = [
+    "Projection",
+    "Pix2SkyProjection",
+    "Sky2PixProjection",
+    "Zenithal",
+    "Conic",
+    "Cylindrical",
+    "PseudoCylindrical",
+    "PseudoConic",
+    "QuadCube",
+    "HEALPix",
+    "AffineTransformation2D",
+    "projcodes",
+    "Pix2Sky_ZenithalPerspective",
+]
 for p in proj_to_remove:
     projections_all.remove(p)
 
 for code in projections.projcodes:
-    projections_all.remove(f'Pix2Sky_{code}')
-    projections_all.remove(f'Sky2Pix_{code}')
+    projections_all.remove(f"Pix2Sky_{code}")
+    projections_all.remove(f"Sky2Pix_{code}")
 
 
 # can parametrize on x,y as well
-x, y = .3, .4
-x_math, y_math = 1, -.5
+x, y = 0.3, 0.4
+x_math, y_math = 1, -0.5
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason="requires scipy")
@@ -52,7 +63,7 @@ def test_pickle_functional(model):
     m = getattr(functional_models, model)()
     m1 = loads(dumps(m))
     if m.n_inputs == 1:
-        assert_allclose(m(x) , m1(x))
+        assert_allclose(m(x), m1(x))
     else:
         assert_allclose(m(x, y), m1(x, y))
 
@@ -62,7 +73,7 @@ def test_pickle_math_functions(model):
     m = getattr(math_functions, model)()
     m1 = loads(dumps(m))
     if m.n_inputs == 1:
-        assert_allclose(m(x_math) , m1(x_math))
+        assert_allclose(m(x_math), m1(x_math))
     else:
         assert_allclose(m(x_math, y_math), m1(x_math, y_math))
 
@@ -71,7 +82,7 @@ def test_pickle_math_functions(model):
 def test_pickle_other():
     # Test models which don't fit in the other test functions.
 
-    x = .5
+    x = 0.5
     y = 1
 
     model = mappings.Mapping((1, 0))
@@ -106,7 +117,9 @@ def test_pickle_other():
     modelp = loads(dumps(model))
     assert_allclose(model(x), modelp(x))
 
-    model = projections.AffineTransformation2D(matrix=[[1, 1], [1, 1]], translation=[1, 1])
+    model = projections.AffineTransformation2D(
+        matrix=[[1, 1], [1, 1]], translation=[1, 1]
+    )
     model.matrix.fixed = True
     modelp = loads(dumps(model))
     assert_allclose(model(x, y), modelp(x, y))
@@ -118,24 +131,24 @@ def test_pickle_physical_models(model):
     m = getattr(physical_models, model)()
     m1 = loads(dumps(m))
     if m.n_inputs == 1:
-        assert_allclose(m(x) , m1(x))
+        assert_allclose(m(x), m1(x))
     else:
         assert_allclose(m(x, y), m1(x, y))
 
 
 def test_pickle_polynomial():
     # models initialized with 1 degree
-    models2d = ['Chebyshev2D', 'Hermite2D', 'Legendre2D', 'InverseSIP']
+    models2d = ["Chebyshev2D", "Hermite2D", "Legendre2D", "InverseSIP"]
     # models initialized with 2 degree
-    models1d = ['Chebyshev1D', 'Hermite1D', 'Legendre1D', 'Polynomial1D']
+    models1d = ["Chebyshev1D", "Hermite1D", "Legendre1D", "Polynomial1D"]
 
-    sip = ['SIP', 'InverseSIP']
+    sip = ["SIP", "InverseSIP"]
 
     for model in models1d:
         m = getattr(polynomial, model)
         m = m(2)
         m1 = loads(dumps(m))
-        assert_allclose(m(x) , m1(x))
+        assert_allclose(m(x), m1(x))
 
     for model in models2d:
         m = getattr(polynomial, model)
@@ -145,12 +158,12 @@ def test_pickle_polynomial():
 
     # Polynomial2D is initialized with 1 degree but
     # requires 2 inputs
-    m = getattr(polynomial, 'Polynomial2D')
+    m = polynomial.Polynomial2D
     m = m(2)
     m1 = loads(dumps(m))
-    assert_allclose(m(x, y) , m1(x, y))
+    assert_allclose(m(x, y), m1(x, y))
 
-    m = getattr(polynomial, 'SIP')
+    m = polynomial.SIP
     m = m((21, 23), 2, 3)
     m1 = loads(dumps(m))
     assert_allclose(m(x, y), m1(x, y))
@@ -161,7 +174,7 @@ def test_pickle_powerlaws(model):
     m = getattr(powerlaws, model)()
     m1 = loads(dumps(m))
     if m.n_inputs == 1:
-        assert_allclose(m(x) , m1(x))
+        assert_allclose(m(x), m1(x))
     else:
         assert_allclose(m(x, y), m1(x, y))
 
@@ -174,24 +187,23 @@ def test_pickle_projections(model):
 
 
 def test_pickle_rotations():
-
-    for model in ['RotateCelestial2Native', 'RotateNative2Celestial']:
+    for model in ["RotateCelestial2Native", "RotateNative2Celestial"]:
         m = getattr(rotations, model)(12, 23, 34)
         m1 = loads(dumps(m))
         assert_allclose(m(x, y), m1(x, y))
 
-    m = getattr(rotations, 'EulerAngleRotation')(12, 23, 34, 'xyz')
+    m = rotations.EulerAngleRotation(12, 23, 34, "xyz")
     m1 = loads(dumps(m))
     assert_allclose(m(x, y), m1(x, y))
 
-    m = getattr(rotations, 'RotationSequence3D')([12, 23, 34], axes_order='xyz')
+    m = rotations.RotationSequence3D([12, 23, 34], axes_order="xyz")
     m1 = loads(dumps(m))
     assert_allclose(m(x, y, y), m1(x, y, y))
 
-    m = getattr(rotations, 'SphericalRotationSequence')([12, 23, 34], 'xyz')
+    m = rotations.SphericalRotationSequence([12, 23, 34], "xyz")
     m1 = loads(dumps(m))
     assert_allclose(m(x, y), m1(x, y))
 
-    m = getattr(rotations, 'Rotation2D')(12)
+    m = rotations.Rotation2D(12)
     m1 = loads(dumps(m))
     assert_allclose(m(x, y), m1(x, y))

--- a/astropy/modeling/tests/test_pickle.py
+++ b/astropy/modeling/tests/test_pickle.py
@@ -2,6 +2,7 @@
 
 from pickle import dumps, loads
 
+import numpy as np
 from numpy.testing import assert_allclose
 import pytest
 
@@ -16,6 +17,7 @@ from astropy.modeling import polynomial
 from astropy.modeling import powerlaws
 from astropy.modeling import projections
 from astropy.modeling import rotations
+from astropy.modeling import spline
 from astropy.modeling import tabular
 
 from astropy.modeling.math_functions import ArctanhUfunc
@@ -189,3 +191,19 @@ def test_pickle_rotations(inputs, m):
         assert_allclose(m(*inputs), mp(*inputs))
     else:
         assert_allclose(m(inputs[0], *inputs), mp(inputs[0], *inputs))
+
+
+def test_pickle_spline(inputs):
+    def func(x, noise):
+        return np.exp(-(x**2)) + 0.1 * noise
+
+    noise = np.random.randn(50)
+    x = np.linspace(-3, 3, 50)
+    y = func(x, noise)
+
+    fitter = spline.SplineInterpolateFitter()
+    spl = spline.Spline1D(degree=3)
+    m = fitter(spl, x, y)
+
+    mp = loads(dumps(m))
+    assert_allclose(m(inputs[0]), mp(inputs[0]))

--- a/astropy/modeling/tests/test_pickle.py
+++ b/astropy/modeling/tests/test_pickle.py
@@ -1,6 +1,7 @@
 """Tests that models are picklable."""
 
 from pickle import dumps, loads
+
 from numpy.testing import assert_allclose
 import pytest
 

--- a/astropy/modeling/tests/test_pickle.py
+++ b/astropy/modeling/tests/test_pickle.py
@@ -193,6 +193,7 @@ def test_pickle_rotations(inputs, m):
         assert_allclose(m(inputs[0], *inputs), mp(inputs[0], *inputs))
 
 
+@pytest.mark.skipif(not HAS_SCIPY, reason="requires scipy")
 def test_pickle_spline(inputs):
     def func(x, noise):
         return np.exp(-(x**2)) + 0.1 * noise

--- a/docs/changes/modeling/14902.bugfix.rst
+++ b/docs/changes/modeling/14902.bugfix.rst
@@ -1,0 +1,1 @@
+All models except splines can be pickled now.

--- a/docs/changes/modeling/14902.bugfix.rst
+++ b/docs/changes/modeling/14902.bugfix.rst
@@ -1,1 +1,1 @@
-All models except splines can be pickled now.
+All models can be pickled now.

--- a/docs/modeling/new-model.rst
+++ b/docs/modeling/new-model.rst
@@ -87,7 +87,7 @@ define a "validator" method for each parameter, enabling custom code to check
 whether that parameter's value is valid according to the model definition (for
 example if it must be non-negative).  See the example in
 `Parameter.validator <astropy.modeling.Parameter.validator>` for more details.
-Note, that if pickling the model is important the validator function should be 
+Note, that if pickling the model is important the validator function should be
 assigned directly to the instance ``Parameter._validator`` instead of using
 the decorator.
 

--- a/docs/modeling/new-model.rst
+++ b/docs/modeling/new-model.rst
@@ -87,6 +87,9 @@ define a "validator" method for each parameter, enabling custom code to check
 whether that parameter's value is valid according to the model definition (for
 example if it must be non-negative).  See the example in
 `Parameter.validator <astropy.modeling.Parameter.validator>` for more details.
+Note, that if pickling the model is important the validator function should be 
+assigned directly to the instance ``Parameter._validator`` instead of using
+the decorator.
 
 ::
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address two problems with pickling models.
- `modeling.parameters.Parameter.validator` is a property which is used as a decorator in model classes. Being a decorator it hides the name of the function which is the actual validator and prevents models from pickling. The error looks like
```
_pickle.PicklingError: Can't pickle <function AffineTransformation2D.matrix at 0x7fb318f45820>: it's not the same object as astropy.modeling.projections.AffineTransformation2D.matrix
```
This PR assigns the validator function directly and does not use the decorator thus allowing these kind of models to be pickled.
- The second issue is pickling of projections which now include a wrapped c attribute in the constructor. It follows the solution in #14850 and expands it to include constraints.

I thought about deprecating the `Parameter.validator` but it causes all kinds of errors in `cosmology` which need to be addressed separately.

If this approach is acceptable I will turn it into a PR.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>
