### PR TITLE
Build: Replace oldest-supported-numpy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = ["setuptools",
             "setuptools_scm>=6.2",
             "cython==0.29.34",
-            "oldest-supported-numpy",
+            "numpy>=1.25,<2",
             "extension-helpers"]
 build-backend = 'setuptools.build_meta'
 

--- a/setup.py
+++ b/setup.py
@@ -66,4 +66,11 @@ from setuptools import setup  # noqa: E402
 
 from extension_helpers import get_extensions  # noqa: E402
 
-setup(ext_modules=get_extensions())
+ext_modules = get_extensions()
+
+# Specify the minimum version for the Numpy C-API
+for ext in ext_modules:
+    if ext.include_dirs and "numpy" in ext.include_dirs[0]:
+        ext.define_macros.append(("NPY_TARGET_VERSION", "NPY_1_21_API_VERSION"))
+
+setup(ext_modules=ext_modules)


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to replace oldest-supported-numpy with numpy 1.25 that guarantee backward compatible C-API.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #14915
