### PR TITLE
Better masking for non-finite values in model fitting

### DIFF
--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -1279,16 +1279,25 @@ class _NonLinearLSQFitter(metaclass=_FitterMeta):
         MESSAGE = "Non-Finite input data has been removed by the fitter."
 
         if z is None:
-            mask = np.isfinite(y)
+            mask = np.isfinite(y) & (
+                np.isfinite(weights)
+                if weights is not None
+                else np.ones_like(y).astype(bool)
+            )
             if not np.all(mask):
                 warnings.warn(MESSAGE, AstropyUserWarning)
             z_out = None
         else:
-            mask = np.isfinite(z)
+            mask = np.isfinite(z) & (
+                np.isfinite(weights)
+                if weights is not None
+                else np.ones_like(z).astype(bool)
+            )
             if not np.all(mask):
                 warnings.warn(MESSAGE, AstropyUserWarning)
-            z_out = z[mask]
-
+                z_out = z[mask]
+            else:
+                return x, y, z, None if weights is None else weights
         return x[mask], y[mask], z_out, None if weights is None else weights[mask]
 
     @fitter_unit_support

--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -1278,27 +1278,18 @@ class _NonLinearLSQFitter(metaclass=_FitterMeta):
         """
         MESSAGE = "Non-Finite input data has been removed by the fitter."
 
-        if z is None:
-            mask = np.isfinite(y) & (
-                np.isfinite(weights)
-                if weights is not None
-                else np.ones_like(y).astype(bool)
-            )
-            if not np.all(mask):
-                warnings.warn(MESSAGE, AstropyUserWarning)
-            z_out = None
-        else:
-            mask = np.isfinite(z) & (
-                np.isfinite(weights)
-                if weights is not None
-                else np.ones_like(z).astype(bool)
-            )
-            if not np.all(mask):
-                warnings.warn(MESSAGE, AstropyUserWarning)
-                z_out = z[mask]
-            else:
-                return x, y, z, None if weights is None else weights
-        return x[mask], y[mask], z_out, None if weights is None else weights[mask]
+        mask = np.ones_like(x, dtype=bool) if weights is None else np.isfinite(weights)
+        mask &= np.isfinite(y) if z is None else np.isfinite(z)
+
+        if not np.all(mask):
+            warnings.warn(MESSAGE, AstropyUserWarning)
+
+        return (
+            x[mask],
+            y[mask],
+            None if z is None else z[mask],
+            None if weights is None else weights[mask],
+        )
 
     @fitter_unit_support
     def __call__(

--- a/astropy/modeling/tests/test_fitters.py
+++ b/astropy/modeling/tests/test_fitters.py
@@ -1433,6 +1433,9 @@ def test_non_finite_filter_1D(fitter, weights):
     m_init = models.Gaussian1D()
     fit = fitter()
 
+    if weights is not None:
+        weights[[1, 4]] = np.nan
+
     with pytest.warns(
         AstropyUserWarning,
         match=r"Non-Finite input data has been removed by the fitter",
@@ -1454,6 +1457,10 @@ def test_non_finite_filter_2D(fitter, weights):
     z[0, 0] = np.nan
     z[3, 3] = np.inf
     z[7, 5] = -np.inf
+
+    if weights is not None:
+        weights[1, 1] = np.nan
+        weights[4, 3] = np.inf
 
     m_init = models.Gaussian2D()
     fit = fitter()

--- a/docs/changes/modeling/15215.bugfix.rst
+++ b/docs/changes/modeling/15215.bugfix.rst
@@ -1,2 +1,3 @@
-Apply filtering for non-finite values in either/both the data values
-and the weights for the ``LevMarLSQFitter``.
+Astropy modeling can filter non-finite data values using the ``filter_non_finite``
+keyword argument in a fitter call. Now when ``filter_non_finite`` is True,
+non-finite *weights* will also be filtered to prevent crashes in ``LevMarLSQFitter``.

--- a/docs/changes/modeling/15215.bugfix.rst
+++ b/docs/changes/modeling/15215.bugfix.rst
@@ -1,0 +1,2 @@
+Apply filtering for non-finite values in either/both the data values
+and the weights for the ``LevMarLSQFitter``.


### PR DESCRIPTION
### Description

As addressed in #13259, astropy modeling supports data values with non-finite values. Passing `filter_non_finite=True` to the fitter will simply ignore those data during the fit. 

In (unfortunate) real datasets, you may have NaNs in your uncertainties, which become non-finite weights. The logic for filtering non-finite values in `LevMarLSQFitter` skips does not check if there are non-finite values in the weights:

https://github.com/astropy/astropy/blob/dce55cd3250e66e80f3fa6b0fbf4ecb58d1c287c/astropy/modeling/fitting.py#L1270-L1292

which causes fits to crash. Here are exampe:
```python
import numpy as np

from astropy.modeling.fitting import LevMarLSQFitter
from astropy.modeling.models import Linear1D

x = np.linspace(0, 10)
y = 2 * x - 2
weights = np.ones_like(x)

# define some non-finite weights:
ind = [10, 30]
weights[ind] = np.nan

fitter = LevMarLSQFitter()
model = Linear1D()

result = fitter(model, x, y, weights=weights, filter_non_finite=True)

# the above code raises this error:

# NonFiniteValueError: Objective function has encountered a non-finite value, this will cause the fit to fail!
# Please remove non-finite values from your input data before fitting to avoid this error.
```

The error can be avoided by reworking the logic a bit, which I've done in this PR.

***

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
