### PR TITLE
Pre-commit docformatter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -77,6 +77,7 @@ repos:
         args: [--in-place, --config, ./pyproject.toml]
         exclude: |
           (?x)(
+              test.*\.py |
               astropy/__init__\.py |
               astropy/_dev/ |
               astropy/config/ |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -85,7 +85,6 @@ repos:
               astropy/constants/ |
               astropy/convolution/ |
               astropy/coordinates/ |
-              astropy/cosmology/ |
               astropy/extern/ |
               astropy/io/ |
               astropy/logger\.py |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -69,6 +69,43 @@ repos:
       - id: ruff
         args: ["--fix"]
 
+  - repo: https://github.com/PyCQA/docformatter
+    rev: v1.7.5
+    hooks:
+      - id: docformatter
+        additional_dependencies: [tomli]
+        args: [--in-place, --config, ./pyproject.toml]
+        exclude: |
+          (?x)(
+              astropy/__init__\.py |
+              astropy/_dev/ |
+              astropy/config/ |
+              astropy/conftest\.py |
+              astropy/constants/ |
+              astropy/convolution/ |
+              astropy/coordinates/ |
+              astropy/cosmology/ |
+              astropy/extern/ |
+              astropy/io/ |
+              astropy/logger\.py |
+              astropy/modeling/ |
+              astropy/nddata/ |
+              astropy/samp/ |
+              astropy/stats/ |
+              astropy/table/ |
+              astropy/tests/ |
+              astropy/time/ |
+              astropy/timeseries/ |
+              astropy/uncertainty/ |
+              astropy/units/ |
+              astropy/utils/ |
+              astropy/version\.py |
+              astropy/visualization/ |
+              astropy/wcs/ |
+              docs/ |
+              examples/
+          )
+
   - repo: https://github.com/psf/black
     rev: 23.7.0
     hooks:

--- a/astropy/cosmology/__init__.py
+++ b/astropy/cosmology/__init__.py
@@ -1,10 +1,10 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-"""``astropy.cosmology`` contains classes and functions for cosmological
-distance measures and other cosmology-related calculations.
+"""Cosmology with Astropy.
 
-See the :ref:`astropy-cosmology` for more
-detailed usage examples and references.
+:mod:`~astropy.cosmology` contains classes and functions for cosmological distance
+measures and other cosmology-related calculations.
 
+See the :ref:`astropy-cosmology` for more detailed usage examples and references.
 """
 
 from . import realizations, units
@@ -68,8 +68,7 @@ __all__ = [
 
 
 def __getattr__(name):
-    """Get realizations using lazy import from
-    `PEP 562 <https://www.python.org/dev/peps/pep-0562/>`_.
+    """Get realizations using lazy import from ``PEP 562``.
 
     Raises
     ------

--- a/astropy/cosmology/_io/__init__.py
+++ b/astropy/cosmology/_io/__init__.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""Read/Write/Interchange methods for `astropy.cosmology`.
 
-"""
-Read/Write/Interchange methods for `astropy.cosmology`. **NOT public API**.
+**NOT public API**.
 """
 
 # Import to register with the I/O machinery

--- a/astropy/cosmology/_io/cosmology.py
+++ b/astropy/cosmology/_io/cosmology.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-
 """|Cosmology| I/O, using |Cosmology.to_format| and |Cosmology.from_format|.
 
 This module provides functions to transform a |Cosmology| object to and from another

--- a/astropy/cosmology/_io/ecsv.py
+++ b/astropy/cosmology/_io/ecsv.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-
 """|Cosmology| <-> ECSV I/O, using |Cosmology.read| and |Cosmology.write|.
 
 This module provides functions to write/read a |Cosmology| object to/from an ECSV file.

--- a/astropy/cosmology/_io/mapping.py
+++ b/astropy/cosmology/_io/mapping.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-
 """|Cosmology| <-> Mapping I/O, using |Cosmology.to_format| and |Cosmology.from_format|.
 
 This module provides functions to transform a |Cosmology| instance to a mapping

--- a/astropy/cosmology/_io/model.py
+++ b/astropy/cosmology/_io/model.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-
 """|Cosmology| <-> Model I/O, using |Cosmology.to_format| and |Cosmology.from_format|.
 
 This module provides functions to transform a |Cosmology| object to and from a
@@ -66,11 +65,17 @@ class _CosmologyModel(FittableModel):
 
     @abc.abstractmethod
     def _cosmology_class(self):
-        """Cosmology class as a private attribute. Set in subclasses."""
+        """Cosmology class as a private attribute.
+
+        Set in subclasses.
+        """
 
     @abc.abstractmethod
     def _method_name(self):
-        """Cosmology method name as a private attribute. Set in subclasses."""
+        """Cosmology method name as a private attribute.
+
+        Set in subclasses.
+        """
 
     @classproperty
     def cosmology_class(cls):

--- a/astropy/cosmology/_io/row.py
+++ b/astropy/cosmology/_io/row.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-
 """|Cosmology| <-> |Row| I/O, using |Cosmology.to_format| and |Cosmology.from_format|.
 
 A `~astropy.cosmology.Cosmology` as a `~astropy.table.Row` will have

--- a/astropy/cosmology/_io/table.py
+++ b/astropy/cosmology/_io/table.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-
 """|Cosmology| <-> |Table| I/O, using |Cosmology.to_format| and |Cosmology.from_format|.
 
 This module provides functions to transform a |Cosmology| object to and from a |Table|

--- a/astropy/cosmology/_io/yaml.py
+++ b/astropy/cosmology/_io/yaml.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-
 r"""|Cosmology| <-> YAML I/O, using |Cosmology.to_format| and |Cosmology.from_format|.
 
 This module provides functions to transform a |Cosmology| object to and from a `yaml

--- a/astropy/cosmology/_utils.py
+++ b/astropy/cosmology/_utils.py
@@ -35,9 +35,10 @@ def vectorize_redshift_method(func=None, nin=1):
 
     @functools.wraps(func)
     def wrapper(self, *args, **kwargs):
-        """
-        :func:`functools.wraps` of ``func`` where the first ``nin``
-        arguments are converted from |Quantity| to `numpy.ndarray` or scalar.
+        """Wrapper converting arguments to numpy-compatible inputs.
+
+        :func:`functools.wraps` of ``func`` where the first ``nin`` arguments are
+        converted from |Quantity| to `numpy.ndarray` or scalar.
         """
         # process inputs
         # TODO! quantity-aware vectorization can simplify this.
@@ -58,8 +59,8 @@ def vectorize_redshift_method(func=None, nin=1):
 
 
 def aszarr(z):
-    """
-    Redshift as a `~numbers.Number` or `~numpy.ndarray` / |Quantity| / |Column|.
+    """Redshift as a `~numbers.Number` or |ndarray| / |Quantity| / |Column|.
+
     Allows for any ndarray ducktype by checking for attribute "shape".
     """
     if isinstance(z, (Number, np.generic)):  # scalars

--- a/astropy/cosmology/connect.py
+++ b/astropy/cosmology/connect.py
@@ -176,7 +176,6 @@ class CosmologyFromFormat(io_registry.UnifiedReadWrite):
     -------
     out : `~astropy.cosmology.Cosmology` subclass instance
         `~astropy.cosmology.Cosmology` corresponding to ``obj`` contents.
-
     """
 
     def __init__(self, instance, cosmo_cls):
@@ -236,7 +235,6 @@ class CosmologyToFormat(io_registry.UnifiedReadWrite):
         first argument is the output filename.
     **kwargs
         Keyword arguments passed through to data writer.
-
     """
 
     def __init__(self, instance, cls):

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -166,8 +166,8 @@ class Cosmology(metaclass=abc.ABCMeta):
     @property
     @abc.abstractmethod
     def is_flat(self):
-        """
-        Return bool; `True` if the cosmology is flat.
+        """Return bool; `True` if the cosmology is flat.
+
         This is abstract and must be defined in subclasses.
         """
         raise NotImplementedError("is_flat is not implemented")
@@ -421,12 +421,13 @@ class Cosmology(metaclass=abc.ABCMeta):
 
 
 class FlatCosmologyMixin(metaclass=abc.ABCMeta):
-    """
-    Mixin class for flat cosmologies. Do NOT instantiate directly.
-    Note that all instances of ``FlatCosmologyMixin`` are flat, but not all
-    flat cosmologies are instances of ``FlatCosmologyMixin``. As example,
-    ``LambdaCDM`` **may** be flat (for the a specific set of parameter values),
-    but ``FlatLambdaCDM`` **will** be flat.
+    """Mixin class for flat cosmologies.
+
+    Do NOT instantiate directly. Note that all instances of
+    ``FlatCosmologyMixin`` are flat, but not all flat cosmologies are
+    instances of ``FlatCosmologyMixin``. As example, ``LambdaCDM`` **may**
+    be flat (for the a specific set of parameter values), but
+    ``FlatLambdaCDM`` **will** be flat.
     """
 
     __all_parameters__: tuple[str, ...]
@@ -562,7 +563,7 @@ class FlatCosmologyMixin(metaclass=abc.ABCMeta):
     # ===============================================================
 
     def __equiv__(self, other):
-        """flat-|Cosmology| equivalence.
+        """Flat-|Cosmology| equivalence.
 
         Use `astropy.cosmology.funcs.cosmology_equal` with
         ``allow_equivalent=True`` for actual checks!

--- a/astropy/cosmology/flrw/base.py
+++ b/astropy/cosmology/flrw/base.py
@@ -99,9 +99,7 @@ class _ScaleFactorMixin:
 
 
 class FLRW(Cosmology, _ScaleFactorMixin):
-    """
-    A class describing an isotropic and homogeneous
-    (Friedmann-Lemaitre-Robertson-Walker) cosmology.
+    """An isotropic and homogeneous (Friedmann-Lemaitre-Robertson-Walker) cosmology.
 
     This is an abstract base class -- you cannot instantiate examples of this
     class, but must work with one of its subclasses, such as
@@ -309,9 +307,9 @@ class FLRW(Cosmology, _ScaleFactorMixin):
     def m_nu(self, param, value):
         """Validate neutrino masses to right value, units, and shape.
 
-        There are no neutrinos if floor(Neff) or Tcmb0 are 0.
-        The number of neutrinos must match floor(Neff).
-        Neutrino masses cannot be negative.
+        There are no neutrinos if floor(Neff) or Tcmb0 are 0. The number of
+        neutrinos must match floor(Neff). Neutrino masses cannot be
+        negative.
         """
         # Check if there are any neutrinos
         if (nneutrinos := floor(self._Neff)) == 0 or self._Tcmb0.value == 0:
@@ -360,9 +358,7 @@ class FLRW(Cosmology, _ScaleFactorMixin):
 
     @property
     def Tnu0(self):
-        """
-        Temperature of the neutrino background as `~astropy.units.Quantity` at z=0.
-        """
+        """Temperature of the neutrino background as |Quantity| at z=0."""
         return self._Tnu0
 
     @property
@@ -447,9 +443,7 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         return self.Om(z) + self.Ogamma(z) + self.Onu(z) + self.Ode(z) + self.Ok(z)
 
     def Om(self, z):
-        """
-        Return the density parameter for non-relativistic matter
-        at redshift ``z``.
+        """Return the density parameter for non-relativistic matter at redshift ``z``.
 
         Parameters
         ----------
@@ -530,8 +524,7 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         return self._Odm0 * (z + 1.0) ** 3 * self.inv_efunc(z) ** 2
 
     def Ok(self, z):
-        """
-        Return the equivalent density parameter for curvature at redshift ``z``.
+        """Return the equivalent density parameter for curvature at redshift ``z``.
 
         Parameters
         ----------
@@ -993,9 +986,9 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         return quad(self._lookback_time_integrand_scalar, 0, z)[0]
 
     def lookback_distance(self, z):
-        """
-        The lookback distance is the light travel time distance to a given
-        redshift. It is simply c * lookback_time. It may be used to calculate
+        """The lookback distance is the light travel time distance to a given redshift.
+
+        It is simply c * lookback_time. It may be used to calculate
         the proper distance between two redshifts, e.g. for the mean free path
         to ionizing radiation.
 
@@ -1104,9 +1097,7 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         return self._comoving_distance_z1z2(0, z)
 
     def _comoving_distance_z1z2(self, z1, z2):
-        """
-        Comoving line-of-sight distance in Mpc between objects at redshifts
-        ``z1`` and ``z2``.
+        """Comoving line-of-sight distance in Mpc between redshifts ``z1`` and ``z2``.
 
         The comoving distance along the line-of-sight between two objects
         remains constant with time for objects in the Hubble flow.
@@ -1125,9 +1116,7 @@ class FLRW(Cosmology, _ScaleFactorMixin):
 
     @vectorize_redshift_method(nin=2)
     def _integral_comoving_distance_z1z2_scalar(self, z1, z2, /):
-        """
-        Comoving line-of-sight distance between objects at redshifts ``z1`` and
-        ``z2``. Value in Mpc.
+        """Comoving line-of-sight distance in Mpc between objects at redshifts ``z1`` and ``z2``.
 
         The comoving distance along the line-of-sight between two objects
         remains constant with time for objects in the Hubble flow.
@@ -1146,11 +1135,10 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         return quad(self._inv_efunc_scalar, z1, z2, args=self._inv_efunc_scalar_args)[0]
 
     def _integral_comoving_distance_z1z2(self, z1, z2):
-        """
-        Comoving line-of-sight distance in Mpc between objects at redshifts
-        ``z1`` and ``z2``. The comoving distance along the line-of-sight
-        between two objects remains constant with time for objects in the
-        Hubble flow.
+        """Comoving line-of-sight distance in Mpc between objects at redshifts ``z1`` and ``z2``.
+
+        The comoving distance along the line-of-sight between two objects remains
+        constant with time for objects in the Hubble flow.
 
         Parameters
         ----------
@@ -1413,9 +1401,7 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         return self._hubble_distance * (dm**2.0) / (self.efunc(z) << u.steradian)
 
     def kpc_comoving_per_arcmin(self, z):
-        """
-        Separation in transverse comoving kpc corresponding to an arcminute at
-        redshift ``z``.
+        """Separation in transverse comoving kpc equal to an arcmin at redshift ``z``.
 
         Parameters
         ----------
@@ -1431,9 +1417,7 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         return self.comoving_transverse_distance(z).to(u.kpc) / _radian_in_arcmin
 
     def kpc_proper_per_arcmin(self, z):
-        """
-        Separation in transverse proper kpc corresponding to an arcminute at
-        redshift ``z``.
+        """Separation in transverse proper kpc equal to an arcminute at redshift ``z``.
 
         Parameters
         ----------
@@ -1449,9 +1433,7 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         return self.angular_diameter_distance(z).to(u.kpc) / _radian_in_arcmin
 
     def arcsec_per_kpc_comoving(self, z):
-        """
-        Angular separation in arcsec corresponding to a comoving kpc at
-        redshift ``z``.
+        """Angular separation in arcsec equal to a comoving kpc at redshift ``z``.
 
         Parameters
         ----------
@@ -1467,9 +1449,7 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         return _radian_in_arcsec / self.comoving_transverse_distance(z).to(u.kpc)
 
     def arcsec_per_kpc_proper(self, z):
-        """
-        Angular separation in arcsec corresponding to a proper kpc at redshift
-        ``z``.
+        """Angular separation in arcsec corresponding to a proper kpc at redshift ``z``.
 
         Parameters
         ----------
@@ -1486,14 +1466,14 @@ class FLRW(Cosmology, _ScaleFactorMixin):
 
 
 class FlatFLRWMixin(FlatCosmologyMixin):
-    """
-    Mixin class for flat FLRW cosmologies. Do NOT instantiate directly.
-    Must precede the base class in the multiple-inheritance so that this
-    mixin's ``__init__`` proceeds the base class'.
-    Note that all instances of ``FlatFLRWMixin`` are flat, but not all
-    flat cosmologies are instances of ``FlatFLRWMixin``. As example,
-    ``LambdaCDM`` **may** be flat (for the a specific set of parameter values),
-    but ``FlatLambdaCDM`` **will** be flat.
+    """Mixin class for flat FLRW cosmologies.
+
+    Do NOT instantiate directly. Must precede the base class in the
+    multiple-inheritance so that this mixin's ``__init__`` proceeds the
+    base class'. Note that all instances of ``FlatFLRWMixin`` are flat, but
+    not all flat cosmologies are instances of ``FlatFLRWMixin``. As
+    example, ``LambdaCDM`` **may** be flat (for the a specific set of
+    parameter values), but ``FlatLambdaCDM`` **will** be flat.
     """
 
     Ode0 = FLRW.Ode0.clone(derived=True)  # same as FLRW, but now a derived param.

--- a/astropy/cosmology/flrw/lambdacdm.py
+++ b/astropy/cosmology/flrw/lambdacdm.py
@@ -284,10 +284,11 @@ class LambdaCDM(FLRW):
         return prefactor * g * (ellipkinc(phi_z1, k2) - ellipkinc(phi_z2, k2))
 
     def _dS_comoving_distance_z1z2(self, z1, z2):
-        r"""
-        Comoving line-of-sight distance in Mpc between objects at redshifts
-        ``z1`` and ``z2`` in a flat, :math:`\Omega_{\Lambda}=1` cosmology
-        (de Sitter).
+        r"""De Sitter comoving LoS distance in Mpc between two redshifts.
+
+        The Comoving line-of-sight distance in Mpc between objects at
+        redshifts ``z1`` and ``z2`` in a flat, :math:`\Omega_{\Lambda}=1`
+        cosmology (de Sitter).
 
         The comoving distance along the line-of-sight between two objects
         remains constant with time for objects in the Hubble flow.
@@ -312,16 +313,17 @@ class LambdaCDM(FLRW):
         return self._hubble_distance * (z2 - z1)
 
     def _EdS_comoving_distance_z1z2(self, z1, z2):
-        r"""
-        Comoving line-of-sight distance in Mpc between objects at redshifts
-        ``z1`` and ``z2`` in a flat, :math:`\Omega_M=1` cosmology
-        (Einstein - de Sitter).
+        r"""Einstein-de Sitter comoving LoS distance in Mpc between two redshifts.
+
+        The Comoving line-of-sight distance in Mpc between objects at
+        redshifts ``z1`` and ``z2`` in a flat, :math:`\Omega_M=1`
+        cosmology (Einstein - de Sitter).
 
         The comoving distance along the line-of-sight between two objects
         remains constant with time for objects in the Hubble flow.
 
-        For :math:`\Omega_M=1`, :math:`\Omega_{rad}=0` the comoving distance
-        has an analytic solution.
+        For :math:`\Omega_M=1`, :math:`\Omega_{rad}=0` the comoving
+        distance has an analytic solution.
 
         Parameters
         ----------
@@ -342,9 +344,10 @@ class LambdaCDM(FLRW):
         return prefactor * ((z1 + 1.0) ** (-1.0 / 2) - (z2 + 1.0) ** (-1.0 / 2))
 
     def _hypergeometric_comoving_distance_z1z2(self, z1, z2):
-        r"""
-        Comoving line-of-sight distance in Mpc between objects at redshifts
-        ``z1`` and ``z2``.
+        r"""Hypergeoemtric comoving LoS distance in Mpc between two redshifts.
+
+        The Comoving line-of-sight distance in Mpc at redshifts ``z1`` and
+        ``z2``.
 
         The comoving distance along the line-of-sight between two objects
         remains constant with time for objects in the Hubble flow.
@@ -365,8 +368,8 @@ class LambdaCDM(FLRW):
         References
         ----------
         .. [1] Baes, M., Camps, P., & Van De Putte, D. (2017). Analytical
-               expressions and numerical evaluation of the luminosity distance
-               in a flat cosmology. MNRAS, 468(1), 927-930.
+               expressions and numerical evaluation of the luminosity
+               distance in a flat cosmology. MNRAS, 468(1), 927-930.
         """
         try:
             z1, z2 = np.broadcast_arrays(z1, z2)

--- a/astropy/cosmology/flrw/w0cdm.py
+++ b/astropy/cosmology/flrw/w0cdm.py
@@ -16,8 +16,7 @@ __doctest_requires__ = {"*": ["scipy"]}
 
 
 class wCDM(FLRW):
-    """
-    FLRW cosmology with a constant dark energy equation of state and curvature.
+    """FLRW cosmology with a constant dark energy EoS and curvature.
 
     This has one additional attribute beyond those of FLRW.
 
@@ -236,9 +235,7 @@ class wCDM(FLRW):
 
 
 class FlatwCDM(FlatFLRWMixin, wCDM):
-    """
-    FLRW cosmology with a constant dark energy equation of state and no spatial
-    curvature.
+    """FLRW cosmology with a constant dark energy EoS and no spatial curvature.
 
     This has one additional attribute beyond those of FLRW.
 

--- a/astropy/cosmology/flrw/w0wacdm.py
+++ b/astropy/cosmology/flrw/w0wacdm.py
@@ -15,9 +15,9 @@ __doctest_requires__ = {"*": ["scipy"]}
 
 
 class w0waCDM(FLRW):
-    r"""FLRW cosmology with a CPL dark energy equation of state and curvature.
+    r"""FLRW cosmology with a CPL dark energy EoS and curvature.
 
-    The equation for the dark energy equation of state uses the
+    The equation for the dark energy equation of state (EoS) uses the
     CPL form as described in Chevallier & Polarski [1]_ and Linder [2]_:
     :math:`w(z) = w_0 + w_a (1-a) = w_0 + w_a z / (1+z)`.
 
@@ -214,10 +214,9 @@ class w0waCDM(FLRW):
 
 
 class Flatw0waCDM(FlatFLRWMixin, w0waCDM):
-    """FLRW cosmology with a CPL dark energy equation of state and no
-    curvature.
+    """FLRW cosmology with a CPL dark energy EoS and no curvature.
 
-    The equation for the dark energy equation of state uses the CPL form as
+    The equation for the dark energy equation of state (EoS) uses the CPL form as
     described in Chevallier & Polarski [1]_ and Linder [2]_:
     :math:`w(z) = w_0 + w_a (1-a) = w_0 + w_a z / (1+z)`.
 

--- a/astropy/cosmology/flrw/w0wzcdm.py
+++ b/astropy/cosmology/flrw/w0wzcdm.py
@@ -15,10 +15,9 @@ __doctest_requires__ = {"*": ["scipy"]}
 
 
 class w0wzCDM(FLRW):
-    """
-    FLRW cosmology with a variable dark energy equation of state and curvature.
+    """FLRW cosmology with a variable dark energy EoS and curvature.
 
-    The equation for the dark energy equation of state uses the simple form:
+    The equation for the dark energy equation of state (EoS) uses the simple form:
     :math:`w(z) = w_0 + w_z z`.
 
     This form is not recommended for z > 1.
@@ -212,10 +211,9 @@ class w0wzCDM(FLRW):
 
 
 class Flatw0wzCDM(FlatFLRWMixin, w0wzCDM):
-    """
-    FLRW cosmology with a variable dark energy equation of state and no curvature.
+    """FLRW cosmology with a variable dark energy EoS and no curvature.
 
-    The equation for the dark energy equation of state uses the simple form:
+    The equation for the dark energy equation of state (EoS) uses the simple form:
     :math:`w(z) = w_0 + w_z z`.
 
     This form is not recommended for z > 1.

--- a/astropy/cosmology/flrw/wpwazpcdm.py
+++ b/astropy/cosmology/flrw/wpwazpcdm.py
@@ -16,11 +16,9 @@ __doctest_requires__ = {"*": ["scipy"]}
 
 
 class wpwaCDM(FLRW):
-    r"""
-    FLRW cosmology with a CPL dark energy equation of state, a pivot redshift,
-    and curvature.
+    r"""FLRW cosmology with a CPL dark energy EoS, a pivot redshift, and curvature.
 
-    The equation for the dark energy equation of state uses the CPL form as
+    The equation for the dark energy equation of state (EoS) uses the CPL form as
     described in Chevallier & Polarski [1]_ and Linder [2]_, but modified to
     have a pivot redshift as in the findings of the Dark Energy Task Force
     [3]_: :math:`w(a) = w_p + w_a (a_p - a) = w_p + w_a( 1/(1+zp) - 1/(1+z) )`.
@@ -239,11 +237,9 @@ class wpwaCDM(FLRW):
 
 
 class FlatwpwaCDM(FlatFLRWMixin, wpwaCDM):
-    r"""
-    FLRW cosmology with a CPL dark energy equation of state, a pivot redshift,
-    and no curvature.
+    r"""FLRW cosmology with a CPL dark energy EoS, a pivot redshift, and no curvature.
 
-    The equation for the dark energy equation of state uses the CPL form as
+    The equation for the dark energy equation of state (EoS) uses the CPL form as
     described in Chevallier & Polarski [1]_ and Linder [2]_, but modified to
     have a pivot redshift as in the findings of the Dark Energy Task Force
     [3]_: :math:`w(a) = w_p + w_a (a_p - a) = w_p + w_a( 1/(1+zp) - 1/(1+z) )`.

--- a/astropy/cosmology/funcs/__init__.py
+++ b/astropy/cosmology/funcs/__init__.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-
 """Functions for `astropy.cosmology`."""
 
 from .comparison import cosmology_equal

--- a/astropy/cosmology/funcs/comparison.py
+++ b/astropy/cosmology/funcs/comparison.py
@@ -1,10 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-"""
-Comparison functions for `astropy.cosmology.Cosmology`.
+"""Comparison functions for `astropy.cosmology.Cosmology`.
 
 This module is **NOT** public API. To use these functions, import them from
-the top-level namespace -- :mod:`astropy.cosmology`.
-This module will be moved.
+the top-level namespace -- :mod:`astropy.cosmology`. This module will be
+moved.
 """
 
 from __future__ import annotations
@@ -38,8 +37,8 @@ _COSMO_AOK: set[Any] = {None, True_, False_, "astropy.cosmology"}
 
 
 class _CosmologyWrapper:
-    """
-    A private wrapper class to hide things from :mod:`numpy`.
+    """A private wrapper class to hide things from :mod:`numpy`.
+
     This should never be exposed to the user.
     """
 
@@ -47,7 +46,8 @@ class _CosmologyWrapper:
     # Use less memory and speed up initialization.
 
     _cantbroadcast: tuple[type, ...] = (table.Row, table.Table)
-    """
+    """Things that cannot broadcast.
+
     Have to deal with things that do not broadcast well. e.g.
     `~astropy.table.Row` cannot be used in an array, even if ``dtype=object``
     and will raise a segfault when used in a `numpy.ufunc`.

--- a/astropy/cosmology/funcs/optimize.py
+++ b/astropy/cosmology/funcs/optimize.py
@@ -1,7 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-"""
-Convenience functions for `astropy.cosmology`.
-"""
+"""Convenience functions for `astropy.cosmology`."""
 
 import warnings
 
@@ -28,8 +26,8 @@ def _z_at_scalar_value(
     bracket=None,
     verbose=False,
 ):
-    """
-    Find the redshift ``z`` at which ``func(z) = fval``.
+    """Find the redshift ``z`` at which ``func(z) = fval``.
+
     See :func:`astropy.cosmology.funcs.z_at_value`.
     """
     from scipy.optimize import minimize_scalar

--- a/astropy/cosmology/parameter/_converter.py
+++ b/astropy/cosmology/parameter/_converter.py
@@ -60,8 +60,8 @@ def _register_validator(key, fvalidate=None):
 
 @_register_validator("default")
 def _validate_with_unit(cosmology, param, value):
-    """
-    Default Parameter value validator.
+    """Default Parameter value validator.
+
     Adds/converts units if Parameter has a unit.
     """
     if param.unit is not None:

--- a/astropy/cosmology/parameter/_core.py
+++ b/astropy/cosmology/parameter/_core.py
@@ -119,7 +119,10 @@ class Parameter:
     """Parameter description."""
 
     name: str | None = field(init=False, compare=True, default=None, repr=False)
-    """The name of the Parameter on the Cosmology. Cannot be set directly."""
+    """The name of the Parameter on the Cosmology.
+
+    Cannot be set directly.
+    """
 
     if PYTHON_LT_3_10:
 
@@ -166,7 +169,10 @@ class Parameter:
         return getattr(cosmology, self._attr_name)
 
     def __set__(self, cosmology, value):
-        """Allows attribute setting once. Raises AttributeError subsequently."""
+        """Allows attribute setting once.
+
+        Raises AttributeError subsequently.
+        """
         # Raise error if setting 2nd time.
         if hasattr(cosmology, self._attr_name):
             raise AttributeError(f"can't set attribute {self.name} again")

--- a/astropy/cosmology/parameters.py
+++ b/astropy/cosmology/parameters.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-"""This module contains dictionaries with sets of parameters for a
-given cosmology.
+"""This module contains dictionaries with sets of parameters for a given cosmology.
 
 The list of cosmologies available are given by the tuple `available`.
 """
@@ -26,9 +25,7 @@ __all__ += [  # noqa: F822
 
 
 def __getattr__(name):
-    """Get parameters of cosmology representations with lazy import from
-    `PEP 562 <https://www.python.org/dev/peps/pep-0562/>`_.
-    """
+    """Get parameters of cosmology representations with lazy import from ``PEP 562``."""
     from astropy.cosmology import realizations
 
     cosmo = getattr(realizations, name)

--- a/astropy/cosmology/realizations.py
+++ b/astropy/cosmology/realizations.py
@@ -1,6 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""Built-in cosmologies.
 
-"""Preloaded cosmologies. See ``available``."""
+See :attr:`~astropy.cosmology.realizations.available` for a full list.
+"""
 
 from __future__ import annotations
 
@@ -48,8 +50,7 @@ available = (
 
 
 def __getattr__(name):
-    """Make specific realizations from data files with lazy import from
-    `PEP 562 <https://www.python.org/dev/peps/pep-0562/>`_.
+    """Make specific realizations from data files with lazy import from ``PEP 562``.
 
     Raises
     ------

--- a/astropy/cosmology/units.py
+++ b/astropy/cosmology/units.py
@@ -1,7 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-
-"""Cosmological units and equivalencies.
-"""  # (newline needed for unit summary)
+"""Cosmological units and equivalencies."""
 
 import astropy.units as u
 from astropy.units.utils import generate_unit_summary as _generate_unit_summary
@@ -59,10 +57,10 @@ littleh = u.def_unit(
 def dimensionless_redshift():
     """Allow redshift to be 1-to-1 equivalent to dimensionless.
 
-    It is special compared to other equivalency pairs in that it
-    allows this independent of the power to which the redshift is raised,
-    and independent of whether it is part of a more complicated unit.
-    It is similar to u.dimensionless_angles() in this respect.
+    It is special compared to other equivalency pairs in that it allows
+    this independent of the power to which the redshift is raised, and
+    independent of whether it is part of a more complicated unit. It is
+    similar to u.dimensionless_angles() in this respect.
     """
     return u.Equivalency([(redshift, None)], "dimensionless_redshift")
 
@@ -359,8 +357,7 @@ def with_redshift(
 
 
 def with_H0(H0=None):
-    """
-    Convert between quantities with little-h and the equivalent physical units.
+    """Convert between quantities with little-h and the equivalent physical units.
 
     Parameters
     ----------
@@ -398,4 +395,4 @@ u.add_enabled_equivalencies(dimensionless_redshift())
 # This generates a docstring for this module that describes all of the
 # standard units defined here.
 if __doc__ is not None:
-    __doc__ += _generate_unit_summary(_ns)
+    __doc__ += "\n" + _generate_unit_summary(_ns)

--- a/astropy/cosmology/utils.py
+++ b/astropy/cosmology/utils.py
@@ -9,8 +9,7 @@ from astropy.utils.decorators import deprecated
 
 # TODO: complete the deprecation for v6.2 / v7
 def __getattr__(name):
-    """Get realizations using lazy import from
-    `PEP 562 <https://www.python.org/dev/peps/pep-0562/>`_.
+    """Get realizations using lazy import from ``PEP 562``.
 
     Raises
     ------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,16 @@ force-exclude = '''
 '''
 
 
+[tool.docformatter]
+    # The ``summaries`` are not (yet) 75 characters because the summary lines can't be
+    # automatically wrapped and must be re-written, which should be done at some point.
+    recursive = true
+    wrap-summaries = 1000
+    wrap-descriptions = 75
+    black = true
+    syntax = "numpy"
+
+
 [tool.flynt]
 exclude= [
     "astropy/extern",


### PR DESCRIPTION
- Add docformatter to pre-commit, configured to black & numpy styles
- Applied to Cosmology

Not sure this is a good idea. I don't think docformatter is very configurable; it doesn't have in-file config like per-line ignores.