### PR TITLE
remove back compat import from v5.2

### DIFF
--- a/astropy/cosmology/funcs/__init__.py
+++ b/astropy/cosmology/funcs/__init__.py
@@ -3,8 +3,6 @@
 """Functions for `astropy.cosmology`."""
 
 from .comparison import cosmology_equal
-
-# _z_at_scalar_value is imported for backwards compatibility
-from .optimize import _z_at_scalar_value, z_at_value
+from .optimize import z_at_value
 
 __all__ = ["z_at_value", "cosmology_equal"]

--- a/astropy/cosmology/funcs/tests/test_funcs.py
+++ b/astropy/cosmology/funcs/tests/test_funcs.py
@@ -9,7 +9,8 @@ import pytest
 
 from astropy import units as u
 from astropy.cosmology import core, flrw
-from astropy.cosmology.funcs import _z_at_scalar_value, z_at_value
+from astropy.cosmology.funcs import z_at_value
+from astropy.cosmology.funcs.optimize import _z_at_scalar_value
 from astropy.cosmology.realizations import (
     WMAP1,
     WMAP3,


### PR DESCRIPTION
The `funcs` folder was made in v5.2 and a private import was kept for backward compatibility. While we had no obligation to maintain the private import, we did to make seamless the transition from the `funcs` file to folder.
2 versions later I am removing this private import.
