### PR TITLE
TST: Un-ignore deprecation warning from h5py

### DIFF
--- a/astropy/io/misc/tests/test_hdf5.py
+++ b/astropy/io/misc/tests/test_hdf5.py
@@ -592,9 +592,7 @@ def test_skip_meta(tmp_path):
     )
     with pytest.warns(AstropyUserWarning, match=wtext) as w:
         t1.write(test_file, path="the_table")
-    # TODO: Uncomment when h5py catches up with numpy 1.25, see
-    # https://github.com/astropy/astropy/issues/14881
-    # assert len(w) == 1
+    assert len(w) == 1
 
 
 @pytest.mark.skipif(not HAS_H5PY, reason="requires h5py")

--- a/setup.cfg
+++ b/setup.cfg
@@ -144,9 +144,6 @@ filterwarnings =
     ignore:Unknown config option:pytest.PytestConfigWarning
     ignore:matplotlibrc text\.usetex:UserWarning:matplotlib
     ignore:The 'text' argument to find\(\)-type methods is deprecated:DeprecationWarning
-    # TODO: Uncomment when h5py catches up with numpy 1.25, see
-    # https://github.com/astropy/astropy/issues/14881
-    ignore:.*product.*is deprecated as of NumPy 1\.25\.0.*:DeprecationWarning
     # Triggered by ProgressBar > ipykernel.iostream
     ignore:the imp module is deprecated:DeprecationWarning
     # Ignore a warning we emit about not supporting the parallel


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to un-ignore deprecation warning from h5py caused by numpy 1.25.0 because there is a new h5py 3.9.0. This reverts part of #14955 .

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->
