### PR TITLE
TST: Use legacy numpy 1.25 print

### DIFF
--- a/astropy/conftest.py
+++ b/astropy/conftest.py
@@ -19,6 +19,12 @@ except ImportError:
 import pytest
 
 from astropy import __version__
+from astropy.utils.compat.numpycompat import NUMPY_LT_2_0
+
+if not NUMPY_LT_2_0:
+    import numpy as np
+
+    np.set_printoptions(legacy="1.25")
 
 # This is needed to silence a warning from matplotlib caused by
 # PyInstaller's matplotlib runtime hook.  This can be removed once the

--- a/astropy/modeling/tests/test_constraints.py
+++ b/astropy/modeling/tests/test_constraints.py
@@ -209,7 +209,9 @@ class TestBounds:
             if isinstance(fitter, fitting.TRFLSQFitter):
                 ctx = np.errstate(invalid="ignore", divide="ignore")
                 if not NUMPY_LT_2_0:
-                    ctx2 = pytest.warns(AstropyUserWarning, match="The fit may be unsuccessful")
+                    ctx2 = pytest.warns(
+                        AstropyUserWarning, match="The fit may be unsuccessful"
+                    )
             else:
                 ctx = nullcontext()
             with ctx, ctx2:

--- a/astropy/modeling/tests/test_constraints.py
+++ b/astropy/modeling/tests/test_constraints.py
@@ -4,6 +4,7 @@
 import platform
 import types
 import warnings
+from contextlib import nullcontext
 
 import numpy as np
 import pytest
@@ -13,6 +14,7 @@ from numpy.testing import assert_allclose
 from astropy.modeling import fitting, models
 from astropy.modeling.core import Fittable1DModel
 from astropy.modeling.parameters import Parameter
+from astropy.utils.compat.numpycompat import NUMPY_LT_2_0
 from astropy.utils.compat.optional_deps import HAS_SCIPY
 from astropy.utils.exceptions import AstropyUserWarning
 
@@ -203,7 +205,15 @@ class TestBounds:
             with pytest.warns(AstropyUserWarning, match="The fit may be unsuccessful"):
                 model = fitter(gauss, X, Y, self.data)
         else:
-            model = fitter(gauss, X, Y, self.data)
+            ctx2 = nullcontext()
+            if isinstance(fitter, fitting.TRFLSQFitter):
+                ctx = np.errstate(invalid="ignore", divide="ignore")
+                if not NUMPY_LT_2_0:
+                    ctx2 = pytest.warns(AstropyUserWarning, match="The fit may be unsuccessful")
+            else:
+                ctx = nullcontext()
+            with ctx, ctx2:
+                model = fitter(gauss, X, Y, self.data)
         x_mean = model.x_mean.value
         y_mean = model.y_mean.value
         x_stddev = model.x_stddev.value
@@ -439,13 +449,20 @@ def test_fit_with_fixed_and_bound_constraints(fitter):
     x = np.linspace(0, 10, 10)
     y = np.exp(-(x**2) / 2)
 
-    fitted_1 = fitter(m, x, y)
-    assert fitted_1.mean >= 4
-    assert fitted_1.mean <= 5
-    assert fitted_1.amplitude == 3.0
+    if isinstance(fitter, fitting.TRFLSQFitter):
+        ctx = np.errstate(invalid="ignore", divide="ignore")
+    else:
+        ctx = nullcontext()
 
-    m.amplitude.fixed = False
-    _ = fitter(m, x, y)
+    with ctx:
+        fitted_1 = fitter(m, x, y)
+        assert fitted_1.mean >= 4
+        assert fitted_1.mean <= 5
+        assert fitted_1.amplitude == 3.0
+
+        m.amplitude.fixed = False
+        # Cannot enter np.errstate twice, so we need to indent everything in between.
+        _ = fitter(m, x, y)
     # It doesn't matter anymore what the amplitude ends up as so long as the
     # bounds constraint was still obeyed
     assert fitted_1.mean >= 4

--- a/astropy/modeling/tests/test_physical_models.py
+++ b/astropy/modeling/tests/test_physical_models.py
@@ -94,7 +94,8 @@ def test_blackbody_fit(fitter):
     wav = np.array([0.5, 5, 10]) * u.micron
     fnu = np.array([1, 10, 5]) * u.Jy / u.sr
 
