### PR TITLE
MNT: Pin pytest<8 for v5.0.x

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -54,14 +54,14 @@ asdf_extensions =
 
 [options.extras_require]
 test =  # Required to run the astropy test suite.
-    pytest>=7.0
+    pytest>=7.0,<8
     pytest-doctestplus>=0.12
     pytest-astropy-header>=0.2.1
     hypothesis==6.72.3
     pytest-astropy>=0.9
     pytest-xdist
 test_all =  # Required for testing, plus packages used by particular tests.
-    pytest>=7.0
+    pytest>=7.0,<8
     pytest-doctestplus>=0.12
     pytest-astropy-header>=0.2.1
     pytest-astropy>=0.9
@@ -92,12 +92,12 @@ all =
     asdf>=2.9.2
     bottleneck
     ipython>=4.2
-    pytest>=7.0
+    pytest>=7.0,<8
     typing_extensions>=3.10.0.1
 docs =
     sphinx
     sphinx-astropy>=1.6
-    pytest>=7.0
+    pytest>=7.0,<8
     scipy>=1.3
     matplotlib>=3.1,!=3.4.0,!=3.5.2
     sphinx-changelog>=1.2.0


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to pin maxversion of pytest in LTS branch that is v5.0.x because pytest 8 will have breaking changes that affect our tests. This is a companion PR to #15054 . Also see #15015 .