### PR TITLE
Add astropy/test-support repository to other architectures for wcslib8

### DIFF
--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -131,6 +131,7 @@ jobs:
             IS_CRON: ${{ env.IS_CRON }}
 
           install: |
+            apt-get install software-properties-common
             add-apt-repository ppa:astropy/test-support  # for wcslib8
             apt-get update -q -y
             apt-get install -q -y git \

--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -131,6 +131,7 @@ jobs:
             IS_CRON: ${{ env.IS_CRON }}
 
           install: |
+            add-apt-repository ppa:astropy/test-support  # for wcslib8
             apt-get update -q -y
             apt-get install -q -y git \
                                   g++ \

--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -133,7 +133,8 @@ jobs:
           install: |
             # Add test-support repository for wcslib8
             # Add test-support repository for wcslib8
-            echo "deb [trusted=yes] http://ppa.launchpadcontent.net/astropy/test-support/ubuntu lunar main" > /etc/apt/sources.list.d/test-support.list
+            gpg --ignore-time-conflict --no-options --no-default-keyring --secret-keyring /etc/apt/secring.gpg --trusteddb-name /etc/apt/trusteddb.gpg --keyring /etc/apt/trusted.gpg --keyserver keyserver.ubuntu.com --recv A985963D264907FDE1AE677FCC75F07B3EF41EFC
+            echo "deb http://ppa.launchpadcontent.net/astropy/test-support/ubuntu lunar main" > /etc/apt/sources.list.d/test-support.list
             apt-get update -q -y
             apt-get install -q -y git \
                                   g++ \

--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -132,7 +132,7 @@ jobs:
 
           install: |
             # Add test-support repository for wcslib8
-            echo "deb https://ppa.launchpadcontent.net/astropy/test-support/ubuntu lunar main" > /etc/apt/sources.list.d/test-support.list
+            echo "deb [trusted=yes] https://ppa.launchpadcontent.net/astropy/test-support/ubuntu lunar main" > /etc/apt/sources.list.d/test-support.list
             apt-get update -q -y
             apt-get install -q -y git \
                                   g++ \

--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -132,9 +132,8 @@ jobs:
 
           install: |
             # Add test-support repository for wcslib8
-            apt-get update -q -y
-            apt-get install software-properties-common  # for add-apt-repository
-            add-apt-repository ppa:astropy/test-support  # for wcslib8
+            # Add test-support repository for wcslib8
+            echo "deb http://ppa.launchpadcontent.net/astropy/test-support/ubuntu lunar main" > /etc/apt/sources.list.d/test-support.list
             apt-get update -q -y
             apt-get install -q -y git \
                                   g++ \

--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -131,8 +131,8 @@ jobs:
             IS_CRON: ${{ env.IS_CRON }}
 
           install: |
-            apt-get install software-properties-common
-            add-apt-repository ppa:astropy/test-support  # for wcslib8
+            # Add test-support repository for wcslib8
+            echo "deb https://ppa.launchpadcontent.net/astropy/test-support/ubuntu lunar main" > /etc/apt/sources.list.d/test-support.list
             apt-get update -q -y
             apt-get install -q -y git \
                                   g++ \

--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -132,6 +132,7 @@ jobs:
 
           install: |
             # Add test-support repository for wcslib8
+            apt-get update -q -y
             apt-get install ca-certificates
             echo "deb https://ppa.launchpadcontent.net/astropy/test-support/ubuntu lunar main" > /etc/apt/sources.list.d/test-support.list
             apt-get update -q -y

--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -132,7 +132,8 @@ jobs:
 
           install: |
             # Add test-support repository for wcslib8
-            echo "deb [trusted=yes] https://ppa.launchpadcontent.net/astropy/test-support/ubuntu lunar main" > /etc/apt/sources.list.d/test-support.list
+            apt-get install ca-certificates
+            echo "deb https://ppa.launchpadcontent.net/astropy/test-support/ubuntu lunar main" > /etc/apt/sources.list.d/test-support.list
             apt-get update -q -y
             apt-get install -q -y git \
                                   g++ \

--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -133,7 +133,9 @@ jobs:
           install: |
             # Add test-support repository for wcslib8
             # Add test-support repository for wcslib8
-            gpg --ignore-time-conflict --no-options --no-default-keyring --secret-keyring /etc/apt/secring.gpg --trusteddb-name /etc/apt/trusteddb.gpg --keyring /etc/apt/trusted.gpg --keyserver keyserver.ubuntu.com --recv A985963D264907FDE1AE677FCC75F07B3EF41EFC
+            apt-get update -q -y
+            apt-get install -q -y gpg
+            gpg --ignore-time-conflict --no-options --no-default-keyring --trustdb-name /etc/apt/trusteddb.gpg --keyring /etc/apt/trusted.gpg --keyserver keyserver.ubuntu.com --recv A985963D264907FDE1AE677FCC75F07B3EF41EFC
             echo "deb http://ppa.launchpadcontent.net/astropy/test-support/ubuntu lunar main" > /etc/apt/sources.list.d/test-support.list
             apt-get update -q -y
             apt-get install -q -y git \
@@ -145,7 +147,6 @@ jobs:
                                   python3-ply \
                                   python3-venv \
                                   cython3 \
-                                  libwcs7 \
                                   wcslib-dev \
                                   liberfa1
 

--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -133,7 +133,7 @@ jobs:
           install: |
             # Add test-support repository for wcslib8
             # Add test-support repository for wcslib8
-            echo "deb http://ppa.launchpadcontent.net/astropy/test-support/ubuntu lunar main" > /etc/apt/sources.list.d/test-support.list
+            echo "deb [trusted=yes] http://ppa.launchpadcontent.net/astropy/test-support/ubuntu lunar main" > /etc/apt/sources.list.d/test-support.list
             apt-get update -q -y
             apt-get install -q -y git \
                                   g++ \

--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -133,10 +133,7 @@ jobs:
           install: |
             # Add test-support repository for wcslib8
             # Add test-support repository for wcslib8
-            apt-get update -q -y
-            apt-get install -q -y gpg
-            gpg --ignore-time-conflict --no-options --no-default-keyring --trustdb-name /etc/apt/trusteddb.gpg --keyring /etc/apt/trusted.gpg --keyserver keyserver.ubuntu.com --recv A985963D264907FDE1AE677FCC75F07B3EF41EFC
-            echo "deb http://ppa.launchpadcontent.net/astropy/test-support/ubuntu lunar main" > /etc/apt/sources.list.d/test-support.list
+            echo "deb [trusted=yes] http://ppa.launchpadcontent.net/astropy/test-support/ubuntu lunar main" > /etc/apt/sources.list.d/test-support.list
             apt-get update -q -y
             apt-get install -q -y git \
                                   g++ \

--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -133,8 +133,8 @@ jobs:
           install: |
             # Add test-support repository for wcslib8
             apt-get update -q -y
-            apt-get install ca-certificates
-            echo "deb https://ppa.launchpadcontent.net/astropy/test-support/ubuntu lunar main" > /etc/apt/sources.list.d/test-support.list
+            apt-get install software-properties-common  # for add-apt-repository
+            add-apt-repository ppa:astropy/test-support  # for wcslib8
             apt-get update -q -y
             apt-get install -q -y git \
                                   g++ \


### PR DESCRIPTION
This is a test PR to see whether with the extra stanza wcslib8 is used for the other architectures. If so, the commit can be cherrypicked in #14820