-    b_fit = fitter(b, wav, fnu, maxiter=1000)
+    with np.errstate(divide="ignore", over="ignore"):
+        b_fit = fitter(b, wav, fnu, maxiter=1000)
 
     assert_quantity_allclose(b_fit.temperature, 2840.7438355865065 * u.K, rtol=rtol)
     assert_quantity_allclose(b_fit.scale, 5.803783292762381e-17, atol=atol)
@@ -139,9 +140,10 @@ def test_blackbody_exceptions_and_warnings():
     bb = BlackBody(5000 * u.K)
 
     # Zero wavelength given for conversion to Hz
-    with pytest.warns(AstropyUserWarning, match="invalid") as w:
-        bb(0 * u.AA)
-    assert len(w) == 3  # 2 of these are RuntimeWarning from zero divide
+    with np.errstate(divide="ignore", invalid="ignore"):
+        with pytest.warns(AstropyUserWarning, match="invalid") as w:
+            bb(0 * u.AA)
+    assert len(w) == 1
 
     # Negative wavelength given for conversion to Hz
     with pytest.warns(AstropyUserWarning, match="invalid") as w:

--- a/astropy/nddata/tests/test_bitmask.py
+++ b/astropy/nddata/tests/test_bitmask.py
@@ -11,8 +11,8 @@ import pytest
 
 from astropy.nddata import bitmask
 
-MAX_INT_TYPE = np.maximum_sctype(np.int_)
-MAX_UINT_TYPE = np.maximum_sctype(np.uint)
+MAX_INT_TYPE = np.int64
+MAX_UINT_TYPE = np.uint64
 MAX_UINT_FLAG = np.left_shift(
     MAX_UINT_TYPE(1), MAX_UINT_TYPE(np.iinfo(MAX_UINT_TYPE).bits - 1)
 )

--- a/astropy/units/quantity_helper/function_helpers.py
+++ b/astropy/units/quantity_helper/function_helpers.py
@@ -987,9 +987,10 @@ def array2string(a, *args, **kwargs):
         a = a.value
     else:
         # See whether it covers our dtype.
-        from numpy.core.arrayprint import _get_format_function
+        from numpy.core.arrayprint import _get_format_function, _make_options_dict
 
         with np.printoptions(formatter=formatter) as options:
+            options = _make_options_dict(**options)
             try:
                 ff = _get_format_function(a.value, **options)
             except Exception:
@@ -998,7 +999,7 @@ def array2string(a, *args, **kwargs):
                 pass
             else:
                 # If the selected format function is that of numpy, we know
-                # things will fail
+                # things will fail if we pass in the Quantity, so use .value.
                 if "numpy" in ff.__module__:
                     a = a.value
 

--- a/astropy/utils/compat/numpycompat.py
+++ b/astropy/utils/compat/numpycompat.py
@@ -13,6 +13,7 @@ __all__ = [
     "NUMPY_LT_1_23",
     "NUMPY_LT_1_24",
     "NUMPY_LT_1_25",
+    "NUMPY_LT_2_0",
 ]
 
 # TODO: It might also be nice to have aliases to these named for specific
@@ -22,3 +23,4 @@ NUMPY_LT_1_22_1 = not minversion(np, "1.22.1")
 NUMPY_LT_1_23 = not minversion(np, "1.23")
 NUMPY_LT_1_24 = not minversion(np, "1.24")
 NUMPY_LT_1_25 = not minversion(np, "1.25")
+NUMPY_LT_2_0 = not minversion(np, "2.0.dev")

--- a/astropy/utils/tests/test_misc.py
+++ b/astropy/utils/tests/test_misc.py
@@ -42,7 +42,7 @@ def test_api_lookup():
     assert strurl == objurl
     assert (
         strurl
-        == "http://devdocs.astropy.org/utils/index.html#module-astropy.utils.misc"
+        == "http://devdocs.astropy.org/utils/ref_api.html#module-astropy.utils.misc"
     )
 
     # Try a non-dev version


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to use legacy numpy 1.25 print so the new numpy 2.0 print will not break CI until we are ready to patch it properly over at #15065.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Temporary workaround for #15095

This patch is as suggested by `seberg` over at https://github.com/astropy/pyvo/issues/464#issuecomment-1652232845 and similar to `bsipocz` patch at https://github.com/astropy/pyvo/pull/465 .
