### PR TITLE
get each slice using a threadpool

### DIFF
--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -3,6 +3,7 @@
 import mmap
 import sys
 import warnings
+from concurrent.futures import ThreadPoolExecutor
 
 import numpy as np
 
@@ -1056,7 +1057,9 @@ class Section:
                 break
             # This should always break at some point if _getdata is called.
 
-        data = [self[keys[:idx] + (k,) + keys[idx + 1 :]] for k in ks]
+        with ThreadPoolExecutor() as pool:
+            futures = pool.map(lambda k: self[keys[:idx] + (k,) + keys[idx + 1 :]], ks)
+        data = list(futures)
 
         if any(isinstance(key, slice) or isiterable(key) for key in keys[idx + 1 :]):
             # data contains multidimensional arrays; combine them.


### PR DESCRIPTION
### Description

This pull request is to improve performance on remote files with `astropy.io.fits.Section`

Currently, the `Section` class method `_getdata` executes a list comprehension to pull in data.

https://github.com/astropy/astropy/blob/0a71105fbaa71439206d496a44df11abc0e3ac96/astropy/io/fits/hdu/image.py#L1059

For remote files, this ends up generating a sequence of http range requests (through fsspec) which, since they run in sequence, ends up being slow.

If we instead run this operation in a threadpool, we observe a large performance increase by running each concurrently.

Given this simple benchmark:

```python
from astropy.io import fits

uri = "s3://stpubdata/hst/public/j8pu/j8pu0y010/j8pu0y010_drc.fits"  # 224 MB
section_slice = (slice(10, 60), slice(30, 50))


def main():
    with fits.open(
        uri, fsspec_kwargs={"anon": True, "default_block_size": 10_000}
    ) as hdul:
        data = hdul[1].section[section_slice]


if __name__ == "__main__":
    import timeit

    print(min(timeit.repeat("main()", globals=locals(), repeat=5, number=1)))
```

We observe `2.55` seconds on the `main` branch, and `0.63` seconds with this patch applied.

Importantly, with this (relatively) small data file, you must specify a relatively small block size to observe the effect. Otherwise, fsspec will use the default blocksize (5MB) which would download the entire range, so you would not see the benefit to threading.

*side note*: why not just specify a very large blocksize all the time? For very large files (such as TESS cubes which are >100GB) making small cutouts with a small block_size avoids downloading too much extra data. In these large cubes, even with a block size of 5MB, each slice would still result in separate requests being made, and most of the data wouldn't be used. This is relevant for [astrocut](https://github.com/spacetelescope/astrocut) library (and [tesscut](https://mast.stsci.edu/tesscut) application which uses it).

Is there any reason a user would want to opt out of multhreading?