### PR TITLE
The sigma_clip mask parameter description is corrected

### DIFF
--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -777,8 +777,7 @@ def sigma_clip(
     masked : bool, optional
         If `True`, then a `~numpy.ma.MaskedArray` is returned, where
         the mask is `True` for clipped values. If `False`, then a
-        `~numpy.ndarray` and the minimum and maximum clipping thresholds
-        are returned. The default is `True`.
+        `~numpy.ndarray` is returned. The default is `True`.
 
     return_bounds : bool, optional
         If `True`, then the minimum and maximum clipping bounds are also


### PR DESCRIPTION
The [sigma_clip](https://docs.astropy.org/en/stable/api/astropy.stats.sigma_clip.html#sigma-clip) mask parameter description is corrected. 

### Description

> masked: bool, optional
>   
> If True, then a MaskedArray is returned, where the mask is True for clipped values. If False, then a ndarray and the minimum and maximum clipping thresholds are returned. The default is True.
 
was changed to

> masked: bool, optional
>   
> If True, then a MaskedArray is returned, where the mask is True for clipped values. If False, then a ndarray is returned. The default is True.
 


<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->


<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->


<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #15057
