### PR TITLE
Address useless comparisons in tests

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -17,7 +17,6 @@ ignore = [
     # flake8-bugbear (B)
     "B006",  # MutableArgumentDefault
     "B007",  # UnusedLoopControlVariable
-    "B015",  # UselessComparison
     "B023",  # FunctionUsesLoopVariable
     "B028",  # No-explicit-stacklevel
     "B904",  # RaiseWithoutFromInsideExcept
@@ -289,10 +288,17 @@ unfixable = [
 "astropy/convolution/*" = ["I001"]
 "astropy/coordinates/*" = ["I001", "C408"]
 "astropy/cosmology/*" = ["C408"]
-"astropy/io/*" = ["I001"]
+"astropy/io/*" = [
+    "B015",
+    "I001",
+]
 "astropy/logger.py" = ["C408"]
 "astropy/modeling/*" = ["I001", "C408"]
-"astropy/nddata/*" = ["I001", "C408"]
+"astropy/nddata/*" = [
+    "B015",
+    "C408",
+    "I001",
+]
 "astropy/samp/*" = []
 "astropy/stats/*" = ["I001"]
 "astropy/table/*" = ["I001", "C408"]
@@ -302,7 +308,11 @@ unfixable = [
 "astropy/units/*" = ["I001", "C408"]
 "astropy/uncertainty/*" = ["C408"]
 "astropy/utils/*" = ["C408"]
-"astropy/visualization/*" = ["I001", "C408"]
+"astropy/visualization/*" = [
+    "B015",
+    "C408",
+    "I001",
+]
 "astropy/wcs/*" = ["I001", "C408"]
 "docs/*" = []
 "examples/coordinates/*" = []

--- a/astropy/coordinates/tests/test_erfa_astrom.py
+++ b/astropy/coordinates/tests/test_erfa_astrom.py
@@ -18,7 +18,7 @@ def test_science_state():
     res = 300 * u.s
     with erfa_astrom.set(ErfaAstromInterpolator(res)):
         assert isinstance(erfa_astrom.get(), ErfaAstromInterpolator)
-        erfa_astrom.get().mjd_resolution == res.to_value(u.day)
+        assert erfa_astrom.get().mjd_resolution == res.to_value(u.day)
 
     # context manager should have switched it back
     assert erfa_astrom.get().__class__ is ErfaAstrom

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -926,9 +926,9 @@ def test_represent_as():
     cart1 = icrs.represent_as("cartesian")
     cart2 = icrs.represent_as(r.CartesianRepresentation)
 
-    cart1.x == cart2.x
-    cart1.y == cart2.y
-    cart1.z == cart2.z
+    assert cart1.x == cart2.x
+    assert cart1.y == cart2.y
+    assert cart1.z == cart2.z
 
     # now try with velocities
     icrs = ICRS(
@@ -1021,7 +1021,7 @@ def test_equal_exceptions():
     # Shape mismatch
     sc1 = FK4([1, 2, 3] * u.deg, [3, 4, 5] * u.deg)
     with pytest.raises(ValueError, match="cannot compare: shape mismatch"):
-        sc1 == sc1[:2]
+        sc1 == sc1[:2]  # noqa: B015
 
     # Different representation_type
     sc1 = FK4(1, 2, 3, representation_type="cartesian")
@@ -1033,7 +1033,7 @@ def test_equal_exceptions():
             "class: CartesianRepresentation vs. SphericalRepresentation"
         ),
     ):
-        sc1 == sc2
+        sc1 == sc2  # noqa: B015
 
     # Different differential type
     sc1 = FK4(1 * u.deg, 2 * u.deg, radial_velocity=1 * u.km / u.s)
@@ -1047,7 +1047,7 @@ def test_equal_exceptions():
             "class: RadialDifferential vs. UnitSphericalCosLatDifferential"
         ),
     ):
-        sc1 == sc2
+        sc1 == sc2  # noqa: B015
 
     # Different frame attribute
     sc1 = FK5(1 * u.deg, 2 * u.deg)
@@ -1058,7 +1058,7 @@ def test_equal_exceptions():
         r"frames: <FK5 Frame \(equinox=J2000.000\)> "
         r"vs. <FK5 Frame \(equinox=J1999.000\)>",
     ):
