### PR TITLE
pytest 8 compatibility

### DIFF
--- a/astropy/coordinates/tests/test_iau_fullstack.py
+++ b/astropy/coordinates/tests/test_iau_fullstack.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import warnings
+from contextlib import nullcontext
 
 import erfa
 import numpy as np
@@ -12,6 +13,7 @@ from astropy.coordinates import EarthLocation, SkyCoord
 from astropy.coordinates.angle_utilities import golden_spiral_grid
 from astropy.coordinates.builtin_frames import ICRS, AltAz
 from astropy.coordinates.builtin_frames.utils import get_jd12
+from astropy.tests.helper import PYTEST_LT_8_0
 from astropy.time import Time
 from astropy.utils import iers
 
@@ -201,7 +203,12 @@ def test_future_altaz():
     # assured of being "fresh".  In this case getting times outside the range of the
     # table does not raise an exception.  Only if using IERS_B (which happens without
     # --remote-data, i.e. for all CI testing) do we expect another warning.
-    with pytest.warns(
+    if PYTEST_LT_8_0:
+        ctx1 = ctx2 = nullcontext()
+    else:
+        ctx1 = pytest.warns(erfa.core.ErfaWarning)
+        ctx2 = pytest.warns(AstropyWarning, match=r".*times are outside of range.*")
+    with ctx1, ctx2, pytest.warns(
         AstropyWarning,
         match=r"Tried to get polar motions for times after IERS data is valid.*",
     ) as found_warnings:

--- a/astropy/coordinates/tests/test_iau_fullstack.py
+++ b/astropy/coordinates/tests/test_iau_fullstack.py
@@ -207,10 +207,10 @@ def test_future_altaz():
         ctx1 = ctx2 = nullcontext()
     else:
         ctx1 = pytest.warns(erfa.core.ErfaWarning)
-        ctx2 = pytest.warns(AstropyWarning, match=r".*times are outside of range.*")
+        ctx2 = pytest.warns(AstropyWarning, match=".*times are outside of range.*")
     with ctx1, ctx2, pytest.warns(
         AstropyWarning,
-        match=r"Tried to get polar motions for times after IERS data is valid.*",
+        match="Tried to get polar motions for times after IERS data is valid.*",
     ) as found_warnings:
         SkyCoord(1 * u.deg, 2 * u.deg).transform_to(AltAz(location=location, obstime=t))
 

--- a/astropy/coordinates/tests/test_regression.py
+++ b/astropy/coordinates/tests/test_regression.py
@@ -255,8 +255,8 @@ def test_regression_futuretimes_4302():
     if PYTEST_LT_8_0:
         ctx2 = ctx3 = nullcontext()
     else:
-        ctx2 = pytest.warns(ErfaWarning, match=r".*dubious year.*")
-        ctx3 = pytest.warns(AstropyWarning, match=r".*times after IERS data is valid.*")
+        ctx2 = pytest.warns(ErfaWarning, match=".*dubious year.*")
+        ctx3 = pytest.warns(AstropyWarning, match=".*times after IERS data is valid.*")
 
     with ctx1, ctx2, ctx3:
         future_time = Time("2511-5-1")

--- a/astropy/coordinates/tests/test_regression.py
+++ b/astropy/coordinates/tests/test_regression.py
@@ -42,7 +42,7 @@ from astropy.coordinates import (
 )
 from astropy.coordinates.sites import get_builtin_sites
 from astropy.table import Table
-from astropy.tests.helper import assert_quantity_allclose
+from astropy.tests.helper import PYTEST_LT_8_0, assert_quantity_allclose
 from astropy.time import Time
 from astropy.units import allclose as quantity_allclose
 from astropy.utils import iers
@@ -245,13 +245,20 @@ def test_regression_futuretimes_4302():
     # if using IERS_B (which happens without --remote-data, i.e. for all CI
     # testing) do we expect another warning.
     if isinstance(iers.earth_orientation_table.get(), iers.IERS_B):
-        ctx = pytest.warns(
+        ctx1 = pytest.warns(
             AstropyWarning,
             match=r"\(some\) times are outside of range covered by IERS table.*",
         )
     else:
-        ctx = nullcontext()
-    with ctx:
+        ctx1 = nullcontext()
+
+    if PYTEST_LT_8_0:
+        ctx2 = ctx3 = nullcontext()
+    else:
+        ctx2 = pytest.warns(ErfaWarning, match=r".*dubious year.*")
+        ctx3 = pytest.warns(AstropyWarning, match=r".*times after IERS data is valid.*")
+
+    with ctx1, ctx2, ctx3:
         future_time = Time("2511-5-1")
         c = CIRS(1 * u.deg, 2 * u.deg, obstime=future_time)
         c.transform_to(ITRS(obstime=future_time))

--- a/astropy/coordinates/tests/test_utils.py
+++ b/astropy/coordinates/tests/test_utils.py
@@ -1,3 +1,6 @@
+from contextlib import nullcontext
+
+import erfa
 import pytest
 
 from astropy.coordinates.builtin_frames.utils import (
@@ -5,7 +8,7 @@ from astropy.coordinates.builtin_frames.utils import (
     get_polar_motion,
 )
 from astropy.coordinates.solar_system import get_body_barycentric_posvel
-from astropy.tests.helper import assert_quantity_allclose
+from astropy.tests.helper import PYTEST_LT_8_0, assert_quantity_allclose
 from astropy.time import Time
 from astropy.utils.exceptions import AstropyWarning
 
@@ -13,10 +16,15 @@ from astropy.utils.exceptions import AstropyWarning
 def test_polar_motion_unsupported_dates():
     msg = r"Tried to get polar motions for times {} IERS.*"
 
-    with pytest.warns(AstropyWarning, match=msg.format("before")):
+    if PYTEST_LT_8_0:
+        ctx = nullcontext()
+    else:
+        ctx = pytest.warns(erfa.core.ErfaWarning, match=r".*dubious year.*")
+
+    with pytest.warns(AstropyWarning, match=msg.format("before")), ctx:
         get_polar_motion(Time("1900-01-01"))
 
-    with pytest.warns(AstropyWarning, match=msg.format("after")):
+    with pytest.warns(AstropyWarning, match=msg.format("after")), ctx:
         get_polar_motion(Time("2100-01-01"))
 
 

--- a/astropy/coordinates/tests/test_utils.py
+++ b/astropy/coordinates/tests/test_utils.py
@@ -19,7 +19,7 @@ def test_polar_motion_unsupported_dates():
     if PYTEST_LT_8_0:
         ctx = nullcontext()
     else:
-        ctx = pytest.warns(erfa.core.ErfaWarning, match=r".*dubious year.*")
+        ctx = pytest.warns(erfa.core.ErfaWarning, match=".*dubious year.*")
 
     with pytest.warns(AstropyWarning, match=msg.format("before")), ctx:
         get_polar_motion(Time("1900-01-01"))

--- a/astropy/cosmology/flrw/tests/test_w0wzcdm.py
+++ b/astropy/cosmology/flrw/tests/test_w0wzcdm.py
@@ -129,7 +129,9 @@ class Testw0wzCDM(FLRWTest, Parameterw0TestMixin, ParameterwzTestMixin):
 
     def test_Otot_overflow(self, cosmo):
         """Test :meth:`astropy.cosmology.w0wzCDM.Otot` for overflow."""
-        with pytest.warns(RuntimeWarning, match="overflow encountered in exp"):
+        with np.errstate(invalid="ignore", over="warn"), pytest.warns(
+            RuntimeWarning, match="overflow encountered in exp"
+        ):
             cosmo.Otot(1e3)
 
     # ===============================================================

--- a/astropy/cosmology/funcs/tests/test_funcs.py
+++ b/astropy/cosmology/funcs/tests/test_funcs.py
@@ -62,12 +62,12 @@ def test_z_at_value_scalar():
     # test behavior when the solution is outside z limits (should
     # raise a CosmologyError)
     with pytest.raises(core.CosmologyError), pytest.warns(
-        AstropyUserWarning, match=r"fval is not bracketed"
+        AstropyUserWarning, match="fval is not bracketed"
     ):
         z_at_value(cosmo.angular_diameter_distance, 1500 * u.Mpc, zmax=0.5)
 
     with pytest.raises(core.CosmologyError), pytest.warns(
-        AstropyUserWarning, match=r"fval is not bracketed"
+        AstropyUserWarning, match="fval is not bracketed"
     ), np.errstate(over="ignore"):
         z_at_value(cosmo.angular_diameter_distance, 1500 * u.Mpc, zmin=4.0)
 
@@ -204,7 +204,7 @@ def test_z_at_value_bracketed(method):
         ctx_fval = pytest.warns(AstropyUserWarning, match="fval is not bracketed")
 
     if method == "Bounded":
-        with pytest.warns(AstropyUserWarning, match=r"fval is not bracketed"):
+        with pytest.warns(AstropyUserWarning, match="fval is not bracketed"):
             z = z_at_value(cosmo.angular_diameter_distance, 1500 * u.Mpc, method=method)
         if z > 1.6:
             z = 3.7914908
@@ -212,7 +212,7 @@ def test_z_at_value_bracketed(method):
         else:
             z = 0.6812777
             bracket = (1.6, 2.0)
-        with pytest.warns(UserWarning, match=r"Option 'bracket' is ignored"), ctx_fval:
+        with pytest.warns(UserWarning, match="Option 'bracket' is ignored"), ctx_fval:
             assert allclose(
                 z_at_value(
                     cosmo.angular_diameter_distance,
@@ -316,7 +316,7 @@ def test_z_at_value_bracketed(method):
         ctx_bracket = nullcontext()
 
     with pytest.raises(core.CosmologyError), pytest.warns(
-        AstropyUserWarning, match=r"fval is not bracketed"
+        AstropyUserWarning, match="fval is not bracketed"
     ), ctx_bracket:
         z_at_value(
             cosmo.angular_diameter_distance,

--- a/astropy/cosmology/funcs/tests/test_funcs.py
+++ b/astropy/cosmology/funcs/tests/test_funcs.py
@@ -199,9 +199,9 @@ def test_z_at_value_bracketed(method):
     cosmo = Planck13
 
     if PYTEST_LT_8_0:
-        ctx = nullcontext()
+        ctx_fval = nullcontext()
     else:
-        ctx = pytest.warns(AstropyUserWarning, match="fval is not bracketed")
+        ctx_fval = pytest.warns(AstropyUserWarning, match="fval is not bracketed")
 
     if method == "Bounded":
         with pytest.warns(AstropyUserWarning, match=r"fval is not bracketed"):
@@ -212,7 +212,7 @@ def test_z_at_value_bracketed(method):
         else:
             z = 0.6812777
             bracket = (1.6, 2.0)
-        with pytest.warns(UserWarning, match=r"Option 'bracket' is ignored"), ctx:
+        with pytest.warns(UserWarning, match=r"Option 'bracket' is ignored"), ctx_fval:
             assert allclose(
                 z_at_value(
                     cosmo.angular_diameter_distance,
@@ -309,15 +309,15 @@ def test_z_at_value_bracketed(method):
         )
 
     if not PYTEST_LT_8_0 and method == "Bounded":
-        ctx = pytest.warns(
+        ctx_bracket = pytest.warns(
             UserWarning, match="Option 'bracket' is ignored by method Bounded"
         )
     else:
-        ctx = nullcontext()
+        ctx_bracket = nullcontext()
 
     with pytest.raises(core.CosmologyError), pytest.warns(
         AstropyUserWarning, match=r"fval is not bracketed"
-    ), ctx:
+    ), ctx_bracket:
         z_at_value(
             cosmo.angular_diameter_distance,
             1500 * u.Mpc,

--- a/astropy/io/fits/tests/test_hdulist.py
+++ b/astropy/io/fits/tests/test_hdulist.py
@@ -1056,13 +1056,16 @@ class TestHDUListFunctions(FitsTestCase):
         match = "Found a SIMPLE card but its format doesn't respect the FITS Standard"
 
         with pytest.warns(VerifyWarning, match=match):
-            fits.open(filename)
+            with fits.open(filename):
+                pass
 
         with pytest.warns(VerifyWarning, match=match):
-            fits.open(filename, mode="append")
+            with fits.open(filename, mode="append"):
+                pass
 
         with pytest.warns(VerifyWarning, match=match):
-            fits.open(filename, mode="update")
+            with fits.open(filename, mode="update"):
+                pass
 
         with fits.open(filename, ignore_missing_simple=True) as hdul:
             assert isinstance(hdul[0], _ValidHDU)
@@ -1076,7 +1079,8 @@ class TestHDUListFunctions(FitsTestCase):
             f.write(buf.read())
 
         with pytest.warns(VerifyWarning, match=match):
-            fits.open(filename)
+            with fits.open(filename):
+                pass
 
     def test_proper_error_raised_on_non_fits_file_with_unicode(self):
         """
@@ -1133,7 +1137,7 @@ class TestHDUListFunctions(FitsTestCase):
             assert not f.closed
 
         with open(filename, mode="rb") as f:
-            with pytest.raises(OSError), pytest.warns(VerifyWarning):
+            with pytest.raises(OSError):
                 fits.open(f, ignore_missing_end=True)
 
             assert not f.closed
@@ -1141,7 +1145,7 @@ class TestHDUListFunctions(FitsTestCase):
         with pytest.raises(OSError):
             fits.open(filename, ignore_missing_end=False)
 
-        with pytest.raises(OSError), pytest.warns(VerifyWarning):
+        with pytest.raises(OSError):
             fits.open(filename, ignore_missing_end=True)
 
     def test_pop_with_lazy_load(self):

--- a/astropy/io/fits/tests/test_image.py
+++ b/astropy/io/fits/tests/test_image.py
@@ -4,6 +4,7 @@ import math
 import os
 import re
 import time
+from contextlib import nullcontext
 from io import BytesIO
 from itertools import product
 
@@ -19,6 +20,7 @@ from astropy.io.fits.hdu.compressed import (
     DITHER_SEED_CHECKSUM,
     SUBTRACTIVE_DITHER_1,
 )
+from astropy.tests.helper import PYTEST_LT_8_0
 from astropy.utils.data import download_file, get_pkg_data_filename
 from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyUserWarning
 
@@ -396,13 +398,25 @@ class TestImageFunctions(FitsTestCase):
         # make a defect HDUList first
         x = fits.ImageHDU()
         hdu = fits.HDUList(x)  # HDUList can take a list or one single HDU
-        with pytest.warns(
+
+        if PYTEST_LT_8_0:
+            ctx_zero_idx = ctx_ver_err = nullcontext()
+        else:
+            ctx_zero_idx = pytest.warns(
+                fits.verify.VerifyWarning,
+                match=r"Note: astropy\.io\.fits uses zero-based indexing",
+            )
+            ctx_ver_err = pytest.warns(
+                fits.verify.VerifyWarning, match="Verification reported errors"
+            )
+
+        with ctx_zero_idx, ctx_ver_err, pytest.warns(
             AstropyUserWarning, match=r"HDUList's 0th element is not a primary HDU\."
         ) as w:
             hdu.verify()
         assert len(w) == 3
 
-        with pytest.warns(
+        with ctx_zero_idx, ctx_ver_err, pytest.warns(
             AstropyUserWarning,
             match=r"HDUList's 0th element is not a primary HDU\.  "
             r"Fixed by inserting one as 0th HDU\.",
@@ -1046,10 +1060,18 @@ class TestImageFunctions(FitsTestCase):
         data = np.arange(100, dtype=np.float64)
         hdu = fits.PrimaryHDU(data)
         hdu.header["BLANK"] = "nan"
+
+        if PYTEST_LT_8_0:
+            ctx = nullcontext()
+        else:
+            ctx = pytest.warns(
+                fits.verify.VerifyWarning, match=r"Invalid 'BLANK' keyword in header"
+            )
+
         with pytest.warns(
             fits.verify.VerifyWarning,
             match=r"Invalid value for 'BLANK' keyword in header: 'nan'",
-        ):
+        ), ctx:
             hdu.writeto(self.temp("test.fits"))
 
         with pytest.warns(AstropyUserWarning) as w:

--- a/astropy/io/votable/tests/test_tree.py
+++ b/astropy/io/votable/tests/test_tree.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import io
+from contextlib import nullcontext
 
 import pytest
 
@@ -7,6 +8,7 @@ from astropy.io.votable import tree
 from astropy.io.votable.exceptions import W07, W08, W21, W41
 from astropy.io.votable.table import parse
 from astropy.io.votable.tree import Resource, VOTableFile
+from astropy.tests.helper import PYTEST_LT_8_0
 from astropy.utils.data import get_pkg_data_filename
 from astropy.utils.exceptions import AstropyDeprecationWarning
 
@@ -129,9 +131,14 @@ def test_version():
         )
     parse(io.BytesIO(begin + b"1.4" + middle + b"1.3" + end), verify="exception")
 
+    if PYTEST_LT_8_0:
+        ctx = nullcontext()
+    else:
+        ctx = pytest.warns(W41)
+
     # Invalid versions
     for bversion in (b"1.0", b"2.0"):
-        with pytest.warns(W21):
+        with pytest.warns(W21), ctx:
             parse(
                 io.BytesIO(begin + bversion + middle + bversion + end),
                 verify="exception",

--- a/astropy/io/votable/tests/test_vo.py
+++ b/astropy/io/votable/tests/test_vo.py
@@ -181,21 +181,21 @@ def _test_regression(tmp_path, _python_based=False, binary_mode=1):
 @pytest.mark.xfail("legacy_float_repr")
 def test_regression(tmp_path):
     # W39: Bit values can not be masked
-    with pytest.warns(W39):
+    with pytest.warns(W39), np.errstate(over="ignore"):
         _test_regression(tmp_path, False)
 
 
 @pytest.mark.xfail("legacy_float_repr")
 def test_regression_python_based_parser(tmp_path):
     # W39: Bit values can not be masked
-    with pytest.warns(W39):
+    with pytest.warns(W39), np.errstate(over="ignore"):
         _test_regression(tmp_path, True)
 
 
 @pytest.mark.xfail("legacy_float_repr")
 def test_regression_binary2(tmp_path):
     # W39: Bit values can not be masked
-    with pytest.warns(W39):
+    with pytest.warns(W39), np.errstate(over="ignore"):
         _test_regression(tmp_path, False, 2)
 
 

--- a/astropy/io/votable/util.py
+++ b/astropy/io/votable/util.py
@@ -47,7 +47,7 @@ def convert_to_writable_filelike(fd, compressed=False):
     if isinstance(fd, str):
         fd = os.path.expanduser(fd)
         if fd.endswith(".gz") or compressed:
-            with gzip.GzipFile(fd, "wb") as real_fd:
+            with gzip.GzipFile(filename=fd, mode="wb") as real_fd:
                 encoded_fd = io.TextIOWrapper(real_fd, encoding="utf8")
                 yield encoded_fd
                 encoded_fd.flush()
@@ -61,7 +61,7 @@ def convert_to_writable_filelike(fd, compressed=False):
         assert callable(fd.write)
 
         if compressed:
-            fd = gzip.GzipFile(fileobj=fd)
+            fd = gzip.GzipFile(fileobj=fd, mode="wb")
 
         # If we can't write Unicode strings, use a codecs.StreamWriter
         # object

--- a/astropy/modeling/tests/test_physical_models.py
+++ b/astropy/modeling/tests/test_physical_models.py
@@ -140,9 +140,10 @@ def test_blackbody_exceptions_and_warnings():
     bb = BlackBody(5000 * u.K)
 
     # Zero wavelength given for conversion to Hz
-    with np.errstate(divide="ignore", invalid="ignore"):
-        with pytest.warns(AstropyUserWarning, match="invalid") as w:
-            bb(0 * u.AA)
+    with pytest.warns(AstropyUserWarning, match="invalid") as w, np.errstate(
+        divide="ignore", invalid="ignore"
+    ):
+        bb(0 * u.AA)
     assert len(w) == 1
 
     # Negative wavelength given for conversion to Hz

--- a/astropy/nddata/tests/test_ccddata.py
+++ b/astropy/nddata/tests/test_ccddata.py
@@ -718,9 +718,9 @@ def test_wcs_keywords_removed_from_header():
     if PYTEST_LT_8_0:
         ctx = nullcontext()
     else:
-        ctx = pytest.warns(FITSFixedWarning, match=r"'datfix' made the change")
+        ctx = pytest.warns(FITSFixedWarning, match="'datfix' made the change")
 
-    with pytest.warns(FITSFixedWarning, match=r"'unitfix' made the change"), ctx:
+    with pytest.warns(FITSFixedWarning, match="'unitfix' made the change"), ctx:
         ccd = CCDData.read(data_file1, unit="count")
 
 

--- a/astropy/nddata/tests/test_ccddata.py
+++ b/astropy/nddata/tests/test_ccddata.py
@@ -2,6 +2,7 @@
 
 import os
 import textwrap
+from contextlib import nullcontext
 
 import numpy as np
 import pytest
@@ -18,6 +19,7 @@ from astropy.nddata.nduncertainty import (
     VarianceUncertainty,
 )
 from astropy.table import Table
+from astropy.tests.helper import PYTEST_LT_8_0
 from astropy.utils import NumpyRNGContext
 from astropy.utils.data import (
     get_pkg_data_contents,
@@ -710,8 +712,15 @@ def test_wcs_keywords_removed_from_header():
 
     # Make sure that exceptions are not raised when trying to remove missing
     # keywords. o4sp040b0_raw.fits of io.fits is missing keyword 'PC1_1'.
-    data_file1 = get_pkg_data_filename("../../io/fits/tests/data/o4sp040b0_raw.fits")
-    with pytest.warns(FITSFixedWarning, match=r"'unitfix' made the change"):
+    data_file1 = get_pkg_data_filename(
+        "data/o4sp040b0_raw.fits", package="astropy.io.fits.tests"
+    )
+    if PYTEST_LT_8_0:
+        ctx = nullcontext()
+    else:
+        ctx = pytest.warns(FITSFixedWarning, match=r"'datfix' made the change")
+
+    with pytest.warns(FITSFixedWarning, match=r"'unitfix' made the change"), ctx:
         ccd = CCDData.read(data_file1, unit="count")
 
 
@@ -761,6 +770,7 @@ def test_wcs_keyword_removal_for_wcs_test_files():
     )
 
     keepers = set(_KEEP_THESE_KEYWORDS_IN_HEADER)
+    # NOTE: pyinstaller requires relative path here.
     wcs_headers = get_pkg_data_filenames("../../wcs/tests/data", pattern="*.hdr")
 
     for hdr in wcs_headers:

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -26,7 +26,7 @@ from astropy.table import (
     TableAttribute,
     TableReplaceWarning,
 )
-from astropy.tests.helper import assert_follows_unicode_guidelines, PYTEST_LT_8_0
+from astropy.tests.helper import PYTEST_LT_8_0, assert_follows_unicode_guidelines
 from astropy.time import Time, TimeDelta
 from astropy.utils.compat import NUMPY_LT_1_25
 from astropy.utils.compat.optional_deps import HAS_PANDAS
@@ -2158,7 +2158,7 @@ class TestPandas:
                 if PYTEST_LT_8_0:
                     ctx = nullcontext()
                 else:
-                    ctx = pytest.warns(FutureWarning, match=r".*IntCastingNaNError.*")
+                    ctx = pytest.warns(FutureWarning, match=".*IntCastingNaNError.*")
                 with pytest.warns(
                     TableReplaceWarning,
                     match=r"converted column 'a' from int(32|64) to float64",

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -7,6 +7,7 @@ import pathlib
 import pickle
 import sys
 from collections import OrderedDict
+from contextlib import nullcontext
 from io import StringIO
 
 import numpy as np
@@ -25,7 +26,7 @@ from astropy.table import (
     TableAttribute,
     TableReplaceWarning,
 )
-from astropy.tests.helper import assert_follows_unicode_guidelines
+from astropy.tests.helper import assert_follows_unicode_guidelines, PYTEST_LT_8_0
 from astropy.time import Time, TimeDelta
 from astropy.utils.compat import NUMPY_LT_1_25
 from astropy.utils.compat.optional_deps import HAS_PANDAS
@@ -2152,12 +2153,16 @@ class TestPandas:
             import pandas
             from packaging.version import Version
 
-            PANDAS_LT_2_0 = Version(pandas.__version__) < Version("2.0dev")
+            PANDAS_LT_2_0 = Version(pandas.__version__) < Version("2.0")
             if PANDAS_LT_2_0:
+                if PYTEST_LT_8_0:
+                    ctx = nullcontext()
+                else:
+                    ctx = pytest.warns(FutureWarning, match=r".*IntCastingNaNError.*")
                 with pytest.warns(
                     TableReplaceWarning,
                     match=r"converted column 'a' from int(32|64) to float64",
-                ):
+                ), ctx:
                     d = t.to_pandas(use_nullable_int=use_nullable_int)
             else:
                 from pandas.core.dtypes.cast import IntCastingNaNError

--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -10,6 +10,7 @@ import pytest
 
 from astropy.units import allclose as quantity_allclose  # noqa: F401
 from astropy.utils.compat import PYTHON_LT_3_11
+from astropy.utils.introspection import minversion
 
 # For backward-compatibility with affiliated packages
 from .runner import TestRunner  # noqa: F401
@@ -21,6 +22,8 @@ __all__ = [
     "pickle_protocol",
     "generic_recursive_equality_test",
 ]
+
+PYTEST_LT_8_0 = not minversion(pytest, "8.0.dev")
 
 
 def _save_coverage(cov, result, rootdir, testing_path):

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -19,6 +19,7 @@ import urllib.parse
 import urllib.request
 import warnings
 from concurrent.futures import ThreadPoolExecutor
+from contextlib import nullcontext
 from itertools import islice
 from tempfile import NamedTemporaryFile, TemporaryDirectory
 
@@ -28,6 +29,7 @@ import pytest
 import astropy.utils.data
 from astropy import units as _u  # u is taken
 from astropy.config import paths
+from astropy.tests.helper import PYTEST_LT_8_0
 from astropy.utils.data import (
     CacheDamaged,
     CacheMissingWarning,
@@ -2077,9 +2079,14 @@ def test_removal_of_open_files_windows(temp_cache, valid_urls, monkeypatch):
         # This platform is able to remove files while in use.
         monkeypatch.setattr(astropy.utils.data, "_rmtree", no_rmtree)
 
+    if PYTEST_LT_8_0:
+        ctx = nullcontext()
+    else:
+        ctx = pytest.warns(CacheMissingWarning, match=r".*PermissionError.*")
+
     u, c = next(valid_urls)
     with open(download_file(u, cache=True)):
-        with pytest.warns(CacheMissingWarning, match=r".*in use.*"):
+        with pytest.warns(CacheMissingWarning, match=r".*in use.*"), ctx:
             clear_download_cache(u)
 
 
@@ -2092,10 +2099,15 @@ def test_update_of_open_files_windows(temp_cache, valid_urls, monkeypatch):
         # This platform is able to remove files while in use.
         monkeypatch.setattr(astropy.utils.data, "_rmtree", no_rmtree)
 
+    if PYTEST_LT_8_0:
+        ctx = nullcontext()
+    else:
+        ctx = pytest.warns(CacheMissingWarning, match=r".*read-only.*")
+
     u, c = next(valid_urls)
     with open(download_file(u, cache=True)):
         u2, c2 = next(valid_urls)
-        with pytest.warns(CacheMissingWarning, match=r".*in use.*"):
+        with pytest.warns(CacheMissingWarning, match=r".*in use.*"), ctx:
             f = download_file(u, cache="update", sources=[u2])
         check_download_cache()
         assert is_url_in_cache(u)

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -2082,11 +2082,11 @@ def test_removal_of_open_files_windows(temp_cache, valid_urls, monkeypatch):
     if PYTEST_LT_8_0:
         ctx = nullcontext()
     else:
-        ctx = pytest.warns(CacheMissingWarning, match=r".*PermissionError.*")
+        ctx = pytest.warns(CacheMissingWarning, match=".*PermissionError.*")
 
     u, c = next(valid_urls)
     with open(download_file(u, cache=True)):
-        with pytest.warns(CacheMissingWarning, match=r".*in use.*"), ctx:
+        with pytest.warns(CacheMissingWarning, match=".*in use.*"), ctx:
             clear_download_cache(u)
 
 
@@ -2102,12 +2102,12 @@ def test_update_of_open_files_windows(temp_cache, valid_urls, monkeypatch):
     if PYTEST_LT_8_0:
         ctx = nullcontext()
     else:
-        ctx = pytest.warns(CacheMissingWarning, match=r".*read-only.*")
+        ctx = pytest.warns(CacheMissingWarning, match=".*read-only.*")
 
     u, c = next(valid_urls)
     with open(download_file(u, cache=True)):
         u2, c2 = next(valid_urls)
-        with pytest.warns(CacheMissingWarning, match=r".*in use.*"), ctx:
+        with pytest.warns(CacheMissingWarning, match=".*in use.*"), ctx:
             f = download_file(u, cache="update", sources=[u2])
         check_download_cache()
         assert is_url_in_cache(u)

--- a/astropy/utils/tests/test_misc.py
+++ b/astropy/utils/tests/test_misc.py
@@ -70,7 +70,7 @@ def test_skip_hidden():
         # subdirectories that don't have these files
         break
     with pytest.warns(
-        AstropyDeprecationWarning, match="^The walk_skip_hidden function is deprecated"
+        AstropyDeprecationWarning, match="^The .*_hidden function is deprecated"
     ):
         for root, dirs, files in misc.walk_skip_hidden(path):
             assert ".hidden_file.txt" not in files

--- a/astropy/wcs/tests/test_pickle.py
+++ b/astropy/wcs/tests/test_pickle.py
@@ -2,6 +2,7 @@
 
 import os
 import pickle
+from contextlib import nullcontext
 
 import numpy as np
 import pytest
@@ -9,6 +10,7 @@ from numpy.testing import assert_array_almost_equal
 
 from astropy import wcs
 from astropy.io import fits
+from astropy.tests.helper import PYTEST_LT_8_0
 from astropy.utils.data import (
     get_pkg_data_contents,
     get_pkg_data_filename,
@@ -26,12 +28,19 @@ def test_basic():
 
 
 def test_dist():
+    if PYTEST_LT_8_0:
+        ctx = nullcontext()
+    else:
+        ctx = pytest.warns(
+            wcs.FITSFixedWarning, match="The WCS transformation has more axes"
+        )
+
     with get_pkg_data_fileobj(
         os.path.join("data", "dist.fits"), encoding="binary"
     ) as test_file:
         hdulist = fits.open(test_file)
         # The use of ``AXISCORR`` for D2IM correction has been deprecated
-        with pytest.warns(AstropyDeprecationWarning):
+        with pytest.warns(AstropyDeprecationWarning), ctx:
             wcs1 = wcs.WCS(hdulist[0].header, hdulist)
         assert wcs1.det2im2 is not None
 

--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -21,7 +21,7 @@ from astropy.coordinates import SkyCoord
 from astropy.io import fits
 from astropy.io.fits.verify import VerifyWarning
 from astropy.nddata import Cutout2D
-from astropy.tests.helper import assert_quantity_allclose, PYTEST_LT_8_0
+from astropy.tests.helper import PYTEST_LT_8_0, assert_quantity_allclose
 from astropy.utils.data import (
     get_pkg_data_contents,
     get_pkg_data_filename,

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -3758,8 +3758,10 @@ def validate(source):
 
     if isinstance(source, fits.HDUList):
         hdulist = source
+        close_file = False
     else:
         hdulist = fits.open(source)
+        close_file = True
 
     results = _WcsValidateResults()
 
@@ -3798,5 +3800,8 @@ def validate(source):
                     wcs_results.append(str(e))
 
                 wcs_results.extend([str(x.message) for x in warning_lines])
+
+    if close_file:
+        hdulist.close()
 
     return results

--- a/astropy/wcs/wcsapi/tests/test_fitswcs.py
+++ b/astropy/wcs/wcsapi/tests/test_fitswcs.py
@@ -3,6 +3,7 @@
 # a mix-in)
 
 import warnings
+from contextlib import nullcontext
 from itertools import product
 
 import numpy as np
@@ -24,7 +25,7 @@ from astropy.coordinates import (
 from astropy.io import fits
 from astropy.io.fits import Header
 from astropy.io.fits.verify import VerifyWarning
-from astropy.tests.helper import assert_quantity_allclose
+from astropy.tests.helper import assert_quantity_allclose, PYTEST_LT_8_0
 from astropy.time import Time
 from astropy.units import Quantity
 from astropy.units.core import UnitsWarning
@@ -806,10 +807,17 @@ def test_time_1d_unsupported_ctype(header_time_1d_no_obs):
     # Case where the MJDREF is split into two for high precision
     header_time_1d_no_obs["CTYPE1"] = "UT(WWV)"
 
+    if PYTEST_LT_8_0:
+        ctx = nullcontext()
+    else:
+        ctx = pytest.warns(
+            UserWarning, match="Missing or incomplete observer location information"
+        )
+
     wcs = WCS(header_time_1d_no_obs)
     with pytest.warns(
         UserWarning, match="Dropping unsupported sub-scale WWV from scale UT"
-    ):
+    ), ctx:
         time = wcs.pixel_to_world(10)
 
     assert isinstance(time, Time)

--- a/astropy/wcs/wcsapi/tests/test_fitswcs.py
+++ b/astropy/wcs/wcsapi/tests/test_fitswcs.py
@@ -25,7 +25,7 @@ from astropy.coordinates import (
 from astropy.io import fits
 from astropy.io.fits import Header
 from astropy.io.fits.verify import VerifyWarning
-from astropy.tests.helper import assert_quantity_allclose, PYTEST_LT_8_0
+from astropy.tests.helper import PYTEST_LT_8_0, assert_quantity_allclose
 from astropy.time import Time
 from astropy.units import Quantity
 from astropy.units.core import UnitsWarning

--- a/docs/changes/wcs/15054.bugfix.rst
+++ b/docs/changes/wcs/15054.bugfix.rst
@@ -1,0 +1,1 @@
+``wcs.validate(filename)`` now properly closes the file handler.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address pytest 8 compatibility, which also allows us to fix some poor test warnings handling. Also see https://github.com/pytest-dev/pytest/pull/10937#issuecomment-1619222493

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #15015 

- [x] Finish fixing stuff, ran out of time...
- [x] In a separate PR, pin maxversion of pytest in v5.0.x because I don't want to redo this in old LTS branch. See #15060

After merge: Open follow-up issue to just require `pytest>=8` in the future so we can clean up the if-else logic here.