### PR TITLE
Adjust to numpy dev scalar format

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -62,8 +62,10 @@ jobs:
       envs: |
         # NOTE: this coverage test is needed for tests and code that
         #       run only with minimal dependencies.
+        # 2024-05-30: added predeps to ensure new PRs do not break numpy 2.0
+        # docs.  Fine to remove once numpy 2.0 is released (if problematic).
         - name: Python 3.12 with minimal dependencies and full coverage
-          linux: py312-test-cov
+          linux: py312-test-cov-predeps
           coverage: codecov
 
         - name: Python 3.11 in Parallel with all optional dependencies

--- a/astropy/conftest.py
+++ b/astropy/conftest.py
@@ -17,7 +17,6 @@ except ImportError:
     PYTEST_HEADER_MODULES = {}
     TESTED_VERSIONS = {}
 
-import numpy as np
 import pytest
 
 from astropy import __version__
@@ -61,17 +60,6 @@ def fast_thread_switching():
     sys.setswitchinterval(1e-6)
     yield
     sys.setswitchinterval(old)
-
-
-@pytest.fixture
-def without_legacy_printoptions():
-    # this can be removed when/after removing the call to np.set_printoptions
-    # at the top level
-    # reverting https://github.com/astropy/astropy/pull/15096
-    legacy_val = np.get_printoptions()["legacy"]
-    np.set_printoptions(legacy=False)
-    yield
-    np.set_printoptions(legacy=legacy_val)
 
 
 def pytest_configure(config):

--- a/astropy/conftest.py
+++ b/astropy/conftest.py
@@ -21,10 +21,6 @@ import numpy as np
 import pytest
 
 from astropy import __version__
-from astropy.utils.compat.numpycompat import NUMPY_LT_2_0
-
-if not NUMPY_LT_2_0:
-    np.set_printoptions(legacy="1.25")
 
 # This is needed to silence a warning from matplotlib caused by
 # PyInstaller's matplotlib runtime hook.  This can be removed once the

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -1766,13 +1766,13 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
         >>> from astropy.coordinates import ICRS, SkyCoord
         >>> c1 = SkyCoord(0*u.deg, 0*u.deg)
         >>> c2 = ICRS(1*u.deg, 0*u.deg)
-        >>> c1.position_angle(c2).degree
-        90.0
-        >>> c2.position_angle(c1).degree
-        270.0
+        >>> c1.position_angle(c2).to(u.deg)
+        <Angle 90. deg>
+        >>> c2.position_angle(c1).to(u.deg)
+        <Angle 270. deg>
         >>> c3 = SkyCoord(1*u.deg, 1*u.deg)
-        >>> c1.position_angle(c3).degree  # doctest: +FLOAT_CMP
-        44.995636455344844
+        >>> c1.position_angle(c3).to(u.deg)  # doctest: +FLOAT_CMP
+        <Angle 44.995636455344844 deg>
         """
         return position_angle(*self._prepare_unit_sphere_coords(other, "ignore"))
 

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -766,7 +766,6 @@ def test_repr():
     assert repr(sc_default) == "<SkyCoord (ICRS): (ra, dec) in deg\n    (0., 1.)>"
 
 
-@pytest.mark.usefixtures("without_legacy_printoptions")
 def test_repr_altaz():
     sc2 = SkyCoord(1 * u.deg, 1 * u.deg, frame="icrs", distance=1 * u.kpc)
 

--- a/astropy/io/fits/tests/test_diff.py
+++ b/astropy/io/fits/tests/test_diff.py
@@ -677,7 +677,6 @@ class TestDiff(FitsTestCase):
         assert "a: 2\n b: 3" in report
         assert "No differences found between common HDUs" in report
 
-    @pytest.mark.usefixtures("without_legacy_printoptions")
     def test_partially_identical_files2(self):
         """
         Test files that have some identical HDUs but one different HDU.

--- a/astropy/io/fits/tests/test_fitsdiff.py
+++ b/astropy/io/fits/tests/test_fitsdiff.py
@@ -64,7 +64,6 @@ class TestFITSDiff_script(FitsTestCase):
         numdiff = fitsdiff.main([tmp_a, tmp_b])
         assert numdiff == 1
 
-    @pytest.mark.usefixtures("without_legacy_printoptions")
     def test_manydiff(self, capsys):
         a = np.arange(100).reshape(10, 10)
         hdu_a = PrimaryHDU(data=a)
@@ -95,7 +94,6 @@ class TestFITSDiff_script(FitsTestCase):
             "     100 different pixels found (100.00% different).",
         ]
 
-    @pytest.mark.usefixtures("without_legacy_printoptions")
     def test_outputfile(self):
         a = np.arange(100).reshape(10, 10)
         hdu_a = PrimaryHDU(data=a)
@@ -148,7 +146,6 @@ class TestFITSDiff_script(FitsTestCase):
         numdiff = fitsdiff.main(["-r", "1e-1", tmp_a, tmp_b])
         assert numdiff == 0
 
-    @pytest.mark.usefixtures("without_legacy_printoptions")
     def test_rtol_diff(self, capsys):
         a = np.arange(100, dtype=float).reshape(10, 10)
         hdu_a = PrimaryHDU(data=a)

--- a/astropy/io/misc/tests/test_yaml.py
+++ b/astropy/io/misc/tests/test_yaml.py
@@ -46,7 +46,6 @@ from astropy.time import Time
         np.complex128(1.0 - 2**-52 + 1j * (1.0 - 2**-52)),
     ],
 )
-@pytest.mark.usefixtures("without_legacy_printoptions")
 def test_numpy_types(c):
     cy = load(dump(c))
     assert c == cy

--- a/astropy/io/votable/tests/test_converter.py
+++ b/astropy/io/votable/tests/test_converter.py
@@ -134,7 +134,6 @@ def test_float_mask_permissive():
     assert c.parse("null", config=config) == (c.null, True)
 
 
-@pytest.mark.usefixtures("without_legacy_printoptions")
 def test_double_array():
     config = {"verify": "exception", "version_1_3_or_later": True}
     field = tree.Field(None, name="c", datatype="double", arraysize="3", config=config)
@@ -278,7 +277,6 @@ def test_integer_overflow():
         c.parse("-2208988800", config=config)
 
 
-@pytest.mark.usefixtures("without_legacy_printoptions")
 def test_float_default_precision():
     config = {"verify": "exception"}
 

--- a/astropy/io/votable/tests/test_vo.py
+++ b/astropy/io/votable/tests/test_vo.py
@@ -178,7 +178,6 @@ def _test_regression(tmp_path, _python_based=False, binary_mode=1):
 
 
 @pytest.mark.xfail("legacy_float_repr")
-@pytest.mark.usefixtures("without_legacy_printoptions")
 def test_regression(tmp_path):
     # W39: Bit values can not be masked
     with pytest.warns(W39), np.errstate(over="ignore"):
@@ -186,7 +185,6 @@ def test_regression(tmp_path):
 
 
 @pytest.mark.xfail("legacy_float_repr")
-@pytest.mark.usefixtures("without_legacy_printoptions")
 def test_regression_python_based_parser(tmp_path):
     # W39: Bit values can not be masked
     with pytest.warns(W39), np.errstate(over="ignore"):
@@ -194,7 +192,6 @@ def test_regression_python_based_parser(tmp_path):
 
 
 @pytest.mark.xfail("legacy_float_repr")
-@pytest.mark.usefixtures("without_legacy_printoptions")
 def test_regression_binary2(tmp_path):
     # W39: Bit values can not be masked
     with pytest.warns(W39), np.errstate(over="ignore"):
@@ -267,7 +264,6 @@ class TestReferences:
         pytest.param(["c1", "string_test", "c2"], ["c1", "c2"], id="list-only-missing"),
     ],
 )
-@pytest.mark.usefixtures("without_legacy_printoptions")
 def test_select_missing_columns_error_message(columns, expected_missing):
     # see https://github.com/astropy/astropy/pull/15956
     filename = get_pkg_data_filename("data/regression.xml")
@@ -461,7 +457,6 @@ class TestParse:
         )
         assert_array_equal(self.mask["long"], [False, True, False, False, True])
 
-    @pytest.mark.usefixtures("without_legacy_printoptions")
     def test_double(self):
         assert issubclass(self.array["double"].dtype.type, np.float64)
         assert_array_equal(
@@ -642,7 +637,6 @@ class TestParse:
             ],
         )
 
-    @pytest.mark.usefixtures("without_legacy_printoptions")
     def test_double_array(self):
         assert issubclass(self.array["doublearray"].dtype.type, np.object_)
         assert len(self.array["doublearray"][0]) == 0
