### PR TITLE
Adjust IERS update workflow to open PRs against v5.0.x and v5.3.x

### DIFF
--- a/.github/workflows/update_iers.yml
+++ b/.github/workflows/update_iers.yml
@@ -1,0 +1,89 @@
+# NOTE: this workflow can be removed once v6.0.0 is released
+
+name: Auto-update IERS tables
+
+on:
+  schedule:
+    - cron: '0 0 1 * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+
+  update-iers-50x:
+    permissions:
+      contents: write  # for peter-evans/create-pull-request to create branch
+      pull-requests: write  # for peter-evans/create-pull-request to create a PR
+    name: Auto-update IERS tables in v5.0.x
+    runs-on: ubuntu-latest
+    if: github.repository == 'astropy/astropy'
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        ref: v5.0.x
+    - name: Download latest IERS files
+      run: ./update_builtin_iers.sh
+      working-directory: astropy/utils/iers/data
+    - name: Commit changes
+      run: |
+        git config user.name github-actions
+        git config user.email github-actions@github.com
+        git add astropy/utils/iers/data/Leap_Second.dat
+        git add astropy/utils/iers/data/eopc04_IAU2000.62-now
+        if ! git diff --cached --exit-code; then
+          git commit -m "Update IERS Earth rotation and leap second tables"
+        fi
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v5
+      with:
+        base: v5.0.x
+        branch: update-iers-5.0.x
+        branch-suffix: timestamp
+        delete-branch: true
+        labels: no-changelog-entry-needed, utils.iers
+        title: Update IERS Earth rotation and leap second tables in v5.0.x
+        body: |
+          This is an automated update of the IERS Earth rotation and leap second tables to the v5.0.x branch.
+
+          :warning: Please close and re-open this pull request to trigger the CI :warning:
+
+  update-iers-53x:
+    permissions:
+      contents: write  # for peter-evans/create-pull-request to create branch
+      pull-requests: write  # for peter-evans/create-pull-request to create a PR
+    name: Auto-update IERS tables in v5.3.x
+    runs-on: ubuntu-latest
+    if: github.repository == 'astropy/astropy'
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        ref: v5.3.x
+    - name: Download latest IERS files
+      run: ./update_builtin_iers.sh
+      working-directory: astropy/utils/iers/data
+    - name: Commit changes
+      run: |
+        git config user.name github-actions
+        git config user.email github-actions@github.com
+        git add astropy/utils/iers/data/Leap_Second.dat
+        git add astropy/utils/iers/data/eopc04.1962-now
+        if ! git diff --cached --exit-code; then
+          git commit -m "Update IERS Earth rotation and leap second tables"
+        fi
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v5
+      with:
+        base: v5.3.x
+        branch: update-iers-v5.3.x
+        branch-suffix: timestamp
+        delete-branch: true
+        labels: no-changelog-entry-needed, utils.iers
+        title: Update IERS Earth rotation and leap second tables in v5.3.x
+        body: |
+          This is an automated update of the IERS Earth rotation and leap second tables to the v5.3.x branch.
+
+          :warning: Please close and re-open this pull request to trigger the CI :warning:


### PR DESCRIPTION
This will be needed once https://github.com/astropy/astropy/pull/14819 is merged. I have tested this on my local fork and it seems to work (including on the LTS branch).