### PR TITLE
Refactor `astropy/coordinates/transformations.py`

### DIFF
--- a/astropy/coordinates/transformations.py
+++ b/astropy/coordinates/transformations.py
@@ -301,14 +301,12 @@ class TransformGraph:
 
         # use Dijkstra's algorithm to find shortest path in all other cases
 
-        nodes = []
-        # first make the list of nodes
-        for a in self._graph:
-            if a not in nodes:
-                nodes.append(a)
-            for b in self._graph[a]:
-                if b not in nodes:
-                    nodes.append(b)
+        # We store nodes as `dict` keys because differently from `list` uniqueness is
+        # guaranteed and differently from `set` insertion order is preserved.
+        nodes = {}
+        for node, node_graph in self._graph.items():
+            nodes[node] = None
+            nodes |= {node: None for node in node_graph}
 
         if fromsys not in nodes or tosys not in nodes:
             # fromsys or tosys are isolated or not registered, so there's
@@ -489,17 +487,13 @@ class TransformGraph:
         dotgraph : str
             A string with the DOT format graph.
         """
-        nodes = []
-        # find the node names
-        for a in self._graph:
-            if a not in nodes:
-                nodes.append(a)
-            for b in self._graph[a]:
-                if b not in nodes:
-                    nodes.append(b)
-        for node in addnodes:
-            if node not in nodes:
-                nodes.append(node)
+        # We store nodes as `dict` keys because differently from `list` uniqueness is
+        # guaranteed and differently from `set` insertion order is preserved.
+        nodes = {}
+        for node, node_graph in self._graph.items():
+            nodes[node] = None
+            nodes |= {node: None for node in node_graph}
+        nodes |= {node: None for node in addnodes}
         nodenames = []
         invclsaliases = {
             f: [k for k, v in self._cached_names.items() if v == f]


### PR DESCRIPTION
### Description

The [Ruff rule PLR0912](https://beta.ruff.rs/docs/rules/too-many-branches/) checks for functions with too many branches. Although the number of allowed code branches is somewhat arbitrary, functions with very many branches are good targets for refactoring. Running the command `ruff --select=PLR0912 --show-source astropy/coordinates/transformations.py` highlighted 5 functions that I managed to simplify both in terms of line count and number of code branches. Similar improvements are likely possible throughout `astropy`, but I am limiting this pull request to a single file because the number of edited lines of code is large enough.