### PR TITLE
Use explicit imports

### DIFF
--- a/astropy/cosmology/__init__.py
+++ b/astropy/cosmology/__init__.py
@@ -8,24 +8,74 @@ detailed usage examples and references.
 
 """
 
-from . import core, flrw, funcs, parameter, realizations, units, utils
-from .core import *
-from .flrw import *
-from .funcs import *
-from .parameter import *
-from .realizations import available, default_cosmology
-from .utils import *
-
-__all__ = (
-    core.__all__
-    + flrw.__all__  # cosmology classes
-    + realizations.__all__  # instances thereof
-    + ["units"]
-    # utils
-    + funcs.__all__
-    + parameter.__all__
-    + utils.__all__
+from . import realizations, units
+from .core import Cosmology, CosmologyError, FlatCosmologyMixin
+from .flrw import (
+    FLRW,
+    FlatFLRWMixin,
+    FlatLambdaCDM,
+    Flatw0waCDM,
+    Flatw0wzCDM,
+    FlatwCDM,
+    FlatwpwaCDM,
+    LambdaCDM,
+    w0waCDM,
+    w0wzCDM,
+    wCDM,
+    wpwaCDM,
 )
+from .funcs import cosmology_equal, z_at_value
+from .parameter import Parameter
+from .realizations import (
+    WMAP1,
+    WMAP3,
+    WMAP5,
+    WMAP7,
+    WMAP9,
+    Planck13,
+    Planck15,
+    Planck18,
+    available,
+    default_cosmology,
+)
+
+__all__ = [
+    # Core
+    "Cosmology",
+    "CosmologyError",
+    "FlatCosmologyMixin",
+    # FLRW
+    "FLRW",
+    "FlatFLRWMixin",
+    "LambdaCDM",
+    "FlatLambdaCDM",
+    "wCDM",
+    "FlatwCDM",
+    "w0waCDM",
+    "Flatw0waCDM",
+    "w0wzCDM",
+    "Flatw0wzCDM",
+    "wpwaCDM",
+    "FlatwpwaCDM",
+    # Funcs
+    "z_at_value",
+    "cosmology_equal",
+    # Parameter
+    "Parameter",
+    # Realizations
+    "available",
+    "default_cosmology",
+    "WMAP1",
+    "WMAP3",
+    "WMAP5",
+    "WMAP7",
+    "WMAP9",
+    "Planck13",
+    "Planck15",
+    "Planck18",
+    # Units
+    "units",
+]
 
 
 def __getattr__(name):

--- a/astropy/cosmology/flrw/__init__.py
+++ b/astropy/cosmology/flrw/__init__.py
@@ -1,19 +1,30 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Astropy FLRW classes."""
 
-from . import base, lambdacdm, w0cdm, w0wacdm, w0wzcdm, wpwazpcdm
-from .base import *
-from .lambdacdm import *
-from .w0cdm import *
-from .w0wacdm import *
-from .w0wzcdm import *
-from .wpwazpcdm import *
+__all__ = [
+    # base
+    "FLRW",
+    "FlatFLRWMixin",
+    # lambdacdm
+    "LambdaCDM",
+    "FlatLambdaCDM",
+    # w0cdm
+    "wCDM",
+    "FlatwCDM",
+    # w0wacdm
+    "w0waCDM",
+    "Flatw0waCDM",
+    # w0wzcdm
+    "w0wzCDM",
+    "Flatw0wzCDM",
+    # wpwazpcdm
+    "wpwaCDM",
+    "FlatwpwaCDM",
+]
 
-__all__ = (
-    base.__all__
-    + lambdacdm.__all__
-    + w0cdm.__all__
-    + w0wacdm.__all__
-    + wpwazpcdm.__all__
-    + w0wzcdm.__all__
-)
+from .base import FLRW, FlatFLRWMixin
+from .lambdacdm import FlatLambdaCDM, LambdaCDM
+from .w0cdm import FlatwCDM, wCDM
+from .w0wacdm import Flatw0waCDM, w0waCDM
+from .w0wzcdm import Flatw0wzCDM, w0wzCDM
+from .wpwazpcdm import FlatwpwaCDM, wpwaCDM

--- a/astropy/cosmology/parameters.py
+++ b/astropy/cosmology/parameters.py
@@ -63,7 +63,17 @@ from types import MappingProxyType
 # LOCAL
 from .realizations import available
 
-__all__ = ["available"] + list(available)
+__all__ = ["available"]
+__all__ += [  # noqa: F822
+    "WMAP1",
+    "WMAP3",
+    "WMAP5",
+    "WMAP7",
+    "WMAP9",
+    "Planck13",
+    "Planck15",
+    "Planck18",
+]
 
 
 def __getattr__(name):

--- a/astropy/cosmology/realizations.py
+++ b/astropy/cosmology/realizations.py
@@ -1,5 +1,19 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+__all__ = [  # noqa: F822 (undefined name)
+    "available",
+    "default_cosmology",
+    # Realizations (dynamic attribute, see __getattr__)
+    "WMAP1",
+    "WMAP3",
+    "WMAP5",
+    "WMAP7",
+    "WMAP9",
+    "Planck13",
+    "Planck15",
+    "Planck18",
+]
+
 # STDLIB
 import pathlib
 import sys
@@ -13,15 +27,21 @@ from astropy.utils.state import ScienceState
 from . import _io  # Ensure IO methods are registered, to read realizations # noqa: F401
 from .core import Cosmology
 
+__doctest_requires__ = {"*": ["scipy"]}
+
 _COSMOLOGY_DATA_DIR = pathlib.Path(
     get_pkg_data_path("cosmology", "data", package="astropy")
 )
-available = tuple(sorted(p.stem for p in _COSMOLOGY_DATA_DIR.glob("*.ecsv")))
-
-
-__all__ = ["available", "default_cosmology"] + list(available)
-
-__doctest_requires__ = {"*": ["scipy"]}
+available = (
+    "WMAP1",
+    "WMAP3",
+    "WMAP5",
+    "WMAP7",
+    "WMAP9",
+    "Planck13",
+    "Planck15",
+    "Planck18",
+)
 
 
 def __getattr__(name):


### PR DESCRIPTION
Changing the imports to be explicit. I prefer it, and so does my static checker.
While more verbose, I also think this is much more explicit and now I can tell at a glance what is imported.
Also, it's going to make some planned deprecations easier.
There shouldn't be any API change in this PR.