### PR TITLE
MNT: Deprecate tests/command.py

### DIFF
--- a/astropy/tests/command.py
+++ b/astropy/tests/command.py
@@ -15,6 +15,7 @@ from contextlib import contextmanager
 from setuptools import Command
 
 from astropy.logger import log
+from astropy.utils.decorators import deprecated
 
 
 @contextmanager
@@ -34,6 +35,7 @@ def _suppress_stdout():
             sys.stdout = old_stdout
 
 
+@deprecated("6.0")
 class FixRemoteDataOption(type):
     """
     This metaclass is used to catch cases where the user is running the tests
@@ -61,6 +63,7 @@ class FixRemoteDataOption(type):
         return super().__init__(name, bases, dct)
 
 
+@deprecated("6.0")
 class AstropyTest(Command, metaclass=FixRemoteDataOption):
     description = "Run the tests for this package"
 

--- a/docs/changes/tests/15204.api.rst
+++ b/docs/changes/tests/15204.api.rst
@@ -1,0 +1,2 @@
+``astropy.tests.command.FixRemoteDataOption`` and ``astropy.tests.command.AstropyTest`` are deprecated.
+They are no longer necessary after sunsetting ``astropy-helpers``.

--- a/setup.cfg
+++ b/setup.cfg
@@ -155,6 +155,7 @@ filterwarnings =
     ignore:'cgi' is deprecated and slated for removal in Python 3.13:DeprecationWarning
 doctest_norecursedirs =
     */setup_package.py
+    */tests/command.py
 doctest_subpackage_requires =
     astropy/table/mixins/dask.py = dask
     docs/io/fits/index.rst = numpy<1.25  # NUMPY_LT_1_25 (Issue 14545)


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

Deprecate tests/command.py because astropy-helpers had reached EOL a long time ago.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #12686

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
