### PR TITLE
Cosmo parameters properties

### DIFF
--- a/astropy/cosmology/_io/html.py
+++ b/astropy/cosmology/_io/html.py
@@ -313,15 +313,15 @@ def write_html_table(
 
     cosmo_cls = type(cosmology)
     for name, col in table.columns.items():
-        param = getattr(cosmo_cls, name, None)
+        param = cosmo_cls.parameters.get(name)
         if not isinstance(param, Parameter) or param.unit in (None, u.one):
             continue
         # Replace column with unitless version
         table.replace_column(name, (col << param.unit).value, copy=False)
 
     if latex_names:
-        new_names = [_FORMAT_TABLE.get(k, k) for k in cosmology.__parameters__]
-        table.rename_columns(cosmology.__parameters__, new_names)
+        new_names = [_FORMAT_TABLE.get(k, k) for k in cosmology.parameters]
+        table.rename_columns(tuple(cosmology.parameters), new_names)
 
     # Write HTML, using table I/O
     table.write(file, overwrite=overwrite, format="ascii.html", **kwargs)

--- a/astropy/cosmology/_io/latex.py
+++ b/astropy/cosmology/_io/latex.py
@@ -170,7 +170,7 @@ def write_latex(
 
     cosmo_cls = type(cosmology)
     for name in table.columns.keys():
-        param = getattr(cosmo_cls, name, None)
+        param = cosmo_cls.parameters.get(name)
         if not isinstance(param, Parameter) or param.unit in (None, u.one):
             continue
         # Get column to correct unit
@@ -178,8 +178,8 @@ def write_latex(
 
     # Convert parameter names to LaTeX format
     if latex_names:
-        new_names = [_FORMAT_TABLE.get(k, k) for k in cosmology.__parameters__]
-        table.rename_columns(cosmology.__parameters__, new_names)
+        new_names = [_FORMAT_TABLE.get(k, k) for k in cosmology.parameters]
+        table.rename_columns(tuple(cosmology.parameters), new_names)
 
     table.write(file, overwrite=overwrite, format="ascii.latex", **kwargs)
 

--- a/astropy/cosmology/_io/mapping.py
+++ b/astropy/cosmology/_io/mapping.py
@@ -403,13 +403,7 @@ def to_mapping(
         m.update(meta)
 
     # Add all the immutable inputs
-    m.update(
-        {
-            k: v
-            for k, v in cosmology._init_arguments.items()
-            if k not in ("meta", "name")
-        }
-    )
+    m.update(cosmology.parameters)
     # Lastly, add the metadata, if haven't already (above)
     if not move_from_meta:
         m["meta"] = meta  # TODO? should meta be type(cls)

--- a/astropy/cosmology/_io/model.py
+++ b/astropy/cosmology/_io/model.py
@@ -240,17 +240,13 @@ def to_model(cosmology, *_, method):
     attrs["n_inputs"] = n_inputs
     attrs["n_outputs"] = 1
 
-    params = {}  # Parameters (also class attributes)
-    for n in cosmology.__parameters__:
-        v = getattr(cosmology, n)  # parameter value
-
-        if v is None:  # skip unspecified parameters
-            continue
-
-        # add as Model Parameter
-        params[n] = convert_parameter_to_model_parameter(
-            getattr(cosmo_cls, n), v, cosmology.meta.get(n)
+    params = {
+        k: convert_parameter_to_model_parameter(
+            cosmo_cls.parameters[k], v, meta=cosmology.meta.get(k)
         )
+        for k, v in cosmology.parameters.items()
+        if v is not None
+    }
 
     # class name is cosmology name + Cosmology + method name + Model
     clsname = (
@@ -269,8 +265,9 @@ def to_model(cosmology, *_, method):
     )
 
     # instantiate class using default values
-    ps = {n: getattr(cosmology, n) for n in params.keys()}
-    model = CosmoModel(**ps, name=cosmology.name, meta=copy.deepcopy(cosmology.meta))
+    model = CosmoModel(
+        **cosmology.parameters, name=cosmology.name, meta=copy.deepcopy(cosmology.meta)
+    )
 
     return model
 

--- a/astropy/cosmology/_io/table.py
+++ b/astropy/cosmology/_io/table.py
@@ -428,9 +428,9 @@ def to_table(cosmology, *args, cls=QTable, cosmology_in_meta=True, rename=None):
     # - list for anything else
     cosmo_cls = cosmology.__class__
     for k, v in data.items():
-        if k in cosmology.__parameters__:
+        if k in cosmology.parameters:
             col = convert_parameter_to_column(
-                getattr(cosmo_cls, k), v, cosmology.meta.get(k)
+                cosmo_cls.parameters[k], v, cosmology.meta.get(k)
             )
         else:
             col = Column([v])

--- a/astropy/cosmology/_io/tests/test_html.py
+++ b/astropy/cosmology/_io/tests/test_html.py
@@ -4,7 +4,6 @@ import pytest
 
 import astropy.units as u
 from astropy.cosmology._io.html import _FORMAT_TABLE, read_html_table, write_html_table
-from astropy.cosmology.parameter import Parameter
 from astropy.table import QTable, Table, vstack
 from astropy.utils.compat.optional_deps import HAS_BS4
 
@@ -190,10 +189,10 @@ class ReadWriteHTMLTestMixin(ReadWriteTestMixinBase):
         assert cosmo is not None
 
         for n, col in zip(table.colnames, table.itercols()):
-            if n == "cosmology":
+            if n not in cosmo_cls.parameters:
                 continue
-            param = getattr(cosmo_cls, n)
-            if not isinstance(param, Parameter) or param.unit in (None, u.one):
+            param = cosmo_cls.parameters[n]
+            if param.unit in (None, u.one):
                 continue
             # Replace column with unitless version
             table.replace_column(n, (col << param.unit).value, copy=False)

--- a/astropy/cosmology/_io/tests/test_mapping.py
+++ b/astropy/cosmology/_io/tests/test_mapping.py
@@ -34,9 +34,9 @@ class ToFromMappingTestMixin(ToFromTestMixinBase):
         assert m.pop("cosmology") is cosmo.__class__
         assert keys[1] == "name"
         assert m.pop("name") == cosmo.name
-        for i, k in enumerate(cosmo.__parameters__, start=2):
+        for i, (k, v) in enumerate(cosmo.parameters.items(), start=2):
             assert keys[i] == k
-            assert np.array_equal(m.pop(k), getattr(cosmo, k))
+            np.testing.assert_array_equal(m.pop(k), v)
         assert keys[-1] == "meta"
         assert m.pop("meta") == cosmo.meta
 

--- a/astropy/cosmology/_io/tests/test_model.py
+++ b/astropy/cosmology/_io/tests/test_model.py
@@ -80,7 +80,7 @@ class ToFromModelTestMixin(ToFromTestMixinBase):
         assert isinstance(model, _CosmologyModel)
 
         # Parameters
-        expect = tuple(n for n in cosmo.__parameters__ if getattr(cosmo, n) is not None)
+        expect = tuple(k for k, v in cosmo.parameters.items() if v is not None)
         assert model.param_names == expect
 
         # scalar result

--- a/astropy/cosmology/_io/tests/test_table.py
+++ b/astropy/cosmology/_io/tests/test_table.py
@@ -74,8 +74,7 @@ class ToFromTableTestMixin(ToFromTestMixinBase):
         assert tbl.indices  # indexed
 
         # Test each Parameter column has expected information.
-        for n in cosmo.__parameters__:
-            P = getattr(cosmo_cls, n)  # Parameter
+        for n, P in cosmo_cls.parameters.items():
             col = tbl[n]  # Column
 
             # Compare the two

--- a/astropy/cosmology/_utils.py
+++ b/astropy/cosmology/_utils.py
@@ -1,15 +1,19 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+from __future__ import annotations
+
+__all__ = []  # nothing is publicly scoped
+
 import functools
+import operator
 from numbers import Number
+from typing import Any
 
 import numpy as np
 
 from astropy.units import Quantity
 
 from . import units as cu
-
-__all__ = []  # nothing is publicly scoped
 
 
 def vectorize_redshift_method(func=None, nin=1):
@@ -71,3 +75,9 @@ def aszarr(z):
         return z
     # not one of the preferred types: Number / array ducktype
     return Quantity(z, cu.redshift).value
+
+
+def all_cls_vars(obj: object | type, /) -> dict[str, Any]:
+    """Return all variables in the whole class hierarchy."""
+    cls = obj if isinstance(obj, type) else obj.__class__
+    return functools.reduce(operator.__or__, map(vars, cls.mro()[::-1]))

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import abc
 import inspect
-from typing import TYPE_CHECKING, Any, TypeVar
+from types import MappingProxyType
+from typing import TYPE_CHECKING, Any, ClassVar, TypeVar
 
 import numpy as np
 
@@ -12,6 +13,7 @@ from astropy.io.registry import UnifiedReadWriteMethod
 from astropy.utils.decorators import classproperty
 from astropy.utils.metadata import MetaData
 
+from ._utils import all_cls_vars
 from .connect import (
     CosmologyFromFormat,
     CosmologyRead,
@@ -19,6 +21,7 @@ from .connect import (
     CosmologyWrite,
 )
 from .parameter import Parameter
+from .parameter._descriptors import ParametersAttribute
 
 if TYPE_CHECKING:  # pragma: no cover
     from collections.abc import Mapping
@@ -93,8 +96,25 @@ class Cosmology(metaclass=abc.ABCMeta):
     write = UnifiedReadWriteMethod(CosmologyWrite)
 
     # Parameters
-    __parameters__: tuple[str, ...] = ()
-    __all_parameters__: tuple[str, ...] = ()
+    parameters = ParametersAttribute()
+    """Immutable mapping of the Parameters.
+
+    If accessed from the class, this returns a mapping of the Parameter
+    objects themselves.  If accessed from an instance, this returns a
+    mapping of the values of the Parameters.
+    """
+
+    derived_parameters = ParametersAttribute()
+    """Immutable mapping of the derived Parameters.
+
+    If accessed from the class, this returns a mapping of the Parameter
+    objects themselves.  If accessed from an instance, this returns a
+    mapping of the values of the Parameters.
+    """
+
+    _parameters: ClassVar = MappingProxyType[str, Parameter]({})
+    _derived_parameters: ClassVar = MappingProxyType[str, Parameter]({})
+    _parameters_all: ClassVar = frozenset[str]()
 
     # ---------------------------------------------------------------
 
@@ -104,29 +124,25 @@ class Cosmology(metaclass=abc.ABCMeta):
         # -------------------
         # Parameters
 
-        # Get parameters that are still Parameters, either in this class or above.
-        parameters = []
-        derived_parameters = []
-        for n in cls.__parameters__:
-            p = getattr(cls, n)
-            if isinstance(p, Parameter):
-                derived_parameters.append(n) if p.derived else parameters.append(n)
-
-        # Add new parameter definitions
-        for n, v in cls.__dict__.items():
-            if n in parameters or n.startswith("_") or not isinstance(v, Parameter):
+        params = {}
+        derived_params = {}
+        for n, v in all_cls_vars(cls).items():
+            if not isinstance(v, Parameter):
                 continue
-            derived_parameters.append(n) if v.derived else parameters.append(n)
+            if v.derived:
+                derived_params[n] = v
+            else:
+                params[n] = v
 
-        # reorder to match signature
-        ordered = [
-            parameters.pop(parameters.index(n))
+        # reorder to match signature, placing "unordered" at the end
+        ordered = {
+            n: params.pop(n)
             for n in cls._init_signature.parameters.keys()
-            if n in parameters
-        ]
-        parameters = ordered + parameters  # place "unordered" at the end
-        cls.__parameters__ = tuple(parameters)
-        cls.__all_parameters__ = cls.__parameters__ + tuple(derived_parameters)
+            if n in params
+        }
+        cls._parameters = MappingProxyType(ordered | params)
+        cls._derived_parameters = MappingProxyType(derived_params)
+        cls._parameters_all = frozenset(cls.parameters).union(cls.derived_parameters)
 
         # -------------------
         # Registration
@@ -239,7 +255,7 @@ class Cosmology(metaclass=abc.ABCMeta):
     @property
     def _init_arguments(self):
         # parameters
-        kw = {n: getattr(self, n) for n in self.__parameters__}
+        kw = dict(self.parameters)
 
         # other info
         kw["name"] = self.name
@@ -350,9 +366,10 @@ class Cosmology(metaclass=abc.ABCMeta):
 
         # Check all parameters in 'other' match those in 'self' and 'other' has
         # no extra parameters (latter part should never happen b/c same class)
-        return set(self.__all_parameters__) == set(other.__all_parameters__) and all(
-            np.all(getattr(self, k) == getattr(other, k))
-            for k in self.__all_parameters__
+        # We do not use `self.parameters == other.parameters` because it does not work
+        # for aggregating the truthiness of arrays, e.g. `m_nu`.
+        return self._parameters_all == other._parameters_all and all(
+            np.all(getattr(self, k) == getattr(other, k)) for k in self._parameters_all
         )
 
     def __eq__(self, other: Any, /) -> bool:
@@ -378,11 +395,13 @@ class Cosmology(metaclass=abc.ABCMeta):
             self.name == other.name
             # check all parameters in 'other' match those in 'self' and 'other'
             # has no extra parameters (latter part should never happen b/c same
-            # class) TODO! element-wise when there are array cosmologies
-            and set(self.__all_parameters__) == set(other.__all_parameters__)
+            # class). We do not use `self.parameters == other.parameters` because
+            # it does not work for aggregating the truthiness of arrays, e.g. `m_nu`.
+            # TODO! element-wise when there are array cosmologies
+            and self._parameters_all == other._parameters_all
             and all(
                 np.all(getattr(self, k) == getattr(other, k))
-                for k in self.__all_parameters__
+                for k in self._parameters_all
             )
         )
 
@@ -395,14 +414,14 @@ class Cosmology(metaclass=abc.ABCMeta):
         if self.name is not None:
             namelead += f"name={self.name!r}, "
         # nicely formatted parameters
-        fmtps = (f"{k}={getattr(self, k)!r}" for k in self.__parameters__)
+        fmtps = (f"{k}={getattr(self, k)!r}" for k in self._parameters)
 
         return namelead + ", ".join(fmtps) + ")"
 
     def __str__(self):
         """Return a string representation of the cosmology."""
         name_str = "" if self.name is None else f'name="{self.name}", '
-        param_strs = (f"{k!s}={getattr(self, k)!s}" for k in self.__parameters__)
+        param_strs = (f"{k!s}={getattr(self, k)!s}" for k in self._parameters)
         return f"{type(self).__name__}({name_str}{', '.join(param_strs)})"
 
     def __astropy_table__(self, cls, copy, **kwargs):
@@ -436,8 +455,8 @@ class FlatCosmologyMixin(metaclass=abc.ABCMeta):
     ``FlatLambdaCDM`` **will** be flat.
     """
 
-    __all_parameters__: tuple[str, ...]
-    __parameters__: tuple[str, ...]
+    _parameters: ClassVar[MappingProxyType[str, Parameter]]
+    _derived_parameters: ClassVar[MappingProxyType[str, Parameter]]
 
     def __init_subclass__(cls: type[_FlatCosmoT]) -> None:
         super().__init_subclass__()
@@ -600,11 +619,11 @@ class FlatCosmologyMixin(metaclass=abc.ABCMeta):
         # Check if have equivalent parameters and all parameters in `other`
         # match those in `self`` and `other`` has no extra parameters.
         params_eq = (
-            set(self.__all_parameters__) == set(other.__all_parameters__)  # no extra
+            # no extra parameters
+            self._parameters_all == other._parameters_all
             # equal
             and all(
-                np.all(getattr(self, k) == getattr(other, k))
-                for k in self.__parameters__
+                np.all(getattr(self, k) == getattr(other, k)) for k in self.parameters
             )
             # flatness check
             and other.is_flat

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -238,7 +238,7 @@ class Cosmology(metaclass=abc.ABCMeta):
         meta = meta if meta is not None else {}
         new_meta = {**self.meta, **meta}
         # Mix kwargs into initial arguments, preferring the former.
-        new_init = {**self._init_arguments, "meta": new_meta, **kwargs}
+        new_init = {**self.parameters, "meta": new_meta, **kwargs}
         # Create BoundArgument to handle args versus kwargs.
         # This also handles all errors from mismatched arguments
         ba = self._init_signature.bind_partial(**new_init)
@@ -251,17 +251,6 @@ class Cosmology(metaclass=abc.ABCMeta):
             cloned._name = self.name
 
         return cloned
-
-    @property
-    def _init_arguments(self):
-        # parameters
-        kw = dict(self.parameters)
-
-        # other info
-        kw["name"] = self.name
-        kw["meta"] = self.meta
-
-        return kw
 
     # ---------------------------------------------------------------
     # comparison methods

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -410,18 +410,13 @@ class Cosmology(metaclass=abc.ABCMeta):
     # ---------------------------------------------------------------
 
     def __repr__(self):
-        namelead = f"{self.__class__.__qualname__}("
-        if self.name is not None:
-            namelead += f"name={self.name!r}, "
-        # nicely formatted parameters
-        fmtps = (f"{k}={getattr(self, k)!r}" for k in self._parameters)
-
-        return namelead + ", ".join(fmtps) + ")"
+        fmtps = (f"{k}={v!r}" for k, v in self.parameters.items())
+        return f"{type(self).__qualname__}(name={self.name!r}, {', '.join(fmtps)})"
 
     def __str__(self):
         """Return a string representation of the cosmology."""
         name_str = "" if self.name is None else f'name="{self.name}", '
-        param_strs = (f"{k!s}={getattr(self, k)!s}" for k in self._parameters)
+        param_strs = (f"{k!s}={v!s}" for k, v in self.parameters.items())
         return f"{type(self).__name__}({name_str}{', '.join(param_strs)})"
 
     def __astropy_table__(self, cls, copy, **kwargs):

--- a/astropy/cosmology/flrw/base.py
+++ b/astropy/cosmology/flrw/base.py
@@ -95,6 +95,12 @@ class _ScaleFactorMixin:
         return 1.0 / (aszarr(z) + 1.0)
 
 
+ParameterOde0 = Parameter(
+    doc="Omega dark energy; dark energy density/critical density at z=0.",
+    fvalidate="float",
+)
+
+
 class FLRW(Cosmology, _ScaleFactorMixin):
     """An isotropic and homogeneous (Friedmann-Lemaitre-Robertson-Walker) cosmology.
 
@@ -162,10 +168,7 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         doc="Omega matter; matter density/critical density at z=0.",
         fvalidate="non-negative",
     )
-    Ode0 = Parameter(
-        doc="Omega dark energy; dark energy density/critical density at z=0.",
-        fvalidate="float",
-    )
+    Ode0 = ParameterOde0
     Tcmb0 = Parameter(
         default=0.0 * u.K,
         doc="Temperature of the CMB as `~astropy.units.Quantity` at z=0.",
@@ -1480,7 +1483,7 @@ class FlatFLRWMixin(FlatCosmologyMixin):
     parameter values), but ``FlatLambdaCDM`` **will** be flat.
     """
 
-    Ode0 = FLRW.Ode0.clone(derived=True)  # same as FLRW, but now a derived param.
+    Ode0 = ParameterOde0.clone(derived=True)  # same as FLRW, but derived.
 
     def __init_subclass__(cls):
         super().__init_subclass__()
@@ -1505,7 +1508,7 @@ class FlatFLRWMixin(FlatCosmologyMixin):
         # Make new instance, respecting args vs kwargs
         inst = self.__nonflatclass__(*ba.args, **ba.kwargs)
         # Because of machine precision, make sure parameters exactly match
-        for n in inst.__all_parameters__ + ("Ok0",):
+        for n in (*inst._parameters_all, "Ok0"):
             setattr(inst, "_" + n, getattr(self, n))
 
         return inst

--- a/astropy/cosmology/flrw/base.py
+++ b/astropy/cosmology/flrw/base.py
@@ -1503,7 +1503,7 @@ class FlatFLRWMixin(FlatCosmologyMixin):
         # Create BoundArgument to handle args versus kwargs.
         # This also handles all errors from mismatched arguments
         ba = self.__nonflatclass__._init_signature.bind_partial(
-            **self._init_arguments, Ode0=self.Ode0
+            **self.parameters, Ode0=self.Ode0, name=self.name
         )
         # Make new instance, respecting args vs kwargs
         inst = self.__nonflatclass__(*ba.args, **ba.kwargs)

--- a/astropy/cosmology/flrw/tests/conftest.py
+++ b/astropy/cosmology/flrw/tests/conftest.py
@@ -2,5 +2,35 @@
 
 """Configure the tests for :mod:`astropy.cosmology`."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, TypeVar
+
 from astropy.cosmology.tests.helper import clean_registry  # noqa: F401
 from astropy.tests.helper import pickle_protocol  # noqa: F401
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping, Sequence
+
+K = TypeVar("K")
+V = TypeVar("V")
+
+
+def filter_keys_from_items(
+    m: Mapping[K, V], /, filter_out: Sequence[K]
+) -> Iterable[K, V]:
+    """Filter ``m``, returning key-value pairs not including keys in ``filter``.
+
+    Parameters
+    ----------
+    m : mapping[K, V]
+        A mapping from which to remove keys in ``filter_out``.
+    filter_out : sequence[K]
+        Sequence of keys to filter out from ``m``.
+
+    Returns
+    -------
+    iterable[K, V]
+        Iterable of ``(key, value)`` pairs with the ``filter_out`` keys removed.
+    """
+    return ((k, v) for k, v in m.items() if k not in filter_out)

--- a/astropy/cosmology/flrw/tests/test_base.py
+++ b/astropy/cosmology/flrw/tests/test_base.py
@@ -763,9 +763,7 @@ class FLRWTest(
         super().test_clone_change_param(cosmo)
 
         # don't change any values
-        kwargs = cosmo._init_arguments.copy()
-        kwargs.pop("name", None)  # make sure not setting name
-        kwargs.pop("meta", None)  # make sure not setting name
+        kwargs = dict(cosmo.parameters)
         c = cosmo.clone(**kwargs)
         assert c.__class__ == cosmo.__class__
         assert c == cosmo

--- a/astropy/cosmology/flrw/tests/test_base.py
+++ b/astropy/cosmology/flrw/tests/test_base.py
@@ -24,7 +24,10 @@ from astropy.cosmology.tests.test_core import (
     invalid_zs,
     valid_zs,
 )
+from astropy.tests.helper import assert_quantity_allclose
 from astropy.utils.compat.optional_deps import HAS_SCIPY
+
+from .conftest import filter_keys_from_items
 
 ##############################################################################
 # SETUP / TEARDOWN
@@ -773,14 +776,12 @@ class FLRWTest(
         assert c.__class__ == cosmo.__class__
         assert c.name == cosmo.name + " (modified)"
         assert c.H0.value == 100
-        for n in set(cosmo.parameters) - {"H0"}:
-            v = getattr(c, n)
+        for n, v in filter_keys_from_items(c.parameters, ("H0",)):
+            v_expect = getattr(cosmo, n)
             if v is None:
-                assert v is getattr(cosmo, n)
+                assert v is v_expect
             else:
-                assert u.allclose(
-                    v, getattr(cosmo, n), atol=1e-4 * getattr(v, "unit", 1)
-                )
+                assert_quantity_allclose(v, v_expect, atol=1e-4 * getattr(v, "unit", 1))
         assert not u.allclose(c.Ogamma0, cosmo.Ogamma0)
         assert not u.allclose(c.Onu0, cosmo.Onu0)
 
@@ -791,14 +792,12 @@ class FLRWTest(
         assert c.H0.value == 100
         assert c.Tcmb0.value == 2.8
         assert c.meta == {**cosmo.meta, **dict(zz="tops")}
-        for n in set(cosmo.parameters) - {"H0", "Tcmb0"}:
-            v = getattr(c, n)
+        for n, v in filter_keys_from_items(c.parameters, ("H0", "Tcmb0")):
+            v_expect = getattr(cosmo, n)
             if v is None:
-                assert v is getattr(cosmo, n)
+                assert v is v_expect
             else:
-                assert u.allclose(
-                    v, getattr(cosmo, n), atol=1e-4 * getattr(v, "unit", 1)
-                )
+                assert_quantity_allclose(v, v_expect, atol=1e-4 * getattr(v, "unit", 1))
         assert not u.allclose(c.Ogamma0, cosmo.Ogamma0)
         assert not u.allclose(c.Onu0, cosmo.Onu0)
         assert not u.allclose(c.Tcmb0.value, cosmo.Tcmb0.value)

--- a/astropy/cosmology/flrw/tests/test_base.py
+++ b/astropy/cosmology/flrw/tests/test_base.py
@@ -2,14 +2,9 @@
 
 """Testing :mod:`astropy.cosmology.flrw.base`."""
 
-##############################################################################
-# IMPORTS
-
-# STDLIB
 import abc
 import copy
 
-# THIRD PARTY
 import numpy as np
 import pytest
 
@@ -68,16 +63,17 @@ class ParameterH0TestMixin(ParameterTestMixin):
         unit = u.Unit("km/(s Mpc)")
 
         # on the class
-        assert isinstance(cosmo_cls.H0, Parameter)
-        assert "Hubble constant" in cosmo_cls.H0.__doc__
-        assert cosmo_cls.H0.unit == unit
-        assert cosmo_cls.H0.default is MISSING
+        H0 = cosmo_cls.parameters["H0"]
+        assert isinstance(H0, Parameter)
+        assert "Hubble constant" in H0.__doc__
+        assert H0.unit == unit
+        assert H0.default is MISSING
 
         # validation
-        assert cosmo_cls.H0.validate(cosmo, 1) == 1 * unit
-        assert cosmo_cls.H0.validate(cosmo, 10 * unit) == 10 * unit
+        assert H0.validate(cosmo, 1) == 1 * unit
+        assert H0.validate(cosmo, 10 * unit) == 10 * unit
         with pytest.raises(ValueError, match="H0 is a non-scalar quantity"):
-            cosmo_cls.H0.validate(cosmo, [1, 2])
+            H0.validate(cosmo, [1, 2])
 
         # on the instance
         assert cosmo.H0 is cosmo._H0
@@ -112,15 +108,16 @@ class ParameterOm0TestMixin(ParameterTestMixin):
     def test_Om0(self, cosmo_cls, cosmo):
         """Test Parameter ``Om0``."""
         # on the class
-        assert isinstance(cosmo_cls.Om0, Parameter)
-        assert "Omega matter" in cosmo_cls.Om0.__doc__
-        assert cosmo_cls.Om0.default is MISSING
+        Om0 = cosmo_cls.parameters["Om0"]
+        assert isinstance(Om0, Parameter)
+        assert "Omega matter" in Om0.__doc__
+        assert Om0.default is MISSING
 
         # validation
-        assert cosmo_cls.Om0.validate(cosmo, 1) == 1
-        assert cosmo_cls.Om0.validate(cosmo, 10 * u.one) == 10
+        assert Om0.validate(cosmo, 1) == 1
+        assert Om0.validate(cosmo, 10 * u.one) == 10
         with pytest.raises(ValueError, match="Om0 cannot be negative"):
-            cosmo_cls.Om0.validate(cosmo, -1)
+            Om0.validate(cosmo, -1)
 
         # on the instance
         assert cosmo.Om0 is cosmo._Om0
@@ -155,16 +152,22 @@ class ParameterOde0TestMixin(ParameterTestMixin):
 
     def test_Parameter_Ode0(self, cosmo_cls):
         """Test Parameter ``Ode0`` on the class."""
-        assert isinstance(cosmo_cls.Ode0, Parameter)
-        assert "Omega dark energy" in cosmo_cls.Ode0.__doc__
-        assert cosmo_cls.Ode0.default is MISSING
+        Ode0 = cosmo_cls.parameters.get(
+            "Ode0", cosmo_cls.derived_parameters.get("Ode0")
+        )
+        assert isinstance(Ode0, Parameter)
+        assert "Omega dark energy" in Ode0.__doc__
+        assert Ode0.default is MISSING
 
     def test_Parameter_Ode0_validation(self, cosmo_cls, cosmo):
         """Test Parameter ``Ode0`` validation."""
-        assert cosmo_cls.Ode0.validate(cosmo, 1.1) == 1.1
-        assert cosmo_cls.Ode0.validate(cosmo, 10 * u.one) == 10.0
+        Ode0 = cosmo_cls.parameters.get(
+            "Ode0", cosmo_cls.derived_parameters.get("Ode0")
+        )
+        assert Ode0.validate(cosmo, 1.1) == 1.1
+        assert Ode0.validate(cosmo, 10 * u.one) == 10.0
         with pytest.raises(TypeError, match="only dimensionless"):
-            cosmo_cls.Ode0.validate(cosmo, 10 * u.km)
+            Ode0.validate(cosmo, 10 * u.km)
 
     def test_Ode0(self, cosmo):
         """Test Parameter ``Ode0`` validation."""
@@ -208,16 +211,17 @@ class ParameterTcmb0TestMixin(ParameterTestMixin):
     def test_Tcmb0(self, cosmo_cls, cosmo):
         """Test Parameter ``Tcmb0``."""
         # on the class
-        assert isinstance(cosmo_cls.Tcmb0, Parameter)
-        assert "Temperature of the CMB" in cosmo_cls.Tcmb0.__doc__
-        assert cosmo_cls.Tcmb0.unit == u.K
-        assert cosmo_cls.Tcmb0.default == 0.0 * u.K
+        Tcmb0 = cosmo_cls.parameters["Tcmb0"]
+        assert isinstance(Tcmb0, Parameter)
+        assert "Temperature of the CMB" in Tcmb0.__doc__
+        assert Tcmb0.unit == u.K
+        assert Tcmb0.default == 0.0 * u.K
 
         # validation
-        assert cosmo_cls.Tcmb0.validate(cosmo, 1) == 1 * u.K
-        assert cosmo_cls.Tcmb0.validate(cosmo, 10 * u.K) == 10 * u.K
+        assert Tcmb0.validate(cosmo, 1) == 1 * u.K
+        assert Tcmb0.validate(cosmo, 10 * u.K) == 10 * u.K
         with pytest.raises(ValueError, match="Tcmb0 is a non-scalar quantity"):
-            cosmo_cls.Tcmb0.validate(cosmo, [1, 2])
+            Tcmb0.validate(cosmo, [1, 2])
 
         # on the instance
         assert cosmo.Tcmb0 is cosmo._Tcmb0
@@ -252,15 +256,16 @@ class ParameterNeffTestMixin(ParameterTestMixin):
     def test_Neff(self, cosmo_cls, cosmo):
         """Test Parameter ``Neff``."""
         # on the class
-        assert isinstance(cosmo_cls.Neff, Parameter)
-        assert "Number of effective neutrino species" in cosmo_cls.Neff.__doc__
-        assert cosmo_cls.Neff.default == 3.04
+        Neff = cosmo_cls.parameters["Neff"]
+        assert isinstance(Neff, Parameter)
+        assert "Number of effective neutrino species" in Neff.__doc__
+        assert Neff.default == 3.04
 
         # validation
-        assert cosmo_cls.Neff.validate(cosmo, 1) == 1
-        assert cosmo_cls.Neff.validate(cosmo, 10 * u.one) == 10
+        assert Neff.validate(cosmo, 1) == 1
+        assert Neff.validate(cosmo, 10 * u.one) == 10
         with pytest.raises(ValueError, match="Neff cannot be negative"):
-            cosmo_cls.Neff.validate(cosmo, -1)
+            Neff.validate(cosmo, -1)
 
         # on the instance
         assert cosmo.Neff is cosmo._Neff
@@ -295,11 +300,12 @@ class Parameterm_nuTestMixin(ParameterTestMixin):
     def test_m_nu(self, cosmo_cls, cosmo):
         """Test Parameter ``m_nu``."""
         # on the class
-        assert isinstance(cosmo_cls.m_nu, Parameter)
-        assert "Mass of neutrino species" in cosmo_cls.m_nu.__doc__
-        assert cosmo_cls.m_nu.unit == u.eV
-        assert cosmo_cls.m_nu.equivalencies == u.mass_energy()
-        assert cosmo_cls.m_nu.default == 0.0 * u.eV
+        m_nu = cosmo_cls.parameters["m_nu"]
+        assert isinstance(m_nu, Parameter)
+        assert "Mass of neutrino species" in m_nu.__doc__
+        assert m_nu.unit == u.eV
+        assert m_nu.equivalencies == u.mass_energy()
+        assert m_nu.default == 0.0 * u.eV
 
         # on the instance
         # assert cosmo.m_nu is cosmo._m_nu
@@ -404,18 +410,19 @@ class ParameterOb0TestMixin(ParameterTestMixin):
     def test_Ob0(self, cosmo_cls, cosmo):
         """Test Parameter ``Ob0``."""
         # on the class
-        assert isinstance(cosmo_cls.Ob0, Parameter)
-        assert "Omega baryon;" in cosmo_cls.Ob0.__doc__
-        assert cosmo_cls.Ob0.default is None
+        Ob0 = cosmo_cls.parameters["Ob0"]
+        assert isinstance(Ob0, Parameter)
+        assert "Omega baryon;" in Ob0.__doc__
+        assert Ob0.default is None
 
         # validation
-        assert cosmo_cls.Ob0.validate(cosmo, None) is None
-        assert cosmo_cls.Ob0.validate(cosmo, 0.1) == 0.1
-        assert cosmo_cls.Ob0.validate(cosmo, 0.1 * u.one) == 0.1
+        assert Ob0.validate(cosmo, None) is None
+        assert Ob0.validate(cosmo, 0.1) == 0.1
+        assert Ob0.validate(cosmo, 0.1 * u.one) == 0.1
         with pytest.raises(ValueError, match="Ob0 cannot be negative"):
-            cosmo_cls.Ob0.validate(cosmo, -1)
+            Ob0.validate(cosmo, -1)
         with pytest.raises(ValueError, match="baryonic density can not be larger"):
-            cosmo_cls.Ob0.validate(cosmo, cosmo.Om0 + 1)
+            Ob0.validate(cosmo, cosmo.Om0 + 1)
 
         # on the instance
         assert cosmo.Ob0 is cosmo._Ob0
@@ -766,7 +773,7 @@ class FLRWTest(
         assert c.__class__ == cosmo.__class__
         assert c.name == cosmo.name + " (modified)"
         assert c.H0.value == 100
-        for n in set(cosmo.__parameters__) - {"H0"}:
+        for n in set(cosmo.parameters) - {"H0"}:
             v = getattr(c, n)
             if v is None:
                 assert v is getattr(cosmo, n)
@@ -784,7 +791,7 @@ class FLRWTest(
         assert c.H0.value == 100
         assert c.Tcmb0.value == 2.8
         assert c.meta == {**cosmo.meta, **dict(zz="tops")}
-        for n in set(cosmo.__parameters__) - {"H0", "Tcmb0"}:
+        for n in set(cosmo.parameters) - {"H0", "Tcmb0"}:
             v = getattr(c, n)
             if v is None:
                 assert v is getattr(cosmo, n)
@@ -943,7 +950,8 @@ class ParameterFlatOde0TestMixin(ParameterOde0TestMixin):
     def test_Parameter_Ode0(self, cosmo_cls):
         """Test Parameter ``Ode0`` on the class."""
         super().test_Parameter_Ode0(cosmo_cls)
-        assert cosmo_cls.Ode0.derived in (True, np.True_)
+        Ode0 = cosmo_cls.parameters.get("Ode0", cosmo_cls.derived_parameters["Ode0"])
+        assert Ode0.derived in (True, np.True_)
 
     def test_Ode0(self, cosmo):
         """Test no-longer-Parameter ``Ode0``."""

--- a/astropy/cosmology/flrw/tests/test_w0cdm.py
+++ b/astropy/cosmology/flrw/tests/test_w0cdm.py
@@ -14,8 +14,10 @@ import astropy.units as u
 from astropy.cosmology import FlatwCDM, wCDM
 from astropy.cosmology.parameter import Parameter
 from astropy.cosmology.tests.test_core import ParameterTestMixin, valid_zs
+from astropy.tests.helper import assert_quantity_allclose
 from astropy.utils.compat.optional_deps import HAS_SCIPY
 
+from .conftest import filter_keys_from_items
 from .test_base import FlatFLRWMixinTest, FLRWTest
 
 ##############################################################################
@@ -82,14 +84,12 @@ class TestwCDM(FLRWTest, Parameterw0TestMixin):
         # `w` params
         c = cosmo.clone(w0=0.1)
         assert c.w0 == 0.1
-        for n in set(cosmo.parameters) - {"w0"}:
-            v = getattr(c, n)
+        for n, v in filter_keys_from_items(c.parameters, ("w0",)):
+            v_expect = getattr(cosmo, n)
             if v is None:
-                assert v is getattr(cosmo, n)
+                assert v is v_expect
             else:
-                assert u.allclose(
-                    v, getattr(cosmo, n), atol=1e-4 * getattr(v, "unit", 1)
-                )
+                assert_quantity_allclose(v, v_expect, atol=1e-4 * getattr(v, "unit", 1))
 
     @pytest.mark.parametrize("z", valid_zs)
     def test_w(self, cosmo, z):

--- a/astropy/cosmology/flrw/tests/test_w0cdm.py
+++ b/astropy/cosmology/flrw/tests/test_w0cdm.py
@@ -34,10 +34,11 @@ class Parameterw0TestMixin(ParameterTestMixin):
     def test_w0(self, cosmo_cls, cosmo):
         """Test Parameter ``w0``."""
         # on the class
-        assert isinstance(cosmo_cls.w0, Parameter)
-        assert "Dark energy equation of state" in cosmo_cls.w0.__doc__
-        assert cosmo_cls.w0.unit is None
-        assert cosmo_cls.w0.default == -1.0
+        w0 = cosmo_cls.parameters["w0"]
+        assert isinstance(w0, Parameter)
+        assert "Dark energy equation of state" in w0.__doc__
+        assert w0.unit is None
+        assert w0.default == -1.0
 
         # on the instance
         assert cosmo.w0 is cosmo._w0
@@ -81,7 +82,7 @@ class TestwCDM(FLRWTest, Parameterw0TestMixin):
         # `w` params
         c = cosmo.clone(w0=0.1)
         assert c.w0 == 0.1
-        for n in set(cosmo.__parameters__) - {"w0"}:
+        for n in set(cosmo.parameters) - {"w0"}:
             v = getattr(c, n)
             if v is None:
                 assert v is getattr(cosmo, n)

--- a/astropy/cosmology/flrw/tests/test_w0wacdm.py
+++ b/astropy/cosmology/flrw/tests/test_w0wacdm.py
@@ -35,10 +35,11 @@ class ParameterwaTestMixin(ParameterTestMixin):
     def test_wa(self, cosmo_cls, cosmo):
         """Test Parameter ``wa``."""
         # on the class
-        assert isinstance(cosmo_cls.wa, Parameter)
-        assert "Negative derivative" in cosmo_cls.wa.__doc__
-        assert cosmo_cls.wa.unit is None
-        assert cosmo_cls.wa.default == 0.0
+        wa = cosmo_cls.parameters["wa"]
+        assert isinstance(wa, Parameter)
+        assert "Negative derivative" in wa.__doc__
+        assert wa.unit is None
+        assert wa.default == 0.0
 
         # on the instance
         assert cosmo.wa is cosmo._wa
@@ -82,7 +83,7 @@ class Testw0waCDM(FLRWTest, Parameterw0TestMixin, ParameterwaTestMixin):
         c = cosmo.clone(w0=0.1, wa=0.2)
         assert c.w0 == 0.1
         assert c.wa == 0.2
-        for n in set(cosmo.__parameters__) - {"w0", "wa"}:
+        for n in set(cosmo.parameters) - {"w0", "wa"}:
             v = getattr(c, n)
             if v is None:
                 assert v is getattr(cosmo, n)

--- a/astropy/cosmology/flrw/tests/test_w0wacdm.py
+++ b/astropy/cosmology/flrw/tests/test_w0wacdm.py
@@ -14,8 +14,10 @@ import astropy.units as u
 from astropy.cosmology import Flatw0waCDM, Planck18, w0waCDM
 from astropy.cosmology.parameter import Parameter
 from astropy.cosmology.tests.test_core import ParameterTestMixin
+from astropy.tests.helper import assert_quantity_allclose
 from astropy.utils.compat.optional_deps import HAS_SCIPY
 
+from .conftest import filter_keys_from_items
 from .test_base import FlatFLRWMixinTest, FLRWTest
 from .test_w0cdm import Parameterw0TestMixin
 
@@ -83,14 +85,12 @@ class Testw0waCDM(FLRWTest, Parameterw0TestMixin, ParameterwaTestMixin):
         c = cosmo.clone(w0=0.1, wa=0.2)
         assert c.w0 == 0.1
         assert c.wa == 0.2
-        for n in set(cosmo.parameters) - {"w0", "wa"}:
-            v = getattr(c, n)
+        for n, v in filter_keys_from_items(c.parameters, ("w0", "wa")):
+            v_expect = getattr(cosmo, n)
             if v is None:
-                assert v is getattr(cosmo, n)
+                assert v is v_expect
             else:
-                assert u.allclose(
-                    v, getattr(cosmo, n), atol=1e-4 * getattr(v, "unit", 1)
-                )
+                assert_quantity_allclose(v, v_expect, atol=1e-4 * getattr(v, "unit", 1))
 
     # @pytest.mark.parametrize("z", valid_zs)  # TODO! recompute comparisons below
     def test_w(self, cosmo):

--- a/astropy/cosmology/flrw/tests/test_w0wacdm.py
+++ b/astropy/cosmology/flrw/tests/test_w0wacdm.py
@@ -266,7 +266,7 @@ def test_varyde_lumdist_mathematica():
 def test_equality():
     """Test equality and equivalence."""
     # mismatched signatures, both directions.
-    newcosmo = w0waCDM(**Planck18._init_arguments, Ode0=0.6)
+    newcosmo = w0waCDM(**Planck18.parameters, Ode0=0.6)
     assert newcosmo != Planck18
     assert Planck18 != newcosmo
 

--- a/astropy/cosmology/flrw/tests/test_w0wzcdm.py
+++ b/astropy/cosmology/flrw/tests/test_w0wzcdm.py
@@ -40,10 +40,11 @@ class ParameterwzTestMixin(ParameterTestMixin):
     def test_wz(self, cosmo_cls, cosmo):
         """Test Parameter ``wz``."""
         # on the class
-        assert isinstance(cosmo_cls.wz, Parameter)
-        assert "Derivative of the dark energy" in cosmo_cls.wz.__doc__
-        assert cosmo_cls.wz.unit is None
-        assert cosmo_cls.wz.default == 0.0
+        wz = cosmo_cls.parameters["wz"]
+        assert isinstance(wz, Parameter)
+        assert "Derivative of the dark energy" in wz.__doc__
+        assert wz.unit is None
+        assert wz.default == 0.0
 
         # on the instance
         assert cosmo.wz is cosmo._wz
@@ -87,7 +88,7 @@ class Testw0wzCDM(FLRWTest, Parameterw0TestMixin, ParameterwzTestMixin):
         c = cosmo.clone(w0=0.1, wz=0.2)
         assert c.w0 == 0.1
         assert c.wz == 0.2
-        for n in set(cosmo.__parameters__) - {"w0", "wz"}:
+        for n in set(cosmo.parameters) - {"w0", "wz"}:
             v = getattr(c, n)
             if v is None:
                 assert v is getattr(cosmo, n)

--- a/astropy/cosmology/flrw/tests/test_w0wzcdm.py
+++ b/astropy/cosmology/flrw/tests/test_w0wzcdm.py
@@ -13,6 +13,7 @@ from astropy.cosmology.parameter import Parameter
 from astropy.cosmology.tests.test_core import ParameterTestMixin, make_valid_zs
 from astropy.utils.compat.optional_deps import HAS_SCIPY
 
+from .conftest import filter_keys_from_items
 from .test_base import FlatFLRWMixinTest, FLRWTest
 from .test_w0cdm import Parameterw0TestMixin
 
@@ -88,8 +89,7 @@ class Testw0wzCDM(FLRWTest, Parameterw0TestMixin, ParameterwzTestMixin):
         c = cosmo.clone(w0=0.1, wz=0.2)
         assert c.w0 == 0.1
         assert c.wz == 0.2
-        for n in set(cosmo.parameters) - {"w0", "wz"}:
-            v = getattr(c, n)
+        for n, v in filter_keys_from_items(c.parameters, ("w0", "wz")):
             if v is None:
                 assert v is getattr(cosmo, n)
             else:

--- a/astropy/cosmology/flrw/tests/test_wpwazpcdm.py
+++ b/astropy/cosmology/flrw/tests/test_wpwazpcdm.py
@@ -40,10 +40,11 @@ class ParameterwpTestMixin(ParameterTestMixin):
     def test_wp(self, cosmo_cls, cosmo):
         """Test Parameter ``wp``."""
         # on the class
-        assert isinstance(cosmo_cls.wp, Parameter)
-        assert "at the pivot" in cosmo_cls.wp.__doc__
-        assert cosmo_cls.wp.unit is None
-        assert cosmo_cls.wp.default == -1.0
+        wp = cosmo_cls.parameters["wp"]
+        assert isinstance(wp, Parameter)
+        assert "at the pivot" in wp.__doc__
+        assert wp.unit is None
+        assert wp.default == -1.0
 
         # on the instance
         assert cosmo.wp is cosmo._wp
@@ -78,10 +79,11 @@ class ParameterzpTestMixin(ParameterTestMixin):
     def test_zp(self, cosmo_cls, cosmo):
         """Test Parameter ``zp``."""
         # on the class
-        assert isinstance(cosmo_cls.zp, Parameter)
-        assert "pivot redshift" in cosmo_cls.zp.__doc__
-        assert cosmo_cls.zp.unit == cu.redshift
-        assert cosmo_cls.zp.default == 0.0
+        zp = cosmo_cls.parameters["zp"]
+        assert isinstance(zp, Parameter)
+        assert "pivot redshift" in zp.__doc__
+        assert zp.unit == cu.redshift
+        assert zp.default == 0.0
 
         # on the instance
         assert cosmo.zp is cosmo._zp
@@ -128,7 +130,7 @@ class TestwpwaCDM(
         assert c.wp == 0.1
         assert c.wa == 0.2
         assert c.zp == 14
-        for n in set(cosmo.__parameters__) - {"wp", "wa", "zp"}:
+        for n in set(cosmo.parameters) - {"wp", "wa", "zp"}:
             v = getattr(c, n)
             if v is None:
                 assert v is getattr(cosmo, n)

--- a/astropy/cosmology/flrw/tests/test_wpwazpcdm.py
+++ b/astropy/cosmology/flrw/tests/test_wpwazpcdm.py
@@ -13,8 +13,10 @@ import astropy.units as u
 from astropy.cosmology import FlatwpwaCDM, wpwaCDM
 from astropy.cosmology.parameter import Parameter
 from astropy.cosmology.tests.test_core import ParameterTestMixin
+from astropy.tests.helper import assert_quantity_allclose
 from astropy.utils.compat.optional_deps import HAS_SCIPY
 
+from .conftest import filter_keys_from_items
 from .test_base import FlatFLRWMixinTest, FLRWTest
 from .test_w0wacdm import ParameterwaTestMixin
 
@@ -130,14 +132,12 @@ class TestwpwaCDM(
         assert c.wp == 0.1
         assert c.wa == 0.2
         assert c.zp == 14
-        for n in set(cosmo.parameters) - {"wp", "wa", "zp"}:
-            v = getattr(c, n)
+        for n, v in filter_keys_from_items(c.parameters, ("wp", "wa", "zp")):
+            v_expect = getattr(cosmo, n)
             if v is None:
-                assert v is getattr(cosmo, n)
+                assert v is v_expect
             else:
-                assert u.allclose(
-                    v, getattr(cosmo, n), atol=1e-4 * getattr(v, "unit", 1)
-                )
+                assert_quantity_allclose(v, v_expect, atol=1e-4 * getattr(v, "unit", 1))
 
     # @pytest.mark.parametrize("z", valid_zs)  # TODO! recompute comparisons below
     def test_w(self, cosmo):

--- a/astropy/cosmology/funcs/tests/test_comparison.py
+++ b/astropy/cosmology/funcs/tests/test_comparison.py
@@ -66,8 +66,7 @@ class ComparisonFunctionTestBase(ToFromTestMixinBase):
     @pytest.fixture(scope="class")
     def pert_cosmo(self, cosmo):
         # change one parameter
-        p = cosmo.__parameters__[0]
-        v = getattr(cosmo, p)
+        p, v = next(iter(cosmo.parameters.items()))
         cosmo2 = cosmo.clone(
             **{p: v * 1.0001 if v != 0 else 0.001 * getattr(v, "unit", 1)}
         )

--- a/astropy/cosmology/parameter/__init__.py
+++ b/astropy/cosmology/parameter/__init__.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-__all__ = ["Parameter"]
+from . import _core
+from ._core import *
 
-from ._core import Parameter
+__all__ = _core.__all__

--- a/astropy/cosmology/parameter/_core.py
+++ b/astropy/cosmology/parameter/_core.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__all__ = []
+__all__ = ["Parameter"]
 
 import copy
 from dataclasses import dataclass, field, fields, replace

--- a/astropy/cosmology/parameter/_descriptors.py
+++ b/astropy/cosmology/parameter/_descriptors.py
@@ -1,0 +1,47 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+from __future__ import annotations
+
+__all__ = []
+
+from dataclasses import dataclass, field
+from types import MappingProxyType
+from typing import TYPE_CHECKING, Any, NoReturn
+
+from astropy.utils.compat.misc import PYTHON_LT_3_10
+
+if TYPE_CHECKING:
+    from astropy.cosmology.core import Cosmology
+
+
+_dataclass_kwargs = {} if PYTHON_LT_3_10 else {"slots": True}
+
+
+@dataclass(frozen=True, **_dataclass_kwargs)
+class ParametersAttribute:
+    """Immutable mapping of the Parameters.
+
+    If accessed from the class, this returns a mapping of the Parameter
+    objects themselves.  If accessed from an instance, this returns a
+    mapping of the values of the Parameters.
+    """
+
+    attr_name: str = field(init=False)
+
+    def __set_name__(self, owner: type[Cosmology], name: str) -> None:
+        object.__setattr__(self, "attr_name", f"_{name}")
+
+    def __get__(
+        self, instance: Cosmology | None, owner: type[Cosmology] | None
+    ) -> MappingProxyType[str, Any]:
+        # called from the class
+        if instance is None:
+            return getattr(owner, self.attr_name)
+        # called from the instance
+        return MappingProxyType(
+            {n: getattr(instance, n) for n in getattr(instance, self.attr_name)}
+        )
+
+    def __set__(self, instance: Any, value: Any) -> NoReturn:
+        msg = f"cannot set {self.attr_name.lstrip('_').rstrip('_')!r} of {instance!r}."
+        raise AttributeError(msg)

--- a/astropy/cosmology/parameter/tests/conftest.py
+++ b/astropy/cosmology/parameter/tests/conftest.py
@@ -1,0 +1,6 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+"""Configure the tests for :mod:`astropy.cosmology.parameter`."""
+
+from astropy.cosmology.tests.helper import clean_registry  # noqa: F401
+from astropy.tests.helper import pickle_protocol  # noqa: F401

--- a/astropy/cosmology/parameter/tests/test_descriptors.py
+++ b/astropy/cosmology/parameter/tests/test_descriptors.py
@@ -1,0 +1,42 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+"""Testing :mod:`astropy.cosmology.parameter._descriptor`."""
+
+from types import MappingProxyType
+
+import pytest
+
+from astropy.cosmology.parameter import Parameter
+
+
+class ParametersAttributeTestMixin:
+    """Test the descriptor for ``parameters`` on Cosmology classes."""
+
+    @pytest.mark.parametrize("name", ["parameters", "derived_parameters"])
+    def test_parameters_from_class(self, cosmo_cls, name):
+        """Test descriptor ``parameters`` accessed from the class."""
+        # test presence
+        assert hasattr(cosmo_cls, name)
+        # test Parameter is a MappingProxyType
+        parameters = getattr(cosmo_cls, name)
+        assert isinstance(parameters, MappingProxyType)
+        # Test items
+        assert set(parameters.keys()) == set(getattr(cosmo_cls, f"_{name}"))
+        assert all(isinstance(p, Parameter) for p in parameters.values())
+
+    @pytest.mark.parametrize("name", ["parameters", "derived_parameters"])
+    def test_parameters_from_instance(self, cosmo, name):
+        """Test descriptor ``parameters`` accessed from the instance."""
+        # test presence
+        assert hasattr(cosmo, name)
+        # test Parameter is a MappingProxyType
+        parameters = getattr(cosmo, name)
+        assert isinstance(parameters, MappingProxyType)
+        # Test keys
+        assert set(parameters) == set(getattr(cosmo, f"_{name}"))
+
+    @pytest.mark.parametrize("name", ["parameters", "derived_parameters"])
+    def test_parameters_cannot_set_on_instance(self, cosmo, name):
+        """Test descriptor ``parameters`` cannot be set on the instance."""
+        with pytest.raises(AttributeError, match=f"cannot set {name!r} of"):
+            setattr(cosmo, name, {})

--- a/astropy/cosmology/parameter/tests/test_parameter.py
+++ b/astropy/cosmology/parameter/tests/test_parameter.py
@@ -85,18 +85,17 @@ class ParameterTestMixin:
     @pytest.fixture
     def parameter(self, cosmo_cls):
         """Cosmological Parameters"""
-        # I wish this would work
-        # yield from cosmo_cls.parameters.values()
-
-        # just return one parameter at random
-        yield set(cosmo_cls.parameters.values()).pop()
+        yield from cosmo_cls.parameters.values()
 
     @pytest.fixture
     def all_parameter(self, cosmo_cls):
         """Cosmological All Parameter instances"""
         # just return one parameter at random
-        ps = cosmo_cls.parameters | cosmo_cls.derived_parameters
-        yield ps[set(ps).pop()]
+        n = set(cosmo_cls._parameters_all).pop()
+        try:
+            yield cosmo_cls.parameters[n]
+        except KeyError:
+            yield cosmo_cls.derived_parameters[n]
 
     # ===============================================================
     # Method Tests

--- a/astropy/cosmology/parameter/tests/test_parameter.py
+++ b/astropy/cosmology/parameter/tests/test_parameter.py
@@ -6,7 +6,6 @@
 # IMPORTS
 
 # STDLIB
-import inspect
 from typing import Callable
 
 # THIRD PARTY
@@ -87,19 +86,17 @@ class ParameterTestMixin:
     def parameter(self, cosmo_cls):
         """Cosmological Parameters"""
         # I wish this would work
-        # yield from {getattr(cosmo_cls, n) for n in cosmo_cls.__parameters__}
+        # yield from cosmo_cls.parameters.values()
 
         # just return one parameter at random
-        yield getattr(cosmo_cls, set(cosmo_cls.__parameters__).pop())
+        yield set(cosmo_cls.parameters.values()).pop()
 
     @pytest.fixture
     def all_parameter(self, cosmo_cls):
         """Cosmological All Parameter instances"""
-        # I wish this would work
-        # yield from {getattr(cosmo_cls, n) for n in cosmo_cls.__all_parameters__}
-
         # just return one parameter at random
-        yield getattr(cosmo_cls, set(cosmo_cls.__all_parameters__).pop())
+        ps = cosmo_cls.parameters | cosmo_cls.derived_parameters
+        yield ps[set(ps).pop()]
 
     # ===============================================================
     # Method Tests
@@ -150,9 +147,7 @@ class ParameterTestMixin:
         assert isinstance(all_parameter.derived, bool)
 
         # test value
-        assert all_parameter.derived is (
-            all_parameter.name not in cosmo_cls.__parameters__
-        )
+        assert all_parameter.derived is (all_parameter.name not in cosmo_cls.parameters)
 
     def test_Parameter_default(self, cosmo_cls, all_parameter):
         """Test :attr:`astropy.cosmology.Parameter.default`."""
@@ -167,8 +162,9 @@ class ParameterTestMixin:
     def test_Parameter_descriptor_get(self, cosmo_cls, cosmo, all_parameter):
         """Test :attr:`astropy.cosmology.Parameter.__get__`."""
         # from class
-        parameter = getattr(cosmo_cls, all_parameter.name)
-        np.testing.assert_array_equal(parameter.default, all_parameter.default)
+        np.testing.assert_array_equal(
+            getattr(cosmo_cls, all_parameter.name).default, all_parameter.default
+        )
 
         # from instance
         parameter = getattr(cosmo, all_parameter.name)
@@ -196,16 +192,10 @@ class ParameterTestMixin:
         assert isinstance(all_parameter, Parameter)
 
         # the reverse: check that if it is a Parameter, it's listed.
-        # note have to check the more inclusive ``__all_parameters__``
-        assert all_parameter.name in cosmo_cls.__all_parameters__
-        if not all_parameter.derived:
-            assert all_parameter.name in cosmo_cls.__parameters__
-
-    def test_parameter_related_attributes_on_Cosmology(self, cosmo_cls):
-        """Test `astropy.cosmology.Parameter`-related on Cosmology."""
-        # establish has expected attribute
-        assert hasattr(cosmo_cls, "__parameters__")
-        assert hasattr(cosmo_cls, "__all_parameters__")
+        if all_parameter.derived:
+            assert all_parameter.name in cosmo_cls.derived_parameters
+        else:
+            assert all_parameter.name in cosmo_cls.parameters
 
     def test_Parameter_not_unique(self, cosmo_cls, clean_registry):
         """Cosmology Parameter not unique to class when subclass defined."""
@@ -217,8 +207,8 @@ class ParameterTestMixin:
         class Example(ExampleBase):
             pass
 
-        assert Example.param is ExampleBase.param
-        assert Example.__parameters__ == ExampleBase.__parameters__
+        assert Example.parameters["param"] is ExampleBase.parameters["param"]
+        assert Example.parameters == ExampleBase.parameters
 
     def test_Parameters_reorder_by_signature(self, cosmo_cls, clean_registry):
         """Test parameters are reordered."""
@@ -230,11 +220,11 @@ class ParameterTestMixin:
                 pass  # never actually initialized
 
         # param should be 1st, all other parameters next
-        assert Example.__parameters__[0] == "param"
+        assert next(iter(Example.parameters)) == "param"
         # Check the other parameters are as expected.
         # only run this test if "param" is not already on the cosmology
-        if cosmo_cls.__parameters__[0] != "param":
-            assert set(Example.__parameters__[1:]) == set(cosmo_cls.__parameters__)
+        if next(iter(cosmo_cls.parameters)) != "param":
+            assert set(tuple(Example.parameters)[1:]) == set(cosmo_cls.parameters)
 
     def test_make_from_Parameter(self, cosmo_cls, clean_registry):
         """Test the parameter creation process. Uses ``__set__``."""
@@ -265,12 +255,14 @@ class TestParameter(ParameterTestMixin):
     """
 
     def setup_class(self):
+        Param = Parameter(
+            doc="Description of example parameter.",
+            unit=u.m,
+            equivalencies=u.mass_energy(),
+        )
+
         class Example1(Cosmology):
-            param = Parameter(
-                doc="Description of example parameter.",
-                unit=u.m,
-                equivalencies=u.mass_energy(),
-            )
+            param = Param
 
             def __init__(self, param=15):
                 self.param = param
@@ -284,7 +276,7 @@ class TestParameter(ParameterTestMixin):
             def __init__(self, param=15 * u.m):
                 self.param = param
 
-            @Example1.param.validator
+            @Param.validator
             def param(self, param, value):
                 return value.to(u.km)
 
@@ -308,12 +300,12 @@ class TestParameter(ParameterTestMixin):
     @pytest.fixture(scope="class")
     def param(self, cosmo_cls):
         """Get Parameter 'param' from cosmology class."""
-        return cosmo_cls.param
+        return cosmo_cls.parameters["param"]
 
     @pytest.fixture(scope="class")
-    def param_cls(self, cosmo_cls):
+    def param_cls(self, param):
         """Get Parameter class from cosmology class."""
-        return cosmo_cls.param.__class__
+        return type(param)
 
     # ==============================================================
 
@@ -453,8 +445,8 @@ class TestParameter(ParameterTestMixin):
     # -------------------------------------------
 
     def test_Parameter_equality(self):
-        """
-        Test Parameter equality.
+        """Test Parameter equality.
+
         Determined from the processed initialization args (including defaults).
         """
         p1 = Parameter(unit="km / (s Mpc)")
@@ -495,35 +487,3 @@ class TestParameter(ParameterTestMixin):
         NP = eval(repr(P))  # Evaluate string representation back into a param.
 
         assert P == NP
-
-    # ==============================================================
-
-    def test_Parameter_doesnt_change_with_generic_class(self):
-        """Descriptors are initialized once and not updated on subclasses."""
-
-        class ExampleBase:
-            def __init__(self, param=15):
-                self._param = param
-
-            sig = inspect.signature(__init__)
-            _init_signature = sig.replace(parameters=list(sig.parameters.values())[1:])
-
-            param = Parameter(doc="example parameter")
-
-        class Example(ExampleBase):
-            pass
-
-        assert Example.param is ExampleBase.param
-
-    def test_Parameter_doesnt_change_with_cosmology(self, cosmo_cls):
-        """Cosmology reinitializes all descriptors when a subclass is defined."""
-
-        # define subclass to show param is same
-        class Example(cosmo_cls):
-            pass
-
-        assert Example.param is cosmo_cls.param
-
-        # unregister
-        _COSMOLOGY_CLASSES.pop(Example.__qualname__)
-        assert Example.__qualname__ not in _COSMOLOGY_CLASSES

--- a/astropy/cosmology/tests/helper.py
+++ b/astropy/cosmology/tests/helper.py
@@ -5,16 +5,10 @@ This module provides the tools used to internally run the cosmology test suite
 from the installed astropy.  It makes use of the `pytest`_ testing framework.
 """
 
-##############################################################################
-# IMPORTS
-
-# STDLIB
 import inspect
 
-# THIRD PARTY
 import pytest
 
-# LOCAL
 from astropy.cosmology import core
 
 __all__ = ["get_redshift_methods", "clean_registry"]

--- a/astropy/cosmology/tests/test_core.py
+++ b/astropy/cosmology/tests/test_core.py
@@ -14,11 +14,16 @@ import astropy.units as u
 from astropy.cosmology import Cosmology, FlatCosmologyMixin
 from astropy.cosmology.core import _COSMOLOGY_CLASSES
 from astropy.cosmology.parameter import Parameter
+from astropy.cosmology.parameter.tests.test_descriptors import (
+    ParametersAttributeTestMixin,
+)
+from astropy.cosmology.parameter.tests.test_parameter import ParameterTestMixin
+from astropy.cosmology.tests.test_connect import (
+    ReadWriteTestMixin,
+    ToFromFormatTestMixin,
+)
 from astropy.table import Column, QTable, Table
 from astropy.utils.compat import PYTHON_LT_3_11
-
-from .test_connect import ReadWriteTestMixin, ToFromFormatTestMixin
-from .test_parameter import ParameterTestMixin
 
 ##############################################################################
 # SETUP / TEARDOWN
@@ -99,14 +104,13 @@ class MetaTestMixin:
 
 class CosmologyTest(
     ParameterTestMixin,
+    ParametersAttributeTestMixin,
     MetaTestMixin,
     ReadWriteTestMixin,
     ToFromFormatTestMixin,
     metaclass=abc.ABCMeta,
 ):
-    """
-    Test subclasses of :class:`astropy.cosmology.Cosmology`.
-    """
+    """Test subclasses of :class:`astropy.cosmology.Cosmology`."""
 
     @abc.abstractmethod
     def setup_class(self):
@@ -154,7 +158,7 @@ class CosmologyTest(
             pass
 
         # test parameters
-        assert InitSubclassTest.__parameters__ == cosmo_cls.__parameters__
+        assert InitSubclassTest.parameters == cosmo_cls.parameters
 
         # test and cleanup registry
         registrant = _COSMOLOGY_CLASSES.pop(InitSubclassTest.__qualname__)
@@ -168,7 +172,7 @@ class CosmologyTest(
             def _register_cls(cls):
                 """Override to not register."""
 
-        assert UnRegisteredSubclassTest.__parameters__ == cosmo_cls.__parameters__
+        assert UnRegisteredSubclassTest.parameters == cosmo_cls.parameters
         assert UnRegisteredSubclassTest.__qualname__ not in _COSMOLOGY_CLASSES
 
     def test_init_signature(self, cosmo_cls, cosmo):
@@ -182,9 +186,7 @@ class CosmologyTest(
 
         # test matches __init__, but without 'self'
         sig = inspect.signature(cosmo.__init__)  # (instances don't have self)
-        assert set(sig.parameters.keys()) == set(
-            cosmo._init_signature.parameters.keys()
-        )
+        assert set(sig.parameters) == set(cosmo._init_signature.parameters)
         assert all(
             np.all(sig.parameters[k].default == p.default)
             for k, p in cosmo._init_signature.parameters.items()
@@ -320,8 +322,7 @@ class CosmologyTest(
             r = r[6 + len(cosmo.name) + 3 :]  # remove
 
         # parameters in string rep
-        ps = {k: getattr(cosmo, k) for k in cosmo.__parameters__}
-        for k, v in ps.items():
+        for k, v in cosmo.parameters.items():
             sv = f"{k}={v!r}"
             assert sv in r
             assert r.index(k) == 0
@@ -337,7 +338,7 @@ class CosmologyTest(
 
         assert isinstance(tbl, table_cls)
         # the name & all parameters are columns
-        for n in ("name", *cosmo.__parameters__):
+        for n in ("name", *cosmo.parameters):
             assert n in tbl.colnames
             assert np.all(tbl[n] == getattr(cosmo, n))
         # check if Cosmology is in metadata or a column
@@ -359,7 +360,7 @@ class CosmologyTest(
         Test immutability of cosmologies.
         The metadata is mutable: see ``test_meta_mutable``.
         """
-        for n in cosmo.__all_parameters__:
+        for n in (*cosmo.parameters, *cosmo.derived_parameters):
             with pytest.raises(AttributeError):
                 setattr(cosmo, n, getattr(cosmo, n))
 

--- a/astropy/cosmology/tests/test_parameters.py
+++ b/astropy/cosmology/tests/test_parameters.py
@@ -36,8 +36,8 @@ def test_getting_parameters(name):
     assert params["name"] == cosmo.name
     assert params["cosmology"] == cosmo.__class__.__qualname__
     # All the cosmology parameters are equal
-    for n in cosmo.__parameters__:
-        assert np.array_equal(params[n], getattr(cosmo, n))
+    for k, v in cosmo.parameters.items():
+        np.testing.assert_array_equal(params[k], v)
     # All the metadata is included. Parameter values take precedence, so only
     # checking the keys.
     assert set(cosmo.meta.keys()).issubset(params.keys())

--- a/astropy/cosmology/tests/test_utils.py
+++ b/astropy/cosmology/tests/test_utils.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 
 from astropy.cosmology import utils
-from astropy.cosmology._utils import aszarr, vectorize_redshift_method
+from astropy.cosmology._utils import all_cls_vars, aszarr, vectorize_redshift_method
 from astropy.utils.exceptions import AstropyDeprecationWarning
 
 from .test_core import invalid_zs, valid_zs, z_arr
@@ -73,3 +73,27 @@ class Test_aszarr:
         """Test :func:`astropy.cosmology._utils.aszarr`."""
         with pytest.raises(exc):
             aszarr(z)
+
+
+# -------------------------------------------------------------------
+
+
+def test_all_cls_vars():
+    """Test :func:`astropy.cosmology._utils.all_cls_vars`."""
+
+    class ClassA:
+        a = 1
+        b = 2
+
+    all_vars = all_cls_vars(ClassA)
+    public_all_vars = {k: v for k, v in all_vars.items() if not k.startswith("_")}
+    assert public_all_vars == {"a": 1, "b": 2}
+
+    class ClassB(ClassA):
+        c = 3
+
+    all_vars = all_cls_vars(ClassB)
+    public_all_vars = {k: v for k, v in all_vars.items() if not k.startswith("_")}
+    assert public_all_vars == {"a": 1, "b": 2, "c": 3}
+    assert "a" not in vars(ClassB)
+    assert "b" not in vars(ClassB)

--- a/docs/changes/cosmology/15168.feature.rst
+++ b/docs/changes/cosmology/15168.feature.rst
@@ -1,0 +1,5 @@
+The ``Cosmology`` class now has two new properties to access the parameters of the
+cosmology: ``.parameters`` and ``.derived_parameters``. These properties return a
+read-only dictionary of all the (derived) parameter values on the cosmology object.
+When accessed from the class (not an instance) the dictionary contains ``Parameter``
+objects, not the values.

--- a/docs/cosmology/dev.rst
+++ b/docs/cosmology/dev.rst
@@ -116,10 +116,10 @@ the definition of |FLRW|.
                 raise ValueError("baryonic density can not be larger than total matter density.")
             return value
 
-First note that all the parameters are also arguments in ``__init__``. This is
-not strictly necessary, but is good practice. If the parameter has units (and
-related equivalencies) these must be specified on the Parameter, as seen in
-:attr:`~astropy.cosmology.FLRW.H0` and :attr:`~astropy.cosmology.FLRW.m_nu`.
+First note that all the parameters are also arguments in ``__init__()``. This is not
+strictly necessary, but is good practice. If the parameter has units (and related
+equivalencies) these must be specified on the |Parameter|, as seen in
+The "H0" item in :attr:`~astropy.cosmology.FLRW.parameters`.
 
 The next important thing to note is how the parameter value is set, in
 ``__init__``. |Parameter| allows for a value to be set once (before
@@ -147,7 +147,7 @@ parameter and change any constructor argument. For example, see
     class FlatFLRWMixin(FlatCosmologyMixin):
         ...
 
-        Ode0 = FLRW.Ode0.clone(derived=True)  # now a derived param.
+        Ode0 = FLRW.parameters["Ode0"].clone(derived=True)
 
 Mixins
 ------

--- a/docs/whatsnew/6.0.rst
+++ b/docs/whatsnew/6.0.rst
@@ -187,6 +187,32 @@ format::
     Planck18        67.66 0.30966  2.7255   3.046 0.0 .. 0.06 0.04897
 
 
+New properties to access |Cosmology| parameters
+-----------------------------------------------
+
+The :class:`~astropy.cosmology.Cosmology` class now has two new properties
+to access the parameters of the cosmology: :attr:`~astropy.cosmology.Cosmology.parameters`
+and :attr:`~astropy.cosmology.Cosmology.derived_parameters`. These properties
+return a :class:`~types.MappingProxyType` object, which is a read-only dictionary
+of all the (derived-)parameter values on the |Cosmology| instance. For example::
+
+    >>> from astropy.cosmology import Planck18
+    >>> Planck18.parameters["H0"]
+    <Quantity 67.66 km / (Mpc s)>
+    >>> Planck18.derived_parameters["Ode0"]
+    0.6888463055445441
+
+When accessed from the cosmology class itself, the returned dictionary is
+not the parameter values but :class:`~astropy.cosmology.Parameter` objects
+with information about the parameter used when setting up the cosmology::
+
+    >>> from astropy.cosmology import FlatLambdaCDM
+    >>> FlatLambdaCDM.parameters["H0"]
+    Parameter(derived=False, unit=Unit("km / (Mpc s)"), equivalencies=[], ...)
+    >>> FlatLambdaCDM.derived_parameters["Ode0"]
+    Parameter(derived=True, unit=None, equivalencies=[], ...)
+
+
 :class:`~astropy.cosmology.Parameter` as a :func:`~dataclasses.dataclass`
 -------------------------------------------------------------------------
 
@@ -196,7 +222,7 @@ This means that the :mod:`dataclasses` machinery can be used to work with
 
     >>> from dataclasses import replace
     >>> from astropy.cosmology import FlatLambdaCDM
-    >>> m_nu = FlatLambdaCDM.m_nu
+    >>> m_nu = FlatLambdaCDM.parameters["m_nu"]
     >>> m_nu
     Parameter(default=<Quantity 0. eV>, derived=False, unit=Unit("eV"), ...)
     >>> replace(m_nu, derived=True)


### PR DESCRIPTION
I've added 2 properties to `Cosmology`:
1. `parameters` : an immutable dictionary of the non-derived ``Parameter``s defined on `Cosmology`. When accessed from the class the values are the Parameter objects. When accessed from the cosmology instance the values are the Parameter values on the cosmology instance.
2. `derived_parameters` : the same, but for the derived parameters, e.g `Ode0` in flat cosmologies.

The idea is that when `Cosmology` is a dataclass you eventually won't be able to do `Cosmology.H0` to get the `Parameter` object. But it will be still be easy to access the `Parameter` object as `Cosmology.parameters["H0"]`.
For v6.0 I do not plan to remove direct access to `Cosmology.H0`, etc. This will either be deprecated in a future version or will be supported through Python's [dataclass_transform](https://peps.python.org/pep-0681/) mechanism. Pros and cons to both.


Please do NOT squash.