### PR TITLE
Bugfix for collapses with NDData without masks, or without units

### DIFF
--- a/astropy/nddata/mixins/ndarithmetic.py
+++ b/astropy/nddata/mixins/ndarithmetic.py
@@ -375,8 +375,8 @@ class NDArithmeticMixin:
             Quantity.
         """
         # Do the calculation with or without units
-        if self.unit is None:
-            if operand.unit is None:
+        if self.unit is None and hasattr(operand, "data"):
+            if hasattr(operand, "unit") and operand.unit is None:
                 result = operation(self.data, operand.data)
             else:
                 result = operation(
@@ -520,7 +520,10 @@ class NDArithmeticMixin:
         elif self.mask is None and operand is not None:
             # Make a copy so there is no reference in the result.
             return deepcopy(operand.mask)
-        elif operand.mask is None:
+        elif operand is None or getattr(operand, "mask", None) is None:
+            # first condition lets through masks within collapse operations,
+            # second lets through masks when doing arithmetic on an
+            # operand without a mask:
             return deepcopy(self.mask)
         else:
             # Now let's calculate the resulting mask (operation enforces copy)

--- a/astropy/nddata/mixins/tests/test_ndarithmetic.py
+++ b/astropy/nddata/mixins/tests/test_ndarithmetic.py
@@ -298,6 +298,24 @@ def test_arithmetics_data_masks(mask1, mask2):
         assert nd.wcs is None
 
 
+# Check that masks are preserved+propagated in NDData collapse operations
+@pytest.mark.parametrize(
+    ("collapse_axis", "mask_sum", "unit"),
+    [(0, [3, 0, 3, 0], "Jy"), (1, [2, 0, 2, 0], None), (2, [2, 2, 2], "Jy")],
+)
+def test_collapse_masks(collapse_axis, mask_sum, unit):
+    shape = (2, 3, 4)
+    data = np.arange(np.prod(shape)).reshape(shape)
+    mask = data % 2 == 0
+    nd_masked = NDDataArithmetic(data=data, mask=mask, unit=unit)
+    nd_nomask = NDDataArithmetic(data=data, unit=unit)
+
+    assert_array_equal(nd_masked.sum(axis=collapse_axis).mask.sum(axis=0), mask_sum)
+
+    # if no mask is given, the collapse result should have no mask:
+    assert nd_nomask.sum(axis=collapse_axis).mask is None
+
+
 # One additional case which can not be easily incorporated in the test above
 # what happens if the masks are numpy ndarrays are not broadcastable
 def test_arithmetics_data_masks_invalid():

--- a/docs/changes/nddata/15082.bugfix.rst
+++ b/docs/changes/nddata/15082.bugfix.rst
@@ -1,0 +1,1 @@
+Fix for collapse operations on ``NDData`` without masks or units.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description

#14175 introduced collapse operations on NDDataArray objects. In #14995, a bugfix was added for handling masks in ND arithmetic to restore bitmask propagation in NDDataArray objects (released in v5.3.1). The bugfix in #14995 removed one bit of intended functionality from #14175, which is that NDData objects *without masks* should be collapsible. The fix in #14995 removed this option by replacing a conditional where I should have added an `or` to the existing one. 

As a result of the incomplete fix in #14995, a user calling `nddata.sum()` for NDDataArray without a mask raises an error in v5.3.1, since the `operand` in collapse operations is `None`:
```
from astropy.nddata import NDDataArray
import numpy as np

shape = (2, 3, 4)
data = np.arange(np.prod(shape)).reshape(shape)
nd = NDDataArray(data=data, unit='Jy')
nd.sum(axis=(0, 1))
# raises: AttributeError: 'NoneType' object has no attribute 'mask'
```

I also found that collapsing `NDData` without a `unit` triggers an error in `NDArithmeticMixin._arithmetic_data`, due to a missing condition in the logic for calling the `operation`. Revising only the second-to-last line in the example above raises a different error:
```
nd = NDDataArray(data=data)
nd.sum(axis=(0, 1))
# raises: AttributeError: 'NoneType' object has no attribute 'unit'
```

This pull request implements the whole (🤞🏻) solution to each bug, and adds a test to check that (1) masks are preserved in collapses, and (2) units are not required to collapse.


<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