-        sc1 == sc2
+        sc1 == sc2  # noqa: B015
 
     # Different frame
     sc1 = FK4(1 * u.deg, 2 * u.deg)
@@ -1069,18 +1069,18 @@ def test_equal_exceptions():
         r"frames: <FK4 Frame \(equinox=B1950.000, obstime=B1950.000\)> "
         r"vs. <FK5 Frame \(equinox=J2000.000\)>",
     ):
-        sc1 == sc2
+        sc1 == sc2  # noqa: B015
 
     sc1 = FK4(1 * u.deg, 2 * u.deg)
     sc2 = FK4()
     with pytest.raises(
         ValueError, match="cannot compare: one frame has data and the other does not"
     ):
-        sc1 == sc2
+        sc1 == sc2  # noqa: B015
     with pytest.raises(
         ValueError, match="cannot compare: one frame has data and the other does not"
     ):
-        sc2 == sc1
+        sc2 == sc1  # noqa: B015
 
 
 def test_dynamic_attrs():
@@ -1655,15 +1655,15 @@ def test_frame_coord_comparison():
     assert not (frame == other)
     error_msg = "objects must have equivalent frames"
     with pytest.raises(TypeError, match=error_msg):
-        frame == SkyCoord(AltAz("0d", "1d"))
+        frame == SkyCoord(AltAz("0d", "1d"))  # noqa: B015
 
     coord = SkyCoord(ra=12 * u.hourangle, dec=5 * u.deg, frame=FK5(equinox="J1950"))
     frame = FK5(ra=12 * u.hourangle, dec=5 * u.deg, equinox="J2000")
     with pytest.raises(TypeError, match=error_msg):
-        coord == frame
+        coord == frame  # noqa: B015
 
     frame = ICRS()
     coord = SkyCoord(0 * u.deg, 0 * u.deg, frame=frame)
     error_msg = "Can only compare SkyCoord to Frame with data"
     with pytest.raises(ValueError, match=error_msg):
-        frame == coord
+        frame == coord  # noqa: B015

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -439,7 +439,7 @@ def test_equal_exceptions():
             r" \(perhaps compare the frames directly to avoid this exception\)"
         ),
     ):
-        sc1 == sc2
+        sc1 == sc2  # noqa: B015
     # Note that this exception is the only one raised directly in SkyCoord.
     # All others come from lower-level classes and are tested in test_frames.py.
 

--- a/astropy/cosmology/tests/test_parameter.py
+++ b/astropy/cosmology/tests/test_parameter.py
@@ -209,7 +209,7 @@ class ParameterTestMixin:
                 pass  # never actually initialized
 
         # param should be 1st, all other parameters next
-        Example.__parameters__[0] == "param"
+        assert Example.__parameters__[0] == "param"
         # Check the other parameters are as expected.
         # only run this test if "param" is not already on the cosmology
         if cosmo_cls.__parameters__[0] != "param":

