### PR TITLE
Fix PLW0120 warnings in Astropy library

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -131,7 +131,6 @@ ignore = [
     "PLR0915",  # too-many-statements
     "PLR2004",  # MagicValueComparison
     "PLR5501",  # collapsible-else-if
-    "PLW0120",  # useless-else-on-loop
     "PLW0129",  # assert-on-string-literal
     "PLW0130",  # duplicate value in set
     "PLW0602",  # global-variable-not-assigned

--- a/astropy/coordinates/representation/base.py
+++ b/astropy/coordinates/representation/base.py
@@ -1348,15 +1348,13 @@ class BaseDifferential(BaseRepresentationOrDifferential):
                 d_unit_si._scale = 1  # remove the scale from the unit
 
                 return str(d_unit_si)
-
-        else:
-            raise RuntimeError(
-                "Invalid representation-differential units! This likely happened "
-                "because either the representation or the associated differential "
-                "have non-standard units. Check that the input positional data have "
-                "positional units, and the input velocity data have velocity units, "
-                "or are both dimensionless."
-            )
+        raise RuntimeError(
+            "Invalid representation-differential units! This likely happened "
+            "because either the representation or the associated differential "
+            "have non-standard units. Check that the input positional data have "
+            "positional units, and the input velocity data have velocity units, "
+            "or are both dimensionless."
+        )
 
     @classmethod
     def _get_base_vectors(cls, base):

--- a/astropy/io/ascii/ipac.py
+++ b/astropy/io/ascii/ipac.py
@@ -164,10 +164,9 @@ class IpacHeader(fixedwidth.FixedWidthHeader):
         for col_type_key, col_type in self.col_type_list:
             if col_type_key.startswith(col.raw_type.lower()):
                 return col_type
-        else:
-            raise ValueError(
-                f'Unknown data type ""{col.raw_type}"" for column "{col.name}"'
-            )
+        raise ValueError(
+            f'Unknown data type ""{col.raw_type}"" for column "{col.name}"'
+        )
 
     def get_cols(self, lines):
         """

--- a/astropy/io/ascii/latex.py
+++ b/astropy/io/ascii/latex.py
@@ -84,8 +84,7 @@ def find_latex_line(lines, latex):
     for i, line in enumerate(lines):
         if re_string.match(line):
             return i
-    else:
-        return None
+    return None
 
 
 class LatexInputter(core.BaseInputter):

--- a/astropy/io/fits/header.py
+++ b/astropy/io/fits/header.py
@@ -1400,8 +1400,7 @@ class Header:
         for idx in range(start, stop, step):
             if self._cards[idx].keyword.upper() == norm_keyword:
                 return idx
-        else:
-            raise ValueError(f"The keyword {keyword!r} is not in the  header.")
+        raise ValueError(f"The keyword {keyword!r} is not in the  header.")
 
     def insert(self, key, card, useblanks=True, after=False):
         """

--- a/astropy/io/registry/core.py
+++ b/astropy/io/registry/core.py
@@ -150,13 +150,12 @@ class UnifiedInputRegistry(_UnifiedIORegistryBase):
         for reader_format, reader_class in readers:
             if self._is_best_match(data_class, reader_class, readers):
                 return self._readers[(reader_format, reader_class)][0]
-        else:
-            format_table_str = self._get_format_table_str(data_class, "Read")
-            raise IORegistryError(
-                f"No reader defined for format '{data_format}' and class"
-                f" '{data_class.__name__}'.\n\nThe available formats"
-                f" are:\n\n{format_table_str}"
-            )
+        format_table_str = self._get_format_table_str(data_class, "Read")
+        raise IORegistryError(
+            f"No reader defined for format '{data_format}' and class"
+            f" '{data_class.__name__}'.\n\nThe available formats"
+            f" are:\n\n{format_table_str}"
+        )
 
     def read(self, cls, *args, format=None, cache=False, **kwargs):
         """
@@ -329,13 +328,13 @@ class UnifiedOutputRegistry(_UnifiedIORegistryBase):
         for writer_format, writer_class in writers:
             if self._is_best_match(data_class, writer_class, writers):
                 return self._writers[(writer_format, writer_class)][0]
-        else:
-            format_table_str = self._get_format_table_str(data_class, "Write")
-            raise IORegistryError(
-                f"No writer defined for format '{data_format}' and class"
-                f" '{data_class.__name__}'.\n\nThe available formats"
-                f" are:\n\n{format_table_str}"
-            )
+
+        format_table_str = self._get_format_table_str(data_class, "Write")
+        raise IORegistryError(
+            f"No writer defined for format '{data_format}' and class"
+            f" '{data_class.__name__}'.\n\nThe available formats"
+            f" are:\n\n{format_table_str}"
+        )
 
     def write(self, data, *args, format=None, **kwargs):
         """

--- a/astropy/modeling/bounding_box.py
+++ b/astropy/modeling/bounding_box.py
@@ -1252,10 +1252,7 @@ class _SelectorArguments(tuple):
         for index, selector_arg in enumerate(self):
             if selector_arg.is_argument(model, argument):
                 return index
-        else:
-            raise ValueError(
-                f"{argument} does not correspond to any selector argument."
-            )
+        raise ValueError(f"{argument} does not correspond to any selector argument.")
 
     def reduce(self, model, argument):
         """

--- a/astropy/table/index.py
+++ b/astropy/table/index.py
@@ -674,8 +674,7 @@ def get_index_by_names(table, names):
         index_names = [col.info.name for col in index.columns]
         if index_names == names:
             return index
-    else:
-        return None
+    return None
 
 
 class _IndexModeContext:

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -609,11 +609,10 @@ class TimeBase(ShapedLikeNDArray):
                     ) from err
                 else:
                     problems[name] = err
-        else:
-            raise ValueError(
-                "Input values did not match any of the formats where the format "
-                f"keyword is optional: {problems}"
-            ) from problems[formats[0][0]]
+        raise ValueError(
+            "Input values did not match any of the formats where the format "
+            f"keyword is optional: {problems}"
+        ) from problems[formats[0][0]]
 
     @property
     def writeable(self):

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -1505,8 +1505,7 @@ class TimeString(TimeUnique):
                     continue
 
             return vals
-        else:
-            raise ValueError(f"Time {timestr} does not match {self.name} format")
+        raise ValueError(f"Time {timestr} does not match {self.name} format")
 
     def set_jds(self, val1, val2):
         """Parse the time strings contained in val1 and set jd1, jd2."""


### PR DESCRIPTION
This pull request addresses multiple instances of the PLW0120 warnings in the Astropy library. The PLW0120 warning indicates the presence of an else clause on a loop without a break statement, which can lead to code readability issues. To resolve this, the else clauses are removed, and the code inside them is properly de-indented.

The affected files and line numbers are as follows:
- astropy/coordinates/representation/base.py:1355
- astropy/io/ascii/ipac.py:167
- astropy/io/ascii/latex.py:87
- astropy/io/ascii/ui.py:601
- astropy/io/fits/header.py:1403
- astropy/io/registry/core.py:153, 332
- astropy/modeling/bounding_box.py:1255
- astropy/table/index.py:677
- astropy/time/core.py:612
- astropy/time/formats.py:1510

Fix: #14908 