### PR TITLE
Broadcast frames over both data and attributes

### DIFF
--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -311,7 +311,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
 
         shapes = []
         if data is not None:
-            shapes.append(getattr(data, "shape", ()))
+            shapes.append(data.shape)
 
         # Set frame attributes, if any.
         # Keep track of their shapes, but do not broadcast them yet.
@@ -346,7 +346,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
             ) from err
 
         # Broadcast the data if necessary and set it
-        if data is not None and getattr(data, "shape", ()) != self._shape:
+        if data is not None and data.shape != self._shape:
             if isinstance(data, ShapedLikeNDArray):
                 data = data._apply(np.broadcast_to, shape=self._shape, subok=True)
             else:

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -309,9 +309,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
         )
         data = self._infer_data(args, copy, kwargs)  # possibly None.
 
-        shapes = []
-        if data is not None:
-            shapes.append(data.shape)
+        shapes = [] if data is None else [data.shape]
 
         # Set frame attributes, if any.
         # Keep track of their shapes, but do not broadcast them yet.
@@ -347,10 +345,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
 
         # Broadcast the data if necessary and set it
         if data is not None and data.shape != self._shape:
-            if isinstance(data, ShapedLikeNDArray):
-                data = data._apply(np.broadcast_to, shape=self._shape, subok=True)
-            else:
-                data = np.broadcast_to(data, shape=self._shape, subok=True)
+            data = data._apply(np.broadcast_to, shape=self._shape, subok=True)
         self._data = data
 
         # Broadcast and set the attributes (leave scalars as is)

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -347,16 +347,10 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
         if data is not None and data.shape != self._shape:
             data = data._apply(np.broadcast_to, shape=self._shape, subok=True)
         self._data = data
-
-        # Broadcast and set the attributes (leave scalars as is)
-        for key, value in values.items():
-            shape = getattr(value, "shape", ())
-            if shape != () and shape != self._shape:
-                if isinstance(value, ShapedLikeNDArray):
-                    value = value._apply(np.broadcast_to, shape=self._shape, subok=True)
-                else:
-                    value = np.broadcast_to(value, shape=self._shape, subok=True)
-            setattr(self, "_" + key, value)
+        # Broadcast the attributes if necessary by getting them again
+        # (we now know the shapes will be OK).
+        for key in values:
+            getattr(self, key)
 
         # The logic of this block is not related to the previous one
         if self.has_data:

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -753,12 +753,12 @@ def test_time_inputs():
         c = FK4(1 * u.deg, 2 * u.deg, obstime="hello")
     assert "Invalid time input" in str(err.value)
 
-    # A vector time should work if the shapes match, but we don't automatically
-    # broadcast the basic data (just like time).
-    FK4([1, 2] * u.deg, [2, 3] * u.deg, obstime=["J2000", "J2001"])
-    with pytest.raises(ValueError) as err:
-        FK4(1 * u.deg, 2 * u.deg, obstime=["J2000", "J2001"])
-    assert "shape" in str(err.value)
+    # A vector time should work if the shapes match, and we automatically
+    # broadcast the basic data.
+    c = FK4([1, 2] * u.deg, [2, 3] * u.deg, obstime=["J2000", "J2001"])
+    assert c.shape == (2,)
+    c = FK4(1 * u.deg, 2 * u.deg, obstime=["J2000", "J2001"])
+    assert c.shape == (2,)
 
 
 def test_is_frame_attr_default():
@@ -1676,3 +1676,49 @@ def test_frame_coord_comparison():
     error_msg = "Can only compare SkyCoord to Frame with data"
     with pytest.raises(ValueError, match=error_msg):
         frame == coord  # noqa: B015
