### PR TITLE
Remove deprecated Quantity.nansum() method

### DIFF
--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -19,7 +19,6 @@ import numpy as np
 from astropy import config as _config
 from astropy.utils.compat.numpycompat import NUMPY_LT_2_0
 from astropy.utils.data_info import ParentDtypeInfo
-from astropy.utils.decorators import deprecated
 from astropy.utils.exceptions import AstropyWarning
 from astropy.utils.misc import isiterable
 
@@ -2002,19 +2001,6 @@ class Quantity(np.ndarray):
 
     def ediff1d(self, to_end=None, to_begin=None):
         return self._wrap_function(np.ediff1d, to_end, to_begin)
-
-    @deprecated("5.3", alternative="np.nansum", obj_type="method")
-    def nansum(self, axis=None, out=None, keepdims=False, *, initial=None, where=True):
-        if initial is not None:
-            initial = self._to_own_unit(initial)
-        return self._wrap_function(
-            np.nansum,
-            axis,
-            out=out,
-            keepdims=keepdims,
-            initial=initial,
-            where=where,
-        )
 
     def insert(self, obj, values, axis=None):
         """

--- a/astropy/units/tests/test_quantity_array_methods.py
+++ b/astropy/units/tests/test_quantity_array_methods.py
@@ -347,37 +347,6 @@ class TestQuantityStatsFuncs:
         q1.cumsum(out=q1)
         assert np.all(q2 == qi)
 
-    @pytest.mark.filterwarnings("ignore:The nansum method is deprecated")
-    def test_nansum(self):
-        q1 = np.array([1.0, 2.0, np.nan]) * u.m
-        assert np.all(q1.nansum() == 3.0 * u.m)
-        assert np.all(np.nansum(q1) == 3.0 * u.m)
-
-        q2 = np.array([[np.nan, 5.0, 9.0], [1.0, np.nan, 1.0]]) * u.s
-        assert np.all(q2.nansum(0) == np.array([1.0, 5.0, 10.0]) * u.s)
-        assert np.all(np.nansum(q2, 0) == np.array([1.0, 5.0, 10.0]) * u.s)
-
-    @pytest.mark.filterwarnings("ignore:The nansum method is deprecated")
-    def test_nansum_inplace(self):
-        q1 = np.array([1.0, 2.0, np.nan]) * u.m
-        qi = 1.5 * u.s
-        qout = q1.nansum(out=qi)
-        assert qout is qi
-        assert qi == np.nansum(q1.value) * q1.unit
-
-        qi2 = 1.5 * u.s
-        qout2 = np.nansum(q1, out=qi2)
-        assert qout2 is qi2
-        assert qi2 == np.nansum(q1.value) * q1.unit
-
-    @pytest.mark.filterwarnings("ignore:The nansum method is deprecated")
-    def test_nansum_where(self):
-        q1 = np.array([1.0, 2.0, np.nan, 4.0]) * u.m
-        initial = 0 * u.m
-        where = q1 < 4 * u.m
-        assert np.all(q1.nansum(initial=initial, where=where) == 3.0 * u.m)
-        assert np.all(np.nansum(q1, initial=initial, where=where) == 3.0 * u.m)
-
     def test_prod(self):
         q1 = np.array([1, 2, 6]) * u.m
         with pytest.raises(u.UnitsError) as exc:

--- a/docs/changes/units/14977.api.rst
+++ b/docs/changes/units/14977.api.rst
@@ -1,0 +1,1 @@
+The deprecated ``Quantity.nansum()`` method has been removed.


### PR DESCRIPTION
~**DO NOT MERGE before branching v6.0.x**~ The deprecation warning was introduced in 5.3, so we can merge this for 6.1.

As the title suggests. Reminded of it when closing #14265. I think for this basically unused method, a single deprecation period seems ample.