### PR TITLE
DOC: Fix broken ASDF link

### DIFF
--- a/docs/io/misc.rst
+++ b/docs/io/misc.rst
@@ -165,7 +165,7 @@ coordinate frames). Documentation of the individual schemas defined by
 Not all ``astropy`` types are currently serializable by ASDF. Attempting to
 write unsupported types to an ASDF file will lead to a ``RepresenterError``. In
 order to support new types, new tags and schemas must be created. See `Writing
-ASDF Extensions <https://asdf.readthedocs.io/en/latest/asdf/extending/legacy.html>`_
+ASDF Extensions <https://asdf.readthedocs.io/en/2.15.0/asdf/extending/legacy.html>`_
 for additional details, as well as the following example.
 
 Example: Adding a New Object to the Astropy ASDF Extension


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to fix broken ASDF link in backport branches because they removed the legacy extension page. This does not affect `main` because we removed `astropy.io.misc.asdf` for v6.0.

See https://github.com/asdf-format/asdf/issues/1566