### PR TITLE
Improve finite difference coordinate transformation tests

### DIFF
--- a/astropy/coordinates/tests/test_finite_difference_velocities.py
+++ b/astropy/coordinates/tests/test_finite_difference_velocities.py
@@ -18,23 +18,20 @@ from astropy.coordinates import (
 )
 from astropy.coordinates.baseframe import frame_transform_graph
 from astropy.coordinates.builtin_frames import FK5, GCRS, ICRS, LSR, AltAz, Galactic
+from astropy.coordinates.builtin_frames.galactic_transforms import (
+    _gal_to_fk5,
+    fk5_to_gal,
+)
 from astropy.coordinates.sites import get_builtin_sites
 from astropy.time import Time
 from astropy.units import allclose as quantity_allclose
 
-J2000 = Time("J2000")
 
-
-@pytest.mark.parametrize(
-    "dt, symmetric",
-    [
-        (1 * u.second, True),
-        (1 * u.year, True),
-        (1 * u.second, False),
-        (1 * u.year, False),
-    ],
-)
+@pytest.mark.parametrize("dt", [1 * u.second, 1 * u.year])
+@pytest.mark.parametrize("symmetric", [True, False])
 def test_faux_lsr(dt, symmetric):
+    J2000 = Time("J2000")
+
     class LSR2(LSR):
         obstime = TimeAttribute(default=J2000)
 
@@ -46,8 +43,7 @@ def test_faux_lsr(dt, symmetric):
         symmetric_finite_difference=symmetric,
     )
     def icrs_to_lsr(icrs_coo, lsr_frame):
-        dt = lsr_frame.obstime - J2000
-        offset = lsr_frame.v_bary * dt.to(u.second)
+        offset = lsr_frame.v_bary * (lsr_frame.obstime - J2000)
         return lsr_frame.realize_frame(icrs_coo.data.without_differentials() + offset)
 
     @frame_transform_graph.transform(
@@ -58,17 +54,19 @@ def test_faux_lsr(dt, symmetric):
         symmetric_finite_difference=symmetric,
     )
     def lsr_to_icrs(lsr_coo, icrs_frame):
-        dt = lsr_coo.obstime - J2000
-        offset = lsr_coo.v_bary * dt.to(u.second)
+        offset = lsr_coo.v_bary * (lsr_coo.obstime - J2000)
         return icrs_frame.realize_frame(lsr_coo.data - offset)
 
+    common_coords = {
+        "dec": 45.6 * u.deg,
+        "distance": 7.8 * u.au,
+        "pm_ra_cosdec": 0 * u.marcsec / u.yr,
+    }
     ic = ICRS(
         ra=12.3 * u.deg,
-        dec=45.6 * u.deg,
-        distance=7.8 * u.au,
-        pm_ra_cosdec=0 * u.marcsec / u.yr,
         pm_dec=0 * u.marcsec / u.yr,
         radial_velocity=0 * u.km / u.s,
+        **common_coords,
     )
     lsrc = ic.transform_to(LSR2())
 
@@ -76,17 +74,14 @@ def test_faux_lsr(dt, symmetric):
 
     idiff = ic.cartesian.differentials["s"]
     ldiff = lsrc.cartesian.differentials["s"]
-    change = (ldiff.d_xyz - idiff.d_xyz).to(u.km / u.s)
-    totchange = np.sum(change**2) ** 0.5
+    totchange = np.sum((ldiff.d_xyz - idiff.d_xyz) ** 2) ** 0.5
     assert quantity_allclose(totchange, np.sum(lsrc.v_bary.d_xyz**2) ** 0.5)
 
     ic2 = ICRS(
         ra=120.3 * u.deg,
-        dec=45.6 * u.deg,
-        distance=7.8 * u.au,
-        pm_ra_cosdec=0 * u.marcsec / u.yr,
         pm_dec=10 * u.marcsec / u.yr,
         radial_velocity=1000 * u.km / u.s,
+        **common_coords,
     )
     lsrc2 = ic2.transform_to(LSR2())
     ic2_roundtrip = lsrc2.transform_to(ICRS())
@@ -98,11 +93,6 @@ def test_faux_lsr(dt, symmetric):
 
 
 def test_faux_fk5_galactic():
-    from astropy.coordinates.builtin_frames.galactic_transforms import (
-        _gal_to_fk5,
-        fk5_to_gal,
-    )
-
     class Galactic2(Galactic):
         pass
 
@@ -117,8 +107,7 @@ def test_faux_fk5_galactic():
         finite_difference_frameattr_name=None,
     )
     def fk5_to_gal2(fk5_coo, gal_frame):
