### PR TITLE
Backport PR #15158: Finalizing changelog for v5.3.2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,69 @@
+Version 5.3.2 (2023-08-11)
+==========================
+
+Bug Fixes
+---------
+
+astropy.coordinates
+^^^^^^^^^^^^^^^^^^^
+
+- Fixed import when called with Python ``-OO`` flag. [#15037]
+
+astropy.nddata
+^^^^^^^^^^^^^^
+
+- Fix for collapse operations on ``NDData`` without masks or units. [#15082]
+
+astropy.units
+^^^^^^^^^^^^^
+
+- Modified the implementation of ``np.power()`` for instances of ``Quantity`` to
+  allow any array as the second operand if all its elements have the same value. [#15101]
+
+Version 5.3.1 (2023-07-06)
+==========================
+
+Bug Fixes
+---------
+
+astropy.cosmology
+^^^^^^^^^^^^^^^^^
+
+- The exponent in ``wowzCDM.de_density_scale`` has been corrected to 3, from -3. [#14991]
+
+astropy.io.fits
+^^^^^^^^^^^^^^^
+
+- Fix crash when a PrimaryHDU has a GROUPS keyword with a non-boolean value (i.e.
+  not a random-groups HDU). [#14998]
+
+- Fixed a bug that caused ``Cutout2D`` to not work correctly with ``CompImageHDU.section`` [#14999]
+
+- Fixed a bug that caused compressed images with TFORM missing the optional '1' prefix to not be readable. [#15001]
+
+astropy.modeling
+^^^^^^^^^^^^^^^^
+
+- All models can be pickled now. [#14902]
+
+astropy.nddata
+^^^^^^^^^^^^^^
+
+- Restore bitmask propagation behavior in ``NDData.mask``, plus a fix
+  for arithmetic between masked and unmasked ``NDData`` objects. [#14995]
+
+astropy.table
+^^^^^^^^^^^^^
+
+- Fix a bug where table indexes were not using a stable sort order. This was causing the
+  order of rows within groups to not match the original table order when an indexed table
+  was grouped. [#14907]
+
+astropy.units
+^^^^^^^^^^^^^
+
+- In VOunits, "pix", "au", "a", and "ct" are removed from the list of deprecated units. [#14885]
+
 Version 5.3 (2023-05-22)
 ========================
 

--- a/docs/changes/coordinates/15037.bugfix.rst
+++ b/docs/changes/coordinates/15037.bugfix.rst
@@ -1,1 +1,0 @@
-Fixed import when called with Python ``-OO`` flag.

--- a/docs/changes/nddata/15082.bugfix.rst
+++ b/docs/changes/nddata/15082.bugfix.rst
@@ -1,1 +1,0 @@
-Fix for collapse operations on ``NDData`` without masks or units.

--- a/docs/changes/units/15101.bugfix.rst
+++ b/docs/changes/units/15101.bugfix.rst
@@ -1,2 +1,0 @@
-Modified the implementation of ``np.power()`` for instances of ``Quantity`` to
-allow any array as the second operand if all its elements have the same value.


### PR DESCRIPTION
It looks like the 5.3.1 changelog entries were never forward-ported which is what caused the conflict