### PR TITLE
Test (again) docs build with sphinx-automodapi fork that fixes the inheritance-diagram links

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,7 +10,8 @@ build:
     pre_install:
       - git update-index --assume-unchanged docs/conf.py docs/rtd_environment.yaml
     post_install:
-      - pip install -U git+https://github.com/ayshih/sphinx@fix_inheritance_diagrams
+      - pip install -U git+https://github.com/sphinx-doc/sphinx
+      - pip install -U git+https://github.com/ayshih/sphinx-automodapi@broken_links
 
 conda:
   environment: docs/rtd_environment.yaml

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,6 +9,8 @@ build:
       - git fetch --shallow-since=2023-01-01  || true
     pre_install:
       - git update-index --assume-unchanged docs/conf.py docs/rtd_environment.yaml
+    post_install:
+      - pip install -U git+https://github.com/ayshih/sphinx@fix_inheritance_diagrams
 
 conda:
   environment: docs/rtd_environment.yaml


### PR DESCRIPTION
sphinx-doc/sphinx#10614 has now been merged.  The remaining broken inheritance-diagram links needs a fix in sphinx-automodapi: astropy/sphinx-automodapi#172


Original post:
---
This is a test PR to confirm that the pending Sphinx PR https://github.com/sphinx-doc/sphinx/pull/10614 to fix the bug with links in inheritance diagrams does in fact fix the issue in Astropy's docs (https://github.com/astropy/astropy/issues/4935). Do not merge this PR.

There's renewed activity on the Sphinx PR, but my previous test PR (#13357) apparently can't be re-opened.