### PR TITLE
add step in release procedure to update SECURITY.md

### DIFF
--- a/docs/development/releasing.rst
+++ b/docs/development/releasing.rst
@@ -489,6 +489,10 @@ Post-Release procedures
    "Actual date" column of this version's release with the date you performed
    the release (probably the date of the tag and PyPI upload).
 
+#. In the main branch, update the `SECURITY.md file in the astropy repo 
+   <https://github.com/astropy/astropy/blob/main/SECURITY.md>`_ to include the
+   newly released version, and as needed mark older versions as not supported.
+
 .. _release-procedure-bug-fix:
 
 Maintaining Bug Fix Releases

--- a/docs/development/releasing.rst
+++ b/docs/development/releasing.rst
@@ -489,7 +489,7 @@ Post-Release procedures
    "Actual date" column of this version's release with the date you performed
    the release (probably the date of the tag and PyPI upload).
 
-#. In the main branch, update the `SECURITY.md file in the astropy repo 
+#. In the main branch, update the `SECURITY.md file in the astropy repo
    <https://github.com/astropy/astropy/blob/main/SECURITY.md>`_ to include the
    newly released version, and as needed mark older versions as not supported.
 


### PR DESCRIPTION
This is a follow-up from #15212 to add a step to the release procedure to update the newly-added `SECURITY.md` file. 

Should probably get some eyes from @astropy/astropy-project-release-team