### PR TITLE
ruff: use extend-per-file-ignores

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -251,35 +251,8 @@ unfixable = [
     "E711"  # NoneComparison. Hard to fix b/c numpy has it's own None.
 ]
 
-# TODO: move these to pyproject.toml when ruff allows cascading per-file-ignores.
-[per-file-ignores]
-"setup.py" = ["INP001"]  # Part of configuration, not a package.
+[extend-per-file-ignores]
 "__init__.py" = ["E402", "F401", "F403"]
-"astropy/io/registry/compat.py" = ["F822"]
-"astropy/modeling/models.py" = ["F401", "F403", "F405"]
-"astropy/utils/decorators.py" = [
-    "D214", "D215",  # keep Examples section indented.
-    "D411",  # sphinx treats spaced example sections as real sections
-]
-"test_*.py" = [
-    "B018",  # UselessExpression
-    "B011",  # Do not assert False, raise AssertionError()
-    "D",  # pydocstyle
-    "E402",  # Module level import not at top of file
-    "PGH001",  # No builtin eval() allowed
-    "S101",  # Use of assert detected
-]
-".pyinstaller/*.py" = ["INP001"]  # Not a package.
-"conftest.py" = ["INP001"]  # Part of configuration, not a package.
-"docs/*.py" = [
-    "INP001",  # implicit-namespace-package. The examples are not a package.
-]
-"examples/*.py" = [
-    "E402",   # Imports are done as needed.
-    "INP001", # implicit-namespace-package. The examples are not a package.
-    "T203"    # pprint found
-]
-
 # TODO: fix these, on a per-subpackage basis.
 # When a general exclusion is being fixed, but it affects many subpackages, it
 # is better to fix for subpackages individually. The general exclusion should be

--- a/astropy/coordinates/tests/test_sites.py
+++ b/astropy/coordinates/tests/test_sites.py
@@ -240,9 +240,8 @@ def check_builtin_matches_remote(download_url=True):
                     "download:",
                     dl_registry[name],
                 )
-        assert False, (
-            "Builtin and download registry aren't consistent - failures printed to"
-            " stdout"
+        raise AssertionError(
+            "Builtin and download registry aren't consistent - failures printed to stdout"
         )
 
 

--- a/astropy/cosmology/_io/tests/test_html.py
+++ b/astropy/cosmology/_io/tests/test_html.py
@@ -6,7 +6,6 @@ import astropy.units as u
 from astropy.cosmology._io.html import _FORMAT_TABLE, read_html_table, write_html_table
 from astropy.cosmology.parameter import Parameter
 from astropy.table import QTable, Table, vstack
-from astropy.units.decorators import NoneType
 from astropy.utils.compat.optional_deps import HAS_BS4
 
 from .base import ReadWriteDirectTestBase, ReadWriteTestMixinBase
@@ -188,8 +187,7 @@ class ReadWriteHTMLTestMixin(ReadWriteTestMixinBase):
         )
 
         cosmo_cls = type(cosmo)
-        if cosmo_cls == NoneType:
-            assert False
+        assert cosmo is not None
 
         for n, col in zip(table.colnames, table.itercols()):
             if n == "cosmology":

--- a/astropy/io/registry/compat.py
+++ b/astropy/io/registry/compat.py
@@ -4,7 +4,7 @@ import functools
 
 from .core import UnifiedIORegistry
 