@@ -698,7 +692,6 @@ class TestParse:
             info = self.votable.get_info_by_id("ErrorInfo")
             assert info.value == "One might expect to find some INFO here, too..."
 
-    @pytest.mark.usefixtures("without_legacy_printoptions")
     def test_repr(self):
         assert "3 tables" in repr(self.votable)
         assert (
@@ -877,7 +870,6 @@ def test_too_many_columns():
         parse(get_pkg_data_filename("data/too_many_columns.xml.gz"))
 
 
-@pytest.mark.usefixtures("without_legacy_printoptions")
 def test_build_from_scratch(tmp_path):
     # Create a new VOTable file...
     votable = tree.VOTableFile()

--- a/astropy/stats/info_theory.py
+++ b/astropy/stats/info_theory.py
@@ -95,7 +95,7 @@ def bayesian_info_criterion(log_likelihood, n_params, n_samples):
     >>> bic_g = bayesian_info_criterion(lnL_g, n_params_g, n_samples)
     >>> bic_t = bayesian_info_criterion(lnL_t, n_params_t, n_samples)
     >>> bic_g - bic_t # doctest: +FLOAT_CMP
-    2.1948298140119391
+    np.float64(2.1948298140119391)
 
     Therefore, there exist a moderate evidence that the increasing in
     likelihood for t-Student model is due to the larger number of parameters.
@@ -385,11 +385,11 @@ def akaike_info_criterion_lsq(ssr, n_params, n_samples):
     >>> ssr_g2 = np.sum((g2_fit(x) - y)**2.0)
     >>> ssr_g1 = np.sum((g1_fit(x) - y)**2.0)
     >>> akaike_info_criterion_lsq(ssr_g3, 9, x.shape[0]) # doctest: +FLOAT_CMP
-    -634.5257517810961
+    np.float64(-634.5257517810961)
     >>> akaike_info_criterion_lsq(ssr_g2, 6, x.shape[0]) # doctest: +FLOAT_CMP
-    -662.83834510232043
+    np.float64(-662.83834510232043)
     >>> akaike_info_criterion_lsq(ssr_g1, 3, x.shape[0]) # doctest: +FLOAT_CMP
-    -647.47312032659499
+    np.float64(-647.47312032659499)
 
     Hence, from the AIC values, we would prefer to choose the model g2_fit.
     However, we can considerably support the model g3_fit, since the

--- a/astropy/stats/jackknife.py
+++ b/astropy/stats/jackknife.py
@@ -116,11 +116,11 @@ def jackknife_stats(data, statistic, confidence_level=0.95):
     >>> estimate, bias, stderr, conf_interval = jackknife_stats(
     ...     data, test_statistic, 0.95)
     >>> estimate
-    4.5
+    np.float64(4.5)
     >>> bias
-    0.0
+    np.float64(0.0)
     >>> stderr  # doctest: +FLOAT_CMP
-    0.95742710775633832
+    np.float64(0.95742710775633832)
     >>> conf_interval
     array([2.62347735,  6.37652265])
 

--- a/astropy/table/row.py
+++ b/astropy/table/row.py
@@ -26,9 +26,9 @@ class Row:
       ----- -----
           2     4
       >>> row['a']
-      2
+      np.int32(2)
       >>> row[1]
-      4
+      np.int32(4)
     """
 
     def __init__(self, table, index):
@@ -132,9 +132,9 @@ class Row:
         >>> from astropy.table import Table
         >>> t = Table({"a": [2, 3, 5], "b": [7, 11, 13]})
         >>> t[0].get("a")
-        2
+        np.int64(2)
         >>> t[1].get("b", 0)
-        11
+        np.int64(11)
         >>> t[2].get("c", 0)
         0
         """

--- a/astropy/table/table_helpers.py
+++ b/astropy/table/table_helpers.py
@@ -105,7 +105,7 @@ def simple_table(size=3, cols=None, kinds="ifS", masked=False):
         elif kind == "O":
             indices = (np.arange(size) + jj) % len(letters)
             vals = letters[indices]
-            data = [{val: index} for val, index in zip(vals, indices)]
+            data = [{val.item(): index.item()} for val, index in zip(vals, indices)]
         else:
             raise ValueError("Unknown data kind")
         columns.append(Column(data))

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -848,7 +848,6 @@ def test_quantity_representation():
         ),
     ],
 )
-@pytest.mark.usefixtures("without_legacy_printoptions")
 def test_representation_representation(c, expected_pformat):
     """
     Test that Representations are represented correctly.
@@ -900,7 +899,6 @@ def test_skycoord_representation():
 
 
 @pytest.mark.parametrize("as_ndarray_mixin", [True, False])
-@pytest.mark.usefixtures("without_legacy_printoptions")
 def test_ndarray_mixin(as_ndarray_mixin):
     """
     Test directly adding various forms of structured ndarray columns to a table.

--- a/astropy/table/tests/test_operations.py
+++ b/astropy/table/tests/test_operations.py
@@ -927,7 +927,6 @@ class TestJoin:
         with pytest.raises(ValueError, match=msg):
             table.join(t1, t2, keys_left=["a"], keys_right=["a"], join_funcs={})
 
-    @pytest.mark.usefixtures("without_legacy_printoptions")
     def test_join_structured_column(self):
         """Regression tests for gh-13271."""
         # Two tables with matching names, including a structured column.
@@ -1514,7 +1513,6 @@ class TestVStack:
         with pytest.raises(ValueError, match="representations are inconsistent"):
             table.vstack([t1, t3])
 
-    @pytest.mark.usefixtures("without_legacy_printoptions")
     def test_vstack_structured_column(self):
         """Regression tests for gh-13271."""
         # Two tables with matching names, including a structured column.
@@ -1740,7 +1738,6 @@ class TestDStack:
         assert skycoord_equal(sc1, t12["col0"][:, 0])
         assert skycoord_equal(sc2, t12["col0"][:, 1])
 
-    @pytest.mark.usefixtures("without_legacy_printoptions")
     def test_dstack_structured_column(self):
         """Regression tests for gh-13271."""
         # Two tables with matching names, including a structured column.

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -885,17 +885,17 @@ class TimeUnixTai(TimeUnix):
       >>> from astropy.time import Time
       >>> t = Time('2020-01-01', scale='utc')
       >>> t.unix_tai - t.unix
-      37.0
+      np.float64(37.0)
 
       >>> # Before 1972, the offset between TAI and UTC was not integer
       >>> t = Time('1970-01-01', scale='utc')
       >>> t.unix_tai - t.unix  # doctest: +FLOAT_CMP
-      8.000082
+      np.float64(8.000082)
 
       >>> # Initial offset of 10 seconds in 1972
       >>> t = Time('1972-01-01', scale='utc')
       >>> t.unix_tai - t.unix
-      10.0
+      np.float64(10.0)
     """
 
     name = "unix_tai"
@@ -1261,7 +1261,7 @@ class TimeYMDHMS(TimeUnique):
       >>> t.iso
       '2015-02-03 12:13:14.567'
       >>> t.ymdhms.year
-      2015
+      np.int32(2015)
     """
 
     name = "ymdhms"

--- a/astropy/timeseries/periodograms/bls/core.py
+++ b/astropy/timeseries/periodograms/bls/core.py
@@ -56,7 +56,7 @@ class BoxLeastSquares(BasePeriodogram):
     >>> model = BoxLeastSquares(t, y)
     >>> results = model.autopower(0.16)
     >>> results.period[np.argmax(results.power)]  # doctest: +FLOAT_CMP
-    2.000412388152837
+    np.float64(2.000412388152837)
 
     Compute the periodogram on a user-specified period grid:
 

--- a/astropy/timeseries/periodograms/lombscargle/core.py
+++ b/astropy/timeseries/periodograms/lombscargle/core.py
@@ -68,7 +68,7 @@ class LombScargle(BasePeriodogram):
 
     >>> frequency, power = LombScargle(t, y).autopower()
     >>> frequency[np.argmax(power)]  # doctest: +FLOAT_CMP
-    1.0007641728995051
+    np.float64(1.0007641728995051)
 
     Compute the Lomb-Scargle periodogram at a user-specified frequency grid:
 

--- a/astropy/units/structured.py
+++ b/astropy/units/structured.py
@@ -121,7 +121,7 @@ class StructuredUnit:
     Structured units share most methods with regular units::
 
         >>> su.physical_type
