### PR TITLE
Add property scale_factor0 to FLRW cosmologies

### DIFF
--- a/astropy/cosmology/flrw/base.py
+++ b/astropy/cosmology/flrw/base.py
@@ -66,7 +66,39 @@ _FlatFLRWMixinT = TypeVar("_FlatFLRWMixinT", bound="FlatFLRWMixin")
 ##############################################################################
 
 
-class FLRW(Cosmology):
+class _ScaleFactorMixin:
+    @property
+    def scale_factor0(self):
+        r"""Scale factor at redshift 0.
+
+        The scale factor is defined as :math:`a = \frac{a_0}{1 + z}`. The common
+        convention is to set :math:`a_0 = 1`. However, in some cases, e.g. in some old
+        CMB papers, :math:`a_0` is used to normalize `a` to be a convenient number at
+        the redshift of interest for that paper. Explicitly using :math:`a_0` in both
+        calculation and code avoids ambiguity.
+        """
+        return u.Quantity(self.scale_factor(0), unit=u.one)
+
+    def scale_factor(self, z):
+        """Scale factor at redshift ``z``.
+
+        The scale factor is defined as :math:`a = 1 / (1 + z)`.
+
+        Parameters
+        ----------
+        z : Quantity-like ['redshift'], array-like, or `~numbers.Number`
+            Input redshift.
+
+        Returns
+        -------
+        a : ndarray or float
+            Scale factor at each input redshift.
+            Returns `float` if the input is scalar.
+        """
+        return 1.0 / (aszarr(z) + 1.0)
+
+
+class FLRW(Cosmology, _ScaleFactorMixin):
     """
     A class describing an isotropic and homogeneous
     (Friedmann-Lemaitre-Robertson-Walker) cosmology.
@@ -899,24 +931,6 @@ class FLRW(Cosmology):
             Hubble parameter at each input redshift.
         """
         return self._H0 * self.efunc(z)
-
-    def scale_factor(self, z):
-        """Scale factor at redshift ``z``.
-
-        The scale factor is defined as :math:`a = 1 / (1 + z)`.
-
-        Parameters
-        ----------
-        z : Quantity-like ['redshift'], array-like, or `~numbers.Number`
-            Input redshift.
-
-        Returns
-        -------
-        a : ndarray or float
-            Scale factor at each input redshift.
-            Returns `float` if the input is scalar.
-        """
-        return 1.0 / (aszarr(z) + 1.0)
 
     def lookback_time(self, z):
         """Lookback time in Gyr to redshift ``z``.

--- a/astropy/cosmology/flrw/tests/test_base.py
+++ b/astropy/cosmology/flrw/tests/test_base.py
@@ -711,6 +711,18 @@ class FLRWTest(
             cosmo.Om(z) + cosmo.Ogamma(z) + cosmo.Onu(z) + cosmo.Ode(z) + cosmo.Ok(z),
         )
 
+    def test_scale_factor0(self, cosmo):
+        """Test :meth:`astropy.cosmology.FLRW.scale_factor`."""
+        assert isinstance(cosmo.scale_factor0, u.Quantity)
+        assert cosmo.scale_factor0.unit == u.one
+        assert cosmo.scale_factor0 == 1
+        assert np.allclose(cosmo.scale_factor0, cosmo.scale_factor(0))
+
+    @pytest.mark.parametrize("z", valid_zs)
+    def test_scale_factor(self, cosmo, z):
+        """Test :meth:`astropy.cosmology.FLRW.scale_factor`."""
+        assert np.allclose(cosmo.scale_factor(z), 1 / (1 + np.array(z)))
+
     # ---------------------------------------------------------------
 
     def test_efunc_vs_invefunc(self, cosmo):

--- a/docs/changes/cosmology/14931.api.rst
+++ b/docs/changes/cosmology/14931.api.rst
@@ -1,0 +1,2 @@
+A new property -- ``scale_factor0`` -- has been added to Cosmology objects.
+This is the scale factor at redshift 0, and is defined to be 1.0.


### PR DESCRIPTION
This PR is part of a sequence to implement the [Cosmology API](https://cosmology.readthedocs.io/projects/api/en/latest/).
Ping @ntessore.
