### PR TITLE
Add MetaDataField and hasdocstringfield

### DIFF
--- a/astropy/utils/dataclasses.py
+++ b/astropy/utils/dataclasses.py
@@ -1,0 +1,84 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""A module containing utilities for working with dataclasses."""
+
+__all__ = ["hasdocstringfield"]
+
+from dataclasses import dataclass
+
+from astropy.utils.compat.misc import PYTHON_LT_3_10
+
+if PYTHON_LT_3_10:
+    _dataclass_kwargs = {}
+else:
+    _dataclass_kwargs = {"slots": True}
+
+
+@dataclass(frozen=True, **_dataclass_kwargs)
+class DocstringConnectedProperty:
+    """Descriptor returning different docstrings based on access from class or instance.
+
+    Users are unlikely to need to use this class directly, but it is used by
+    :func:`~astropy.utils.dataclasses.hasdocstringfield` to allow for a slotted
+    dataclass to have a docstring that is different when accessed from the class or an
+    instance.
+    """
+
+    name: str
+    cls__doc__: str
+
+    def __get__(self, instance, owner):
+        return getattr(instance, self.name) if instance is not None else self.cls__doc__
+
+
+def hasdocstringfield(name: str):
+    """Decorator to add a docstring to a field in a slotted dataclass.
+
+    This decorator is intended to be used with slotted dataclasses, which do not
+    allow for ``__doc__`` to be a field.  This decorator allows for a different
+    field, specified by ``name`` (e.g. "doc"), to also set the docstring of the
+    slotted class.
+
+    Parameters
+    ----------
+    name : str
+        The name of the field that should be used to set the docstring of the
+        slotted class.
+
+    Examples
+    --------
+    >>> from dataclasses import dataclass
+    >>> from astropy.utils.compat.misc import PYTHON_LT_3_10
+    >>> from astropy.utils.dataclasses import hasdocstringfield
+
+    >>> @dataclass(**({"slots": True} if not PYTHON_LT_3_10 else {}))
+    ... @hasdocstringfield('doc')
+    ... class Foo:
+    ...     '''This is the docstring of the class Foo.'''
+    ...     doc: str
+
+    >>> Foo.__doc__
+    'This is the docstring of the class Foo.'
+
+    >>> foo = Foo('This is the docstring of an instance of Foo.')
+    >>> foo.doc
+    'This is the docstring of an instance of Foo.'
+
+    >>> foo.__doc__
+    'This is the docstring of an instance of Foo.'
+
+    >>> foo.__doc__ is foo.doc
+    True
+
+    Notes
+    -----
+    This decorator must be used *before* the ``dataclass`` decorator, as in the
+    example above.  This is because the ``dataclass`` decorator will make the class
+    slotted, which will prevent the ``__doc__`` attribute from being set on the
+    class and its instances.
+    """
+
+    def decorator(cls):
+        cls.__doc__ = DocstringConnectedProperty(name, cls.__doc__)
+        return cls
+
+    return decorator

--- a/astropy/utils/metadata.py
+++ b/astropy/utils/metadata.py
@@ -19,6 +19,9 @@ from astropy.utils.dataclasses import hasdocstringfield
 from astropy.utils.exceptions import AstropyWarning
 from astropy.utils.misc import dtype_bytes_or_chars
 
+if not PYTHON_LT_3_10:
+    from dataclasses import KW_ONLY
+
 __all__ = [
     "MergeConflictError",
     "MergeConflictWarning",
@@ -416,20 +419,20 @@ class MetaDataField:
 
     Parameters
     ----------
-    doc : str, optional
+    doc : str, optional keyword-only
         Documentation for the attribute of the class.
         Default is ``""``.
 
         .. versionadded:: 1.2
 
-    copy : bool, optional
+    copy : bool, optional keyword-only
         If ``True`` the the value is deepcopied before setting, otherwise it
         is saved as reference.
         Default is ``True``.
 
         .. versionadded:: 1.2
 
-    use_obj_setter : bool, optional
+    use_obj_setter : bool, optional keyword-only
         If `True` then the ``meta`` attribute can be set on a frozen object.
         This is required for ``meta`` to be a field on a frozen dataclass.
 
@@ -460,6 +463,8 @@ class MetaDataField:
     {'b': 2}
     """
 