-        ((PhysicalType('length'), PhysicalType({'speed', 'velocity'})), PhysicalType('time'))
+        astropy.units.structured.Structure((astropy.units.structured.Structure((PhysicalType('length'), PhysicalType({'speed', 'velocity'})), dtype=[('f0', 'O'), ('f1', 'O')]), PhysicalType('time')), dtype=[('f0', 'O'), ('f1', 'O')])
         >>> su.si
         Unit("((1.49598e+11 m, 1.73146e+06 m / s), 3.15576e+07 s)")
 

--- a/astropy/utils/masked/tests/test_masked.py
+++ b/astropy/utils/masked/tests/test_masked.py
@@ -1405,7 +1405,6 @@ def test_masked_str_explicit_string():
     assert repr(msa) == repr_
 
 
-@pytest.mark.usefixtures("without_legacy_printoptions")
 def test_masked_str_explicit_structured():
     sa = np.array([(1.0, 2.0), (3.0, 4.0)], dtype="f8,f8")
     msa = Masked(sa, [(False, True), (False, False)])

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -3104,10 +3104,10 @@ reduce these to 2 dimensions using the naxis kwarg.
         the `printwcs()` method.
         """
         description = ["WCS Keywords\n", f"Number of WCS axes: {self.naxis!r}"]
-        sfmt = " : " + "".join([f"{{{i}!r}} " for i in range(self.naxis)])
+        sfmt = " : " + "".join([f"{{{i}}} " for i in range(self.naxis)])
 
         keywords = ["CTYPE", "CRVAL", "CRPIX"]
-        values = [self.wcs.ctype, self.wcs.crval, self.wcs.crpix]
+        values = [[repr(v) for v in self.wcs.ctype], self.wcs.crval, self.wcs.crpix]
         for keyword, value in zip(keywords, values):
             description.append(keyword + sfmt.format(*value))
 

--- a/docs/coordinates/angles.rst
+++ b/docs/coordinates/angles.rst
@@ -81,41 +81,41 @@ There are many ways to represent the value of an |Angle|::
     >>> a  # doctest: +FLOAT_CMP
     <Angle 1. rad>
     >>> a.radian
-    1.0
+    np.float64(1.0)
     >>> a.degree  # doctest: +FLOAT_CMP
-    57.29577951308232
+    np.float64(57.29577951308232)
     >>> a.hour  # doctest: +FLOAT_CMP
-    3.8197186342054885
+    np.float64(3.8197186342054885)
     >>> a.hms  # doctest: +FLOAT_CMP
-    hms_tuple(h=3.0, m=49.0, s=10.987083139758766)
+    hms_tuple(h=np.float64(3.0), m=np.float64(49.0), s=np.float64(10.987083139758766))
     >>> a.dms  # doctest: +FLOAT_CMP
-    dms_tuple(d=57.0, m=17.0, s=44.806247096362313)
+    dms_tuple(d=np.float64(57.0), m=np.float64(17.0), s=np.float64(44.806247096362313))
     >>> a.signed_dms  # doctest: +FLOAT_CMP
-    signed_dms_tuple(sign=1.0, d=57.0, m=17.0, s=44.806247096362313)
+    signed_dms_tuple(sign=np.float64(1.0), d=np.float64(57.0), m=np.float64(17.0), s=np.float64(44.806247096362313))
     >>> (-a).dms  # doctest: +FLOAT_CMP
-    dms_tuple(d=-57.0, m=-17.0, s=-44.806247096362313)
+    dms_tuple(d=np.float64(-57.0), m=np.float64(-17.0), s=np.float64(-44.806247096362313))
     >>> (-a).signed_dms  # doctest: +FLOAT_CMP
-    signed_dms_tuple(sign=-1.0, d=57.0, m=17.0, s=44.806247096362313)
+    signed_dms_tuple(sign=np.float64(-1.0), d=np.float64(57.0), m=np.float64(17.0), s=np.float64(44.806247096362313))
     >>> a.arcminute  # doctest: +FLOAT_CMP
-    3437.7467707849396
+    np.float64(3437.7467707849396)
     >>> f"{a}"
     '1.0 rad'
     >>> f"{a:latex}"
-    '$1\\;\\mathrm{rad}$'
+    np.str_('$1\\;\\mathrm{rad}$')
     >>> f"{a.to(u.deg):latex}"
-    '$57^\\circ17{}^\\prime44.8062471{}^{\\prime\\prime}$'
+    np.str_('$57^\\circ17{}^\\prime44.8062471{}^{\\prime\\prime}$')
     >>> a.to_string()
-    '1 rad'
+    np.str_('1 rad')
     >>> a.to_string(unit=u.degree)
-    '57d17m44.8062471s'
+    np.str_('57d17m44.8062471s')
     >>> a.to_string(unit=u.degree, sep=':')
-    '57:17:44.8062471'
+    np.str_('57:17:44.8062471')
     >>> a.to_string(unit=u.degree, sep=('deg', 'm', 's'))
-    '57deg17m44.8062471s'
+    np.str_('57deg17m44.8062471s')
     >>> a.to_string(unit=u.hour)
-    '3h49m10.98708314s'
+    np.str_('3h49m10.98708314s')
     >>> a.to_string(unit=u.hour, decimal=True)
-    '3.81972'
+    np.str_('3.81972')
 
 ..
   EXAMPLE END

--- a/docs/coordinates/frames.rst
+++ b/docs/coordinates/frames.rst
@@ -96,7 +96,7 @@ These same attributes can be used to access the data in the frames as
     >>> coo.ra  # doctest: +FLOAT_CMP
     <Longitude 1.1 deg>
     >>> coo.ra.value  # doctest: +FLOAT_CMP
-    1.1
+    np.float64(1.1)
     >>> coo.ra.to(u.hourangle)  # doctest: +FLOAT_CMP
     <Longitude 0.07333333 hourangle>
 

--- a/docs/coordinates/index.rst
+++ b/docs/coordinates/index.rst
@@ -112,15 +112,15 @@ default, ICRS, the coordinate component names are ``ra`` and ``dec``::
     >>> c.ra  # doctest: +FLOAT_CMP
     <Longitude 10.68458 deg>
     >>> c.ra.hour  # doctest: +FLOAT_CMP
-    0.7123053333333335
+    np.float64(0.7123053333333335)
     >>> c.ra.hms  # doctest: +FLOAT_CMP
-    hms_tuple(h=0.0, m=42.0, s=44.299200000000525)
+    hms_tuple(h=np.float64(0.0), m=np.float64(42.0), s=np.float64(44.299200000000525))
     >>> c.dec  # doctest: +FLOAT_CMP
     <Latitude 41.26917 deg>
     >>> c.dec.degree  # doctest: +FLOAT_CMP
-    41.26917
+    np.float64(41.26917)
     >>> c.dec.radian  # doctest: +FLOAT_CMP
-    0.7202828960652683
+    np.float64(0.7202828960652683)
 
 Coordinates can be converted to strings using the
 :meth:`~astropy.coordinates.SkyCoord.to_string` method::

--- a/docs/coordinates/matchsep.rst
+++ b/docs/coordinates/matchsep.rst
@@ -33,13 +33,13 @@ is possible to access the angle in any of several equivalent angular
 units::
 
     >>> sep.radian  # doctest: +FLOAT_CMP
-    0.36208800460262563
+    np.float64(0.36208800460262563)
     >>> sep.hour  # doctest: +FLOAT_CMP
-    1.3830742984029318
+    np.float64(1.3830742984029318)
     >>> sep.arcminute  # doctest: +FLOAT_CMP
-    1244.7668685626384
+    np.float64(1244.7668685626384)
     >>> sep.arcsecond  # doctest: +FLOAT_CMP
-    74686.0121137583
+    np.float64(74686.0121137583)
 
 Also note that the two input coordinates were not in the same frame —
 one is automatically converted to match the other, ensuring that even
@@ -296,13 +296,13 @@ with an interface very similar to ``match_coordinates_*``:
     >>> import numpy as np
     >>> idxc, idxcatalog, d2d, d3d = catalog.search_around_sky(c, 1*u.deg)
     >>> np.all(d2d < 1*u.deg)
-    True
+    np.True_
 
 .. doctest-requires:: scipy
 
     >>> idxc, idxcatalog, d2d, d3d = catalog.search_around_3d(c, 1*u.kpc)
     >>> np.all(d3d < 1*u.kpc)
-    True
+    np.True_
 
 The key difference for these methods is that there can be multiple (or no)
 matches in ``catalog`` around any locations in ``c``. Hence, indices into both
@@ -313,9 +313,9 @@ matter, any array with the same order:
 ..  doctest-requires:: scipy
 
     >>> np.all(c[idxc].separation(catalog[idxcatalog]) == d2d)
-    True
+    np.True_
     >>> np.all(c[idxc].separation_3d(catalog[idxcatalog]) == d3d)
-    True
+    np.True_
     >>> print(catalog_objectnames[idxcatalog]) #doctest: +SKIP
     ['NGC 1234' 'NGC 4567' ...]
 

--- a/docs/coordinates/skycoord.rst
+++ b/docs/coordinates/skycoord.rst
@@ -1134,7 +1134,7 @@ FK4 => ICRS => FK4 and then compare::
 
   >>> sc1 = SkyCoord(1*u.deg, 2*u.deg, frame='fk4')
   >>> sc1.icrs.fk4 == sc1
-  False
+  np.False_
 
 Matching Within Tolerance
 -------------------------
@@ -1145,7 +1145,7 @@ To test if coordinates are within a certain angular distance of one other, use t
   >>> sc1.icrs.fk4.separation(sc1).to(u.arcsec)  # doctest: +SKIP
   <Angle 7.98873629e-13 arcsec>
   >>> sc1.icrs.fk4.separation(sc1) < 1e-9 * u.arcsec
-  True
+  np.True_
 
 Exact Equality
 --------------
@@ -1175,7 +1175,7 @@ In the first example we show simple comparisons using array-valued coordinates::
   >>> sc2 == sc2[1]  # Broadcasting comparison with a scalar
   array([False,  True])
   >>> sc2[0] == sc2[1]  # Scalar to scalar comparison
-  False
+  np.False_
   >>> sc1 != sc2  # Not equal
   array([False,  True])
 

--- a/docs/cosmology/index.rst
+++ b/docs/cosmology/index.rst
@@ -98,7 +98,7 @@ floating point or array values::
   >>> from astropy.cosmology import WMAP9 as cosmo
   >>> H0 = cosmo.H(0)
   >>> H0.value, H0.unit  # doctest: +FLOAT_CMP
-  (69.32, Unit("km / (Mpc s)"))
+  (np.float64(69.32), Unit("km / (Mpc s)"))
 
 
 Using `astropy.cosmology`
@@ -258,7 +258,7 @@ To make a copy of a cosmological instance using the ``clone`` operation:
   >>> WMAP9.Om0, newcosmo.Om0  # some changed  # doctest: +FLOAT_CMP
   (0.2865, 0.3141)
   >>> WMAP9.Ode0, newcosmo.Ode0  # Indirectly changed since this is flat  # doctest: +FLOAT_CMP
-  (0.7134130719051658, 0.6858130719051657)
+  (np.float64(0.7134130719051658), np.float64(0.6858130719051657))
 
 ..
   EXAMPLE END
@@ -378,7 +378,7 @@ be found as a function of redshift::
 
   >>> from astropy.cosmology import WMAP7   # WMAP 7-year cosmology
   >>> WMAP7.Ogamma0, WMAP7.Onu0  # Current epoch values  # doctest: +FLOAT_CMP
-  (4.985694972799396e-05, 3.442154948307989e-05)
+  (np.float64(4.985694972799396e-05), np.float64(3.442154948307989e-05))
   >>> z = np.array([0, 1.0, 2.0])
   >>> WMAP7.Ogamma(z), WMAP7.Onu(z)  # doctest: +FLOAT_CMP
   (array([4.98603986e-05, 2.74593395e-04, 4.99915942e-04]),
@@ -391,7 +391,7 @@ set ``Tcmb0`` to 0 (which is also the default)::
   >>> import astropy.units as u
   >>> cos = FlatLambdaCDM(70.4 * u.km / u.s / u.Mpc, 0.272, Tcmb0 = 0.0 * u.K)
   >>> cos.Ogamma0, cos.Onu0
-  (0.0, 0.0)
+  (np.float64(0.0), np.float64(0.0))
 
 You can include photons but exclude any contributions from neutrinos by setting
 ``Tcmb0`` to be non-zero (2.725 K is the standard value for our Universe) but

--- a/docs/cosmology/units.rst
+++ b/docs/cosmology/units.rst
@@ -64,7 +64,7 @@ Since the redshift is not a true unit and is used so frequently, the
 redshift / dimensionless equivalency is actually enabled by default.
 
     >>> z == 1100 * u.dimensionless_unscaled
-    True
+    np.True_
 
     >>> q.to(u.K)
     <Quantity 2970. K>

--- a/docs/io/fits/index.rst
+++ b/docs/io/fits/index.rst
@@ -452,7 +452,7 @@ the second index. Similarly, the 1-indexed subsection of x=11 to 20
            [347, 348, 347, 348, 349, 349, 350, 349, 348, 348],
            [349, 349, 350, 348, 350, 347, 349, 349, 349, 348],
            [349, 348, 348, 348, 348, 348, 349, 347, 349, 348],
-           [349, 349, 349, 348, 350, 349, 349, 350, 348, 350]], dtype=int16)
+           [349, 349, 349, 348, 350, 349, 349, 350, 348, 350]], dtype='>i2')
 
 To update the value of a pixel or a subsection::
 
@@ -518,7 +518,7 @@ guide.
 To see the first row of the table::
 
     >>> print(data[0])
-    (1, 'abc', 3.7000000715255736, False)
+    (np.int32(1), 'abc', np.float64(3.7000000715255736), np.False_)
 
 Each row in the table is a :class:`FITS_record` object which looks like a
 (Python) tuple containing elements of heterogeneous data types. In this
@@ -618,7 +618,7 @@ Since each field is a ``numpy`` object, we will have the entire arsenal of
 take the mean of a column::
 
     >>> data['c3'].mean()  # doctest: +FLOAT_CMP
-    5.19999989271164
+    np.float64(5.19999989271164)
 
 and so on.
 

--- a/docs/io/fits/usage/image.rst
+++ b/docs/io/fits/usage/image.rst
@@ -57,7 +57,7 @@ Here is a summary of reading and updating image data values::
            [314, 314, 314, 314, 312, 313, 314, 314, 314, 311],
            [314, 313, 312, 313, 313, 314, 312, 312, 311, 314],
            [313, 313, 313, 314, 313, 313, 315, 313, 312, 313],
-           [314, 313, 313, 314, 313, 312, 312, 314, 310, 314]], dtype=int16)
+           [314, 313, 313, 314, 313, 312, 312, 314, 310, 314]], dtype='>i2')
     >>> data[1,4] = 999  # update a pixel value
     >>> data[30:40, 10:20] = 0  # update values of a subsection
     >>> data[3] = data[2]    # copy the 3rd row to the 4th row
@@ -133,7 +133,7 @@ touched::
     >>> hdu.header['bzero']
     1500.0
     >>> hdu.data[0, 0]  # once data is touched, it is scaled  #  doctest: +FLOAT_CMP
-    557.7563
+    np.float32(557.7563)
     >>> hdu.data.dtype.name
     'float32'
     >>> hdu.header['bitpix']  # BITPIX is also updated

--- a/docs/io/fits/usage/unfamiliar.rst
+++ b/docs/io/fits/usage/unfamiliar.rst
@@ -94,7 +94,9 @@ The other difference is the need to specify the table type when using the
     >>> col3 = fits.Column(name='t1', format='I', array=[91, 92, 93], ascii=True)
     >>> hdu = fits.TableHDU.from_columns([col1, col2, col3])
     >>> hdu.data
-    FITS_rec([('abc', 11.0, 91), ('def', 12.0, 92), ('', 0.0, 93)],
+    FITS_rec([('abc', np.float64(11.0), np.int32(91)),
+              ('def', np.float64(12.0), np.int32(92)),
+              ('', np.float64(0.0), np.int32(93))],
              dtype=(numpy.record, [('abc', 'S3'), ('def', 'S15'), ('t1', 'S10')]))
 
 It should be noted that when the formats of the columns are unambiguously
@@ -301,9 +303,9 @@ Examples
 To show the contents of the third group, including parameters and data::
 
     >>> hdul[0].data[2]  # doctest: +FLOAT_CMP
-    (2.0999999, 42.0, 42.0, array([[[[30., 31., 32., 33., 34.],
+    (np.float32(2.1), np.float32(42.0), np.float32(42.0), array([[[[30., 31., 32., 33., 34.],
              [35., 36., 37., 38., 39.],
-             [40., 41., 42., 43., 44.]]]], dtype=float32))
+             [40., 41., 42., 43., 44.]]]], dtype='>f4'))
 
 The data first lists all of the parameters, then the image array, for the
 specified group(s). As a reminder, the image data in this file has the shape of
@@ -321,9 +323,9 @@ the table :meth:`~FITS_rec.field` method, the argument can be either index or
 name::
 
     >>> hdul[0].data.par(0)[8]  # Access group parameter by name or by index  # doctest: +FLOAT_CMP
-    8.1
+    np.float32(8.1)
     >>> hdul[0].data.par('abc')[8]  # doctest: +FLOAT_CMP
-    8.1
+    np.float32(8.1)
 
 Note that the parameter name 'xyz' appears twice. This is a feature in the
 random access group, and it means to add the values together. Thus::
@@ -331,13 +333,13 @@ random access group, and it means to add the values together. Thus::
     >>> hdul[0].data.parnames  # get the parameter names
     ['abc', 'xyz', 'xyz']
     >>> hdul[0].data.par(1)[8]  # Duplicate parameter name 'xyz'
-    42.0
+    np.float32(42.0)
     >>> hdul[0].data.par(2)[8]
-    42.0
+    np.float32(42.0)
     >>> # When accessed by name, it adds the values together if the name is
     >>> # shared by more than one parameter
     >>> hdul[0].data.par('xyz')[8]
-    84.0
+    np.float64(84.0)
 
 The :meth:`~GroupData.par` is a method for either the entire data object or one
 data item (a group). So there are two possible ways to get a group parameter
@@ -345,9 +347,9 @@ for a certain group, this is similar to the situation in table data (with its
 :meth:`~FITS_rec.field` method)::
 
     >>> hdul[0].data.par(0)[8]  # doctest: +FLOAT_CMP
-    8.1
+    np.float32(8.1)
     >>> hdul[0].data[8].par(0)  # doctest: +FLOAT_CMP
-    8.1
+    np.float32(8.1)
 
 On the other hand, to modify a group parameter, we can either assign the new
 value directly (if accessing the row/group number last) or use the

--- a/docs/known_issues.rst
+++ b/docs/known_issues.rst
@@ -188,12 +188,12 @@ the result may be misleading::
    >>> 0 * u.Celsius == 0 * u.m  # Correct
    False
    >>> 0 * u.Celsius == 0 == 0 * u.m  # Misleading
-   True
+   np.True_
 
 What the second comparison is really doing is this::
 
    >>> (0 * u.Celsius == 0) and (0 == 0 * u.m)
-   True
+   np.True_
 
 See: https://github.com/astropy/astropy/issues/15103
 
@@ -224,9 +224,9 @@ means that an upstream fix in NumPy is required in order for
 ``astropy.units`` to control decomposing the input in these functions::
 
     >>> np.int64((15 * u.km) / (15 * u.imperial.foot))
-    1
+    np.int64(1)
     >>> np.int_((15 * u.km) / (15 * u.imperial.foot))
-    1
+    np.int64(1)
     >>> int((15 * u.km) / (15 * u.imperial.foot))
     3280
 

--- a/docs/modeling/models.rst
+++ b/docs/modeling/models.rst
@@ -319,7 +319,7 @@ a bounding box, then one can use the
 method ::
 
     >>> model1.bounding_box.bounding_box()
-    ((-4.0, 4.0), (-3.0, 3.0), (-2.0, 2.0))
+    ((np.float64(-4.0), np.float64(4.0)), (np.float64(-3.0), np.float64(3.0)), (np.float64(-2.0), np.float64(2.0)))
     >>> model2.bounding_box.bounding_box()
     (-1, 1)
     >>> model3.bounding_box.bounding_box()
@@ -430,7 +430,7 @@ or not. In this case, it makes sense for the selector argument to be ignored ::
     >>> model1(0.5, 1.5, 0, with_bounding_box=True)
     (1.5, 3.5, 0.0)
     >>> model1(0.5, 1.5, 1, with_bounding_box=True)
-    (nan, nan, nan)
+    (np.float64(nan), np.float64(nan), np.float64(nan))
 
 Multiple selector arguments can also be used, in this case the keys of the
 dictionary of bounding boxes need to be specified as tuples of values ::
@@ -493,7 +493,7 @@ dictionary of bounding boxes need to be specified as tuples of values ::
     >>> model2(0.5, 1.5, 0, 0, with_bounding_box=True)
     (1.5, 3.5, 0.0, 0.0)
     >>> model2(0.5, 1.5, 1, 1, with_bounding_box=True)
-    (nan, nan, nan, nan)
+    (np.float64(nan), np.float64(nan), np.float64(nan), np.float64(nan))
 
 Note that one can also specify the ordering for all the bounding boxes
 comprising the compound bounding using the ``order`` keyword argument.

--- a/docs/modeling/units.rst
+++ b/docs/modeling/units.rst
@@ -35,7 +35,7 @@ It is then possible to access the individual properties of the parameter::
     >>> g1.mean.name
     'mean'
     >>> g1.mean.value
-    3.0
+    np.float64(3.0)
     >>> g1.mean.unit
     Unit("m")
 

--- a/docs/nddata/ccddata.rst
+++ b/docs/nddata/ccddata.rst
@@ -201,7 +201,7 @@ operation is between two `~astropy.nddata.CCDData` objects.
     >>> result = ccd.multiply(0.2 * u.adu)
     >>> uncertainty_ratio = result.uncertainty.array[0, 0]/ccd.uncertainty.array[0, 0]
     >>> round(uncertainty_ratio, 5)   # doctest: +FLOAT_CMP
-    0.2
+    np.float64(0.2)
     >>> result.unit
     Unit("adu electron")
 

--- a/docs/nddata/index.rst
+++ b/docs/nddata/index.rst
@@ -231,7 +231,7 @@ changes as expected::
     >>> ccd2 = ccd.copy()
     >>> added_ccds = ccd.add(ccd2, handle_meta='first_found')
     >>> added_ccds.uncertainty.array[0, 0] / ccd.uncertainty.array[0, 0] / np.sqrt(2) # doctest: +FLOAT_CMP
-    0.99999999999999989
+    np.float64(0.99999999999999989)
 
 ..
   EXAMPLE END

--- a/docs/nddata/nddata.rst
+++ b/docs/nddata/nddata.rst
@@ -349,12 +349,12 @@ copies during initialization by setting the ``copy`` parameter to ``True``::
     >>> ndd = NDData(array)
     >>> ndd.data[2] = 10
     >>> array[2]  # Original array has changed
-    10
+    np.int64(10)
 
     >>> ndd2 = NDData(array, copy=True)
     >>> ndd2.data[2] = 3
     >>> array[2]  # Original array hasn't changed.
-    10
+    np.int64(10)
 
 .. note::
     In some cases setting ``copy=True`` will copy the ``data`` twice. Known
@@ -518,4 +518,3 @@ Converting the ``data``, ``unit``, and ``mask`` to a ``MaskedQuantity``::
     >>> from astropy.utils.masked import Masked
     >>> Masked(u.Quantity(ndd.data, ndd.unit), ndd.mask)  # doctest: +FLOAT_CMP
     <MaskedQuantity [——, 2., 3., ——] m>
-

--- a/docs/nddata/subclassing.rst
+++ b/docs/nddata/subclassing.rst
@@ -222,11 +222,11 @@ be anything except ``None`` or ``"first_found"``::
     >>> ndd = NDDataWithMetaArithmetics([1,2,3], meta={'exposure': 10})
     >>> ndd2 = ndd.add(10, handle_meta='')
     >>> ndd2.meta
-    {'exposure': 20}
+    {'exposure': np.int64(20)}
 
     >>> ndd3 = ndd.multiply(0.5, handle_meta='')
     >>> ndd3.meta
-    {'exposure': 5.0}
+    {'exposure': np.float64(5.0)}
 
 .. warning::
   To use these internal `_arithmetic_*` methods there are some restrictions on
@@ -280,7 +280,7 @@ To change the default value of an existing parameter for arithmetic methods::
 
     >>> # But giving other values is still possible:
     >>> ndd1.add(ndd2, handle_mask=np.logical_or).mask
-    True
+    np.True_
 
     >>> ndd1.add(ndd2, handle_mask="ff").mask
     False

--- a/docs/stats/index.rst
+++ b/docs/stats/index.rst
@@ -43,7 +43,7 @@ For example, consider the following dataset with a clear outlier::
 The mean is skewed by the outlier::
 
     >>> x.mean()
-    11.333333333333334
+    np.float64(11.333333333333334)
 
 Sigma-clipping (3 sigma by default) returns a masked array,
 and so functions like ``mean`` will ignore the outlier::
@@ -55,7 +55,7 @@ and so functions like ``mean`` will ignore the outlier::
                        False],
            fill_value=999999)
     >>> clipped.mean()
-    0.375
+    np.float64(0.375)
 
 If you need to access the original data directly, you can use the
 ``data`` property. Combined with the ``mask`` property, you can get the
@@ -87,7 +87,7 @@ To estimate the background of an image::
                  mask=[False, False, False, False,  True, False, False, False],
            fill_value=999999)
     >>> np.mean(data_clipped)  # doctest: +FLOAT_CMP
-    4.285714285714286
+    np.float64(4.285714285714286)
 
 ..
   EXAMPLE END
@@ -119,7 +119,7 @@ the calculation of statistics even more convenient. For example,
 median, and standard deviation of a sigma-clipped array::
 
      >>> stats.sigma_clipped_stats(data, sigma=2, maxiters=5)  # doctest: +FLOAT_CMP
-     (4.2857142857142856, 5.0, 2.2497165354319457)
+     (np.float64(4.285714285714286), np.float64(5.0), np.float64(2.249716535431946))
 
 There are also tools for calculating :ref:`robust statistics
 <stats-robust>`, sampling the data, :ref:`circular statistics

--- a/docs/stats/robust.rst
+++ b/docs/stats/robust.rst
@@ -112,9 +112,9 @@ calculation:
 
      >>> from astropy.stats import sigma_clipped_stats
      >>> y.mean(), np.median(y), y.std()  # doctest: +FLOAT_CMP
-     (0.7068938765410144, 0.013567387681385379, 3.599605215851649)
+     (np.float64(0.7068938765410144), np.float64(0.013567387681385379), np.float64(3.599605215851649))
      >>> sigma_clipped_stats(y, sigma=3, maxiters=10)  # doctest: +FLOAT_CMP
-     (-0.0228473012826993, -0.02356858871405204, 0.2079616996908159)
+     (np.float64(-0.0228473012826993), np.float64(-0.02356858871405204), np.float64(0.2079616996908159))
 
 :func:`~astropy.stats.sigma_clip` and
 :class:`~astropy.stats.SigmaClip` can be combined with other robust

--- a/docs/table/access_table.rst
+++ b/docs/table/access_table.rst
@@ -210,7 +210,7 @@ column with a numerical index::
 
 
   >>> t['a'][1]  # Row 1 of column 'a'
-  3
+  np.int32(3)
 
 When a table column is printed, it is formatted according to the ``format``
 attribute (see :ref:`table_format_string`). Note the difference between the
@@ -237,7 +237,7 @@ Likewise a table row and a column from that row can be selected::
      3.000     4     5
 
   >>> t[1]['a']  # Column 'a' of row 1
-  3
+  np.int32(3)
 
 A |Row| object has the same columns and metadata as its parent table::
 
@@ -341,7 +341,7 @@ In case of a single |Row| it is possible to use its
 
     >>> row = t[2]
     >>> row.get("c", -1)
-    8
+    np.int32(8)
     >>> row.get("y", -1)
     -1
 
@@ -834,10 +834,10 @@ the value, min and max are stored in the in the column as fields named ``val``,
     >>> t['a'] = [1, 2]
     >>> t['par'] = pars
     >>> print(t)
-     a    par [val, min, max]
-    --- ------------------------
-      1    (1.2345678, -20., 3.)
-      2 (12.345678, 4.5678, 33.)
+     a     par [val, min, max]
+    --- -------------------------
+      1   (1.2345678, -20.0, 3.0)
+      2 (12.345678, 4.5678, 33.0)
 
 
 However, setting the format string appropriately allows formatting each of the

--- a/docs/table/construct_table.rst
+++ b/docs/table/construct_table.rst
@@ -132,12 +132,12 @@ of different data types to initialize a table::
   ...                 ([4., 5., 6.], [.4, .5, .6])], 'm,m/s')
   >>> QTable([a, b, c, d])
   <QTable length=2>
-    col0    col1   axis          col3 [f0, f1]
-                                    (m, m / s)
-  float64 int64[2] str1     (float64[3], float64[3])
-  ------- -------- ---- -------------------------------
-      1.0   2 .. 3    x ([1., 2., 3.], [0.1, 0.2, 0.3])
-      4.0   5 .. 6    y ([4., 5., 6.], [0.4, 0.5, 0.6])
+    col0    col1   axis           col3 [f0, f1]
+                                     (m, m / s)
+  float64 int64[2] str1      (float64[3], float64[3])
+  ------- -------- ---- ----------------------------------
+      1.0   2 .. 3    x ([1.0, 2.0, 3.0], [0.1, 0.2, 0.3])
+      4.0   5 .. 6    y ([4.0, 5.0, 6.0], [0.4, 0.5, 0.6])
 
 Notice that in the third column the existing column name ``'axis'`` is used.
 
@@ -355,8 +355,8 @@ including the simple structured array defined previously as a column::
   >>> print(table)
    name arr [a, b, c]
   ----- -------------
-  Micah  (1, 2., 'x')
-  Mazzy  (4, 5., 'y')
+  Micah (1, 2.0, 'x')
+  Mazzy (4, 5.0, 'y')
 
 You can access or print a single field in the structured column as follows::
 
@@ -1151,7 +1151,7 @@ Now see what we have from our specialized ``ParamsRow`` object::
   >>> t[1].keys()
   ['a', 'b', 'id', 'z']
   >>> t[1].values()
-  [2, 3.0, 123123, 'hello']
+  [np.int32(2), np.float32(3.0), 123123, 'hello']
 
 To make this example really useful, you might want to override
 ``Table.__getitem__()`` in order to allow table-level access to the parameter

--- a/docs/table/index.rst
+++ b/docs/table/index.rst
@@ -165,7 +165,7 @@ syntax::
   5
 
   >>> t['a'][1]    # Row 1 of column 'a'
-  4
+  np.int32(4)
 
   >>> t[1]         # Row 1 of the table
   <Row index=1>
@@ -177,7 +177,7 @@ syntax::
 
 
   >>> t[1]['a']    # Column 'a' of row 1
-  4
+  np.int32(4)
 
 You can retrieve a subset of a table by rows (using a :class:`slice`) or by
 columns (using column names), where the subset is returned as a new table::

--- a/docs/table/indexing.rst
+++ b/docs/table/indexing.rst
@@ -288,7 +288,7 @@ property can be indexed either by column value, range of column values
    >>> t = Table([('w', 'x', 'y', 'z'), (10, 1, 9, 9)], names=('a', 'b'), dtype=['str', 'i8'])
    >>> t.add_index('a')
    >>> t.loc_indices['x']
-   1
+   np.int64(1)
 
 .. EXAMPLE END
 

--- a/docs/time/index.rst
+++ b/docs/time/index.rst
@@ -293,7 +293,7 @@ can have higher precision than the standard 64-bit float::
 
   >>> tm = Time('51544.000000000000001', format='mjd')  # String input
   >>> tm.mjd  # float64 output loses last digit but Decimal gets it
-  51544.0
+  np.float64(51544.0)
   >>> tm.to_value('mjd', subfmt='decimal')  # doctest: +SKIP
   Decimal('51544.00000000000000099920072216264')
   >>> tm.to_value('mjd', subfmt='str')
@@ -416,7 +416,7 @@ returning scalar or array objects as appropriate::
   >>> from astropy.time import Time
   >>> t = Time(100.0, format='mjd')
   >>> t.jd
-  2400100.5
+  np.float64(2400100.5)
   >>> t = Time([100.0, 200.0, 300.], format='mjd')
   >>> t.jd  # doctest: +FLOAT_CMP
   array([2400100.5, 2400200.5, 2400300.5])
@@ -609,7 +609,7 @@ the highest precision. For example::
 
   >>> t = Time(100.0, 0.000001, format='mjd', scale='tt')
   >>> t.jd, t.jd1, t.jd2  # doctest: +FLOAT_CMP
-  (2400100.500001, 2400101.0, -0.499999)
+  (np.float64(2400100.500001), 2400101.0, -0.499999)
 
 format
 ^^^^^^
@@ -995,11 +995,11 @@ available format names is in the `time format`_ section.
 
   >>> t = Time('2010-01-01 00:00:00', format='iso', scale='utc')
   >>> t.jd        # JD representation of time in current scale (UTC)
-  2455197.5
+  np.float64(2455197.5)
   >>> t.iso       # ISO representation of time in current scale (UTC)
   '2010-01-01 00:00:00.000'
   >>> t.unix      # seconds since 1970.0 (UTC)
-  1262304000.0
+  np.float64(1262304000.0)
   >>> t.datetime  # Representation as datetime.datetime object
   datetime.datetime(2010, 1, 1, 0, 0)
 
@@ -1299,7 +1299,7 @@ Use of the |TimeDelta| object is illustrated in the few examples below::
   >>> dt
   <TimeDelta object: scale='tai' format='jd' value=31.0>
   >>> dt.sec
-  2678400.0
+  np.float64(2678400.0)
 
   >>> from astropy.time import TimeDelta
   >>> dt2 = TimeDelta(50.0, format='sec')
@@ -1347,7 +1347,7 @@ controlling the type of the output representation by providing either a format
 name and optional `subformat`_ or a valid ``astropy`` unit::
 
   >>> dt.to_value(u.hr)
-  744.0
+  np.float64(744.0)
   >>> dt.to_value('jd', 'str')
   '31.0'
 
@@ -1670,9 +1670,9 @@ from the `~astropy.time.TimeFromEpoch` class and define a few class attributes::
 
   >>> t = Time('2000-01-01')
   >>> t.unix_leap
-  946684832.0
+  np.float64(946684832.0)
   >>> t.unix_leap - t.unix
-  32.0
+  np.float64(32.0)
 
 .. EXAMPLE END
 

--- a/docs/timeseries/lombscargle.rst
+++ b/docs/timeseries/lombscargle.rst
@@ -167,14 +167,14 @@ To tune the heuristic using keywords passed to the
 
 >>> frequency, power = LombScargle(t, y, dy).autopower(nyquist_factor=2)
 >>> len(frequency), frequency.min(), frequency.max()  # doctest: +FLOAT_CMP
-(500, 0.0010327803641893758, 1.0317475838251864)
+(500, np.float64(0.0010327803641893758), np.float64(1.0317475838251864))
 
 Here the highest frequency is two times the average Nyquist frequency.
 If we increase the ``nyquist_factor``, we can probe higher frequencies:
 
 >>> frequency, power = LombScargle(t, y, dy).autopower(nyquist_factor=10)
 >>> len(frequency), frequency.min(), frequency.max()  # doctest: +FLOAT_CMP
-(2500, 0.0010327803641893758, 5.16286904058269)
+(2500, np.float64(0.0010327803641893758), np.float64(5.16286904058269))
 
 Alternatively, we can use the :func:`~astropy.timeseries.LombScargle.power`
 method to evaluate the periodogram at a user-specified set of frequencies:
@@ -542,7 +542,7 @@ this peak? We can address this question using the
 .. doctest-requires:: scipy
 
   >>> ls.false_alarm_probability(power.max())  # doctest: +FLOAT_CMP
-  0.028959671719328808
+  np.float64(0.028959671719328808)
 
 What this tells us is that under the assumption that there is no periodic
 signal in the data, we will observe a peak this high or higher approximately
@@ -598,7 +598,7 @@ which can be chosen using the ``method`` keyword:
 .. doctest-requires:: scipy
 
     >>> ls.false_alarm_probability(power.max(), method='baluev')  # doctest: +FLOAT_CMP
-    0.028959671719328808
+    np.float64(0.028959671719328808)
 
 - ``method="bootstrap"`` implements a bootstrap simulation: effectively it
   computes many Lomb-Scargle periodograms on simulated data at the same
@@ -611,7 +611,7 @@ which can be chosen using the ``method`` keyword:
 .. doctest-requires:: scipy
 
     >>> ls.false_alarm_probability(power.max(), method='bootstrap')  # doctest: +SKIP
-    0.0030000000000000027
+    np.float64(0.0030000000000000027)
 
 - ``method="davies"`` is related to the Baluev method, but loses accuracy
   at large false alarm probabilities.
@@ -619,7 +619,7 @@ which can be chosen using the ``method`` keyword:
 .. doctest-requires:: scipy
 
     >>> ls.false_alarm_probability(power.max(), method='davies')  # doctest: +FLOAT_CMP
-    0.029387277355227746
+    np.float64(0.029387277355227746)
 
 - ``method="naive"`` is a basic method based on the assumption that
   well-separated areas in the periodogram are independent. In general, it
@@ -629,7 +629,7 @@ which can be chosen using the ``method`` keyword:
 .. doctest-requires:: scipy
 
     >>> ls.false_alarm_probability(power.max(), method='naive')  # doctest: +FLOAT_CMP
-    0.00810080828660202
+    np.float64(0.00810080828660202)
 
 The following figure compares these false alarm estimates at a range of
 peak heights for 100 observations with a heavily aliased observing pattern:

--- a/docs/timeseries/masking.rst
+++ b/docs/timeseries/masking.rst
@@ -51,8 +51,8 @@ and operate on columns to ignore the masked entries::
 
     >>> import numpy as np
     >>> np.min(ts['flux'])
-    1.0
+    np.float64(1.0)
     >>> np.ma.median(ts['flux'])
-    4.0
+    np.float64(4.0)
 
 .. EXAMPLE END

--- a/docs/units/equivalencies.rst
+++ b/docs/units/equivalencies.rst
@@ -157,7 +157,7 @@ These equivalencies even work with non-base units::
   >>> # Inches to calories
   >>> from astropy.units import imperial
   >>> imperial.inch.to(imperial.Cal, equivalencies=u.spectral())  # doctest: +FLOAT_CMP
-  1.869180759162485e-27
+  np.float64(1.869180759162485e-27)
 
 .. EXAMPLE END
 
@@ -590,7 +590,7 @@ illustrative::
     ... lambda x: (restfreq-x) / restfreq * si.c.to_value('km/s'),
     ... lambda x: (1-x/si.c.to_value('km/s')) * restfreq )]
     >>> u.Hz.to(u.km / u.s, 116e9, equivalencies=freq_to_vel)  # doctest: +FLOAT_CMP
-    -1895.4321928669262
+    np.float64(-1895.4321928669262)
     >>> (116e9 * u.Hz).to(u.km / u.s, equivalencies=freq_to_vel)  # doctest: +FLOAT_CMP
     <Quantity -1895.4321928669262 km / s>
 

--- a/docs/units/index.rst
+++ b/docs/units/index.rst
@@ -46,7 +46,7 @@ value members::
 
     >>> q = 42.0 * u.meter
     >>> q.value
-    42.0
+    np.float64(42.0)
     >>> q.unit
     Unit("m")
 

--- a/docs/units/logarithmic_units.rst
+++ b/docs/units/logarithmic_units.rst
@@ -53,7 +53,7 @@ As for normal |Quantity| objects, you can access the value with the
 
     >>> logg = 5. * u.dex(u.cm / u.s**2)
     >>> logg.value
-    5.0
+    np.float64(5.0)
     >>> logg.physical  # doctest: +FLOAT_CMP
     <Quantity 100000. cm / s2>
 

--- a/docs/units/quantity.rst
+++ b/docs/units/quantity.rst
@@ -63,7 +63,7 @@ The current unit and value can be accessed via the
     >>> q.unit
     Unit("m / s")
     >>> q.value
-    2.5
+    np.float64(2.5)
 
 .. note:: |Quantity| objects are converted to float by default. Furthermore, any
           data passed in are copied, which for large arrays may not be optimal.
@@ -110,7 +110,7 @@ If you want the value of the quantity in a different unit, you can use
 
     >>> q = 2.5 * u.m
     >>> q.to_value(u.cm)
-    250.0
+    np.float64(250.0)
 
 .. note:: You could get the value in ``cm`` also by using ``q.to(u.cm).value``.
           The difference is that :meth:`~astropy.units.Quantity.to_value` does
@@ -140,7 +140,7 @@ The use of `Python comparison operators
 supported::
 
     >>> 1*u.m < 50*u.cm
-    False
+    np.False_
 
 Plotting Quantities
 ===================
@@ -290,7 +290,7 @@ dimensionless and scale-free. For example:
 Which is different from:
 
     >>> 1. + (1. * u.m / u.km).value
-    2.0
+    np.float64(2.0)
 
 In the latter case, the result is ``2.0`` because the unit of ``(1. * u.m /
 u.km)`` is not scale-free by default:

--- a/docs/utils/masked/index.rst
+++ b/docs/utils/masked/index.rst
@@ -96,7 +96,7 @@ A second difference is that for reductions, the mask propagates as it would
 have if the operations were done on the individual elements::
 
   >>> np_ma.prod()
-  3.0
+  np.float64(3.0)
   >>> np_ma[0] * np_ma[1] * np_ma[2]
   masked
   >>> Masked(np_ma).prod()

--- a/docs/visualization/normalization.rst
+++ b/docs/visualization/normalization.rst
@@ -88,7 +88,7 @@ and the limits can be determined by calling the
 takes the array of values::
 
     >>> interval.get_limits([1, 3, 4, 5, 6])
-    (1, 6)
+    (np.int64(1), np.int64(6))
 
 The ``interval`` instance can also be called like a function to
 actually normalize values to the range::
@@ -108,7 +108,7 @@ normalization when values fall outside the limits::
     >>> from astropy.visualization import PercentileInterval
     >>> interval = PercentileInterval(50.)
     >>> interval.get_limits([1, 3, 4, 5, 6])
-    (3.0, 5.0)
+    (np.float64(3.0), np.float64(5.0))
     >>> interval([1, 3, 4, 5, 6])  # default is clip=True  # doctest: +FLOAT_CMP
     array([0. , 0. , 0.5, 1. , 1. ])
     >>> interval([1, 3, 4, 5, 6], clip=False)  # doctest: +FLOAT_CMP

--- a/docs/wcs/wcsapi.rst
+++ b/docs/wcs/wcsapi.rst
@@ -61,6 +61,7 @@ simple image with two celestial axes (Right Ascension and Declination)::
     >>> wcs = WCS(hdu.header)  # doctest: +REMOTE_DATA
     >>> wcs  # doctest: +REMOTE_DATA
     WCS Keywords
+    <BLANKLINE>
     Number of WCS axes: 2
     CTYPE : 'RA---TAN'  'DEC--TAN'
     CRVAL : 266.4  -28.93333
@@ -131,7 +132,7 @@ the nearest integer values::
     >>> index  # doctest: +REMOTE_DATA
     (357, 357)
     >>> hdu.data[index]  # doctest: +REMOTE_DATA +FLOAT_CMP
-    563.7532
+    np.float32(563.7532)
     >>> hdulist.close()  # doctest: +REMOTE_DATA
 
 Advanced usage
@@ -199,7 +200,7 @@ And as before we can index array values using::
     >>> index  # doctest: +REMOTE_DATA
     (7, 71, 8)
     >>> hdu.data[index]  # doctest: +REMOTE_DATA +FLOAT_CMP
-    0.22262384
+    np.float32(0.22262384)
     >>> hdulist.close()  # doctest: +REMOTE_DATA
 
 If you are interested in converting to/from world values as simple Python scalars

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -212,9 +212,6 @@ doctest_subpackage_requires = [
     "astropy/cosmology/_io/table.py = python<3.12",  # PYTHON_LT_3_12 (PR 14784)
     "astropy/table/table.py = python<3.12",  # PYTHON_LT_3_12 (PR 14784)
     "astropy/table/mixins/dask.py = dask",
-    "docs/io/fits/index.rst = numpy<1.25",  # NUMPY_LT_1_25 (Issue 14545)
-    "docs/io/fits/usage/image.rst = numpy<1.25",  # NUMPY_LT_1_25 (Issue 14545)
-    "docs/io/fits/usage/unfamiliar.rst = numpy<1.25",  # NUMPY_LT_1_25 (Issue 14545)
 ]
 markers = [
     "mpl_image_compare",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -212,6 +212,14 @@ doctest_subpackage_requires = [
     "astropy/cosmology/_io/table.py = python<3.12",  # PYTHON_LT_3_12 (PR 14784)
     "astropy/table/table.py = python<3.12",  # PYTHON_LT_3_12 (PR 14784)
     "astropy/table/mixins/dask.py = dask",
+    "docs/* = numpy>=2.0",   # not NUMPY_LT_2_0 (PR 15065)
+    "astropy/stats/info_theory.py = numpy>=2.0",  # not NUMPY_LT_2_0 (PR 15065)
+    "astropy/stats/jackknife.py = numpy>=2.0",  # not NUMPY_LT_2_0 (PR 15065)
+    "astropy/table/row.py = numpy>=2.0",  # not NUMPY_LT_2_0 (PR 15065)
+    "astropy/time/formats.py = numpy>=2.0",  # not NUMPY_LT_2_0 (PR 15065)
+    "astropy/timeseries/periodograms/bls/core.py = numpy>=2.0",  # not NUMPY_LT_2_0 (PR 15065)
+    "astropy/timeseries/periodograms/lombscargle/core.py = numpy>=2.0",  # not NUMPY_LT_2_0 (PR 15065)
+    "astropy/units/structured.py = numpy>=2.0",  # not NUMPY_LT_2_0 (PR 15065)
 ]
 markers = [
     "mpl_image_compare",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -212,14 +212,14 @@ doctest_subpackage_requires = [
     "astropy/cosmology/_io/table.py = python<3.12",  # PYTHON_LT_3_12 (PR 14784)
     "astropy/table/table.py = python<3.12",  # PYTHON_LT_3_12 (PR 14784)
     "astropy/table/mixins/dask.py = dask",
-    "docs/* = numpy>=2.0",   # not NUMPY_LT_2_0 (PR 15065)
-    "astropy/stats/info_theory.py = numpy>=2.0",  # not NUMPY_LT_2_0 (PR 15065)
-    "astropy/stats/jackknife.py = numpy>=2.0",  # not NUMPY_LT_2_0 (PR 15065)
-    "astropy/table/row.py = numpy>=2.0",  # not NUMPY_LT_2_0 (PR 15065)
-    "astropy/time/formats.py = numpy>=2.0",  # not NUMPY_LT_2_0 (PR 15065)
-    "astropy/timeseries/periodograms/bls/core.py = numpy>=2.0",  # not NUMPY_LT_2_0 (PR 15065)
-    "astropy/timeseries/periodograms/lombscargle/core.py = numpy>=2.0",  # not NUMPY_LT_2_0 (PR 15065)
-    "astropy/units/structured.py = numpy>=2.0",  # not NUMPY_LT_2_0 (PR 15065)
+    "docs/* = numpy>=2.0.0rc1",   # not NUMPY_LT_2_0 (PR 15065)
+    "astropy/stats/info_theory.py = numpy>=2.0.0rc1",  # not NUMPY_LT_2_0 (PR 15065)
+    "astropy/stats/jackknife.py = numpy>=2.0.0rc1",  # not NUMPY_LT_2_0 (PR 15065)
+    "astropy/table/row.py = numpy>=2.0.0rc1",  # not NUMPY_LT_2_0 (PR 15065)
+    "astropy/time/formats.py = numpy>=2.0.0rc1",  # not NUMPY_LT_2_0 (PR 15065)
+    "astropy/timeseries/periodograms/bls/core.py = numpy>=2.0.0rc1",  # not NUMPY_LT_2_0 (PR 15065)
+    "astropy/timeseries/periodograms/lombscargle/core.py = numpy>=2.0.0rc1",  # not NUMPY_LT_2_0 (PR 15065)
+    "astropy/units/structured.py = numpy>=2.0.0rc1",  # not NUMPY_LT_2_0 (PR 15065)
 ]
 markers = [
     "mpl_image_compare",


### PR DESCRIPTION
DEV NOTE: Do not merge until numpy 2.0 is actually out! ~Do not merge until this is merged and available in numpy nightly wheel (when we start to see things fail in devdeps)~

- [x] Revert https://github.com/astropy/astropy/pull/15096 if it got in first. (EDIT: it should get in first; this one is for when 2.0 is actually out)
- [x] Decide for scalar quantity.value whether it should not just return an array scalar (see below) -> made this its own issue: #16508
- [x] Check whether we may want similar adjustments elsewhere (maybe as follow-up; e.g., `Structure` for structure units output) - but this should not be part of this PR, so punted to #15793.
- [x] Decide whether we are happy for the docs to pass tests only on numpy >=2.0. If not, we have to update `doctest-plus` to ignore `np.float64`, etc., in comparing numerical values. 2023-Dec: seems that we are heading to a docs-on-numpy>=2.0 only state

<hr/>

This is a start to adjusting our tests for the change in how scalars are formatted in NEP 51 - see https://github.com/numpy/numpy/pull/22449

~Note that it does not adjust tests of `repr` and the documentation yet!~

Posting this in part to show that outside of `repr` this is not a big deal.

In the documentation, one often will have things like
```
>>> q = 5 * u.m
>>> q.value
5.0  -> np.float64(5.0)
```
This brings up a more general question of whether we should use this opportunity of the `repr` changing to just return an array scalar (i.e., it would be `np.array(5.0)` instead). EDIT: this is better discussed elsewhere - see #16508.

Fix #15095
Fix #16491

- [X] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
