### PR TITLE
MNT: Fix typo

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,7 +17,7 @@ currently being supported with security updates.
 ## Reporting a Vulnerability
 
 [GitHub private security vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability)
-should be unabled for `astropy`. But if that does not work for whatever reason, please report to `coordinators[at]astropy.org` (also see [Astropy Team listing](https://www.astropy.org/team)).
+should be enabled for `astropy`. But if that does not work for whatever reason, please report to `coordinators[at]astropy.org` (also see [Astropy Team listing](https://www.astropy.org/team)).
 
 We will respond as soon as we are able. If vulnerability is accepted, we will work on a hotfix ASAP but that might still take a few weeks given the limited resources.
 If a vulnerability is declined, we will take no further action as far as code is concerned. Either way, we will communicate back with you.


### PR DESCRIPTION
### Description
Fix typo in SECURITY.md.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
