### PR TITLE
MNT: changelog bot moved to Scientific Python

### DIFF
--- a/.github/workflows/check_changelog.yml
+++ b/.github/workflows/check_changelog.yml
@@ -14,7 +14,7 @@ jobs:
     name: Check if towncrier change log entry is correct
     runs-on: ubuntu-latest
     steps:
-    - uses: pllim/actions-towncrier-changelog@main
+    - uses: scientific-python/action-towncrier-changelog@535813cbb8a749517a75e5c0ac339d6ae369b558  # 0.1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         BOT_USERNAME: gilesbot


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to acknowledge that I have moved the bot upstream to Scientific Python. This bot was originally meant to be temporary until Stuart could figure out why the gilesbot refuses to work in this repo. But after 2 years, I have accepted the fact that this bot is here to stay and Scientific Python is willing to host it, so I moved it there during Scipy 2023 conference, with help from @bsipocz and @jarrodmillman .

I will leave this open for like an hour for you to mourn the old bot location. After that, I will just merge this PR. There is no point to run CI here, so I skipped it.

xref https://github.com/scientific-python/action-towncrier-changelog/issues/4