### PR TITLE
API: check_broadcast cannot return None

### DIFF
--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -1061,11 +1061,12 @@ class Model(metaclass=_ModelMeta):
                 )
             )
 
-        input_shape = check_broadcast(*all_shapes)
-        if input_shape is None:
+        try:
+            input_shape = check_broadcast(*all_shapes)
+        except IncompatibleShapeError as e:
             raise ValueError(
                 "All inputs must have identical shapes or must be scalars."
-            )
+            ) from e
 
         return input_shape
 

--- a/astropy/modeling/tests/test_models.py
+++ b/astropy/modeling/tests/test_models.py
@@ -120,6 +120,14 @@ def test_inconsistent_input_shapes():
     y.shape = (1, 10)
     result = g(x, y)
     assert result.shape == (10, 10)
+    # incompatible shapes do _not_ work
+    g = Gaussian2D()
+    x = np.arange(-1.0, 1, 0.2)
+    y = np.arange(-1.0, 1, 0.1)
+    with pytest.raises(
+        ValueError, match="All inputs must have identical shapes or must be scalars"
+    ):
+        g(x, y)
 
 
 def test_custom_model_bounding_box():

--- a/docs/changes/modeling/15209.api.rst
+++ b/docs/changes/modeling/15209.api.rst
@@ -1,0 +1,2 @@
+Creating a model instance with parameters that have incompatible shapes will
+now raise a ``ValueError`` rather than an ``IncompatibleShapeError``.


### PR DESCRIPTION
### Description

`_validate_input_shapes` calls `check_broadcast` and compares its return value with `None`, but `check_broadcast` (as far as I can tell) cannot return `None`.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
