### PR TITLE
DOC: Fix cosmology doctest failure on s390x

### DIFF
--- a/astropy/cosmology/_io/yaml.py
+++ b/astropy/cosmology/_io/yaml.py
@@ -10,21 +10,8 @@ require YAML serialization.
 
     >>> from astropy.cosmology import Planck18
     >>> yml = Planck18.to_format("yaml")
-    >>> yml
-    "!astropy.cosmology.flrw.FlatLambdaCDM\nH0: !astropy.units.Quantity\n
-    unit: !astropy.units.Unit {unit: km / (Mpc s)}\n  value: 67.66\nNeff: 3.046\nOb0:
-    0.04897\nOm0: 0.30966\nTcmb0: !astropy.units.Quantity\n  unit: !astropy.units.Unit
-    {unit: K}\n  value: 2.7255\nm_nu: !astropy.units.Quantity\n
-    unit: !astropy.units.Unit {unit: eV}\n  value: !numpy.ndarray\n
-    buffer: !!binary |\n      QUFBQUFBQUFBQUFBQUFBQUFBQUFBTGdlaGV0UnVLNC8=\n
-    dtype: float64\n    order: C\n    shape: !!python/tuple [3]\nmeta:
-    !!python/tuple\n- !!python/tuple [Oc0, 0.2607]\n- !!python/tuple [n, 0.9665]\n-
-    !!python/tuple [sigma8, 0.8102]\n- !!python/tuple [tau, 0.0561]\n- !!python/tuple\n
-    - z_reion\n  - !astropy.units.Quantity\n    unit: !astropy.units.Unit {unit:
-    redshift}\n    value: 7.82\n- !!python/tuple\n  - t0\n  - !astropy.units.Quantity\n
-    unit: !astropy.units.Unit {unit: Gyr}\n    value: 13.787\n- !!python/tuple [flat,
-    true]\n- !!python/tuple [reference, 'Planck Collaboration 2018, 2020, A&A, 641, A6
-    (Paper\n    VI), Table 2 (TT, TE, EE + lowE + lensing + BAO)']\nname: Planck18\n"
+    >>> yml  # doctest: +NORMALIZE_WHITESPACE
+    "!astropy.cosmology...FlatLambdaCDM\nH0: !astropy.units.Quantity...
 
     >>> Cosmology.from_format(yml, format="yaml")
     FlatLambdaCDM(name="Planck18", H0=67.66 km / (Mpc s), Om0=0.30966,
@@ -212,20 +199,7 @@ def to_yaml(cosmology, *args):
     --------
     >>> from astropy.cosmology import Planck18
     >>> Planck18.to_format("yaml")
-    "!astropy.cosmology.flrw.FlatLambdaCDM\nH0: !astropy.units.Quantity\n
-    unit: !astropy.units.Unit {unit: km / (Mpc s)}\n  value: 67.66\nNeff: 3.046\nOb0:
-    0.04897\nOm0: 0.30966\nTcmb0: !astropy.units.Quantity\n  unit: !astropy.units.Unit
-    {unit: K}\n  value: 2.7255\nm_nu: !astropy.units.Quantity\n
-    unit: !astropy.units.Unit {unit: eV}\n  value: !numpy.ndarray\n
-    buffer: !!binary |\n      QUFBQUFBQUFBQUFBQUFBQUFBQUFBTGdlaGV0UnVLNC8=\n
-    dtype: float64\n    order: C\n    shape: !!python/tuple [3]\nmeta:
-    !!python/tuple\n- !!python/tuple [Oc0, 0.2607]\n- !!python/tuple [n, 0.9665]\n-
-    !!python/tuple [sigma8, 0.8102]\n- !!python/tuple [tau, 0.0561]\n- !!python/tuple\n
-    - z_reion\n  - !astropy.units.Quantity\n    unit: !astropy.units.Unit {unit:
-    redshift}\n    value: 7.82\n- !!python/tuple\n  - t0\n  - !astropy.units.Quantity\n
-    unit: !astropy.units.Unit {unit: Gyr}\n    value: 13.787\n- !!python/tuple [flat,
-    true]\n- !!python/tuple [reference, 'Planck Collaboration 2018, 2020, A&A, 641, A6
-    (Paper\n    VI), Table 2 (TT, TE, EE + lowE + lensing + BAO)']\nname: Planck18\n"
+    "!astropy.cosmology...FlatLambdaCDM\nH0: !astropy.units.Quantity...
     """
     return dump(cosmology)
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address cosmology doctest failure that somehow only pops up on s390x cron job. This is cherry-picked from #15102 by @nstarman .

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
