### PR TITLE
Fix error when a PrimaryHDU has a "GROUPS = 1" keyword

### DIFF
--- a/astropy/io/fits/hdu/base.py
+++ b/astropy/io/fits/hdu/base.py
@@ -855,16 +855,7 @@ class _NonstandardHDU(_BaseHDU, _Verify):
         """
         # The SIMPLE keyword must be in the first card
         card = header.cards[0]
-
-        # The check that 'GROUPS' is missing is a bit redundant, since the
-        # match_header for GroupsHDU will always be called before this one.
-        if card.keyword == "SIMPLE":
-            if "GROUPS" not in header and card.value is False:
-                return True
-            else:
-                raise InvalidHDUException
-        else:
-            return False
+        return card.keyword == "SIMPLE" and card.value is False
 
     @property
     def size(self):

--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -1142,7 +1142,7 @@ class PrimaryHDU(_ImageBaseHDU):
         # keyword to be True/False, have to check the value
         return (
             card.keyword == "SIMPLE"
-            and ("GROUPS" not in header or header["GROUPS"] != True)  # noqa: E712
+            and ("GROUPS" not in header or header["GROUPS"] is not True)
             and card.value
         )
 

--- a/astropy/io/fits/tests/test_groups.py
+++ b/astropy/io/fits/tests/test_groups.py
@@ -243,3 +243,11 @@ class TestGroupsFunctions(FitsTestCase):
             assert len(hdul) == 1
             assert hdul[0].header["GROUPS"]
             assert hdul[0].data is None
+
+    def test_not_groups_file(self):
+        hdu = fits.PrimaryHDU()
+        hdu.header["GROUPS"] = (1, "not a groups HDU")
+        hdu.writeto(self.temp("not_groups.fits"))
+        with fits.open(self.temp("not_groups.fits")) as hdul:
+            assert hdul[0].header["GROUPS"] == 1
+            assert hdul[0].header.comments["GROUPS"] == "not a groups HDU"

--- a/docs/changes/io.fits/14998.bugfix.rst
+++ b/docs/changes/io.fits/14998.bugfix.rst
@@ -1,0 +1,2 @@
+Fix crash when a PrimaryHDU has a GROUPS keyword with a non-boolean value (i.e.
+not a random-groups HDU).


### PR DESCRIPTION
`GROUPS  = 1` was interpreted as `GROUPS  = T` which is wrong.
This occurs on some Euclid commissioning file so I would like to make a bugfix release soon (with also the nddata fix).

```
In [1]: %astropy
Numpy 1.25.0
Astropy 6.0.dev302+g6fd7ebdfc

In [2]: hdu = fits.PrimaryHDU()

In [3]: hdu.header["GROUPS"] = (1, "not a groups HDU")

In [4]: hdu.header
Out[4]: 
SIMPLE  =                    T / conforms to FITS standard                      
BITPIX  =                    8 / array data type                                
NAXIS   =                    0 / number of array dimensions                     
EXTEND  =                    T                                                  
GROUPS  =                    1 / not a groups HDU                               

In [5]: hdu.writeto("test.fits")

In [6]: fits.open("test.fits")
WARNING: An exception occurred matching an HDU header to the appropriate HDU type:  [astropy.io.fits.hdu.base]
WARNING: The HDU will be treated as corrupted. [astropy.io.fits.hdu.base]
Out[6]: [<astropy.io.fits.hdu.base._CorruptedHDU object at 0x7f5640149f10>]
```