### PR TITLE
Added registration label ‘ascii.latex’ to Cosmology IO

### DIFF
--- a/astropy/cosmology/io/latex.py
+++ b/astropy/cosmology/io/latex.py
@@ -48,10 +48,10 @@ def write_latex(
     TypeError
         If kwarg (optional) 'cls' is not a subclass of `astropy.table.Table`
     """
-    # Check that the format is 'latex' (or not specified)
+    # Check that the format is 'latex', 'ascii.latex' (or not specified)
     format = kwargs.pop("format", "latex")
-    if format != "latex":
-        raise ValueError(f"format must be 'latex', not {format}")
+    if format not in ("latex", "ascii.latex"):
+        raise ValueError(f"format must be 'latex' or 'ascii.latex', not {format}")
 
     # Set cosmology_in_meta as false for now since there is no metadata being kept
     table = to_table(cosmology, cls=cls, cosmology_in_meta=False)
@@ -76,3 +76,4 @@ def write_latex(
 # Register
 
 readwrite_registry.register_writer("latex", Cosmology, write_latex)
+readwrite_registry.register_writer("ascii.latex", Cosmology, write_latex)

--- a/astropy/cosmology/io/tests/test_latex.py
+++ b/astropy/cosmology/io/tests/test_latex.py
@@ -5,6 +5,7 @@ import pytest
 
 # LOCAL
 from astropy.cosmology.io.latex import _FORMAT_TABLE, write_latex
+from astropy.io.registry.base import IORegistryError
 from astropy.table import QTable, Table
 
 from .base import ReadWriteDirectTestBase, ReadWriteTestMixinBase
@@ -59,6 +60,15 @@ class WriteLATEXTestMixin(ReadWriteTestMixinBase):
         write(fp, format="latex")
         with pytest.raises(OSError, match="overwrite=True"):
             write(fp, format=format, overwrite=False)
+
+    def test_write_latex_unsupported_format(self, write, tmp_path):
+        """Test for unsupported format"""
+        fp = tmp_path / "test_write_latex_unsupported_format.tex"
+        invalid_format = "unsupported"
+        with pytest.raises((ValueError, IORegistryError)) as exc_info:
+            pytest.raises(ValueError, match="format must be 'latex' or 'ascii.latex'")
+            pytest.raises(IORegistryError, match="No writer defined for format")
+            write(fp, format=invalid_format)
 
 
 class TestReadWriteLaTex(ReadWriteDirectTestBase, WriteLATEXTestMixin):

--- a/astropy/cosmology/io/tests/test_latex.py
+++ b/astropy/cosmology/io/tests/test_latex.py
@@ -20,40 +20,45 @@ class WriteLATEXTestMixin(ReadWriteTestMixinBase):
     See ``TestCosmology`` for an example.
     """
 
-    def test_to_latex_failed_cls(self, write, tmp_path):
+    @pytest.mark.parametrize("format", ["latex", "ascii.latex"])
+    def test_to_latex_failed_cls(self, write, tmp_path, format):
         """Test failed table type."""
         fp = tmp_path / "test_to_latex_failed_cls.tex"
 
         with pytest.raises(TypeError, match="'cls' must be"):
-            write(fp, format="latex", cls=list)
+            write(fp, format=format, cls=list)
 
+    @pytest.mark.parametrize("format", ["latex", "ascii.latex"])
     @pytest.mark.parametrize("tbl_cls", [QTable, Table])
-    def test_to_latex_cls(self, write, tbl_cls, tmp_path):
+    def test_to_latex_cls(self, write, tbl_cls, tmp_path, format):
         fp = tmp_path / "test_to_latex_cls.tex"
-        write(fp, format="latex", cls=tbl_cls)
+        write(fp, format=format, cls=tbl_cls)
 
-    def test_latex_columns(self, write, tmp_path):
+    @pytest.mark.parametrize("format", ["latex", "ascii.latex"])
+    def test_latex_columns(self, write, tmp_path, format):
         fp = tmp_path / "test_rename_latex_columns.tex"
-        write(fp, format="latex", latex_names=True)
+        write(fp, format=format, latex_names=True)
         tbl = QTable.read(fp)
         # asserts each column name has not been reverted yet
         # For now, Cosmology class and name are stored in first 2 slots
         for column_name in tbl.colnames[2:]:
             assert column_name in _FORMAT_TABLE.values()
 
-    def test_write_latex_invalid_path(self, write):
+    @pytest.mark.parametrize("format", ["latex", "ascii.latex"])
+    def test_write_latex_invalid_path(self, write, format):
         """Test passing an invalid path"""
         invalid_fp = ""
         with pytest.raises(FileNotFoundError, match="No such file or directory"):
-            write(invalid_fp, format="latex")
+            write(invalid_fp, format=format)
 
-    def test_write_latex_false_overwrite(self, write, tmp_path):
+    @pytest.mark.parametrize("format", ["latex", "ascii.latex"])
+    def test_write_latex_false_overwrite(self, write, tmp_path, format):
         """Test to write a LaTeX file without overwriting an existing file"""
         # Test that passing an invalid path to write_latex() raises a IOError
         fp = tmp_path / "test_write_latex_false_overwrite.tex"
         write(fp, format="latex")
         with pytest.raises(OSError, match="overwrite=True"):
-            write(fp, format="latex", overwrite=False)
+            write(fp, format=format, overwrite=False)
 
 
 class TestReadWriteLaTex(ReadWriteDirectTestBase, WriteLATEXTestMixin):
@@ -67,10 +72,11 @@ class TestReadWriteLaTex(ReadWriteDirectTestBase, WriteLATEXTestMixin):
     def setup_class(self):
         self.functions = {"write": write_latex}
 
-    def test_rename_direct_latex_columns(self, write, tmp_path):
+    @pytest.mark.parametrize("format", ["latex", "ascii.latex"])
+    def test_rename_direct_latex_columns(self, write, tmp_path, format):
         """Tests renaming columns"""
         fp = tmp_path / "test_rename_latex_columns.tex"
-        write(fp, format="latex", latex_names=True)
+        write(fp, format=format, latex_names=True)
         tbl = QTable.read(fp)
         # asserts each column name has not been reverted yet
         for column_name in tbl.colnames[2:]:

--- a/astropy/cosmology/tests/test_connect.py
+++ b/astropy/cosmology/tests/test_connect.py
@@ -33,6 +33,7 @@ cosmo_instances = cosmology.realizations.available
 readwrite_formats = {
     ("ascii.ecsv", True, True),
     ("ascii.html", False, HAS_BS4),
+    ("ascii.latex", False, True),
     ("json", True, True),
     ("latex", False, True),
 }

--- a/docs/changes/cosmology/14938.api.rst
+++ b/docs/changes/cosmology/14938.api.rst
@@ -1,0 +1,1 @@
+Added registration label ``ascii.latex`` to Cosmology IO.

--- a/docs/whatsnew/6.0.rst
+++ b/docs/whatsnew/6.0.rst
@@ -60,7 +60,7 @@ supports the latex format in its :attr:`~astropy.cosmology.Cosmology.write()`
 method, allowing users to export a cosmology object to a LaTeX table.::
 
     >>> from astropy.cosmology import Planck18
-    >>> Planck18.write("example_cosmology.tex", format="latex")
+    >>> Planck18.write("example_cosmology.tex", format="ascii.latex")
 
 This will write the cosmology object to a file in LaTeX format,
 with appropriate formatting of units and table alignment.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address #14872 

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #14872 

Registered ```ascii.latex``` to  Cosmology IO.
