### PR TITLE
BUG: fix an incompatibility with numpy 2.0 (np.lib.arraysetops is removed)

### DIFF
--- a/astropy/utils/masked/function_helpers.py
+++ b/astropy/utils/masked/function_helpers.py
@@ -136,8 +136,9 @@ IGNORED_FUNCTIONS |= {
 if NUMPY_LT_2_0:
     NP_LIB_ARRAYSETOP_FUNCS = np.lib.arraysetops.__all__
 else:
-    # np.lib.arraysetops is private in numpy 2.0 and raises AttributeError
-    # substitute a hard-coded copy for now
+    # Public set operations have been moved to the top-level namespace in numpy 2.0
+    # (numpy/numpy#24507), raising an AttributeError when accessed through np.lib.arraysetops.
+    # Listing them explicitly here.
     NP_LIB_ARRAYSETOP_FUNCS = [
         'ediff1d', 'intersect1d', 'setxor1d', 'union1d', 'setdiff1d', 'unique',
         'in1d', 'isin'

--- a/astropy/utils/masked/function_helpers.py
+++ b/astropy/utils/masked/function_helpers.py
@@ -134,17 +134,13 @@ IGNORED_FUNCTIONS |= {
 
 # Really should do these...
 if NUMPY_LT_2_0:
-    NP_LIB_ARRAYSETOP_FUNCS = np.lib.arraysetops.__all__
+    from numpy.lib import arraysetops
 else:
     # Public set operations have been moved to the top-level namespace in numpy 2.0
     # (numpy/numpy#24507), raising an AttributeError when accessed through np.lib.arraysetops.
-    # Listing them explicitly here.
-    NP_LIB_ARRAYSETOP_FUNCS = [
-        'ediff1d', 'intersect1d', 'setxor1d', 'union1d', 'setdiff1d', 'unique',
-        'in1d', 'isin'
-    ]  # fmt: skip
-IGNORED_FUNCTIONS |= {getattr(np, setopsname) for setopsname in NP_LIB_ARRAYSETOP_FUNCS}
-del NP_LIB_ARRAYSETOP_FUNCS
+    from numpy.lib import _arraysetops_impl as arraysetops
+
+IGNORED_FUNCTIONS |= {getattr(np, setopsname) for setopsname in arraysetops.__all__}
 
 if NUMPY_LT_1_23:
     IGNORED_FUNCTIONS |= {

--- a/astropy/utils/masked/function_helpers.py
+++ b/astropy/utils/masked/function_helpers.py
@@ -133,10 +133,17 @@ IGNORED_FUNCTIONS |= {
 }  # fmt: skip
 
 # Really should do these...
-IGNORED_FUNCTIONS |= {
-    getattr(np, setopsname) for setopsname in np.lib.arraysetops.__all__
-}
-
+if NUMPY_LT_2_0:
+    NP_LIB_ARRAYSETOP_FUNCS = np.lib.arraysetops.__all__
+else:
+    # np.lib.arraysetops is private in numpy 2.0 and raises AttributeError
+    # substitute a hard-coded copy for now
+    NP_LIB_ARRAYSETOP_FUNCS = [
+        'ediff1d', 'intersect1d', 'setxor1d', 'union1d', 'setdiff1d', 'unique',
+        'in1d', 'isin'
+    ]  # fmt: skip
+IGNORED_FUNCTIONS |= {getattr(np, setopsname) for setopsname in NP_LIB_ARRAYSETOP_FUNCS}
+del NP_LIB_ARRAYSETOP_FUNCS
 
 if NUMPY_LT_1_23:
     IGNORED_FUNCTIONS |= {


### PR DESCRIPTION
### Description

fix e.g. `python -c "import astropy.coordinates"` with the latest and newest numpy dev.
for context: https://github.com/numpy/numpy/pull/24567

Opening as a draft because I'm not 100% confident my naive approach is the correct one yet.

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
