### PR TITLE
Ruff fix PT013 — pytest import

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -152,7 +152,6 @@ ignore = [
     "PT007",   # pytest-parametrize-values-wrong-type
     "PT011",   # pytest-raises-too-broad
     "PT012",   # pytest-raises-with-multiple-statements
-    "PT013",   # pytest-incorrect-pytest-import
     "PT015",   # pytest-assert-always-false
     "PT017",   # pytest-assert-in-exceptinstead
     "PT018",   # pytest-composite-assertion

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -152,7 +152,6 @@ ignore = [
     "PT007",   # pytest-parametrize-values-wrong-type
     "PT011",   # pytest-raises-too-broad
     "PT012",   # pytest-raises-with-multiple-statements
-    "PT015",   # pytest-assert-always-false
     "PT017",   # pytest-assert-in-exceptinstead
     "PT018",   # pytest-composite-assertion
     "PT019",   # pytest-fixture-param-without-value

--- a/astropy/wcs/wcsapi/tests/test_low_level_api.py
+++ b/astropy/wcs/wcsapi/tests/test_low_level_api.py
@@ -1,4 +1,4 @@
-from pytest import raises
+import pytest
 
 from astropy.wcs.wcsapi.low_level_api import validate_physical_types
 
@@ -10,11 +10,13 @@ def test_validate_physical_types():
     validate_physical_types(["time", None])
 
     # Make sure validation is case sensitive
-    with raises(
+    with pytest.raises(
         ValueError, match=r"'Pos\.eq\.dec' is not a valid IOVA UCD1\+ physical type"
     ):
         validate_physical_types(["pos.eq.ra", "Pos.eq.dec"])
 
     # Make sure nonsense types are picked up
-    with raises(ValueError, match=r"'spam' is not a valid IOVA UCD1\+ physical type"):
+    with pytest.raises(
+        ValueError, match=r"'spam' is not a valid IOVA UCD1\+ physical type"
+    ):
         validate_physical_types(["spam"])

--- a/astropy/wcs/wcsapi/tests/test_utils.py
+++ b/astropy/wcs/wcsapi/tests/test_utils.py
@@ -1,4 +1,4 @@
-from pytest import raises
+import pytest
 
 from astropy import units as u
 from astropy.tests.helper import assert_quantity_allclose
@@ -19,7 +19,7 @@ def test_noconstruct():
 
 
 def test_invalid():
-    with raises(ValueError) as exc:
+    with pytest.raises(ValueError) as exc:
         deserialize_class(("astropy.units.Quantity", (), {"unit": "deg"}, ()))
     assert exc.value.args[0] == "Expected a tuple of three values"
 


### PR DESCRIPTION
Fixes an easy ruff rule that standardizes pytest imports.
And a rule that has no violations.