### PR TITLE
Avoid `inspect.isclass()`

### DIFF
--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -7,7 +7,6 @@ classes.
 
 # Standard library
 import copy
-import inspect
 import warnings
 from collections import defaultdict, namedtuple
 
@@ -394,7 +393,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
         if representation_type is None:
             representation_type = self.default_representation
 
-        if inspect.isclass(differential_type) and issubclass(
+        if isinstance(differential_type, type) and issubclass(
             differential_type, r.BaseDifferential
         ):
             # TODO: assumes the differential class is for the velocity
@@ -938,7 +937,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
         # This is to provide a slightly nicer error message if the user tries
         # to use frame_obj.representation instead of frame_obj.data to get the
         # underlying representation object [e.g., #2890]
-        if inspect.isclass(data):
+        if isinstance(data, type):
             raise TypeError(
                 "Class passed as data instead of a representation instance. If you"
                 " called frame.representation, this returns the representation class."
@@ -1276,7 +1275,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
                 " https://github.com/astropy/astropy/issues/6280"
             )
 
-        if inspect.isclass(new_frame):
+        if isinstance(new_frame, type):
             warnings.warn(
                 "Transforming a frame instance to a frame class (as opposed to another "
                 "frame instance) will not be supported in the future.  Either "
@@ -1334,7 +1333,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
         transformation between two objects of the same frame class but with
         different attributes.
         """
-        new_frame_cls = new_frame if inspect.isclass(new_frame) else new_frame.__class__
+        new_frame_cls = new_frame if isinstance(new_frame, type) else type(new_frame)
         trans = frame_transform_graph.get_transform(self.__class__, new_frame_cls)
 
         if trans is None:

--- a/astropy/coordinates/representation/base.py
+++ b/astropy/coordinates/representation/base.py
@@ -3,7 +3,6 @@
 
 import abc
 import functools
-import inspect
 import operator
 import warnings
 
@@ -816,7 +815,7 @@ class BaseRepresentation(BaseRepresentationOrDifferential):
 
         elif (
             len(self.differentials) == 1
-            and inspect.isclass(differential_class)
+            and isinstance(differential_class, type)
             and issubclass(differential_class, BaseDifferential)
         ):
             # TODO: is there a better way to do this?

--- a/astropy/coordinates/representation/spherical.py
+++ b/astropy/coordinates/representation/spherical.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Spherical representations and differentials."""
-import inspect
 import operator
 
 import numpy as np
@@ -120,7 +119,7 @@ class UnitSphericalRepresentation(BaseRepresentation):
         # keeps differentials' unit keys, but this can result in a mismatch
         # between the UnitSpherical expected key (e.g. "s") and that expected
         # in the other class (here "s / m"). For more info, see PR #11467
-        if inspect.isclass(other_class) and not differential_class:
+        if isinstance(other_class, type) and not differential_class:
             if issubclass(other_class, PhysicsSphericalRepresentation):
                 return other_class(
                     phi=self.lon, theta=90 * u.deg - self.lat, r=1.0, copy=False
@@ -511,7 +510,7 @@ class SphericalRepresentation(BaseRepresentation):
     def represent_as(self, other_class, differential_class=None):
         # Take a short cut if the other class is a spherical representation
 
-        if inspect.isclass(other_class):
+        if isinstance(other_class, type):
             if issubclass(other_class, PhysicsSphericalRepresentation):
                 diffs = self._re_represent_differentials(
                     other_class, differential_class
@@ -718,7 +717,7 @@ class PhysicsSphericalRepresentation(BaseRepresentation):
     def represent_as(self, other_class, differential_class=None):
         # Take a short cut if the other class is a spherical representation
 
-        if inspect.isclass(other_class):
+        if isinstance(other_class, type):
             if issubclass(other_class, SphericalRepresentation):
                 diffs = self._re_represent_differentials(
                     other_class, differential_class

--- a/astropy/coordinates/sky_coordinate_parsers.py
+++ b/astropy/coordinates/sky_coordinate_parsers.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-import inspect
 import re
 from collections.abc import Sequence
 
@@ -51,7 +50,7 @@ def _get_frame_class(frame):
             )
         frame_cls = frame_transform_graph.lookup_name(frame)
 
-    elif inspect.isclass(frame) and issubclass(frame, BaseCoordinateFrame):
+    elif isinstance(frame, type) and issubclass(frame, BaseCoordinateFrame):
         frame_cls = frame
 
     else:

--- a/astropy/coordinates/transformations.py
+++ b/astropy/coordinates/transformations.py
@@ -16,7 +16,6 @@ transformations that are typically how the algorithms are defined.
 
 
 import heapq
-import inspect
 import subprocess
 from abc import ABCMeta, abstractmethod
 from collections import defaultdict
@@ -170,9 +169,9 @@ class TransformGraph:
             not callable.
 
         """
-        if not inspect.isclass(fromsys):
+        if not isinstance(fromsys, type):
             raise TypeError("fromsys must be a class")
-        if not inspect.isclass(tosys):
+        if not isinstance(tosys, type):
             raise TypeError("tosys must be a class")
         if not callable(transform):
             raise TypeError("transform must be callable")
@@ -412,9 +411,9 @@ class TransformGraph:
         consistent with 1-hop transformations.
 
         """
-        if not inspect.isclass(fromsys):
+        if not isinstance(fromsys, type):
             raise TypeError("fromsys is not a class")
-        if not inspect.isclass(tosys):
+        if not isinstance(tosys, type):
             raise TypeError("tosys is not a class")
 
         path, distance = self.find_shortest_path(fromsys, tosys)
@@ -816,9 +815,9 @@ class CoordinateTransform(metaclass=ABCMeta):
     """
 
     def __init__(self, fromsys, tosys, priority=1, register_graph=None):
-        if not inspect.isclass(fromsys):
+        if not isinstance(fromsys, type):
             raise TypeError("fromsys must be a class")
-        if not inspect.isclass(tosys):
+        if not isinstance(tosys, type):
             raise TypeError("tosys must be a class")
 
         self.fromsys = fromsys
@@ -829,7 +828,7 @@ class CoordinateTransform(metaclass=ABCMeta):
             # this will do the type-checking when it adds to the graph
             self.register(register_graph)
         else:
-            if not inspect.isclass(fromsys) or not inspect.isclass(tosys):
+            if not isinstance(fromsys, type) or not isinstance(tosys, type):
                 raise TypeError("fromsys and tosys must be classes")
 
         self.overlapping_frame_attr_names = overlap = []

--- a/astropy/cosmology/_io/tests/test_mapping.py
+++ b/astropy/cosmology/_io/tests/test_mapping.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-import inspect
 from collections import OrderedDict
 
 import numpy as np
@@ -61,7 +60,7 @@ class ToFromMappingTestMixin(ToFromTestMixinBase):
 
         # Cosmology is the class
         m = to_format("mapping", cosmology_as_str=False)
-        assert inspect.isclass(m["cosmology"])
+        assert isinstance(m["cosmology"], type)
         assert cosmo_cls is m["cosmology"]
 
         assert m == default  # False is the default option

--- a/astropy/cosmology/tests/helper.py
+++ b/astropy/cosmology/tests/helper.py
@@ -56,7 +56,7 @@ def get_redshift_methods(cosmology, include_private=True, include_z2=True):
     # Sieve out incompatible methods.
     # The index to check for redshift depends on whether cosmology is a class
     # or instance and does/doesn't include 'self'.
-    iz1 = 1 if inspect.isclass(cosmology) else 0
+    iz1 = int(isinstance(cosmology, type))
     for n in tuple(methods):
         try:
             sig = inspect.signature(getattr(cosmology, n))

--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -323,14 +323,14 @@ class Fitter(metaclass=_FitterMeta):
             raise ValueError("Expected an optimizer.")
         if statistic is None:
             raise ValueError("Expected a statistic function.")
-        if inspect.isclass(optimizer):
+        if isinstance(optimizer, type):
             # a callable class
             self._opt_method = optimizer()
         elif inspect.isfunction(optimizer):
             self._opt_method = optimizer
         else:
             raise ValueError("Expected optimizer to be a callable class or a function.")
-        if inspect.isclass(statistic):
+        if isinstance(statistic, type):
             self._stat_method = statistic()
         else:
             self._stat_method = statistic
@@ -2184,7 +2184,7 @@ def populate_entry_points(entry_points):
                 )
             )
         else:
-            if not inspect.isclass(entry_point):
+            if not isinstance(entry_point, type):
                 warnings.warn(
                     AstropyUserWarning(
                         f"Modeling entry point {name} expected to be a Class."

--- a/astropy/table/info.py
+++ b/astropy/table/info.py
@@ -6,7 +6,6 @@ import os
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import sys
 from contextlib import contextmanager
-from inspect import isclass
 
 import numpy as np
 
@@ -172,7 +171,7 @@ def serialize_method_as(tbl, serialize_method):
 
         # Otherwise look for subclass matches
         for key in serialize_method:
-            if isclass(key) and isinstance(col, key):
+            if isinstance(key, type) and isinstance(col, key):
                 return serialize_method[key]
 
         return None

--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -3,7 +3,6 @@
 This module provides the tools used to internally run the astropy test suite
 from the installed astropy.  It makes use of the `pytest`_ testing framework.
 """
-import inspect
 import os
 import pickle
 
@@ -142,7 +141,7 @@ def generic_recursive_equality_test(a, b, class_history):
         # with required argument(s) are passed to this function.
         # For a class with `__slots__` the default state is not a `dict`;
         # with neither `__dict__` nor `__slots__` it is `None`.
-        state = a.__getstate__(a) if inspect.isclass(a) else a.__getstate__()
+        state = a.__getstate__(a) if isinstance(a, type) else a.__getstate__()
         dict_a = state if isinstance(state, dict) else getattr(a, "__dict__", dict())
     dict_b = b.__dict__
     for key in dict_a:


### PR DESCRIPTION
### Description

In Python 3 (but not in Python 2) [`inspect.isclass(x)`](https://docs.python.org/3/library/inspect.html#inspect.isclass) produces the same result as [`isinstance(x, type)`](https://docs.python.org/3/library/functions.html?highlight=isinstance#isinstance), but the latter does not require importing `inspect`:
https://github.com/python/cpython/blob/1528b420b33ae5c636b6016ce6c6afb0b09e7694/Lib/inspect.py#L73-L79

A single use of `inspect.isclass` in a `filter()` call remains because avoiding it there would not simplify the code: https://github.com/astropy/astropy/blob/e9ef294ddb8a47e212f0465645250238e7120d7c/astropy/utils/masked/tests/test_function_helpers.py#L1438

### Approvals by sub-package
 - [x] coordinates https://github.com/astropy/astropy/pull/14967#pullrequestreview-1488908087
 - [x] cosmology https://github.com/astropy/astropy/pull/14967#pullrequestreview-1488646171
 - [x] modeling
 - [x] table https://github.com/astropy/astropy/pull/14967#pullrequestreview-1488908087
 - [ ] tests