### PR TITLE
Manual backport of #14924 (Fix broken test in ndslicing)

### DIFF
--- a/astropy/nddata/mixins/tests/test_ndslicing.py
+++ b/astropy/nddata/mixins/tests/test_ndslicing.py
@@ -8,7 +8,11 @@ from numpy.testing import assert_array_equal
 from astropy import units as u
 from astropy.nddata import NDData, NDSlicingMixin
 from astropy.nddata import _testing as nd_testing
-from astropy.nddata.nduncertainty import NDUncertainty, StdDevUncertainty
+from astropy.nddata.nduncertainty import (
+    NDUncertainty,
+    StdDevUncertainty,
+    UnknownUncertainty,
+)
 
 
 # Just add the Mixin to NDData
@@ -153,7 +157,7 @@ def test_slicing_all_npndarray_shape_diff():
 def test_slicing_all_something_wrong():
     data = np.arange(10)
     mask = [False] * 10
-    uncertainty = {"rdnoise": 2.9, "gain": 1.4}
+    uncertainty = UnknownUncertainty({"rdnoise": 2.9, "gain": 1.4})
     naxis = 1
     wcs = nd_testing._create_wcs_simple(
         naxis=naxis,
@@ -169,7 +173,9 @@ def test_slicing_all_something_wrong():
     assert_array_equal(data[2:5], nd2.data)
     assert_array_equal(mask[2:5], nd2.mask)
     # Not sliced attributes (they will raise a Info nevertheless)
-    uncertainty is nd2.uncertainty
+    assert uncertainty.array == nd2.uncertainty.array
+    assert uncertainty.uncertainty_type == nd2.uncertainty.uncertainty_type
+    assert uncertainty.unit == nd2.uncertainty.unit
     assert nd2.wcs.pixel_to_world(1) == nd.wcs.pixel_to_world(3)
 
 


### PR DESCRIPTION
Fix broken test in ndslicing

(cherry picked from commit 62ef8af6db01bca29e1c15a709c217786f0a0160)

<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to manually backport #14924