+
+
+@pytest.mark.parametrize(
+    ["s1", "s2"],
+    (
+        ((1,), (1,)),
+        ((2,), (1,)),
+        ((1,), (2,)),
+        ((2,), (2,)),
+        ((2, 1), (1,)),
+        ((1,), (2, 1)),
+        ((2, 1), (1, 3)),
+    ),
+)
+def test_altaz_broadcast(s1, s2):
+    """Note: Regression test for #5982"""
+    where = EarthLocation.from_geodetic(lat=45 * u.deg, lon=30 * u.deg, height=0 * u.m)
+    time = Time(np.full(s1, 58000.0), format="mjd")
+    angle = np.full(s2, 45.0) * u.deg
+    result = AltAz(alt=angle, az=angle, obstime=time, location=where)
+    assert result.shape == np.broadcast_shapes(s1, s2)
+
+
+def test_transform_altaz_array_obstime():
+    """Note: Regression test for #12965"""
+    obstime = Time("2010-01-01T00:00:00")
+    location = EarthLocation(0 * u.deg, 0 * u.deg, 0 * u.m)
+
+    frame1 = AltAz(location=location, obstime=obstime)
+    coord1 = SkyCoord(alt=80 * u.deg, az=0 * u.deg, frame=frame1)
+
+    obstimes = obstime + np.linspace(0, 15, 50) * u.min
+    frame2 = AltAz(location=location, obstime=obstimes)
+    coord2 = SkyCoord(alt=coord1.alt, az=coord1.az, frame=frame2)
+    assert np.all(coord2.alt == 80 * u.deg)
+    assert np.all(coord2.az == 0 * u.deg)
+
+    # test transformation to ICRS works
+    assert len(coord2.icrs) == 50
+
+
+def test_spherical_offsets_by_broadcast():
+    """Note: Regression test for #14383"""
+    assert SkyCoord(
+        ra=np.array([123, 134, 145]), dec=np.array([45, 56, 67]), unit=u.deg
+    ).spherical_offsets_by(2 * u.deg, 2 * u.deg).shape == (3,)

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -1712,6 +1712,7 @@ def test_transform_altaz_array_obstime():
     coord2 = SkyCoord(alt=coord1.alt, az=coord1.az, frame=frame2)
     assert np.all(coord2.alt == 80 * u.deg)
     assert np.all(coord2.az == 0 * u.deg)
+    assert coord2.shape == (50,)
 
     # test transformation to ICRS works
     assert len(coord2.icrs) == 50

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -760,6 +760,10 @@ def test_time_inputs():
     c = FK4(1 * u.deg, 2 * u.deg, obstime=["J2000", "J2001"])
     assert c.shape == (2,)
 
