### PR TITLE
BLD: set a temporary upper limit on runtime-requirement for numpy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,8 @@
 requires = ["setuptools",
             "setuptools_scm>=6.2",
             "cython==0.29.34",
+            # TODO: update runtime requirements (setup.cfg)
+            # when numpy is bumped to >=2.0 here
             "numpy>=1.25,<2",
             "extension-helpers"]
 build-backend = 'setuptools.build_meta'

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,9 @@ packages = find:
 zip_safe = False
 tests_require = pytest-astropy
 install_requires =
-    numpy>=1.22
+    # TODO: remove the upper limit on numpy when build-time requirement (pyproject.toml)
+    # is bumped to >=2.0
+    numpy>=1.22,<2.0
     pyerfa>=2.0
     astropy-iers-data>=0.2023.7.31.0.32.45
     PyYAML>=3.13


### PR DESCRIPTION
### Description

This is a follow up to #14949, following recommendations from numpy/oldest-supported-numpy maintainers (see https://github.com/scipy/oldest-supported-numpy/issues/76#issuecomment-1628819676)

The issue here is that wheels built with numpy 1.x will no be runtime compatible with numpy 2.0, so it's preferable to prevent users from installing astropy in a broken env.
Additional context:
- using the backward compatibility mechanism introduced in numpy 1.25, and used in astropy since #14949, wheels built with numpy 2.0 *will* be backward compatible at runtime, so the version capping I'm introducing here can (and should) be lifted after numpy 2.0 is released.
- this capping doesn't prevent future-compatibility testing using nightlies numpy builds, because the dev version currently used by numpy (`2.0.0dev0`) compares as `< 2.0`.

In [the initial thread](https://github.com/astropy/astropy/pull/14949#discussion_r1298669317), @pllim said:
> I don't mind max pinning numpy in release branches, but I would rather not do it in the main branch.

I don't know exactly what branching strategy is used on astropy, so maybe I'm just not getting this right; my goal here is indeed to protect *users* from installing broken envs, so I'm in favour of this going into a release if needed, but it's not clear to me why this patch wouldn't be acceptable in the main branch.


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
