### PR TITLE
Fix an improper implementation of a special function supporting a binary operation

### DIFF
--- a/astropy/nddata/bitmask.py
+++ b/astropy/nddata/bitmask.py
@@ -179,9 +179,7 @@ class BitFlagNameMeta(type):
         )
 
     def __iadd__(cls, other):
-        raise NotImplementedError(
-            "Unary '+' is not supported. Use binary operator instead."
-        )
+        return NotImplemented
 
     def __delattr__(cls, name):
         raise AttributeError(


### PR DESCRIPTION
In file: bitmask.py, class: BitFlagNameMeta, there is a special method `__iadd__` that raises a [`NotImplementedError`](https://docs.python.org/3/library/exceptions.html#NotImplementedError). If a special method supporting a binary operation is not implemented it should return [`NotImplemented`](https://docs.python.org/3/library/constants.html#NotImplemented). On the other hand, `NotImplementedError` should be raised from abstract methods inside user defined base classes to indicate that the derived classes should override those methods. I suggested that the special method `__iadd__` should return `NotImplemented` instead of raising an exception. An example of how `NotImplemented` helps the interpreter support a binary operation is interpreter support a binary operation is [here](https://docs.python.org/3/library/numbers.html#implementing-the-arithmetic-operations). 

Sponsorship and Support:

This work is done by the security researchers from OpenRefactory and is supported by the Open Source Security Foundation (OpenSSF)(https://openssf.org/): Project Alpha-Omega(https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.