### PR TITLE
split init into post-init

### DIFF
--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -157,6 +157,11 @@ class Cosmology(metaclass=abc.ABCMeta):
         self._name = str(name) if name is not None else name
         self.meta.update(meta or {})
 
+        self.__post_init__()
+
+    def __post_init__(self):  # noqa: B027
+        pass
+
     @property
     def name(self):
         """The name of the Cosmology instance."""

--- a/astropy/cosmology/flrw/base.py
+++ b/astropy/cosmology/flrw/base.py
@@ -199,8 +199,6 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         name=None,
         meta=None,
     ):
-        super().__init__(name=name, meta=meta)
-
         # Assign (and validate) Parameters
         self.H0 = H0
         self.Om0 = Om0
@@ -284,6 +282,9 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         # Compute curvature density
         self._Ok0 = 1.0 - self._Om0 - self._Ode0 - self._Ogamma0 - self._Onu0
 
+        super().__init__(name=name, meta=meta)
+
+    def __post_init__(self):
         # Subclasses should override this reference if they provide
         #  more efficient scalar versions of inv_efunc.
         self._inv_efunc_scalar = self.inv_efunc

--- a/astropy/cosmology/flrw/lambdacdm.py
+++ b/astropy/cosmology/flrw/lambdacdm.py
@@ -112,6 +112,7 @@ class LambdaCDM(FLRW):
             meta=meta,
         )
 
+    def __post_init__(self):
         # Please see :ref:`astropy-cosmology-fast-integrals` for discussion
         # about what is being done here.
         if self._Tcmb0.value == 0:

--- a/astropy/cosmology/flrw/w0cdm.py
+++ b/astropy/cosmology/flrw/w0cdm.py
@@ -94,6 +94,7 @@ class wCDM(FLRW):
         name=None,
         meta=None
     ):
+        self.w0 = w0
         super().__init__(
             H0=H0,
             Om0=Om0,
@@ -105,8 +106,8 @@ class wCDM(FLRW):
             name=name,
             meta=meta,
         )
-        self.w0 = w0
 
+    def __post_init__(self):
         # Please see :ref:`astropy-cosmology-fast-integrals` for discussion
         # about what is being done here.
         if self._Tcmb0.value == 0:

--- a/astropy/cosmology/flrw/w0wacdm.py
+++ b/astropy/cosmology/flrw/w0wacdm.py
@@ -110,6 +110,8 @@ class w0waCDM(FLRW):
         name=None,
         meta=None
     ):
+        self.w0 = w0
+        self.wa = wa
         super().__init__(
             H0=H0,
             Om0=Om0,
@@ -121,9 +123,8 @@ class w0waCDM(FLRW):
             name=name,
             meta=meta,
         )
-        self.w0 = w0
-        self.wa = wa
 
+    def __post_init__(self):
         # Please see :ref:`astropy-cosmology-fast-integrals` for discussion
         # about what is being done here.
         if self._Tcmb0.value == 0:

--- a/astropy/cosmology/flrw/w0wzcdm.py
+++ b/astropy/cosmology/flrw/w0wzcdm.py
@@ -104,6 +104,8 @@ class w0wzCDM(FLRW):
         name=None,
         meta=None
     ):
+        self.w0 = w0
+        self.wz = wz
         super().__init__(
             H0=H0,
             Om0=Om0,
@@ -115,9 +117,8 @@ class w0wzCDM(FLRW):
             name=name,
             meta=meta,
         )
-        self.w0 = w0
-        self.wz = wz
 
+    def __post_init__(self):
         # Please see :ref:`astropy-cosmology-fast-integrals` for discussion
         # about what is being done here.
         if self._Tcmb0.value == 0:

--- a/astropy/cosmology/flrw/wpwazpcdm.py
+++ b/astropy/cosmology/flrw/wpwazpcdm.py
@@ -125,6 +125,9 @@ class wpwaCDM(FLRW):
         name=None,
         meta=None
     ):
+        self.wp = wp
+        self.wa = wa
+        self.zp = zp
         super().__init__(
             H0=H0,
             Om0=Om0,
@@ -136,10 +139,8 @@ class wpwaCDM(FLRW):
             name=name,
             meta=meta,
         )
-        self.wp = wp
-        self.wa = wa
-        self.zp = zp
 
+    def __post_init__(self):
         # Please see :ref:`astropy-cosmology-fast-integrals` for discussion
         # about what is being done here.
         apiv = 1.0 / (1.0 + self._zp.value)


### PR DESCRIPTION
For eventually making cosmologies dataclasses, which will significantly simplify cosmology classes.

The plan is for most of the stuff which is currently in `__init__` to be in `__post_init__`, and the parameters of the cosmology to be the fields of the dataclass. This PR continues this project, moving some of the behind-the-scene `__init__` stuff.
