### PR TITLE
Bugfix for bitmasks passed to nddata

### DIFF
--- a/astropy/nddata/mixins/ndarithmetic.py
+++ b/astropy/nddata/mixins/ndarithmetic.py
@@ -520,10 +520,10 @@ class NDArithmeticMixin:
         elif self.mask is None and operand is not None:
             # Make a copy so there is no reference in the result.
             return deepcopy(operand.mask)
-        elif operand is None:
+        elif operand.mask is None:
             return deepcopy(self.mask)
         else:
-            # Now lets calculate the resulting mask (operation enforces copy)
+            # Now let's calculate the resulting mask (operation enforces copy)
             return handle_mask(self.mask, operand.mask, **kwds)
 
     def _arithmetic_wcs(self, operation, operand, compare_wcs, **kwds):

--- a/astropy/nddata/mixins/tests/test_ndarithmetic.py
+++ b/astropy/nddata/mixins/tests/test_ndarithmetic.py
@@ -1310,3 +1310,42 @@ def test_raise_method_not_supported():
     # raise error for unsupported propagation operations:
     with pytest.raises(ValueError):
         ndd1.uncertainty.propagate(np.mod, ndd2, result, correlation)
+
+
+def test_nddata_bitmask_arithmetic():
+    # NDData.mask is usually assumed to be boolean, but could be
+    # a bitmask. Ensure bitmask works:
+    array = np.array([[0, 1, 0], [1, 0, 1], [0, 1, 0]])
+    mask = np.array([[0, 1, 64], [8, 0, 1], [2, 1, 0]])
+
+    nref_nomask = NDDataRef(array)
+    nref_masked = NDDataRef(array, mask=mask)
+
+    # multiply no mask by constant (no mask * no mask)
+    assert nref_nomask.multiply(1.0, handle_mask=np.bitwise_or).mask is None
+
+    # multiply no mask by itself (no mask * no mask)
+    assert nref_nomask.multiply(nref_nomask, handle_mask=np.bitwise_or).mask is None
+
+    # multiply masked by constant (mask * no mask)
+    np.testing.assert_equal(
+        nref_masked.multiply(1.0, handle_mask=np.bitwise_or).mask, mask
+    )
+
+    # multiply masked by itself (mask * mask)
+    np.testing.assert_equal(
+        nref_masked.multiply(nref_masked, handle_mask=np.bitwise_or).mask, mask
+    )
+
+    # multiply masked by no mask (mask * no mask)
+    np.testing.assert_equal(
+        nref_masked.multiply(nref_nomask, handle_mask=np.bitwise_or).mask, mask
+    )
+
+    # check bitwise logic still works
+    other_mask = np.array([[64, 1, 0], [2, 1, 0], [8, 0, 2]])
+    nref_mask_other = NDDataRef(array, mask=other_mask)
+    np.testing.assert_equal(
+        nref_mask_other.multiply(nref_masked, handle_mask=np.bitwise_or).mask,
+        np.bitwise_or(mask, other_mask),
+    )

--- a/docs/changes/nddata/14995.bugfix.rst
+++ b/docs/changes/nddata/14995.bugfix.rst
@@ -1,0 +1,2 @@
+Restore bitmask propagation behavior in ``NDData.mask``, plus a fix
+for arithmetic between masked and unmasked ``NDData`` objects.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request revises one line changed in PR #14175, which gave rise to Issue #14978. I've added a test to ensure that we will notice if this happens again in the future.

### Discussion
This PR adds the first test for bitmask support in ndarithmetic. We may want to discuss if in the docs and tests we should explicitly claim support for bitmasks in the `NDData.mask` attribute (@eteq), as well as whether https://github.com/astropy/astropy-APEs/pull/14 should be revived (@perrygreenfield, @mwcraig, @jehturner @crawfordsm @MSeifert04, @parejkoj).

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #14978.

cc @KathleenLabrie @chris-simpson
