### PR TITLE
Only keep 10 latest developer versions of wheels

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,6 +41,7 @@ jobs:
       upload_to_anaconda: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
       anaconda_user: astropy
       anaconda_package: astropy
+      anaconda_keep_n_latest: 10
 
       test_extras: test
       # FIXME: we exclude the test_data_out_of_range test since it


### PR DESCRIPTION
This will ensure that we don't run into issues with our quota on anaconda.org - happy to adjust that value, but thought 10 might be sensible?

xref https://github.com/astropy/astropy/issues/15123