-__all__ = [
+__all__ = [  # noqa: F822
     "register_reader",
     "register_writer",
     "register_identifier",

--- a/astropy/io/registry/tests/test_registries.py
+++ b/astropy/io/registry/tests/test_registries.py
@@ -282,11 +282,11 @@ class TestUnifiedIORegistryBase:
 
     @pytest.mark.skip("TODO!")
     def test_compat_get_formats(self, registry, fmtcls1):
-        assert False
+        raise AssertionError()
 
     @pytest.mark.skip("TODO!")
     def test_compat_delay_doc_updates(self, registry, fmtcls1):
-        assert False
+        raise AssertionError()
 
 
 class TestUnifiedInputRegistry(TestUnifiedIORegistryBase):
@@ -330,7 +330,7 @@ class TestUnifiedInputRegistry(TestUnifiedIORegistryBase):
     @pytest.mark.skip("TODO!")
     def test_get_formats(self, registry):
         """Test ``registry.get_formats()``."""
-        assert False
+        raise AssertionError()
 
     def test_delay_doc_updates(self, registry, fmtcls1):
         """Test ``registry.delay_doc_updates()``."""
@@ -730,7 +730,7 @@ class TestUnifiedOutputRegistry(TestUnifiedIORegistryBase):
     @pytest.mark.skip("TODO!")
     def test_get_formats(self, registry):
         """Test ``registry.get_formats()``."""
-        assert False
+        raise AssertionError()
 
     def test_identify_write_format(self, registry, fmtcls1):
         """Test ``registry.identify_format()``."""
@@ -1003,7 +1003,7 @@ class TestUnifiedIORegistry(TestUnifiedInputRegistry, TestUnifiedOutputRegistry)
     @pytest.mark.skip("TODO!")
     def test_get_formats(self, registry):
         """Test ``registry.get_formats()``."""
-        assert False
+        raise AssertionError()
 
     def test_delay_doc_updates(self, registry, fmtcls1):
         """Test ``registry.delay_doc_updates()``."""

--- a/astropy/modeling/models.py
+++ b/astropy/modeling/models.py
@@ -4,8 +4,8 @@
 Creates a common namespace for all pre-defined models.
 """
 
-from . import math_functions as math
-from .core import custom_model, fix_inputs, hide_inverse
+from . import math_functions as math  # noqa: F401
+from .core import custom_model, fix_inputs, hide_inverse  # noqa: F401
 from .functional_models import *
 from .mappings import *
 from .physical_models import *

--- a/astropy/modeling/tests/test_parameters.py
+++ b/astropy/modeling/tests/test_parameters.py
@@ -809,37 +809,25 @@ class TestParameters:
         param = Parameter(name="test", default=1)
         assert param.value == 1
         assert np.all(param)
-        if param:
-            assert True
-        else:
-            assert False
+        assert param
 
         # single value is false
         param = Parameter(name="test", default=0)
         assert param.value == 0
         assert not np.all(param)
-        if param:
-            assert False
-        else:
-            assert True
+        assert not param
 
         # vector value all true
         param = Parameter(name="test", default=[1, 2, 3, 4])
         assert np.all(param.value == [1, 2, 3, 4])
         assert np.all(param)
-        if param:
-            assert True
-        else:
-            assert False
+        assert param
 
         # vector value at least one false
         param = Parameter(name="test", default=[1, 2, 0, 3, 4])
         assert np.all(param.value == [1, 2, 0, 3, 4])
         assert not np.all(param)
-        if param:
-            assert False
-        else:
-            assert True
+        assert not param
 
     def test_param_repr_oneline(self):
         # Single value no units

--- a/astropy/tests/test_logger.py
+++ b/astropy/tests/test_logger.py
@@ -208,17 +208,13 @@ def test_exception_logging_overridden():
 @pytest.mark.xfail("ip is not None")
 def test_exception_logging():
     # Without exception logging
-    try:
+    with pytest.raises(Exception, match="This is an Exception"):
         with log.log_to_list() as log_list:
             raise Exception("This is an Exception")
-    except Exception as exc:
-        sys.excepthook(*sys.exc_info())
-        assert exc.args[0] == "This is an Exception"
-    else:
-        assert False  # exception should have been raised
     assert len(log_list) == 0
 
-    # With exception logging
+    # With exception logging. Note that this test can't use `pytest.raises` because it
+    # cleans the exception chain, so the exception is not logged.
     try:
         log.enable_exception_logging()
         with log.log_to_list() as log_list:
@@ -227,13 +223,14 @@ def test_exception_logging():
         sys.excepthook(*sys.exc_info())
         assert exc.args[0] == "This is an Exception"
     else:
-        assert False  # exception should have been raised
+        raise AssertionError()  # exception should have been raised
     assert len(log_list) == 1
     assert log_list[0].levelname == "ERROR"
     assert log_list[0].message.startswith("Exception: This is an Exception")
     assert log_list[0].origin == "astropy.tests.test_logger"
 
-    # Without exception logging
+    # Without exception logging. Note that this test can't use `pytest.raises` because
+    # it cleans the exception chain, so any exception is not logged, regardless.
     log.disable_exception_logging()
     try:
         with log.log_to_list() as log_list:
@@ -242,7 +239,7 @@ def test_exception_logging():
         sys.excepthook(*sys.exc_info())
         assert exc.args[0] == "This is an Exception"
     else:
-        assert False  # exception should have been raised
+        raise AssertionError()  # exception should have been raised
     assert len(log_list) == 0
 
 
@@ -264,7 +261,7 @@ def test_exception_logging_origin():
             "homogeneous list must contain only objects of type "
         )
     else:
-        assert False
+        raise AssertionError()
     assert len(log_list) == 1
     assert log_list[0].levelname == "ERROR"
     assert log_list[0].message.startswith(
@@ -290,7 +287,7 @@ def test_exception_logging_argless_exception():
     except Exception:
         sys.excepthook(*sys.exc_info())
     else:
-        assert False  # exception should have been raised
+        raise AssertionError()  # exception should have been raised
     assert len(log_list) == 1
     assert log_list[0].levelname == "ERROR"
     assert log_list[0].message == "Exception [astropy.tests.test_logger]"

--- a/astropy/units/tests/test_equivalencies.py
+++ b/astropy/units/tests/test_equivalencies.py
@@ -900,7 +900,7 @@ def test_compose_equivalencies():
             )
             break
     else:
-        assert False, "Didn't find speed in compose results"
+        raise AssertionError("Didn't find speed in compose results")
 
 
 def test_pixel_scale():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,7 +168,7 @@ ignore = [  # NOTE: non-permeanent exclusions should be added to `.ruff.toml` in
 
 [tool.ruff.extend-per-file-ignores]
 "setup.py" = ["INP001"]  # Part of configuration, not a package.
-"astropy/modeling/models.py" = ["F401", "F403", "F405"]
+"astropy/modeling/models.py" = ["F405"]
 "astropy/utils/decorators.py" = [
     "D214", "D215",  # keep Examples section indented.
     "D411",  # sphinx treats spaced example sections as real sections

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,7 +168,6 @@ ignore = [  # NOTE: non-permeanent exclusions should be added to `.ruff.toml` in
 
 [tool.ruff.extend-per-file-ignores]
 "setup.py" = ["INP001"]  # Part of configuration, not a package.
-"astropy/io/registry/compat.py" = ["F822"]
 "astropy/modeling/models.py" = ["F401", "F403", "F405"]
 "astropy/utils/decorators.py" = [
     "D214", "D215",  # keep Examples section indented.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,9 +119,7 @@ exclude=[
     "*_parsetab.py",
     "*_lextab.py"
 ]
-ignore = [
-    # ---------------------------------------------------------------
-    # Permanent
+ignore = [  # NOTE: non-permeanent exclusions should be added to `.ruff.toml` instead.
 
     # flake8-builtins (A) : shadowing a Python built-in.
     # New ones should be avoided and is up to maintainers to enforce.
@@ -142,18 +140,18 @@ ignore = [
     "D200",  # FitsOnOneLine
     # Docstring Content Issues
     "D410",  # BlankLineAfterSection. Using D412 instead.
-    "D400",  # EndsInPeriod.
+    "D400",  # EndsInPeriod.  NOTE: might want to revisit this.
 
     # pycodestyle (E, W)
     "E711",  # NoneComparison  (see unfixable)
-    "E741",  # AmbiguousVariableName | physics variables are often poor code variables
+    "E741",  # AmbiguousVariableName. Physics variables are often poor code variables
 
     # Pyflakes (F)
     "F403",  # ImportStarUsed
 
     # pep8-naming (N)
-    "N803",  # invalid-argument-name | physics variables are often poor code variables
-    "N806",  # non-lowercase-variable-in-function | physics variables are often poor code variables
+    "N803",  # invalid-argument-name. Physics variables are often poor code variables
+    "N806",  # non-lowercase-variable-in-function. Physics variables are often poor code variables
 
     # pandas-vet (PD)
     "PD",
@@ -166,6 +164,33 @@ ignore = [
 
     # Ruff-specific rules (RUF)
     "RUF005",  # unpack-instead-of-concatenating-to-collection-literal -- it's not clearly faster.
+]
+
+[tool.ruff.extend-per-file-ignores]
+"setup.py" = ["INP001"]  # Part of configuration, not a package.
+"astropy/io/registry/compat.py" = ["F822"]
+"astropy/modeling/models.py" = ["F401", "F403", "F405"]
+"astropy/utils/decorators.py" = [
+    "D214", "D215",  # keep Examples section indented.
+    "D411",  # sphinx treats spaced example sections as real sections
+]
+"test_*.py" = [
+    "B018",  # UselessExpression
+    "B011",  # Do not assert False, raise AssertionError()
+    "D",  # pydocstyle
+    "E402",  # Module level import not at top of file
+    "PGH001",  # No builtin eval() allowed
+    "S101",  # Use of assert detected
+]
+".pyinstaller/*.py" = ["INP001"]  # Not a package.
+"conftest.py" = ["INP001"]  # Part of configuration, not a package.
+"docs/*.py" = [
+    "INP001",  # implicit-namespace-package. The examples are not a package.
+]
+"examples/*.py" = [
+    "E402",   # Imports are done as needed.
+    "INP001", # implicit-namespace-package. The examples are not a package.
+    "T203"    # pprint found
 ]
 
 [tool.ruff.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -176,7 +176,6 @@ ignore = [  # NOTE: non-permeanent exclusions should be added to `.ruff.toml` in
 ]
 "test_*.py" = [
     "B018",  # UselessExpression
-    "B011",  # Do not assert False, raise AssertionError()
     "D",  # pydocstyle
     "E402",  # Module level import not at top of file
     "PGH001",  # No builtin eval() allowed


### PR DESCRIPTION
Move the permanent `per-file-ignores` from `.ruff.toml` to `pyproject.toml` using the new `extend-per-file-ignores`.