### PR TITLE
Remove obsolete `Quantity` concatenation workarounds

### DIFF
--- a/astropy/coordinates/funcs.py
+++ b/astropy/coordinates/funcs.py
@@ -280,16 +280,10 @@ def _concatenate_components(reps_difs, names):
     concatenates all of the individual components for an iterable of
     representations or differentials.
     """
-    values = []
-    for name in names:
-        unit0 = getattr(reps_difs[0], name).unit
-        # Go via to_value because np.concatenate doesn't work with Quantity
-        data_vals = [getattr(x, name).to_value(unit0) for x in reps_difs]
-        concat_vals = np.concatenate(np.atleast_1d(*data_vals))
-        concat_vals = concat_vals << unit0
-        values.append(concat_vals)
-
-    return values
+    return [
+        np.concatenate(np.atleast_1d(*[getattr(x, name) for x in reps_difs]))
+        for name in names
+    ]
 
 
 def concatenate_representations(reps):


### PR DESCRIPTION
### Description

With `numpy` < 1.17 or `astropy` < 4.0 calling `np.concatenate()` on `Quantity` instances produced an output without a unit. Two workarounds have persisted in the code until now, despite having been obsolete for quite some time.

See also pull request #8808 and 82ffaadf03036ae5f7f90c959bd6f872ca73d290 that updated the relevant documentation.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.