### PR TITLE
MNT: avoid numpy.maximum_sctype (deprecated in numpy 2.0)

### DIFF
--- a/astropy/nddata/bitmask.py
+++ b/astropy/nddata/bitmask.py
@@ -19,8 +19,7 @@ __all__ = [
 
 
 _ENABLE_BITFLAG_CACHING = True
-_MAX_UINT_TYPE = np.maximum_sctype(np.uint)
-_SUPPORTED_FLAGS = int(np.bitwise_not(0, dtype=_MAX_UINT_TYPE, casting="unsafe"))
+_SUPPORTED_FLAGS = int(np.bitwise_not(0, dtype="uint64", casting="unsafe"))
 
 
 def _is_bit_flag(n):


### PR DESCRIPTION
xref https://github.com/numpy/numpy/pull/24154