### PR TITLE
Address Ruff Rule PT021 and PIE804 violations

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -154,7 +154,6 @@ ignore = [
     "PT017",   # pytest-assert-in-exceptinstead
     "PT018",   # pytest-composite-assertion
     "PT019",   # pytest-fixture-param-without-value
-    "PT021",   # pytest-fixture-finalizer-callback
     "PT022",   # pytest-useless-yield-fixture
     "PT023",   # pytest-incorrect-mark-parentheses-style
 

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -117,7 +117,6 @@ ignore = [
     # flake8-pie (PIE)
     "PIE790",  # unnecessary-pass
     "PIE794",  # duplicate-class-field-definition
-    "PIE804",  # no-unnecessary-dict-kwargs
     "PIE810",  # single-starts-ends-with
 
     # pygrep-hooks (PGH)

--- a/astropy/samp/tests/test_client.py
+++ b/astropy/samp/tests/test_client.py
@@ -31,11 +31,12 @@ def test_SAMPIntegratedClient():
 
 
 @pytest.fixture
-def samp_hub(request):
+def samp_hub():
     """A fixture that can be used by client tests that require a HUB."""
     my_hub = SAMPHubServer()
     my_hub.start()
-    request.addfinalizer(my_hub.stop)
+    yield
+    my_hub.stop()
 
 
 def test_SAMPIntegratedClient_notify_all(samp_hub):

--- a/astropy/utils/decorators.py
+++ b/astropy/utils/decorators.py
@@ -209,12 +209,10 @@ def deprecated(
 
         message = (
             message.format(
-                **{
-                    "func": name,
-                    "name": name,
-                    "alternative": alternative,
-                    "obj_type": obj_type_name,
-                }
+                func=name,
+                name=name,
+                alternative=alternative,
+                obj_type=obj_type_name,
             )
         ) + altmessage
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This Pull Request addresses Rule PT021and Rule PIE804.


Rule PT021 checks whether request.addfinalizer is used and suggests to "use yield instead of request.addfinalizer". 
I replaced the only use of request.addfinalizer in astropy/samp/tests/test_client.py and removed the rule in the .ruff.toml file.
Running `ruff --select=PT021 --statistics astropy/` now yields no violations.

Rule PIE804 checks for unnecessary dictionary-style keyword arguments.
I fixed the only occurrence in astropy/utils/decorators.py by explicitly passing the keyword arguments instead of unpacking them from a dictionary.  
Running `ruff --select=PIE804 --statistics astropy/` now yields no violations.


This pull request is to address Issue #14818

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->