+    if not PYTHON_LT_3_10:
+        _: KW_ONLY
     doc: str = field(default_factory=str)
     copy: bool = True
     use_obj_setter: bool = False

--- a/astropy/utils/tests/test_metadata.py
+++ b/astropy/utils/tests/test_metadata.py
@@ -1,5 +1,5 @@
-import abc
 from collections import OrderedDict
+from dataclasses import dataclass
 
 import numpy as np
 import pytest
@@ -9,6 +9,7 @@ from astropy.utils import metadata
 from astropy.utils.metadata import (
     MergeConflictError,
     MetaData,
+    MetaDataField,
     common_dtype,
     enable_merge_strategies,
     merge,
@@ -20,8 +21,6 @@ class OrderedDictSubclass(OrderedDict):
 
 
 class MetaBaseTest:
-    __metaclass__ = abc.ABCMeta
-
     def test_none(self):
         d = self.test_class(*self.args)
         assert isinstance(d.meta, OrderedDict)
@@ -74,6 +73,26 @@ class ExampleData:
 
 class TestMetaExampleData(MetaBaseTest):
     test_class = ExampleData
+    args = ()
+
+
+@dataclass
+class ExampleDataclass:
+    meta: MetaDataField = MetaDataField()  # noqa: RUF009
+
+
+class TestMetaExampleDataclass(MetaBaseTest):
+    test_class = ExampleDataclass
+    args = ()
+
+
+@dataclass(frozen=True)
+class ExampleFrozenDataclass:
+    meta: MetaDataField = MetaDataField(use_obj_setter=True)  # noqa: RUF009
+
+
+class TestMetaExampleFrozenDataclass(MetaBaseTest):
+    test_class = ExampleFrozenDataclass
     args = ()
 
 

--- a/docs/changes/utils/15167.feature.rst
+++ b/docs/changes/utils/15167.feature.rst
@@ -1,0 +1,5 @@
+A new class ``MetaDataField`` has been added for use as field in dataclasses that have
+a ``meta`` property.
+
+Also there is a new decorator, ``hasdocstringfield``, to add a docstring to a field in a
+slotted dataclass.


### PR DESCRIPTION
In its current form ``astropy.utils.metadata.MetaData`` cannot be used as a field of a dataclass, especially not a frozen one, e.g. like in the following.

```python
from astropy.utils.metadata import MetaData

@dataclass
class Object:
    meta: MetaData = MetaData()
```

Why?

1. because `MetaData` returns `self` when accessed from the class. [Python dataclasses use the class-level return to determine the default value of a field](https://docs.python.org/3/library/dataclasses.html#descriptor-typed-fields), so on a dataclass the default value becomes the MetaData object itself, which is incorrect.
2. On frozen dataclasses object assignment must be done with `object.__setattr__`. This is a known limitation of frozen dataclasses, but must be taken into account.

This PR adds a new class `MetaDataField`, and helper function `hasdocstringfield` for docstring attributes on slotted dataclasses. Making `MetaDataField` slotted should make it consume much less memory; however if we un-slot it then we can remove `hasdocstringfield` and reduce the (non-public) API surface introduced in this PR.
In the future I hope to transition the existing `MetaData` to be `MetaDataField` (keeping the name `MetaData`, of course) by making `MetaData` subclass `MetaDataField`, then merging the two classes into 1 (called `MetaData`, with `MetaDataField` as an alias). However, IMO this is not worth doing at this point, as `MetaData` is used throughout Astropy, `MetaDataField` and `MetaData` have meaningfully different mechanics, and the transition will require a careful PR with deprecations, etc. If we want to do the transition in one big push, then I can move the contents to if this PR to `cosmology._utils`, though I would prefer to keep the metadata machinery public.

This PR is necessary for my plans to make `Cosmology` a dataclass!



