### PR TITLE
Don't run trailing-whitespace check on astropy/*.py

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,8 @@ repos:
       # - id: fix-encoding-pragma  # covered by pyupgrade
       - id: trailing-whitespace
         # Trims trailing whitespace.
-        exclude: ".*(data.*|extern.*|licenses.*|_parsetab.py|test_cds.py)$"
+        exclude_types: [python]  # Covered by Ruff W291.
+        exclude: ".*(data.*|extern.*|licenses.*)$"
 
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.10.0


### PR DESCRIPTION
Ruff W291 is equivalent and has per-line ignore support.