-        trans = DynamicMatrixTransform(fk5_to_gal, FK5, Galactic2)
-        return trans(fk5_coo, gal_frame)
+        return DynamicMatrixTransform(fk5_to_gal, FK5, Galactic2)(fk5_coo, gal_frame)
 
     @frame_transform_graph.transform(
         FunctionTransformWithFiniteDifference,
@@ -129,8 +118,7 @@ def test_faux_fk5_galactic():
         finite_difference_frameattr_name=None,
     )
     def gal2_to_fk5(gal_coo, fk5_frame):
-        trans = DynamicMatrixTransform(_gal_to_fk5, Galactic2, FK5)
-        return trans(gal_coo, fk5_frame)
+        return DynamicMatrixTransform(_gal_to_fk5, Galactic2, FK5)(gal_coo, fk5_frame)
 
     c1 = FK5(
         ra=150 * u.deg,
@@ -161,22 +149,14 @@ def test_gcrs_diffs():
     msungr = CartesianRepresentation(-sung.cartesian.xyz).represent_as(
         SphericalRepresentation
     )
-    suni = ICRS(
-        ra=msungr.lon,
-        dec=msungr.lat,
-        distance=100 * u.au,
-        pm_ra_cosdec=0 * u.marcsec / u.yr,
-        pm_dec=0 * u.marcsec / u.yr,
-        radial_velocity=0 * u.km / u.s,
-    )
-    qtrsuni = ICRS(
-        ra=qtrsung.ra,
-        dec=qtrsung.dec,
-        distance=100 * u.au,
-        pm_ra_cosdec=0 * u.marcsec / u.yr,
-        pm_dec=0 * u.marcsec / u.yr,
-        radial_velocity=0 * u.km / u.s,
-    )
+    common_coords = {
+        "distance": 100 * u.au,
+        "pm_ra_cosdec": 0 * u.marcsec / u.yr,
+        "pm_dec": 0 * u.marcsec / u.yr,
+        "radial_velocity": 0 * u.km / u.s,
+    }
+    suni = ICRS(ra=msungr.lon, dec=msungr.lat, **common_coords)
+    qtrsuni = ICRS(ra=qtrsung.ra, dec=qtrsung.dec, **common_coords)
 
     # Now we transform those parallel- and perpendicular-to Earth's orbit
     # directions to GCRS, which should shift the velocity to either include
@@ -187,8 +167,7 @@ def test_gcrs_diffs():
 
     # should be high along the ecliptic-not-sun sun axis and
     # low along the sun axis
-    assert np.abs(qtrsung.radial_velocity) > 30 * u.km / u.s
-    assert np.abs(qtrsung.radial_velocity) < 40 * u.km / u.s
+    assert 30 * u.km / u.s < np.abs(qtrsung.radial_velocity) < 40 * u.km / u.s
     assert np.abs(sung.radial_velocity) < 1 * u.km / u.s
 
     suni2 = sung.transform_to(ICRS())
@@ -199,8 +178,7 @@ def test_gcrs_diffs():
 
 def test_altaz_diffs():
     time = Time("J2015") + np.linspace(-1, 1, 1000) * u.day
-    loc = get_builtin_sites()["greenwich"]
-    aa = AltAz(obstime=time, location=loc)
+    aa = AltAz(obstime=time, location=get_builtin_sites()["greenwich"])
 
     icoo = ICRS(
         np.zeros(time.shape) * u.deg,
@@ -250,23 +228,19 @@ def test_numerical_limits(distance):
     difference transformation calculation.  This is *known* to fail for at
     >~1kpc, but this may be improved in future versions.
     """
-    time = Time("J2017") + np.linspace(-0.5, 0.5, 100) * u.year
-
-    icoo = ICRS(
+    gcrs_coord = ICRS(
         ra=0 * u.deg,
         dec=10 * u.deg,
         distance=distance,
         pm_ra_cosdec=0 * u.marcsec / u.yr,
         pm_dec=0 * u.marcsec / u.yr,
         radial_velocity=0 * u.km / u.s,
-    )
-    gcoo = icoo.transform_to(GCRS(obstime=time))
-    rv = gcoo.radial_velocity.to("km/s")
+    ).transform_to(GCRS(obstime=Time("J2017") + np.linspace(-0.5, 0.5, 100) * u.year))
 
     # if its a lot bigger than this - ~the maximal velocity shift along
     # the direction above with a small allowance for noise - finite-difference
     # rounding errors have ruined the calculation
-    assert np.ptp(rv) < 65 * u.km / u.s
+    assert np.ptp(gcrs_coord.radial_velocity) < 65 * u.km / u.s
 
 
 def diff_info_plot(frame, time):


### PR DESCRIPTION
### Description
The first commit refactors the tests.

The second improves `pytest` output if the [`verbose`](https://docs.pytest.org/en/stable/how-to/output.html#verbosity) option is used or if a test fails.

The third implements a simple test for the finite difference `dt` being specified as a function. This is a follow-up to #15020 where we noticed that such a test was missing.
