### PR TITLE
Cosmo latex identify and cleanup

### DIFF
--- a/astropy/cosmology/_io/latex.py
+++ b/astropy/cosmology/_io/latex.py
@@ -30,6 +30,7 @@ def write_latex(
     Parameters
     ----------
     cosmology : `~astropy.cosmology.Cosmology` subclass instance
+        The cosmology to serialize.
     file : path-like or file-like
         Location to save the serialized cosmology.
 
@@ -49,15 +50,15 @@ def write_latex(
         If kwarg (optional) 'cls' is not a subclass of `astropy.table.Table`
     """
     # Check that the format is 'latex', 'ascii.latex' (or not specified)
-    format = kwargs.pop("format", "latex")
-    if format not in ("latex", "ascii.latex"):
-        raise ValueError(f"format must be 'latex' or 'ascii.latex', not {format}")
+    fmt = kwargs.pop("format", "ascii.latex")
+    if fmt != "ascii.latex":
+        raise ValueError(f"format must be 'ascii.latex', not {fmt}")
 
     # Set cosmology_in_meta as false for now since there is no metadata being kept
     table = to_table(cosmology, cls=cls, cosmology_in_meta=False)
 
     cosmo_cls = type(cosmology)
-    for name, col in table.columns.copy().items():
+    for name in table.columns.keys():
         param = getattr(cosmo_cls, name, None)
         if not isinstance(param, Parameter) or param.unit in (None, u.one):
             continue
@@ -69,11 +70,10 @@ def write_latex(
         new_names = [_FORMAT_TABLE.get(k, k) for k in cosmology.__parameters__]
         table.rename_columns(cosmology.__parameters__, new_names)
 
-    table.write(file, overwrite=overwrite, format="latex", **kwargs)
+    table.write(file, overwrite=overwrite, format="ascii.latex", **kwargs)
 
 
 # ===================================================================
 # Register
 
-readwrite_registry.register_writer("latex", Cosmology, write_latex)
 readwrite_registry.register_writer("ascii.latex", Cosmology, write_latex)

--- a/astropy/cosmology/_io/latex.py
+++ b/astropy/cosmology/_io/latex.py
@@ -48,6 +48,56 @@ def write_latex(
     ------
     TypeError
         If kwarg (optional) 'cls' is not a subclass of `astropy.table.Table`
+
+    Examples
+    --------
+    Writing a cosmology to a LaTeX file will produce a table with the cosmology's type,
+    name, and parameters as columns.
+
+    .. code-block:: python
+
+        from astropy.cosmology import Planck18
+        Planck18.write("file.tex", overwrite=True)
+
+    .. code-block:: latex
+        \begin{table}
+        \begin{tabular}{cccccccc}
+        cosmology & name & $H_0$ & $\Omega_{m,0}$ & $T_{0}$ & $N_{eff}$ & $m_{nu}$ & $\Omega_{b,0}$ \\
+        &  & $\mathrm{km\,Mpc^{-1}\,s^{-1}}$ &  & $\mathrm{K}$ &  & $\mathrm{eV}$ &  \\
+        FlatLambdaCDM & Planck18 & 67.66 & 0.30966 & 2.7255 & 3.046 & 0.0 .. 0.06 & 0.04897 \\
+        \end{tabular}
+        \end{table}
+        <BLANKLINE>
+
+    The cosmology's metadata is not included in the table.
+
+    To save the cosmology in an existing file, use ``overwrite=True``; otherwise, an
+    error will be raised.
+
+    .. code-block:: python
+
+        Planck18.write("file.tex", overwrite=True)
+
+    To use a different table class as the underlying writer, use the ``cls`` kwarg. For
+    more information on the available table classes, see the documentation on Astropy's
+    table classes and on ``Cosmology.to_format("astropy.table")``.
+
+    By default the parameter names are converted to LaTeX format. To disable this, set
+    ``latex_names=False``.
+
+    .. code-block:: python
+
+        Planck18.write("file2.tex", latex_names=False)
+
+    .. code-block:: latex
+        \begin{table}
+        \begin{tabular}{cccccccc}
+        cosmology & name & H0 & Om0 & Tcmb0 & Neff & m_nu & Ob0 \\
+        &  & $\mathrm{km\,Mpc^{-1}\,s^{-1}}$ &  & $\mathrm{K}$ &  & $\mathrm{eV}$ &  \\
+        FlatLambdaCDM & Planck18 & 67.66 & 0.30966 & 2.7255 & 3.046 & 0.0 .. 0.06 & 0.04897 \\
+        \end{tabular}
+        \end{table}
+        <BLANKLINE>
     """
     # Check that the format is 'latex', 'ascii.latex' (or not specified)
     fmt = kwargs.pop("format", "ascii.latex")
@@ -73,7 +123,18 @@ def write_latex(
     table.write(file, overwrite=overwrite, format="ascii.latex", **kwargs)
 
 
+def latex_identify(origin, filepath, fileobj, *args, **kwargs):
+    """Identify if object uses the Table format.
+
+    Returns
+    -------
+    bool
+    """
+    return filepath is not None and filepath.endswith(".tex")
+
+
 # ===================================================================
 # Register
 
 readwrite_registry.register_writer("ascii.latex", Cosmology, write_latex)
+readwrite_registry.register_identifier("ascii.latex", Cosmology, latex_identify)

--- a/astropy/cosmology/_io/tests/test_latex.py
+++ b/astropy/cosmology/_io/tests/test_latex.py
@@ -24,16 +24,16 @@ class WriteLATEXTestMixin(ReadWriteTestMixinBase):
         fp = tmp_path / "test_to_latex_failed_cls.tex"
 
         with pytest.raises(TypeError, match="'cls' must be"):
-            write(fp, format="ascii.latex", cls=list)
+            write(fp, cls=list)
 
     @pytest.mark.parametrize("tbl_cls", [QTable, Table])
     def test_to_latex_cls(self, write, tbl_cls, tmp_path):
         fp = tmp_path / "test_to_latex_cls.tex"
-        write(fp, format="ascii.latex", cls=tbl_cls)
+        write(fp, cls=tbl_cls)
 
     def test_latex_columns(self, write, tmp_path):
         fp = tmp_path / "test_rename_latex_columns.tex"
-        write(fp, format="ascii.latex", latex_names=True)
+        write(fp, latex_names=True)
         tbl = QTable.read(fp)
         # asserts each column name has not been reverted yet
         # For now, Cosmology class and name are stored in first 2 slots
@@ -50,9 +50,9 @@ class WriteLATEXTestMixin(ReadWriteTestMixinBase):
         """Test to write a LaTeX file without overwriting an existing file"""
         # Test that passing an invalid path to write_latex() raises a IOError
         fp = tmp_path / "test_write_latex_false_overwrite.tex"
-        write(fp, format="ascii.latex")
+        write(fp)
         with pytest.raises(OSError, match="overwrite=True"):
-            write(fp, format="ascii.latex", overwrite=False)
+            write(fp, overwrite=False)
 
     def test_write_latex_unsupported_format(self, write, tmp_path):
         """Test for unsupported format"""

--- a/astropy/cosmology/_io/tests/test_latex.py
+++ b/astropy/cosmology/_io/tests/test_latex.py
@@ -19,52 +19,47 @@ class WriteLATEXTestMixin(ReadWriteTestMixinBase):
     See ``TestCosmology`` for an example.
     """
 
-    @pytest.mark.parametrize("format", ["latex", "ascii.latex"])
-    def test_to_latex_failed_cls(self, write, tmp_path, format):
+    def test_to_latex_failed_cls(self, write, tmp_path):
         """Test failed table type."""
         fp = tmp_path / "test_to_latex_failed_cls.tex"
 
         with pytest.raises(TypeError, match="'cls' must be"):
-            write(fp, format=format, cls=list)
+            write(fp, format="ascii.latex", cls=list)
 
-    @pytest.mark.parametrize("format", ["latex", "ascii.latex"])
     @pytest.mark.parametrize("tbl_cls", [QTable, Table])
-    def test_to_latex_cls(self, write, tbl_cls, tmp_path, format):
+    def test_to_latex_cls(self, write, tbl_cls, tmp_path):
         fp = tmp_path / "test_to_latex_cls.tex"
-        write(fp, format=format, cls=tbl_cls)
+        write(fp, format="ascii.latex", cls=tbl_cls)
 
-    @pytest.mark.parametrize("format", ["latex", "ascii.latex"])
-    def test_latex_columns(self, write, tmp_path, format):
+    def test_latex_columns(self, write, tmp_path):
         fp = tmp_path / "test_rename_latex_columns.tex"
-        write(fp, format=format, latex_names=True)
+        write(fp, format="ascii.latex", latex_names=True)
         tbl = QTable.read(fp)
         # asserts each column name has not been reverted yet
         # For now, Cosmology class and name are stored in first 2 slots
         for column_name in tbl.colnames[2:]:
             assert column_name in _FORMAT_TABLE.values()
 
-    @pytest.mark.parametrize("format", ["latex", "ascii.latex"])
-    def test_write_latex_invalid_path(self, write, format):
+    def test_write_latex_invalid_path(self, write):
         """Test passing an invalid path"""
         invalid_fp = ""
         with pytest.raises(FileNotFoundError, match="No such file or directory"):
-            write(invalid_fp, format=format)
+            write(invalid_fp, format="ascii.latex")
 
-    @pytest.mark.parametrize("format", ["latex", "ascii.latex"])
-    def test_write_latex_false_overwrite(self, write, tmp_path, format):
+    def test_write_latex_false_overwrite(self, write, tmp_path):
         """Test to write a LaTeX file without overwriting an existing file"""
         # Test that passing an invalid path to write_latex() raises a IOError
         fp = tmp_path / "test_write_latex_false_overwrite.tex"
-        write(fp, format="latex")
+        write(fp, format="ascii.latex")
         with pytest.raises(OSError, match="overwrite=True"):
-            write(fp, format=format, overwrite=False)
+            write(fp, format="ascii.latex", overwrite=False)
 
     def test_write_latex_unsupported_format(self, write, tmp_path):
         """Test for unsupported format"""
         fp = tmp_path / "test_write_latex_unsupported_format.tex"
         invalid_format = "unsupported"
         with pytest.raises((ValueError, IORegistryError)) as exc_info:
-            pytest.raises(ValueError, match="format must be 'latex' or 'ascii.latex'")
+            pytest.raises(ValueError, match="format must be 'ascii.latex'")
             pytest.raises(IORegistryError, match="No writer defined for format")
             write(fp, format=invalid_format)
 
@@ -80,11 +75,10 @@ class TestReadWriteLaTex(ReadWriteDirectTestBase, WriteLATEXTestMixin):
     def setup_class(self):
         self.functions = {"write": write_latex}
 
-    @pytest.mark.parametrize("format", ["latex", "ascii.latex"])
-    def test_rename_direct_latex_columns(self, write, tmp_path, format):
+    def test_rename_direct_latex_columns(self, write, tmp_path):
         """Tests renaming columns"""
         fp = tmp_path / "test_rename_latex_columns.tex"
-        write(fp, format=format, latex_names=True)
+        write(fp, latex_names=True)
         tbl = QTable.read(fp)
         # asserts each column name has not been reverted yet
         for column_name in tbl.colnames[2:]:

--- a/docs/changes/cosmology/15088.feature.rst
+++ b/docs/changes/cosmology/15088.feature.rst
@@ -1,0 +1,1 @@
+Cosmology I/O now auto-identifies the '.tex' suffix with the 'ascii.latex' format.


### PR DESCRIPTION
- Add autoidentification
- docstrings
- unregister 'latex' in favor of 'ascii.latex' (this is a new format that isn't yet in any released version)
- small cleanup