### PR TITLE
Simplify Ruff `pydocstyle` configuration

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -250,10 +250,8 @@ unfixable = [
 [per-file-ignores]
 "setup.py" = ["INP001"]  # Part of configuration, not a package.
 "__init__.py" = ["E402", "F401", "F403"]
-"astropy/coordinates/angle_formats.py" = ["D415"]  # The docstrings are regexes.
 "astropy/io/registry/compat.py" = ["F822"]
 "astropy/modeling/models.py" = ["F401", "F403", "F405"]
-"astropy/units/format/*.py" = ["D415"]  # The docstrings are regexes.
 "astropy/utils/decorators.py" = [
     "D214", "D215",  # keep Examples section indented.
     "D411",  # sphinx treats spaced example sections as real sections
@@ -272,7 +270,6 @@ unfixable = [
     "INP001",  # implicit-namespace-package. The examples are not a package.
 ]
 "examples/*.py" = [
-    "D415",   # EndsInPeriod. The examples use RST syntax, not a one-line title.
     "E402",   # Imports are done as needed.
     "INP001", # implicit-namespace-package. The examples are not a package.
     "T203"    # pprint found

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,16 +138,11 @@ ignore = [
     # Missing Docstrings
     "D102",  # Missing docstring in public method. Don't check b/c docstring inheritance.
     "D105",  # Missing docstring in magic method. Don't check b/c class docstring.
-    "D107",  # Missing docstring in __init__. Don't check b/c class docstring.
-    "D213",  # multi-line-summary-second-line
     # Whitespace Issues
     "D200",  # FitsOnOneLine
-    "D203",  # OneBlankLineBeforeClass.
     # Docstring Content Issues
     "D410",  # BlankLineAfterSection. Using D412 instead.
-    "D400",  # EndsInPeriod. Using D415 instead.
-    "D413",  # BlankLineAfterLastSection.
-    "D416",  # SectionNameEndsInColon.
+    "D400",  # EndsInPeriod.
 
     # pycodestyle (E, W)
     "E711",  # NoneComparison  (see unfixable)


### PR DESCRIPTION
### Description

In ed47e90698e05f2f3868a3c932127e62d39c7ab1 Ruff was configured to use the `numpy` `pydocstyle` convention, which instructs Ruff to ignore the following rules: D107, D203, D212, D213, D402, D413, D415, D416, and D417 (see also https://www.pydocstyle.org/en/stable/error_codes.html#default-conventions for the lists of rules corresponding to the different conventions). There is no need to explicitly ignore those rules again in the configuration files.