+    # If the shapes are not broadcastable, then we should raise an exception.
+    with pytest.raises(ValueError, match="inconsistent shapes"):
+        FK4([1, 2, 3] * u.deg, [4, 5, 6] * u.deg, obstime=["J2000", "J2001"])
+
 
 def test_is_frame_attr_default():
     """

--- a/docs/changes/coordinates/15121.feature.rst
+++ b/docs/changes/coordinates/15121.feature.rst
@@ -1,0 +1,2 @@
+Support Numpy broadcasting over frame data and attributes. See
+:ref:`whatsnew-6.0-broadcasting-frame-attributes`.

--- a/docs/coordinates/performance.inc.rst
+++ b/docs/coordinates/performance.inc.rst
@@ -15,6 +15,12 @@ coordinate::
 
     >>> coord = SkyCoord(ra_array, dec_array, unit='deg')  # doctest: +SKIP
 
+Frame attributes can be arrays too, as long as the coordinate data and all of
+the frame attributes have shapes that are compatible according to
+:doc:`Numpy broadcasting rules <numpy:user/basics.broadcasting>`::
+
+    >>> coord = FK4(1 * u.deg, 2 * u.deg, obstime=["J2000", "J2001"])  # doctest: +SKIP
+
 In addition, looping over a |SkyCoord| object can be slow. If you need to
 transform the coordinates to a different frame, it is much faster to transform a
 single |SkyCoord| with arrays of values as opposed to looping over the

--- a/docs/coordinates/performance.inc.rst
+++ b/docs/coordinates/performance.inc.rst
@@ -19,7 +19,9 @@ Frame attributes can be arrays too, as long as the coordinate data and all of
 the frame attributes have shapes that are compatible according to
 :doc:`Numpy broadcasting rules <numpy:user/basics.broadcasting>`::
 
-    >>> coord = FK4(1 * u.deg, 2 * u.deg, obstime=["J2000", "J2001"])  # doctest: +SKIP
+    >>> coord = FK4(1 * u.deg, 2 * u.deg, obstime=["J2000", "J2001"])
+    >>> coord.shape
+    (2,)
 
 In addition, looping over a |SkyCoord| object can be slow. If you need to
 transform the coordinates to a different frame, it is much faster to transform a

--- a/docs/coordinates/performance.inc.rst
+++ b/docs/coordinates/performance.inc.rst
@@ -19,9 +19,7 @@ Frame attributes can be arrays too, as long as the coordinate data and all of
 the frame attributes have shapes that are compatible according to
 :doc:`Numpy broadcasting rules <numpy:user/basics.broadcasting>`::
 
-    >>> coord = FK4(1 * u.deg, 2 * u.deg, obstime=["J2000", "J2001"])
-    >>> coord.shape
-    (2,)
+    >>> coord = FK4(1 * u.deg, 2 * u.deg, obstime=["J2000", "J2001"])  # doctest: +SKIP
 
 In addition, looping over a |SkyCoord| object can be slow. If you need to
 transform the coordinates to a different frame, it is much faster to transform a

--- a/docs/coordinates/performance.inc.rst
+++ b/docs/coordinates/performance.inc.rst
@@ -17,9 +17,19 @@ coordinate::
 
 Frame attributes can be arrays too, as long as the coordinate data and all of
 the frame attributes have shapes that are compatible according to
-:doc:`Numpy broadcasting rules <numpy:user/basics.broadcasting>`::
+:doc:`Numpy broadcasting rules <numpy:user/basics.broadcasting>`:
 
-    >>> coord = FK4(1 * u.deg, 2 * u.deg, obstime=["J2000", "J2001"])  # doctest: +SKIP
+
+.. testsetup::
+
+    >>> from astropy.coordinates import FK4
+    >>> from astropy import units as u
+
+::
+
+    >>> coord = FK4(1 * u.deg, 2 * u.deg, obstime=["J2000", "J2001"])
+    >>> coord.shape
+    (2,)
 
 In addition, looping over a |SkyCoord| object can be slow. If you need to
 transform the coordinates to a different frame, it is much faster to transform a

--- a/docs/coordinates/performance.inc.rst
+++ b/docs/coordinates/performance.inc.rst
@@ -70,8 +70,8 @@ properties::
   EXAMPLE END
 
 
-Broadcasting over frame data and attributes
-===========================================
+Broadcasting Over Frame Data and Attributes
+-------------------------------------------
 
 Frames in `astropy.coordinates` support
 :doc:`Numpy broadcasting rules <numpy:user/basics.broadcasting>` over both

--- a/docs/coordinates/performance.inc.rst
+++ b/docs/coordinates/performance.inc.rst
@@ -78,7 +78,7 @@ Frames in `astropy.coordinates` support
 frame data and frame attributes. This makes it easy and fast to do positional
 astronomy calculations and transformations on sweeps of parameters.
 
-For example, the user can now create frame objects with scalar data but vector
+For example, the user can create frame objects with scalar data but vector
 frame attributes, such as::
 
     from astropy.coordinates import FK4

--- a/docs/coordinates/performance.inc.rst
+++ b/docs/coordinates/performance.inc.rst
@@ -73,6 +73,10 @@ properties::
 Broadcasting Over Frame Data and Attributes
 -------------------------------------------
 
+..
+  EXAMPLE START
+  Broadcasting Over Frame Data and Attributes
+
 Frames in `astropy.coordinates` support
 :doc:`Numpy broadcasting rules <numpy:user/basics.broadcasting>` over both
 frame data and frame attributes. This makes it easy and fast to do positional
@@ -85,10 +89,6 @@ of length :samp:`{L}`, a `~astropy.coordinates.SkyCoord` array of length
 Numpy broadcasting rules to evaluate a boolean array of shape
 :samp:`({L}, {M}, {N})` that is `True` for those observing locations, times,
 and sky coordinates, for which the target is above an altitude limit::
-
-..
-  EXAMPLE START
-  Broadcasting Over Frame Data and Attributes
 
     >>> from astropy.coordinates import EarthLocation, AltAz, SkyCoord
     >>> from astropy.coordinates.angles import uniform_spherical_random_surface

--- a/docs/coordinates/performance.inc.rst
+++ b/docs/coordinates/performance.inc.rst
@@ -78,14 +78,6 @@ Frames in `astropy.coordinates` support
 frame data and frame attributes. This makes it easy and fast to do positional
 astronomy calculations and transformations on sweeps of parameters.
 
-For example, the user can create frame objects with scalar data but vector
-frame attributes, such as::
-
-    from astropy.coordinates import FK4
-    from astropy import units as u
-
-    FK4(1 * u.deg, 2 * u.deg, obstime=["J2000", "J2001"])
-
 Where this really shines is doing fast observability calculations over arrays.
 The following example constructs an `~astropy.coordinates.EarthLocation` array
 of length :samp:`{L}`, a `~astropy.coordinates.SkyCoord` array of length

--- a/docs/coordinates/performance.inc.rst
+++ b/docs/coordinates/performance.inc.rst
@@ -86,34 +86,43 @@ Numpy broadcasting rules to evaluate a boolean array of shape
 :samp:`({L}, {M}, {N})` that is `True` for those observing locations, times,
 and sky coordinates, for which the target is above an altitude limit::
 
-    from astropy.coordinates import EarthLocation, AltAz, SkyCoord
-    from astropy.coordinates.angle_utilities import uniform_spherical_random_surface
-    from astropy.time import Time
-    from astropy import units as u
-    import numpy as np
+..
+  EXAMPLE START
+  Broadcasting Over Frame Data and Attributes
 
-    L = 25
-    M = 100
-    N = 50
+    >>> from astropy.coordinates import EarthLocation, AltAz, SkyCoord
+    >>> from astropy.coordinates.angles import uniform_spherical_random_surface
+    >>> from astropy.time import Time
+    >>> from astropy import units as u
+    >>> import numpy as np
 
-    # Earth locations of length L
-    c = uniform_spherical_random_surface(L)
-    locations = EarthLocation.from_geodetic(c.lon, c.lat)
+    >>> L = 25
+    >>> M = 100
+    >>> N = 50
 
-    # Celestial coordinates of length M
-    coords = SkyCoord(uniform_spherical_random_surface(M))
+    >>> # Earth locations of length L
+    >>> c = uniform_spherical_random_surface(L)
+    >>> locations = EarthLocation.from_geodetic(c.lon, c.lat)
 
-    # Observation times of length N
-    obstimes = Time('2023-08-04') + np.linspace(0, 24, N) * u.hour
+    >>> # Celestial coordinates of length M
+    >>> coords = SkyCoord(uniform_spherical_random_surface(M))
 
-    # AltAz coordinates of shape (L, M, N)
-    frame = AltAz(
-        location=locations[:, np.newaxis, np.newaxis],
-        obstime=obstimes[np.newaxis, np.newaxis, :])
-    altaz = coords[np.newaxis, :, np.newaxis].transform_to(frame)
+    >>> # Observation times of length N
+    >>> obstimes = Time('2023-08-04') + np.linspace(0, 24, N) * u.hour
 
-    min_altitude = 30 * u.deg
-    is_above_altitude_limit = (altaz.alt > min_altitude)
+    >>> # AltAz coordinates of shape (L, M, N)
+    >>> frame = AltAz(
+    ...     location=locations[:, np.newaxis, np.newaxis],
+    ...     obstime=obstimes[np.newaxis, np.newaxis, :])
+    >>> altaz = coords[np.newaxis, :, np.newaxis].transform_to(frame)  # doctest: +REMOTE_DATA
+
+    >>> min_altitude = 30 * u.deg
+    >>> is_above_altitude_limit = (altaz.alt > min_altitude)  # doctest: +REMOTE_DATA
+    >>> is_above_altitude_limit.shape  # doctest: +REMOTE_DATA
+    (25, 100, 50)
+
+..
+  EXAMPLE END
 
 
 Improving Performance for Arrays of ``obstime``

--- a/docs/coordinates/performance.inc.rst
+++ b/docs/coordinates/performance.inc.rst
@@ -86,9 +86,9 @@ frame attributes, such as::
 
     FK4(1 * u.deg, 2 * u.deg, obstime=["J2000", "J2001"])
 
-But where this really shines is doing fast observability calculations over
-arrays. The following example constructs an `~astropy.coordinates.EarthLocation`
-array of length :samp:`{L}`, a `~astropy.coordinates.SkyCoord` array of length
+Where this really shines is doing fast observability calculations over arrays.
+The following example constructs an `~astropy.coordinates.EarthLocation` array
+of length :samp:`{L}`, a `~astropy.coordinates.SkyCoord` array of length
 :samp:`{M}`, and a `~astropy.time.Time` array of length :samp:`N`. It uses
 Numpy broadcasting rules to evaluate a boolean array of shape
 :samp:`({L}, {M}, {N})` that is `True` for those observing locations, times,

--- a/docs/whatsnew/6.0.rst
+++ b/docs/whatsnew/6.0.rst
@@ -14,6 +14,7 @@ In particular, this release includes:
 
 * :ref:`whatsnew-6.0-geodetic-representation-geometry`
 * :ref:`whatsnew-6.0-planetary-wcs-bodyfixed`
+* :ref:`whatsnew-6.0-broadcasting-frame-attributes`
 * :ref:`whatsnew-6.0-cosmology-latex-export`
 * :ref:`whatsnew-6.0-iers-data`
 
@@ -73,6 +74,64 @@ See :ref:`creating_planetary_wcs` for an example.
 
 Planetary images or spectral cube WCS description can be manipulated using the
 :mod:`~astropy.wcs` module.
+
+
+.. _whatsnew-6.0-broadcasting-frame-attributes:
+
+Support for Numpy broadcasting over frame data and attributes
+=============================================================
+
+Frames in `astropy.coordinates` now support
+:doc:`Numpy broadcasting rules <numpy:user/basics.broadcasting>` over both
+frame data and frame attributes. Previously, broadcasting was only supported
+over framed data. This makes it much easier and faster to do positional
+astronomy calculations and transformations on sweeps of parameters.
+
+For example, the user can now create frame objects with scalar data but vector
+frame attributes, such as::
+
+    from astropy.coordinates import FK4
+    from astropy import units as u
+
+    FK4(1 * u.deg, 2 * u.deg, obstime=["J2000", "J2001"])
+
+But where this really shines is doing fast observability calculations over
+arrays. The following example constructs an `~astropy.coordinates.EarthLocation`
+array of length :samp:`{L}`, a `~astropy.coordinates.SkyCoord` array of length
+:samp:`{M}`, and a `~astropy.time.Time` array of length :samp:`N`. It uses
+Numpy broadcasting rules to evaluate a boolean array of shape
+:samp:`({L}, {M}, {N})` that is `True` for those observing locations, times,
+and sky coordinates, for which the target is above an altitude limit::
+
+    from astropy.coordinates import EarthLocation, AltAz, SkyCoord
+    from astropy.coordinates.angle_utilities import uniform_spherical_random_surface
+    from astropy.time import Time
+    from astropy import units as u
+    import numpy as np
+
+    L = 25
+    M = 100
+    N = 50
+
+    # Earth locations of length
+    c = uniform_spherical_random_surface(L)
+    locations = EarthLocation.from_geodetic(c.lon, c.lat)
+
+    # Celestial coordinates of length M
+    coords = SkyCoord(uniform_spherical_random_surface(M))
+
+    # Observation times of length N
+    obstimes = Time('2023-08-04') + np.linspace(0, 24, N) * u.hour
+
+    # AltAz coordinates of shape (L, M, N)
+    frame = AltAz(
+        location=locations[:, np.newaxis, np.newaxis],
+        obstime=obstimes[np.newaxis, np.newaxis, :])
+    altaz = coords[np.newaxis, :, np.newaxis].transform_to(frame)
+
+    min_altitude = 30 * u.deg
+    is_above_altitude_limit = (altaz.alt > min_altitude)
+
 
 .. _whatsnew-6.0-cosmology-latex-export:
 

--- a/docs/whatsnew/6.0.rst
+++ b/docs/whatsnew/6.0.rst
@@ -103,35 +103,36 @@ Numpy broadcasting rules to evaluate a boolean array of shape
 :samp:`({L}, {M}, {N})` that is `True` for those observing locations, times,
 and sky coordinates, for which the target is above an altitude limit::
 
-    from astropy.coordinates import EarthLocation, AltAz, SkyCoord
-    from astropy.coordinates.angle_utilities import uniform_spherical_random_surface
-    from astropy.time import Time
-    from astropy import units as u
-    import numpy as np
+    >>> from astropy.coordinates import EarthLocation, AltAz, SkyCoord
+    >>> from astropy.coordinates.angles import uniform_spherical_random_surface
+    >>> from astropy.time import Time
+    >>> from astropy import units as u
+    >>> import numpy as np
 
-    L = 25
-    M = 100
-    N = 50
+    >>> L = 25
+    >>> M = 100
+    >>> N = 50
 
-    # Earth locations of length L
-    c = uniform_spherical_random_surface(L)
-    locations = EarthLocation.from_geodetic(c.lon, c.lat)
+    >>> # Earth locations of length L
+    >>> c = uniform_spherical_random_surface(L)
+    >>> locations = EarthLocation.from_geodetic(c.lon, c.lat)
 
-    # Celestial coordinates of length M
-    coords = SkyCoord(uniform_spherical_random_surface(M))
+    >>> # Celestial coordinates of length M
+    >>> coords = SkyCoord(uniform_spherical_random_surface(M))
 
-    # Observation times of length N
-    obstimes = Time('2023-08-04') + np.linspace(0, 24, N) * u.hour
+    >>> # Observation times of length N
+    >>> obstimes = Time('2023-08-04') + np.linspace(0, 24, N) * u.hour
 
-    # AltAz coordinates of shape (L, M, N)
-    frame = AltAz(
-        location=locations[:, np.newaxis, np.newaxis],
-        obstime=obstimes[np.newaxis, np.newaxis, :])
-    altaz = coords[np.newaxis, :, np.newaxis].transform_to(frame)
+    >>> # AltAz coordinates of shape (L, M, N)
+    >>> frame = AltAz(
+    ...     location=locations[:, np.newaxis, np.newaxis],
+    ...     obstime=obstimes[np.newaxis, np.newaxis, :])
+    >>> altaz = coords[np.newaxis, :, np.newaxis].transform_to(frame)  # doctest: +REMOTE_DATA
 
-    min_altitude = 30 * u.deg
-    is_above_altitude_limit = (altaz.alt > min_altitude)
-
+    >>> min_altitude = 30 * u.deg
+    >>> is_above_altitude_limit = (altaz.alt > min_altitude)  # doctest: +REMOTE_DATA
+    >>> is_above_altitude_limit.shape  # doctest: +REMOTE_DATA
+    (25, 100, 50)
 
 .. _whatsnew-6.0-cosmology-latex-export:
 

--- a/docs/whatsnew/6.0.rst
+++ b/docs/whatsnew/6.0.rst
@@ -95,9 +95,9 @@ frame attributes, such as::
 
     FK4(1 * u.deg, 2 * u.deg, obstime=["J2000", "J2001"])
 
-But where this really shines is doing fast observability calculations over
-arrays. The following example constructs an `~astropy.coordinates.EarthLocation`
-array of length :samp:`{L}`, a `~astropy.coordinates.SkyCoord` array of length
+Where this really shines is doing fast observability calculations over arrays.
+The following example constructs an `~astropy.coordinates.EarthLocation` array
+of length :samp:`{L}`, a `~astropy.coordinates.SkyCoord` array of length
 :samp:`{M}`, and a `~astropy.time.Time` array of length :samp:`N`. It uses
 Numpy broadcasting rules to evaluate a boolean array of shape
 :samp:`({L}, {M}, {N})` that is `True` for those observing locations, times,

--- a/docs/whatsnew/6.0.rst
+++ b/docs/whatsnew/6.0.rst
@@ -113,7 +113,7 @@ and sky coordinates, for which the target is above an altitude limit::
     M = 100
     N = 50
 
-    # Earth locations of length
+    # Earth locations of length L
     c = uniform_spherical_random_surface(L)
     locations = EarthLocation.from_geodetic(c.lon, c.lat)
 


### PR DESCRIPTION
Support Numpy broadcasting rules for frame attributes.

Fixes #5982, fixes #8812, fixes #11184, fixes #12965, fixes #14383.