### PR TITLE
Backport PR #15049 on branch v5.0.x (fix sign of w0wzCDM inv_efuncs pyx)

### DIFF
--- a/astropy/cosmology/flrw.py
+++ b/astropy/cosmology/flrw.py
@@ -3267,8 +3267,8 @@ class w0wzCDM(FLRW):
 
     The comoving distance in Mpc at redshift z:
 
-    >>> z = 0.5
-    >>> dc = cosmo.comoving_distance(z)
+    >>> cosmo.comoving_distance(0.5)
+    <Quantity 1849.74726272 Mpc>
     """
 
     w0 = Parameter(doc="Dark energy equation of state at z=0.", fvalidate="float")

--- a/astropy/cosmology/scalar_inv_efuncs.pyx
+++ b/astropy/cosmology/scalar_inv_efuncs.pyx
@@ -181,14 +181,14 @@ def wpwacdm_inv_efunc(double z, double Om0, double Ode0, double Ok0,
 def w0wzcdm_inv_efunc_norel(double z, double Om0, double Ode0, double Ok0,
     double w0, double wz):
   cdef double opz = 1.0 + z
-  cdef Odescl = opz**(3. * (1. + w0 - wz)) * exp(-3. * wz * z)
+  cdef Odescl = opz**(3. * (1. + w0 - wz)) * exp(3. * wz * z)
   return pow(opz**2 * (opz * Om0 + Ok0) + Ode0 * Odescl, -0.5)
 
 # Massless neutrinos
 def w0wzcdm_inv_efunc_nomnu(double z, double Om0, double Ode0, double Ok0,
     double Or0, double w0, double wz):
   cdef double opz = 1.0 + z
-  cdef Odescl = opz**(3. * (1. + w0 - wz)) * exp(-3. * wz * z)
+  cdef Odescl = opz**(3. * (1. + w0 - wz)) * exp(3. * wz * z)
   return pow((((opz * Or0 + Om0) * opz) + Ok0) * opz**2 +
           Ode0 * Odescl, -0.5)
 
@@ -199,7 +199,7 @@ def w0wzcdm_inv_efunc(double z, double Om0, double Ode0, double Ok0,
 
   cdef double opz = 1.0 + z
   cdef double Or0 = Ogamma0 * (1.0 + nufunc(opz, NeffPerNu, nmasslessnu, nu_y))
-  cdef Odescl = opz**(3. * (1. + w0 - wz)) * exp(-3. * wz * z)
+  cdef Odescl = opz**(3. * (1. + w0 - wz)) * exp(3. * wz * z)
   return pow((((opz * Or0 + Om0) * opz) + Ok0) * opz**2 + Ode0 * Odescl, -0.5)
 
 ######## Neutrino relative density function

--- a/astropy/cosmology/tests/test_cosmology.py
+++ b/astropy/cosmology/tests/test_cosmology.py
@@ -1421,7 +1421,7 @@ def test_distances():
     cos = flrw.w0wzCDM(75.0, 0.3, 0.6, w0=-0.9, wz=0.1, Tcmb0=0.0)
     assert allclose(
         cos.comoving_distance(z),
-        [3051.68786716, 4756.17714818, 5822.38084257, 6562.70873734] * u.Mpc,
+        [2934.20187523, 4559.94636182, 5590.71080419, 6312.66783729] * u.Mpc,
         rtol=1e-4,
     )
     cos = flrw.w0wzCDM(
@@ -1429,7 +1429,7 @@ def test_distances():
     )
     assert allclose(
         cos.comoving_distance(z),
-        [2997.8115653, 4686.45599916, 5764.54388557, 6524.17408738] * u.Mpc,
+        [2904.47062713, 4528.59073707, 5575.95892989, 6318.98689566] * u.Mpc,
         rtol=1e-4,
     )
     cos = flrw.w0wzCDM(
@@ -1437,7 +1437,7 @@ def test_distances():
     )
     assert allclose(
         cos.comoving_distance(z),
-        [2676.73467639, 3940.57967585, 4686.90810278, 5191.54178243] * u.Mpc,
+        [2613.84726408, 3849.66574595, 4585.51172509, 5085.16795412] * u.Mpc,
         rtol=1e-4,
     )
 

--- a/docs/changes/cosmology/15227.bugfix.rst
+++ b/docs/changes/cosmology/15227.bugfix.rst
@@ -1,0 +1,1 @@
+The exponent of ``w0wzCDM`` functions in ``inv_efunc`` has been corrected to 3, from -3.


### PR DESCRIPTION
Backport of #15049