### PR TITLE
TST: Ignore product DeprecationWarning from h5py when testing against numpy 1.25, update mpl figure hashes

### DIFF
--- a/astropy/io/misc/tests/test_hdf5.py
+++ b/astropy/io/misc/tests/test_hdf5.py
@@ -592,7 +592,9 @@ def test_skip_meta(tmp_path):
     )
     with pytest.warns(AstropyUserWarning, match=wtext) as w:
         t1.write(test_file, path="the_table")
-    assert len(w) == 1
+    # TODO: Uncomment when h5py catches up with numpy 1.25, see
+    # https://github.com/astropy/astropy/issues/14881
+    # assert len(w) == 1
 
 
 @pytest.mark.skipif(not HAS_H5PY, reason="requires h5py")

--- a/astropy/tests/figures/py39-test-image-mpl334-cov.json
+++ b/astropy/tests/figures/py39-test-image-mpl334-cov.json
@@ -47,10 +47,10 @@
   "astropy.visualization.wcsaxes.tests.test_images.test_1d_plot_put_varying_axis_on_bottom_lon[slices0-hpln]": "faa499a2e433ab6b7b600c7163723af9bf075bbc55a7d82f8901b7667417990c",
   "astropy.visualization.wcsaxes.tests.test_images.test_1d_plot_put_varying_axis_on_bottom_lon[slices1-hplt]": "e29d3f05923fcdaa5804dbd0b2239b02745bfb1acaabcff054974f00271ad093",
   "astropy.visualization.wcsaxes.tests.test_images.test_allsky_labels_wrap": "2ddc0aa50392293e18962df062af6075c13d3c16685fee85320d3cd0a7d98b3e",
-  "astropy.visualization.wcsaxes.tests.test_images.test_tickable_gridlines": "1be26963aaba221f9cd396aea0b9618e05ab8a49f8c02c0b4540041e91d06ce7",
-  "astropy.visualization.wcsaxes.tests.test_transform_coord_meta.TestTransformCoordMeta.test_coords_overlay": "f84074e12142676d17aca8e907065cf1eec4a55ea7d60ce7d7f22f456c09c24c",
+  "astropy.visualization.wcsaxes.tests.test_images.test_tickable_gridlines": "acc7588e1a9c4229515e2236bc55432e9d7d9265dcab65e273ff7e428e940b87",
+  "astropy.visualization.wcsaxes.tests.test_transform_coord_meta.TestTransformCoordMeta.test_coords_overlay": "bdb49e3f26611fa4d9cc125dac08e51db216151ae11b59cbf0f1f0192484595d",
   "astropy.visualization.wcsaxes.tests.test_transform_coord_meta.TestTransformCoordMeta.test_coords_overlay_auto_coord_meta": "6e1d2d47e77b710c3a00e0d98e723f0cd9351dd2b35350693744192bec670e8d",
-  "astropy.visualization.wcsaxes.tests.test_transform_coord_meta.TestTransformCoordMeta.test_direct_init": "99e84ea7ae80a9444c73d4fb9f24d707795149e1aeb18c3c1a7072bc3e134732",
+  "astropy.visualization.wcsaxes.tests.test_transform_coord_meta.TestTransformCoordMeta.test_direct_init": "efffd4e7e96acac88c7f1aaeab8af8721c2b5dbde08a3c9b2153a1b20882e9da",
   "astropy.visualization.wcsaxes.tests.test_wcsapi.test_wcsapi_5d_with_names": "d2dd2f7efef595a5819906c3f4f77f68d70d29efca5851d19528aecb0e3f8035",
   "astropy.visualization.wcsaxes.tests.test_wcsapi.test_wcsapi_2d_celestial_arcsec": "4b743d645a85d7516decbcf4a831c127af5a1800072597c2a1299d17fb186adb"
 }

--- a/astropy/tests/figures/py39-test-image-mpldev-cov.json
+++ b/astropy/tests/figures/py39-test-image-mpldev-cov.json
@@ -47,7 +47,7 @@
   "astropy.visualization.wcsaxes.tests.test_images.test_1d_plot_put_varying_axis_on_bottom_lon[slices0-hpln]": "faa499a2e433ab6b7b600c7163723af9bf075bbc55a7d82f8901b7667417990c",
   "astropy.visualization.wcsaxes.tests.test_images.test_1d_plot_put_varying_axis_on_bottom_lon[slices1-hplt]": "e29d3f05923fcdaa5804dbd0b2239b02745bfb1acaabcff054974f00271ad093",
   "astropy.visualization.wcsaxes.tests.test_images.test_allsky_labels_wrap": "2ddc0aa50392293e18962df062af6075c13d3c16685fee85320d3cd0a7d98b3e",
-  "astropy.visualization.wcsaxes.tests.test_images.test_tickable_gridlines": "8be2fd1fd4e60ad4675fd280b42bde9c2a043fac9c4a36a7eca2f2d8df6152be",
+  "astropy.visualization.wcsaxes.tests.test_images.test_tickable_gridlines": "d02ba8cdc79b1eed9eea9518183349ddf222a8ba01b477d7d80b7017dc66c5e7",
   "astropy.visualization.wcsaxes.tests.test_transform_coord_meta.TestTransformCoordMeta.test_coords_overlay": "0a87473ff8e5b5610f4adac1518c608afcd2178b25584fb42f77bcc594c4f47a",
   "astropy.visualization.wcsaxes.tests.test_transform_coord_meta.TestTransformCoordMeta.test_coords_overlay_auto_coord_meta": "4ab8cade790f7ab36c620cb136e076a14eccf1dac7109a3d4d5601cebc46ac8a",
   "astropy.visualization.wcsaxes.tests.test_transform_coord_meta.TestTransformCoordMeta.test_direct_init": "1f24c5243bfdf0f30e88afc4f2f5d66db85954cea50a2910af94975ff8765b45",

--- a/setup.cfg
+++ b/setup.cfg
@@ -144,6 +144,7 @@ filterwarnings =
     ignore:Unknown config option:pytest.PytestConfigWarning
     ignore:matplotlibrc text\.usetex:UserWarning:matplotlib
     ignore:The 'text' argument to find\(\)-type methods is deprecated:DeprecationWarning
+    # TODO: Uncomment when h5py catches up with numpy 1.25, see
     # https://github.com/astropy/astropy/issues/14881
     ignore:.*product.*is deprecated as of NumPy 1\.25\.0.*:DeprecationWarning
     # Triggered by ProgressBar > ipykernel.iostream

--- a/setup.cfg
+++ b/setup.cfg
@@ -144,6 +144,8 @@ filterwarnings =
     ignore:Unknown config option:pytest.PytestConfigWarning
     ignore:matplotlibrc text\.usetex:UserWarning:matplotlib
     ignore:The 'text' argument to find\(\)-type methods is deprecated:DeprecationWarning
+    # https://github.com/astropy/astropy/issues/14881
+    ignore:.*product.*is deprecated as of NumPy 1\.25\.0.*:DeprecationWarning
     # Triggered by ProgressBar > ipykernel.iostream
     ignore:the imp module is deprecated:DeprecationWarning
     # Ignore a warning we emit about not supporting the parallel


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

I tried to wait it out but h5py release is too slow so now we're affected by https://github.com/astropy/astropy/issues/14881 for real in unrelated PRs. We will just ignore the warning as there is nothing we can do about it.

Close #14881 