### PR TITLE
Correct two minor problems with `io.fits` documentation

### DIFF
--- a/astropy/io/fits/hdu/base.py
+++ b/astropy/io/fits/hdu/base.py
@@ -382,7 +382,7 @@ class _BaseHDU:
             Output verification option.  Must be one of ``"fix"``,
             ``"silentfix"``, ``"ignore"``, ``"warn"``, or
             ``"exception"``.  May also be any combination of ``"fix"`` or
-            ``"silentfix"`` with ``"+ignore"``, ``+warn``, or ``+exception"
+            ``"silentfix"`` with ``"+ignore"``, ``"+warn"``, or ``"+exception"``
             (e.g. ``"fix+warn"``).  See :ref:`astropy:verify` for more info.
 
         overwrite : bool, optional

--- a/docs/io/fits/index.rst
+++ b/docs/io/fits/index.rst
@@ -660,7 +660,7 @@ file consisting of only the primary HDU with image data.
 First, we create a ``numpy`` object for the data part::
 
     >>> import numpy as np
-    >>> n = np.arange(100.0) # a simple sequence of floats from 0.0 to 99.9
+    >>> n = np.arange(100.0) # a simple sequence of floats from 0.0 to 99.0
 
 Next, we create a :class:`PrimaryHDU` object to encapsulate the data::
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request addresses some minor errors in FITS-related documentation:
- Pairs of backticks and quotation marks in the docstring for `_BaseHDU.writeto()` were not all closed/consistent, which led to odd/improper formatting when rendered in markdown.
- `np.arange(x)` called with no additional arguments creates an array from `0(.0)` to `x(.0)`, not `x.9`.

---

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
