### PR TITLE
Bugfix for short version of `np.nanmedian`

### DIFF
--- a/astropy/units/quantity_helper/function_helpers.py
+++ b/astropy/units/quantity_helper/function_helpers.py
@@ -82,7 +82,7 @@ SUBCLASS_SAFE_FUNCTIONS |= {
     np.isposinf, np.isneginf, np.isreal, np.iscomplex,
     np.average, np.mean, np.std, np.var, np.trace,
     np.nanmax, np.nanmin, np.nanargmin, np.nanargmax, np.nanmean,
-    np.nanmedian, np.nansum, np.nancumsum, np.nanstd, np.nanvar,
+    np.nansum, np.nancumsum, np.nanstd, np.nanvar,
     np.nanprod, np.nancumprod,
     np.einsum_path, np.trapz, np.linspace,
     np.sort, np.partition, np.meshgrid,
@@ -560,6 +560,11 @@ def percentile(a, q, *args, **kwargs):
     from astropy.units import percent
 
     return quantile(a, q, *args, _q_unit=percent, **kwargs)
+
+
+@function_helper
+def nanmedian(a, axis=None, out=None, **kwargs):
+    return _iterable_helper(a, axis=axis, out=out, **kwargs)
 
 
 @function_helper

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -1006,8 +1006,15 @@ class TestNanFunctions(InvariantUnitTestSetup):
     def test_nanmean(self):
         self.check(np.nanmean)
 
-    def test_nanmedian(self):
-        self.check(np.nanmedian)
+    @pytest.mark.parametrize("axis", [None, 0, 1, -1])
+    def test_nanmedian(self, axis):
+        self.check(np.nanmedian, axis=axis)
+
+    def test_nanmedian_out(self):
+        out = np.empty_like(self.q)
+        o = np.nanmedian(self.q, out=out)
+        assert o is out
+        assert np.all(o == np.nanmedian(self.q))
 
     def test_nansum(self):
         self.check(np.nansum)

--- a/docs/changes/units/15228.bugfix.rst
+++ b/docs/changes/units/15228.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed ``astropy.units.Quantity``'s implementation of ``numpy.nanmedian()``,
+where for Numpy >= 1.25 an exception was raised for some array shapes and axis
+combinations.


### PR DESCRIPTION
numpy/numpy@6ac4d6d changed `numpy.lib.utils._median_nancheck()` to use `numpy.any()` which is not supported by `astropy.units.Quantity`. This PR overrides `nanmedian` to try and deal with this properly.

Fixes #15225