### PR TITLE
Fix Implicitly Concatenated String Literals (Ruff ISC001)

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -91,7 +91,6 @@ ignore = [
     "ICN001",  # import-conventions
 
     # flake8-implicit-str-concat (ISC)
-    "ISC001",  # single-line-implicit-string-concatenation
     "ISC003",  # explicit-string-concatenation
 
     # pep8-naming (N)

--- a/astropy/convolution/tests/test_kernel_class.py
+++ b/astropy/convolution/tests/test_kernel_class.py
@@ -223,7 +223,7 @@ class TestKernels:
         test_gauss_3 = Gaussian1DKernel(5)
 
         with pytest.warns(
-            AstropyUserWarning, match=r"Both array and kernel " r"are Kernel instances"
+            AstropyUserWarning, match=r"Both array and kernel are Kernel instances"
         ):
             gauss_3 = convolve(gauss_1, gauss_2)
 
@@ -238,7 +238,7 @@ class TestKernels:
         test_gauss_3 = Gaussian2DKernel(5)
 
         with pytest.warns(
-            AstropyUserWarning, match=r"Both array and kernel " r"are Kernel instances"
+            AstropyUserWarning, match=r"Both array and kernel are Kernel instances"
         ):
             gauss_3 = convolve(gauss_1, gauss_2)
 
@@ -375,7 +375,7 @@ class TestKernels:
 
         with pytest.warns(
             AstropyUserWarning,
-            match=r"kernel cannot be " r"normalized because it sums to zero",
+            match=r"kernel cannot be normalized because it sums to zero",
         ):
             custom.normalize()
 
@@ -393,7 +393,7 @@ class TestKernels:
 
         with pytest.warns(
             AstropyUserWarning,
-            match=r"kernel cannot be " r"normalized because it sums to zero",
+            match=r"kernel cannot be normalized because it sums to zero",
         ):
             custom.normalize()
 

--- a/astropy/coordinates/tests/test_iau_fullstack.py
+++ b/astropy/coordinates/tests/test_iau_fullstack.py
@@ -203,7 +203,7 @@ def test_future_altaz():
     # --remote-data, i.e. for all CI testing) do we expect another warning.
     with pytest.warns(
         AstropyWarning,
-        match=r"Tried to get polar motions for " "times after IERS data is valid.*",
+        match=r"Tried to get polar motions for times after IERS data is valid.*",
     ) as found_warnings:
         SkyCoord(1 * u.deg, 2 * u.deg).transform_to(AltAz(location=location, obstime=t))
 

--- a/astropy/io/ascii/daophot.py
+++ b/astropy/io/ascii/daophot.py
@@ -29,7 +29,7 @@ class DaophotHeader(core.BaseHeader):
     # Regex for extracting the format strings
     re_format = re.compile(r"%-?(\d+)\.?\d?[sdfg]")
     re_header_keyword = re.compile(
-        r"[#]K" r"\s+ (?P<name> \w+)" r"\s* = (?P<stuff> .+) $", re.VERBOSE
+        r"[#]K\s+ (?P<name> \w+)\s* = (?P<stuff> .+) $", re.VERBOSE
     )
     aperture_values = ()
 

--- a/astropy/io/ascii/tests/test_ipac_definitions.py
+++ b/astropy/io/ascii/tests/test_ipac_definitions.py
@@ -98,7 +98,7 @@ def test_reserved_colname_strict(colname):
 def test_too_long_comment():
     with pytest.warns(
         UserWarning,
-        match=r"Comment string > 78 characters was " r"automatically wrapped\.",
+        match=r"Comment string > 78 characters was automatically wrapped\.",
     ):
         table = Table([[3]])
         table.meta["comments"] = ["a" * 79]

--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -272,7 +272,7 @@ class _ImageBaseHDU(_ValidHDU):
                     data = np.array(data)
                 except Exception:  # pragma: no cover
                     raise TypeError(
-                        f"data object {data!r} could not be coerced into an " f"ndarray"
+                        f"data object {data!r} could not be coerced into an ndarray"
                     )
 
             if data.shape == ():

--- a/astropy/io/fits/tests/test_fitstime.py
+++ b/astropy/io/fits/tests/test_fitstime.py
@@ -389,7 +389,7 @@ class TestFitsTime(FitsTestCase):
         filename = self.data("chandra_time.fits")
         with pytest.warns(
             AstropyUserWarning,
-            match=r'Time column "time" reference ' r"position will be ignored",
+            match=r'Time column "time" reference position will be ignored',
         ):
             tm = table_types.read(filename, astropy_native=True)
 

--- a/astropy/table/tests/test_column.py
+++ b/astropy/table/tests/test_column.py
@@ -759,7 +759,7 @@ def test_string_truncation_warning(masked):
 
     with pytest.warns(
         table.StringTruncateWarning,
-        match=r"truncated right side " r"string\(s\) longer than 2 character\(s\)",
+        match=r"truncated right side string\(s\) longer than 2 character\(s\)",
     ) as w:
         frameinfo = getframeinfo(currentframe())
         t["a"][0] = "eee"  # replace item with string that gets truncated
@@ -772,7 +772,7 @@ def test_string_truncation_warning(masked):
 
     with pytest.warns(
         table.StringTruncateWarning,
-        match=r"truncated right side " r"string\(s\) longer than 2 character\(s\)",
+        match=r"truncated right side string\(s\) longer than 2 character\(s\)",
     ) as w:
         t["a"][:] = ["ff", "ggg"]  # replace item with string that gets truncated
     assert np.all(t["a"] == ["ff", "gg"])
@@ -812,7 +812,7 @@ def test_string_truncation_warning_masked():
 
     with pytest.warns(
         table.StringTruncateWarning,
-        match=r"truncated right side " r"string\(s\) longer than 2 character\(s\)",
+        match=r"truncated right side string\(s\) longer than 2 character\(s\)",
     ) as w:
         mc[:] = [np.ma.masked, "ggg"]  # replace item with string that gets truncated
     assert mc[1] == "gg"

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -2234,7 +2234,7 @@ class TestReplaceColumn(SetupData):
 
         with pytest.raises(
             ValueError,
-            match=r"Cannot replace column 'a'.  Use " "Table.replace_column.. instead.",
+            match=r"Cannot replace column 'a'.  Use Table.replace_column.. instead.",
         ):
             t.columns["a"] = [1, 2, 3]
 
@@ -2669,7 +2669,7 @@ def test_replace_update_column_via_setitem_warnings_attributes():
 
     with pytest.warns(
         TableReplaceWarning,
-        match=r"replaced column 'a' " r"and column attributes \['unit'\]",
+        match=r"replaced column 'a' and column attributes \['unit'\]",
     ) as w:
         with table.conf.set_temp(
             "replace_warnings", ["refcount", "attributes", "slice"]

--- a/astropy/timeseries/periodograms/lombscargle_multiband/core.py
+++ b/astropy/timeseries/periodograms/lombscargle_multiband/core.py
@@ -233,7 +233,7 @@ class LombScargleMultiband(LombScargle):
                 try:
                     dy = u.Quantity(dy, unit=y.unit)
                 except u.UnitConversionError:
-                    raise ValueError("Units of dy not equivalent " "to units of y")
+                    raise ValueError("Units of dy not equivalent to units of y")
         return t, y, bands, dy
 
     def autofrequency(

--- a/astropy/units/tests/test_logarithmic.py
+++ b/astropy/units/tests/test_logarithmic.py
@@ -206,9 +206,9 @@ class TestLogUnitStrings:
 
         lu5 = u.mag(u.ct / u.s)
         assert lu5.to_string("latex") == (
-            r"$\mathrm{mag}$$\mathrm{\left( " r"\mathrm{\frac{ct}{s}} \right)}$"
+            r"$\mathrm{mag}$$\mathrm{\left( \mathrm{\frac{ct}{s}} \right)}$"
         )
-        latex_str = r"$\mathrm{mag}$$\mathrm{\left( \mathrm{ct\,s^{-1}} " r"\right)}$"
+        latex_str = r"$\mathrm{mag}$$\mathrm{\left( \mathrm{ct\,s^{-1}} \right)}$"
         assert lu5.to_string("latex_inline") == latex_str
 
 


### PR DESCRIPTION
This pull request fixes a series of Implicitly Concatenated String Literals issues (ISC001).

The following files and lines have been addressed:
- astropy/convolution/tests/test_kernel_class.py:226:39
- astropy/convolution/tests/test_kernel_class.py:241:39
- astropy/convolution/tests/test_kernel_class.py:378:19
- astropy/convolution/tests/test_kernel_class.py:396:19
- astropy/coordinates/tests/test_iau_fullstack.py:206:15
- astropy/io/ascii/daophot.py:32:9
- astropy/io/ascii/daophot.py:32:17
- astropy/io/ascii/tests/test_ipac_definitions.py:101:15
- astropy/io/fits/hdu/image.py:275:25
- astropy/io/fits/tests/test_fitstime.py:392:19
- astropy/table/tests/test_column.py:762:15
- astropy/table/tests/test_column.py:775:15
- astropy/table/tests/test_column.py:815:15
- astropy/table/tests/test_table.py:2237:19
- astropy/table/tests/test_table.py:2672:15
- astropy/timeseries/periodograms/lombscargle_multiband/core.py:236:38
- astropy/units/tests/test_logarithmic.py:209:13
- astropy/units/tests/test_logarithmic.py:211:21

The changes involve explicitly concatenating the string literals

Fix #14910