### PR TITLE
Register YAML on class creation

### DIFF
--- a/astropy/cosmology/_io/yaml.py
+++ b/astropy/cosmology/_io/yaml.py
@@ -200,9 +200,6 @@ def to_yaml(cosmology, *args):
 # ===================================================================
 # Register
 
-for cosmo_cls in _COSMOLOGY_CLASSES.values():
-    register_cosmology_yaml(cosmo_cls)
-
 convert_registry.register_reader("yaml", Cosmology, from_yaml)
 convert_registry.register_writer("yaml", Cosmology, to_yaml)
 # convert_registry.register_identifier("yaml", Cosmology, yaml_identify)

--- a/astropy/cosmology/tests/test_core.py
+++ b/astropy/cosmology/tests/test_core.py
@@ -141,6 +141,9 @@ class CosmologyTest(
     def test_init_subclass(self, cosmo_cls):
         """Test creating subclasses registers classes and manages Parameters."""
 
+        # -----------------------------------------------------------
+        # Normal subclass creation
+
         class InitSubclassTest(cosmo_cls):
             pass
 
@@ -150,6 +153,18 @@ class CosmologyTest(
         # test and cleanup registry
         registrant = _COSMOLOGY_CLASSES.pop(InitSubclassTest.__qualname__)
         assert registrant is InitSubclassTest
+
+        # -----------------------------------------------------------
+        # Skip
+
+        class UnRegisteredSubclassTest(cosmo_cls):
+            @classmethod
+            def _register_cls(cls):
+                """Override to not register."""
+                pass
+
+        assert UnRegisteredSubclassTest.__parameters__ == cosmo_cls.__parameters__
+        assert UnRegisteredSubclassTest.__qualname__ not in _COSMOLOGY_CLASSES
 
     def test_init_signature(self, cosmo_cls, cosmo):
         """Test class-property ``_init_signature``."""


### PR DESCRIPTION
Auto-registration of Cosmology classes with YAML.
Optionally turn off the registration for e.g. temporary classes.