--- a/astropy/io/fits/tests/test_connect.py
+++ b/astropy/io/fits/tests/test_connect.py
@@ -764,7 +764,7 @@ def test_bool_column(tmp_path):
     """
 
     arr = np.ones(5, dtype=bool)
-    arr[::2] == np.False_
+    arr[::2] = False
 
     t = Table([arr])
     t.write(tmp_path / "test.fits", overwrite=True)

--- a/astropy/io/fits/tests/test_core.py
+++ b/astropy/io/fits/tests/test_core.py
@@ -506,7 +506,7 @@ class TestCore(FitsTestCase):
         h1.header["EXTVER"] = 3
         assert h1.ver == 3
         del h1.header["EXTVER"]
-        h1.ver == 1
+        assert h1.ver == 1
 
         h1.level = 2
         assert h1.header.get("EXTLEVEL") == 2

--- a/astropy/modeling/tests/test_fitters.py
+++ b/astropy/modeling/tests/test_fitters.py
@@ -1203,9 +1203,9 @@ def test_optimizers(fitter_class):
             )
         assert fit_info == fitter._opt_method.fit_info
         if isinstance(fitter, SLSQPLSQFitter):
-            fitter._opt_method.acc == 1e-16
+            assert fitter._opt_method.acc == 1e-16
         else:
-            fitter._opt_method.acc == xtol
+            assert fitter._opt_method.acc == xtol
 
 
 @mk.patch.multiple(Optimization, __abstractmethods__=set())

--- a/astropy/modeling/tests/test_quantities_parameters.py
+++ b/astropy/modeling/tests/test_quantities_parameters.py
@@ -306,10 +306,10 @@ def test_parameter_quantity_comparison():
         r" argument .*"
     )
     with pytest.raises(UnitsError, match=MESSAGE):
-        g.mean < 2
+        g.mean < 2  # noqa: B015
 
     with pytest.raises(UnitsError, match=MESSAGE):
-        2 > g.mean
+        2 > g.mean  # noqa: B015
 
     g = Gaussian1D([1, 2] * u.J, [1, 2] * u.m, [0.1, 0.2] * u.m)
 
@@ -319,10 +319,10 @@ def test_parameter_quantity_comparison():
     assert np.all([1, 2] != g.mean)
 
     with pytest.raises(UnitsError, match=MESSAGE):
-        g.mean < [3, 4]
+        g.mean < [3, 4]  # noqa: B015
 
     with pytest.raises(UnitsError, match=MESSAGE):
-        [3, 4] > g.mean
+        [3, 4] > g.mean  # noqa: B015
 
 
 def test_parameters_compound_models():

--- a/astropy/table/tests/test_row.py
+++ b/astropy/table/tests/test_row.py
@@ -83,7 +83,7 @@ class TestRow:
         np_t = self.t.as_array()
         if table_types.Table is MaskedTable:
             with pytest.raises(ValueError):
-                self.t[0] == np_t[0]
+                self.t[0] == np_t[0]  # noqa: B015
         else:
             for row, np_row in zip(self.t, np_t):
                 assert np.all(row == np_row)
@@ -95,7 +95,7 @@ class TestRow:
         np_t["a"] = [0, 0, 0]
         if table_types.Table is MaskedTable:
             with pytest.raises(ValueError):
-                self.t[0] == np_t[0]
+                self.t[0] == np_t[0]  # noqa: B015
         else:
             for row, np_row in zip(self.t, np_t):
                 assert np.all(row != np_row)
@@ -106,7 +106,7 @@ class TestRow:
         np_t = self.t.as_array()
         if table_types.Table is MaskedTable:
             with pytest.raises(ValueError):
-                self.t[0] == np_t[0]
+                self.t[0] == np_t[0]  # noqa: B015
         else:
             for row, np_row in zip(self.t, np_t):
                 assert np.all(np_row == row)

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -1389,7 +1389,7 @@ class TestIterator:
         t = table_types.Table(d)
         if t.masked:
             with pytest.raises(ValueError):
-                t[0] == d[0]
+                t[0] == d[0]  # noqa: B015
         else:
             for row, np_row in zip(t, d):
                 assert np.all(row == np_row)
@@ -1504,7 +1504,7 @@ def test_copy_masked():
     t = table.Table(
         [[1, 2, 3], [2, 3, 4]], names=["x", "y"], masked=True, meta={"name": "test"}
     )
-    t["x"].mask == [True, False, True]
+    t["x"].mask = [True, False, True]
     t2 = t.copy()
     _assert_copies(t, t2)
 
@@ -1527,16 +1527,16 @@ def test_disallow_inequality_comparisons():
     t = table.Table()
 
     with pytest.raises(TypeError):
-        t > 2
+        t > 2  # noqa: B015
 
     with pytest.raises(TypeError):
-        t < 1.1
+        t < 1.1  # noqa: B015
 
     with pytest.raises(TypeError):
-        t >= 5.5
+        t >= 5.5  # noqa: B015
 
     with pytest.raises(TypeError):
-        t <= -1.1
+        t <= -1.1  # noqa: B015
 
 
 def test_values_equal_part1():

--- a/astropy/time/tests/test_comparisons.py
+++ b/astropy/time/tests/test_comparisons.py
@@ -89,7 +89,7 @@ class TestTimeComparisons:
     def test_timedelta(self):
         dt = self.t2 - self.t1
         with pytest.raises(TypeError):
-            self.t1 > dt
+            self.t1 > dt  # noqa: B015
         dt_gt_td0 = dt > TimeDelta(0.0, format="sec")
         assert np.all(
             dt_gt_td0

--- a/astropy/time/tests/test_quantity_interaction.py
+++ b/astropy/time/tests/test_quantity_interaction.py
@@ -96,9 +96,9 @@ class TestTimeQuantity:
         """Check that comparisons of Time with quantities does not work
         (even for time-like, since we cannot compare Time to TimeDelta)"""
         with pytest.raises(TypeError):
-            Time(100000.0, format="cxcsec") > 10.0 * u.m
+            Time(100000.0, format="cxcsec") > 10.0 * u.m  # noqa: B015
         with pytest.raises(TypeError):
-            Time(100000.0, format="cxcsec") > 10.0 * u.second
+            Time(100000.0, format="cxcsec") > 10.0 * u.second  # noqa: B015
 
 
 class TestTimeDeltaQuantity:
@@ -122,7 +122,7 @@ class TestTimeDeltaQuantity:
             Time(2450000.0 * u.dimensionless_unscaled, format="jd", scale="utc")
 
         with pytest.raises(TypeError):
-            TimeDelta(100, format="sec") > 10.0 * u.m
+            TimeDelta(100, format="sec") > 10.0 * u.m  # noqa: B015
 
     def test_quantity_output(self):
         q = 500.25 * u.day
@@ -265,7 +265,7 @@ class TestTimeDeltaQuantity:
     def test_invalid_quantity_operations(self):
         """Check comparisons of TimeDelta with non-time quantities fails."""
         with pytest.raises(TypeError):
-            TimeDelta(100000.0, format="sec") > 10.0 * u.m
+            TimeDelta(100000.0, format="sec") > 10.0 * u.m  # noqa: B015
 
     def test_invalid_quantity_operations2(self):
         """Check that operations with non-time/quantity fail."""

--- a/astropy/timeseries/tests/test_common.py
+++ b/astropy/timeseries/tests/test_common.py
@@ -25,8 +25,8 @@ class CommonTimeSeriesTests:
         assert isinstance(ts, self.series.__class__)
 
     def test_row_indexing(self):
-        self.series[0][self.time_attr] == Time("2015-01-21T12:30:32")
-        self.series[self.time_attr][0] == Time("2015-01-21T12:30:32")
+        assert self.series[1][self.time_attr] == Time("2015-01-21T12:30:32")
+        assert self.series[self.time_attr][1] == Time("2015-01-21T12:30:32")
 
     def test_column_indexing(self):
         assert_equal(self.series["a"], [1, 2, 11])

--- a/astropy/units/tests/test_logarithmic.py
+++ b/astropy/units/tests/test_logarithmic.py
@@ -944,7 +944,7 @@ class TestLogQuantityComparisons:
     def test_comparison_to_non_quantities_fails(self):
         lq = u.Magnitude(np.arange(1.0, 10.0) * u.Jy)
         with pytest.raises(TypeError):
-            lq > "a"
+            lq > "a"  # noqa: B015
 
         assert not (lq == "a")
         assert lq != "a"
@@ -961,21 +961,21 @@ class TestLogQuantityComparisons:
         assert not (lq1 == lq4)
         assert lq1 != lq4
         with pytest.raises(u.UnitsError):
-            lq1 < lq4
+            lq1 < lq4  # noqa: B015
         q5 = 1.5 * u.Jy
         assert np.all((lq1 > q5) == np.array([True, False, False]))
         assert np.all((q5 < lq1) == np.array([True, False, False]))
         with pytest.raises(u.UnitsError):
-            lq1 >= 2.0 * u.m
+            lq1 >= 2.0 * u.m  # noqa: B015
         with pytest.raises(u.UnitsError):
-            lq1 <= lq1.value * u.mag
+            lq1 <= lq1.value * u.mag  # noqa: B015
         # For physically dimensionless, we can compare with the function unit.
         lq6 = u.Magnitude(np.arange(1.0, 4.0))
         fv6 = lq6.value * u.mag
         assert np.all(lq6 == fv6)
         # but not some arbitrary unit, of course.
         with pytest.raises(u.UnitsError):
-            lq6 < 2.0 * u.m
+            lq6 < 2.0 * u.m  # noqa: B015
 
 
 class TestLogQuantityMethods:

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -643,7 +643,7 @@ def test_comparison():
     assert u.cm <= u.m
 
     with pytest.raises(u.UnitsError):
-        u.m > u.kg
+        u.m > u.kg  # noqa: B015
 
 
 def test_compose_into_arbitrary_units():

--- a/astropy/utils/masked/tests/test_masked.py
+++ b/astropy/utils/masked/tests/test_masked.py
@@ -688,7 +688,7 @@ class MaskedOperatorTests(MaskedArraySetup):
 
     def test_not_implemented(self):
         with pytest.raises(TypeError):
-            self.ma > "abc"
+            self.ma > "abc"  # noqa: B015
 
     @pytest.mark.parametrize("different_names", [False, True])
     @pytest.mark.parametrize("op", (operator.eq, operator.ne))
@@ -785,7 +785,7 @@ class TestMaskedArrayOperators(MaskedOperatorTests):
 
     def test_not_implemented(self):
         with pytest.raises(TypeError):
-            Masked(["a", "b"]) > object()
+            Masked(["a", "b"]) > object()  # noqa: B015
 
 
 class TestMaskedQuantityOperators(MaskedOperatorTests, QuantitySetup):

--- a/astropy/utils/tests/test_decorators.py
+++ b/astropy/utils/tests/test_decorators.py
@@ -488,7 +488,7 @@ def test_deprecated_argument_remove():
     assert len(w) == 1
 
     with pytest.warns(AstropyDeprecationWarning, match=r"Use astropy\.y instead"):
-        test(121, 1) == (121, 1)
+        test(121, 1) == (121, 1)  # noqa: B015
 
     assert test() == (11, 3)
     assert test(121) == (121, 3)

--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -1556,7 +1556,7 @@ def test_cunit():
     assert w1.wcs.cunit != ["a", "b", "c"]
     # Comparison is not implemented TypeError will raise
     with pytest.raises(TypeError):
-        w1.wcs.cunit < w2.wcs.cunit
+        w1.wcs.cunit < w2.wcs.cunit  # noqa: B015
 
 
 class TestWcsWithTime:


### PR DESCRIPTION
### Description

Many of the Ruff rules `astropy` is currently ignoring would be good to enforce, but they do not affect code correctness so it is not critical to address them quickly. The [Ruff rule B015](https://beta.ruff.rs/docs/rules/#flake8-bugbear-b), which checks for comparisons whose outcome is ignored, is different because the presence of useless comparisons in tests means that there can be code that is untested despite being executed during the tests.

Currently there are four kinds of useless comparisons in `astropy` tests:
 - invalid comparisons deliberately triggering an error, which Ruff should be told to ignore with a `noqa` comment,
 - comparisons the outcome of which should be asserted,
 - equality comparisons (`==`) that were actually supposed to be assignments (`=`),
 - complicated cases that require familiarity with the subpackage to resolve (see #14920).

The first three cases in the list are properly handled by this pull request. The few of complicated comparisons are ignored at the subpackage level for now, but they should be dealt with sooner rather than later because they might be hiding actual bugs.

### Approvals by subpackage
- [x] coordinates https://github.com/astropy/astropy/pull/14919#pullrequestreview-1465145969
- [x] cosmology https://github.com/astropy/astropy/pull/14919#pullrequestreview-1463358995
- [x] io.fits https://github.com/astropy/astropy/pull/14919#pullrequestreview-1465398952
- [x] modeling https://github.com/astropy/astropy/pull/14919#pullrequestreview-1465398952
- [x] table https://github.com/astropy/astropy/pull/14919#pullrequestreview-1463012793
- [x] time https://github.com/astropy/astropy/pull/14919#pullrequestreview-1463012793
- [x] timeseries https://github.com/astropy/astropy/pull/14919#pullrequestreview-1465398952
- [x] units https://github.com/astropy/astropy/pull/14919#pullrequestreview-1463358995
- [x] utils https://github.com/astropy/astropy/pull/14919#pullrequestreview-1465147712
- [x] wcs https://github.com/astropy/astropy/pull/14919#pullrequestreview-1465398952