### PR TITLE
#14818 Address ruff violations to rule C417

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -29,7 +29,6 @@ ignore = [
     # flake8-comprehensions (C4)
     "C406",  # unnecessary-literal-dict
     "C413",  # unnecessary-call-around-sorted
-    "C417",  # unnecessary-map (over a comprehension)
 
     # mccabe (C90) : code complexity
     # TODO: configure maximum allowed complexity.

--- a/astropy/timeseries/periodograms/lombscargle/implementations/slow_impl.py
+++ b/astropy/timeseries/periodograms/lombscargle/implementations/slow_impl.py
@@ -61,7 +61,7 @@ def lombscargle_slow(
     omega = omega.ravel()[np.newaxis, :]
 
     # make following arrays into column vectors
-    t, y, dy, w = map(lambda x: x[:, np.newaxis], (t, y, dy, w))
+    t, y, dy, w = (x[:, np.newaxis] for x in (t, y, dy, w))
 
     sin_omega_t = np.sin(omega * t)
     cos_omega_t = np.cos(omega * t)


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address violations to Ruff's rule C417 listed  explicitily in https://github.com/astropy/astropy/issues/14818.

The rule has been removed from `.ruff.toml` as the sole violation has been fixed.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Part of #14818.

