### PR TITLE
Fix table group keys for mixin columns

### DIFF
--- a/astropy/table/tests/conftest.py
+++ b/astropy/table/tests/conftest.py
@@ -204,8 +204,7 @@ def mixin_cols(request):
     return cols
 
 
-@pytest.fixture(params=[False, True])
-def T1(request):
+def _get_test_table():
     T = QTable.read(
         [
             " a b c d",
@@ -224,7 +223,42 @@ def T1(request):
     T.meta.update({"ta": 1})
     T["c"].meta.update({"a": 1})
     T["c"].description = "column c"
+    return T
+
+
+@pytest.fixture()
+def T1b(request):
+    """Basic table"""
+    T = _get_test_table()
+    return T
+
+
+@pytest.fixture(params=[False, True])
+def T1(request):
+    """Basic table with or without index on integer column a"""
+    T = _get_test_table()
     if request.param:
+        T.add_index("a")
+    return T
+
+
+@pytest.fixture(params=[False, True])
+def T1q(request):
+    """Basic table where a column is integer or Quantity"""
+    T = _get_test_table()
+    if request.param:
+        T["a"] = T["a"] * u.m
+    return T
+
+
+@pytest.fixture(params=[(False, False), (False, True), (True, False), (True, True)])
+def T1m(request):
+    """Basic table with or without index on column a, where a is integer or Quantity"""
+    T = _get_test_table()
+    add_index, is_quantity = request.param
+    if is_quantity:
+        T["a"] = T["a"] * u.m
+    if add_index:
         T.add_index("a")
     return T
 

--- a/docs/changes/table/14966.bugfix.rst
+++ b/docs/changes/table/14966.bugfix.rst
@@ -1,0 +1,4 @@
+Fixed issue #14964 that when grouping a Table on a mixin column such as ``Quantity`` or
+``Time``, the grouped table keys did not reflect the original column values. For
+``Quantity`` this meant that the key values were pure float values without the unit,
+while for ``Time`` the key values were the pair of ``jd1`` and ``jd2`` float values.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address #14964. That issue mentioned only `Quantity` but the real issue was with mixin columns where the final sort key columns might be different from the original mixin column.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #14964
