### PR TITLE
Pre commit ci update config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,7 +56,7 @@ repos:
         # Enforce that all noqa annotations always occur with specific codes.
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.4
+    rev: v2.2.5
     hooks:
       - id: codespell
         args: ["--write-changes"]
@@ -64,7 +64,7 @@ repos:
           - tomli
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: "v0.0.270"
+    rev: "v0.0.275"
     hooks:
       - id: ruff
         args: ["--fix"]

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -19,6 +19,7 @@ ignore = [
     "B007",  # UnusedLoopControlVariable
     "B023",  # FunctionUsesLoopVariable
     "B028",  # No-explicit-stacklevel
+    "B033",  # Sets should not contain duplicate item
     "B904",  # RaiseWithoutFromInsideExcept
     "B905",  # ZipWithoutExplicitStrict   # requires 3.10+
 
@@ -85,6 +86,11 @@ ignore = [
     "FBT002",  # boolean-default-value-in-function-definition
     "FBT003",  # boolean-positional-value-in-function-call
 
+    # flake8-fixme (FIX)
+    "FIX001",  # Line contains FIXME.  this should be fixed or at least FIXME replaced with TODO
+    "FIX003",  # Line contains XXX.  replace XXX with TODO
+    "FIX004",  # Line contains HACK. replace HACK with NOTE.
+
     # flake8-logging-format (G)
     "G001",  # logging-string-format
     "G004",  # logging-f-string
@@ -125,9 +131,11 @@ ignore = [
     "PGH001",  # eval
 
     # Pylint (PLC, PLE, PLR, PLW)
+    "PLC0208",  # Use a sequence type instead of a `set` when iterating over values
     "PLC1901",  # compare-to-empty-string
     "PLE0101",  # return-in-init
     "PLE0605",  # invalid-all-format
+    "PLR0124",  # Name compared with itself
     "PLR0402",  # ConsiderUsingFromImport
     "PLR0911",  # too-many-return-statements
     "PLR0912",  # too-many-branches
@@ -137,7 +145,6 @@ ignore = [
     "PLR5501",  # collapsible-else-if
     "PLW0120",  # useless-else-on-loop
     "PLW0129",  # assert-on-string-literal
-    "PLW0130",  # duplicate value in set
     "PLW0602",  # global-variable-not-assigned
     "PLW0603",  # global-statement
     "PLW2901",  # redefined-loop-name
@@ -198,6 +205,7 @@ ignore = [
     "RUF001",  # ambiguous-unicode-character-string
     "RUF002",  # ambiguous-unicode-character-docstring
     "RUF010",  # use conversion in f-string
+    "RUF012",  # Mutable class attributes should be annotated with `typing.ClassVar`
 
     # flake8-bandit (S)
     "S101",  # Use of `assert` detected
@@ -226,6 +234,10 @@ ignore = [
     "SIM201",  # NegateEqualOp
     "SIM202",  # NegateNotEqualOp
     "SIM300",  # yoda condition
+
+    # flake8-slots (SLOT)
+    "SLOT000",  # Subclasses of `str` should define `__slots__`
+    "SLOT001",  # Subclasses of `tuple` should define `__slots__`
 
     # flake8-print (T20)
     "T201",  # PrintUsed

--- a/astropy/cosmology/flrw/base.py
+++ b/astropy/cosmology/flrw/base.py
@@ -1527,7 +1527,11 @@ class FlatFLRWMixin(FlatCosmologyMixin):
         return inst
 
     def clone(
-        self, *, meta: Mapping | None = None, to_nonflat: bool = None, **kwargs: Any
+        self,
+        *,
+        meta: Mapping | None = None,
+        to_nonflat: bool | None = None,
+        **kwargs: Any,
     ):
         """Returns a copy of this object with updated parameters, as specified.
 

--- a/astropy/modeling/bounding_box.py
+++ b/astropy/modeling/bounding_box.py
@@ -195,7 +195,7 @@ class _BoundingDomain(abc.ABC):
         on the inputs and returns a complete output.
     """
 
-    def __init__(self, model, ignored: list[int] = None, order: str = "C"):
+    def __init__(self, model, ignored: list[int] | None = None, order: str = "C"):
         self._model = model
         self._ignored = self._validate_ignored(ignored)
         self._order = self._get_order(order)
@@ -212,7 +212,7 @@ class _BoundingDomain(abc.ABC):
     def ignored(self) -> list[int]:
         return self._ignored
 
-    def _get_order(self, order: str = None) -> str:
+    def _get_order(self, order: str | None = None) -> str:
         """
         Get if bounding_box is C/python ordered or Fortran/mathematically
         ordered.
@@ -603,7 +603,7 @@ class ModelBoundingBox(_BoundingDomain):
         self,
         intervals: dict[int, _Interval],
         model,
-        ignored: list[int] = None,
+        ignored: list[int] | None = None,
         order: str = "C",
     ):
         super().__init__(model, ignored, order)
@@ -672,7 +672,7 @@ class ModelBoundingBox(_BoundingDomain):
         else:
             return self._intervals[self._get_index(key)]
 
-    def bounding_box(self, order: str = None):
+    def bounding_box(self, order: str | None = None):
         """
         Return the old tuple of tuples representation of the bounding_box
             order='C' corresponds to the old bounding_box ordering
@@ -730,7 +730,7 @@ class ModelBoundingBox(_BoundingDomain):
 
         return [_input for _input in model_input_index if _input not in self._ignored]
 
-    def _validate_sequence(self, bounding_box, order: str = None):
+    def _validate_sequence(self, bounding_box, order: str | None = None):
         """
         Validate passing tuple of tuples representation (or related) and setting them.
         """
@@ -751,7 +751,7 @@ class ModelBoundingBox(_BoundingDomain):
         else:
             return 0
 
-    def _validate_iterable(self, bounding_box, order: str = None):
+    def _validate_iterable(self, bounding_box, order: str | None = None):
         """Validate and set any iterable representation."""
         if len(bounding_box) != self._n_inputs:
             raise ValueError(
@@ -764,7 +764,7 @@ class ModelBoundingBox(_BoundingDomain):
         else:
             self._validate_sequence(bounding_box, order)
 
-    def _validate(self, bounding_box, order: str = None):
+    def _validate(self, bounding_box, order: str | None = None):
         """Validate and set any representation."""
         if self._n_inputs == 1 and not isinstance(bounding_box, dict):
             self[self._available_input_index[0]] = bounding_box
@@ -776,7 +776,7 @@ class ModelBoundingBox(_BoundingDomain):
         cls,
         model,
         bounding_box,
-        ignored: list = None,
+        ignored: list | None = None,
         order: str = "C",
         _preserve_ignore: bool = False,
         **kwargs,
@@ -836,7 +836,7 @@ class ModelBoundingBox(_BoundingDomain):
     def dimension(self):
         return len(self)
 
-    def domain(self, resolution, order: str = None):
+    def domain(self, resolution, order: str | None = None):
         inputs = self._model.inputs
         order = self._get_order(order)
         if order == "C":
@@ -1112,7 +1112,7 @@ class _SelectorArguments(tuple):
 
     _kept_ignore = None
 
-    def __new__(cls, input_: tuple[_SelectorArgument], kept_ignore: list = None):
+    def __new__(cls, input_: tuple[_SelectorArgument], kept_ignore: list | None = None):
         self = super().__new__(cls, input_)
 
         if kept_ignore is None:
@@ -1152,7 +1152,7 @@ class _SelectorArguments(tuple):
         return self._kept_ignore
 
     @classmethod
-    def validate(cls, model, arguments, kept_ignore: list = None):
+    def validate(cls, model, arguments, kept_ignore: list | None = None):
         """
         Construct a valid Selector description for a CompoundBoundingBox.
 
@@ -1341,8 +1341,8 @@ class CompoundBoundingBox(_BoundingDomain):
         bounding_boxes: dict[Any, ModelBoundingBox],
         model,
         selector_args: _SelectorArguments,
-        create_selector: Callable = None,
-        ignored: list[int] = None,
+        create_selector: Callable | None = None,
+        ignored: list[int] | None = None,
         order: str = "C",
     ):
         super().__init__(model, ignored, order)
@@ -1450,7 +1450,7 @@ class CompoundBoundingBox(_BoundingDomain):
         bounding_box: dict,
         selector_args=None,
         create_selector=None,
-        ignored: list = None,
+        ignored: list | None = None,
         order: str = "C",
         _preserve_ignore: bool = False,
         **kwarg,

--- a/astropy/units/format/generic.py
+++ b/astropy/units/format/generic.py
@@ -187,7 +187,7 @@ class Generic(Base):
                     units += subunit
                 elif isinstance(subunit, StructuredUnit):
                     # Structured unit whose entries should be
-                    # individiually added to the new StructuredUnit.
+                    # individually added to the new StructuredUnit.
                     units += subunit.values()
                 else:
                     # Regular unit to be added to the StructuredUnit.

--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -604,7 +604,7 @@ def test_all_world2pix(
         [i.flatten() for i in np.meshgrid(*map(range, naxesi_l, naxesi_u))]
     )[0]
 
-    # Generage random data (in image coordinates):
+    # Generate random data (in image coordinates):
     with NumpyRNGContext(123456789):
         rnd_pix = np.random.rand(random_npts, ncoord)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,6 +151,9 @@ ignore = [
     # Pyflakes (F)
     "F403",  # ImportStarUsed
 
+    # flake8-fixme (FIX)
+    "FIX002",  # Line contains TODO | notes for improvements are OK iff the code works
+
     # pep8-naming (N)
     "N803",  # invalid-argument-name | physics variables are often poor code variables
     "N806",  # non-lowercase-variable-in-function | physics variables are often poor code variables
@@ -337,6 +340,8 @@ skip = "*.dat,*.fits,*.hdr,*.xml,*egg*,*extern/*,.git,.tox,_build,fitshdr.htest_
 # The following list of words for codespell to ignore may contain some
 # misspellings that should be revisited and fixed in the future.
 ignore-words-list = """
+    aas,
+    afile,
     ans,
     clen,
     cna,


### PR DESCRIPTION
updates:

- [github.com/codespell-project/codespell: v2.2.4 → v2.2.5](https://github.com/codespell-project/codespell/compare/v2.2.4...v2.2.5)
- [github.com/charliermarsh/ruff-pre-commit: v0.0.270 → v0.0.275](https://github.com/charliermarsh/ruff-pre-commit/compare/v0.0.270...v0.0.275)

applies ignores for the new rules, sorting FIX002 into our permanent ignore config, and the rest for later fixes.

Closes: #15019