### PR TITLE
Modified the implementation of `np.power()` for instances of `Quantity` to allow any array as the second operand if all its elements have the same value.

### DIFF
--- a/astropy/units/tests/test_quantity_ufuncs.py
+++ b/astropy/units/tests/test_quantity_ufuncs.py
@@ -426,6 +426,17 @@ class TestQuantityMathFuncs:
         # regression check on #1696
         assert np.power(4.0 * u.m, 0.0) == 1.0 * u.dimensionless_unscaled
 
+    def test_power_scalar_filledarray(self):
+        result = np.power(4.0 * u.m, np.array([2.0, 2.0]))
+        assert np.all(result == 16.0 * u.m**2)
+
+    def test_power_scalar_strarray(self):
+        with pytest.raises(
+            expected_exception=ValueError,
+            match="could not convert string to float",
+        ):
+            np.power(4.0 * u.m, np.array(["foo"]))
+
     def test_power_array(self):
         assert np.all(
             np.power(np.array([1.0, 2.0, 3.0]) * u.m, 3.0)

--- a/astropy/units/utils.py
+++ b/astropy/units/utils.py
@@ -247,11 +247,15 @@ def validate_power(p):
         try:
             p = float(p)
         except Exception:
-            if not np.isscalar(p):
-                raise ValueError(
-                    "Quantities and Units may only be raised to a scalar power"
-                )
-            else:
+            try:
+                p = np.asanyarray(p)
+                if ((first := p.flat[0]) == p).all():
+                    p = float(first)
+                else:
+                    raise ValueError(
+                        "Quantities and Units may only be raised to a scalar power"
+                    )
+            except Exception:
                 raise
 
         # This returns either a (simple) Fraction or the same float.

--- a/docs/changes/units/15101.bugfix.rst
+++ b/docs/changes/units/15101.bugfix.rst
@@ -1,0 +1,2 @@
+Modified the implementation of ``np.power()`` for instances of ``Quantity`` to
+allow any array as the second operand if all its elements have the same value.


### PR DESCRIPTION
As of Numpy 1.25, `np.scalar()` now returns `False` for `size==1` arrays. This changes the behavior of `np.power()` on instances of `astropy.units.Quantity` since `(5 * u.m) ** np.array([[2]])` now returns `ValueError: Quantities and Units may only be raised to a scalar power`.

Before Numpy 1.25, this used to work, so I propose that we modify `np.power()` to have the same behavior as before.
