### PR TITLE
Always convert explicitly longitudes and latitudes to 'rad' instead of 'radians'

### DIFF
--- a/astropy/coordinates/builtin_frames/utils.py
+++ b/astropy/coordinates/builtin_frames/utils.py
@@ -208,7 +208,7 @@ def aticq(srepr, astrom):
     ignore_distance = srepr_distance.unit == u.one
 
     # RA, Dec to cartesian unit vectors
-    pos = erfa.s2c(srepr.lon.radian, srepr.lat.radian)
+    pos = erfa.s2c(srepr.lon.to_value(u.rad), srepr.lat.to_value(u.rad))
 
     # Bias-precession-nutation, giving GCRS proper direction.
     ppr = erfa.trxp(astrom["bpn"], pos)
@@ -293,7 +293,7 @@ def atciqz(srepr, astrom):
     ignore_distance = srepr_distance.unit == u.one
 
     # BCRS coordinate direction (unit vector).
-    pco = erfa.s2c(srepr.lon.radian, srepr.lat.radian)
+    pco = erfa.s2c(srepr.lon.to_value(u.rad), srepr.lat.to_value(u.rad))
 
     # Find BCRS direction of Sun to object
     if ignore_distance:

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -806,8 +806,8 @@ class SkyCoord(ShapedLikeNDArray):
             rv = 0.0
 
         starpm = erfa.pmsafe(
-            icrsrep.lon.radian,
-            icrsrep.lat.radian,
+            icrsrep.lon.to_value(u.rad),
+            icrsrep.lat.to_value(u.rad),
             icrsvel.d_lon.to_value(u.radian / u.yr),
             icrsvel.d_lat.to_value(u.radian / u.yr),
             plx,

--- a/astropy/coordinates/tests/test_transformations.py
+++ b/astropy/coordinates/tests/test_transformations.py
@@ -689,3 +689,13 @@ def test_combine_affine_params(first, second, check):
         assert result[1] is None
     else:
         assert_allclose(result[1].xyz, check[1].xyz)
+
+
+def test_cds_with_coordinates_transformations():
+    """See https://github.com/astropy/astropy/issues/14580."""
+    from astropy.coordinates import SkyCoord
+    from astropy.units import cds
+
+    with cds.enable():
+        c = SkyCoord(ra=10 * u.degree, dec=40 * u.degree, frame="icrs")
+        assert_allclose(c.geocentrictrueecliptic.lon.deg, np.array([26.59]), rtol=1e-3)

--- a/docs/changes/coordinates/14940.bugfix.rst
+++ b/docs/changes/coordinates/14940.bugfix.rst
@@ -1,0 +1,1 @@
+The coordinate transformations will now work even if other unit registries (such as CDS) are enabled.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

When converting between coordinate frames what is currently happening is that `lon` and `lat` attributes get converted to `radians`, which depending on the current unit registry might or might not be defined as an alias to `rad`.

Luckily, the latter is always defined as the official name for radians, so it makes sense to make sure that we convert these quantities always using the guaranteed unit name.

Fixes #14580.

Note that #14933 was originally opened to update the documentation and recall the user to use a context manager when enabling e.g. CDS units (which do not define "radians", only "rad"). This PR should be the effective fix, but I think it still makes sense to have also the older PR.

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #14580
